### PR TITLE
Visibilidad llamadas externas

### DIFF
--- a/app/lib/snaps/SnapsExecutionWebView.test.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 
 import {
+  buildE2EProxyPatchScript,
   createWebView,
   removeWebView,
   SnapsExecutionWebView,
@@ -33,5 +34,27 @@ describe('SnapsExecutionWebView', () => {
     wrapper.rerender(<SnapsExecutionWebView />);
     expect(await wrapper.queryByTestId('foo')).toBeNull();
     expect(await wrapper.queryByTestId('bar')).toBeTruthy();
+  });
+
+  it('builds an iOS proxy patch script without emulator host fallback', () => {
+    const script = buildE2EProxyPatchScript({
+      mockServerPort: '8000',
+      platform: 'ios',
+    });
+
+    expect(script).toContain('/proxy?url=');
+    expect(script).toContain('http://localhost');
+    expect(script).not.toContain('10.0.2.2');
+  });
+
+  it('builds an Android proxy patch script with emulator host fallback', () => {
+    const script = buildE2EProxyPatchScript({
+      mockServerPort: '8000',
+      platform: 'android',
+    });
+
+    expect(script).toContain('/proxy?url=');
+    expect(script).toContain('http://localhost');
+    expect(script).toContain('10.0.2.2');
   });
 });

--- a/app/lib/snaps/SnapsExecutionWebView.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.tsx
@@ -1,6 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React, { Component } from 'react';
-import { View, NativeSyntheticEvent } from 'react-native';
+import { View, NativeSyntheticEvent, Platform } from 'react-native';
 import { WebViewMessageEvent, WebView } from '@metamask/react-native-webview';
 import { createStyles } from './styles';
 import { WebViewInterface } from '@metamask/snaps-controllers/react-native';
@@ -9,8 +9,125 @@ import { PostMessageEvent } from '@metamask/post-message-stream';
 // @ts-expect-error Types are currently broken for this.
 import WebViewHTML from '@metamask/snaps-execution-environments/dist/webpack/webview/index.html';
 import { EmptyObject } from '@metamask/snaps-sdk';
+import {
+  enableApiCallLogs,
+  getMockServerPortInApp,
+  isE2E,
+} from '../../util/test/utils';
 
 const styles = createStyles();
