### PR TITLE
fix: source asset balance formatting

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
@@ -48,10 +48,20 @@ jest.mock('../../hooks/useShouldRenderMaxOption', () => ({
   useShouldRenderMaxOption: jest.fn(() => true),
 }));
 
+jest.mock('../../hooks/useTokenInputAreaFormattedBalance', () => ({
+  useTokenInputAreaFormattedBalance: jest.fn(() => '100'),
+}));
+
 import { useShouldRenderMaxOption } from '../../hooks/useShouldRenderMaxOption';
 const mockUseShouldRenderMaxOption =
   useShouldRenderMaxOption as jest.MockedFunction<
     typeof useShouldRenderMaxOption
+  >;
+
+import { useTokenInputAreaFormattedBalance } from '../../hooks/useTokenInputAreaFormattedBalance';
+const mockUseTokenInputAreaFormattedBalance =
+  useTokenInputAreaFormattedBalance as jest.MockedFunction<
+    typeof useTokenInputAreaFormattedBalance
   >;
 
 const mockOnTokenPress = jest.fn();
@@ -64,6 +74,7 @@ describe('TokenInputArea', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseShouldRenderMaxOption.mockReturnValue(true);
+    mockUseTokenInputAreaFormattedBalance.mockReturnValue('100');
   });
 
   it('renders with initial state', () => {

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -50,6 +50,7 @@ import { useTokenAddress } from '../../hooks/useTokenAddress';
 import { useShouldRenderMaxOption } from '../../hooks/useShouldRenderMaxOption';
 import { calculateInputFontSize } from '../../utils/calculateInputFontSize';
 import { formatAmountWithLocaleSeparators } from '../../utils/formatAmountWithLocaleSeparators';
+import { useTokenInputAreaFormattedBalance } from '../../hooks/useTokenInputAreaFormattedBalance';
 
 const MAX_DECIMALS = 5;
 export const MAX_INPUT_LENGTH = 36;
@@ -257,16 +258,10 @@ export const TokenInputArea = forwardRef<
       nonEvmMultichainAssetRates,
     });
 
-    // Convert non-atomic balance to atomic form and then format it with renderFromTokenMinimalUnit
-    const parsedTokenBalance = parseFloat(tokenBalance || '0');
-    const roundedTokenBalance =
-      Math.floor(parsedTokenBalance * 100000) / 100000;
-    const formattedBalance =
-      token?.symbol && tokenBalance
-        ? `${roundedTokenBalance.toFixed(5).replace(/\.?0+$/, '')} ${
-            token?.symbol
-          }`
-        : undefined;
+    const formattedBalance = useTokenInputAreaFormattedBalance(
+      tokenBalance,
+      token,
+    );
 
     const tokenAddress = useTokenAddress(token);
 

