### PR TITLE
Cherry-picking commits from main to release/7.66.0 for PR #26373

### DIFF
--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
@@ -18,6 +18,7 @@ import {
   PULL_THRESHOLD,
   SCROLL_TOP_THRESHOLD,
   PULL_ACTIVATION_ZONE,
+  PULL_MOVE_ACTIVATION,
 } from './constants';
 
 const styles = StyleSheet.create({
@@ -65,8 +66,10 @@ export interface GestureWebViewWrapperProps {
  * - Right edge swipe: Navigate forward
  * - Pull-to-refresh: Reload page (when scrolled to top)
  *
- * Uses Gesture.Race with manualActivation(true) to coordinate gestures with WebView's
- * native touch handling.
+ * Uses Gesture.Simultaneous with manualActivation(true) to coordinate gestures with
+ * WebView's native touch handling. Simultaneous allows both our Pan and the Native
+ * gesture to coexist so that taps pass through while pull-to-refresh uses deferred
+ * activation.
  */
 export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
   isTabActive,
@@ -90,12 +93,14 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
   const pullProgress = useSharedValue(0);
   const isPulling = useSharedValue(false);
   const pullHapticTriggered = useSharedValue(false);
+  const initialTouchY = useSharedValue(0);
+  const initialTouchX = useSharedValue(0);
   const swipeStartTime = useRef<number>(0);
   const swipeProgress = useSharedValue(0);
   const swipeDirection = useSharedValue<'back' | 'forward' | null>(null);
-  const gestureType = useSharedValue<'back' | 'forward' | 'refresh' | null>(
-    null,
-  );
+  const gestureType = useSharedValue<
+    'back' | 'forward' | 'refresh' | 'pending_refresh' | null
+  >(null);
 
   // Navigation state as shared values - prevents stale reads in worklets
   // These are synced from props to ensure real-time access in UI thread
@@ -244,19 +249,53 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             stateManager.activate();
             runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
           } else if (canPullToRefresh) {
+            gestureType.value = 'pending_refresh';
+            initialTouchY.value = y;
+            initialTouchX.value = x;
+          } else {
+            stateManager.fail();
+          }
+        })
+        .onTouchesMove((event, stateManager) => {
+          'worklet';
+          if (gestureType.value !== 'pending_refresh') return;
+
+          const touch = event.allTouches[0];
+          if (!touch) {
+            gestureType.value = null;
+            stateManager.fail();
+            return;
+          }
+
+          const deltaY = touch.y - initialTouchY.value;
+          const deltaX = Math.abs(touch.x - initialTouchX.value);
+
+          if (deltaY > PULL_MOVE_ACTIVATION && deltaY > deltaX) {
             gestureType.value = 'refresh';
             isPulling.value = true;
             pullProgress.value = 0;
             pullHapticTriggered.value = false;
             stateManager.activate();
-          } else {
+          } else if (
+            deltaX > PULL_MOVE_ACTIVATION ||
+            deltaY < -PULL_MOVE_ACTIVATION
+          ) {
+            gestureType.value = null;
+            stateManager.fail();
+          }
+        })
+        .onTouchesUp((_event, stateManager) => {
+          'worklet';
+          if (gestureType.value === 'pending_refresh') {
+            gestureType.value = null;
             stateManager.fail();
           }
         })
         .onUpdate((event) => {
           'worklet';
           const currentGestureType = gestureType.value;
-          if (!currentGestureType) return;
+          if (!currentGestureType || currentGestureType === 'pending_refresh')
+            return;
 
           const swipeDistance = screenWidth * SWIPE_THRESHOLD;
 
@@ -297,8 +336,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
         .onEnd((event) => {
           'worklet';
           const currentGestureType = gestureType.value;
-          if (!currentGestureType) {
-            // Reset animations directly on UI thread
+          if (!currentGestureType || currentGestureType === 'pending_refresh') {
             swipeProgress.value = withTiming(0, { duration: 200 });
             swipeDirection.value = null;
             pullProgress.value = withTiming(0, { duration: 200 });
@@ -311,14 +349,12 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
 
           if (currentGestureType === 'back') {
             if (event.translationX >= swipeDistance) {
-              // Only runOnJS for callbacks that need JS thread (navigation, analytics)
               runOnJS(handleSwipeNavigation)(
                 'back',
                 event.translationX,
                 duration,
               );
             }
-            // Reset swipe animation directly on UI thread
             swipeProgress.value = withTiming(0, { duration: 200 });
             swipeDirection.value = null;
           } else if (currentGestureType === 'forward') {
@@ -336,7 +372,6 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
               pullDistanceRef.current = event.translationY;
               runOnJS(handleRefresh)();
             }
-            // Reset pull animation directly on UI thread
             pullProgress.value = withTiming(0, { duration: 200 });
             isPulling.value = false;
           }
@@ -367,10 +402,15 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
   );
 
   /**
-   * Combined gesture - uses Race so our gesture takes priority when activated
+   * Combined gesture - Simultaneous allows both our Pan and the WebView's Native
+   * gesture to coexist. This is critical for deferred pull-to-refresh activation:
+   * while Pan is in BEGAN (deciding if touch is a tap vs pull), Native independently
+   * handles the touch so taps pass through to the WebView. When Pan activates for
+   * a real pull, both gestures are active but since we're at the top of the page,
+   * the WebView has nothing to scroll.
    */
   const combinedWebViewGesture = useMemo(
-    () => Gesture.Race(fullyUnifiedGesture, webViewNativeGesture),
+    () => Gesture.Simultaneous(fullyUnifiedGesture, webViewNativeGesture),
     [webViewNativeGesture, fullyUnifiedGesture],
   );
 

--- a/app/components/Views/BrowserTab/constants.ts
+++ b/app/components/Views/BrowserTab/constants.ts
@@ -49,3 +49,11 @@ export const SCROLL_TOP_THRESHOLD = 5;
  * WebView interactions (tapping links, buttons, etc.).
  */
 export const PULL_ACTIVATION_ZONE = 50;
+
+/**
+ * Minimum downward movement in pixels before activating pull-to-refresh.
+ * This prevents taps on buttons near the top of the page from being
+ * swallowed by the gesture handler. The gesture stays in a "pending"
+ * state until the finger moves down by at least this amount.
+ */
+export const PULL_MOVE_ACTIVATION = 10;


### PR DESCRIPTION
## **Description**

Pull-to-refresh gesture was intercepting taps on buttons near the top of the page (e.g., Polymarket "Sign Up" / "Log In" buttons). The gesture handler called `stateManager.activate()` immediately in `onTouchesDown` for the pull zone (`y < 50px`), stealing the touch from the WebView before knowing whether the user intended to tap or pull.

### Changes

**Deferred activation for pull-to-refresh**: Instead of activating immediately, the gesture enters a `pending_refresh` state in `onTouchesDown`. New `onTouchesMove` and `onTouchesUp` handlers measure the movement delta:
- Downward movement >10px → activate pull-to-refresh
- Horizontal/upward movement >10px → fail and let WebView handle
- Finger lifts with <10px movement (tap) → fail and let WebView handle

**`Gesture.Simultaneous` instead of `Gesture.Race`**: Deferred activation requires that the Native gesture (WebView scroll) does not cancel our Pan while it is deciding. `Gesture.Simultaneous` allows both to run independently — taps pass through to the WebView while our Pan stays in BEGAN state deciding, and when Pan activates for a real pull at the top of the page, the WebView has nothing to scroll so both coexist without visual conflict.

### Why not other approaches

- `Gesture.Race` + deferred activation: Native wins the race and cancels Pan before `onTouchesMove` fires
- `Gesture.Race` + immediate activation + synthetic JS click replay: Pull-to-refresh works but synthetic events have `isTrusted = false` — React ignores them
- `Gesture.Exclusive` + deferred activation: Blocks Native while Pan is in BEGAN — nothing works

## **Changelog**

CHANGELOG entry: Fixed pull-to-refresh gesture intercepting taps on buttons near the top of the page in the in-app browser

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-352

## **Manual testing steps**

```gherkin
Feature: Browser gesture tap passthrough

  Scenario: User taps a button near the top of a webpage
    Given the user is on polymarket.com in the in-app browser
    And the page is scrolled to the top (not scrolled at all)

    When user taps the "Log In" or "Sign Up" button
    Then the login/signup modal should appear

  Scenario: User pulls to refresh from the top of the page
    Given the user is on any webpage in the in-app browser
    And the page is scrolled to the top

    When user places finger near the top of the page and drags downward
    Then the refresh indicator should appear
    And the page should reload when pulled past the threshold

  Scenario: User swipes back from the left edge
    Given the user has navigated to at least one page in the in-app browser

    When user swipes from the left edge of the screen toward the right
    Then the browser should navigate back to the previous page

  Scenario: User swipes forward from the right edge
    Given the user has navigated back at least once in the in-app browser

    When user swipes from the right edge of the screen toward the left
    Then the browser should navigate forward

  Scenario: User scrolls normally in the center of the page
    Given the user is on any webpage in the in-app browser

    When user scrolls up or down in the center of the page
    Then the page should scroll normally without triggering any gestures
```

## **Screenshots/Recordings**

### **Before**

<!-- Tapping buttons near the top of the page (e.g. Polymarket Sign Up/Log In) shows button animation but does not trigger the action -->

### **After**

<!-- Tapping the same buttons now correctly opens the login/signup flow -->


https://github.com/user-attachments/assets/75c70094-6f39-4086-aab4-368cc6b81177



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level gesture activation/composition for the in-app browser, which can subtly affect navigation/scroll behavior across platforms; covered by expanded unit tests but still user-interaction sensitive.
> 
> **Overview**
> Fixes in-app browser pull-to-refresh stealing taps near the top of the WebView by **deferring refresh gesture activation**: touches in the pull zone now enter a `pending_refresh` state and only activate refresh after a downward move beyond `PULL_MOVE_ACTIVATION` (10px), otherwise failing on tap, horizontal, or upward movement.
> 
> Switches the WebView gesture composition from `Gesture.Race` to **`Gesture.Simultaneous`** so the WebView’s native gesture can continue handling taps/scroll while the Pan gesture decides whether to activate, and adds comprehensive unit test coverage for the new touch-move/up paths plus the new constant in `constants.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4592322981531a5126694c1aa27dc2e1ec0d76e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
