### PR TITLE
refactor(analytics): migrate Batch 3-1: mobile-platform

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -47,7 +47,7 @@ import {
   SeedlessOnboardingControllerErrorType,
 } from '../Engine/controllers/seedless-onboarding-controller/error';
 import { TraceName, TraceOperation } from '../../util/trace';
-import MetaMetrics from '../Analytics/MetaMetrics';
+import { analytics } from '../../util/analytics/analytics';
 import { resetProviderToken as depositResetProviderToken } from '../../components/UI/Ramp/Deposit/utils/ProviderTokenVault';
 import { clearAllVaultBackups } from '../BackupVault/backupVault';
 import { Engine as EngineClass } from '../Engine/Engine';
@@ -230,15 +230,11 @@ jest.mock('../BackupVault/backupVault', () => ({
   clearAllVaultBackups: jest.fn(),
 }));
 
-jest.mock('../Analytics/MetaMetrics', () => {
-  const mockInstance = {};
-  return {
-    __esModule: true,
-    default: {
-      getInstance: jest.fn(() => mockInstance),
-    },
-  };
-});
+jest.mock('../../util/analytics/analytics', () => ({
+  analytics: {
+    isEnabled: jest.fn().mockReturnValue(true),
+  },
+}));
 
 jest.mock('../../util/analytics/analyticsDataDeletion', () => ({
   createDataDeletionTask: jest.fn().mockResolvedValue(undefined),
@@ -1309,9 +1305,7 @@ describe('Authentication', () => {
           }),
         } as unknown as ReduxStore);
 
-        jest
-          .spyOn(MetaMetrics, 'getInstance')
-          .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+        jest.spyOn(analytics, 'isEnabled').mockReturnValue(true);
 
         await Authentication.unlockWallet();
 
@@ -1344,9 +1338,7 @@ describe('Authentication', () => {
           }),
         } as unknown as ReduxStore);
 
-        jest
-          .spyOn(MetaMetrics, 'getInstance')
-          .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+        jest.spyOn(analytics, 'isEnabled').mockReturnValue(true);
 
         await Authentication.unlockWallet();
 
@@ -1695,10 +1687,7 @@ describe('Authentication', () => {
         }),
       } as unknown as ReduxStore);
 