--- a/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.test.ts
@@ -1,0 +1,376 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useTokenInputAreaFormattedBalance } from '.';
+import { BridgeToken } from '../../types';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import I18n from '../../../../../../locales/i18n';
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  locale: 'en',
+}));
+
+const mockI18n = I18n as unknown as { locale: string };
+
+const makeToken = (overrides?: Partial<BridgeToken>): BridgeToken => ({
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  decimals: 6,
+  chainId: CHAIN_IDS.MAINNET,
+  ...overrides,
+});
+
+describe('useTokenInputAreaFormattedBalance', () => {
+  beforeEach(() => {
+    mockI18n.locale = 'en';
+  });
+
+  describe('guard clauses', () => {
+    it('returns undefined when token is undefined', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('100', undefined),
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when token has no symbol', () => {
+      const token = makeToken({ symbol: '' });
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('100', token),
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when tokenBalance is undefined', () => {
+      const token = makeToken();
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance(undefined, token),
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when tokenBalance is empty string', () => {
+      const token = makeToken();
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('', token),
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when both token and tokenBalance are missing', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance(undefined, undefined),
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe('minimum display threshold', () => {
+    const token = makeToken();
+
+    it('returns "< 0.00001" for a value just below threshold', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.000009', token),
+      );
+
+      expect(result.current).toBe('< 0.00001');
+    });
+
+    it('returns "< 0.00001" for extremely small positive values', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.000000000000000001', token),
+      );
+
+      expect(result.current).toBe('< 0.00001');
+    });
+
+    it('does not trigger for value equal to threshold (0.00001)', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.00001', token),
+      );
+
+      expect(result.current).not.toBe('< 0.00001');
+      expect(result.current).toBe('0.00001');
+    });
+
+    it('does not trigger for value above threshold', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.0001', token),
+      );
+
+      expect(result.current).not.toBe('< 0.00001');
+      expect(result.current).toBe('0.0001');
+    });
+
+    it('does not trigger for zero', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0', token),
+      );
+
+      expect(result.current).toBe('0');
+    });
+
+    it('does not trigger for negative values', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('-0.000001', token),
+      );
+
+      // parseAmount can't parse negative numbers (regex doesn't match "-")
+      // so it falls back to raw tokenBalance
+      expect(result.current).toBe('-0.000001');
+    });
+  });
+
+  describe('integer values', () => {
+    const token = makeToken();
+
+    it('formats a single digit', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('5', token),
+      );
+
+      expect(result.current).toBe('5');
+    });
+
+    it('formats a three-digit number without grouping', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('999', token),
+      );
+
+      expect(result.current).toBe('999');
+    });
+
+    it('formats thousands with grouping separator', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1000', token),
+      );
+
+      expect(result.current).toBe('1,000');
+    });
+
+    it('formats millions with grouping separators', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1234567', token),
+      );
+
+      expect(result.current).toBe('1,234,567');
+    });
+
+    it('formats billions', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1000000000', token),
+      );
+
+      expect(result.current).toBe('1,000,000,000');
+    });
+
+    it('strips leading zeros from integers', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('007', token),
+      );
+
+      expect(result.current).toBe('7');
+    });
+  });
+
+  describe('decimal values', () => {
+    const token = makeToken();
+
+    it('preserves up to 5 decimal places', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1.12345', token),
+      );
+
+      expect(result.current).toBe('1.12345');
+    });
+
+    it('truncates beyond 5 decimal places', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1.123456789', token),
+      );
+
+      expect(result.current).toBe('1.12345');
+    });
+
+    it('trims trailing zeros after truncation', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1.10000', token),
+      );
+
+      expect(result.current).toBe('1.1');
+    });
+
+    it('formats decimal with thousands in integer part', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('12345.6789', token),
+      );
+
+      expect(result.current).toBe('12,345.6789');
+    });
+
+    it('handles value with only a fractional part', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('.5', token),
+      );
+
+      expect(result.current).toBe('0.5');
+    });
+  });
+
+  describe('very large numbers', () => {
+    const token = makeToken();
+
+    it('formats a 12-digit integer', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('999999999999', token),
+      );
+
+      expect(result.current).toBe('999,999,999,999');
+    });
+
+    it('formats a large number with decimals', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('123456789.12345', token),
+      );
+
+      expect(result.current).toBe('123,456,789.12345');
+    });
+
+    it('handles numbers beyond safe integer range', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('99999999999999999999', token),
+      );
+
+      expect(result.current).toMatch(/^[\d,]+$/);
+    });
+  });
+
+  describe('parseAmount fallback', () => {
+    const token = makeToken();
+
+    it('returns raw tokenBalance for strings with commas', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1,234.56', token),
+      );
+
+      // parseAmount regex doesn't match commas, returns undefined → fallback
+      expect(result.current).toBe('1,234.56');
+    });
+
+    it('returns raw tokenBalance for scientific notation', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1e3', token),
+      );
+
+      expect(result.current).toBe('1e3');
+    });
+
+    it('returns raw tokenBalance for non-numeric strings', () => {
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('abc', token),
+      );
+
+      expect(result.current).toBe('abc');
+    });
+  });
+
+  describe('locale formatting', () => {
+    const token = makeToken();
+
+    it('formats with German locale (period grouping, comma decimal)', () => {
+      mockI18n.locale = 'de-DE';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1234567.89', token),
+      );
+
+      expect(result.current).toMatch(/1\.234\.567/);
+      expect(result.current).toMatch(/,89$/);
+    });
+
+    it('formats with French locale (space grouping, comma decimal)', () => {
+      mockI18n.locale = 'fr-FR';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1234567.89', token),
+      );
+
+      // French uses narrow no-break space (U+202F) or non-breaking space for grouping
+      expect(result.current).toMatch(/1\s234\s567/);
+      expect(result.current).toMatch(/,89$/);
+    });
+
+    it('formats integers with German locale', () => {
+      mockI18n.locale = 'de-DE';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('50000', token),
+      );
+
+      expect(result.current).toBe('50.000');
+    });
+
+    it('formats integers with Japanese locale', () => {
+      mockI18n.locale = 'ja-JP';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1000000', token),
+      );
+
+      expect(result.current).toBe('1,000,000');
+    });
+
+    it('formats small number without grouping regardless of locale', () => {
+      mockI18n.locale = 'de-DE';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('999', token),
+      );
+
+      expect(result.current).toBe('999');
+    });
+
+    it('preserves threshold message regardless of locale', () => {
+      mockI18n.locale = 'de-DE';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.000001', token),
+      );
+
+      expect(result.current).toBe('< 0.00001');
+    });
+
+    it('formats with Portuguese (Brazil) locale', () => {
+      mockI18n.locale = 'pt-BR';
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1234.56', token),
+      );
+
+      expect(result.current).toMatch(/1\.234/);
+      expect(result.current).toMatch(/,56$/);
+    });
+  });
+
+  describe('memoization', () => {
+    it('returns same reference when inputs do not change', () => {
+      const token = makeToken();
+
+      const { result, rerender } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1000', token),
+      );
+
+      const firstResult = result.current;
+
+      rerender();
+
+      expect(result.current).toBe(firstResult);
+    });
+  });
+});

