### PR TITLE
fix(analytics): fix user traits types violations

### DIFF
--- a/app/components/Views/ExperienceEnhancerModal/index.tsx
+++ b/app/components/Views/ExperienceEnhancerModal/index.tsx
@@ -42,7 +42,7 @@ const ExperienceEnhancerModal = () => {
       bottomSheetRef.current?.onCloseBottomSheet();
 
       addTraitsToUser({
-        [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.OFF,
+        [UserProfileProperty.HAS_MARKETING_CONSENT]: false,
       });
       trackEvent(
         createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)
@@ -66,7 +66,7 @@ const ExperienceEnhancerModal = () => {
       bottomSheetRef.current?.onCloseBottomSheet();
 
       addTraitsToUser({
-        [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+        [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       });
       trackEvent(
         createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)

--- a/app/components/Views/Settings/SecuritySettings/Sections/BlockaidSettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/BlockaidSettings.tsx
@@ -40,8 +40,8 @@ const BlockaidSettings = () => {
 
     addTraitsToUser({
       [UserProfileProperty.SECURITY_PROVIDERS]: newSecurityAlertsEnabledState
-        ? 'blockaid'
-        : '',
+        ? ['blockaid']
+        : [],
     });
   };
 

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.test.tsx
@@ -667,7 +667,7 @@ describe('MetaMetricsAndDataCollectionSection', () => {
             // if MetaMetrics is initially disabled, addTraitsToUser is called twice and this is 2nd call
             !metaMetricsInitiallyEnabled ? 2 : 1,
             {
-              has_marketing_consent: 'ON',
+              has_marketing_consent: true,
             },
           );
           expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
@@ -726,7 +726,7 @@ describe('MetaMetricsAndDataCollectionSection', () => {
           expect(mockAlert).not.toHaveBeenCalled();
           expect(mockAnalytics.identify).toHaveBeenCalledTimes(1);
           expect(mockAnalytics.identify).toHaveBeenCalledWith({
-            has_marketing_consent: 'OFF',
+            has_marketing_consent: false,
           });
           expect(mockAnalytics.trackEvent).toHaveBeenCalledTimes(1);
           expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
@@ -143,9 +143,7 @@ const MetaMetricsAndDataCollectionSection: React.FC<
 
   const addMarketingConsentToTraits = (marketingOptIn: boolean) => {
     analytics.identify({
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: marketingOptIn
-        ? UserProfileProperty.ON
-        : UserProfileProperty.OFF,
+      [UserProfileProperty.HAS_MARKETING_CONSENT]: marketingOptIn,
     });
     analytics.trackEvent(
       AnalyticsEventBuilder.createEventBuilder(

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -29,10 +29,10 @@ export interface UserProfileMetaData {
   [UserProfileProperty.THEME]: string | null | undefined;
   [UserProfileProperty.TOKEN_DETECTION]: string;
   [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: string;
-  [UserProfileProperty.SECURITY_PROVIDERS]: string;
+  [UserProfileProperty.SECURITY_PROVIDERS]: string[];
   [UserProfileProperty.PRIMARY_CURRENCY]?: string;
   [UserProfileProperty.CURRENT_CURRENCY]?: string;
-  [UserProfileProperty.HAS_MARKETING_CONSENT]: string;
+  [UserProfileProperty.HAS_MARKETING_CONSENT]: boolean;
   [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]?: number;
   [UserProfileProperty.CHAIN_IDS]: CaipChainId[];
   [UserProfileProperty.HAS_REWARDS_OPTED_IN]?: string;

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -72,15 +72,15 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.THEME]: 'dark',
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.ON,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+      [UserProfileProperty.SECURITY_PROVIDERS]: ['blockaid'],
+      [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });
 
   it.each([
-    [UserProfileProperty.ON, true],
-    [UserProfileProperty.OFF, false],
+    [true, true],
+    [false, false],
   ])('returns marketing consent "%s"', (expected, stateConsentValue) => {
     mockGetState.mockReturnValue({
       ...mockState,
@@ -111,7 +111,7 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.NFT_AUTODETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: '',
+      [UserProfileProperty.SECURITY_PROVIDERS]: [],
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -41,11 +41,9 @@ const generateUserProfileAnalyticsMetaData = (): AnalyticsUserTraits => {
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
     [UserProfileProperty.SECURITY_PROVIDERS]:
-      preferencesController?.securityAlertsEnabled ? 'blockaid' : '',
+      preferencesController?.securityAlertsEnabled ? ['blockaid'] : [],
     [UserProfileProperty.HAS_MARKETING_CONSENT]:
-      isDataCollectionForMarketingEnabled
-        ? UserProfileProperty.ON
-        : UserProfileProperty.OFF,
+      !!isDataCollectionForMarketingEnabled,
     [UserProfileProperty.CHAIN_IDS]: chainIds,
   };
   return traits;


### PR DESCRIPTION
## Summary
- Fix Segment schema validation failures for two user traits:
  - `traits.security_providers`: changed from string (`'blockaid'`/`''`) to string array (`['blockaid']`/`[]`)
  - `traits.has_marketing_consent`: changed from string (`'ON'`/`'OFF'`) to boolean (`true`/`false`)
- Updated `UserProfileMetaData` type interface to match Segment schema
- Fixed all trait assignments across components (`BlockaidSettings`, `ExperienceEnhancerModal`, `MetaMetricsAndDataCollectionSection`)
- Updated corresponding unit tests

fixes #23970

## Test plan
- [ ] Verify `generateUserProfileAnalyticsMetaData` unit tests pass
- [ ] Verify `MetaMetricsAndDataCollectionSection` unit tests pass
- [ ] Verify TypeScript compilation succeeds with no type errors
- [ ] Verify Segment events send correct types for `security_providers` (array) and `has_marketing_consent` (boolean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only/serialization changes to analytics traits and associated tests; risk is limited to metrics payload compatibility and potential downstream consumers expecting the old string values.
> 
> **Overview**
> Updates Segment user traits to match the expected schema: `UserProfileProperty.SECURITY_PROVIDERS` is now reported as a `string[]` (e.g. `['blockaid']`/`[]`) and `UserProfileProperty.HAS_MARKETING_CONSENT` as a `boolean` (`true`/`false`) instead of `'ON'/'OFF'`.
> 
> Propagates these type changes through the settings and consent UI (`BlockaidSettings`, `ExperienceEnhancerModal`, `MetaMetricsAndDataCollectionSection`) and through generated user-profile metadata (`generateUserProfileAnalyticsMetaData`), with unit tests updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7acfce12babfff307c6ccfe53dcc48a8db8d2f1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->