### PR TITLE
fix(predict): test balance against full order amount with fees

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -159,7 +159,7 @@ export function usePredictPlaceOrder(
       // Check if user has sufficient balance for the bet amount
       if (side === Side.BUY && balance < totalAmount) {
         await deposit({
-          amountUsd: maxAmountSpent,
+          amountUsd: totalAmount,
           analyticsProperties: {
             ...orderParams.analyticsProperties,
             marketId: orderParams.preview.marketId,

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -157,7 +157,6 @@ export function usePredictPlaceOrder(
       const totalAmount = maxAmountSpent + (fees?.totalFee ?? 0);
 
       // Check if user has sufficient balance for the bet amount
-      // maxAmountSpent includes the bet amount plus all fees
       if (side === Side.BUY && balance < totalAmount) {
         await deposit({
           amountUsd: maxAmountSpent,

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -151,12 +151,14 @@ export function usePredictPlaceOrder(
   const placeOrder = useCallback(
     async (orderParams: PlaceOrderParams): Promise<PlaceOrderOutcome> => {
       const {
-        preview: { minAmountReceived, side, maxAmountSpent },
+        preview: { minAmountReceived, side, maxAmountSpent, fees },
       } = orderParams;
+
+      const totalAmount = maxAmountSpent + (fees?.totalFee ?? 0);
 
       // Check if user has sufficient balance for the bet amount
       // maxAmountSpent includes the bet amount plus all fees
-      if (side === Side.BUY && balance < maxAmountSpent) {
+      if (side === Side.BUY && balance < totalAmount) {
         await deposit({
           amountUsd: maxAmountSpent,
           analyticsProperties: {


### PR DESCRIPTION
## **Description**

The balance check in `usePredictPlaceOrder` was comparing against `maxAmountSpent` alone, which does not include fees. This caused the deposit flow to be skipped when the user's balance was sufficient for the bet amount but insufficient to cover the bet amount plus fees, leading to order failures.

This fix computes the `totalAmount` as `maxAmountSpent + fees.totalFee` and uses it for the balance comparison, ensuring the deposit prompt triggers correctly when the full cost (including fees) exceeds the user's balance.

## **Changelog**

CHANGELOG entry: Fixed a bug where the balance check for prediction market orders did not account for fees, causing orders to fail when the user's balance was insufficient to cover fees

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-678

## **Manual testing steps**

```gherkin
Feature: Predict order balance check includes fees

  Scenario: user places a BUY order with balance less than amount + fees
    Given the user has a balance that covers the bet amount but not the bet amount plus fees

    When user places a BUY order
    Then the deposit flow is triggered to top up the shortfall

  Scenario: user places a BUY order with balance covering full amount with fees
    Given the user has a balance that covers both the bet amount and fees

    When user places a BUY order
    Then the order proceeds without triggering the deposit flow
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A - logic-only change -->

### **After**

<!-- N/A - logic-only change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized logic change to preflight balance validation; main risk is minor behavior change in when the deposit flow triggers.
> 
> **Overview**
> Fixes a Predict order placement bug where the BUY-side balance check only compared against `maxAmountSpent` and could skip the deposit prompt when fees pushed the total cost over the user’s balance.
> 
> `usePredictPlaceOrder` now computes a `totalAmount` as `maxAmountSpent + fees.totalFee` (with a safe default) and uses that value for both the insufficient-funds comparison and the `deposit` amount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 878791248eec59ace59089ed62bcd66da037087c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->