### PR TITLE
chore: add support for x only sources

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -898,11 +898,7 @@ const MainNavigator = () => {
     [predictEnabledFlag],
   );
   // Get feature flag state for conditional Market Insights screen registration
-  const marketInsightsEnabledFlag = useSelector(selectMarketInsightsEnabled);
-  const isMarketInsightsEnabled = useMemo(
-    () => marketInsightsEnabledFlag,
-    [marketInsightsEnabledFlag],
-  );
+  const isMarketInsightsEnabled = useSelector(selectMarketInsightsEnabled);
 
   return (
     <Stack.Navigator

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -140,10 +140,11 @@ const MarketInsightsView: React.FC = () => {
   }, [goToSwaps]);
 
   const handleTrendPress = useCallback((trend: MarketInsightsTrend) => {
-    if (trend.articles.length === 0) {
+    const hasArticles = trend.articles.length > 0;
+    const hasTweets = (trend.tweets?.length ?? 0) > 0;
+    if (!hasArticles && !hasTweets) {
       return;
     }
-
     setSelectedTrend(trend);
   }, []);
 
@@ -334,6 +335,7 @@ const MarketInsightsView: React.FC = () => {
           onClose={handleCloseTrendSources}
           trendTitle={selectedTrend.title}
           articles={selectedTrend.articles}
+          tweets={selectedTrend.tweets ?? []}
         />
       ) : null}
     </Box>

--- a/app/components/UI/MarketInsights/components/MarketInsightsTrendItem/MarketInsightsTrendItem.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTrendItem/MarketInsightsTrendItem.test.tsx
@@ -46,4 +46,28 @@ describe('MarketInsightsTrendItem', () => {
     fireEvent.press(getByTestId('trend-item'));
     expect(onPress).toHaveBeenCalledTimes(1);
   });
+
+  it('shows X icon when trend has only tweets and no articles', () => {
+    const trend = {
+      title: 'Developer debates',
+      description: 'Discussions heat up on consensus.',
+      articles: [],
+      tweets: [
+        {
+          author: 'adam3us',
+          contentSummary: 'Minority protections matter.',
+          date: '2026-02-17',
+          url: 'https://x.com/adam3us/status/123',
+        },
+      ],
+    };
+
+    const { getByText, UNSAFE_getAllByType } = renderWithProvider(
+      <MarketInsightsTrendItem trend={trend as never} testID="trend-item" />,
+    );
+
+    expect(getByText(trend.title)).toBeOnTheScreen();
+    const sourceIcons = UNSAFE_getAllByType(Image);
+    expect(sourceIcons).toHaveLength(1);
+  });
 });

--- a/app/components/UI/MarketInsights/components/MarketInsightsTrendItem/MarketInsightsTrendItem.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTrendItem/MarketInsightsTrendItem.tsx
@@ -46,14 +46,19 @@ const MarketInsightsTrendItem: React.FC<MarketInsightsTrendItemProps> = ({
   const tw = useTailwind();
   const uniqueSources = useMemo(() => {
     const seen = new Set<string>();
-    return trend.articles
+    const fromArticles = trend.articles
       .filter((article) => {
         if (seen.has(article.source)) return false;
         seen.add(article.source);
         return true;
       })
       .map((article) => article.source);
-  }, [trend.articles]);
+    const hasTweets = (trend.tweets?.length ?? 0) > 0;
+    if (hasTweets && !seen.has('x.com')) {
+      return [...fromArticles, 'x.com'];
+    }
+    return fromArticles;
+  }, [trend.articles, trend.tweets]);
 
   return (
     <Pressable

--- a/app/components/UI/MarketInsights/components/MarketInsightsTrendSourcesBottomSheet.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTrendSourcesBottomSheet.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import MarketInsightsTrendSourcesBottomSheet from './MarketInsightsTrendSourcesBottomSheet';
+
+jest.mock(
+  '../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const ReactLib = jest.requireActual('react');
+    const { View: MockView } = jest.requireActual('react-native');
+
+    return ReactLib.forwardRef(
+      (
+        { children }: { children: React.ReactNode },
+        ref: React.Ref<{
+          onOpenBottomSheet: () => void;
+          onCloseBottomSheet: () => void;
+        }>,
+      ) => {
+        ReactLib.useImperativeHandle(ref, () => ({
+          onOpenBottomSheet: jest.fn(),
+          onCloseBottomSheet: jest.fn(),
+        }));
+        return <MockView testID="mock-bottom-sheet">{children}</MockView>;
+      },
+    );
+  },
+);
+
+jest.mock(
+  '../../../../component-library/components/BottomSheets/BottomSheetHeader',
+  () => {
+    const { View: MockView } = jest.requireActual('react-native');
+    return ({ children }: { children: React.ReactNode }) => (
+      <MockView testID="mock-bottom-sheet-header">{children}</MockView>
+    );
+  },
+);
+
+describe('MarketInsightsTrendSourcesBottomSheet', () => {
+  beforeEach(() => {
+    jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders article and tweet sources and opens their URLs', () => {
+    const onClose = jest.fn();
+    const articleUrl = 'https://www.coindesk.com/article';
+    const tweetUrl = 'https://x.com/adam3us/status/123';
+
+    const { getByText } = renderWithProvider(
+      <MarketInsightsTrendSourcesBottomSheet
+        isVisible
+        onClose={onClose}
+        trendTitle="Developer debates"
+        articles={
+          [
+            {
+              title: 'ETF demand remains high',
+              source: 'coindesk.com',
+              date: '2026-02-17',
+              url: articleUrl,
+            },
+          ] as never
+        }
+        tweets={
+          [
+            {
+              author: 'adam3us',
+              contentSummary: 'Minority protections matter.',
+              date: '2026-02-17',
+              url: tweetUrl,
+            },
+          ] as never
+        }
+      />,
+    );
+
+    expect(getByText('Developer debates')).toBeOnTheScreen();
+    expect(getByText('coindesk.com')).toBeOnTheScreen();
+    expect(getByText('@adam3us')).toBeOnTheScreen();
+
+    fireEvent.press(getByText('coindesk.com'));
+    expect(Linking.openURL).toHaveBeenCalledWith(articleUrl);
+
+    fireEvent.press(getByText('@adam3us'));
+    expect(Linking.openURL).toHaveBeenCalledWith(tweetUrl);
+  });
+});

