### PR TITLE
fix: Handle slashes in `StorageService` keys cp-7.66.0

### DIFF
--- a/app/core/Engine/controllers/storage-service-init.ts
+++ b/app/core/Engine/controllers/storage-service-init.ts
@@ -13,20 +13,6 @@ import Device from '../../../util/device';
 import Logger from '../../../util/Logger';
 
 /**
- * Ensures the storage is configured properly and returns it.
- */
-function getStorage() {
-  FilesystemStorage.config({
-    // Converting : to - is the default behavior of redux-persist-filesystem-storage
-    // This is flawed, but we need to keep that for backwards compatiblity even though it does not work properly for keys including -
-    // We use URI encoding to replace /
-    toFileName: (name) => name.split(':').join('-').split('/').join('%2F'),
-    fromFileName: (name) => name.split('-').join(':').split('%2F').join('/'),
-  });
-  return FilesystemStorage;
-}
-
-/**
  * Mobile-specific storage adapter using FilesystemStorage.
  * This provides persistent storage for large controller data.
  *
@@ -46,7 +32,7 @@ const mobileStorageAdapter: StorageAdapter = {
     try {
       // Build full key: storageService:namespace:key
       const fullKey = `${STORAGE_KEY_PREFIX}${namespace}:${key}`;
-      const serialized = await getStorage().getItem(fullKey);
+      const serialized = await FilesystemStorage.getItem(fullKey);
 
       // Key not found - return empty object
       if (serialized === undefined || serialized === null) {
@@ -76,7 +62,7 @@ const mobileStorageAdapter: StorageAdapter = {
       // Build full key: storageService:namespace:key
       const fullKey = `${STORAGE_KEY_PREFIX}${namespace}:${key}`;
 
-      await getStorage().setItem(
+      await FilesystemStorage.setItem(
         fullKey,
         JSON.stringify(value),
         Device.isIos(),
@@ -99,7 +85,7 @@ const mobileStorageAdapter: StorageAdapter = {
     try {
       // Build full key: storageService:namespace:key
       const fullKey = `${STORAGE_KEY_PREFIX}${namespace}:${key}`;
-      await getStorage().removeItem(fullKey);
+      await FilesystemStorage.removeItem(fullKey);
     } catch (error) {
       Logger.error(error as Error, {
         message: `StorageService: Failed to remove item: ${namespace}:${key}`,
@@ -117,7 +103,7 @@ const mobileStorageAdapter: StorageAdapter = {
    */
   async getAllKeys(namespace: string): Promise<string[]> {
     try {
-      const allKeys = await getStorage().getAllKeys();
+      const allKeys = await FilesystemStorage.getAllKeys();
 
       if (!allKeys) {
         return [];
@@ -143,7 +129,7 @@ const mobileStorageAdapter: StorageAdapter = {
    */
   async clear(namespace: string): Promise<void> {
     try {
-      const allKeys = await getStorage().getAllKeys();
+      const allKeys = await FilesystemStorage.getAllKeys();
 
       if (!allKeys) {
         return;

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import './wdyr';
 import 'expo-asset';
 
 import * as Sentry from '@sentry/react-native'; // eslint-disable-line import/no-namespace
+import FilesystemStorage from 'redux-persist-filesystem-storage';
 import { setupSentry } from './app/util/sentry/utils';
 import { AppRegistry, LogBox } from 'react-native';
 import Root from './app/components/Views/Root';
@@ -119,3 +120,12 @@ function setupGlobalErrorHandler() {
 }
 
 setupGlobalErrorHandler();
+
+// Configure FilesystemStorage for use everywhere in the app.
+FilesystemStorage.config({
+  // Converting : to - is the default behavior of redux-persist-filesystem-storage
+  // This is flawed, but we need to keep that for backwards compatiblity even though it does not work properly for keys including -
+  // We use URI encoding to replace /
+  toFileName: (name) => name.split(':').join('-').split('/').join('%2F'),
+  fromFileName: (name) => name.split('-').join(':').split('%2F').join('/'),
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`redux-persist-filesystem-storage` has a number of problems with arbitrary keys. For one it doesn't properly handle slashes but treats them as part of the key. This means that stored data where the key includes slashes are stored in a subdirectory and not returned when using `getAllKeys`. This makes clearing data not work. This PR fixes that by replacing `/` with `%2F`, using URI encoding.

There are other problems, such as `-` being replaced with `:` by default, meaning that keys that include `-` will be misrepresented without recovery. This means there will always be a mismatch between the return value of `getAllKeys` and the actual keys used by the caller of `StorageService`.

Ideally we would URI encode the keys entirely, but this library has been used for so long that migrating would likely be complicated and its configured globally, so we can't even make the breaking change just for the `StorageService` without impacting the rest of the app.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null