### PR TITLE
refactor(predict): clean up usePredictBalance backwards-compat code

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx
@@ -99,7 +99,8 @@ describe('PredictMarketMultiple', () => {
     });
     // Default mock implementation - user has balance
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: false,
+      data: 100,
+      isLoading: false,
     });
   });
 
@@ -275,7 +276,8 @@ describe('PredictMarketMultiple', () => {
     });
     // Mock user has balance
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: false,
+      data: 100,
+      isLoading: false,
     });
 
     const { UNSAFE_getAllByType } = renderWithProvider(
@@ -328,7 +330,8 @@ describe('PredictMarketMultiple', () => {
       refreshEligibility: jest.fn(),
     });
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: true,
+      data: undefined,
+      isLoading: false,
     });
 
     const { getAllByText } = renderWithProvider(
@@ -355,7 +358,8 @@ describe('PredictMarketMultiple', () => {
       refreshEligibility: jest.fn(),
     });
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: true,
+      data: undefined,
+      isLoading: false,
     });
 
     const { getAllByText } = renderWithProvider(

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.test.tsx
@@ -97,7 +97,8 @@ describe('PredictMarketOutcome', () => {
     });
     // Default mock implementation - user has balance
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: false,
+      data: 100,
+      isLoading: false,
     });
   });
 
@@ -248,7 +249,8 @@ describe('PredictMarketOutcome', () => {
       refreshEligibility: jest.fn(),
     });
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: true,
+      data: undefined,
+      isLoading: false,
     });
 
     const { getByText } = renderWithProvider(
@@ -275,7 +277,8 @@ describe('PredictMarketOutcome', () => {
       refreshEligibility: jest.fn(),
     });
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: true,
+      data: undefined,
+      isLoading: false,
     });
 
     const { getByText } = renderWithProvider(

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
@@ -120,7 +120,8 @@ describe('PredictMarketSingle', () => {
     });
     // Default mock implementation - user has balance
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: false,
+      data: 100,
+      isLoading: false,
     });
   });
 
