### PR TITLE
chore: filter out Tron staking special assets

### DIFF
--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
@@ -6,8 +6,8 @@ import ResourceRing from './ResourceRing';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../util/test/initial-root-state';
 import {
-  selectTronResourcesBySelectedAccountGroup,
-  TronResourcesMap,
+  selectTronSpecialAssetsBySelectedAccountGroup,
+  TronSpecialAssetsMap,
 } from '../../../../selectors/assets/assets-list';
 
 jest.mock('./ResourceRing', () => ({
@@ -33,14 +33,14 @@ jest.mock('../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('../../../../selectors/assets/assets-list', () => ({
-  selectTronResourcesBySelectedAccountGroup: jest.fn(),
+  selectTronSpecialAssetsBySelectedAccountGroup: jest.fn(),
 }));
 
 type SelectorReturn = ReturnType<
-  typeof selectTronResourcesBySelectedAccountGroup
+  typeof selectTronSpecialAssetsBySelectedAccountGroup
 >;
 
-const createEmptyResourcesMap = (): TronResourcesMap => ({
+const createEmptySpecialAssetsMap = (): TronSpecialAssetsMap => ({
   energy: undefined,
   bandwidth: undefined,
   maxEnergy: undefined,
@@ -48,6 +48,9 @@ const createEmptyResourcesMap = (): TronResourcesMap => ({
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
   totalStakedTrx: 0,
+  trxReadyForWithdrawal: undefined,
+  trxStakingRewards: undefined,
+  trxInLockPeriod: undefined,
 });
 
 interface Resource {
@@ -78,7 +81,7 @@ describe('TronEnergyBandwidthDetail', () => {
   });
 
   it('renders values, coverage counts, and passes correct progress to ResourceRing', () => {
-    jest.mocked(selectTronResourcesBySelectedAccountGroup).mockReturnValue({
+    jest.mocked(selectTronSpecialAssetsBySelectedAccountGroup).mockReturnValue({
       energy: res('energy', 130000),
       bandwidth: res('bandwidth', 560),
       maxEnergy: res('max-energy', 200000),
@@ -110,7 +113,7 @@ describe('TronEnergyBandwidthDetail', () => {
   });
 
   it('parses balances and caps progress', () => {
-    jest.mocked(selectTronResourcesBySelectedAccountGroup).mockReturnValue({
+    jest.mocked(selectTronSpecialAssetsBySelectedAccountGroup).mockReturnValue({
       energy: res('energy', '1000'),
       bandwidth: res('bandwidth', '2000'),
       maxEnergy: res('max-energy', '400'),
@@ -136,8 +139,8 @@ describe('TronEnergyBandwidthDetail', () => {
 
   it('handles missing resources by showing zeros and 0 progress', () => {
     jest
-      .mocked(selectTronResourcesBySelectedAccountGroup)
-      .mockReturnValue(createEmptyResourcesMap());
+      .mocked(selectTronSpecialAssetsBySelectedAccountGroup)
+      .mockReturnValue(createEmptySpecialAssetsMap());
 
     const { getAllByText, getByText } = renderWithProvider(
       <TronEnergyBandwidthDetail />,

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.test.ts
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.test.ts
@@ -4,8 +4,8 @@ import { useSelector } from 'react-redux';
 
 import { useTronResources } from './useTronResources';
 import {
-  selectTronResourcesBySelectedAccountGroup,
-  TronResourcesMap,
+  selectTronSpecialAssetsBySelectedAccountGroup,
+  TronSpecialAssetsMap,
 } from '../../../../selectors/assets/assets-list';
 
 jest.mock('react-redux', () => ({
@@ -15,13 +15,13 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../selectors/assets/assets-list', () => ({
   __esModule: true,
   ...jest.requireActual('../../../../selectors/assets/assets-list'),
-  selectTronResourcesBySelectedAccountGroup: jest.fn(),
+  selectTronSpecialAssetsBySelectedAccountGroup: jest.fn(),
 }));
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockSelectTronResourcesBySelectedAccountGroup =
-  selectTronResourcesBySelectedAccountGroup as jest.MockedFunction<
-    typeof selectTronResourcesBySelectedAccountGroup
+const mockSelectTronSpecialAssetsBySelectedAccountGroup =
+  selectTronSpecialAssetsBySelectedAccountGroup as jest.MockedFunction<
+    typeof selectTronSpecialAssetsBySelectedAccountGroup
   >;
 
 interface MockTronAsset {
@@ -29,7 +29,7 @@ interface MockTronAsset {
   balance?: string | number;
 }
 
-const createEmptyResourcesMap = (): TronResourcesMap => ({
+const createEmptySpecialAssetsMap = (): TronSpecialAssetsMap => ({
   energy: undefined,
   bandwidth: undefined,
   maxEnergy: undefined,
@@ -37,6 +37,9 @@ const createEmptyResourcesMap = (): TronResourcesMap => ({
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
   totalStakedTrx: 0,
+  trxReadyForWithdrawal: undefined,
+  trxStakingRewards: undefined,
+  trxInLockPeriod: undefined,
 });
 
 const createTronAsset = (
@@ -52,13 +55,13 @@ describe('useTronResources', () => {
     jest.clearAllMocks();
 
     mockUseSelector.mockImplementation((selector: any) => selector());
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue(
-      createEmptyResourcesMap(),
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue(
+      createEmptySpecialAssetsMap(),
     );
   });
 
   it('builds energy and bandwidth resources from base max capacity', () => {
-    const tronResourcesMap: TronResourcesMap = {
+    const tronSpecialAssetsMap: TronSpecialAssetsMap = {
       energy: createTronAsset('energy', '500') as any,
       bandwidth: createTronAsset('bandwidth', '300') as any,
       maxEnergy: createTronAsset('max-energy', '1000') as any,
@@ -66,10 +69,13 @@ describe('useTronResources', () => {
       stakedTrxForEnergy: createTronAsset('strx-energy', '500') as any,
       stakedTrxForBandwidth: createTronAsset('strx-bandwidth', 0) as any,
       totalStakedTrx: 500,
+      trxReadyForWithdrawal: undefined,
+      trxStakingRewards: undefined,
+      trxInLockPeriod: undefined,
     };
 
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue(
-      tronResourcesMap,
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue(
+      tronSpecialAssetsMap,
     );
 
     const { result } = renderHook(() => useTronResources());
@@ -84,8 +90,8 @@ describe('useTronResources', () => {
   });
 
   it('returns zeroed resources when no Tron resources exist', () => {
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue(
-      createEmptyResourcesMap(),
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue(
+      createEmptySpecialAssetsMap(),
     );
 
     const { result } = renderHook(() => useTronResources());
@@ -106,14 +112,14 @@ describe('useTronResources', () => {
   });
 
   it('parses balances with comma separators', () => {
-    const tronResourcesMap: TronResourcesMap = {
-      ...createEmptyResourcesMap(),
+    const tronSpecialAssetsMap: TronSpecialAssetsMap = {
+      ...createEmptySpecialAssetsMap(),
       energy: createTronAsset('energy', '1,000') as any,
       maxEnergy: createTronAsset('max-energy', '2,000') as any,
     };
 
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue(
-      tronResourcesMap,
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue(
+      tronSpecialAssetsMap,
     );
 
     const { result } = renderHook(() => useTronResources());
@@ -124,14 +130,14 @@ describe('useTronResources', () => {
   });
 
   it('caps percentage at one hundred when current exceeds max', () => {
-    const tronResourcesMap: TronResourcesMap = {
-      ...createEmptyResourcesMap(),
+    const tronSpecialAssetsMap: TronSpecialAssetsMap = {
+      ...createEmptySpecialAssetsMap(),
       energy: createTronAsset('energy', 200) as any,
       maxEnergy: createTronAsset('max-energy', 100) as any,
     };
 
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue(
-      tronResourcesMap,
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue(
+      tronSpecialAssetsMap,
     );
 
     const { result } = renderHook(() => useTronResources());
@@ -141,14 +147,14 @@ describe('useTronResources', () => {
   });
 
   it('sets percentage to zero when balances cannot be parsed', () => {
-    const tronResourcesMap: TronResourcesMap = {
-      ...createEmptyResourcesMap(),
+    const tronSpecialAssetsMap: TronSpecialAssetsMap = {
+      ...createEmptySpecialAssetsMap(),
       energy: createTronAsset('energy', 'invalid') as any,
       maxEnergy: createTronAsset('max-energy', '1000') as any,
     };
 
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue(
-      tronResourcesMap,
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue(
+      tronSpecialAssetsMap,
     );
 
     const { result } = renderHook(() => useTronResources());

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/useTronResources.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 
-import { selectTronResourcesBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
+import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
 import { safeParseBigNumber } from '../../../../util/number/bignumber';
 
 export interface TronResource {
@@ -49,7 +49,7 @@ export const useTronResources = (): {
   bandwidth: TronResource;
 } => {
   const { energy, bandwidth, maxEnergy, maxBandwidth } = useSelector(
-    selectTronResourcesBySelectedAccountGroup,
+    selectTronSpecialAssetsBySelectedAccountGroup,
   );
 
   return useMemo(() => {

--- a/app/components/UI/Bridge/utils/isTradableToken/index.test.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.test.ts
@@ -238,5 +238,38 @@ describe('isTradableToken', () => {
 
       expect(result).toBe(false);
     });
+
+    it('returns false for Tron Ready for Withdrawal token', () => {
+      const token = createTestToken({
+        chainId: TrxScope.Mainnet,
+        symbol: 'TRX-READY-FOR-WITHDRAWAL',
+      });
+
+      const result = isTradableToken(token);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for Tron Staking Rewards token', () => {
+      const token = createTestToken({
+        chainId: TrxScope.Mainnet,
+        symbol: 'TRX-STAKING-REWARDS',
+      });
+
+      const result = isTradableToken(token);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for Tron In Lock Period token', () => {
+      const token = createTestToken({
+        chainId: TrxScope.Mainnet,
+        symbol: 'TRX-IN-LOCK-PERIOD',
+      });
+
+      const result = isTradableToken(token);
+
+      expect(result).toBe(false);
+    });
   });
 });

--- a/app/components/UI/Bridge/utils/isTradableToken/index.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.ts
@@ -1,16 +1,8 @@
 import { TrxScope } from '@metamask/keyring-api';
 import { BridgeToken } from '../../types';
-import {
-  TRON_RESOURCE_SYMBOLS,
-  TronResourceSymbol,
-} from '../../../../../core/Multichain/constants';
+import { isTronSpecialAsset } from '../../../../../core/Multichain/utils';
 import { TokenI } from '../../../Tokens/types';
 
-export const isTradableToken = (token: BridgeToken | TokenI) => {
-  if (token.chainId === TrxScope.Mainnet) {
-    return !TRON_RESOURCE_SYMBOLS.includes(
-      token.symbol?.toLowerCase() as TronResourceSymbol,
-    );
-  }
-  return true;
-};
+export const isTradableToken = (token: BridgeToken | TokenI) =>
+  token.chainId !== TrxScope.Mainnet ||
+  !isTronSpecialAsset(token.chainId, token.symbol);

--- a/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
@@ -5,7 +5,7 @@ import StakingBalance from '../../../Stake/components/StakingBalance/StakingBala
 import { TokenI } from '../../../Tokens/types';
 import EarnLendingBalance from '../EarnLendingBalance';
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
-import { selectTronResourcesBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
+import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import TronStakingButtons from '../Tron/TronStakingButtons';
 import { selectIsMusdConversionFlowEnabledFlag } from '../../selectors/featureFlags';
 
@@ -27,7 +27,7 @@ jest.mock(
 
 jest.mock('../../../../../selectors/assets/assets-list', () => ({
   ...jest.requireActual('../../../../../selectors/assets/assets-list'),
-  selectTronResourcesBySelectedAccountGroup: jest.fn(),
+  selectTronSpecialAssetsBySelectedAccountGroup: jest.fn(),
 }));
 
 jest.mock('../Tron/TronStakingButtons', () => ({
@@ -137,7 +137,7 @@ jest.mock('../../hooks/useTronStakeApy', () => ({
   }),
 }));
 
-const createEmptyResourcesMap = () => ({
+const createEmptySpecialAssetsMap = () => ({
   energy: undefined,
   bandwidth: undefined,
   maxEnergy: undefined,
@@ -145,6 +145,9 @@ const createEmptyResourcesMap = () => ({
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
   totalStakedTrx: 0,
+  trxReadyForWithdrawal: undefined,
+  trxStakingRewards: undefined,
+  trxInLockPeriod: undefined,
 });
 
 describe('EarnBalance', () => {
@@ -152,8 +155,8 @@ describe('EarnBalance', () => {
     jest.clearAllMocks();
     (jest.mocked(selectTrxStakingEnabled) as jest.Mock).mockReturnValue(false);
     (
-      jest.mocked(selectTronResourcesBySelectedAccountGroup) as jest.Mock
-    ).mockReturnValue(createEmptyResourcesMap());
+      jest.mocked(selectTronSpecialAssetsBySelectedAccountGroup) as jest.Mock
+    ).mockReturnValue(createEmptySpecialAssetsMap());
   });
 
   describe('Ethereum Mainnet', () => {
@@ -251,7 +254,7 @@ describe('EarnBalance', () => {
   describe('TRON', () => {
     const mockFlag = selectTrxStakingEnabled as unknown as jest.Mock;
     const mockTronResources =
-      selectTronResourcesBySelectedAccountGroup as unknown as jest.Mock;
+      selectTronSpecialAssetsBySelectedAccountGroup as unknown as jest.Mock;
 
     it('renders TRON stake button with aprText for TRX without staked positions', () => {
       const trx: Partial<TokenI> = {
@@ -261,7 +264,7 @@ describe('EarnBalance', () => {
       };
 
       mockFlag.mockReturnValue(true);
-      mockTronResources.mockReturnValue(createEmptyResourcesMap());
+      mockTronResources.mockReturnValue(createEmptySpecialAssetsMap());
 
       renderWithProvider(<EarnBalance asset={trx as TokenI} />);
 
@@ -283,7 +286,7 @@ describe('EarnBalance', () => {
 
       mockFlag.mockReturnValue(true);
       mockTronResources.mockReturnValue({
-        ...createEmptyResourcesMap(),
+        ...createEmptySpecialAssetsMap(),
         stakedTrxForEnergy: { symbol: 'strx-energy', balance: '1' },
         stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '2' },
         totalStakedTrx: 3,

--- a/app/components/UI/Earn/components/EarnBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/index.tsx
@@ -8,7 +8,7 @@ import EarnLendingBalance from '../EarnLendingBalance';
 import { selectIsStakeableToken } from '../../../Stake/selectors/stakeableTokens';
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import TronStakingButtons from '../Tron/TronStakingButtons';
-import { selectTronResourcesBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
+import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
 import { hasStakedTrxPositions as hasStakedTrxPositionsUtil } from '../../utils/tron';
 import useTronStakeApy from '../../hooks/useTronStakeApy';
@@ -47,10 +47,12 @@ const EarnBalance = ({ asset }: EarnBalanceProps) => {
   const isStakedTrxAsset =
     isTron && (asset?.ticker === 'sTRX' || asset?.symbol === 'sTRX');
 
-  const tronResources = useSelector(selectTronResourcesBySelectedAccountGroup);
+  const tronSpecialAssets = useSelector(
+    selectTronSpecialAssetsBySelectedAccountGroup,
+  );
   const hasStakedTrxPositions = React.useMemo(
-    () => hasStakedTrxPositionsUtil(tronResources),
-    [tronResources],
+    () => hasStakedTrxPositionsUtil(tronSpecialAssets),
+    [tronSpecialAssets],
   );
 
   const { apyPercent: tronApyPercent } = useTronStakeApy();

--- a/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.test.tsx
+++ b/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.test.tsx
@@ -4,8 +4,8 @@ import { useSelector } from 'react-redux';
 
 import TronStakePreview from './TronStakePreview';
 import {
-  selectTronResourcesBySelectedAccountGroup,
-  TronResourcesMap,
+  selectTronSpecialAssetsBySelectedAccountGroup,
+  TronSpecialAssetsMap,
 } from '../../../../../../selectors/assets/assets-list';
 import type { ComputeFeeResult } from '../../../utils/tron-staking-snap';
 
@@ -46,7 +46,9 @@ jest.mock('../../../hooks/useTronStakeApy', () => ({
 
 const mockUseSelector = useSelector as jest.Mock;
 
-const createMockResourcesMap = (totalStakedTrx: number): TronResourcesMap => ({
+const createMockSpecialAssetsMap = (
+  totalStakedTrx: number,
+): TronSpecialAssetsMap => ({
   energy: undefined,
   bandwidth: undefined,
   maxEnergy: undefined,
@@ -54,6 +56,9 @@ const createMockResourcesMap = (totalStakedTrx: number): TronResourcesMap => ({
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
   totalStakedTrx,
+  trxReadyForWithdrawal: undefined,
+  trxStakingRewards: undefined,
+  trxInLockPeriod: undefined,
 });
 
 describe('TronStakePreview', () => {
@@ -68,10 +73,10 @@ describe('TronStakePreview', () => {
     });
 
     // Default: 10 + 5 = 15 TRX staked
-    const mockResourcesMap = createMockResourcesMap(15);
+    const mockResourcesMap = createMockSpecialAssetsMap(15);
 
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectTronResourcesBySelectedAccountGroup) {
+      if (selector === selectTronSpecialAssetsBySelectedAccountGroup) {
         return mockResourcesMap;
       }
       return undefined;
@@ -91,10 +96,10 @@ describe('TronStakePreview', () => {
   });
 
   it('calculates annual reward from floating-point balances without precision errors', () => {
-    const mockResourcesMap = createMockResourcesMap(130.96926);
+    const mockResourcesMap = createMockSpecialAssetsMap(130.96926);
 
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectTronResourcesBySelectedAccountGroup) {
+      if (selector === selectTronSpecialAssetsBySelectedAccountGroup) {
         return mockResourcesMap;
       }
       return undefined;
@@ -174,8 +179,8 @@ describe('TronStakePreview', () => {
 
   it('returns empty reward when total staked balance is zero in stake mode', () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectTronResourcesBySelectedAccountGroup) {
-        return createMockResourcesMap(0);
+      if (selector === selectTronSpecialAssetsBySelectedAccountGroup) {
+        return createMockSpecialAssetsMap(0);
       }
       return undefined;
     });

--- a/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx
+++ b/app/components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx
@@ -12,7 +12,7 @@ import {
   BoxJustifyContent,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import { selectTronResourcesBySelectedAccountGroup } from '../../../../../../selectors/assets/assets-list';
+import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../../../selectors/assets/assets-list';
 import type { ComputeFeeResult } from '../../../types/tron-staking.types';
 import useTronStakeApy from '../../../hooks/useTronStakeApy';
 
@@ -46,7 +46,7 @@ const TronStakePreview = ({
   const tw = useTailwind();
 
   const { totalStakedTrx } = useSelector(
-    selectTronResourcesBySelectedAccountGroup,
+    selectTronSpecialAssetsBySelectedAccountGroup,
   );
 
   const { apyDecimal } = useTronStakeApy();

--- a/app/components/UI/Earn/hooks/useTronUnstake.test.ts
+++ b/app/components/UI/Earn/hooks/useTronUnstake.test.ts
@@ -12,7 +12,7 @@ import { TokenI } from '../../Tokens/types';
 
 const mockSelectSelectedInternalAccountByScope = jest.fn();
 const mockSelectTrxStakingEnabled = jest.fn();
-const mockSelectTronResourcesBySelectedAccountGroup = jest.fn();
+const mockSelectTronSpecialAssetsBySelectedAccountGroup = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn((selector) => selector()),
@@ -31,8 +31,8 @@ jest.mock(
 );
 
 jest.mock('../../../../selectors/assets/assets-list', () => ({
-  selectTronResourcesBySelectedAccountGroup: () =>
-    mockSelectTronResourcesBySelectedAccountGroup(),
+  selectTronSpecialAssetsBySelectedAccountGroup: () =>
+    mockSelectTronSpecialAssetsBySelectedAccountGroup(),
 }));
 
 jest.mock('../utils/tron-staking-snap', () => ({
@@ -46,7 +46,7 @@ jest.mock('../../../../core/Multichain/utils', () => ({
 }));
 
 jest.mock('../utils/tron', () => ({
-  getStakedTrxTotalFromResources: jest.fn(() => 100),
+  getStakedTrxTotalFromSpecialAssets: jest.fn(() => 100),
   buildTronEarnTokenIfEligible: jest.fn(() => ({
     symbol: 'TRX',
     balance: '100',
@@ -102,7 +102,7 @@ describe('useTronUnstake', () => {
     // Setup default mock values
     mockSelectSelectedInternalAccountByScope.mockReturnValue(mockAccount);
     mockSelectTrxStakingEnabled.mockReturnValue(true);
-    mockSelectTronResourcesBySelectedAccountGroup.mockReturnValue({
+    mockSelectTronSpecialAssetsBySelectedAccountGroup.mockReturnValue({
       energy: undefined,
       bandwidth: undefined,
       maxEnergy: undefined,
@@ -110,6 +110,9 @@ describe('useTronUnstake', () => {
       stakedTrxForEnergy: { symbol: 'strx-energy', balance: '50' },
       stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '50' },
       totalStakedTrx: 100,
+      trxReadyForWithdrawal: undefined,
+      trxStakingRewards: undefined,
+      trxInLockPeriod: undefined,
     });
   });
 

--- a/app/components/UI/Earn/hooks/useTronUnstake.ts
+++ b/app/components/UI/Earn/hooks/useTronUnstake.ts
@@ -6,14 +6,14 @@ import { useSelector } from 'react-redux';
 import { TronResourceType } from '../../../../core/Multichain/constants';
 import Logger from '../../../../util/Logger';
 import { isTronChainId } from '../../../../core/Multichain/utils';
-import { selectTronResourcesBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
+import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
 import { selectTrxStakingEnabled } from '../../../../selectors/featureFlagController/trxStakingEnabled';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { TokenI } from '../../Tokens/types';
 import { EarnTokenDetails } from '../types/lending.types';
 import {
   buildTronEarnTokenIfEligible,
-  getStakedTrxTotalFromResources,
+  getStakedTrxTotalFromSpecialAssets,
 } from '../utils/tron';
 import {
   computeStakeFee,
@@ -70,7 +70,9 @@ const useTronUnstake = ({
     TrxScope.Mainnet,
   );
   const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
-  const tronResources = useSelector(selectTronResourcesBySelectedAccountGroup);
+  const tronSpecialAssets = useSelector(
+    selectTronSpecialAssetsBySelectedAccountGroup,
+  );
 
   // Derive whether token is on Tron chain
   const isTronAsset = useMemo(
@@ -81,10 +83,10 @@ const useTronUnstake = ({
   // Tron unstaking is enabled when both flag is on and token is on Tron chain
   const isTronEnabled = Boolean(isTrxStakingEnabled && isTronAsset);
 
-  // Compute staked TRX total from resources
   const stakedTrxTotal = useMemo(
-    () => (isTronEnabled ? getStakedTrxTotalFromResources(tronResources) : 0),
-    [isTronEnabled, tronResources],
+    () =>
+      isTronEnabled ? getStakedTrxTotalFromSpecialAssets(tronSpecialAssets) : 0,
+    [isTronEnabled, tronSpecialAssets],
   );
 
   // Determine the staked balance to use for withdrawal

--- a/app/components/UI/Earn/utils/tron.test.ts
+++ b/app/components/UI/Earn/utils/tron.test.ts
@@ -3,11 +3,11 @@ import Routes from '../../../../constants/navigation/Routes';
 import { EARN_EXPERIENCES } from '../constants/experiences';
 import type { EarnTokenDetails } from '../types/lending.types';
 import type { TokenI } from '../../Tokens/types';
-import type { TronResourcesMap } from '../../../../selectors/assets/assets-list';
+import type { TronSpecialAssetsMap } from '../../../../selectors/assets/assets-list';
 import {
   buildTronEarnTokenIfEligible,
   getLocalizedErrorMessage,
-  getStakedTrxTotalFromResources,
+  getStakedTrxTotalFromSpecialAssets,
   handleTronStakingNavigationResult,
   hasStakedTrxPositions,
 } from './tron';
@@ -51,22 +51,21 @@ describe('tron utils', () => {
     };
   });
 
-  describe('getStakedTrxTotalFromResources', () => {
-    it('returns zero when resources are missing', () => {
-      const total = getStakedTrxTotalFromResources(undefined);
+  describe('getStakedTrxTotalFromSpecialAssets', () => {
+    it('returns zero when special assets are missing', () => {
+      const total = getStakedTrxTotalFromSpecialAssets(undefined);
 
       expect(total).toBe(0);
     });
 
-    it('returns zero when resources are null', () => {
-      const total = getStakedTrxTotalFromResources(null);
+    it('returns zero when special assets are null', () => {
+      const total = getStakedTrxTotalFromSpecialAssets(null);
 
       expect(total).toBe(0);
     });
 
-    it('returns totalStakedTrx from resources', () => {
-      // totalStakedTrx is now pre-computed in the selector
-      const resources: TronResourcesMap = {
+    it('returns totalStakedTrx from special assets', () => {
+      const specialAssets: TronSpecialAssetsMap = {
         energy: undefined,
         bandwidth: undefined,
         maxEnergy: undefined,
@@ -74,26 +73,27 @@ describe('tron utils', () => {
         stakedTrxForEnergy: undefined,
         stakedTrxForBandwidth: undefined,
         totalStakedTrx: 15,
+        trxReadyForWithdrawal: undefined,
+        trxStakingRewards: undefined,
+        trxInLockPeriod: undefined,
       };
 
-      const total = getStakedTrxTotalFromResources(resources);
+      const total = getStakedTrxTotalFromSpecialAssets(specialAssets);
 
       expect(total).toBe(15);
     });
 
     it('defaults to zero when totalStakedTrx is undefined at runtime', () => {
-      // Simulates a malformed object where totalStakedTrx is missing,
-      // exercising the ?? 0 fallback in getStakedTrxTotalFromResources
-      const resources = {
+      const specialAssets = {
         energy: undefined,
         bandwidth: undefined,
         maxEnergy: undefined,
         maxBandwidth: undefined,
         stakedTrxForEnergy: undefined,
         stakedTrxForBandwidth: undefined,
-      } as unknown as TronResourcesMap;
+      } as unknown as TronSpecialAssetsMap;
 
-      const total = getStakedTrxTotalFromResources(resources);
+      const total = getStakedTrxTotalFromSpecialAssets(specialAssets);
 
       expect(total).toBe(0);
     });
@@ -101,7 +101,7 @@ describe('tron utils', () => {
 
   describe('hasStakedTrxPositions', () => {
     it('returns false when totalStakedTrx is zero', () => {
-      const resources: TronResourcesMap = {
+      const specialAssets: TronSpecialAssetsMap = {
         energy: undefined,
         bandwidth: undefined,
         maxEnergy: undefined,
@@ -109,15 +109,18 @@ describe('tron utils', () => {
         stakedTrxForEnergy: undefined,
         stakedTrxForBandwidth: undefined,
         totalStakedTrx: 0,
+        trxReadyForWithdrawal: undefined,
+        trxStakingRewards: undefined,
+        trxInLockPeriod: undefined,
       };
 
-      const result = hasStakedTrxPositions(resources);
+      const result = hasStakedTrxPositions(specialAssets);
 
       expect(result).toBe(false);
     });
 
     it('returns true when totalStakedTrx is greater than zero', () => {
-      const resources: TronResourcesMap = {
+      const specialAssets: TronSpecialAssetsMap = {
         energy: undefined,
         bandwidth: undefined,
         maxEnergy: undefined,
@@ -125,9 +128,12 @@ describe('tron utils', () => {
         stakedTrxForEnergy: undefined,
         stakedTrxForBandwidth: undefined,
         totalStakedTrx: 1,
+        trxReadyForWithdrawal: undefined,
+        trxStakingRewards: undefined,
+        trxInLockPeriod: undefined,
       };
 
-      const result = hasStakedTrxPositions(resources);
+      const result = hasStakedTrxPositions(specialAssets);
 
       expect(result).toBe(true);
     });

--- a/app/components/UI/Earn/utils/tron.ts
+++ b/app/components/UI/Earn/utils/tron.ts
@@ -13,24 +13,24 @@ import { TokenI } from '../../Tokens/types';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { safeParseBigNumber } from '../../../../util/number/bignumber';
-import type { TronResourcesMap } from '../../../../selectors/assets/assets-list';
+import type { TronSpecialAssetsMap } from '../../../../selectors/assets/assets-list';
 
 /**
- * Returns the total staked TRX (sTRX) amount from TRON resources.
+ * Returns the total staked TRX (sTRX) amount from Tron special assets.
  * This is pre-computed in the selector using BigNumber to avoid floating-point precision errors.
  */
-export function getStakedTrxTotalFromResources(
-  resources?: TronResourcesMap | null,
+export function getStakedTrxTotalFromSpecialAssets(
+  specialAssets?: TronSpecialAssetsMap | null,
 ): number {
-  return resources?.totalStakedTrx ?? 0;
+  return specialAssets?.totalStakedTrx ?? 0;
 }
 
 /**
- * True if the user holds any sTRX according to TRON resources.
+ * True if the user holds any sTRX according to Tron special assets.
  */
 export const hasStakedTrxPositions = (
-  resources?: TronResourcesMap | null,
-): boolean => getStakedTrxTotalFromResources(resources) > 0;
+  specialAssets?: TronSpecialAssetsMap | null,
+): boolean => getStakedTrxTotalFromSpecialAssets(specialAssets) > 0;
 
 export const buildTronEarnTokenIfEligible = (
   token: TokenI,

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
@@ -3,12 +3,12 @@ import { useTokenBalance } from './useTokenBalance';
 import { TokenI } from '../../Tokens/types';
 import {
   selectAsset,
-  selectTronResourcesBySelectedAccountGroup,
-  TronResourcesMap,
+  selectTronSpecialAssetsBySelectedAccountGroup,
+  TronSpecialAssetsMap,
 } from '../../../../selectors/assets/assets-list';
 import { createStakedTrxAsset } from '../../AssetOverview/utils/createStakedTrxAsset';
 
-const createEmptyResourcesMap = (): TronResourcesMap => ({
+const createEmptySpecialAssetsMap = (): TronSpecialAssetsMap => ({
   energy: undefined,
   bandwidth: undefined,
   maxEnergy: undefined,
@@ -16,12 +16,15 @@ const createEmptyResourcesMap = (): TronResourcesMap => ({
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
   totalStakedTrx: 0,
+  trxReadyForWithdrawal: undefined,
+  trxStakingRewards: undefined,
+  trxInLockPeriod: undefined,
 });
 
 jest.mock('../../../../selectors/assets/assets-list', () => ({
   selectAsset: jest.fn(),
-  selectTronResourcesBySelectedAccountGroup: jest.fn(
-    (): TronResourcesMap => ({
+  selectTronSpecialAssetsBySelectedAccountGroup: jest.fn(
+    (): TronSpecialAssetsMap => ({
       energy: undefined,
       bandwidth: undefined,
       maxEnergy: undefined,
@@ -29,6 +32,9 @@ jest.mock('../../../../selectors/assets/assets-list', () => ({
       stakedTrxForEnergy: undefined,
       stakedTrxForBandwidth: undefined,
       totalStakedTrx: 0,
+      trxReadyForWithdrawal: undefined,
+      trxStakingRewards: undefined,
+      trxInLockPeriod: undefined,
     }),
   ),
 }));
@@ -39,14 +45,14 @@ jest.mock('../../AssetOverview/utils/createStakedTrxAsset', () => ({
 
 const mockSelectAsset = jest.mocked(selectAsset);
 const mockSelectTronResources = jest.mocked(
-  selectTronResourcesBySelectedAccountGroup,
+  selectTronSpecialAssetsBySelectedAccountGroup,
 );
 const mockCreateStakedTrxAsset = jest.mocked(createStakedTrxAsset);
 
 describe('useTokenBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSelectTronResources.mockReturnValue(createEmptyResourcesMap());
+    mockSelectTronResources.mockReturnValue(createEmptySpecialAssetsMap());
   });
 
   afterEach(() => {
@@ -119,10 +125,10 @@ describe('useTokenBalance', () => {
     } as TokenI);
 
     mockSelectTronResources.mockReturnValue({
-      ...createEmptyResourcesMap(),
+      ...createEmptySpecialAssetsMap(),
       stakedTrxForEnergy: { symbol: 'strx-energy', balance: '100' },
       stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '200' },
-    } as TronResourcesMap);
+    } as TronSpecialAssetsMap);
 
     mockCreateStakedTrxAsset.mockReturnValue(mockStakedAsset);
 

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
@@ -5,7 +5,7 @@ import { TokenI } from '../../Tokens/types';
 import {
   selectAsset,
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  selectTronResourcesBySelectedAccountGroup,
+  selectTronSpecialAssetsBySelectedAccountGroup,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../../selectors/assets/assets-list';
 import { toFormattedAddress } from '../../../../util/address';
@@ -34,7 +34,7 @@ export const useTokenBalance = (token: TokenI): UseTokenBalanceResult => {
 
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const { stakedTrxForEnergy, stakedTrxForBandwidth } = useSelector(
-    selectTronResourcesBySelectedAccountGroup,
+    selectTronSpecialAssetsBySelectedAccountGroup,
   );
 
   const isTronNative =

--- a/app/core/Multichain/constants.ts
+++ b/app/core/Multichain/constants.ts
@@ -140,14 +140,21 @@ export const PRICE_API_CURRENCIES = [
   'zar',
 ];
 
-// Tron resource asset symbols
-export const TRON_RESOURCE = {
+/**
+ * Tron special asset types that should be filtered out from asset selectors.
+ * These are virtual resources and staking state assets passed from the Tron Snap
+ * to the extension for informational purposes, not actual tradeable tokens.
+ */
+export const TRON_SPECIAL_ASSET_SYMBOLS = {
   ENERGY: 'energy',
   BANDWIDTH: 'bandwidth',
   MAX_ENERGY: 'max-energy',
   MAX_BANDWIDTH: 'max-bandwidth',
   STRX_ENERGY: 'strx-energy',
   STRX_BANDWIDTH: 'strx-bandwidth',
+  TRX_READY_FOR_WITHDRAWAL: 'trx-ready-for-withdrawal',
+  TRX_STAKING_REWARDS: 'trx-staking-rewards',
+  TRX_IN_LOCK_PERIOD: 'trx-in-lock-period',
 } as const;
 
 export enum TronResourceType {
@@ -155,11 +162,10 @@ export enum TronResourceType {
   BANDWIDTH = 'BANDWIDTH',
 }
 
-export type TronResourceSymbol =
-  (typeof TRON_RESOURCE)[keyof typeof TRON_RESOURCE];
+export type TronSpecialAssetSymbol =
+  (typeof TRON_SPECIAL_ASSET_SYMBOLS)[keyof typeof TRON_SPECIAL_ASSET_SYMBOLS];
 
-export const TRON_RESOURCE_SYMBOLS = Object.values(
-  TRON_RESOURCE,
-) as readonly TronResourceSymbol[];
-export const TRON_RESOURCE_SYMBOLS_SET: ReadonlySet<TronResourceSymbol> =
-  new Set(TRON_RESOURCE_SYMBOLS);
+export const TRON_SPECIAL_ASSET_SYMBOLS_SET: ReadonlySet<TronSpecialAssetSymbol> =
+  new Set(
+    Object.values(TRON_SPECIAL_ASSET_SYMBOLS) as TronSpecialAssetSymbol[],
+  );

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -10,7 +10,11 @@ import { isAddress as isSolanaAddress } from '@solana/addresses';
 import Engine from '../Engine';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { validate, Network } from 'bitcoin-address-validation';
-import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from './constants';
+import {
+  MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP,
+  TRON_SPECIAL_ASSET_SYMBOLS_SET,
+  TronSpecialAssetSymbol,
+} from './constants';
 import { formatAddress, isEthAddress } from '../../util/address';
 import {
   formatBlockExplorerAddressUrl,
@@ -257,3 +261,23 @@ export function shortenTransactionId(txId: string) {
   // For transactions we use a similar output for now, but shortenTransactionId will be added later.
   return formatAddress(txId, 'short');
 }
+
+/**
+ * Checks if a token is a Tron special asset (resources, staking state, etc.)
+ * that should be filtered out from user-facing asset lists.
+ *
+ * @param chainId - The chain ID to check
+ * @param symbol - The token symbol to check
+ * @returns true if the token is a Tron special asset
+ */
+export const isTronSpecialAsset = (
+  chainId: string | undefined,
+  symbol: string | undefined,
+): boolean => {
+  if (!chainId?.startsWith('tron:') || !symbol) {
+    return false;
+  }
+  return TRON_SPECIAL_ASSET_SYMBOLS_SET.has(
+    symbol.toLowerCase() as TronSpecialAssetSymbol,
+  );
+};

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -14,7 +14,7 @@ import {
   selectAsset,
   selectAssetsBySelectedAccountGroup,
   selectSortedAssetsBySelectedAccountGroup,
-  selectTronResourcesBySelectedAccountGroup,
+  selectTronSpecialAssetsBySelectedAccountGroup,
 } from './assets-list';
 import I18n from '../../../locales/i18n';
 
@@ -588,7 +588,7 @@ describe('selectSortedAssetsBySelectedAccountGroup', () => {
     ]);
   });
 
-  it('filters out Tron Energy and Bandwidth resources from assets', () => {
+  it('filters out Tron special assets from the sorted asset list', () => {
     const stateWithTronAssets = {
       ...mockState(),
       engine: {
@@ -600,6 +600,9 @@ describe('selectSortedAssetsBySelectedAccountGroup', () => {
               '2d89e6a0-b4e6-45a8-a707-f10cef143b42': [
                 'tron:728126428/slip44:energy',
                 'tron:728126428/slip44:bandwidth',
+                'tron:728126428/slip44:195-ready-for-withdrawal',
+                'tron:728126428/slip44:195-staking-rewards',
+                'tron:728126428/slip44:195-in-lock-period',
                 'tron:728126428/slip44:195',
               ],
             },
@@ -618,6 +621,45 @@ describe('selectSortedAssetsBySelectedAccountGroup', () => {
                 iconUrl: 'test-url',
                 units: [
                   { name: 'Bandwidth', symbol: 'BANDWIDTH', decimals: 0 },
+                ],
+              },
+              'tron:728126428/slip44:195-ready-for-withdrawal': {
+                name: 'Ready for Withdrawal',
+                symbol: 'TRX-READY-FOR-WITHDRAWAL',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'Ready for Withdrawal',
+                    symbol: 'TRX-READY-FOR-WITHDRAWAL',
+                    decimals: 6,
+                  },
+                ],
+              },
+              'tron:728126428/slip44:195-staking-rewards': {
+                name: 'Staking Rewards',
+                symbol: 'TRX-STAKING-REWARDS',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'Staking Rewards',
+                    symbol: 'TRX-STAKING-REWARDS',
+                    decimals: 6,
+                  },
+                ],
+              },
+              'tron:728126428/slip44:195-in-lock-period': {
+                name: 'In Lock Period',
+                symbol: 'TRX-IN-LOCK-PERIOD',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'In Lock Period',
+                    symbol: 'TRX-IN-LOCK-PERIOD',
+                    decimals: 6,
+                  },
                 ],
               },
               'tron:728126428/slip44:195': {
@@ -640,6 +682,18 @@ describe('selectSortedAssetsBySelectedAccountGroup', () => {
                 'tron:728126428/slip44:bandwidth': {
                   amount: '604',
                   unit: 'BANDWIDTH',
+                },
+                'tron:728126428/slip44:195-ready-for-withdrawal': {
+                  amount: '10',
+                  unit: 'TRX-READY-FOR-WITHDRAWAL',
+                },
+                'tron:728126428/slip44:195-staking-rewards': {
+                  amount: '5',
+                  unit: 'TRX-STAKING-REWARDS',
+                },
+                'tron:728126428/slip44:195-in-lock-period': {
+                  amount: '20',
+                  unit: 'TRX-IN-LOCK-PERIOD',
                 },
                 'tron:728126428/slip44:195': { amount: '1000', unit: 'TRX' },
               },
@@ -670,21 +724,34 @@ describe('selectSortedAssetsBySelectedAccountGroup', () => {
     const tronAssets = result.filter((asset) =>
       asset.chainId?.includes('tron:'),
     );
-    const energyAsset = result.find((asset) =>
-      asset.address?.includes('energy'),
+
+    const trxAsset = tronAssets.find(
+      (asset) => asset.address === 'tron:728126428/slip44:195',
     );
-    const bandwidthAsset = result.find((asset) =>
-      asset.address?.includes('bandwidth'),
+    const energyAsset = tronAssets.find(
+      (asset) => asset.address === 'tron:728126428/slip44:energy',
     );
-    const trxAsset = result.find((asset) =>
-      asset.address?.includes('slip44:195'),
+    const bandwidthAsset = tronAssets.find(
+      (asset) => asset.address === 'tron:728126428/slip44:bandwidth',
+    );
+    const readyForWithdrawalAsset = tronAssets.find(
+      (asset) =>
+        asset.address === 'tron:728126428/slip44:195-ready-for-withdrawal',
+    );
+    const stakingRewardsAsset = tronAssets.find(
+      (asset) => asset.address === 'tron:728126428/slip44:195-staking-rewards',
+    );
+    const inLockPeriodAsset = tronAssets.find(
+      (asset) => asset.address === 'tron:728126428/slip44:195-in-lock-period',
     );
 
+    expect(trxAsset).toBeDefined();
     expect(energyAsset).toBeUndefined();
     expect(bandwidthAsset).toBeUndefined();
-    expect(trxAsset).toBeDefined();
+    expect(readyForWithdrawalAsset).toBeUndefined();
+    expect(stakingRewardsAsset).toBeUndefined();
+    expect(inLockPeriodAsset).toBeUndefined();
 
-    // Only TRX is in the list after filtering
     expect(tronAssets).toHaveLength(1);
   });
 });
@@ -1027,7 +1094,7 @@ describe('selectAsset', () => {
   });
 });
 
-describe('selectTronResourcesBySelectedAccountGroup', () => {
+describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
   it('returns Tron energy and bandwidth resources when Tron network is enabled', () => {
     const stateWithTronAssets = {
       ...mockState(),
@@ -1105,7 +1172,7 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
     } as unknown as RootState;
 
     const result =
-      selectTronResourcesBySelectedAccountGroup(stateWithTronAssets);
+      selectTronSpecialAssetsBySelectedAccountGroup(stateWithTronAssets);
 
     // Verify the object structure with named properties
     expect(result.energy?.assetId).toBe('tron:728126428/slip44:energy');
@@ -1117,7 +1184,7 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
   });
 
   it('maps all resource types and computes totalStakedTrx with BigNumber precision', () => {
-    const stateWithAllResources = {
+    const stateWithAllSpecialAssets = {
       ...mockState(),
       engine: {
         ...mockState().engine,
@@ -1132,6 +1199,9 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
                 'tron:728126428/slip44:max-bandwidth',
                 'tron:728126428/slip44:strx-energy',
                 'tron:728126428/slip44:strx-bandwidth',
+                'tron:728126428/slip44:195-ready-for-withdrawal',
+                'tron:728126428/slip44:195-staking-rewards',
+                'tron:728126428/slip44:195-in-lock-period',
                 'tron:728126428/slip44:195',
               ],
             },
@@ -1200,6 +1270,45 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
                   },
                 ],
               },
+              'tron:728126428/slip44:195-ready-for-withdrawal': {
+                name: 'Ready for Withdrawal',
+                symbol: 'TRX-READY-FOR-WITHDRAWAL',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'Ready for Withdrawal',
+                    symbol: 'TRX-READY-FOR-WITHDRAWAL',
+                    decimals: 6,
+                  },
+                ],
+              },
+              'tron:728126428/slip44:195-staking-rewards': {
+                name: 'Staking Rewards',
+                symbol: 'TRX-STAKING-REWARDS',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'Staking Rewards',
+                    symbol: 'TRX-STAKING-REWARDS',
+                    decimals: 6,
+                  },
+                ],
+              },
+              'tron:728126428/slip44:195-in-lock-period': {
+                name: 'In Lock Period',
+                symbol: 'TRX-IN-LOCK-PERIOD',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'In Lock Period',
+                    symbol: 'TRX-IN-LOCK-PERIOD',
+                    decimals: 6,
+                  },
+                ],
+              },
               'tron:728126428/slip44:195': {
                 name: 'TRON',
                 symbol: 'TRX',
@@ -1237,6 +1346,18 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
                   amount: '65.48463',
                   unit: 'STRX-BANDWIDTH',
                 },
+                'tron:728126428/slip44:195-ready-for-withdrawal': {
+                  amount: '25.5',
+                  unit: 'TRX-READY-FOR-WITHDRAWAL',
+                },
+                'tron:728126428/slip44:195-staking-rewards': {
+                  amount: '12.3',
+                  unit: 'TRX-STAKING-REWARDS',
+                },
+                'tron:728126428/slip44:195-in-lock-period': {
+                  amount: '50',
+                  unit: 'TRX-IN-LOCK-PERIOD',
+                },
                 'tron:728126428/slip44:195': {
                   amount: '1000',
                   unit: 'TRX',
@@ -1263,11 +1384,11 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
       },
     } as unknown as RootState;
 
-    const result = selectTronResourcesBySelectedAccountGroup(
-      stateWithAllResources,
+    const result = selectTronSpecialAssetsBySelectedAccountGroup(
+      stateWithAllSpecialAssets,
     );
 
-    // All 6 resource types should be mapped
+    // All 9 special assets should be mapped
     expect(result.energy?.assetId).toBe('tron:728126428/slip44:energy');
     expect(result.bandwidth?.assetId).toBe('tron:728126428/slip44:bandwidth');
     expect(result.maxEnergy?.assetId).toBe('tron:728126428/slip44:max-energy');
@@ -1279,6 +1400,15 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
     );
     expect(result.stakedTrxForBandwidth?.assetId).toBe(
       'tron:728126428/slip44:strx-bandwidth',
+    );
+    expect(result.trxReadyForWithdrawal?.assetId).toBe(
+      'tron:728126428/slip44:195-ready-for-withdrawal',
+    );
+    expect(result.trxStakingRewards?.assetId).toBe(
+      'tron:728126428/slip44:195-staking-rewards',
+    );
+    expect(result.trxInLockPeriod?.assetId).toBe(
+      'tron:728126428/slip44:195-in-lock-period',
     );
 
     // totalStakedTrx computed via BigNumber avoids floating-point errors
@@ -1345,7 +1475,7 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
       },
     } as unknown as RootState;
 
-    const result = selectTronResourcesBySelectedAccountGroup(
+    const result = selectTronSpecialAssetsBySelectedAccountGroup(
       stateWithTronDisabled,
     );
 
@@ -1358,6 +1488,9 @@ describe('selectTronResourcesBySelectedAccountGroup', () => {
       stakedTrxForEnergy: undefined,
       stakedTrxForBandwidth: undefined,
       totalStakedTrx: 0,
+      trxReadyForWithdrawal: undefined,
+      trxStakingRewards: undefined,
+      trxInLockPeriod: undefined,
     });
   });
 });

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -27,10 +27,11 @@ import {
 import { safeParseBigNumber } from '../../util/number/bignumber';
 import { selectAccountsByChainId } from '../accountTrackerController';
 import {
-  TRON_RESOURCE,
-  TRON_RESOURCE_SYMBOLS_SET,
-  TronResourceSymbol,
+  TRON_SPECIAL_ASSET_SYMBOLS,
+  TRON_SPECIAL_ASSET_SYMBOLS_SET,
+  TronSpecialAssetSymbol,
 } from '../../core/Multichain/constants';
+import { isTronSpecialAsset } from '../../core/Multichain/utils';
 import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
 import { selectAllTokens } from '../tokensController';
 import { selectSelectedInternalAccountAddress } from '../accountsController';
@@ -38,10 +39,14 @@ import { selectSelectedInternalAccountByScope } from '../multichainAccounts/acco
 import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
 
 /**
- * Structured map of Tron resources for efficient access.
- * Each property corresponds to a specific Tron resource type.
+ * Structured map of Tron special assets for efficient access.
+ *
+ * Includes network resources (Energy, Bandwidth and their max capacities),
+ * staking-related assets (staked TRX for Energy/Bandwidth, total staked TRX),
+ * and additional staking lifecycle assets (Ready for Withdrawal, Staking
+ * Rewards, In Lock Period).
  */
-export interface TronResourcesMap {
+export interface TronSpecialAssetsMap {
   /** Current available energy */
   energy: Asset | undefined;
   /** Current available bandwidth */
@@ -56,12 +61,18 @@ export interface TronResourcesMap {
   stakedTrxForBandwidth: Asset | undefined;
   /** Total staked TRX (sum of energy + bandwidth staking) */
   totalStakedTrx: number;
+  /** TRX ready for withdrawal (unstaked TRX that has completed the lock period) */
+  trxReadyForWithdrawal: Asset | undefined;
+  /** TRX staking rewards */
+  trxStakingRewards: Asset | undefined;
+  /** TRX in lock period (unstaked but waiting for lock period to end) */
+  trxInLockPeriod: Asset | undefined;
 }
 
 /**
  * Empty constant to avoid creating new objects on each call when no Tron networks are enabled.
  */
-const EMPTY_TRON_RESOURCES_MAP: TronResourcesMap = Object.freeze({
+const EMPTY_TRON_SPECIAL_ASSETS_MAP: TronSpecialAssetsMap = Object.freeze({
   energy: undefined,
   bandwidth: undefined,
   maxEnergy: undefined,
@@ -69,6 +80,9 @@ const EMPTY_TRON_RESOURCES_MAP: TronResourcesMap = Object.freeze({
   stakedTrxForEnergy: undefined,
   stakedTrxForBandwidth: undefined,
   totalStakedTrx: 0,
+  trxReadyForWithdrawal: undefined,
+  trxStakingRewards: undefined,
+  trxInLockPeriod: undefined,
 });
 
 const getStateForAssetSelector = (state: RootState) => {
@@ -245,7 +259,11 @@ export const selectSortedAssetsBySelectedAccountGroup = createDeepEqualSelector(
   (bip44Assets, enabledNetworks, tokenSortConfig, stakedAssets) => {
     const assets = Object.entries(bip44Assets)
       .filter(([networkId, _]) => enabledNetworks.includes(networkId))
-      .flatMap(([_, chainAssets]) => chainAssets);
+      .flatMap(([_, chainAssets]) =>
+        chainAssets.filter(
+          (asset) => !isTronSpecialAsset(asset.chainId, asset.symbol),
+        ),
+      );
 
     const stakedAssetsArray = [];
     for (const asset of assets) {
@@ -425,22 +443,26 @@ function assetToToken(
 }
 
 /**
- * Selects Tron resources (Energy, Bandwidth, Max values, and staked TRX) for the
- * currently selected account group.
+ * Selects Tron special assets for the currently selected account group.
  *
- * Returns a structured object with all resources pre-mapped for efficient access,
- * eliminating the need for consumers to iterate/search the array.
+ * This includes:
+ * - **Network resources**: Energy, Bandwidth, and their maximum capacities.
+ * - **Staking assets**: TRX staked for Energy/Bandwidth and a pre-computed `totalStakedTrx` sum.
+ * - **Staking lifecycle assets**: TRX Ready for Withdrawal, Staking Rewards, and TRX In Lock Period.
+ *
+ * Returns a structured {@link TronSpecialAssetsMap} with all assets pre-mapped by type
+ * for efficient access, eliminating the need for consumers to iterate or search the array.
  */
-export const selectTronResourcesBySelectedAccountGroup =
+export const selectTronSpecialAssetsBySelectedAccountGroup =
   createDeepEqualSelector(
     [getStateForAssetSelector, selectEnabledNetworks],
-    (assetsState, enabledNetworks): TronResourcesMap => {
+    (assetsState, enabledNetworks): TronSpecialAssetsMap => {
       const enabledTronNetworks = enabledNetworks.filter((networkId) =>
         networkId.startsWith('tron:'),
       );
 
       if (enabledTronNetworks.length === 0) {
-        return EMPTY_TRON_RESOURCES_MAP;
+        return EMPTY_TRON_SPECIAL_ASSETS_MAP;
       }
 
       const allAssets = _selectAssetsBySelectedAccountGroup(assetsState, {
@@ -449,7 +471,7 @@ export const selectTronResourcesBySelectedAccountGroup =
 
       const enabledTronNetworksSet = new Set(enabledTronNetworks);
 
-      const resourceMap: TronResourcesMap = {
+      const specialAssetsMap: TronSpecialAssetsMap = {
         energy: undefined,
         bandwidth: undefined,
         maxEnergy: undefined,
@@ -457,33 +479,45 @@ export const selectTronResourcesBySelectedAccountGroup =
         stakedTrxForEnergy: undefined,
         stakedTrxForBandwidth: undefined,
         totalStakedTrx: 0,
+        trxReadyForWithdrawal: undefined,
+        trxStakingRewards: undefined,
+        trxInLockPeriod: undefined,
       };
 
       for (const [networkId, chainAssets] of Object.entries(allAssets)) {
         if (!enabledTronNetworksSet.has(networkId)) continue;
 
         for (const asset of chainAssets) {
-          const symbol = asset.symbol?.toLowerCase() as TronResourceSymbol;
-          if (!TRON_RESOURCE_SYMBOLS_SET.has(symbol)) continue;
+          const symbol = asset.symbol?.toLowerCase() as TronSpecialAssetSymbol;
+          if (!TRON_SPECIAL_ASSET_SYMBOLS_SET.has(symbol)) continue;
 
           switch (symbol) {
-            case TRON_RESOURCE.ENERGY:
-              resourceMap.energy = asset;
+            case TRON_SPECIAL_ASSET_SYMBOLS.ENERGY:
+              specialAssetsMap.energy = asset;
               break;
-            case TRON_RESOURCE.BANDWIDTH:
-              resourceMap.bandwidth = asset;
+            case TRON_SPECIAL_ASSET_SYMBOLS.BANDWIDTH:
+              specialAssetsMap.bandwidth = asset;
               break;
-            case TRON_RESOURCE.MAX_ENERGY:
-              resourceMap.maxEnergy = asset;
+            case TRON_SPECIAL_ASSET_SYMBOLS.MAX_ENERGY:
+              specialAssetsMap.maxEnergy = asset;
               break;
-            case TRON_RESOURCE.MAX_BANDWIDTH:
-              resourceMap.maxBandwidth = asset;
+            case TRON_SPECIAL_ASSET_SYMBOLS.MAX_BANDWIDTH:
+              specialAssetsMap.maxBandwidth = asset;
               break;
-            case TRON_RESOURCE.STRX_ENERGY:
-              resourceMap.stakedTrxForEnergy = asset;
+            case TRON_SPECIAL_ASSET_SYMBOLS.STRX_ENERGY:
+              specialAssetsMap.stakedTrxForEnergy = asset;
               break;
-            case TRON_RESOURCE.STRX_BANDWIDTH:
-              resourceMap.stakedTrxForBandwidth = asset;
+            case TRON_SPECIAL_ASSET_SYMBOLS.STRX_BANDWIDTH:
+              specialAssetsMap.stakedTrxForBandwidth = asset;
+              break;
+            case TRON_SPECIAL_ASSET_SYMBOLS.TRX_READY_FOR_WITHDRAWAL:
+              specialAssetsMap.trxReadyForWithdrawal = asset;
+              break;
+            case TRON_SPECIAL_ASSET_SYMBOLS.TRX_STAKING_REWARDS:
+              specialAssetsMap.trxStakingRewards = asset;
+              break;
+            case TRON_SPECIAL_ASSET_SYMBOLS.TRX_IN_LOCK_PERIOD:
+              specialAssetsMap.trxInLockPeriod = asset;
               break;
           }
         }
@@ -493,17 +527,17 @@ export const selectTronResourcesBySelectedAccountGroup =
        * Compute total staked TRX using BigNumber to avoid floating-point precision errors
        */
       const stakedTrxForEnergyBN = safeParseBigNumber(
-        resourceMap.stakedTrxForEnergy?.balance,
+        specialAssetsMap.stakedTrxForEnergy?.balance,
       );
       const stakedTrxForBandwidthBN = safeParseBigNumber(
-        resourceMap.stakedTrxForBandwidth?.balance,
+        specialAssetsMap.stakedTrxForBandwidth?.balance,
       );
       const totalStakedTrxBN = stakedTrxForEnergyBN.plus(
         stakedTrxForBandwidthBN,
       );
 
-      resourceMap.totalStakedTrx = totalStakedTrxBN.toNumber();
+      specialAssetsMap.totalStakedTrx = totalStakedTrxBN.toNumber();
 
-      return resourceMap;
+      return specialAssetsMap;
     },
   );

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -46,11 +46,8 @@ import { TokenI } from '../../components/UI/Tokens/types';
 import { createSelector } from 'reselect';
 import { selectSelectedAccountGroupInternalAccounts } from '../multichainAccounts/accountTreeController';
 import { selectAccountTokensAcrossChains } from '../multichain';
-import {
-  MULTICHAIN_ACCOUNT_TYPE_TO_MAINNET,
-  TRON_RESOURCE_SYMBOLS_SET,
-  TronResourceSymbol,
-} from '../../core/Multichain/constants';
+import { MULTICHAIN_ACCOUNT_TYPE_TO_MAINNET } from '../../core/Multichain/constants';
+import { isTronSpecialAsset } from '../../core/Multichain/utils';
 
 export const selectMultichainDefaultToken = createDeepEqualSelector(
   selectIsEvmNetworkSelected,
@@ -366,12 +363,7 @@ export const selectAccountTokensAcrossChainsUnified = createDeepEqualSelector(
         selectMultichainTokenListForAccountsAnyChain(state, [account]) || [];
 
       for (const token of nonEvmTokensForAccount) {
-        if (
-          String(token.chainId).includes('tron:') &&
-          TRON_RESOURCE_SYMBOLS_SET.has(
-            (token.symbol || '').toLowerCase() as TronResourceSymbol,
-          )
-        ) {
+        if (isTronSpecialAsset(String(token.chainId), token.symbol)) {
           continue;
         }
         // We just need tron mainnet, at least for now


### PR DESCRIPTION
## **Description**

As part of Tron's staking experience improvements we will be sending more special assets from the Snap to the Extension. These special assets are not tradeable tokens and should be filtered out from selectors like we already do for Staked TRX for example.

This PR:
- Adds the new special assets that should be ignored by the selectors
- Renames the variables that deal with this logic to be more inclusive of assets that are not resources (only Energy and Bandwidth are resources)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: [NEB-582](https://consensyssoftware.atlassian.net/browse/NEB-582), [NEB-584](https://consensyssoftware.atlassian.net/browse/NEB-584), [NEB-586](https://consensyssoftware.atlassian.net/browse/NEB-586)

## **Manual testing steps**

All existing Tron functionality should remain unchanged

## **Screenshots/Recordings**

As you can see, the new assets being loaded from the preview build of https://github.com/MetaMask/snap-tron-wallet/pull/226 are not being shown here.

### **Before**

n/a

### **After**

n/a

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

[NEB-582]: https://consensyssoftware.atlassian.net/browse/NEB-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEB-584]: https://consensyssoftware.atlassian.net/browse/NEB-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEB-586]: https://consensyssoftware.atlassian.net/browse/NEB-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token/asset filtering for Tron by excluding additional Snap-provided “special assets” from sorted asset lists and unified multichain token lists, which could inadvertently hide tokens if symbols collide or filtering is misapplied. Scope is contained to Tron selectors/utilities and related UI consumers, with broad test updates.
> 
> **Overview**
> Introduces a broader Tron *“special assets”* concept (resources + staking lifecycle assets) and filters these virtual tokens out of user-facing asset/token lists.
> 
> Renames and expands the Tron selector from `selectTronResourcesBySelectedAccountGroup` to `selectTronSpecialAssetsBySelectedAccountGroup` (and `TronResourcesMap` to `TronSpecialAssetsMap`), adding mappings for `trxReadyForWithdrawal`, `trxStakingRewards`, and `trxInLockPeriod` while preserving `totalStakedTrx` computation.
> 
> Centralizes special-asset detection in `core/Multichain/utils` via `isTronSpecialAsset` and reuses it in `selectSortedAssetsBySelectedAccountGroup`, `selectAccountTokensAcrossChainsUnified`, and Bridge `isTradableToken`; updates related Earn/TokenDetails/AssetOverview hooks and tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 893e98a8928ebcfff7a24e656cac48ba3ac77d6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->