### PR TITLE
chore(predict): cp-7.66.0 remove code related to super bowl banner on carousel

### DIFF
--- a/app/components/UI/Carousel/index.test.tsx
+++ b/app/components/UI/Carousel/index.test.tsx
@@ -23,7 +23,6 @@ import Routes from '../../../constants/navigation/Routes';
 import { WalletClientType } from '../../../core/SnapKeyring/MultichainWalletSnapClient';
 import { SolScope } from '@metamask/keyring-api';
 import { setContentPreviewToken } from '../../../actions/notification/helpers';
-import { PREDICT_SUPERBOWL_VARIABLE_NAME } from '../Predict/constants/carousel';
 
 const makeMockState = () =>
   ({
@@ -96,32 +95,6 @@ jest.mock('./fetchCarouselSlidesFromContentful', () => ({
   ...jest.requireActual('./fetchCarouselSlidesFromContentful'),
   fetchCarouselSlidesFromContentful: jest.fn(),
 }));
-
-jest.mock('../Predict/components/PredictMarketSportCard', () => {
-  const { useEffect } = jest.requireActual('react');
-  const { View, Text } = jest.requireActual('react-native');
-  return {
-    PredictMarketSportCardWrapper: function MockPredictMarketSportCardWrapper({
-      marketId,
-      testID,
-      onLoad,
-    }: {
-      marketId: string;
-      testID?: string;
-      onLoad?: () => void;
-    }) {
-      useEffect(() => {
-        onLoad?.();
-      }, [onLoad]);
-
-      return (
-        <View testID={testID ?? 'predict-sport-card-wrapper'}>
-          <Text testID="predict-sport-card-market-id">{marketId}</Text>
-        </View>
-      );
-    },
-  };
-});
 
 const mockDispatch = jest.fn();
 const mockFetchCarouselSlides = jest.mocked(fetchCarouselSlidesFromContentful);
@@ -512,112 +485,5 @@ describe('useFetchCarouselSlides()', () => {
 
     // Should not fetch when feature is disabled
     expect(mockFetchCarouselSlides).not.toHaveBeenCalled();
-  });
-});
-
-describe('Carousel Predict Superbowl Integration', () => {
-  it('renders PredictMarketSportCardWrapper for predict-superbowl slides', async () => {
-    const predictSlide = createMockSlide({
-      id: 'predict-superbowl-slide',
-      variableName: PREDICT_SUPERBOWL_VARIABLE_NAME,
-      metadata: { marketId: 'test-market-123' },
-    });
-    mockFetchCarouselSlides.mockResolvedValue({
-      prioritySlides: [],
-      regularSlides: [predictSlide],
-    });
-
-    const { findByTestId } = render(<Carousel />);
-
-    const marketIdElement = await findByTestId('predict-sport-card-market-id');
-    expect(marketIdElement).toHaveTextContent('test-market-123');
-  });
-
-  it('does not render PredictMarketSportCardWrapper when metadata is missing marketId', async () => {
-    const regularSlide = createMockSlide({ id: 'regular-slide' });
-    const predictSlide = createMockSlide({
-      id: 'predict-superbowl-slide',
-      variableName: PREDICT_SUPERBOWL_VARIABLE_NAME,
-      metadata: undefined,
-    });
-    mockFetchCarouselSlides.mockResolvedValue({
-      prioritySlides: [],
-      regularSlides: [predictSlide, regularSlide],
-    });
-
-    const { findByTestId, queryByTestId } = render(<Carousel />);
-
-    await findByTestId('carousel-slide-regular-slide');
-
-    expect(queryByTestId('predict-sport-card-wrapper')).toBeNull();
-  });
-
-  it('does not render PredictMarketSportCardWrapper when marketId is empty', async () => {
-    const regularSlide = createMockSlide({ id: 'regular-slide' });
-    const predictSlide = createMockSlide({
-      id: 'predict-superbowl-slide',
-      variableName: PREDICT_SUPERBOWL_VARIABLE_NAME,
-      metadata: { marketId: '' },
-    });
-    mockFetchCarouselSlides.mockResolvedValue({
-      prioritySlides: [],
-      regularSlides: [predictSlide, regularSlide],
-    });
-
-    const { findByTestId, queryByTestId } = render(<Carousel />);
-
-    await findByTestId('carousel-slide-regular-slide');
-
-    expect(queryByTestId('predict-sport-card-wrapper')).toBeNull();
-  });
-
-  it('passes correct props to PredictMarketSportCardWrapper', async () => {
-    const predictSlide = createMockSlide({
-      id: 'predict-superbowl-slide',
-      variableName: PREDICT_SUPERBOWL_VARIABLE_NAME,
-      metadata: { marketId: 'market-abc-123' },
-      testID: 'custom-test-id',
-    });
-    mockFetchCarouselSlides.mockResolvedValue({
-      prioritySlides: [predictSlide],
-      regularSlides: [],
-    });
-
-    const { findByTestId } = render(<Carousel />);
-
-    const wrapper = await findByTestId('custom-test-id');
-    expect(wrapper).toBeOnTheScreen();
-
-    const marketId = await findByTestId('predict-sport-card-market-id');
-    expect(marketId).toHaveTextContent('market-abc-123');
-  });
-
-  it('fires Banner Display tracking event for predict-superbowl slide', async () => {
-    mockTrackEvent.mockClear();
-    mockCreateEventBuilder.mockClear();
-    const predictSlide = createMockSlide({
-      id: 'predict-superbowl-slide',
-      variableName: PREDICT_SUPERBOWL_VARIABLE_NAME,
-      metadata: { marketId: 'test-market-123' },
-    });
-    mockFetchCarouselSlides.mockResolvedValue({
-      prioritySlides: [],
-      regularSlides: [predictSlide],
-    });
-
-    const { findByTestId } = render(<Carousel />);
-
-    await findByTestId('predict-sport-card-market-id');
-
-    await waitFor(() => {
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith({
-        category: 'Banner Display',
-        properties: {
-          name: PREDICT_SUPERBOWL_VARIABLE_NAME,
-        },
-      });
-    });
-
-    expect(mockTrackEvent).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -45,10 +45,6 @@ import { subscribeToContentPreviewToken } from '../../../actions/notification/he
 import SharedDeeplinkManager from '../../../core/DeeplinkManager/DeeplinkManager';
 import { isInternalDeepLink } from '../../../core/DeeplinkManager/util/deeplinks';
 import AppConstants from '../../../core/AppConstants';
-import { PredictMarketSportCardWrapper } from '../Predict/components/PredictMarketSportCard';
-import { PredictEventValues } from '../Predict/constants/eventNames';
-import { PREDICT_SUPERBOWL_VARIABLE_NAME } from '../Predict/constants/carousel';
-import { PredictCarouselMetadata } from '../Predict/types';
 
 const MAX_CAROUSEL_SLIDES = 8;
 
@@ -276,24 +272,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     dismissedBanners,
   ]);
 
-  const predictSuperbowlSlide = useMemo(
-    () =>
-      slidesConfig.find(
-        (slide) =>
-          slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME &&
-          !dismissedBanners.includes(slide.id),
-      ),
-    [slidesConfig, dismissedBanners],
-  );
-
-  const predictSuperbowlMarketId = useMemo(() => {
-    if (!predictSuperbowlSlide) return null;
-    const metadata = predictSuperbowlSlide.metadata as
-      | PredictCarouselMetadata
-      | undefined;
-    return metadata?.marketId ?? null;
-  }, [predictSuperbowlSlide]);
-
   const visibleSlides = useMemo(() => {
     const filtered = slidesConfig.filter((slide: CarouselSlide) => {
       const active = isActive(slide);
@@ -307,11 +285,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         return false;
       }
       ///: END:ONLY_INCLUDE_IF
-
-      // We dont want to show the predict superbowl slide in the carousel
-      if (slide.variableName === PREDICT_SUPERBOWL_VARIABLE_NAME) {
-        return false;
-      }
 
       return !dismissedBanners.includes(slide.id);
     });
@@ -564,11 +537,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     }
   }, [transitionToEmpty, onEmptyState]);
 