+
+interface E2EProxyPatchScriptParams {
+  mockServerPort: string;
+  platform: string;
+}
+
+/**
+ * Build a script to patch fetch/XMLHttpRequest inside the Snaps WebView runtime.
+ * This makes Snap network access visible in the E2E proxy the same way as app requests.
+ */
+export const buildE2EProxyPatchScript = ({
+  mockServerPort,
+  platform,
+}: E2EProxyPatchScriptParams): string => {
+  const proxyCandidates =
+    platform === 'android'
+      ? ['http://localhost', 'http://10.0.2.2']
+      : ['http://localhost'];
+
+  return `
+    (() => {
+      try {
+        if (window.__MM_E2E_SNAP_PROXY_PATCHED__) {
+          return;
+        }
+        window.__MM_E2E_SNAP_PROXY_PATCHED__ = true;
+
+        const mockServerPort = ${JSON.stringify(mockServerPort)};
+        const proxyCandidates = ${JSON.stringify(proxyCandidates)}.map(
+          (host) => \`\${host}:\${mockServerPort}\`,
+        );
+
+        const shouldProxyUrl = (targetUrl) =>
+          typeof targetUrl === 'string' &&
+          /^https?:\\/\\//.test(targetUrl) &&
+          !targetUrl.includes('/proxy?url=') &&
+          !proxyCandidates.some((candidate) => targetUrl.startsWith(candidate));
+
+        const toUrlString = (input) => {
+          if (typeof input === 'string') {
+            return input;
+          }
+          if (typeof URL !== 'undefined' && input instanceof URL) {
+            return input.toString();
+          }
+          if (input && typeof input === 'object' && typeof input.url === 'string') {
+            return input.url;
+          }
+          return String(input);
+        };
+
+        if (typeof window.fetch === 'function') {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = async (input, init) => {
+            const targetUrl = toUrlString(input);
+            if (!shouldProxyUrl(targetUrl)) {
+              return originalFetch(input, init);
+            }
+
+            let lastError;
+            for (const proxyBaseUrl of proxyCandidates) {
+              try {
+                return await originalFetch(
+                  \`\${proxyBaseUrl}/proxy?url=\${encodeURIComponent(targetUrl)}\`,
+                  init,
+                );
+              } catch (error) {
+                lastError = error;
+              }
+            }
+
+            if (lastError) {
+              return originalFetch(input, init);
+            }
+            return originalFetch(input, init);
+          };
+        }
+
+        const OriginalXHR = window.XMLHttpRequest;
+        if (typeof OriginalXHR === 'function') {
+          window.XMLHttpRequest = function (...args) {
+            const xhr = new OriginalXHR(...args);
+            const originalOpen = xhr.open;
+            xhr.open = function (method, url, ...openArgs) {
+              const targetUrl = toUrlString(url);
+              if (shouldProxyUrl(targetUrl)) {
+                const proxiedUrl =
+                  \`\${proxyCandidates[0]}/proxy?url=\${encodeURIComponent(targetUrl)}\`;
+                return originalOpen.call(this, method, proxiedUrl, ...openArgs);
+              }
+              return originalOpen.call(this, method, url, ...openArgs);
+            };
+            return xhr;
+          };
+          try {
+            Object.setPrototypeOf(window.XMLHttpRequest, OriginalXHR);
+            Object.assign(window.XMLHttpRequest, OriginalXHR);
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.log('[SNAPS E2E PROXY] Failed to copy XHR properties', error);
+          }
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log('[SNAPS E2E PROXY] Failed to patch network APIs', error);
+      }
+    })();
+    true;
+  `;
+};
+
+const shouldPatchSnapsWebViewProxy = () => isE2E || enableApiCallLogs;
 
 // This is a hack to allow us to asynchronously await the creation of the WebView.
 // eslint-disable-next-line import/no-mutable-exports
