### PR TITLE
fix(perps): connection-aware ensureReady() to fix stale cache on slow connections cp-7.67.0

### DIFF
--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -129,35 +129,16 @@ export function usePerpsLivePositions(
 
   // Subscribe to position updates
   useEffect(() => {
-    DevLogger.log(
-      '[PERPS_DEBUG] usePerpsLivePositions: Subscribing to position stream',
-      {
-        hasPreloadedData: hasPreloadedData('cachedPositions'),
-      },
-    );
-
-    let updateCount = 0;
-    const subscribeTime = Date.now();
-
     const unsubscribe = stream.positions.subscribe({
       callback: (newPositions) => {
         if (newPositions === null) {
-          DevLogger.log(
-            '[PERPS_DEBUG] usePerpsLivePositions: Received NULL positions, ignoring',
-          );
           return;
-        }
-
-        updateCount++;
-        if (updateCount <= 3) {
-          DevLogger.log(
-            `[PERPS_DEBUG] usePerpsLivePositions: Update #${updateCount} (${newPositions.length} positions, ${Date.now() - subscribeTime}ms since subscribe)`,
-          );
         }
 
         if (!hasReceivedFirstUpdate.current) {
           DevLogger.log(
-            `[PERPS_DEBUG] usePerpsLivePositions: FIRST update received (${newPositions.length} positions, ${Date.now() - subscribeTime}ms since subscribe)`,
+            'usePerpsLivePositions: Received first WebSocket update',
+            { positionsCount: newPositions?.length ?? 0 },
           );
           hasReceivedFirstUpdate.current = true;
           setIsInitialLoading(false);

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -129,16 +129,35 @@ export function usePerpsLivePositions(
 
   // Subscribe to position updates
   useEffect(() => {
+    DevLogger.log(
+      '[PERPS_DEBUG] usePerpsLivePositions: Subscribing to position stream',
+      {
+        hasPreloadedData: hasPreloadedData('cachedPositions'),
+      },
+    );
+
+    let updateCount = 0;
+    const subscribeTime = Date.now();
+
     const unsubscribe = stream.positions.subscribe({
       callback: (newPositions) => {
         if (newPositions === null) {
+          DevLogger.log(
+            '[PERPS_DEBUG] usePerpsLivePositions: Received NULL positions, ignoring',
+          );
           return;
+        }
+
+        updateCount++;
+        if (updateCount <= 3) {
+          DevLogger.log(
+            `[PERPS_DEBUG] usePerpsLivePositions: Update #${updateCount} (${newPositions.length} positions, ${Date.now() - subscribeTime}ms since subscribe)`,
+          );
         }
 
         if (!hasReceivedFirstUpdate.current) {
           DevLogger.log(
-            'usePerpsLivePositions: Received first WebSocket update',
-            { positionsCount: newPositions?.length ?? 0 },
+            `[PERPS_DEBUG] usePerpsLivePositions: FIRST update received (${newPositions.length} positions, ${Date.now() - subscribeTime}ms since subscribe)`,
           );
           hasReceivedFirstUpdate.current = true;
           setIsInitialLoading(false);

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -131,6 +131,11 @@ describe('PerpsStreamManager', () => {
       isConnecting: false,
       error: null,
     });
+    mockPerpsConnectionManager.waitForConnection = jest.fn().mockReturnValue(
+      new Promise((_resolve) => {
+        /* never resolves */
+      }),
+    );
   });
 
   afterEach(() => {
@@ -3463,7 +3468,7 @@ describe('PerpsStreamManager', () => {
       jest.advanceTimersByTime(150 * 200 + 100);
 
       expect(mockDevLogger.log).toHaveBeenCalledWith(
-        expect.stringContaining('MAX RETRIES EXCEEDED'),
+        expect.stringContaining('Max connect retries exceeded'),
       );
     });
   });

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -3463,7 +3463,7 @@ describe('PerpsStreamManager', () => {
       jest.advanceTimersByTime(150 * 200 + 100);
 
       expect(mockDevLogger.log).toHaveBeenCalledWith(
-        expect.stringContaining('Max connect retries exceeded'),
+        expect.stringContaining('MAX RETRIES EXCEEDED'),
       );
     });
   });

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -173,7 +173,10 @@ abstract class StreamChannel<T> {
     if (this.deferConnectTimer) {
       clearTimeout(this.deferConnectTimer);
     }
-    this.deferConnectTimer = setTimeout(() => this.connect(), delayMs);
+    this.deferConnectTimer = setTimeout(() => {
+      this.deferConnectTimer = null;
+      this.connect();
+    }, delayMs);
   }
 
   /**

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -839,4 +839,70 @@ describe('PerpsConnectionManager', () => {
       });
     });
   });
+
+  describe('waitForConnection', () => {
+    it('awaits resolving initPromise', async () => {
+      // Arrange — set initPromise to a resolved promise
+      const m = PerpsConnectionManager as unknown as {
+        initPromise: Promise<void> | null;
+      };
+      m.initPromise = Promise.resolve();
+
+      // Act & Assert — should complete without error
+      await expect(
+        PerpsConnectionManager.waitForConnection(),
+      ).resolves.toBeUndefined();
+
+      // Cleanup
+      m.initPromise = null;
+    });
+
+    it('swallows initPromise rejection', async () => {
+      // Arrange — set initPromise to a rejected promise
+      const m = PerpsConnectionManager as unknown as {
+        initPromise: Promise<void> | null;
+      };
+      m.initPromise = Promise.reject(new Error('init failed'));
+
+      // Act & Assert — should resolve (not throw) even though initPromise rejects
+      await expect(
+        PerpsConnectionManager.waitForConnection(),
+      ).resolves.toBeUndefined();
+
+      // Cleanup
+      m.initPromise = null;
+    });
+
+    it('awaits resolving pendingReconnectPromise', async () => {
+      // Arrange — set pendingReconnectPromise to a resolved promise
+      const m = PerpsConnectionManager as unknown as {
+        pendingReconnectPromise: Promise<void> | null;
+      };
+      m.pendingReconnectPromise = Promise.resolve();
+
+      // Act & Assert — should complete without error
+      await expect(
+        PerpsConnectionManager.waitForConnection(),
+      ).resolves.toBeUndefined();
+
+      // Cleanup
+      m.pendingReconnectPromise = null;
+    });
+
+    it('swallows pendingReconnectPromise rejection', async () => {
+      // Arrange — set pendingReconnectPromise to a rejected promise
+      const m = PerpsConnectionManager as unknown as {
+        pendingReconnectPromise: Promise<void> | null;
+      };
+      m.pendingReconnectPromise = Promise.reject(new Error('reconnect failed'));
+
+      // Act & Assert — should resolve (not throw) even though promise rejects
+      await expect(
+        PerpsConnectionManager.waitForConnection(),
+      ).resolves.toBeUndefined();
+
+      // Cleanup
+      m.pendingReconnectPromise = null;
+    });
+  });
 });

--- a/app/controllers/perps/constants/perpsConfig.ts
+++ b/app/controllers/perps/constants/perpsConfig.ts
@@ -25,6 +25,7 @@ export const PERPS_CONSTANTS = {
   ConnectionGracePeriodMs: 20_000, // 20 seconds grace period before actual disconnection (same as BackgroundDisconnectDelay for semantic clarity)
   ConnectionAttemptTimeoutMs: 30_000, // 30 seconds timeout for connection attempts to prevent indefinite hanging
   WebsocketPingTimeoutMs: 5_000, // 5 seconds timeout for WebSocket health check ping
+  ConnectRetryDelayMs: 200, // Delay before retrying connect() when connection isn't ready yet
   ReconnectionCleanupDelayMs: 500, // Platform-agnostic delay to ensure WebSocket is ready
   ReconnectionDelayAndroidMs: 300, // Android-specific reconnection delay for better reliability on slower devices
   ReconnectionDelayIosMs: 100, // iOS-specific reconnection delay for optimal performance


### PR DESCRIPTION
## **Description**

Fixes [TAT-2597](https://consensys-mesh.atlassian.net/browse/TAT-2597) and [TAT-2598](https://consensys-mesh.atlassian.net/browse/TAT-2598): After the preload PR merged, slow connections caused StreamChannels to exhaust 150 polling retries (30s) in `ensureReady()` and silently give up, leaving users with stale REST cache and no live WebSocket data — positions not appearing after trade, missing prices.

**Root Cause:** `StreamChannel.ensureReady()` used blind polling (`isReady` every 200ms × 150 retries) with no awareness of WebSocket connection state. On slow connections, the connection had not even established yet, so polling burned through all retries before data could arrive.

**Fix:**
- `PerpsConnectionManager.waitForConnection()` — exposes init/reconnect promises so channels can `await` instead of blind-polling
- `StreamChannel.ensureReady()` — detects `isConnecting` state and awaits the connection promise via `awaitConnectionThenConnect()`

**Result:** PriceStreamChannel retries dropped from **33 → 0** on device after this fix.

## **Changelog**

CHANGELOG entry: Fixed stale cache on slow connections where positions and prices were not updating after a trade

## **Related issues**

Fixes: [TAT-2597](https://consensys-mesh.atlassian.net/browse/TAT-2597), [TAT-2598](https://consensys-mesh.atlassian.net/browse/TAT-2598)

## **Manual testing steps**

```gherkin
Feature: Perps live data on slow connections

  Scenario: user opens a trade on a slow connection
    Given the app is connected to a slow 3G network
    And the user has navigated to the Perps trading screen

    When user opens a new position
    Then the position appears immediately in the positions list
    And price stream connects without excessive retries

  Scenario: user recovers from network drop
    Given the user is viewing live perps positions
    And the network connection drops momentarily

    When the network connection is restored
    Then live WebSocket data resumes without stale cache
```

## **Screenshots/Recordings**

### **Before**

<!-- PriceStreamChannel: 33 retries before data appears, positions missing on slow connections -->

### **After**

<!-- PriceStreamChannel: 0 retries, positions appear immediately -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2597]: https://consensyssoftware.atlassian.net/browse/TAT-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAT-2598]: https://consensyssoftware.atlassian.net/browse/TAT-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAT-2597]: https://consensyssoftware.atlassian.net/browse/TAT-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps connection/stream reconnection timing and retry logic; mistakes could cause missed subscriptions or delayed real-time updates, though changes are localized and well-covered by tests.
> 
> **Overview**
> Prevents Perps stream channels from burning through retry polling on slow connections by making `StreamChannel.ensureReady()` detect `isConnecting` and wait on the connection manager before retrying `connect()`.
> 
> Adds `PerpsConnectionManager.waitForConnection()` (awaits init/reconnect promises, swallowing rejections) and introduces `awaitConnectionThenConnect()` with a sentinel timer to avoid duplicate awaits, plus a small `deferConnect()` timer cleanup fix and a shared `PERPS_CONSTANTS.ConnectRetryDelayMs` constant.
> 
> Expands unit tests to cover the new await/guard behavior (duplicate-await prevention, resolve/reject fallbacks) and updates market-data channel tests to use the new retry delay constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e0d5994f0b655ba7cd28c2d033e42f5d2aedfc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->