### PR TITLE
chore: bump `@metamask/tron-wallet-snap` version to `^1.22.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/transaction-controller": "^62.16.0",
     "@metamask/transaction-pay-controller": "^15.0.1",
-    "@metamask/tron-wallet-snap": "^1.21.1",
+    "@metamask/tron-wallet-snap": "^1.22.0",
     "@metamask/utils": "^11.8.1",
     "@myx-trade/sdk": "^0.1.265",
     "@ngraveio/bc-ur": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10206,10 +10206,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.21.1":
-  version: 1.21.1
-  resolution: "@metamask/tron-wallet-snap@npm:1.21.1"
-  checksum: 10/02b479ad79758dc7ddafd694f4d54ed1e928d98740fc89e489b951f0029a02aeab1f8b5a565139a2ce17c52fd1c109007ebbe27938ff7b92c539e62b35ec838d
+"@metamask/tron-wallet-snap@npm:^1.22.0":
+  version: 1.22.0
+  resolution: "@metamask/tron-wallet-snap@npm:1.22.0"
+  checksum: 10/454fbeef40468b19187468995d0f0d59cec699586a4b6e240238bdd44090861a1250e35b4271b9a4986638553009b3d1980375003402023f7e9b7c845c740b7b
   languageName: node
   linkType: hard
 
@@ -35524,7 +35524,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^62.16.0"
     "@metamask/transaction-pay-controller": "npm:^15.0.1"
-    "@metamask/tron-wallet-snap": "npm:^1.21.1"
+    "@metamask/tron-wallet-snap": "npm:^1.22.0"
     "@metamask/utils": "npm:^11.8.1"
     "@myx-trade/sdk": "npm:^0.1.265"
     "@ngraveio/bc-ur": "npm:^1.1.6"


### PR DESCRIPTION
## **Description**

This PR bumps the Tron snap to the latest version bringing in a fix for empty IDs on derived accounts leading to state saving failures during account discovery.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

n/a

## **Manual testing steps**

All Tron features

## **Screenshots/Recordings**

### **Before**

n/a

### **After**

n/a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump; behavior changes are confined to the Tron snap version update.
> 
> **Overview**
> Bumps `@metamask/tron-wallet-snap` from `^1.21.1` to `^1.22.0`.
> 
> Updates `yarn.lock` accordingly to resolve the new snap version (no other dependency or code changes in this diff).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f3595146effd0c60e55bb5dab86cb5c075ecf76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->