--- a/app/components/UI/MarketInsights/components/MarketInsightsTrendSourcesBottomSheet.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTrendSourcesBottomSheet.tsx
@@ -11,8 +11,14 @@ import {
   IconSize,
   IconColor,
   FontWeight,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
 } from '@metamask/design-system-react-native';
-import type { MarketInsightsArticle } from '@metamask/ai-controllers';
+import type {
+  MarketInsightsArticle,
+  MarketInsightsTweet,
+} from '@metamask/ai-controllers';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../component-library/components/BottomSheets/BottomSheet';
@@ -25,11 +31,12 @@ interface MarketInsightsTrendSourcesBottomSheetProps {
   onClose: () => void;
   trendTitle: string;
   articles: MarketInsightsArticle[];
+  tweets?: MarketInsightsTweet[];
 }
 
 const MarketInsightsTrendSourcesBottomSheet: React.FC<
   MarketInsightsTrendSourcesBottomSheetProps
-> = ({ isVisible, onClose, trendTitle, articles }) => {
+> = ({ isVisible, onClose, trendTitle, articles, tweets = [] }) => {
   const tw = useTailwind();
   const bottomSheetRef = useRef<BottomSheetRef>(null);
 
@@ -42,7 +49,7 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
     }
   }, [isVisible]);
 
-  const handleArticlePress = useCallback((url: string) => {
+  const handleSourcePress = useCallback((url: string) => {
     Linking.openURL(url);
   }, []);
 
@@ -71,7 +78,7 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
         {articles.map((article) => (
           <Pressable
             key={article.url}
-            onPress={() => handleArticlePress(article.url)}
+            onPress={() => handleSourcePress(article.url)}
             style={({ pressed }) =>
               tw.style(
                 'flex-row items-center py-3 border-b border-muted',
@@ -95,6 +102,49 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
                 numberOfLines={2}
               >
                 {article.title}
+              </Text>
+            </Box>
+            <Icon
+              name={IconName.Export}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+          </Pressable>
+        ))}
+
+        {tweets.map((tweet) => (
+          <Pressable
+            key={tweet.url}
+            onPress={() => handleSourcePress(tweet.url)}
+            style={({ pressed }) =>
+              tw.style(
+                'flex-row items-center py-3 border-b border-muted',
+                pressed && 'opacity-70',
+              )
+            }
+          >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              twClassName="w-8 h-8 rounded-full bg-muted mr-3"
+            >
+              <Icon
+                name={IconName.X}
+                size={IconSize.Sm}
+                color={IconColor.IconAlternative}
+              />
+            </Box>
+            <Box twClassName="flex-1">
+              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+                @{tweet.author}
+              </Text>
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+                numberOfLines={2}
+              >
+                {tweet.contentSummary}
               </Text>
             </Box>
             <Icon


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Market Insights "What’s driving the price?" previously showed source icons and the sources sheet only for trends with articles. This PR adds support for tweet-only trends as well.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to Market Insights source rendering/selection with added test coverage; no auth, payments, or persistence logic touched.
> 
> **Overview**
> Enables Market Insights trends to surface **tweet-only sources** in both the trend list and the “sources” bottom sheet, instead of only supporting article-backed trends.
> 
> Trend selection now opens the sources sheet when a trend has tweets (even if it has no articles), the sheet renders tweet entries with an X icon and opens tweet URLs, and trend items include `x.com` in their displayed source icons. Adds/updates unit tests to cover tweet-only trends and tweet source passing/URL opening, plus a small selector memoization simplification in `MainNavigator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe5970d2cf8739581a060467b851d425161c4a31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->