### PR TITLE
chore: Use env variable for withdraw to any token

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -15,8 +15,9 @@ const log = createProjectLogger('transaction-pay-post-quote');
  * quote retrieval. The UI renders the default token when no payment
  * token is selected.
  *
- * When the withdrawal token picker feature flag (predictWithdrawAnyToken)
- * is disabled via canSelectWithdrawToken, this hook does nothing -
+ * When the withdrawal token picker (MM_PREDICT_WITHDRAW_ANY_TOKEN env var
+ * AND predictWithdrawAnyToken feature flag) is disabled via
+ * canSelectWithdrawToken, this hook does nothing -
  * withdrawals will use same-token-same-chain flow without bridging.
  */
 export function useTransactionPayPostQuote(): void {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts
@@ -6,12 +6,15 @@ import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagCont
 export interface UseTransactionPayWithdrawResult {
   /** Whether this transaction is a withdraw type */
   isWithdraw: boolean;
-  /** Whether the user can select a different withdraw token (feature flag) */
+  /** Whether the user can select a different withdraw token (env var AND feature flag) */
   canSelectWithdrawToken: boolean;
 }
 
 /**
  * Hook for checking withdraw transaction status and feature flag.
+ *
+ * Both the MM_PREDICT_WITHDRAW_ANY_TOKEN env var AND the
+ * predictWithdrawAnyToken remote feature flag must be enabled.
  *
  * Note: To update the withdraw destination token, use setPayToken from
  * useTransactionPayToken - it handles both deposit and withdraw token updates.
@@ -21,7 +24,10 @@ export function useTransactionPayWithdraw(): UseTransactionPayWithdrawResult {
   const isWithdraw = isTransactionPayWithdraw(transactionMeta);
   const { predictWithdrawAnyToken } = useSelector(selectMetaMaskPayFlags);
 
-  const canSelectWithdrawToken = isWithdraw && predictWithdrawAnyToken;
+  const isEnabledByEnv = process.env.MM_PREDICT_WITHDRAW_ANY_TOKEN === 'true';
+
+  const canSelectWithdrawToken =
+    isWithdraw && isEnabledByEnv && predictWithdrawAnyToken;
 
   return {
     isWithdraw,

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -33,6 +33,8 @@ const newOverrides = [
       'app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts',
       'app/components/UI/Ramp/hooks/useRampTokens.ts',
       'app/components/UI/Ramp/hooks/useRampTokens.test.ts',
+      'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts',
+      'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.test.ts',
       'app/store/migrations/**',
       'app/util/networks/customNetworks.tsx',
     ],


### PR DESCRIPTION
## **Description**

Add `MM_PREDICT_WITHDRAW_ANY_TOKEN` env var as an additional gate for the withdraw token picker. Both the env var AND the `predictWithdrawAnyToken` remote feature flag must be enabled for `canSelectWithdrawToken` to be `true`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6987

## **Manual testing steps**

```gherkin
Feature: Withdraw token picker gating

  Scenario: user sees token picker when both gates are enabled
    Given MM_PREDICT_WITHDRAW_ANY_TOKEN="true" in .js.env
    And predictWithdrawAnyToken remote feature flag is enabled

    When user opens a Predict Withdraw confirmation
    Then user sees the token select box on the withdraw page

  Scenario: user does not see token picker when env var is disabled
    Given MM_PREDICT_WITHDRAW_ANY_TOKEN="false" in .js.env

    When user opens a Predict Withdraw confirmation
    Then user does not see the token select box
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested gating change that only affects whether the withdraw token picker/bridging flow is enabled; minimal risk outside of feature rollout configuration.
> 
> **Overview**
> Adds `MM_PREDICT_WITHDRAW_ANY_TOKEN` as an additional gate for withdraw token selection: `useTransactionPayWithdraw` now requires *both* the env var and the `predictWithdrawAnyToken` remote flag to set `canSelectWithdrawToken`.
> 
> Updates unit tests to cover all env/flag combinations and adjusts the test Babel config to avoid inlining environment variables for the affected hook and test files; `useTransactionPayPostQuote` docs are updated to reflect the new gating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 681cd43f9074bc2e62e4060a307128e52dc33869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->