### PR TITLE
fix(ramps): fix Android navigation showing raw screen names

### DIFF
--- a/app/components/UI/Ramp/Deposit/routes/index.tsx
+++ b/app/components/UI/Ramp/Deposit/routes/index.tsx
@@ -82,7 +82,7 @@ const MainRoutes = ({ route }: MainRoutesProps) => {
         name={Routes.DEPOSIT.ROOT}
         component={Root}
         initialParams={parentParams}
-        options={{ animationEnabled: false }}
+        options={{ animationEnabled: false, headerShown: false }}
       />
       <Stack.Screen
         name={Routes.DEPOSIT.BUILD_QUOTE}

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
@@ -1,6 +1,6 @@
 import React, {
   useCallback,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -232,7 +232,7 @@ function TokenSelection() {
     return Array.from(uniqueNetworksSet);
   }, [supportedTokens]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     navigation.setOptions(
       getDepositNavbarOptions(
         navigation,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an Android navigation bug in the Ramps Deposit flow where users see raw screen names ("DepositRoot", "RampTokenSelection") as header titles and a 5-second loading spinner after selecting a token.

Three root causes were identified and fixed:

1. **"DepositRoot" header title**: The `Root` screen in the Deposit navigator had `headerMode="screen"` but never set `headerShown: false`. Since Root is a transient routing screen that never calls `navigation.setOptions()`, React Navigation fell back to displaying the raw route name.
2. **"RampTokenSelection" header flash**: The `TokenSelection` component set its header options in `useEffect`, which runs after the first paint. Switching to `useLayoutEffect` eliminates the single-frame flash of the raw route name.
3. **5-second loading delay**: `checkExistingToken()` hangs on Android, and the timeout was set to 5000ms. The token check result is only relevant when a `CREATED` order exists. Restructured the flow to check for created orders first (synchronous, from Redux) and skip the token check entirely for the common case. Reduced the timeout from 5s to 2s for the rare created-order path.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Follow up from this PR https://github.com/MetaMask/metamask-mobile/pull/26140

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Deposit flow routing and auth-token gating logic; mistakes could misroute users between `BuildQuote`, `EnterEmail`, and `BankDetails`, though changes are scoped and covered by updated tests.
> 
> **Overview**
> Fixes Deposit/Ramps navigation UI issues by hiding the header on the transient `DepositRoot` screen and setting token-selection header options in `useLayoutEffect` to prevent a first-frame flash of raw route names.
> 
> Restructures the Deposit `Root` initialization to *skip `checkExistingToken()` unless a `CREATED` order exists*, and reduces the token-check timeout from `5000ms` to `2000ms`; updates tests to cover the new routing behavior (default route when no created order, `EnterEmail` fallback on token-check failure, and bank-details routing when authenticated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9073c855493f93ed13526670c2faed76763fc708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->