--- a/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.test.ts
@@ -96,7 +96,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
       );
 
       expect(result.current).not.toBe('< 0.00001');
-      expect(result.current).toBe('0.00001');
+      expect(result.current).toBe('0.00001 USDC');
     });
 
     it('does not trigger for value above threshold', () => {
@@ -105,7 +105,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
       );
 
       expect(result.current).not.toBe('< 0.00001');
-      expect(result.current).toBe('0.0001');
+      expect(result.current).toBe('0.0001 USDC');
     });
 
     it('does not trigger for zero', () => {
@@ -113,7 +113,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('0', token),
       );
 
-      expect(result.current).toBe('0');
+      expect(result.current).toBe('0 USDC');
     });
 
     it('does not trigger for negative values', () => {
@@ -122,8 +122,8 @@ describe('useTokenInputAreaFormattedBalance', () => {
       );
 
       // parseAmount can't parse negative numbers (regex doesn't match "-")
-      // so it falls back to raw tokenBalance
-      expect(result.current).toBe('-0.000001');
+      // so it falls back to raw tokenBalance + symbol
+      expect(result.current).toBe('-0.000001 USDC');
     });
   });
 
@@ -135,7 +135,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('5', token),
       );
 
-      expect(result.current).toBe('5');
+      expect(result.current).toBe('5 USDC');
     });
 
     it('formats a three-digit number without grouping', () => {
@@ -143,7 +143,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('999', token),
       );
 
-      expect(result.current).toBe('999');
+      expect(result.current).toBe('999 USDC');
     });
 
     it('formats thousands with grouping separator', () => {
@@ -151,7 +151,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1000', token),
       );
 
-      expect(result.current).toBe('1,000');
+      expect(result.current).toBe('1,000 USDC');
     });
 
     it('formats millions with grouping separators', () => {
@@ -159,7 +159,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1234567', token),
       );
 
-      expect(result.current).toBe('1,234,567');
+      expect(result.current).toBe('1,234,567 USDC');
     });
 
     it('formats billions', () => {
@@ -167,7 +167,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1000000000', token),
       );
 
-      expect(result.current).toBe('1,000,000,000');
+      expect(result.current).toBe('1,000,000,000 USDC');
     });
 
     it('strips leading zeros from integers', () => {
@@ -175,7 +175,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('007', token),
       );
 
-      expect(result.current).toBe('7');
+      expect(result.current).toBe('7 USDC');
     });
   });
 
@@ -187,7 +187,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1.12345', token),
       );
 
