### PR TITLE
fix(perps): order book grouping

### DIFF
--- a/app/components/UI/Perps/utils/orderBookGrouping.test.ts
+++ b/app/components/UI/Perps/utils/orderBookGrouping.test.ts
@@ -222,9 +222,9 @@ describe('orderBookGrouping', () => {
     describe('BTC at ~$90,000', () => {
       const btcPrice = 90000;
 
-      it('returns nSigFigs: 5 with mantissa: 2 for grouping 1', () => {
+      it('returns nSigFigs: 5 without mantissa for grouping 1', () => {
         const result = calculateAggregationParams(1, btcPrice);
-        expect(result).toEqual({ nSigFigs: 5, mantissa: 2 });
+        expect(result).toEqual({ nSigFigs: 5 });
       });
 
       it('returns nSigFigs: 5 with mantissa: 2 for grouping 2', () => {
@@ -256,9 +256,9 @@ describe('orderBookGrouping', () => {
     describe('ETH at ~$3,000', () => {
       const ethPrice = 3000;
 
-      it('returns nSigFigs: 5 with mantissa for grouping 0.1', () => {
+      it('returns nSigFigs: 5 without mantissa for grouping 0.1', () => {
         const result = calculateAggregationParams(0.1, ethPrice);
-        expect(result).toEqual({ nSigFigs: 5, mantissa: 2 });
+        expect(result).toEqual({ nSigFigs: 5 });
       });
 
       it('returns nSigFigs: 4 for grouping 1', () => {
@@ -286,7 +286,7 @@ describe('orderBookGrouping', () => {
       it('returns finest granularity for smallest groupings', () => {
         const result = calculateAggregationParams(0.0000001, pumpPrice);
         expect(result.nSigFigs).toBe(5);
-        expect(result.mantissa).toBeDefined();
+        expect(result.mantissa).toBeUndefined();
       });
     });
 

--- a/app/components/UI/Perps/utils/orderBookGrouping.ts
+++ b/app/components/UI/Perps/utils/orderBookGrouping.ts
@@ -17,7 +17,8 @@ export interface AggregationParams {
 /**
  * Calculate nSigFigs and mantissa based on grouping and price.
  * These parameters match Hyperliquid's L2Book API aggregation:
- * - nSigFigs: 5, mantissa: 2 → finest granularity (~$1-2 for BTC)
+ * - nSigFigs: 5 (no mantissa) → finest granularity (~$1 for BTC)
+ * - nSigFigs: 5, mantissa: 2 → ~$2 increments for BTC
  * - nSigFigs: 5, mantissa: 5 → ~$5 increments for BTC
  * - nSigFigs: 4 → ~$10 increments for BTC
  * - nSigFigs: 3 → ~$100 increments for BTC
@@ -43,9 +44,10 @@ export function calculateAggregationParams(
   const baseNSigFigs = magnitude - groupingMagnitude + 1;
 
   if (baseNSigFigs >= 5) {
-    // Finest granularity needs mantissa
-    // Derive mantissa from the first digit of grouping
     const firstDigit = Math.floor(grouping / Math.pow(10, groupingMagnitude));
+    if (firstDigit <= 1) {
+      return { nSigFigs: 5 };
+    }
     const mantissa = firstDigit <= 2 ? 2 : 5;
     return { nSigFigs: 5, mantissa };
   }


### PR DESCRIPTION
## **Description**

Fixed order book grouping where selecting the finest unit filter (e.g., "1" for BTC, "0.1" for ETH) would actually group by 2x the selected value, mixing volume data across incorrect price levels.

**Root cause:** In `calculateAggregationParams`, when the grouping's leading digit was 1 (e.g., grouping=1 for BTC at ~$90k), the mantissa calculation `firstDigit <= 2 ? 2 : 5` mapped it to `mantissa: 2`. In the Hyperliquid L2Book API, `nSigFigs: 5, mantissa: 2` means "group in multiples of 2", so a $1 selection produced $2 increments. The fix returns `{ nSigFigs: 5 }` (no mantissa) when `firstDigit <= 1`, which gives the finest possible granularity.

## **Changelog**

CHANGELOG entry: Fixed: Order book grouping by 1 unit no longer incorrectly groups by 2

## **Related issues**

Fixes: #26264

## **Manual testing steps**

```gherkin
Feature: Order book price grouping

  Scenario: user selects finest grouping for BTC
    Given user is on the BTC order book screen
    And the grouping dropdown shows options [1, 2, 5, 10, 100, 1000]

    When user selects grouping "1"
    Then order book price levels should increment by $1
    And volume data at each level should match Hyperliquid's web order book

  Scenario: user selects grouping "2" for BTC
    Given user is on the BTC order book screen

    When user selects grouping "2"
    Then order book price levels should increment by $2
    And volume data should be correctly aggregated per $2 bucket
```

## **Screenshots/Recordings**

<!-- Not a UI change — the fix is in the API parameters sent to Hyperliquid. Verify by comparing order book values against https://app.hyperliquid.xyz -->

### **Before**

Selecting grouping "1" sends `{ nSigFigs: 5, mantissa: 2 }` → prices grouped by $2, mixing volume data.

### **After**

Selecting grouping "1" sends `{ nSigFigs: 5 }` → prices grouped by $1, matching Hyperliquid.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested adjustment to aggregation parameter calculation; risk is limited to potentially changing order book bucketing at the finest grouping option.
> 
> **Overview**
> Fixes a bug in `calculateAggregationParams` where “finest” grouping values (e.g., `1` for BTC or `0.1` for ETH) were incorrectly mapped to `nSigFigs: 5, mantissa: 2`, causing order book levels to aggregate at 2× the selected increment.
> 
> The logic now returns `{ nSigFigs: 5 }` (no mantissa) when the grouping’s leading digit is `<= 1`, and updates tests/docs to assert no `mantissa` is sent for those finest-granularity cases (including very small-price assets).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0006cc5fb596a483e5b815546af16a5f9395f0c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->