### PR TITLE
chore: make OTA Version Display more robust 

### DIFF
--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -180,7 +180,8 @@ class AppInformation extends PureComponent {
     const { appName, appVersion, buildNumber } = this.state;
     const appInfo = `${appName} v${appVersion} (${buildNumber})`;
     const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
-    return __DEV__ || isEmbeddedLaunch ? appInfo : appInfoOta;
+    const isRunningEmbedded = isEmbeddedLaunch || !isOTAUpdatesEnabled;
+    return __DEV__ || isRunningEmbedded ? appInfo : appInfoOta;
   };
 
   /**

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -6,7 +6,7 @@ import otaConfig from '../../ota.config.js';
  * Reset to v0 when releasing a new native build
  * We keep this OTA_VERSION here to because changes in ota.config.js will affect the fingerprint and break the workflow in Github Actions
  */
-export const OTA_VERSION: string = 'vX.XX.X';
+export const OTA_VERSION: string = 'v7.65.1';
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
I ran into weird issues where we are displaying OTA version on main-test. I believe isEmbeddedLaunch returns false as the default so I am moving it out of componentDidMount. There should be no UI changes. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adjusts UI display logic for version/OTA info and bumps a constant; low risk aside from potentially showing the wrong version string under certain update/embedded conditions.
> 
> **Overview**
> Updates the About/App Information screen to compute the displayed version dynamically, distinguishing native vs OTA version using `isOTAUpdatesEnabled` (not just `isEmbeddedLaunch`), and refactors the OTA status message into helper methods.
> 
> Adds explicit `OTA Version: ${OTA_VERSION}` to the long-press environment info section, and bumps `OTA_VERSION` in `app/constants/ota.ts` to `v7.65.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560e19161daa5b82a3b5d2a28c99d4d38f7ffbbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->