-      expect(result.current).toBe('1.12345');
+      expect(result.current).toBe('1.12345 USDC');
     });
 
     it('truncates beyond 5 decimal places', () => {
@@ -195,7 +195,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1.123456789', token),
       );
 
-      expect(result.current).toBe('1.12345');
+      expect(result.current).toBe('1.12345 USDC');
     });
 
     it('trims trailing zeros after truncation', () => {
@@ -203,7 +203,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1.10000', token),
       );
 
-      expect(result.current).toBe('1.1');
+      expect(result.current).toBe('1.1 USDC');
     });
 
     it('formats decimal with thousands in integer part', () => {
@@ -211,7 +211,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('12345.6789', token),
       );
 
-      expect(result.current).toBe('12,345.6789');
+      expect(result.current).toBe('12,345.6789 USDC');
     });
 
     it('handles value with only a fractional part', () => {
@@ -219,7 +219,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('.5', token),
       );
 
-      expect(result.current).toBe('0.5');
+      expect(result.current).toBe('0.5 USDC');
     });
   });
 
@@ -231,7 +231,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('999999999999', token),
       );
 
-      expect(result.current).toBe('999,999,999,999');
+      expect(result.current).toBe('999,999,999,999 USDC');
     });
 
     it('formats a large number with decimals', () => {
@@ -239,7 +239,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('123456789.12345', token),
       );
 
-      expect(result.current).toBe('123,456,789.12345');
+      expect(result.current).toBe('123,456,789.12345 USDC');
     });
 
     it('handles numbers beyond safe integer range', () => {
@@ -247,36 +247,78 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('99999999999999999999', token),
       );
 
-      expect(result.current).toMatch(/^[\d,]+$/);
+      expect(result.current).toMatch(/^[\d,]+ USDC$/);
     });
   });
 
   describe('parseAmount fallback', () => {
     const token = makeToken();
 
-    it('returns raw tokenBalance for strings with commas', () => {
+    it('returns raw tokenBalance with symbol for strings with commas', () => {
       const { result } = renderHook(() =>
         useTokenInputAreaFormattedBalance('1,234.56', token),
       );
 
-      // parseAmount regex doesn't match commas, returns undefined → fallback
-      expect(result.current).toBe('1,234.56');
+      expect(result.current).toBe('1,234.56 USDC');
     });
 
-    it('returns raw tokenBalance for scientific notation', () => {
+    it('returns raw tokenBalance with symbol for scientific notation', () => {
       const { result } = renderHook(() =>
         useTokenInputAreaFormattedBalance('1e3', token),
       );
 
-      expect(result.current).toBe('1e3');
+      expect(result.current).toBe('1e3 USDC');
     });
 
-    it('returns raw tokenBalance for non-numeric strings', () => {
+    it('returns raw tokenBalance with symbol for non-numeric strings', () => {
       const { result } = renderHook(() =>
         useTokenInputAreaFormattedBalance('abc', token),
       );
 
-      expect(result.current).toBe('abc');
+      expect(result.current).toBe('abc USDC');
+    });
+  });
+
+  describe('symbol in output', () => {
+    it('appends token symbol to formatted balance', () => {
+      const token = makeToken({ symbol: 'ETH' });
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1.5', token),
+      );
+
+      expect(result.current).toBe('1.5 ETH');
+    });
+
+    it('appends different token symbols correctly', () => {
+      const wbtc = makeToken({ symbol: 'WBTC' });
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.00123', wbtc),
+      );
+
+      expect(result.current).toBe('0.00123 WBTC');
+    });
+
+    it('does not append symbol to threshold message', () => {
+      const token = makeToken({ symbol: 'ETH' });
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('0.000001', token),
+      );
+
+      expect(result.current).toBe('< 0.00001');
+      expect(result.current).not.toContain('ETH');
+    });
+
+    it('appends symbol in fallback path', () => {
+      const token = makeToken({ symbol: 'DAI' });
+
+      const { result } = renderHook(() =>
+        useTokenInputAreaFormattedBalance('1e3', token),
+      );
+
+      expect(result.current).toBe('1e3 DAI');
     });
   });
 
@@ -291,7 +333,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
       );
 
       expect(result.current).toMatch(/1\.234\.567/);
-      expect(result.current).toMatch(/,89$/);
+      expect(result.current).toMatch(/,89 USDC$/);
     });
 
     it('formats with French locale (space grouping, comma decimal)', () => {
@@ -303,7 +345,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
 
       // French uses narrow no-break space (U+202F) or non-breaking space for grouping
       expect(result.current).toMatch(/1\s234\s567/);
-      expect(result.current).toMatch(/,89$/);
+      expect(result.current).toMatch(/,89 USDC$/);
     });
 
     it('formats integers with German locale', () => {
@@ -313,7 +355,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('50000', token),
       );
 
-      expect(result.current).toBe('50.000');
+      expect(result.current).toBe('50.000 USDC');
     });
 
     it('formats integers with Japanese locale', () => {
@@ -323,7 +365,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('1000000', token),
       );
 
-      expect(result.current).toBe('1,000,000');
+      expect(result.current).toBe('1,000,000 USDC');
     });
 
     it('formats small number without grouping regardless of locale', () => {
@@ -333,7 +375,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
         useTokenInputAreaFormattedBalance('999', token),
       );
 
-      expect(result.current).toBe('999');
+      expect(result.current).toBe('999 USDC');
     });
 
     it('preserves threshold message regardless of locale', () => {
@@ -354,7 +396,7 @@ describe('useTokenInputAreaFormattedBalance', () => {
       );
 
       expect(result.current).toMatch(/1\.234/);
-      expect(result.current).toMatch(/,56$/);
+      expect(result.current).toMatch(/,56 USDC$/);
     });
   });
 