-      // Mock MetaMetrics.getInstance to return true for isEnabled
-      jest
-        .spyOn(MetaMetrics, 'getInstance')
-        .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+      jest.spyOn(analytics, 'isEnabled').mockReturnValue(true);
 
       const mockKeyring = {
         getAccounts: jest.fn().mockResolvedValue(['0x1234567890abcdef']),
@@ -2142,10 +2131,7 @@ describe('Authentication', () => {
         getState: jest.fn(() => mockState),
       } as unknown as ReduxStore);
 
-      // Mock MetaMetrics.getInstance to return true for isEnabled
-      jest
-        .spyOn(MetaMetrics, 'getInstance')
-        .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+      jest.spyOn(analytics, 'isEnabled').mockReturnValue(true);
 
       Engine.context.SeedlessOnboardingController = {
         state: { vault: {} },
@@ -2632,10 +2618,7 @@ describe('Authentication', () => {
         },
       } as unknown as KeyringController;
 
-      // Mock MetaMetrics.getInstance to return true for isEnabled
-      jest
-        .spyOn(MetaMetrics, 'getInstance')
-        .mockReturnValue({ isEnabled: () => true } as MetaMetrics);
+      jest.spyOn(analytics, 'isEnabled').mockReturnValue(true);
     });
 
     it('throw an error if not using seedless onboarding flow', async () => {
@@ -4494,10 +4477,7 @@ describe('Authentication', () => {
     beforeEach(() => {
       // Mock lockApp.
       jest.spyOn(Authentication, 'lockApp').mockResolvedValueOnce(undefined);
-      // Mock MetaMetrics.getInstance to return true for isEnabled.
-      jest
-        .spyOn(MetaMetrics, 'getInstance')
-        .mockReturnValueOnce({ isEnabled: () => true } as MetaMetrics);
+      jest.spyOn(analytics, 'isEnabled').mockReturnValue(true);
 
       const Engine = jest.requireMock('../Engine');
       // Restore the KeyringController mock that may have been replaced by other test suites.
@@ -4590,11 +4570,7 @@ describe('Authentication', () => {
     it('navigates to the optin metrics flow when metrics are not enabled and UI has not been seen', async () => {
       // Mock StorageWrapper.getItem to return null for OPTIN_META_METRICS_UI_SEEN.
       jest.spyOn(StorageWrapper, 'getItem').mockResolvedValue(null);
-      // Clear beforeEach mock and set MetaMetrics.getInstance to return false for isEnabled.
-      jest.spyOn(MetaMetrics, 'getInstance').mockReset();
-      jest
-        .spyOn(MetaMetrics, 'getInstance')
-        .mockReturnValue({ isEnabled: () => false } as MetaMetrics);
+      jest.spyOn(analytics, 'isEnabled').mockReturnValue(false);
 
       // Call unlockWallet with a password.
       await Authentication.unlockWallet({ password: passwordToUse });

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -67,7 +67,7 @@ import { toChecksumHexAddress } from '@metamask/controller-utils';
 import AccountTreeInitService from '../../multichain-accounts/AccountTreeInitService';
 import { renewSeedlessControllerRefreshTokens } from '../OAuthService/SeedlessControllerHelper';
 import { EntropySourceId } from '@metamask/keyring-api';
-import MetaMetrics from '../Analytics/MetaMetrics';
+import { analytics } from '../../util/analytics/analytics';
 import { createDataDeletionTask as createDataDeletionTaskUtil } from '../../util/analytics/analyticsDataDeletion';
 import { resetProviderToken as depositResetProviderToken } from '../../components/UI/Ramp/Deposit/utils/ProviderTokenVault';
 import { setAllowLoginWithRememberMe } from '../../actions/security';
@@ -782,7 +782,7 @@ class AuthenticationService {
 
           // TODO: Refactor this orchestration to sagas.
           // Navigate to optin metrics or home screen based on metrics consent and UI seen.
-          const isMetricsEnabled = MetaMetrics.getInstance().isEnabled();
+          const isMetricsEnabled = analytics.isEnabled();
           const isOptinMetaMetricsUISeen = await StorageWrapper.getItem(
             OPTIN_META_METRICS_UI_SEEN,
           );


### PR DESCRIPTION
## **Description**

Phase 3 analytics migration (Batch 3-1): migrate Authentication core's `Authentication.ts` from `MetaMetrics.getInstance()` to the new analytics system.

**Reason**: Deprecate MetaMetrics in favour of the shared analytics utility and AnalyticsController.

**Changes**: `Authentication.ts` now uses `analytics.isEnabled()` from `app/util/analytics/analytics` instead of `MetaMetrics.getInstance().isEnabled()`; test mocks updated to mock the analytics utility instead of MetaMetrics.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-301 (Batch 3-1)

## **Manual testing steps**

```gherkin
Feature: Authentication analytics

  Scenario: user triggers an authentication flow event
    Given app is open and user is in an authentication flow

    When user performs an action that triggers analytics (e.g. unlock wallet, login)
    Then the event is tracked on Mixpanel
```

## **Screenshots/Recordings**

N/A – analytics migration, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to how the “metrics enabled” flag is read plus corresponding test mock updates; minimal behavioral risk beyond potential differences in enabled-state resolution.
> 
> **Overview**
> `Authentication.unlockWallet` now uses the shared `analytics.isEnabled()` helper (instead of `MetaMetrics.getInstance().isEnabled()`) to decide whether to route users into the opt-in metrics onboarding flow.
> 
> Updates `Authentication.test.ts` to mock the new `analytics` module and replaces all `MetaMetrics` spies with `analytics.isEnabled` spies to keep navigation/login tests consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22c425d2d7169f5953eb02c1a1ff23175f16ec9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->