### PR TITLE
fix: Fix normalising gas inputs regardless of keyboard separator

### DIFF
--- a/app/components/Views/confirmations/components/gas/max-base-fee-input/max-base-fee-input.tsx
+++ b/app/components/Views/confirmations/components/gas/max-base-fee-input/max-base-fee-input.tsx
@@ -12,7 +12,7 @@ import { hexWEIToDecGWEI } from '../../../../../../util/conversions';
 import { limitToMaximumDecimalPlaces } from '../../../../../../util/number';
 import { useGasFeeEstimates } from '../../../hooks/gas/useGasFeeEstimates';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { convertGasInputToHexWEI } from '../../../utils/gas';
+import { convertGasInputToHexWEI, normalizeGasInput } from '../../../utils/gas';
 import { validateMaxBaseFee } from '../../../utils/validations/gas';
 import { TextFieldWithLabel } from '../../UI/text-field-with-label';
 import styleSheet from './max-base-fee-input.styles';
@@ -64,9 +64,10 @@ export const MaxBaseFeeInput = ({
 
   const handleChange = useCallback(
     (text: string) => {
-      validateMaxBaseFeeCallback(text);
-      setValue(text);
-      const updatedMaxBaseFee = convertGasInputToHexWEI(text);
+      const normalisedInput = normalizeGasInput(text);
+      validateMaxBaseFeeCallback(normalisedInput);
+      setValue(normalisedInput);
+      const updatedMaxBaseFee = convertGasInputToHexWEI(normalisedInput);
       onChange(updatedMaxBaseFee);
     },
     [onChange, validateMaxBaseFeeCallback],

--- a/app/components/Views/confirmations/components/gas/priority-fee-input/priority-fee-input.tsx
+++ b/app/components/Views/confirmations/components/gas/priority-fee-input/priority-fee-input.tsx
@@ -12,7 +12,7 @@ import { hexWEIToDecGWEI } from '../../../../../../util/conversions';
 import { limitToMaximumDecimalPlaces } from '../../../../../../util/number';
 import { useGasFeeEstimates } from '../../../hooks/gas/useGasFeeEstimates';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { convertGasInputToHexWEI } from '../../../utils/gas';
+import { convertGasInputToHexWEI, normalizeGasInput } from '../../../utils/gas';
 import { validatePriorityFee } from '../../../utils/validations/gas';
 import { TextFieldWithLabel } from '../../UI/text-field-with-label';
 import styleSheet from './priority-fee-input.styles';
@@ -62,9 +62,10 @@ export const PriorityFeeInput = ({
 
   const handleChange = useCallback(
     (text: string) => {
-      validatePriorityFeeCallback(text);
-      setValue(text);
-      const updatedPriorityFee = convertGasInputToHexWEI(text);
+      const normalisedInput = normalizeGasInput(text);
+      validatePriorityFeeCallback(normalisedInput);
+      setValue(normalisedInput);
+      const updatedPriorityFee = convertGasInputToHexWEI(normalisedInput);
       onChange(updatedPriorityFee);
     },
     [onChange, validatePriorityFeeCallback],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to accept `Priority fee` and `Max base fee` inputs to ignore separator depending on the locale. 

After fix it accepts both `,` and `.`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes an issue where validation triggered when user tries `,` separator in gas fields

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="583" height="1113" alt="Screenshot 2026-02-23 at 13 43 00" src="https://github.com/user-attachments/assets/9f3c996c-3120-4be5-924f-e3bbe6893e47" />


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
