### PR TITLE
fix(account-menu): handle plain boolean remote feature flag in selectAccountMenuEnabled

### DIFF
--- a/app/selectors/featureFlagController/accountMenu/index.test.ts
+++ b/app/selectors/featureFlagController/accountMenu/index.test.ts
@@ -58,6 +58,20 @@ describe('Account Menu Feature Flag Selectors', () => {
       expect(result).toBe(false);
     });
 
+    it('returns true when remote flag is a plain boolean true', () => {
+      const result = selectAccountMenuEnabled.resultFunc({
+        mobileUxAccountMenu: true,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is a plain boolean false', () => {
+      const result = selectAccountMenuEnabled.resultFunc({
+        mobileUxAccountMenu: false,
+      });
+      expect(result).toBe(false);
+    });
+
     it('returns false when remote feature flags are empty', () => {
       const result = selectAccountMenuEnabled.resultFunc({});
       expect(result).toBe(false);

--- a/app/selectors/featureFlagController/accountMenu/index.ts
+++ b/app/selectors/featureFlagController/accountMenu/index.ts
@@ -14,9 +14,14 @@ const ACCOUNT_MENU_FLAG_KEY = 'mobileUxAccountMenu';
 export const selectAccountMenuEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    const remoteFlag = remoteFeatureFlags[
-      ACCOUNT_MENU_FLAG_KEY
-    ] as unknown as VersionGatedFeatureFlag;
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+    const remoteFlag = remoteFeatureFlags[ACCOUNT_MENU_FLAG_KEY];
+    if (typeof remoteFlag === 'boolean') {
+      return remoteFlag;
+    }
+    return (
+      validatedVersionGatedFeatureFlag(
+        remoteFlag as unknown as VersionGatedFeatureFlag,
+      ) ?? false
+    );
   },
 );


### PR DESCRIPTION
## **Description**

`selectAccountMenuEnabled` was returning false even when the `mobileUxAccountMenu` LaunchDarkly flag was set to true. The selector assumed all remote feature flags use the `{ enabled, minimumVersion }` shape, but this flag is configured as a plain boolean in LaunchDarkly. Added a boolean short-circuit so the selector returns the value directly without passing it through `validatedVersionGatedFeatureFlag`.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-433

## **Manual testing steps**

```gherkin
Feature: Account menu feature flag

  Scenario: user has mobileUxAccountMenu enabled in LaunchDarkly as a boolean
    Given the remote feature flag mobileUxAccountMenu is set to true
    When the app loads
    Then the account menu is visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

`selectAccountMenuEnabled` returns `false` despite flag being true

### **After**

`selectAccountMenuEnabled` correctly returns true

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested selector change limited to feature-flag evaluation logic; minimal blast radius and no sensitive data handling.
> 
> **Overview**
> `selectAccountMenuEnabled` now short-circuits when `mobileUxAccountMenu` is a plain boolean, returning it directly instead of forcing the version-gated `{ enabled, minimumVersion }` shape.
> 
> Tests are expanded to cover both `true` and `false` boolean flag values to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f8a3e884bca7a63bda35f42ab184fd0a8c30f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->