### PR TITLE
chore: upgrade @metamask/utils to ^11.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "@metamask/transaction-controller": "^62.16.0",
     "@metamask/transaction-pay-controller": "^15.0.1",
     "@metamask/tron-wallet-snap": "^1.21.1",
-    "@metamask/utils": "^11.8.1",
+    "@metamask/utils": "^11.10.0",
     "@myx-trade/sdk": "^0.1.265",
     "@ngraveio/bc-ur": "^1.1.6",
     "@nktkas/hyperliquid": "^0.30.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10296,6 +10296,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/utils@npm:^11.10.0":
+  version: 11.10.0
+  resolution: "@metamask/utils@npm:11.10.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    "@types/lodash": "npm:^4.17.20"
+    debug: "npm:^4.3.4"
+    lodash: "npm:^4.17.21"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
+  languageName: node
+  linkType: hard
+
 "@metamask/utils@npm:^8.2.0":
   version: 8.5.0
   resolution: "@metamask/utils@npm:8.5.0"
@@ -35572,7 +35591,7 @@ __metadata:
     "@metamask/transaction-controller": "npm:^62.16.0"
     "@metamask/transaction-pay-controller": "npm:^15.0.1"
     "@metamask/tron-wallet-snap": "npm:^1.21.1"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.10.0"
     "@myx-trade/sdk": "npm:^0.1.265"
     "@ngraveio/bc-ur": "npm:^1.1.6"
     "@nktkas/hyperliquid": "npm:^0.30.2"


### PR DESCRIPTION
## **Description**

Upgrades `@metamask/utils` from `^11.8.1` to `^11.10.0` to satisfy the new peer dependency introduced by `@metamask/design-system-react-native@^0.7.0`.

This is a dependency of #26450.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #26450 (review comment https://github.com/MetaMask/metamask-mobile/pull/26450#discussion_r2843317586)

## **Manual testing steps**

```gherkin
Feature: @metamask/utils upgrade

  Scenario: app builds successfully
    Given the upgraded package is installed
    When yarn setup:expo is run
    Then the app builds without peer dependency warnings for @metamask/utils
```

## **Screenshots/Recordings**

N/A — dependency-only change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no application code changes; risk is limited to potential upstream behavior changes in `@metamask/utils` affecting consumers at runtime/build time.
> 
> **Overview**
> Upgrades the `@metamask/utils` dependency from `^11.8.1` to `^11.10.0`.
> 
> Updates `yarn.lock` to include the resolved `11.10.0` package entry and align the workspace dependency list accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef5ef3c0632c60a1d179f96b53c6dedfab8a19a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->