### PR TITLE
feat(homepage): add DeFi section with positions display

### DIFF
--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { screen } from '@testing-library/react-native';
+import React, { createRef } from 'react';
+import { screen, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import DeFiSection from './DeFiSection';
+import { SectionRefreshHandle } from '../../types';
 
 jest.mock(
   '../../../../../selectors/featureFlagController/assetsDefiPositions',
@@ -10,18 +11,75 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(() => false),
+}));
+
+const mockUseDeFiPositionsForHomepage = jest.fn();
+
+jest.mock('./hooks', () => ({
+  useDeFiPositionsForHomepage: (...args: unknown[]) =>
+    mockUseDeFiPositionsForHomepage(...args),
+  DeFiPositionEntry: {},
+}));
+
+// Mock DeFiPositionsListItem to avoid deep import chain issues
+jest.mock('../../../../UI/DeFiPositions/DeFiPositionsListItem', () => {
+  const { Text } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  const MockComponent = ({
+    protocolAggregate,
+  }: {
+    protocolAggregate: { protocolDetails: { name: string } };
+  }) =>
+    ReactActual.createElement(
+      Text,
+      null,
+      protocolAggregate.protocolDetails.name,
+    );
+  MockComponent.displayName = 'DeFiPositionsListItem';
+  return MockComponent;
+});
+
+const createMockPosition = (name: string) => ({
+  chainId: '0x1',
+  protocolId: name.toLowerCase(),
+  protocolAggregate: {
+    protocolDetails: {
+      name,
+      iconUrl: `https://example.com/${name}.png`,
+    },
+    aggregatedMarketValue: 1000,
+    positionTypes: {},
+  },
+});
+
 describe('DeFiSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset mock return value to default (true) to ensure test isolation
+    // Reset mock return values to defaults
     jest
       .requireMock(
         '../../../../../selectors/featureFlagController/assetsDefiPositions',
       )
       .selectAssetsDefiPositionsEnabled.mockReturnValue(true);
+
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [],
+      isLoading: false,
+      hasError: false,
+      isEmpty: true,
+    });
   });
 
-  it('renders section title when enabled', () => {
+  it('renders section title when enabled with positions', () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [createMockPosition('Aave')],
+      isLoading: false,
+      hasError: false,
+      isEmpty: false,
+    });
+
     renderWithProvider(<DeFiSection />);
 
     expect(screen.getByText('DeFi')).toBeOnTheScreen();
@@ -37,5 +95,97 @@ describe('DeFiSection', () => {
     const { toJSON } = renderWithProvider(<DeFiSection />);
 
     expect(toJSON()).toBeNull();
+  });
+
+  it('returns null when positions are empty and not loading', () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [],
+      isLoading: false,
+      hasError: false,
+      isEmpty: true,
+    });
+
+    const { toJSON } = renderWithProvider(<DeFiSection />);
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null when there is an error and not loading', () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [],
+      isLoading: false,
+      hasError: true,
+      isEmpty: false,
+    });
+
+    const { toJSON } = renderWithProvider(<DeFiSection />);
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders skeleton when loading', () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [],
+      isLoading: true,
+      hasError: false,
+      isEmpty: false,
+    });
+
+    renderWithProvider(<DeFiSection />);
+
+    expect(screen.getByText('DeFi')).toBeOnTheScreen();
+    // Skeleton renders 3 placeholder items
+  });
+
+  it('renders DeFi positions list items', () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [createMockPosition('Aave'), createMockPosition('Uniswap')],
+      isLoading: false,
+      hasError: false,
+      isEmpty: false,
+    });
+
+    renderWithProvider(<DeFiSection />);
+
+    expect(screen.getByText('Aave')).toBeOnTheScreen();
+    expect(screen.getByText('Uniswap')).toBeOnTheScreen();
+  });
+
+  it('title is not interactive (no drill-down for DeFi)', () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [createMockPosition('Aave')],
+      isLoading: false,
+      hasError: false,
+      isEmpty: false,
+    });
+
+    renderWithProvider(<DeFiSection />);
+
+    // DeFi section title exists but is not interactive - no onPress passed to SectionTitle
+    expect(screen.getByText('DeFi')).toBeOnTheScreen();
+    // Verify no arrow icon is rendered (arrow only shows when onPress is provided)
+    expect(screen.queryByTestId('icon-arrow-right')).toBeNull();
+  });
+
+  it('exposes refresh function via ref', async () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [createMockPosition('Aave')],
+      isLoading: false,
+      hasError: false,
+      isEmpty: false,
+    });
+
+    const ref = createRef<SectionRefreshHandle>();
+
+    renderWithProvider(<DeFiSection ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current?.refresh).toBe('function');
+
+    await act(async () => {
+      await ref.current?.refresh();
+    });
+
+    // Refresh is a no-op for DeFi (data comes from controller)
   });
 });

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -1,23 +1,72 @@
 import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { View } from 'react-native';
 import { useSelector } from 'react-redux';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { Box } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useTheme } from '../../../../../util/theme';
 import SectionTitle from '../../components/SectionTitle';
 import SectionRow from '../../components/SectionRow';
 import { SectionRefreshHandle } from '../../types';
