### PR TITLE
fix(predict): use event.markets[0].description in about tab

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -954,7 +954,8 @@ describe('polymarket utils', () => {
         {
           conditionId: 'market-1',
           question: 'Will it rain?',
-          description: 'Weather prediction',
+          // Event description matches markets' descriptions (as per Polymarket's team)
+          description: 'A test event',
           icon: 'https://example.com/market-icon.png',
           image: 'https://example.com/market-image.png',
           groupItemTitle: 'Weather',
@@ -998,7 +999,7 @@ describe('polymarket utils', () => {
             providerId: POLYMARKET_PROVIDER_ID,
             marketId: 'event-1',
             title: 'Will it rain?',
-            description: 'Weather prediction',
+            description: 'A test event',
             image: 'https://example.com/market-icon.png',
             groupItemTitle: 'Weather',
             status: 'open',

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -661,7 +661,10 @@ export const parsePolymarketEvents = (
         slug: event.slug,
         providerId: POLYMARKET_PROVIDER_ID,
         title: event.title,
-        description: event.description,
+        // As per Polymarket's team, we should use the first market's description
+        // rather than the event's description. The event's description is not
+        // guaranteed to be accurate. They also do this on their webbsite.
+        description: event.markets?.[0]?.description ?? event.description,
         image: event.icon,
         status: event.closed
           ? PredictMarketStatus.CLOSED


### PR DESCRIPTION
## **Description**

As per Polymarket's team guidance, the event's `description` field is not guaranteed to be accurate. Instead, we should use the first market's description (`event.markets[0].description`), which is what Polymarket does on their own website.

This PR updates `parsePolymarketEvents` to use `event.markets?.[0]?.description` with a fallback to `event.description` when unavailable.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-693

## **Manual testing steps**

```gherkin
Feature: Predict About Tab Description

  Scenario: user views event description in about tab
    Given user is on the Predict tab with a Polymarket event

    When user opens an event and views the About tab
    Then the description should show the first market's description instead of the event description
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A - logic-only change -->

### **After**

<!-- N/A - logic-only change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized data-mapping change affecting only displayed description text; logic includes a safe fallback and is covered by updated tests.
> 
> **Overview**
> Adjusts `parsePolymarketEvents` to set a parsed Polymarket event’s `description` from `event.markets?.[0]?.description`, falling back to `event.description` when missing, to better match Polymarket’s canonical descriptions.
> 
> Updates the associated unit test fixture/expectations in `utils.test.ts` to reflect the new source of truth for the event and outcome descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1eb86a09b6c660bd246f3155446f1b1f3f6d40d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->