### PR TITLE
feat(homepage): add SectionTitle component and homepage sections structure

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -4,23 +4,72 @@ import renderWithProvider from '../../../util/test/renderWithProvider';
 import Homepage from './Homepage';
 import { SectionRefreshHandle } from './types';
 
+// Mock navigation
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  };
+});
+
+// Mock feature flags - enable all sections
+jest.mock('../../UI/Perps', () => ({
+  selectPerpsEnabledFlag: jest.fn(() => true),
+}));
+
+jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
+  selectPredictEnabledFlag: jest.fn(() => true),
+}));
+
+jest.mock(
+  '../../../selectors/featureFlagController/assetsDefiPositions',
+  () => ({
+    selectAssetsDefiPositionsEnabled: jest.fn(() => true),
+  }),
+);
+
 describe('Homepage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('renders placeholder content', () => {
-    renderWithProvider(<Homepage />);
-
-    expect(
-      screen.getByText('Homepage sections coming soon...'),
-    ).toBeOnTheScreen();
   });
 
   it('renders container element', () => {
     renderWithProvider(<Homepage />);
 
     expect(screen.getByTestId('homepage-container')).toBeOnTheScreen();
+  });
+
+  it('renders Tokens section title', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(screen.getByText('Tokens')).toBeOnTheScreen();
+  });
+
+  it('renders Perpetuals section title', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
+  });
+
+  it('renders Predictions section title', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(screen.getByText('Predictions')).toBeOnTheScreen();
+  });
+
+  it('renders DeFi section title', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(screen.getByText('DeFi')).toBeOnTheScreen();
+  });
+
+  it('renders NFTs section title', () => {
+    renderWithProvider(<Homepage />);
+
+    expect(screen.getByText('NFTs')).toBeOnTheScreen();
   });
 
   it('exposes refresh function via ref', () => {

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -1,23 +1,49 @@
-import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { Box } from '@metamask/design-system-react-native';
+import TokensSection from './Sections/Tokens';
+import PerpsSection from './Sections/Perps';
+import PredictionsSection from './Sections/Predictions';
+import DeFiSection from './Sections/DeFi';
+import NFTsSection from './Sections/NFTs';
 import { SectionRefreshHandle } from './types';
 
 /**
  * Homepage component - Main view for the redesigned wallet homepage.
  *
- * This component will contain various sections like Tokens, NFTs, DeFi, etc.
- * Currently a placeholder while sections are being incrementally adopted.
+ * This component orchestrates all homepage sections and coordinates
+ * their refresh functionality via refs.
  */
 const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const tokensSectionRef = useRef<SectionRefreshHandle>(null);
+  const perpsSectionRef = useRef<SectionRefreshHandle>(null);
+  const predictionsSectionRef = useRef<SectionRefreshHandle>(null);
+  const defiSectionRef = useRef<SectionRefreshHandle>(null);
+  const nftsSectionRef = useRef<SectionRefreshHandle>(null);
+
   const refresh = useCallback(async () => {
-    // TODO: Implement refresh logic as sections are added
+    await Promise.allSettled([
+      tokensSectionRef.current?.refresh(),
+      perpsSectionRef.current?.refresh(),
+      predictionsSectionRef.current?.refresh(),
+      defiSectionRef.current?.refresh(),
+      nftsSectionRef.current?.refresh(),
+    ]);
   }, []);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
   return (
     <Box gap={6} marginBottom={8} testID="homepage-container">
-      <Text variant={TextVariant.BodyMd}>Homepage sections coming soon...</Text>
+      <TokensSection ref={tokensSectionRef} />
+      <PerpsSection ref={perpsSectionRef} />
+      <PredictionsSection ref={predictionsSectionRef} />
+      <DeFiSection ref={defiSectionRef} />
+      <NFTsSection ref={nftsSectionRef} />
     </Box>
   );
 });

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import DeFiSection from './DeFiSection';
+
+jest.mock(
+  '../../../../../selectors/featureFlagController/assetsDefiPositions',
+  () => ({
+    selectAssetsDefiPositionsEnabled: jest.fn(() => true),
+  }),
+);
+
+describe('DeFiSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset mock return value to default (true) to ensure test isolation
+    jest
+      .requireMock(
+        '../../../../../selectors/featureFlagController/assetsDefiPositions',
+      )
+      .selectAssetsDefiPositionsEnabled.mockReturnValue(true);
+  });
+
+  it('renders section title when enabled', () => {
+    renderWithProvider(<DeFiSection />);
+
+    expect(screen.getByText('DeFi')).toBeOnTheScreen();
+  });
+
+  it('returns null when DeFi is disabled', () => {
+    jest
+      .requireMock(
+        '../../../../../selectors/featureFlagController/assetsDefiPositions',
+      )
+      .selectAssetsDefiPositionsEnabled.mockReturnValue(false);
+
+    const { toJSON } = renderWithProvider(<DeFiSection />);
+
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -7,8 +7,6 @@ import { SectionRefreshHandle } from '../../types';
 import { selectAssetsDefiPositionsEnabled } from '../../../../../selectors/featureFlagController/assetsDefiPositions';
 import { strings } from '../../../../../../locales/i18n';
 
-const TITLE = strings('homepage.sections.defi');
-
 /**
  * DeFiSection - Displays DeFi positions on the homepage
  *
@@ -16,6 +14,7 @@ const TITLE = strings('homepage.sections.defi');
  */
 const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const isDeFiEnabled = useSelector(selectAssetsDefiPositionsEnabled);
+  const title = strings('homepage.sections.defi');
 
   const refresh = useCallback(async () => {
     // TODO: Implement DeFi refresh logic
@@ -30,7 +29,7 @@ const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   return (
     <Box gap={3}>
-      <SectionTitle title={TITLE} />
+      <SectionTitle title={title} />
       <SectionRow>
         <>{/* DeFi content will be added here */}</>
       </SectionRow>

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -1,0 +1,41 @@
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react-native';
+import SectionTitle from '../../components/SectionTitle';
+import SectionRow from '../../components/SectionRow';
+import { SectionRefreshHandle } from '../../types';
+import { selectAssetsDefiPositionsEnabled } from '../../../../../selectors/featureFlagController/assetsDefiPositions';
+import { strings } from '../../../../../../locales/i18n';
+
+const TITLE = strings('homepage.sections.defi');
+
+/**
+ * DeFiSection - Displays DeFi positions on the homepage
+ *
+ * Only renders when the DeFi positions feature flag is enabled.
+ */
+const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const isDeFiEnabled = useSelector(selectAssetsDefiPositionsEnabled);
+
+  const refresh = useCallback(async () => {
+    // TODO: Implement DeFi refresh logic
+  }, []);
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+  // Don't render if DeFi is disabled
+  if (!isDeFiEnabled) {
+    return null;
+  }
+
+  return (
+    <Box gap={3}>
+      <SectionTitle title={TITLE} />
+      <SectionRow>
+        <>{/* DeFi content will be added here */}</>
+      </SectionRow>
+    </Box>
+  );
+});
+
+export default DeFiSection;

--- a/app/components/Views/Homepage/Sections/DeFi/index.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DeFiSection';

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import NFTsSection from './NFTsSection';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+describe('NFTsSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders section title', () => {
+    renderWithProvider(<NFTsSection />);
+
+    expect(screen.getByText('NFTs')).toBeOnTheScreen();
+  });
+
+  it('navigates to NFTs full view on title press', () => {
+    renderWithProvider(<NFTsSection />);
+
+    fireEvent.press(screen.getByText('NFTs'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.NFTS_FULL_VIEW);
+  });
+});

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -1,0 +1,38 @@
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { Box } from '@metamask/design-system-react-native';
+import SectionTitle from '../../components/SectionTitle';
+import SectionRow from '../../components/SectionRow';
+import Routes from '../../../../../constants/navigation/Routes';
+import { SectionRefreshHandle } from '../../types';
+import { strings } from '../../../../../../locales/i18n';
+
+const TITLE = strings('homepage.sections.nfts');
+
+/**
+ * NFTsSection - Displays user's NFTs on the homepage
+ */
+const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const navigation = useNavigation();
+
+  const refresh = useCallback(async () => {
+    // TODO: Implement NFTs refresh logic
+  }, []);
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+  const handleViewAllNfts = useCallback(() => {
+    navigation.navigate(Routes.WALLET.NFTS_FULL_VIEW);
+  }, [navigation]);
+
+  return (
+    <Box gap={3}>
+      <SectionTitle title={TITLE} onPress={handleViewAllNfts} />
+      <SectionRow>
+        <>{/* NFTs content will be added here */}</>
+      </SectionRow>
+    </Box>
+  );
+});
+
+export default NFTsSection;

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -7,13 +7,12 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { SectionRefreshHandle } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
 