@@ -43,6 +160,15 @@ export class SnapsExecutionWebView extends Component {
   createWebView(jobId: string) {
     const promise = new Promise<WebViewInterface>((resolve, reject) => {
       const onWebViewLoad = () => {
+        if (shouldPatchSnapsWebViewProxy()) {
+          this.webViews[jobId]?.ref?.injectJavaScript(
+            buildE2EProxyPatchScript({
+              mockServerPort: String(getMockServerPortInApp()),
+              platform: Platform.OS,
+            }),
+          );
+        }
+
         const api = {
           injectJavaScript: (js: string) => {
             this.webViews[jobId]?.ref?.injectJavaScript(js);

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -5,6 +5,7 @@ export const flushPromises = () => new Promise(setImmediate);
 // iOS: These are overridden by LaunchArgs at runtime
 export const FALLBACK_FIXTURE_SERVER_PORT = 12345;
 export const FALLBACK_COMMAND_QUEUE_SERVER_PORT = 2446;
+export const FALLBACK_MOCKSERVER_PORT = 8000;
 
 // E2E test configuration required in app
 export const testConfig = {};
@@ -37,5 +38,7 @@ export const getFixturesServerPortInApp = () =>
   testConfig.fixtureServerPort ?? FALLBACK_FIXTURE_SERVER_PORT;
 export const getCommandQueueServerPortInApp = () =>
   testConfig.commandQueueServerPort ?? FALLBACK_COMMAND_QUEUE_SERVER_PORT;
+export const getMockServerPortInApp = () =>
+  testConfig.mockServerPort ?? FALLBACK_MOCKSERVER_PORT;
 
 export const isRc = process.env.METAMASK_ENVIRONMENT === 'rc';

--- a/shim.js
+++ b/shim.js
@@ -9,6 +9,7 @@ import { LaunchArguments } from 'react-native-launch-arguments';
 import {
   FALLBACK_FIXTURE_SERVER_PORT,
   FALLBACK_COMMAND_QUEUE_SERVER_PORT,
+  FALLBACK_MOCKSERVER_PORT,
   isE2E,
   isTest,
   enableApiCallLogs,
@@ -66,6 +67,9 @@ if (isTest) {
   testConfig.commandQueueServerPort = raw?.commandQueueServerPort
     ? raw.commandQueueServerPort
     : FALLBACK_COMMAND_QUEUE_SERVER_PORT;
+  testConfig.mockServerPort = raw?.mockServerPort
+    ? raw.mockServerPort
+    : FALLBACK_MOCKSERVER_PORT;
 }
 
 // Fix for https://github.com/facebook/react-native/issues/5667
@@ -160,7 +164,8 @@ if (typeof localStorage !== 'undefined') {
 if (enableApiCallLogs || isTest) {
   (async () => {
     const raw = LaunchArguments.value();
-    const mockServerPort = raw?.mockServerPort ?? defaultMockPort;
+    const mockServerPort =
+      testConfig.mockServerPort ?? raw?.mockServerPort ?? defaultMockPort;
     const { fetch: originalFetch } = global;
 
     // eslint-disable-next-line no-console

--- a/tests/smoke/snaps/test-snap-multichain-provider.spec.ts
+++ b/tests/smoke/snaps/test-snap-multichain-provider.spec.ts
@@ -14,6 +14,25 @@ import { mockGenesisBlocks } from './mocks';
 
 jest.setTimeout(150_000);
 
+const getSeenProxiedUrls = async (mockServer: Mockttp): Promise<string[]> => {
+  const mockedEndpoints = await mockServer.getMockedEndpoints();
+  const requests = (
+    await Promise.all(
+      mockedEndpoints.map((endpoint) => endpoint.getSeenRequests()),
+    )
+  ).flat();
+
+  return requests
+    .map((request) => {
+      try {
+        return new URL(request.url).searchParams.get('url');
+      } catch {
+        return null;
+      }
+    })
+    .filter((url): url is string => Boolean(url));
+};
+
 describe(FlaskBuildTests('Multichain Provider Snap Tests'), () => {
   it('can use the Multichain provider', async () => {
     await withFixtures(
@@ -29,7 +48,7 @@ describe(FlaskBuildTests('Multichain Provider Snap Tests'), () => {
           await mockGenesisBlocks(mockServer);
         },
       },
-      async () => {
+      async ({ mockServer }) => {
         await loginToApp();
 
         // Navigate to test snaps URL once for all tests
@@ -143,6 +162,18 @@ describe(FlaskBuildTests('Multichain Provider Snap Tests'), () => {
             );
           }
         }
+
+        // PoC: prove requests from multichain snaps are visible in E2E proxy traffic.
+        const proxiedUrls = await getSeenProxiedUrls(mockServer);
+        const multichainInfuraUrls = proxiedUrls.filter((url) =>
+          /https:\/\/(bitcoin|tron|solana)-mainnet\.infura\.io\//u.test(url),
+        );
+
+        expect(multichainInfuraUrls).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/^https:\/\/solana-mainnet\.infura\.io\//u),
+          ]),
+        );
       },
     );
   });


### PR DESCRIPTION
Enable visibility of external API calls from Snaps dependencies in e2e tests by routing them through the mock proxy.

Previously, calls originating from the Snap's WebView runtime bypassed the standard e2e proxy, making it impossible to observe or assert against them. This change injects a proxy mechanism directly into the WebView, ensuring all external network requests are captured.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-aad2c325-5d27-4924-8e81-4bb6fa75ad66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aad2c325-5d27-4924-8e81-4bb6fa75ad66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

