### PR TITLE
Earn mUSD header font

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.styles.ts
@@ -20,13 +20,6 @@ export const styleSheet = (_params: { theme: Theme }) =>
       paddingHorizontal: 16,
       alignItems: 'center',
     },
-    heading: {
-      fontFamily: 'MMPoly-Regular',
-      fontSize: 40,
-      lineHeight: 40,
-      paddingVertical: 16,
-      textAlign: 'center',
-    },
     bodyText: {
       textAlign: 'center',
       paddingHorizontal: 30,

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -4,9 +4,6 @@ import { useDispatch } from 'react-redux';
 import { View, Image, useColorScheme, Linking } from 'react-native';
 import { setMusdConversionEducationSeen } from '../../../../../actions/user';
 import Logger from '../../../../../util/Logger';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -23,6 +20,10 @@ import { useNavigation } from '@react-navigation/native';
 import {
   Button as DesignSystemButton,
   ButtonVariant as DesignSystemButtonVariant,
+  Text as DesignSystemText,
+  TextVariant as DesignSystemTextVariant,
+  FontFamily,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
@@ -39,10 +40,6 @@ import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
 import { RampIntent } from '../../../Ramp/types';
 import { EARN_TEST_IDS } from '../../constants/testIds';
 import AppConstants from '../../../../../core/AppConstants';
-import {
-  Text as DesignSystemText,
-  FontFamily,
-} from '@metamask/design-system-react-native';
 interface EarnMusdConversionEducationViewRouteParams {
   /**
    * Indicates if this navigation originated from a deeplink
@@ -314,18 +311,21 @@ const EarnMusdConversionEducationView = () => {
             percentage: MUSD_CONVERSION_APY,
           })}
         </DesignSystemText>
-        <Text variant={TextVariant.BodyMD} style={styles.bodyText}>
+        <DesignSystemText
+          variant={DesignSystemTextVariant.BodyMd}
+          style={styles.bodyText}
+        >
           {strings('earn.musd_conversion.education.description', {
             percentage: MUSD_CONVERSION_APY,
           })}{' '}
-          <Text
-            variant={TextVariant.BodyMD}
+          <DesignSystemText
+            variant={DesignSystemTextVariant.BodyMd}
             style={styles.termsText}
             onPress={handleTermsOfUsePressed}
           >
             {strings('earn.musd_conversion.education.terms_apply')}
-          </Text>
-        </Text>
+          </DesignSystemText>
+        </DesignSystemText>
       </View>
       <View style={styles.imageContainer}>
         <Image
@@ -350,9 +350,12 @@ const EarnMusdConversionEducationView = () => {
           onPress={handleGoBack}
           testID={EARN_TEST_IDS.MUSD.CONVERSION_EDUCATION_VIEW.SECONDARY_BUTTON}
         >
-          <Text variant={TextVariant.BodyMDMedium}>
+          <DesignSystemText
+            variant={DesignSystemTextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+          >
             {strings('earn.musd_conversion.education.secondary_button')}
-          </Text>
+          </DesignSystemText>
         </DesignSystemButton>
       </View>
     </SafeAreaView>

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -39,6 +39,10 @@ import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
 import { RampIntent } from '../../../Ramp/types';
 import { EARN_TEST_IDS } from '../../constants/testIds';
 import AppConstants from '../../../../../core/AppConstants';
+import {
+  Text as DesignSystemText,
+  FontFamily,
+} from '@metamask/design-system-react-native';
 interface EarnMusdConversionEducationViewRouteParams {
   /**
    * Indicates if this navigation originated from a deeplink
@@ -301,11 +305,15 @@ const EarnMusdConversionEducationView = () => {
       testID={EARN_TEST_IDS.MUSD.CONVERSION_EDUCATION_VIEW.CONTAINER}
     >
       <View style={styles.content}>
-        <Text style={styles.heading} numberOfLines={2} adjustsFontSizeToFit>
+        <DesignSystemText
+          fontFamily={FontFamily.Hero}
+          numberOfLines={2}
+          adjustsFontSizeToFit
+        >
           {strings('earn.musd_conversion.education.heading', {
             percentage: MUSD_CONVERSION_APY,
           })}
-        </Text>
+        </DesignSystemText>
         <Text variant={TextVariant.BodyMD} style={styles.bodyText}>
           {strings('earn.musd_conversion.education.description', {
             percentage: MUSD_CONVERSION_APY,


### PR DESCRIPTION
Update Earn screen header text to use design system's `Text` component with `FontFamily.Hero` and remove custom styles.

---
[Slack Thread](https://consensys.slack.com/archives/C0A917EJME0/p1771606020404099?thread_ts=1771606020.404099&cid=C0A917EJME0)

<p><a href="https://cursor.com/agents?id=bc-9904a6ed-58b0-562c-9930-4036930121d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9904a6ed-58b0-562c-9930-4036930121d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentation-level typography change with no impact to navigation, business logic, or data handling.
> 
> **Overview**
> Updates the mUSD conversion education screen header to use the design system `Text` component with `FontFamily.Hero` instead of a locally styled `Text` variant.
> 
> Removes the custom `heading` style block from `EarnMusdConversionEducationView.styles.ts`, centralizing typography styling in the design system.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa385f32fb81a0e76bb154f1716339c08470c8d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->