### PR TITLE
fix: cp-7.66.0 deduplicate getSeasonStatus calls

### DIFF
--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonSummary.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonSummary.tsx
@@ -22,7 +22,7 @@ import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 
 const PreviousSeasonSummary = () => {
   const { fetchSeasonStatus } = useSeasonStatus({
-    onlyForExplicitFetch: false,
+    onlyForExplicitFetch: true,
   });
   const seasonName = useSelector(selectSeasonName);
   const seasonError = useSelector(selectSeasonStatusError);

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.tsx
@@ -29,7 +29,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 const SeasonStatus: React.FC = () => {
   const theme = useTheme();
   const { fetchSeasonStatus } = useSeasonStatus({
-    onlyForExplicitFetch: false,
+    onlyForExplicitFetch: true,
   });
   const tw = useTailwind();
   const balanceTotal = useSelector(selectBalanceTotal);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Deduplicate getSeasonStatus calls when navigating to Rewards tab

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change limited to Rewards UI fetch triggering; main risk is stale season status if no other code path performs the initial fetch or refresh.
> 
> **Overview**
> Prevents duplicate season-status requests when navigating to Rewards by changing `PreviousSeasonSummary` and `SeasonStatus` to call `useSeasonStatus` with `onlyForExplicitFetch: true`, disabling the hook’s auto-fetch/on-focus refresh in those components.
> 
> Season status fetching is now centralized to the existing navigator-level hook usage, with these widgets still able to manually retry via their error banners’ `fetchSeasonStatus()` callbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17969595646b27f1758b7df571f3bc72aef0a074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->