### PR TITLE
feat(card): add freeze/unfreeze option

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -487,7 +487,9 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'card.card_home.manage_card_options.freeze_error':
         'Failed to update card status. Please try again.',
       'card.card_home.biometric_verification_required':
-        'Biometric verification required',
+        'Authentication required to view card details.',
+      'card.card_home.unfreeze_auth_required':
+        'Authentication required to resume spending on your card.',
       'card.password_bottomsheet.description_unfreeze':
         'Enter your wallet password to unfreeze your card.',
     };

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -4368,7 +4368,7 @@ describe('CardHome Component', () => {
       holderName: 'John Doe',
       panLast4: '1234',
       status: 'ACTIVE',
-      expiryDate: '12/25',
+      isFreezable: true,
     };
 
     const mockUserDetailsForProvisioning = {
@@ -4430,7 +4430,7 @@ describe('CardHome Component', () => {
         holderName: 'John Doe',
         panLast4: '1234',
         status: 'ACTIVE',
-        expiryDate: '12/25',
+        isFreezable: true,
       });
     });
 

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -150,7 +150,7 @@ const mockSelectedInternalAccount = {
 const mockFetchAllData = jest.fn().mockResolvedValue(undefined);
 const mockRefetchAllData = jest.fn().mockResolvedValue(undefined);
 const mockFetchCardDetails = jest.fn().mockResolvedValue(undefined);
-const mockToggleFreeze = jest.fn().mockResolvedValue(undefined);
+const mockToggleFreeze = jest.fn().mockResolvedValue(true);
 const mockUseCardFreeze = jest.fn(
   (): {
     isFrozen: boolean;
@@ -497,6 +497,10 @@ jest.mock('../../../../../../locales/i18n', () => ({
         'Reactivate your card to resume transactions',
       'card.card_home.manage_card_options.freeze_error':
         'Failed to update card status. Please try again.',
+      'card.card_home.manage_card_options.freeze_success':
+        'Card successfully frozen',
+      'card.card_home.manage_card_options.unfreeze_success':
+        'Card successfully unfrozen',
       'card.card_home.biometric_verification_required':
         'Authentication required to view card details.',
       'card.card_home.unfreeze_auth_required':
@@ -718,7 +722,7 @@ describe('CardHome Component', () => {
     mockIsSolanaChainId.mockReturnValue(false);
 
     // Reset freeze hook mock
-    mockToggleFreeze.mockResolvedValue(undefined);
+    mockToggleFreeze.mockResolvedValue(true);
     mockUseCardFreeze.mockReturnValue({
       isFrozen: false,
       status: { type: 'idle' },

--- a/app/components/UI/Card/Views/CardHome/CardHome.testIds.ts
+++ b/app/components/UI/Card/Views/CardHome/CardHome.testIds.ts
@@ -28,4 +28,5 @@ export const CardHomeSelectors = {
   PASSWORD_CANCEL_BUTTON: 'password-cancel-button',
   PASSWORD_CONFIRM_BUTTON: 'password-confirm-button',
   ORDER_METAL_CARD_ITEM: 'order-metal-card-item',
+  FREEZE_CARD_TOGGLE: 'freeze-card-toggle',
 };

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -480,7 +480,7 @@ const CardHome = () => {
         variant: ToastVariants.Icon,
         labelOptions: [
           {
-            label: strings('card.card_home.biometric_verification_required'),
+            label: strings('card.card_home.unfreeze_auth_required'),
           },
         ],
         hasNoTimeout: false,

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -1307,6 +1307,7 @@ const CardHome = () => {
                       ? undefined
                       : handleToggleFreeze
                   }
+                  disabled={freezeStatus.type === 'toggling'}
                   style={tw.style(Platform.OS === 'ios' ? 'mr-2' : '')}
                   testID={CardHomeSelectors.FREEZE_CARD_TOGGLE}
                 />

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -444,15 +444,44 @@ const CardHome = () => {
     }
   }, [freezeStatus, toastRef]);
 
+  const showFreezeSuccessToast = useCallback(
+    (wasFrozen: boolean) => {
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        labelOptions: [
+          {
+            label: strings(
+              wasFrozen
+                ? 'card.card_home.manage_card_options.unfreeze_success'
+                : 'card.card_home.manage_card_options.freeze_success',
+            ),
+          },
+        ],
+        iconName: IconName.Confirmation,
+        iconColor: theme.colors.success.default,
+        hasNoTimeout: false,
+      });
+    },
+    [toastRef, theme],
+  );
+
   const handleToggleFreeze = useCallback(async () => {
+    const wasFrozen = isFrozen;
+
     if (!isFrozen) {
-      await toggleFreeze();
+      const success = await toggleFreeze();
+      if (success) {
+        showFreezeSuccessToast(wasFrozen);
+      }
       return;
     }
 
     try {
       await reauthenticate();
-      await toggleFreeze();
+      const success = await toggleFreeze();
+      if (success) {
+        showFreezeSuccessToast(wasFrozen);
+      }
     } catch (error) {
       const errorMessage = (error as Error).message;
 
@@ -463,8 +492,11 @@ const CardHome = () => {
       ) {
         navigation.navigate(
           ...createPasswordBottomSheetNavigationDetails({
-            onSuccess: () => {
-              toggleFreeze();
+            onSuccess: async () => {
+              const success = await toggleFreeze();
+              if (success) {
+                showFreezeSuccessToast(wasFrozen);
+              }
             },
             description: strings(
               'card.password_bottomsheet.description_unfreeze',
@@ -489,7 +521,14 @@ const CardHome = () => {
         iconName: IconName.Warning,
       });
     }
-  }, [isFrozen, toggleFreeze, reauthenticate, navigation, toastRef]);
+  }, [
+    isFrozen,
+    toggleFreeze,
+    reauthenticate,
+    navigation,
+    toastRef,
+    showFreezeSuccessToast,
+  ]);
 
   const addFundsAction = useCallback(() => {
     trackEvent(

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -463,7 +463,9 @@ const CardHome = () => {
       ) {
         navigation.navigate(
           ...createPasswordBottomSheetNavigationDetails({
-            onSuccess: toggleFreeze,
+            onSuccess: () => {
+              toggleFreeze();
+            },
             description: strings(
               'card.password_bottomsheet.description_unfreeze',
             ),
@@ -727,7 +729,9 @@ const CardHome = () => {
       ) {
         navigation.navigate(
           ...createPasswordBottomSheetNavigationDetails({
-            onSuccess: fetchAndShowCardDetails,
+            onSuccess: () => {
+              fetchAndShowCardDetails();
+            },
           }),
         );
         return;
@@ -1285,9 +1289,8 @@ const CardHome = () => {
         )}
         {isAuthenticated &&
           !isLoading &&
-          cardDetails &&
-          cardDetails.isFreezable &&
-          cardDetails.status !== CardStatus.BLOCKED && (
+          cardDetails?.isFreezable &&
+          cardDetails?.status !== CardStatus.BLOCKED && (
             <ManageCardListItem
               title={
                 isFrozen

--- a/app/components/UI/Card/components/ManageCardListItem/ManageCardListItem.tsx
+++ b/app/components/UI/Card/components/ManageCardListItem/ManageCardListItem.tsx
@@ -21,6 +21,7 @@ export interface ManageCardListItemProps {
   description: string | React.ReactNode;
   descriptionOrientation?: 'row' | 'column';
   rightIcon?: IconName;
+  rightElement?: React.ReactNode;
   testID?: string;
   onPress?: () => void;
   isLoading?: boolean;
@@ -32,6 +33,7 @@ const ManageCardListItem: React.FC<ManageCardListItemProps> = ({
   description,
   descriptionOrientation = 'column',
   rightIcon,
+  rightElement,
   testID = 'manage-card-list-item',
   isLoading = false,
 }) => {
@@ -51,18 +53,19 @@ const ManageCardListItem: React.FC<ManageCardListItemProps> = ({
             description
           )}
         </ListItemColumn>
-        {(isLoading || rightIcon) && (
+        {(isLoading || rightIcon || rightElement) && (
           <ListItemColumn>
             {isLoading ? (
               <ActivityIndicator size="small" />
             ) : (
-              rightIcon && (
+              (rightElement ??
+              (rightIcon && (
                 <Icon
                   style={styles.action}
                   size={IconSize.Md}
                   name={rightIcon}
                 />
-              )
+              )))
             )}
           </ListItemColumn>
         )}

--- a/app/components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.test.tsx
@@ -106,13 +106,32 @@ describe('PasswordBottomSheet', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('displays title and description text', () => {
+  it('displays title and default description text', () => {
     const { getByText } = setupComponent();
 
     expect(getByText('Enter password')).toBeTruthy();
     expect(
       getByText('Enter your wallet password to view card details.'),
     ).toBeTruthy();
+  });
+
+  it('displays custom description when provided', () => {
+    mockUseParams.mockReturnValue({
+      onSuccess: mockOnSuccess,
+      description: 'Enter your wallet password to unfreeze your card.',
+    });
+
+    const { getByText, queryByText } = renderWithProvider(() => (
+      <PasswordBottomSheet />
+    ));
+
+    expect(getByText('Enter password')).toBeTruthy();
+    expect(
+      getByText('Enter your wallet password to unfreeze your card.'),
+    ).toBeTruthy();
+    expect(
+      queryByText('Enter your wallet password to view card details.'),
+    ).toBeNull();
   });
 
   it('displays password input field', () => {

--- a/app/components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.tsx
+++ b/app/components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.tsx
@@ -28,6 +28,7 @@ import { CardHomeSelectors } from '../../Views/CardHome/CardHome.testIds';
 
 interface PasswordBottomSheetParams {
   onSuccess: () => void;
+  description?: string;
 }
 
 export const createPasswordBottomSheetNavigationDetails =
@@ -38,7 +39,7 @@ export const createPasswordBottomSheetNavigationDetails =
 
 const PasswordBottomSheet: React.FC = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
-  const { onSuccess } = useParams<PasswordBottomSheetParams>();
+  const { onSuccess, description } = useParams<PasswordBottomSheetParams>();
   const { reauthenticate } = useAuthentication();
   const theme = useTheme();
   const tw = useTailwind();
@@ -87,7 +88,7 @@ const PasswordBottomSheet: React.FC = () => {
           variant={TextVariant.BodyMD}
           style={tw.style('text-text-alternative mb-4')}
         >
-          {strings('card.password_bottomsheet.description')}
+          {description ?? strings('card.password_bottomsheet.description')}
         </Text>
 
         <TextInput

--- a/app/components/UI/Card/hooks/useCardDetails.test.ts
+++ b/app/components/UI/Card/hooks/useCardDetails.test.ts
@@ -42,7 +42,7 @@ describe('useCardDetails', () => {
   const mockCardDetailsResponse: CardDetailsResponse = {
     id: 'card-123',
     holderName: 'John Doe',
-    expiryDate: '12/25',
+    isFreezable: true,
     panLast4: '1234',
     status: CardStatus.ACTIVE,
     type: CardType.VIRTUAL,

--- a/app/components/UI/Card/hooks/useCardFreeze.test.ts
+++ b/app/components/UI/Card/hooks/useCardFreeze.test.ts
@@ -79,10 +79,12 @@ describe('useCardFreeze', () => {
         }),
       );
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(true);
       expect(mockFreezeCard).toHaveBeenCalledTimes(1);
       expect(mockUnfreezeCard).not.toHaveBeenCalled();
       expect(mockFetchCardDetails).toHaveBeenCalledTimes(1);
@@ -106,18 +108,20 @@ describe('useCardFreeze', () => {
 
       expect(result.current.status.type).toBe('idle');
 
-      let togglePromise: Promise<void>;
+      let togglePromise: Promise<boolean>;
       act(() => {
         togglePromise = result.current.toggleFreeze();
       });
 
       expect(result.current.status).toEqual({ type: 'toggling' });
 
+      let success: boolean | undefined;
       await act(async () => {
         resolveFreeze();
-        await togglePromise;
+        success = await togglePromise;
       });
 
+      expect(success).toBe(true);
       expect(result.current.status).toEqual({ type: 'idle' });
     });
   });
@@ -131,10 +135,12 @@ describe('useCardFreeze', () => {
         }),
       );
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(true);
       expect(mockUnfreezeCard).toHaveBeenCalledTimes(1);
       expect(mockFreezeCard).not.toHaveBeenCalled();
       expect(mockFetchCardDetails).toHaveBeenCalledTimes(1);
@@ -160,7 +166,7 @@ describe('useCardFreeze', () => {
 
       expect(result.current.isFrozen).toBe(false);
 
-      let togglePromise: Promise<void>;
+      let togglePromise: Promise<boolean>;
       act(() => {
         togglePromise = result.current.toggleFreeze();
       });
@@ -190,7 +196,7 @@ describe('useCardFreeze', () => {
 
       expect(result.current.isFrozen).toBe(true);
 
-      let togglePromise: Promise<void>;
+      let togglePromise: Promise<boolean>;
       act(() => {
         togglePromise = result.current.toggleFreeze();
       });
@@ -215,10 +221,12 @@ describe('useCardFreeze', () => {
 
       expect(result.current.isFrozen).toBe(false);
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(false);
       expect(result.current.isFrozen).toBe(false);
       expect(result.current.status).toEqual({
         type: 'error',
@@ -238,10 +246,12 @@ describe('useCardFreeze', () => {
 
       expect(result.current.isFrozen).toBe(true);
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(false);
       expect(result.current.isFrozen).toBe(true);
       expect(result.current.status).toEqual({
         type: 'error',
@@ -411,7 +421,7 @@ describe('useCardFreeze', () => {
   });
 
   describe('Guard Conditions', () => {
-    it('does nothing when SDK is not available', async () => {
+    it('returns false when SDK is not available', async () => {
       mockUseCardSDK.mockReturnValue({
         ...jest.requireMock('../sdk'),
         sdk: null,
@@ -424,16 +434,18 @@ describe('useCardFreeze', () => {
         }),
       );
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(false);
       expect(mockFreezeCard).not.toHaveBeenCalled();
       expect(mockUnfreezeCard).not.toHaveBeenCalled();
       expect(mockFetchCardDetails).not.toHaveBeenCalled();
     });
 
-    it('does nothing when card status is BLOCKED', async () => {
+    it('returns false when card status is BLOCKED', async () => {
       const { result } = renderHook(() =>
         useCardFreeze({
           cardStatus: CardStatus.BLOCKED,
@@ -441,16 +453,18 @@ describe('useCardFreeze', () => {
         }),
       );
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(false);
       expect(mockFreezeCard).not.toHaveBeenCalled();
       expect(mockUnfreezeCard).not.toHaveBeenCalled();
       expect(mockFetchCardDetails).not.toHaveBeenCalled();
     });
 
-    it('does nothing when card status is undefined', async () => {
+    it('returns false when card status is undefined', async () => {
       const { result } = renderHook(() =>
         useCardFreeze({
           cardStatus: undefined,
@@ -458,10 +472,12 @@ describe('useCardFreeze', () => {
         }),
       );
 
+      let success: boolean | undefined;
       await act(async () => {
-        await result.current.toggleFreeze();
+        success = await result.current.toggleFreeze();
       });
 
+      expect(success).toBe(false);
       expect(mockFreezeCard).not.toHaveBeenCalled();
       expect(mockUnfreezeCard).not.toHaveBeenCalled();
       expect(mockFetchCardDetails).not.toHaveBeenCalled();

--- a/app/components/UI/Card/hooks/useCardFreeze.test.ts
+++ b/app/components/UI/Card/hooks/useCardFreeze.test.ts
@@ -1,0 +1,402 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useCardSDK } from '../sdk';
+import useCardFreeze from './useCardFreeze';
+import { CardStatus } from '../types';
+import { CardSDK } from '../sdk/CardSDK';
+
+jest.mock('../sdk', () => ({
+  useCardSDK: jest.fn(),
+}));
+
+const mockUseCardSDK = useCardSDK as jest.MockedFunction<typeof useCardSDK>;
+
+describe('useCardFreeze', () => {
+  const mockFreezeCard = jest.fn();
+  const mockUnfreezeCard = jest.fn();
+  const mockFetchCardDetails = jest.fn();
+
+  const mockSDK = {
+    freezeCard: mockFreezeCard,
+    unfreezeCard: mockUnfreezeCard,
+  } as unknown as CardSDK;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseCardSDK.mockReturnValue({
+      ...jest.requireMock('../sdk'),
+      sdk: mockSDK,
+    });
+
+    mockFreezeCard.mockResolvedValue({ success: true });
+    mockUnfreezeCard.mockResolvedValue({ success: true });
+    mockFetchCardDetails.mockResolvedValue(null);
+  });
+
+  describe('Initial State', () => {
+    it('returns isFrozen false and idle status when card is ACTIVE', () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(false);
+      expect(result.current.status).toEqual({ type: 'idle' });
+    });
+
+    it('returns isFrozen true and idle status when card is FROZEN', () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.FROZEN,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(true);
+      expect(result.current.status).toEqual({ type: 'idle' });
+    });
+
+    it('returns isFrozen false when card status is undefined', () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: undefined,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(false);
+    });
+  });
+
+  describe('Freeze Card', () => {
+    it('calls freezeCard and refreshes card details when card is ACTIVE', async () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockFreezeCard).toHaveBeenCalledTimes(1);
+      expect(mockUnfreezeCard).not.toHaveBeenCalled();
+      expect(mockFetchCardDetails).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toEqual({ type: 'idle' });
+    });
+
+    it('transitions to toggling status during freeze operation', async () => {
+      let resolveFreeze: () => void = () => undefined;
+      mockFreezeCard.mockReturnValue(
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveFreeze = () => resolve({ success: true });
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.status.type).toBe('idle');
+
+      let togglePromise: Promise<void>;
+      act(() => {
+        togglePromise = result.current.toggleFreeze();
+      });
+
+      expect(result.current.status).toEqual({ type: 'toggling' });
+
+      await act(async () => {
+        resolveFreeze();
+        await togglePromise;
+      });
+
+      expect(result.current.status).toEqual({ type: 'idle' });
+    });
+  });
+
+  describe('Unfreeze Card', () => {
+    it('calls unfreezeCard and refreshes card details when card is FROZEN', async () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.FROZEN,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockUnfreezeCard).toHaveBeenCalledTimes(1);
+      expect(mockFreezeCard).not.toHaveBeenCalled();
+      expect(mockFetchCardDetails).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toEqual({ type: 'idle' });
+    });
+  });
+
+  describe('Optimistic Update', () => {
+    it('shows frozen state immediately when freezing an ACTIVE card', async () => {
+      let resolveFreeze: () => void = () => undefined;
+      mockFreezeCard.mockReturnValue(
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveFreeze = () => resolve({ success: true });
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(false);
+
+      let togglePromise: Promise<void>;
+      act(() => {
+        togglePromise = result.current.toggleFreeze();
+      });
+
+      expect(result.current.isFrozen).toBe(true);
+
+      await act(async () => {
+        resolveFreeze();
+        await togglePromise;
+      });
+    });
+
+    it('shows active state immediately when unfreezing a FROZEN card', async () => {
+      let resolveUnfreeze: () => void = () => undefined;
+      mockUnfreezeCard.mockReturnValue(
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveUnfreeze = () => resolve({ success: true });
+        }),
+      );
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.FROZEN,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(true);
+
+      let togglePromise: Promise<void>;
+      act(() => {
+        togglePromise = result.current.toggleFreeze();
+      });
+
+      expect(result.current.isFrozen).toBe(false);
+
+      await act(async () => {
+        resolveUnfreeze();
+        await togglePromise;
+      });
+    });
+
+    it('reverts to original state when freeze API call fails', async () => {
+      mockFreezeCard.mockRejectedValue(new Error('Freeze failed'));
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(false);
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.isFrozen).toBe(false);
+      expect(result.current.status).toEqual({
+        type: 'error',
+        error: expect.objectContaining({ message: 'Freeze failed' }),
+      });
+    });
+
+    it('reverts to original state when unfreeze API call fails', async () => {
+      mockUnfreezeCard.mockRejectedValue(new Error('Unfreeze failed'));
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.FROZEN,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      expect(result.current.isFrozen).toBe(true);
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.isFrozen).toBe(true);
+      expect(result.current.status).toEqual({
+        type: 'error',
+        error: expect.objectContaining({ message: 'Unfreeze failed' }),
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('transitions to error status when freezeCard fails', async () => {
+      const freezeError = new Error('Freeze failed');
+      mockFreezeCard.mockRejectedValue(freezeError);
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.status).toEqual({
+        type: 'error',
+        error: freezeError,
+      });
+      expect(mockFetchCardDetails).not.toHaveBeenCalled();
+    });
+
+    it('transitions to error status when unfreezeCard fails', async () => {
+      const unfreezeError = new Error('Unfreeze failed');
+      mockUnfreezeCard.mockRejectedValue(unfreezeError);
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.FROZEN,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.status).toEqual({
+        type: 'error',
+        error: unfreezeError,
+      });
+      expect(mockFetchCardDetails).not.toHaveBeenCalled();
+    });
+
+    it('wraps non-Error thrown values', async () => {
+      mockFreezeCard.mockRejectedValue('string error');
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.status.type).toBe('error');
+      if (result.current.status.type === 'error') {
+        expect(result.current.status.error).toBeInstanceOf(Error);
+        expect(result.current.status.error.message).toBe('Unknown error');
+      }
+    });
+
+    it('resets to toggling then idle on retry after error', async () => {
+      mockFreezeCard
+        .mockRejectedValueOnce(new Error('First failure'))
+        .mockResolvedValueOnce({ success: true });
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.status.type).toBe('error');
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(result.current.status).toEqual({ type: 'idle' });
+    });
+  });
+
+  describe('Guard Conditions', () => {
+    it('does nothing when SDK is not available', async () => {
+      mockUseCardSDK.mockReturnValue({
+        ...jest.requireMock('../sdk'),
+        sdk: null,
+      });
+
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockFreezeCard).not.toHaveBeenCalled();
+      expect(mockUnfreezeCard).not.toHaveBeenCalled();
+      expect(mockFetchCardDetails).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when card status is BLOCKED', async () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.BLOCKED,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockFreezeCard).not.toHaveBeenCalled();
+      expect(mockUnfreezeCard).not.toHaveBeenCalled();
+      expect(mockFetchCardDetails).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when card status is undefined', async () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: undefined,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockFreezeCard).not.toHaveBeenCalled();
+      expect(mockUnfreezeCard).not.toHaveBeenCalled();
+      expect(mockFetchCardDetails).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/UI/Card/hooks/useCardFreeze.test.ts
+++ b/app/components/UI/Card/hooks/useCardFreeze.test.ts
@@ -290,6 +290,32 @@ describe('useCardFreeze', () => {
 
       expect(result.current.isFrozen).toBe(true);
     });
+
+    it('calls the correct API on rapid double-toggle before cardStatus refreshes', async () => {
+      const { result } = renderHook(() =>
+        useCardFreeze({
+          cardStatus: CardStatus.ACTIVE,
+          fetchCardDetails: mockFetchCardDetails,
+        }),
+      );
+
+      // First toggle: freeze (ACTIVE → FROZEN)
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockFreezeCard).toHaveBeenCalledTimes(1);
+      expect(result.current.isFrozen).toBe(true);
+
+      // cardStatus prop is still stale (ACTIVE), but optimistic is FROZEN.
+      // Second toggle should call unfreezeCard, not freezeCard again.
+      await act(async () => {
+        await result.current.toggleFreeze();
+      });
+
+      expect(mockUnfreezeCard).toHaveBeenCalledTimes(1);
+      expect(mockFreezeCard).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Error Handling', () => {

--- a/app/components/UI/Card/hooks/useCardFreeze.ts
+++ b/app/components/UI/Card/hooks/useCardFreeze.ts
@@ -15,7 +15,7 @@ interface UseCardFreezeParams {
 interface UseCardFreezeResult {
   isFrozen: boolean;
   status: CardFreezeStatus;
-  toggleFreeze: () => Promise<void>;
+  toggleFreeze: () => Promise<boolean>;
 }
 
 const useCardFreeze = ({
@@ -43,15 +43,15 @@ const useCardFreeze = ({
   const effectiveStatus = optimisticStatus ?? cardStatus;
   const isFrozen = effectiveStatus === CardStatus.FROZEN;
 
-  const toggleFreeze = useCallback(async () => {
+  const toggleFreeze = useCallback(async (): Promise<boolean> => {
     if (!sdk || status.type === 'toggling') {
-      return;
+      return false;
     }
 
     const current = optimisticStatusRef.current ?? cardStatus;
 
     if (current !== CardStatus.ACTIVE && current !== CardStatus.FROZEN) {
-      return;
+      return false;
     }
 
     const nextStatus =
@@ -72,11 +72,12 @@ const useCardFreeze = ({
         type: 'error',
         error: err instanceof Error ? err : new Error('Unknown error'),
       });
-      return;
+      return false;
     }
 
     setStatus({ type: 'idle' });
     fetchCardDetails();
+    return true;
   }, [sdk, cardStatus, status.type, fetchCardDetails]);
 
   return {

--- a/app/components/UI/Card/hooks/useCardFreeze.ts
+++ b/app/components/UI/Card/hooks/useCardFreeze.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from 'react';
+import { useCardSDK } from '../sdk';
+import { CardStatus } from '../types';
+
+type CardFreezeStatus =
+  | { type: 'idle' }
+  | { type: 'toggling' }
+  | { type: 'error'; error: Error };
+
+interface UseCardFreezeParams {
+  cardStatus: CardStatus | undefined;
+  fetchCardDetails: () => Promise<unknown>;
+}
+
+interface UseCardFreezeResult {
+  isFrozen: boolean;
+  status: CardFreezeStatus;
+  toggleFreeze: () => Promise<void>;
+}
+
+const useCardFreeze = ({
+  cardStatus,
+  fetchCardDetails,
+}: UseCardFreezeParams): UseCardFreezeResult => {
+  const { sdk } = useCardSDK();
+  const [status, setStatus] = useState<CardFreezeStatus>({ type: 'idle' });
+  const [optimisticStatus, setOptimisticStatus] = useState<CardStatus | null>(
+    null,
+  );
+
+  const effectiveStatus = optimisticStatus ?? cardStatus;
+  const isFrozen = effectiveStatus === CardStatus.FROZEN;
+
+  const toggleFreeze = useCallback(async () => {
+    if (!sdk || status.type === 'toggling') {
+      return;
+    }
+
+    if (cardStatus !== CardStatus.ACTIVE && cardStatus !== CardStatus.FROZEN) {
+      return;
+    }
+
+    const nextStatus =
+      cardStatus === CardStatus.ACTIVE ? CardStatus.FROZEN : CardStatus.ACTIVE;
+
+    setOptimisticStatus(nextStatus);
+    setStatus({ type: 'toggling' });
+
+    try {
+      if (cardStatus === CardStatus.ACTIVE) {
+        await sdk.freezeCard();
+      } else {
+        await sdk.unfreezeCard();
+      }
+
+      await fetchCardDetails();
+      setStatus({ type: 'idle' });
+    } catch (err) {
+      setOptimisticStatus(null);
+      setStatus({
+        type: 'error',
+        error: err instanceof Error ? err : new Error('Unknown error'),
+      });
+    } finally {
+      setOptimisticStatus(null);
+    }
+  }, [sdk, cardStatus, status.type, fetchCardDetails]);
+
+  return {
+    isFrozen,
+    status,
+    toggleFreeze,
+  };
+};
+
+export default useCardFreeze;
+export type { CardFreezeStatus };

--- a/app/components/UI/Card/hooks/useLoadCardData.test.ts
+++ b/app/components/UI/Card/hooks/useLoadCardData.test.ts
@@ -85,7 +85,7 @@ describe('useLoadCardData', () => {
   const mockCardDetails: CardDetailsResponse = {
     id: 'card-123',
     holderName: 'John Doe',
-    expiryDate: '12/28',
+    isFreezable: true,
     panLast4: '1234',
     status: CardStatus.ACTIVE,
     type: CardType.VIRTUAL,

--- a/app/components/UI/Card/hooks/useLoadCardData.ts
+++ b/app/components/UI/Card/hooks/useLoadCardData.ts
@@ -227,6 +227,7 @@ const useLoadCardData = () => {
     isBaanxLoginEnabled,
     // Fetch functions
     fetchAllData,
+    fetchCardDetails,
   };
 };
 

--- a/app/components/UI/Card/pushProvisioning/hooks/usePushProvisioning.test.ts
+++ b/app/components/UI/Card/pushProvisioning/hooks/usePushProvisioning.test.ts
@@ -92,7 +92,6 @@ describe('usePushProvisioning', () => {
     holderName: 'John Doe',
     panLast4: '1234',
     status: 'ACTIVE',
-    isFreezable: true,
   };
 
   const mockUserAddress = {

--- a/app/components/UI/Card/pushProvisioning/hooks/usePushProvisioning.test.ts
+++ b/app/components/UI/Card/pushProvisioning/hooks/usePushProvisioning.test.ts
@@ -92,7 +92,7 @@ describe('usePushProvisioning', () => {
     holderName: 'John Doe',
     panLast4: '1234',
     status: 'ACTIVE',
-    expiryDate: '12/25',
+    isFreezable: true,
   };
 
   const mockUserAddress = {

--- a/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.test.ts
+++ b/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.test.ts
@@ -45,7 +45,7 @@ describe('PushProvisioningService', () => {
     holderName: 'John Doe',
     panLast4: '1234',
     status: 'ACTIVE',
-    expiryDate: '12/25',
+    isFreezable: true,
   };
 
   const mockUserAddress: UserAddress = {

--- a/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.test.ts
+++ b/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.test.ts
@@ -45,7 +45,6 @@ describe('PushProvisioningService', () => {
     holderName: 'John Doe',
     panLast4: '1234',
     status: 'ACTIVE',
-    isFreezable: true,
   };
 
   const mockUserAddress: UserAddress = {

--- a/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.ts
+++ b/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.ts
@@ -90,13 +90,12 @@ export class PushProvisioningService {
         );
       }
 
-      const { id: cardId, holderName, panLast4, isFreezable } = cardDetails;
+      const { id: cardId, holderName, panLast4 } = cardDetails;
 
       // 3. Build CardDisplayInfo from card details
       const cardDisplayInfo: CardDisplayInfo = {
         cardId,
         cardholderName: holderName,
-        isFreezable,
         lastFourDigits: panLast4,
         cardNetwork: 'MASTERCARD',
         cardDescription: `MetaMask Card ending in ${panLast4}`,

--- a/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.ts
+++ b/app/components/UI/Card/pushProvisioning/service/PushProvisioningService.ts
@@ -90,13 +90,13 @@ export class PushProvisioningService {
         );
       }
 
-      const { id: cardId, holderName, panLast4, expiryDate } = cardDetails;
+      const { id: cardId, holderName, panLast4, isFreezable } = cardDetails;
 
       // 3. Build CardDisplayInfo from card details
       const cardDisplayInfo: CardDisplayInfo = {
         cardId,
         cardholderName: holderName,
-        expiryDate,
+        isFreezable,
         lastFourDigits: panLast4,
         cardNetwork: 'MASTERCARD',
         cardDescription: `MetaMask Card ending in ${panLast4}`,

--- a/app/components/UI/Card/pushProvisioning/types.ts
+++ b/app/components/UI/Card/pushProvisioning/types.ts
@@ -102,7 +102,6 @@ export interface CardDisplayInfo {
   lastFourDigits: string;
   cardNetwork: CardNetwork;
   cardDescription?: string;
-  isFreezable: boolean;
 }
 
 // ============================================================================
@@ -265,7 +264,6 @@ export interface CardDetails {
   holderName: string;
   panLast4: string;
   status: string;
-  isFreezable: boolean;
 }
 
 /**

--- a/app/components/UI/Card/pushProvisioning/types.ts
+++ b/app/components/UI/Card/pushProvisioning/types.ts
@@ -102,7 +102,7 @@ export interface CardDisplayInfo {
   lastFourDigits: string;
   cardNetwork: CardNetwork;
   cardDescription?: string;
-  expiryDate?: string;
+  isFreezable: boolean;
 }
 
 // ============================================================================
@@ -265,7 +265,7 @@ export interface CardDetails {
   holderName: string;
   panLast4: string;
   status: string;
-  expiryDate?: string;
+  isFreezable: boolean;
 }
 
 /**

--- a/app/components/UI/Card/sdk/CardSDK.test.ts
+++ b/app/components/UI/Card/sdk/CardSDK.test.ts
@@ -5023,4 +5023,118 @@ describe('CardSDK', () => {
       });
     });
   });
+
+  describe('freezeCard', () => {
+    it('freezes card successfully', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ success: true }),
+      });
+
+      const result = await cardSDK.freezeCard();
+
+      expect(result).toEqual({ success: true });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/v1/card/freeze'),
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+
+    it('throws error on server failure', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: jest.fn().mockResolvedValue({ message: 'Server error' }),
+      });
+
+      await expect(cardSDK.freezeCard()).rejects.toMatchObject({
+        type: CardErrorType.SERVER_ERROR,
+      });
+
+      expect(Logger.error).toHaveBeenCalled();
+    });
+
+    it('throws INVALID_CREDENTIALS on 401', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: jest.fn().mockResolvedValue({ message: 'Unauthorized' }),
+      });
+
+      await expect(cardSDK.freezeCard()).rejects.toMatchObject({
+        type: CardErrorType.INVALID_CREDENTIALS,
+      });
+    });
+
+    it('handles network errors', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(
+        new Error('Network failure'),
+      );
+
+      await expect(cardSDK.freezeCard()).rejects.toMatchObject({
+        type: CardErrorType.NETWORK_ERROR,
+      });
+    });
+  });
+
+  describe('unfreezeCard', () => {
+    it('unfreezes card successfully', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ success: true }),
+      });
+
+      const result = await cardSDK.unfreezeCard();
+
+      expect(result).toEqual({ success: true });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/v1/card/unfreeze'),
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+
+    it('throws error on server failure', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: jest.fn().mockResolvedValue({ message: 'Server error' }),
+      });
+
+      await expect(cardSDK.unfreezeCard()).rejects.toMatchObject({
+        type: CardErrorType.SERVER_ERROR,
+      });
+
+      expect(Logger.error).toHaveBeenCalled();
+    });
+
+    it('throws INVALID_CREDENTIALS on 403', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: jest.fn().mockResolvedValue({ message: 'Forbidden' }),
+      });
+
+      await expect(cardSDK.unfreezeCard()).rejects.toMatchObject({
+        type: CardErrorType.INVALID_CREDENTIALS,
+      });
+    });
+
+    it('handles network errors', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(
+        new Error('Network failure'),
+      );
+
+      await expect(cardSDK.unfreezeCard()).rejects.toMatchObject({
+        type: CardErrorType.NETWORK_ERROR,
+      });
+    });
+  });
 });

--- a/app/components/UI/Card/sdk/CardSDK.ts
+++ b/app/components/UI/Card/sdk/CardSDK.ts
@@ -1046,6 +1046,57 @@ export class CardSDK {
   };
 
   /**
+   * Freeze the user's card to temporarily disable all transactions.
+   * The card can be unfrozen at any time.
+   *
+   * @returns Promise resolving to success status
+   */
+  freezeCard = async (): Promise<{ success: boolean }> =>
+    this.withErrorHandling(
+      'freezeCard',
+      'card/freeze',
+      'Failed to freeze card. Please try again.',
+      async () => {
+        const response = await this.makeRequest('/v1/card/freeze', {
+          fetchOptions: { method: 'POST' },
+          authenticated: true,
+        });
+
+        return this.handleApiResponse<{ success: boolean }>(
+          response,
+          'freezeCard',
+          'card/freeze',
+          'Failed to freeze card',
+        );
+      },
+    );
+
+  /**
+   * Unfreeze the user's card to resume normal transaction processing.
+   *
+   * @returns Promise resolving to success status
+   */
+  unfreezeCard = async (): Promise<{ success: boolean }> =>
+    this.withErrorHandling(
+      'unfreezeCard',
+      'card/unfreeze',
+      'Failed to unfreeze card. Please try again.',
+      async () => {
+        const response = await this.makeRequest('/v1/card/unfreeze', {
+          fetchOptions: { method: 'POST' },
+          authenticated: true,
+        });
+
+        return this.handleApiResponse<{ success: boolean }>(
+          response,
+          'unfreezeCard',
+          'card/unfreeze',
+          'Failed to unfreeze card',
+        );
+      },
+    );
+
+  /**
    * Generate a secure token for displaying sensitive card details through an image-based display.
    * The token is time-limited (~10 minutes) and single-use.
    *

--- a/app/components/UI/Card/types.ts
+++ b/app/components/UI/Card/types.ts
@@ -147,12 +147,12 @@ export enum CardType {
 
 export interface CardDetailsResponse {
   id: string;
-  holderName: string;
-  expiryDate: string;
+  isFreezable: boolean;
+  orderedAt: string;
   panLast4: string;
   status: CardStatus;
   type: CardType;
-  orderedAt: string;
+  holderName: string;
 }
 
 export interface CardWalletExternalResponse {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6729,6 +6729,7 @@
     "password_bottomsheet": {
       "title": "Enter password",
       "description": "Enter your wallet password to view card details.",
+      "description_unfreeze": "Enter your wallet password to resume spending on your card.",
       "placeholder": "Password",
       "confirm": "Confirm",
       "cancel": "Cancel",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7065,7 +7065,9 @@
         "unfreeze_card": "Unfreeze card",
         "freeze_card_description": "Pause all spending on your card",
         "unfreeze_card_description": "Resume all spending on your card",
-        "freeze_error": "Failed to update card status. Please try again."
+        "freeze_error": "Failed to update card status. Please try again.",
+        "freeze_success": "Card successfully frozen",
+        "unfreeze_success": "Card successfully unfrozen"
       }
     },
     "card_spending_limit": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7008,7 +7008,7 @@
         },
         "frozen": {
           "title": "Your card is frozen",
-          "description": "Please contact support to unfreeze your card"
+          "description": "Your card is temporarily frozen. You can unfreeze it anytime."
         },
         "blocked": {
           "title": "Your card is blocked",
@@ -7058,7 +7058,12 @@
         "travel_description": "Book hotels with up to 70% discounts",
         "card_tos_title": "Terms and conditions",
         "order_metal_card": "Metal Card",
-        "order_metal_card_description": "Order your physical Metal Card now"
+        "order_metal_card_description": "Order your physical Metal Card now",
+        "freeze_card": "Freeze card",
+        "unfreeze_card": "Unfreeze card",
+        "freeze_card_description": "Pause all spending on your card",
+        "unfreeze_card_description": "Resume all spending on your card",
+        "freeze_error": "Failed to update card status. Please try again."
       }
     },
     "card_spending_limit": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6992,6 +6992,7 @@
       "enable_card_error": "Failed to enable card. Please try again later.",
       "view_card_details_error": "Unable to load card details. Please try again.",
       "biometric_verification_required": "Authentication required to view card details.",
+      "unfreeze_auth_required": "Authentication required to resume spending on your card.",
       "warnings": {
         "close_spending_limit": {
           "title": "You're close to your spending limit",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added the ability for users to freeze and unfreeze their card directly from the CardHome screen via a toggle switch. Now users can self-service freeze/unfreeze without leaving the app.

Key changes:
- Added `freezeCard()` and `unfreezeCard()` SDK methods calling `POST /v1/card/freeze` and `POST /v1/card/unfreeze`
- Created `useCardFreeze` hook with optimistic UI updates (switch flips immediately, reverts on API failure) and a discriminated union status (`idle | toggling | error`)
- Unfreezing requires biometric/password verification (same pattern as "View card details"), with a dedicated password bottom sheet description and error toast message
- Extended `ManageCardListItem` with an optional `rightElement` prop to render a `Switch` in the right column
- Made `PasswordBottomSheet` accept an optional `description` param so callers can customize the copy per context
- Exposed `fetchCardDetails` from `useLoadCardData` so the freeze hook can refresh only card status without refetching all data (delegation, KYC, tokens, etc.)
- Optimistic state persists until the real `cardStatus` prop catches up (via `useEffect`), preventing UI revert if `fetchCardDetails` silently fails
- Uses a ref-based approach to read the latest optimistic status inside `toggleFreeze`, ensuring rapid double-toggles call the correct API even before `cardStatus` refreshes
- Cleaned up dead `CardOnboardingWebviewParams` type and `CardOnboardingWebview` route entry left after webview route removal
- Restored `expiryDate` in push provisioning types that was incorrectly replaced with `isFreezable`
- Updated frozen warning copy to reflect that users can now unfreeze on their own
- Freezing does not require confirmation — it is instant and reversible

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added card freeze/unfreeze toggle to the Card Home screen, allowing users to temporarily disable and re-enable their card.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card freeze/unfreeze toggle

  Scenario: freeze an active card
    Given the user is authenticated and has an active card
    And the card status is ACTIVE

    When the user toggles the freeze switch on the Card Home screen
    Then the switch immediately flips to the frozen (on) position
    And the title changes to "Unfreeze card"
    And the description changes to "Resume all spending on your card"
    And the card status updates to FROZEN after the API call completes

  Scenario: unfreeze a frozen card requires authentication
    Given the user is authenticated and has a frozen card
    And the card status is FROZEN

    When the user toggles the freeze switch on the Card Home screen
    Then the user is prompted for biometric verification (or password fallback)

    When the user successfully authenticates
    Then the switch immediately flips to the active (off) position
    And the title changes to "Freeze card"
    And the description changes to "Pause all spending on your card"
    And the card status updates to ACTIVE after the API call completes

  Scenario: unfreeze authentication fails via biometric cancellation
    Given the user is authenticated and has a frozen card

    When the user toggles the freeze switch
    And the biometric prompt appears
    And the user cancels the biometric prompt
    Then the switch stays in the frozen (on) position
    And no error toast is shown

  Scenario: unfreeze falls back to password bottom sheet
    Given the user is authenticated and has a frozen card
    And biometrics are not configured on the device

    When the user toggles the freeze switch
    Then the password bottom sheet appears with "Enter your wallet password to unfreeze your card."

    When the user enters the correct password and taps Confirm
    Then the switch flips to the active (off) position
    And the card is unfrozen

  Scenario: freeze/unfreeze API call fails
    Given the user is authenticated and has an active or frozen card

    When the user toggles the freeze switch
    And the API call fails (e.g. network error, server error)
    Then the switch reverts to its previous position
    And a toast notification is shown with the error message "Failed to update card status. Please try again."

  Scenario: toggle is hidden for blocked cards
    Given the user is authenticated and has a blocked card

    Then the freeze toggle is not visible on the Card Home screen

  Scenario: toggle is hidden for non-freezable cards
    Given the user is authenticated and has a card where isFreezable is false

    Then the freeze toggle is not visible on the Card Home screen

  Scenario: toggle is hidden when not authenticated
    Given the user is not authenticated

    Then the freeze toggle is not visible on the Card Home screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/79179463-22a1-422e-a3f4-70a0fbe6cba7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new state-changing card actions and reauthentication-dependent flows; main risk is incorrect gating/optimistic state or API error handling leading to mismatched UI vs card status.
> 
> **Overview**
> Adds an in-app **freeze/unfreeze** control on `CardHome` via a new `useCardFreeze` hook and `CardSDK.freezeCard`/`unfreezeCard` endpoints, with optimistic UI, disabled-while-toggling behavior, and success/error toasts.
> 
> Unfreezing now requires re-auth (biometrics with password-bottom-sheet fallback), `PasswordBottomSheet` supports a custom description, and `useLoadCardData` exposes `fetchCardDetails` so the toggle can refresh only card status; push-provisioning types/service are adjusted to drop `expiryDate` usage, and tests are expanded to cover visibility, auth flows, and SDK/hook behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61a0329af7fdc6b8c97be4c90886dd4b717d0a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->