+import { useDeFiPositionsForHomepage, DeFiPositionEntry } from './hooks';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
+import DeFiPositionsListItem from '../../../../UI/DeFiPositions/DeFiPositionsListItem';
 import { selectAssetsDefiPositionsEnabled } from '../../../../../selectors/featureFlagController/assetsDefiPositions';
 import { strings } from '../../../../../../locales/i18n';
 
+const MAX_POSITIONS_DISPLAYED = 5;
+
 /**
- * DeFiSection - Displays DeFi positions on the homepage
+ * Skeleton placeholder for loading state - matches DeFi list item layout
+ */
+const DeFiPositionsSkeleton = () => {
+  const { colors } = useTheme();
+  const tw = useTailwind();
+
+  return (
+    <SkeletonPlaceholder
+      backgroundColor={colors.background.section}
+      highlightColor={colors.background.subsection}
+    >
+      <View style={tw.style('gap-4')}>
+        {Array.from({ length: 3 }, (_, index) => (
+          <View
+            key={index}
+            style={tw.style('flex-row items-center gap-5 py-2')}
+          >
+            <View style={tw.style('w-10 h-10 rounded-full')} />
+            <View style={tw.style('flex-1 gap-1')}>
+              <View style={tw.style('w-32 h-5 rounded')} />
+              <View style={tw.style('w-24 h-4 rounded')} />
+            </View>
+            <View style={tw.style('items-end gap-1')}>
+              <View style={tw.style('w-16 h-5 rounded')} />
+              <View style={tw.style('w-12 h-4 rounded')} />
+            </View>
+          </View>
+        ))}
+      </View>
+    </SkeletonPlaceholder>
+  );
+};
+
+/**
+ * DeFiSection - Displays user's DeFi positions on the homepage.
  *
- * Only renders when the DeFi positions feature flag is enabled.
+ * Only renders if the user has DeFi positions.
+ * Uses Redux state from DeFiPositionsController.
  */
 const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const isDeFiEnabled = useSelector(selectAssetsDefiPositionsEnabled);
+  const privacyMode = useSelector(selectPrivacyMode);
   const title = strings('homepage.sections.defi');
 
+  const { positions, isLoading, hasError, isEmpty } =
+    useDeFiPositionsForHomepage(MAX_POSITIONS_DISPLAYED);
+
+  // DeFi positions come from Redux selectors - no async refresh needed
   const refresh = useCallback(async () => {
-    // TODO: Implement DeFi refresh logic
+    // Data refreshes automatically via DeFiPositionsController
   }, []);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
@@ -27,11 +76,30 @@ const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     return null;
   }
 