--- a/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { BridgeToken } from '../../types';
+import { MINIMUM_DISPLAY_THRESHOLD } from '../../../../../util/number';
+import { formatAmountWithLocaleSeparators } from '../../utils/formatAmountWithLocaleSeparators';
+import parseAmount from '../../../../../util/parseAmount';
+
+export const useTokenInputAreaFormattedBalance = (
+  tokenBalance?: string,
+  token?: BridgeToken,
+) =>
+  useMemo(() => {
+    if (!token?.symbol || !tokenBalance) {
+      return;
+    }
+
+    const value = parseFloat(tokenBalance);
+
+    if (value < MINIMUM_DISPLAY_THRESHOLD && value > 0) {
+      return `< ${MINIMUM_DISPLAY_THRESHOLD}`;
+    }
+
+    const parsedTotalBalance = parseAmount(tokenBalance, 5);
+
+    if (!parsedTotalBalance) {
+      // Guard against corrupted parsing. Should never be reachable
+      // except in cases where parseAmount has a bug.
+      // Return the whole token balance amount without formatting
+      // rather than empty balance.
+      return tokenBalance;
+    }
+
+    return formatAmountWithLocaleSeparators(parsedTotalBalance);
+  }, [token?.symbol, tokenBalance]);

--- a/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokenInputAreaFormattedBalance/index.ts
@@ -26,8 +26,10 @@ export const useTokenInputAreaFormattedBalance = (
       // except in cases where parseAmount has a bug.
       // Return the whole token balance amount without formatting
       // rather than empty balance.
-      return tokenBalance;
+      return tokenBalance + ' ' + token.symbol;
     }
 
-    return formatAmountWithLocaleSeparators(parsedTotalBalance);
+    return (
+      formatAmountWithLocaleSeparators(parsedTotalBalance) + ' ' + token.symbol
+    );
   }, [token?.symbol, tokenBalance]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix issues with balance rounding, localization formatting and decimal representation on source swap asset balance.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix issues with balance rounding, localization formatting and decimal representation on source swap asset balance.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4143

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="180" height="113" alt="Screenshot 2026-02-19 at 2 41 45 PM" src="https://github.com/user-attachments/assets/cbe35729-07e5-4251-84d5-ca07df047994" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only formatting logic is refactored into a new hook with extensive unit coverage; risk is mainly small regressions in edge-case numeric/locale formatting.
> 
> **Overview**
> Fixes source-asset balance display in Bridge `TokenInputArea` by replacing ad-hoc rounding/string building with a new `useTokenInputAreaFormattedBalance` hook that truncates to 5 decimals, applies locale separators, and shows a "< 0.00001" threshold for tiny positive balances.
> 
> Adds a comprehensive test suite for the hook (locales, truncation/zero-stripping, fallbacks) and updates `TokenInputArea` tests to mock the new hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 843e73086a5efa03f13b3841f9eadf54322d161e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->