### PR TITLE
refactor(musd): replace decodeMerklClaimAmount with getClaimPayoutFromReceipt cp-7.66.0

### DIFF
--- a/app/components/UI/Earn/utils/musd.test.ts
+++ b/app/components/UI/Earn/utils/musd.test.ts
@@ -6,9 +6,12 @@ import {
   isMusdClaimForCurrentView,
   convertMusdClaimAmount,
   decodeMerklClaimParams,
-  decodeMerklClaimAmount,
+  getClaimPayoutFromReceipt,
 } from './musd';
-import { DISTRIBUTOR_CLAIM_ABI } from '../components/MerklRewards/constants';
+import {
+  DISTRIBUTOR_CLAIM_ABI,
+  MERKL_DISTRIBUTOR_ADDRESS,
+} from '../components/MerklRewards/constants';
 import { MUSD_TOKEN_ADDRESS } from '../constants/musd';
 
 const LINEA_CHAIN_ID = '0xe708' as Hex;
@@ -258,28 +261,120 @@ describe('musd utils', () => {
     });
   });
 
-  describe('decodeMerklClaimAmount', () => {
-    const userAddress = '0x1234567890123456789012345678901234567890';
-    const tokenAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-    const amount = '999000';
+  describe('getClaimPayoutFromReceipt', () => {
+    const USER = SELECTED_ADDRESS;
+    const TRANSFER_TOPIC =
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 
-    it('returns the amount from valid claim data', () => {
-      const iface = new Interface(DISTRIBUTOR_CLAIM_ABI);
-      const data = iface.encodeFunctionData('claim', [
-        [userAddress],
-        [tokenAddress],
-        [amount],
-        [[]],
-      ]);
-      expect(decodeMerklClaimAmount(data)).toBe(amount);
+    const padAddress = (addr: string) =>
+      `0x${addr.slice(2).toLowerCase().padStart(64, '0')}`;
+
+    const makeTransferLog = (
+      tokenAddress: string,
+      from: string,
+      to: string,
+      amount: bigint,
+    ) => ({
+      address: tokenAddress,
+      topics: [TRANSFER_TOPIC, padAddress(from), padAddress(to)],
+      data: `0x${amount.toString(16).padStart(64, '0')}`,
     });
 
-    it('returns null for undefined data', () => {
-      expect(decodeMerklClaimAmount(undefined)).toBeNull();
+    it('extracts the payout from a matching Transfer log', () => {
+      const payout = 70000000n; // 70 mUSD
+      const logs = [
+        makeTransferLog(
+          MUSD_TOKEN_ADDRESS,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          USER,
+          payout,
+        ),
+      ];
+
+      expect(getClaimPayoutFromReceipt(logs, USER)).toBe(payout.toString());
     });
 
-    it('returns null for invalid data', () => {
-      expect(decodeMerklClaimAmount('0xbaddata')).toBeNull();
+    it('ignores Transfer logs from other senders', () => {
+      const logs = [
+        makeTransferLog(MUSD_TOKEN_ADDRESS, OTHER_ADDRESS, USER, 100n),
+      ];
+
+      expect(getClaimPayoutFromReceipt(logs, USER)).toBeNull();
+    });
+
+    it('ignores Transfer logs to other recipients', () => {
+      const logs = [
+        makeTransferLog(
+          MUSD_TOKEN_ADDRESS,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          OTHER_ADDRESS,
+          100n,
+        ),
+      ];
+
+      expect(getClaimPayoutFromReceipt(logs, USER)).toBeNull();
+    });
+
+    it('ignores Transfer logs from a different token', () => {
+      const logs = [
+        makeTransferLog(
+          '0x0000000000000000000000000000000000000099',
+          MERKL_DISTRIBUTOR_ADDRESS,
+          USER,
+          100n,
+        ),
+      ];
+
+      expect(getClaimPayoutFromReceipt(logs, USER)).toBeNull();
+    });
+
+    it('returns null for undefined logs', () => {
+      expect(getClaimPayoutFromReceipt(undefined, USER)).toBeNull();
+    });
+
+    it('returns null for empty logs', () => {
+      expect(getClaimPayoutFromReceipt([], USER)).toBeNull();
+    });
+
+    it('returns null for undefined user address', () => {
+      const logs = [
+        makeTransferLog(
+          MUSD_TOKEN_ADDRESS,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          USER,
+          100n,
+        ),
+      ];
+
+      expect(getClaimPayoutFromReceipt(logs, undefined)).toBeNull();
+    });
+
+    it('picks the correct log among multiple logs', () => {
+      const payout = 42000000n;
+      const logs = [
+        // Some unrelated log
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          topics: ['0xabc'],
+          data: '0x00',
+        },
+        // The actual mUSD transfer from distributor
+        makeTransferLog(
+          MUSD_TOKEN_ADDRESS,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          USER,
+          payout,
+        ),
+        // Another unrelated transfer
+        makeTransferLog(
+          '0x0000000000000000000000000000000000000099',
+          MERKL_DISTRIBUTOR_ADDRESS,
+          USER,
+          999n,
+        ),
+      ];
+
+      expect(getClaimPayoutFromReceipt(logs, USER)).toBe(payout.toString());
     });
   });
 });

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -37,7 +37,7 @@ import { hasTransactionType } from '../../Views/confirmations/utils/transaction'
 import { BigNumber } from 'bignumber.js';
 import {
   convertMusdClaimAmount,
-  decodeMerklClaimAmount,
+  getClaimPayoutFromReceipt,
 } from '../Earn/utils/musd';
 
 const POSITIVE_TRANSFER_TRANSACTION_TYPES = [
@@ -829,7 +829,8 @@ function decodeMusdClaimTx(args) {
   const {
     tx: {
       txParams,
-      txParams: { from, gas, data },
+      txParams: { from, gas },
+      txReceipt,
       hash,
     },
     txChainId,
@@ -843,8 +844,7 @@ function decodeMusdClaimTx(args) {
   const totalGas = calculateTotalGas(txParams);
   const renderFrom = renderFullAddress(from);
 
-  // Decode the claim amount from transaction data
-  const claimAmountRaw = decodeMerklClaimAmount(data);
+  const claimAmountRaw = getClaimPayoutFromReceipt(txReceipt?.logs, from);
 
   // Calculate display values
   let renderClaimAmount = strings('transaction.value_not_available');

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -22,7 +22,7 @@ import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { BigNumber } from 'bignumber.js';
 import {
   convertMusdClaimAmount,
-  decodeMerklClaimAmount,
+  getClaimPayoutFromReceipt,
 } from '../../../../../UI/Earn/utils/musd';
 import {
   selectConversionRateByChainId,
@@ -130,8 +130,13 @@ function useClaimAmount(): { amount: BigNumber | null; isConverted: boolean } {
     return { amount: null, isConverted: false };
   }
 
-  const { data } = transactionMeta.txParams ?? {};
-  const claimAmountRaw = decodeMerklClaimAmount(data as string);
+  const { from } = transactionMeta.txParams ?? {};
+  const claimAmountRaw = getClaimPayoutFromReceipt(
+    transactionMeta.txReceipt?.logs as Parameters<
+      typeof getClaimPayoutFromReceipt
+    >[0],
+    from as string,
+  );
 
   if (!claimAmountRaw) {
     return { amount: null, isConverted: false };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The mUSD claim transaction amount was displaying the cumulative total reward (from Merkl distributor calldata `amounts[0]`) instead of the actual per-transaction payout. This caused incorrect amounts in the Activity list and transaction detail views — e.g., if a user made multiple claims, each one would show the running total rather than what was actually claimed in that specific transaction.

The fix introduces `getClaimPayoutFromReceipt()` which extracts the real payout from the ERC-20 `Transfer` event in the transaction receipt logs (emitted when the Merkl distributor transfers mUSD to the user). This is used as the primary source for confirmed transactions across:
- Activity list (`decodeMusdClaimTx`)
- Transaction detail hero (`useClaimAmount`)
- Confirmation flow (`useMerklClaimAmount`)

## **Changelog**

CHANGELOG entry: Fixed mUSD claim transactions showing incorrect cumulative total instead of per-transaction payout amount


## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: mUSD claim transaction amount display

  Scenario: user views a confirmed mUSD claim transaction in Activity
    Given user has made one or more mUSD claim transactions from this device
    And at least one claim transaction is confirmed

    When user navigates to the Activity tab
    Then the claim transaction shows the correct per-transaction payout amount (not cumulative total)

  Scenario: user views claim transaction details
    Given user has a confirmed mUSD claim transaction visible in Activity

    When user taps on the claim transaction
    Then the detail view shows the correct claimed amount matching the actual payout

  Scenario: user views a pending mUSD claim in the Activity list
    Given user has a pending mUSD claim transaction

    When user views the transaction in Activity
    Then the amount shows "Not available" until the transaction confirms
    And once confirmed, the correct payout amount appears
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction amount display logic across multiple surfaces and relies on receipt log shape/topic matching; incorrect parsing could cause missing/incorrect amounts but does not affect signing or on-chain behavior.
> 
> **Overview**
> mUSD claim amount rendering is updated to use the **actual per-transaction payout** by extracting the mUSD `Transfer` event from the confirmed transaction receipt, replacing the prior calldata-based decode that returned cumulative totals.
> 
> This introduces `getClaimPayoutFromReceipt()` in `Earn/utils/musd` (matches `Transfer` topic + mUSD token address + `from=MERKL_DISTRIBUTOR_ADDRESS` + `to=user`) and wires it into the Activity list (`decodeMusdClaimTx`), the transaction details hero (`useClaimAmount`), and the confirmations flow (`useMerklClaimAmount`, with receipt-first for confirmed txs and contract-computed fallback for pending). Tests are updated accordingly to validate log parsing and UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9674cf7471fcf7c6570a9f912e4ec03caf438be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->