+  // Don't render if error or empty (and not loading)
+  if (!isLoading && (hasError || isEmpty)) {
+    return null;
+  }
+
   return (
     <Box gap={3}>
       <SectionTitle title={title} />
       <SectionRow>
-        <>{/* DeFi content will be added here */}</>
+        <Box>
+          {isLoading ? (
+            <DeFiPositionsSkeleton />
+          ) : (
+            positions.map((position: DeFiPositionEntry) => (
+              <DeFiPositionsListItem
+                key={`${position.chainId}-${position.protocolAggregate.protocolDetails.name}`}
+                chainId={position.chainId}
+                protocolId={position.protocolId}
+                protocolAggregate={position.protocolAggregate}
+                privacyMode={privacyMode}
+              />
+            ))
+          )}
+        </Box>
       </SectionRow>
     </Box>
   );

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/index.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useDeFiPositionsForHomepage';

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useDeFiPositionsForHomepage } from './useDeFiPositionsForHomepage';
+
+const mockSelectDeFiPositionsByAddress = jest.fn();
+const mockSelectDefiPositionsByEnabledNetworks = jest.fn();
+const mockSelectTokenSortConfig = jest.fn();
+
+jest.mock('../../../../../../selectors/defiPositionsController', () => ({
+  selectDeFiPositionsByAddress: () => mockSelectDeFiPositionsByAddress(),
+  selectDefiPositionsByEnabledNetworks: () =>
+    mockSelectDefiPositionsByEnabledNetworks(),
+}));
+
+jest.mock('../../../../../../selectors/preferencesController', () => ({
+  selectTokenSortConfig: () => mockSelectTokenSortConfig(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('../../../../../UI/Tokens/util', () => ({
+  sortAssets: jest.fn((assets) => assets),
+}));
+
+const createMockProtocolAggregate = (name: string, marketValue: number) => ({
+  protocolDetails: {
+    name,
+    iconUrl: `https://example.com/${name}.png`,
+  },
+  aggregatedMarketValue: marketValue,
+  positionTypes: {},
+});
+
+describe('useDeFiPositionsForHomepage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectTokenSortConfig.mockReturnValue({
+      key: 'tokenFiatAmount',
+      order: 'dsc',
+    });
+  });
+
+  it('returns loading state when defiPositions is undefined', () => {
+    mockSelectDeFiPositionsByAddress.mockReturnValue(undefined);
+    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useDeFiPositionsForHomepage());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.hasError).toBe(false);
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.positions).toEqual([]);
+  });
+
+  it('returns error state when defiPositions is null', () => {
+    mockSelectDeFiPositionsByAddress.mockReturnValue(null);
+    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(null);
+
+    const { result } = renderHook(() => useDeFiPositionsForHomepage());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.positions).toEqual([]);
+  });
+
+  it('returns empty state when defiPositions is empty object', () => {
+    mockSelectDeFiPositionsByAddress.mockReturnValue({});
+    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue({});
+
+    const { result } = renderHook(() => useDeFiPositionsForHomepage());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasError).toBe(false);
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.positions).toEqual([]);
+  });
+
+  it('returns positions flattened from multiple chains', () => {
+    const mockPositions = {
+      '0x1': {
+        protocols: {
+          aave: createMockProtocolAggregate('Aave', 1000),
+          uniswap: createMockProtocolAggregate('Uniswap', 500),
+        },
+      },
+      '0x89': {
+        protocols: {
+          quickswap: createMockProtocolAggregate('QuickSwap', 300),
+        },
+      },
+    };
+
+    mockSelectDeFiPositionsByAddress.mockReturnValue(mockPositions);
+    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(mockPositions);
+
+    const { result } = renderHook(() => useDeFiPositionsForHomepage());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasError).toBe(false);
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.positions).toHaveLength(3);
+  });
+
+  it('limits positions to maxPositions parameter', () => {
+    const mockPositions = {
+      '0x1': {
+        protocols: {
+          aave: createMockProtocolAggregate('Aave', 1000),
+          uniswap: createMockProtocolAggregate('Uniswap', 500),
+          compound: createMockProtocolAggregate('Compound', 400),
+          curve: createMockProtocolAggregate('Curve', 300),
+        },
+      },
+    };
+
+    mockSelectDeFiPositionsByAddress.mockReturnValue(mockPositions);
+    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(mockPositions);
+
+    const { result } = renderHook(() => useDeFiPositionsForHomepage(2));
+
+    expect(result.current.positions).toHaveLength(2);
+  });
+});

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
@@ -1,0 +1,138 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
+import { GroupedDeFiPositions } from '@metamask/assets-controllers';
+import { toHex } from '@metamask/controller-utils';
+import {
+  selectDeFiPositionsByAddress,
+  selectDefiPositionsByEnabledNetworks,
+} from '../../../../../../selectors/defiPositionsController';
+import { selectTokenSortConfig } from '../../../../../../selectors/preferencesController';
+import { sortAssets } from '../../../../../UI/Tokens/util';
+
+/**
+ * Represents a single DeFi position entry for the homepage.
+ * This matches the props expected by DeFiPositionsListItem.
+ */
+export interface DeFiPositionEntry {
+  chainId: Hex;
+  protocolId: string;
+  protocolAggregate: GroupedDeFiPositions['protocols'][number];
+}
+
+export interface UseDeFiPositionsForHomepageResult {
+  /** Array of DeFi positions, limited to maxPositions */
+  positions: DeFiPositionEntry[];
+  /** True when position data is still loading (undefined state) */
+  isLoading: boolean;
+  /** True when there was an error fetching positions (null state) */
+  hasError: boolean;
+  /** True when positions loaded successfully but array is empty */
+  isEmpty: boolean;
+}
+
+const MAX_POSITIONS_DEFAULT = 5;
+
+/**
+ * Lightweight hook for retrieving DeFi positions for the homepage.
+ *
+ * This hook reads from the DeFiPositionsController state (already populated
+ * by the controller's background polling) and formats the data for display.
+ *
+ * Positions are sorted by market value (descending) and limited to maxPositions.
+ *
+ * @param maxPositions - Maximum number of positions to return (default: 5)
+ * @returns DeFi positions data with loading/error/empty states
+ */
+export const useDeFiPositionsForHomepage = (
+  maxPositions: number = MAX_POSITIONS_DEFAULT,
+): UseDeFiPositionsForHomepageResult => {
+  const tokenSortConfig = useSelector(selectTokenSortConfig);
+  const defiPositions = useSelector(selectDeFiPositionsByAddress);
+  const defiPositionsByEnabledNetworks = useSelector(
+    selectDefiPositionsByEnabledNetworks,
+  );
+
+  const result = useMemo((): UseDeFiPositionsForHomepageResult => {
+    // Loading state - data not yet available
+    if (defiPositions === undefined) {
+      return {
+        positions: [],
+        isLoading: true,
+        hasError: false,
+        isEmpty: false,
+      };
+    }
+
+    // Error state - data fetch failed
+    if (defiPositions === null) {
+      return {
+        positions: [],
+        isLoading: false,
+        hasError: true,
+        isEmpty: false,
+      };
+    }
+
+    const chainFilteredDeFiPositions = defiPositionsByEnabledNetworks as {
+      [key: Hex]: GroupedDeFiPositions;
+    };
+
+    if (!chainFilteredDeFiPositions) {
+      return {
+        positions: [],
+        isLoading: false,
+        hasError: false,
+        isEmpty: true,
+      };
+    }
+
+    // Flatten positions from all chains and protocols
+    const defiPositionsList: DeFiPositionEntry[] = Object.entries(
+      chainFilteredDeFiPositions,
+    )
+      .map(([chainId, chainDeFiPositions]) =>
+        Object.entries(chainDeFiPositions.protocols).map(
+          ([protocolId, protocolAggregate]) => ({
+            chainId: toHex(chainId),
+            protocolId,
+            protocolAggregate,
+          }),
+        ),
+      )
+      .flat();
+
+    // Sort by market value (descending) or name
+    const defiSortConfig = {
+      ...tokenSortConfig,
+      key:
+        tokenSortConfig.key === 'tokenFiatAmount'
+          ? 'protocolAggregate.aggregatedMarketValue'
+          : 'protocolAggregate.protocolDetails.name',
+    };
+
+    const sortedPositions = sortAssets(
+      defiPositionsList,
+      defiSortConfig,
+    ) as DeFiPositionEntry[];
+
+    // Limit to maxPositions
+    const limitedPositions = sortedPositions.slice(0, maxPositions);
+
+    return {
+      positions: limitedPositions,
+      isLoading: false,
+      hasError: false,
+      isEmpty: limitedPositions.length === 0,
+    };
+  }, [
+    defiPositions,
+    defiPositionsByEnabledNetworks,
+    tokenSortConfig,
+    maxPositions,
+  ]);
+
+  return result;
+};
+
+export default useDeFiPositionsForHomepage;