@@ -356,7 +357,8 @@ describe('PredictMarketSingle', () => {
       refreshEligibility: jest.fn(),
     });
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: true,
+      data: undefined,
+      isLoading: false,
     });
 
     const { getByText } = renderWithProvider(
@@ -383,7 +385,8 @@ describe('PredictMarketSingle', () => {
       refreshEligibility: jest.fn(),
     });
     mockUsePredictBalance.mockReturnValue({
-      hasNoBalance: true,
+      data: undefined,
+      isLoading: false,
     });
 
     const { getByText } = renderWithProvider(

--- a/app/components/UI/Predict/hooks/usePredictBalance.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.test.ts
@@ -57,24 +57,8 @@ describe('usePredictBalance', () => {
     jest.restoreAllMocks();
   });
 
-  describe('initial state', () => {
-    it('returns undefined data and no fetching when disabled', () => {
-      const { Wrapper } = createWrapper();
-
-      const { result } = renderHook(
-        () => usePredictBalance({ enabled: false }),
-        { wrapper: Wrapper },
-      );
-
-      expect(result.current.data).toBeUndefined();
-      expect(result.current.isFetching).toBe(false);
-      expect(result.current.error).toBeNull();
-      expect(mockGetBalance).not.toHaveBeenCalled();
-    });
-  });
-
   describe('fetching behavior', () => {
-    it('fetches balance automatically when enabled (default)', async () => {
+    it('fetches balance automatically on mount', async () => {
       const { Wrapper } = createWrapper();
       mockGetBalance.mockResolvedValue(150.5);
 
@@ -88,33 +72,6 @@ describe('usePredictBalance', () => {
 
       expect(result.current.data).toBe(150.5);
       expect(result.current.error).toBeNull();
-      expect(mockGetBalance).toHaveBeenCalledWith({
-        address: MOCK_ADDRESS,
-      });
-    });
-
-    it('does not fetch when enabled is false', () => {
-      const { Wrapper } = createWrapper();
-
-      renderHook(() => usePredictBalance({ enabled: false }), {
-        wrapper: Wrapper,
-      });
-
-      expect(mockGetBalance).not.toHaveBeenCalled();
-    });
-
-    it('fetches with default options when no options provided', async () => {
-      const { Wrapper } = createWrapper();
-      mockGetBalance.mockResolvedValue(42);
-
-      const { result } = renderHook(() => usePredictBalance(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.data).toBe(42);
-      });
-
       expect(mockGetBalance).toHaveBeenCalledWith({
         address: MOCK_ADDRESS,
       });

--- a/app/components/UI/Predict/hooks/usePredictBalance.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.ts
@@ -1,70 +1,20 @@
 import { useEffect } from 'react';
-import {
-  useQuery,
-  type RefetchOptions,
-  type QueryObserverResult,
-} from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { predictQueries } from '../queries';
 
-interface UsePredictBalanceOptions {
-  enabled?: boolean;
-  // TODO: Remove once confirmations code migrates to `data` from useQuery.
-  loadOnMount?: boolean;
-}
-
-type Refetch = (
-  options?: RefetchOptions,
-) => Promise<QueryObserverResult<number, Error>>;
-
-interface UsePredictBalanceResult {
-  data?: number;
-  isLoading: boolean;
-  isFetching?: boolean;
-  error: Error | null;
-  refetch?: Refetch;
-  // TODO: Remove legacy fields once confirmations code migrates to `data`.
-  balance: number;
-  hasNoBalance: boolean;
-  isRefreshing: boolean;
-  loadBalance: Refetch;
-}
-
-export function usePredictBalance(
-  options?: UsePredictBalanceOptions,
-): UsePredictBalanceResult {
-  const { enabled = true } = options ?? {};
-
+export function usePredictBalance(): UseQueryResult<number, Error> {
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
 
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const address = evmAccount?.address ?? '0x0';
 
   useEffect(() => {
-    if (!enabled) return;
     ensurePolygonNetworkExists().catch(() => {
       // Network may already exist — swallow so the query can still proceed.
     });
-  }, [enabled, ensurePolygonNetworkExists]);
+  }, [ensurePolygonNetworkExists]);
 
-  const query = useQuery({
-    ...predictQueries.balance.options({ address }),
-    enabled,
-  });
-
-  const balance = query.data ?? 0;
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    isFetching: query.isFetching,
-    error: query.error,
-    refetch: query.refetch,
-    // TODO: Remove legacy fields once confirmations code migrates to `data`.
-    balance,
-    hasNoBalance: !query.isLoading && balance === 0,
-    isRefreshing: query.isRefetching,
-    loadBalance: query.refetch,
-  };
+  return useQuery(predictQueries.balance.options({ address }));
 }

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -195,12 +195,9 @@ jest.mock('../../hooks/usePredictPositions', () => ({
 
 jest.mock('../../hooks/usePredictBalance', () => ({
   usePredictBalance: jest.fn(() => ({
-    balance: 100,
-    hasNoBalance: false,
+    data: 100,
     isLoading: false,
-    isRefreshing: false,
     error: null,
-    loadBalance: jest.fn(),
   })),
 }));
 
@@ -2400,7 +2397,8 @@ describe('PredictMarketDetails', () => {
         '../../hooks/usePredictBalance',
       );
       usePredictBalance.mockReturnValue({
-        hasNoBalance: true,
+        data: undefined,
+        isLoading: false,
       });
 
       const singleOutcomeMarket = createMockMarket({
@@ -2444,7 +2442,8 @@ describe('PredictMarketDetails', () => {
         '../../hooks/usePredictBalance',
       );
       usePredictBalance.mockReturnValue({
-        hasNoBalance: true,
+        data: undefined,
+        isLoading: false,
       });
 
       const singleOutcomeMarket = createMockMarket({

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-withdraw-balance/predict-withdraw-balance.test.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-withdraw-balance/predict-withdraw-balance.test.tsx
@@ -30,13 +30,10 @@ describe('PredictWithdrawBalance', () => {
     jest.clearAllMocks();
 
     mockUsePredictBalance.mockReturnValue({
-      balance: 1232.39,
-      hasNoBalance: false,
+      data: 1232.39,
       isLoading: false,
-      isRefreshing: false,
       error: null,
-      loadBalance: jest.fn(),
-    });
+    } as never);
   });
 
   afterEach(() => {

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-withdraw-balance/predict-withdraw-balance.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-withdraw-balance/predict-withdraw-balance.tsx
@@ -16,7 +16,7 @@ import { PREDICT_CURRENCY } from '../../../constants/predict';
 export function PredictWithdrawBalance() {
   const { styles } = useStyles(styleSheet, {});
   const formatFiat = useFiatFormatter({ currency: PREDICT_CURRENCY });
-  const { balance } = usePredictBalance({ loadOnMount: true });
+  const { data: balance = 0 } = usePredictBalance();
 
   const balanceFormatted = useMemo(
     () => formatFiat(new BigNumber(balance)),

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.test.ts
@@ -41,7 +41,7 @@ describe('useInsufficientPredictBalanceAlert', () => {
     } as unknown as TransactionMeta);
 
     useTokenAmountMock.mockReturnValue({} as ReturnType<typeof useTokenAmount>);
-    usePredictBalanceMock.mockReturnValue({ balance: 1233.99 } as never);
+    usePredictBalanceMock.mockReturnValue({ data: 1233.99 } as never);
   });
 
   it('returns alert if predict balance less than pending amount', () => {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.ts
@@ -22,9 +22,7 @@ export function useInsufficientPredictBalanceAlert({
   const { amountPrecise } = useTokenAmount();
   const amountHuman = pendingAmount ?? amountPrecise ?? '0';
 
-  const { balance: predictBalanceHuman } = usePredictBalance({
-    loadOnMount: true,
-  });
+  const { data: predictBalanceHuman = 0 } = usePredictBalance();
 
   const isPredictWithdraw = hasTransactionType(transactionMeta, [
     TransactionType.predictWithdraw,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -134,7 +134,7 @@ describe('useTransactionCustomAmount', () => {
     } as ReturnType<typeof useTransactionPayToken>);
 
     useParamsMock.mockReturnValue({});
-    usePredictBalanceMock.mockReturnValue({ balance: 0 } as never);
+    usePredictBalanceMock.mockReturnValue({ data: 0 } as never);
     useConfirmationMetricEventsMock.mockReturnValue({
       setConfirmationMetric: setConfirmationMetricMock,
     } as unknown as ReturnType<typeof useConfirmationMetricEvents>);
@@ -414,7 +414,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('to percentage of predict balance converted to USD', async () => {
-      usePredictBalanceMock.mockReturnValue({ balance: 4321.23 } as never);
+      usePredictBalanceMock.mockReturnValue({ data: 4321.23 } as never);
 
       const { result } = runHook({
         transactionMeta: {
@@ -430,7 +430,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('to total predict balance when selecting max', async () => {
-      usePredictBalanceMock.mockReturnValue({ balance: 4321.23 } as never);
+      usePredictBalanceMock.mockReturnValue({ data: 4321.23 } as never);
 
       const { result } = runHook({
         transactionMeta: {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -192,9 +192,7 @@ function useTokenBalance(tokenUsdRate: number) {
     payToken?.balanceUsd ?? 0,
   ).toNumber();
 
-  const { balance: predictBalanceHuman } = usePredictBalance({
-    loadOnMount: true,
-  });
+  const { data: predictBalanceHuman = 0 } = usePredictBalance();
 
   const predictBalanceUsd = new BigNumber(predictBalanceHuman ?? '0')
     .multipliedBy(tokenUsdRate)


### PR DESCRIPTION
## **Description**

Cleans up the temporary backwards-compatibility code in `usePredictBalance`.

### What changed

**Hook simplification** — `usePredictBalance` is now a 20-line thin wrapper around `useQuery()` that directly returns `UseQueryResult<number, Error>`. Removed:
- `loadOnMount` and `enabled` options (unused by any consumer)
- `UsePredictBalanceResult` custom interface and `Refetch` type alias
- 5 legacy fields: `balance`, `hasNoBalance`, `isRefreshing`, `loadBalance`, plus manual `data`/`error` spreading

**Confirmations consumer migration** — The 3 confirmations files that still used the legacy `{ balance }` field with `{ loadOnMount: true }` now use standard `{ data: balance = 0 }`:
- `predict-withdraw-balance.tsx`
- `useInsufficientPredictBalanceAlert.ts`
- `useTransactionCustomAmount.ts`

**Test mock updates** — 7 test files updated to use `data`/`isLoading`/`error` instead of legacy mock shapes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Predict balance display

  Scenario: user views their Predict balance
    Given user has a Predict account with funds

    When user navigates to the Predict screen
    Then balance is displayed correctly with loading state

  Scenario: user completes a deposit and balance refreshes
    Given user is on the Predict screen

    When user completes a deposit
    Then balance updates automatically after confirmation toast

  Scenario: user views withdraw confirmation
    Given user initiates a Predict withdrawal

    When the confirmation screen appears
    Then available balance is displayed correctly
```

## **Screenshots/Recordings**

N/A — no visual changes, internal refactor only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a type/shape refactor of a hook return value plus test updates; risk is limited to any missed call sites still expecting legacy fields.
> 
> **Overview**
> **Simplifies `usePredictBalance`** by removing backwards-compat options/fields (`enabled`, `loadOnMount`, `balance`, `hasNoBalance`, refresh helpers) and returning the raw React Query `UseQueryResult<number, Error>`.
> 
> **Migrates remaining consumers/tests** (notably Predict confirmations and several Predict component tests) to read `data`/`isLoading` from the hook and default `data` to `0` where needed, updating mocks and removing tests that asserted the old disabled/legacy behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5537e41d9c086a9f5beb31f85aacd92be7fb0342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->