### PR TITLE
chore: change OTA version display 

### DIFF
--- a/app/components/Views/Settings/AppInformation/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/AppInformation/__snapshots__/index.test.tsx.snap
@@ -480,7 +480,9 @@ exports[`AppInformation renders correctly with snapshot 1`] = `
                                   "textAlign": "left",
                                 }
                               }
-                            />
+                            >
+                              MetaMask v7.0.0 (1000)
+                            </Text>
                             <Text
                               style={
                                 {

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -113,8 +113,9 @@ class AppInformation extends PureComponent {
   };
 
   state = {
-    appInfo: '',
+    appName: '',
     appVersion: '',
+    buildNumber: '',
     showEnvironmentInfo: false,
   };
 
@@ -136,13 +137,7 @@ class AppInformation extends PureComponent {
     const appName = await getApplicationName();
     const appVersion = await getVersion();
     const buildNumber = await getBuildNumber();
-    const appInfo = `${appName} v${appVersion} (${buildNumber})`;
-    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
-    const versionDisplay = isEmbeddedLaunch || __DEV__ ? appInfo : appInfoOta;
-    this.setState({
-      appInfo: versionDisplay,
-      appVersion,
-    });
+    this.setState({ appName, appVersion, buildNumber });
   };
 
   componentDidUpdate = () => {
@@ -195,14 +190,31 @@ class AppInformation extends PureComponent {
     this.setState({ showEnvironmentInfo: true });
   };
 
+  /**
+   * Returns the version string to display (native app version or OTA version).
+   * When OTA is disabled we're always on embedded code; native isEmbeddedLaunch can be false in that case.
+   */
+  getVersionDisplay = () => {
+    const { appName, appVersion, buildNumber } = this.state;
+    const appInfo = `${appName} v${appVersion} (${buildNumber})`;
+    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
+    return __DEV__ || isEmbeddedLaunch ? appInfo : appInfoOta;
+  };
+
+  /**
+   * Returns the OTA update status message for the environment info section.
+   */
+  getOtaUpdateMessage = () => {
+    const isRunningEmbedded = isEmbeddedLaunch || !isOTAUpdatesEnabled;
+    return __DEV__ || isRunningEmbedded
+      ? 'This app is running from built-in code or in development mode'
+      : 'This app is running an update';
+  };
+
   render = () => {
     const colors = this.context.colors || mockTheme.colors;
     const styles = createStyles(colors);
-
-    const otaUpdateMessage =
-      __DEV__ || isEmbeddedLaunch
-        ? 'This app is running from built-in code or in development mode'
-        : 'This app is running an update';
+    const otaUpdateMessage = this.getOtaUpdateMessage();
 
     return (
       <SafeAreaView
@@ -222,7 +234,7 @@ class AppInformation extends PureComponent {
                 resizeMethod={'auto'}
               />
             </TouchableOpacity>
-            <Text style={styles.versionInfo}>{this.state.appInfo}</Text>
+            <Text style={styles.versionInfo}>{this.getVersionDisplay()}</Text>
             {isQa ? (
               <Text style={styles.branchInfo}>
                 {`Branch: ${process.env['GIT_BRANCH']}`}
@@ -259,6 +271,9 @@ class AppInformation extends PureComponent {
                     </Text>
                     <Text style={styles.branchInfo}>
                       {`OTA Update status: ${otaUpdateMessage}`}
+                    </Text>
+                    <Text style={styles.branchInfo}>
+                      {`OTA Version: ${OTA_VERSION}`}
                     </Text>
                   </>
                 )}

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -198,7 +198,8 @@ class AppInformation extends PureComponent {
     const { appName, appVersion, buildNumber } = this.state;
     const appInfo = `${appName} v${appVersion} (${buildNumber})`;
     const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
-    return __DEV__ || isEmbeddedLaunch ? appInfo : appInfoOta;
+    const isRunningEmbedded = isEmbeddedLaunch || !isOTAUpdatesEnabled;
+    return __DEV__ || isRunningEmbedded ? appInfo : appInfoOta;
   };
 
   /**

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -24,7 +24,7 @@ import {
   checkAutomatically,
 } from 'expo-updates';
 import { connect } from 'react-redux';
-import { getFullVersion } from '../../../../constants/ota';
+import { OTA_VERSION } from '../../../../constants/ota';
 import { fontStyles } from '../../../../styles/common';
 import PropTypes from 'prop-types';
 import { strings } from '../../../../../locales/i18n';
@@ -136,8 +136,11 @@ class AppInformation extends PureComponent {
     const appName = await getApplicationName();
     const appVersion = await getVersion();
     const buildNumber = await getBuildNumber();
+    const appInfo = `${appName} v${appVersion} (${buildNumber})`;
+    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
+    const versionDisplay = isEmbeddedLaunch || __DEV__ ? appInfo : appInfoOta;
     this.setState({
-      appInfo: `${appName} v${appVersion} (${buildNumber})`,
+      appInfo: versionDisplay,
       appVersion,
     });
   };
@@ -219,9 +222,7 @@ class AppInformation extends PureComponent {
                 resizeMethod={'auto'}
               />
             </TouchableOpacity>
-            <Text style={styles.versionInfo}>
-              {getFullVersion(this.state.appInfo)}
-            </Text>
+            <Text style={styles.versionInfo}>{this.state.appInfo}</Text>
             {isQa ? (
               <Text style={styles.branchInfo}>
                 {`Branch: ${process.env['GIT_BRANCH']}`}

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -36,15 +36,9 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../constants/ota', () => {
-  const actual = jest.requireActual('../../../../constants/ota');
-
-  return {
-    ...actual,
-    // Make getFullVersion a pass-through so tests don't depend on OTA_VERSION
-    getFullVersion: (appVersion: string) => appVersion,
-  };
-});
+jest.mock('../../../../constants/ota', () => ({
+  OTA_VERSION: 'v0',
+}));
 
 const MOCK_STATE = {
   engine: {
@@ -79,12 +73,15 @@ describe('AppInformation', () => {
     mockGetFeatureFlagAppDistribution.mockReturnValue('main');
   });
 
-  it('renders correctly with snapshot', () => {
-    const { toJSON } = renderScreen(
+  it('renders correctly with snapshot', async () => {
+    const { toJSON, getByText } = renderScreen(
       AppInformation,
       { name: 'AppInformation' },
       { state: MOCK_STATE },
     );
+    await waitFor(() => {
+      expect(getByText('MetaMask v7.0.0 (1000)')).toBeTruthy();
+    });
     expect(toJSON()).toMatchSnapshot();
   });
 

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -6,15 +6,7 @@ import otaConfig from '../../ota.config.js';
  * Reset to v0 when releasing a new native build
  * We keep this OTA_VERSION here to because changes in ota.config.js will affect the fingerprint and break the workflow in Github Actions
  */
-export const OTA_VERSION: string = 'v0';
+export const OTA_VERSION: string = 'vX.XX.X';
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;
-
-/**
- * Gets the full version string including OTA version
- * @param appVersion - The app version from package.json/device info
- * @returns Full version string (e.g., "7.58.0 OTA Version: v3")
- */
-export const getFullVersion = (appVersion: string): string =>
-  OTA_VERSION !== 'v0' ? `${appVersion} OTA: ${OTA_VERSION}` : `${appVersion}`;

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -6,7 +6,7 @@ import otaConfig from '../../ota.config.js';
  * Reset to v0 when releasing a new native build
  * We keep this OTA_VERSION here to because changes in ota.config.js will affect the fingerprint and break the workflow in Github Actions
  */
-export const OTA_VERSION: string = 'vX.XX.X';
+export const OTA_VERSION: string = 'v7.65.1';
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Instead of display OTA version like "v7.65.0 ota v1", we want to display "ota v7.65.1"

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed how OTA version is displayed

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="200" height="450" alt="File" src="https://github.com/user-attachments/assets/b73503f5-378e-4c13-8b94-85d44e7483d2" />

<!-- [screenshots/recordings] -->

### **After**
<img width="200" height="450" alt="Simulator Screenshot - iPhone 16 - 2026-02-19 at 11 39 56" src="https://github.com/user-attachments/assets/a0dffaf5-5f91-4725-939d-95309bd6d419" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only version-string logic and test updates; minimal risk beyond potentially misreporting version/OTA status in edge cases (e.g., OTA disabled/embedded detection).
> 
> **Overview**
> Updates the About MetaMask (`AppInformation`) header version string to **conditionally show the OTA version** when running an update, and the native app version when running embedded code/dev or when OTA is disabled.
> 
> Removes the `getFullVersion` helper (now only exports `OTA_VERSION`), bumps `OTA_VERSION` to `v7.65.1`, and updates tests/snapshots to wait for async device-info rendering and to mock `OTA_VERSION` directly while also showing `OTA Version` in the long-press environment info section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5610e5498b5b27bc6d503b4f7fda3f704ed8d881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->