-  const handleSportCardDismiss = useCallback(() => {
-    if (!predictSuperbowlSlide) return;
-    dispatch(dismissBanner(predictSuperbowlSlide.id));
-  }, [predictSuperbowlSlide, dispatch]);
-
   const renderCard = useCallback(
     (slide: CarouselSlide, isCurrentCard: boolean) => {
       const isEmptyCard = slide.variableName === 'empty';
@@ -648,32 +616,6 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
       );
     }
   }, [currentSlide, trackEvent, createEventBuilder]);
-
-  const handlePredictSuperbowlLoad = useCallback(() => {
-    if (predictSuperbowlSlide) {
-      trackEvent(
-        createEventBuilder({
-          category: 'Banner Display',
-          properties: {
-            name:
-              predictSuperbowlSlide.variableName ?? predictSuperbowlSlide.id,
-          },
-        }).build(),
-      );
-    }
-  }, [predictSuperbowlSlide, trackEvent, createEventBuilder]);
-
-  if (predictSuperbowlMarketId) {
-    return (
-      <PredictMarketSportCardWrapper
-        marketId={predictSuperbowlMarketId}
-        testID={predictSuperbowlSlide?.testID}
-        entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
-        onDismiss={handleSportCardDismiss}
-        onLoad={handlePredictSuperbowlLoad}
-      />
-    );
-  }
 
   if (
     !isCarouselVisible ||


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Carousel previously had special handling for the Predict Superbowl banner: it could replace the entire carousel with a single `PredictMarketSportCardWrapper` when a Superbowl slide with a `marketId` was present, and hid that slide from the normal carousel. This change removes that integration.

**What changed:**

- **Carousel (`index.tsx`):** Removed Predict/Superbowl imports, the `predictSuperbowlSlide` and `predictSuperbowlMarketId` memos, the early return that rendered `PredictMarketSportCardWrapper`, the filter that excluded `PREDICT_SUPERBOWL_VARIABLE_NAME` from visible slides, and the `handleSportCardDismiss` / `handlePredictSuperbowlLoad` callbacks (including "Banner Display" tracking for the Superbowl card).
- **Tests (`index.test.tsx`):** Removed the `PredictMarketSportCardWrapper` mock, the `PREDICT_SUPERBOWL_VARIABLE_NAME` import, and the entire "Carousel Predict Superbowl Integration" describe block and its five tests (render with/without marketId, props, tracking).

The Carousel no longer has any Superbowl-specific behavior; any such slides from Contentful would now be treated as normal carousel slides.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a one-off UI code path and its tests; behavior is simplified with minimal impact outside the Predict Superbowl banner scenario.
> 
> **Overview**
> Removes the Carousel’s special-case integration for the Predict Super Bowl banner. The carousel no longer suppresses `PREDICT_SUPERBOWL_VARIABLE_NAME` slides, no longer renders `PredictMarketSportCardWrapper` as a full replacement view based on `marketId`, and drops the associated dismiss/load handlers and Superbowl-specific metrics.
> 
> Updates `index.test.tsx` by deleting the Predict sport card mock and the entire Predict Superbowl integration test suite, leaving only the generic carousel behavior tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d585da973cf79be4ff01be8f34a1069c36995a95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->