-const TITLE = strings('homepage.sections.nfts');
-
 /**
  * NFTsSection - Displays user's NFTs on the homepage
  */
 const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const navigation = useNavigation();
+  const title = strings('homepage.sections.nfts');
 
   const refresh = useCallback(async () => {
     // TODO: Implement NFTs refresh logic
@@ -27,7 +26,7 @@ const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   return (
     <Box gap={3}>
-      <SectionTitle title={TITLE} onPress={handleViewAllNfts} />
+      <SectionTitle title={title} onPress={handleViewAllNfts} />
       <SectionRow>
         <>{/* NFTs content will be added here */}</>
       </SectionRow>

--- a/app/components/Views/Homepage/Sections/NFTs/index.ts
+++ b/app/components/Views/Homepage/Sections/NFTs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NFTsSection';

--- a/app/components/Views/Homepage/Sections/Perps/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perps/PerpsSection.test.tsx
@@ -23,6 +23,10 @@ jest.mock('../../../../UI/Perps', () => ({
 describe('PerpsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mock return value to default (true) to ensure test isolation
+    jest
+      .requireMock('../../../../UI/Perps')
+      .selectPerpsEnabledFlag.mockReturnValue(true);
   });
 
   it('renders section title when enabled', () => {

--- a/app/components/Views/Homepage/Sections/Perps/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perps/PerpsSection.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import PerpsSection from './PerpsSection';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+jest.mock('../../../../UI/Perps', () => ({
+  selectPerpsEnabledFlag: jest.fn(() => true),
+}));
+
+describe('PerpsSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders section title when enabled', () => {
+    renderWithProvider(<PerpsSection />);
+
+    expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
+  });
+
+  it('navigates to perps home on title press', () => {
+    renderWithProvider(<PerpsSection />);
+
+    fireEvent.press(screen.getByText('Perpetuals'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+    });
+  });
+
+  it('returns null when perps is disabled', () => {
+    jest
+      .requireMock('../../../../UI/Perps')
+      .selectPerpsEnabledFlag.mockReturnValue(false);
+
+    const { toJSON } = renderWithProvider(<PerpsSection />);
+
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/components/Views/Homepage/Sections/Perps/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perps/PerpsSection.tsx
@@ -1,0 +1,50 @@
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react-native';
+import SectionTitle from '../../components/SectionTitle';
+import SectionRow from '../../components/SectionRow';
+import Routes from '../../../../../constants/navigation/Routes';
+import { SectionRefreshHandle } from '../../types';
+import { selectPerpsEnabledFlag } from '../../../../UI/Perps';
+import { strings } from '../../../../../../locales/i18n';
+
+const TITLE = strings('homepage.sections.perpetuals');
+
+/**
+ * PerpsSection - Displays perpetual trading markets on the homepage
+ *
+ * Only renders when the perps feature flag is enabled.
+ */
+const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const navigation = useNavigation();
+  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+
+  const refresh = useCallback(async () => {
+    // TODO: Implement perps refresh logic
+  }, []);
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+  const handleViewAllPerps = useCallback(() => {
+    navigation.navigate(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+    });
+  }, [navigation]);
+
+  // Don't render if perps is disabled
+  if (!isPerpsEnabled) {
+    return null;
+  }
+
+  return (
+    <Box gap={3}>
+      <SectionTitle title={TITLE} onPress={handleViewAllPerps} />
+      <SectionRow>
+        <>{/* Perps content will be added here */}</>
+      </SectionRow>
+    </Box>
+  );
+});
+
+export default PerpsSection;

--- a/app/components/Views/Homepage/Sections/Perps/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perps/PerpsSection.tsx
@@ -9,8 +9,6 @@ import { SectionRefreshHandle } from '../../types';
 import { selectPerpsEnabledFlag } from '../../../../UI/Perps';
 import { strings } from '../../../../../../locales/i18n';
 
-const TITLE = strings('homepage.sections.perpetuals');
-
 /**
  * PerpsSection - Displays perpetual trading markets on the homepage
  *
@@ -19,6 +17,7 @@ const TITLE = strings('homepage.sections.perpetuals');
 const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const navigation = useNavigation();
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+  const title = strings('homepage.sections.perpetuals');
 
   const refresh = useCallback(async () => {
     // TODO: Implement perps refresh logic
@@ -39,7 +38,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   return (
     <Box gap={3}>
-      <SectionTitle title={TITLE} onPress={handleViewAllPerps} />
+      <SectionTitle title={title} onPress={handleViewAllPerps} />
       <SectionRow>
         <>{/* Perps content will be added here */}</>
       </SectionRow>

--- a/app/components/Views/Homepage/Sections/Perps/index.ts
+++ b/app/components/Views/Homepage/Sections/Perps/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PerpsSection';

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import PredictionsSection from './PredictionsSection';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+jest.mock('../../../../UI/Predict/selectors/featureFlags', () => ({
+  selectPredictEnabledFlag: jest.fn(() => true),
+}));
+
+describe('PredictionsSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders section title when enabled', () => {
+    renderWithProvider(<PredictionsSection />);
+
+    expect(screen.getByText('Predictions')).toBeOnTheScreen();
+  });
+
+  it('navigates to predictions market list on title press', () => {
+    renderWithProvider(<PredictionsSection />);
+
+    fireEvent.press(screen.getByText('Predictions'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+    });
+  });
+
+  it('returns null when predict is disabled', () => {
+    jest
+      .requireMock('../../../../UI/Predict/selectors/featureFlags')
+      .selectPredictEnabledFlag.mockReturnValue(false);
+
+    const { toJSON } = renderWithProvider(<PredictionsSection />);
+
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -23,6 +23,10 @@ jest.mock('../../../../UI/Predict/selectors/featureFlags', () => ({
 describe('PredictionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mock return value to default (true) to ensure test isolation
+    jest
+      .requireMock('../../../../UI/Predict/selectors/featureFlags')
+      .selectPredictEnabledFlag.mockReturnValue(true);
   });
 
   it('renders section title when enabled', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -9,8 +9,6 @@ import { SectionRefreshHandle } from '../../types';
 import { selectPredictEnabledFlag } from '../../../../UI/Predict/selectors/featureFlags';
 import { strings } from '../../../../../../locales/i18n';
 
-const TITLE = strings('homepage.sections.predictions');
-
 /**
  * PredictionsSection - Displays prediction markets on the homepage
  *
@@ -19,6 +17,7 @@ const TITLE = strings('homepage.sections.predictions');
 const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const navigation = useNavigation();
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const title = strings('homepage.sections.predictions');
 
   const refresh = useCallback(async () => {
     // TODO: Implement predictions refresh logic
@@ -39,7 +38,7 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   return (
     <Box gap={3}>
-      <SectionTitle title={TITLE} onPress={handleViewAllPredictions} />
+      <SectionTitle title={title} onPress={handleViewAllPredictions} />
       <SectionRow>
         <>{/* Predictions content will be added here */}</>
       </SectionRow>

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -1,0 +1,50 @@
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react-native';
+import SectionTitle from '../../components/SectionTitle';
+import SectionRow from '../../components/SectionRow';
+import Routes from '../../../../../constants/navigation/Routes';
+import { SectionRefreshHandle } from '../../types';
+import { selectPredictEnabledFlag } from '../../../../UI/Predict/selectors/featureFlags';
+import { strings } from '../../../../../../locales/i18n';
+
+const TITLE = strings('homepage.sections.predictions');
+
+/**
+ * PredictionsSection - Displays prediction markets on the homepage
+ *
+ * Only renders when the predict feature flag is enabled.
+ */
+const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const navigation = useNavigation();
+  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+
+  const refresh = useCallback(async () => {
+    // TODO: Implement predictions refresh logic
+  }, []);
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+  const handleViewAllPredictions = useCallback(() => {
+    navigation.navigate(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+    });
+  }, [navigation]);
+
+  // Don't render if predict is disabled
+  if (!isPredictEnabled) {
+    return null;
+  }
+
+  return (
+    <Box gap={3}>
+      <SectionTitle title={TITLE} onPress={handleViewAllPredictions} />
+      <SectionRow>
+        <>{/* Predictions content will be added here */}</>
+      </SectionRow>
+    </Box>
+  );
+});
+
+export default PredictionsSection;

--- a/app/components/Views/Homepage/Sections/Predictions/index.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PredictionsSection';

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import TokensSection from './TokensSection';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+describe('TokensSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders section title', () => {
+    renderWithProvider(<TokensSection />);
+
+    expect(screen.getByText('Tokens')).toBeOnTheScreen();
+  });
+
+  it('navigates to tokens full view on title press', () => {
+    renderWithProvider(<TokensSection />);
+
+    fireEvent.press(screen.getByText('Tokens'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.TOKENS_FULL_VIEW);
+  });
+});

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -7,13 +7,12 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { SectionRefreshHandle } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
 
-const TITLE = strings('homepage.sections.tokens');
-
 /**
  * TokensSection - Displays user's token balances on the homepage
  */
 const TokensSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const navigation = useNavigation();
+  const title = strings('homepage.sections.tokens');
 
   const refresh = useCallback(async () => {
     // TODO: Implement tokens refresh logic
@@ -27,7 +26,7 @@ const TokensSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   return (
     <Box gap={3}>
-      <SectionTitle title={TITLE} onPress={handleViewAllTokens} />
+      <SectionTitle title={title} onPress={handleViewAllTokens} />
       <SectionRow>
         <>{/* Token content will be added here */}</>
       </SectionRow>

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -1,0 +1,38 @@
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { Box } from '@metamask/design-system-react-native';
+import SectionTitle from '../../components/SectionTitle';
+import SectionRow from '../../components/SectionRow';
+import Routes from '../../../../../constants/navigation/Routes';
+import { SectionRefreshHandle } from '../../types';
+import { strings } from '../../../../../../locales/i18n';
+
+const TITLE = strings('homepage.sections.tokens');
+
+/**
+ * TokensSection - Displays user's token balances on the homepage
+ */
+const TokensSection = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const navigation = useNavigation();
+
+  const refresh = useCallback(async () => {
+    // TODO: Implement tokens refresh logic
+  }, []);
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+  const handleViewAllTokens = useCallback(() => {
+    navigation.navigate(Routes.WALLET.TOKENS_FULL_VIEW);
+  }, [navigation]);
+
+  return (
+    <Box gap={3}>
+      <SectionTitle title={TITLE} onPress={handleViewAllTokens} />
+      <SectionRow>
+        <>{/* Token content will be added here */}</>
+      </SectionRow>
+    </Box>
+  );
+});
+
+export default TokensSection;

--- a/app/components/Views/Homepage/Sections/Tokens/index.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TokensSection';

--- a/app/components/Views/Homepage/components/SectionRow/SectionRow.tsx
+++ b/app/components/Views/Homepage/components/SectionRow/SectionRow.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Box } from '@metamask/design-system-react-native';
+
+interface SectionRowProps {
+  /**
+   * Content to render inside the section row
+   */
+  children: React.ReactNode;
+  /**
+   * Test ID for the component
+   */
+  testID?: string;
+}
+
+/**
+ * SectionRow - Provides consistent horizontal padding for section content
+ *
+ * Use this wrapper for content that needs standard section padding.
+ */
+const SectionRow = ({ children, testID }: SectionRowProps) => (
+  <Box paddingHorizontal={4} testID={testID}>
+    {children}
+  </Box>
+);
+
+export default SectionRow;

--- a/app/components/Views/Homepage/components/SectionRow/index.ts
+++ b/app/components/Views/Homepage/components/SectionRow/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SectionRow';

--- a/app/components/Views/Homepage/components/SectionTitle/SectionTitle.tsx
+++ b/app/components/Views/Homepage/components/SectionTitle/SectionTitle.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+import {
+  Box,
+  Text,
+  ButtonIcon,
+  IconName,
+  ButtonIconSize,
+  TextVariant,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import SectionRow from '../SectionRow';
+
+interface SectionTitleProps {
+  /**
+   * The title text or React node to display
+   */
+  title: string | React.ReactNode;
+  /**
+   * Optional callback when the title or arrow is pressed
+   */
+  onPress?: () => void;
+  /**
+   * Optional accessory element to display next to the title (e.g., info button)
+   */
+  endAccessory?: React.ReactNode;
+}
+
+const SectionTitle = ({ title, onPress, endAccessory }: SectionTitleProps) => (
+  <SectionRow>
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={!onPress}
+      accessibilityRole={onPress ? 'button' : undefined}
+      accessibilityLabel={typeof title === 'string' ? title : undefined}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+      >
+        {/* Left side: Title + optional endAccessory */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+        >
+          {typeof title === 'string' ? (
+            <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
+              {title}
+            </Text>
+          ) : (
+            title
+          )}
+          {endAccessory}
+        </Box>
+
+        {/* Right side: Arrow icon (visual indicator, passes touch to parent) */}
+        {onPress && (
+          <View pointerEvents="none">
+            <ButtonIcon
+              iconName={IconName.ArrowRight}
+              size={ButtonIconSize.Sm}
+            />
+          </View>
+        )}
+      </Box>
+    </TouchableOpacity>
+  </SectionRow>
+);
+
+export default SectionTitle;

--- a/app/components/Views/Homepage/components/SectionTitle/index.ts
+++ b/app/components/Views/Homepage/components/SectionTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SectionTitle';

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7679,5 +7679,14 @@
     "description_android": "We've made some important fixes. Close and reopen MetaMask to apply the update.",
     "primary_action_reload": "Reload",
     "primary_action_acknowledge": "Got it"
+  },
+  "homepage": {
+    "sections": {
+      "tokens": "Tokens",
+      "perpetuals": "Perpetuals",
+      "predictions": "Predictions",
+      "defi": "DeFi",
+      "nfts": "NFTs"
+    }
   }
 }


### PR DESCRIPTION
## **Description**

This PR adds the foundational section title component and homepage sections structure for the new homepage redesign.

**Changes:**
1. **SectionTitle component** - A reusable component for section headers with:
   - Full-row touchable area for better UX
   - Optional `endAccessory` prop for additional elements (e.g., info buttons)
   - Arrow icon as visual indicator that passes touches to parent
   - Uses `TextVariant.HeadingMd` for consistent typography

2. **SectionRow component** - Wrapper for consistent horizontal padding across sections

3. **Homepage sections** - Added section components with navigation:
   - `TokensSection` → navigates to Tokens full view
   - `PerpsSection` → navigates to Perpetuals (when feature flag enabled)
   - `PredictionsSection` → navigates to Predictions (when feature flag enabled)
   - `DeFiSection` → displays when DeFi positions feature flag enabled
   - `NFTsSection` → navigates to NFTs full view

4. **Localization** - Added `homepage.sections.*` strings in `en.json`

5. **Tests** - Added unit tests for Homepage rendering and individual section navigation

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-407

## **Manual testing steps**

```gherkin
Feature: Homepage section titles

  Scenario: user taps on a section title to navigate
    Given the homepage is displayed with section titles

    When user taps anywhere on the "Tokens" section row (title or arrow)
    Then user navigates to the Tokens full view

  Scenario: section titles display correctly
    Given the homepage is displayed
    
    When user views the homepage
    Then section titles are displayed: "Tokens", "Perpetuals", "Predictions", "DeFi", "NFTs"
    And each section with navigation shows an arrow icon on the right
```

## **Screenshots/Recordings**

### **Before**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3b471075-2d13-4f2e-8043-1469bdeb1ed5" />


### **After**

### After FLAG OFF
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2cc2c037-9cf5-44ba-b4f8-345c9202cfc7" />

### After FLAG ON 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/80f7c07f-ebd2-425b-9bbd-eed01aaecd3c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI scaffolding, localization, and tests; no data/auth logic is changed. Main risk is navigation/feature-flag wiring causing sections to appear or route incorrectly.
> 
> **Overview**
> Replaces the homepage placeholder with a structured set of section components (`Tokens`, `Perps`, `Predictions`, `DeFi`, `NFTs`), and updates the homepage `refresh` ref to fan out to each section’s `refresh()` via `Promise.allSettled`.
> 
> Adds reusable UI building blocks `SectionTitle` (full-row tappable header with optional accessory and arrow indicator) and `SectionRow` (standard padding), wires section headers to navigation routes, and gates `Perps`/`Predictions`/`DeFi` rendering behind feature flags. Adds unit tests for section rendering/navigation and new `homepage.sections.*` localization strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59adad9b686f4447093c1cfb1dcc938477a7bffd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->