### PR TITLE
Perps view tests failures

### DIFF
--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.view.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.view.test.tsx
@@ -38,8 +38,8 @@ describe('PerpsLimitPriceBottomSheet', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders price preset buttons (Mid, Bid, Ask)', async () => {
-    renderLimitPriceSheet();
+  it('renders price preset buttons for long direction', async () => {
+    renderLimitPriceSheet({ direction: 'long' });
 
     await screen.findByText(strings('perps.order.limit_price_modal.title'));
 
@@ -50,8 +50,24 @@ describe('PerpsLimitPriceBottomSheet', () => {
       screen.getByText(strings('perps.order.limit_price_modal.bid_price')),
     ).toBeOnTheScreen();
     expect(
+      screen.queryByText(strings('perps.order.limit_price_modal.ask_price')),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders ask preset button for short direction', async () => {
+    renderLimitPriceSheet({ direction: 'short' });
+
+    await screen.findByText(strings('perps.order.limit_price_modal.title'));
+
+    expect(
+      screen.getByText(strings('perps.order.limit_price_modal.mid_price')),
+    ).toBeOnTheScreen();
+    expect(
       screen.getByText(strings('perps.order.limit_price_modal.ask_price')),
     ).toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.order.limit_price_modal.bid_price')),
+    ).not.toBeOnTheScreen();
   });
 
   it('does not render when isVisible is false', () => {

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.view.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.view.test.tsx
@@ -6,7 +6,8 @@
  * Run with: yarn test:view --testPathPattern="PerpsMarketTabs.view.test"
  */
 import '../../../../../../tests/component-view/mocks';
-import { fireEvent, screen } from '@testing-library/react-native';
+import { screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
 import {
   renderPerpsComponent,
   defaultPositionForViews,
@@ -28,38 +29,53 @@ const renderMarketTabs = (
 describe('PerpsMarketTabs', () => {
   describe('tab navigation', () => {
     it('renders tab container with position, orders, and statistics tabs', async () => {
-      renderMarketTabs({}, { positions: [defaultPositionForViews] });
+      renderMarketTabs(
+        {},
+        {
+          positions: [defaultPositionForViews],
+          orders: [defaultOrderForViews],
+        },
+      );
 
       expect(
         await screen.findByTestId(PerpsMarketTabsSelectorsIDs.CONTAINER),
       ).toBeOnTheScreen();
+      expect(
+        screen.queryAllByText(strings('perps.market.position')).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.queryAllByText(strings('perps.market.orders')).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.queryAllByText(strings('perps.market.statistics')).length,
+      ).toBeGreaterThan(0);
     });
 
-    it('switches to orders tab and shows empty state when no orders', async () => {
+    it('hides orders tab when no orders exist', async () => {
       renderMarketTabs(
         {},
         { positions: [defaultPositionForViews], orders: [] },
       );
 
-      const ordersTab = await screen.findByTestId(
-        PerpsMarketTabsSelectorsIDs.ORDERS_TAB,
-      );
-      fireEvent.press(ordersTab);
-
       expect(
-        await screen.findByTestId(
-          PerpsMarketTabsSelectorsIDs.ORDERS_EMPTY_STATE,
-        ),
+        await screen.findByTestId(PerpsMarketTabsSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+      expect(screen.queryAllByText(strings('perps.market.orders'))).toHaveLength(
+        0,
+      );
+      expect(
+        screen.getByTestId(PerpsMarketTabsSelectorsIDs.STATISTICS_CONTENT),
       ).toBeOnTheScreen();
     });
 
-    it('switches to statistics tab', async () => {
-      renderMarketTabs({}, { positions: [] });
-
-      const statisticsTab = await screen.findByTestId(
-        PerpsMarketTabsSelectorsIDs.STATISTICS_TAB,
+    it('renders statistics content when statistics is initial tab', async () => {
+      renderMarketTabs(
+        { initialTab: 'statistics' },
+        {
+          positions: [defaultPositionForViews],
+          orders: [defaultOrderForViews],
+        },
       );
-      fireEvent.press(statisticsTab);
 
       expect(
         await screen.findByTestId(
@@ -71,10 +87,13 @@ describe('PerpsMarketTabs', () => {
 
   describe('position tab with position data', () => {
     it('renders position card when a matching position exists in stream', async () => {
-      renderMarketTabs({}, { positions: [defaultPositionForViews] });
+      renderMarketTabs(
+        { initialTab: 'position' },
+        { positions: [defaultPositionForViews] },
+      );
 
       expect(
-        await screen.findByTestId(PerpsMarketTabsSelectorsIDs.POSITION_TAB),
+        await screen.findByTestId(PerpsMarketTabsSelectorsIDs.POSITION_CONTENT),
       ).toBeOnTheScreen();
     });
   });
@@ -82,17 +101,12 @@ describe('PerpsMarketTabs', () => {
   describe('orders tab with order data', () => {
     it('renders order card when orders exist for the symbol', async () => {
       renderMarketTabs(
-        {},
+        { initialTab: 'orders' },
         {
           positions: [],
           orders: [defaultOrderForViews],
         },
       );
-
-      const ordersTab = await screen.findByTestId(
-        PerpsMarketTabsSelectorsIDs.ORDERS_TAB,
-      );
-      fireEvent.press(ordersTab);
 
       expect(
         await screen.findByTestId(PerpsMarketTabsSelectorsIDs.ORDERS_CONTENT),

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -162,6 +162,13 @@ jest.mock('../../app/core/Engine', () => {
         getOrders: jest.fn().mockResolvedValue([]),
         getOpenOrders: jest.fn().mockResolvedValue([]),
         getAccountState: jest.fn().mockResolvedValue(null),
+        depositWithOrder: jest.fn().mockResolvedValue({
+          result: Promise.resolve('0xcomponent-view-deposit'),
+        }),
+        depositWithConfirmation: jest.fn().mockResolvedValue({
+          result: Promise.resolve('0xcomponent-view-deposit'),
+        }),
+        clearDepositResult: jest.fn(),
         calculateFees: jest.fn().mockResolvedValue({}),
         calculateLiquidationPrice: jest.fn().mockResolvedValue('0.00'),
         flipPosition: jest.fn().mockResolvedValue({ success: false }),

--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -687,7 +687,11 @@ export function renderPerpsComponent(
     </PerpsConnectionContext.Provider>
   );
 
-  return renderWithProvider(<WrappedComponent />, { state });
+  return renderComponentViewScreen(
+    WrappedComponent as unknown as React.ComponentType,
+    { name: 'PerpsComponentTestRoute' },
+    { state },
+  );
 }
 
 /**
@@ -722,7 +726,11 @@ export function renderPerpsComponentDisconnected(
     </PerpsConnectionContext.Provider>
   );
 
-  return renderWithProvider(<WrappedComponent />, { state });
+  return renderComponentViewScreen(
+    WrappedComponent as unknown as React.ComponentType,
+    { name: 'PerpsComponentDisconnectedTestRoute' },
+    { state },
+  );
 }
 
 /** Default order for tests that need stream orders. */


### PR DESCRIPTION
Fixes failing Perps component view tests by updating the test renderer, mocks, and test assertions to align with current component behavior.

Several Perps component view tests were failing because the test environment lacked a navigation context for components using `useNavigation`, assertions were outdated for dynamic UI elements (e.g., market tabs and price presets), and the `PerpsController` mock was incomplete for certain actions.

---
<p><a href="https://cursor.com/agents?id=bc-62544d24-9b65-4324-9de4-06f30fdbd543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62544d24-9b65-4324-9de4-06f30fdbd543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

