### PR TITLE
fix(analytics): fix user traits types violations

### DIFF
--- a/app/components/Views/ExperienceEnhancerModal/index.tsx
+++ b/app/components/Views/ExperienceEnhancerModal/index.tsx
@@ -42,7 +42,7 @@ const ExperienceEnhancerModal = () => {
       bottomSheetRef.current?.onCloseBottomSheet();
 
       addTraitsToUser({
-        [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.OFF,
+        [UserProfileProperty.HAS_MARKETING_CONSENT]: false,
       });
       trackEvent(
         createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)
@@ -66,7 +66,7 @@ const ExperienceEnhancerModal = () => {
       bottomSheetRef.current?.onCloseBottomSheet();
 
       addTraitsToUser({
-        [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+        [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       });
       trackEvent(
         createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)

--- a/app/components/Views/Settings/SecuritySettings/Sections/BlockaidSettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/BlockaidSettings.tsx
@@ -40,8 +40,8 @@ const BlockaidSettings = () => {
 
     addTraitsToUser({
       [UserProfileProperty.SECURITY_PROVIDERS]: newSecurityAlertsEnabledState
-        ? 'blockaid'
-        : '',
+        ? ['blockaid']
+        : [],
     });
   };
 

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.test.tsx
@@ -667,7 +667,7 @@ describe('MetaMetricsAndDataCollectionSection', () => {
             // if MetaMetrics is initially disabled, addTraitsToUser is called twice and this is 2nd call
             !metaMetricsInitiallyEnabled ? 2 : 1,
             {
-              has_marketing_consent: 'ON',
+              has_marketing_consent: true,
             },
           );
           expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
@@ -726,7 +726,7 @@ describe('MetaMetricsAndDataCollectionSection', () => {
           expect(mockAlert).not.toHaveBeenCalled();
           expect(mockAnalytics.identify).toHaveBeenCalledTimes(1);
           expect(mockAnalytics.identify).toHaveBeenCalledWith({
-            has_marketing_consent: 'OFF',
+            has_marketing_consent: false,
           });
           expect(mockAnalytics.trackEvent).toHaveBeenCalledTimes(1);
           expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
@@ -143,9 +143,7 @@ const MetaMetricsAndDataCollectionSection: React.FC<
 
   const addMarketingConsentToTraits = (marketingOptIn: boolean) => {
     analytics.identify({
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: marketingOptIn
-        ? UserProfileProperty.ON
-        : UserProfileProperty.OFF,
+      [UserProfileProperty.HAS_MARKETING_CONSENT]: marketingOptIn,
     });
     analytics.trackEvent(
       AnalyticsEventBuilder.createEventBuilder(

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -29,10 +29,10 @@ export interface UserProfileMetaData {
   [UserProfileProperty.THEME]: string | null | undefined;
   [UserProfileProperty.TOKEN_DETECTION]: string;
   [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: string;
-  [UserProfileProperty.SECURITY_PROVIDERS]: string;
+  [UserProfileProperty.SECURITY_PROVIDERS]: string[];
   [UserProfileProperty.PRIMARY_CURRENCY]?: string;
   [UserProfileProperty.CURRENT_CURRENCY]?: string;
-  [UserProfileProperty.HAS_MARKETING_CONSENT]: string;
+  [UserProfileProperty.HAS_MARKETING_CONSENT]: boolean;
   [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]?: number;
   [UserProfileProperty.CHAIN_IDS]: CaipChainId[];
   [UserProfileProperty.HAS_REWARDS_OPTED_IN]?: string;

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -72,15 +72,15 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.THEME]: 'dark',
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.ON,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+      [UserProfileProperty.SECURITY_PROVIDERS]: ['blockaid'],
+      [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });
 
   it.each([
-    [UserProfileProperty.ON, true],
-    [UserProfileProperty.OFF, false],
+    [true, true],
+    [false, false],
   ])('returns marketing consent "%s"', (expected, stateConsentValue) => {
     mockGetState.mockReturnValue({
       ...mockState,
@@ -111,7 +111,7 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.NFT_AUTODETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: '',
+      [UserProfileProperty.SECURITY_PROVIDERS]: [],
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -41,11 +41,9 @@ const generateUserProfileAnalyticsMetaData = (): AnalyticsUserTraits => {
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
     [UserProfileProperty.SECURITY_PROVIDERS]:
-      preferencesController?.securityAlertsEnabled ? 'blockaid' : '',
+      preferencesController?.securityAlertsEnabled ? ['blockaid'] : [],
     [UserProfileProperty.HAS_MARKETING_CONSENT]:
-      isDataCollectionForMarketingEnabled
-        ? UserProfileProperty.ON
-        : UserProfileProperty.OFF,
+      !!isDataCollectionForMarketingEnabled,
     [UserProfileProperty.CHAIN_IDS]: chainIds,
   };
   return traits;


### PR DESCRIPTION
## Summary
- Fixed Segment schema validation failures for two user traits:
  - `traits.security_providers`: was sending a string (`'blockaid'`/`''`), now correctly sends a string array (`['blockaid']`/`[]`)
  - `traits.has_marketing_consent`: was sending a string (`'ON'`/`'OFF'`), now correctly sends a boolean (`true`/`false`)
- Updated `UserProfileMetaData` type interface to match Segment schema
- Fixed all direct trait assignments in `BlockaidSettings`, `ExperienceEnhancerModal`, and `MetaMetricsAndDataCollectionSection`
- Updated corresponding unit tests

fixes #23970

## Test plan
- [ ] `generateUserProfileAnalyticsMetaData` unit tests pass with corrected types
- [ ] `MetaMetricsAndDataCollectionSection` unit tests pass with corrected trait expectations
- [ ] TypeScript compilation succeeds with no type errors
- [ ] Segment events send correct types for `security_providers` (array) and `has_marketing_consent` (boolean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized analytics/telemetry type changes with updated tests; minimal behavioral impact beyond trait payload shape.
> 
> **Overview**
> Ensures Segment user traits match the expected schema by changing `traits.security_providers` from a string to a string array and `traits.has_marketing_consent` from `'ON'/'OFF'` to a boolean.
> 
> Updates all call sites that set these traits (security alerts toggle, marketing consent modal, and settings marketing switch) plus `generateUserProfileAnalyticsMetaData` and related unit tests to assert the new trait shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12aadd06b335d18964b0455603c7c4d0e730faf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->