### PR DESCRIPTION
## **Description**

This PR adds the DeFi section to the new Homepage, displaying the user's top DeFi positions.

**What changed:**
- Added `useDeFiPositionsForHomepage` hook that fetches DeFi positions from the `DeFiPositionsController` Redux state
- Positions are sorted by market value (descending) and limited to 5
- Added skeleton loading state with shimmer effect
- Section only renders when the user has DeFi positions and the feature flag is enabled
- Added comprehensive unit tests for both the hook and component

**Why:**
Part of the Homepage redesign to consolidate wallet views into a single scrollable homepage with sections for Tokens, Perpetuals, Predictions, DeFi, and NFTs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [TMCU-420](https://consensyssoftware.atlassian.net/browse/TMCU-420)
Refs: [TMCU-414](https://consensyssoftware.atlassian.net/browse/TMCU-414)
Refs: [TMCU-457](https://consensyssoftware.atlassian.net/browse/TMCU-457)

## **Manual testing steps**

```gherkin
Feature: DeFi section on Homepage

  Scenario: user views DeFi positions on homepage
    Given user has DeFi positions (e.g., Aave, Uniswap deposits)
    And the homepage sections feature flag is enabled
    And the DeFi feature flag is enabled

    When user navigates to the wallet homepage
    Then user sees a "DeFi" section with their top 5 positions
    And each position shows protocol name, icon, and value

  Scenario: user with no DeFi positions
    Given user has no DeFi positions
    And the homepage sections feature flag is enabled

    When user navigates to the wallet homepage
    Then the DeFi section is not displayed

  Scenario: DeFi positions loading
    Given user has DeFi positions
    And positions are still loading

    When user navigates to the wallet homepage
    Then user sees skeleton placeholders in the DeFi section
```

## **Screenshots/Recordings**

### **Before**

#### Feature flag OFF (no changes)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b21b053e-db87-46f8-8607-9be9a77d5a20" />


#### Feature flag ON 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ad7f2305-1b35-43af-8b19-b805a746ba20" />


### **After**

#### Feature flag OFF (no changes)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b21b053e-db87-46f8-8607-9be9a77d5a20" />

#### Feature flag ON 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/142998bd-8a09-47ea-9831-c054a121feb2" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-420]: https://consensyssoftware.atlassian.net/browse/TMCU-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMCU-414]: https://consensyssoftware.atlassian.net/browse/TMCU-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMCU-457]: https://consensyssoftware.atlassian.net/browse/TMCU-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI now depends on DeFiPositionsController-derived data shaping and sorting; regressions could hide positions or misorder them, but changes are scoped to homepage rendering and tests are included.
> 
> **Overview**
> Adds a functional **DeFi** homepage section that renders up to 5 DeFi protocol positions from controller-backed Redux state, including a skeleton loading UI and `privacyMode`-aware list items.
> 
> Introduces `useDeFiPositionsForHomepage` to flatten multi-chain protocol data, derive loading/error/empty states, and sort/limit positions for display; the section now hides itself when disabled, empty, or errored, and exposes a no-op `refresh` via ref. Comprehensive unit tests were added/expanded for both the hook and the section behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce743bd412ad1d853fd98a4ec480e6b3027da25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->