### PR TITLE
fix: MUSD-318 confirmation toast is delayed after converting max tx

### DIFF
--- a/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.test.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.test.tsx
@@ -12,7 +12,7 @@ import { useMusdConversion } from '../../hooks/useMusdConversion';
 import { selectMusdQuickConvertEnabledFlag } from '../../selectors/featureFlags';
 import {
   createTokenChainKey,
-  selectHasInFlightMusdConversion,
+  selectHasPendingMusdConversion,
   selectMusdConversionStatuses,
 } from '../../selectors/musdConversionStatus';
 import { MUSD_CONVERSION_APY } from '../../constants/musd';
@@ -42,7 +42,7 @@ jest.mock('../../selectors/featureFlags', () => ({
 }));
 jest.mock('../../selectors/musdConversionStatus', () => ({
   ...jest.requireActual('../../selectors/musdConversionStatus'),
-  selectHasInFlightMusdConversion: jest.fn(),
+  selectHasPendingMusdConversion: jest.fn(),
   selectMusdConversionStatuses: jest.fn(),
 }));
 const mockGetStakingNavbar = jest.fn<object, unknown[]>(() => ({}));
@@ -91,9 +91,9 @@ const mockUseMusdConversion = useMusdConversion as jest.MockedFunction<
 const mockUseMusdBalance = useMusdBalance as jest.MockedFunction<
   typeof useMusdBalance
 >;
-const mockSelectHasInFlightMusdConversion =
-  selectHasInFlightMusdConversion as jest.MockedFunction<
-    typeof selectHasInFlightMusdConversion
+const mockSelectHasPendingMusdConversion =
+  selectHasPendingMusdConversion as jest.MockedFunction<
+    typeof selectHasPendingMusdConversion
   >;
 const mockSelectMusdConversionStatuses =
   selectMusdConversionStatuses as jest.MockedFunction<
@@ -171,7 +171,7 @@ describe('MusdQuickConvertView', () => {
       fiatBalanceAggregated: undefined,
       fiatBalanceAggregatedFormatted: '$0.00',
     });
-    mockSelectHasInFlightMusdConversion.mockReturnValue(false);
+    mockSelectHasPendingMusdConversion.mockReturnValue(false);
     mockSelectMusdConversionStatuses.mockReturnValue({});
   });
 
@@ -442,7 +442,7 @@ describe('MusdQuickConvertView', () => {
   });
 
   describe('in-flight conversion', () => {
-    it('does not call initiateMaxConversion or initiateCustomConversion when Max or Edit is pressed and hasInFlightMusdConversion is true', async () => {
+    it('does not call initiateMaxConversion or initiateCustomConversion when Max or Edit is pressed and hasPendingMusdConversion is true', async () => {
       const token = createMockToken();
       mockUseMusdConversionTokens.mockReturnValue({
         tokens: [token],
@@ -451,7 +451,7 @@ describe('MusdQuickConvertView', () => {
         isMusdSupportedOnChain: jest.fn(),
         hasConvertibleTokensByChainId: jest.fn(),
       });
-      mockSelectHasInFlightMusdConversion.mockReturnValue(true);
+      mockSelectHasPendingMusdConversion.mockReturnValue(true);
 
       const { getAllByTestId } = renderWithProvider(<MusdQuickConvertView />, {
         state: initialRootState,

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/index.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/index.tsx
@@ -17,7 +17,7 @@ import { useMusdConversion } from '../../hooks/useMusdConversion';
 import { selectMusdQuickConvertEnabledFlag } from '../../selectors/featureFlags';
 import {
   createTokenChainKey,
-  selectHasInFlightMusdConversion,
+  selectHasPendingMusdConversion,
   selectMusdConversionStatuses,
 } from '../../selectors/musdConversionStatus';
 import ConvertTokenRow from '../../components/Musd/ConvertTokenRow';
@@ -74,9 +74,7 @@ const MusdQuickConvertView = () => {
   // Get convertible tokens
   const { tokens: conversionTokens } = useMusdConversionTokens();
 
-  const hasInFlightMusdConversion = useSelector(
-    selectHasInFlightMusdConversion,
-  );
+  const hasPendingMusdConversion = useSelector(selectHasPendingMusdConversion);
 
   const conversionStatusesByTokenChainKey = useSelector(
     selectMusdConversionStatuses,
@@ -193,7 +191,7 @@ const MusdQuickConvertView = () => {
           token={item}
           onMaxPress={handleMaxPress}
           onEditPress={handleEditPress}
-          isActionsDisabled={hasInFlightMusdConversion}
+          isActionsDisabled={hasPendingMusdConversion}
           isConversionPending={Boolean(txStatusInfo?.isPending)}
         />
       );
@@ -202,7 +200,7 @@ const MusdQuickConvertView = () => {
       conversionStatusesByTokenChainKey,
       handleEditPress,
       handleMaxPress,
-      hasInFlightMusdConversion,
+      hasPendingMusdConversion,
     ],
   );
 

--- a/app/components/UI/Earn/hooks/useMusdConversionStatus.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionStatus.test.ts
@@ -53,6 +53,9 @@ jest.mock('../../../../store', () => ({
 jest.mock('../../../../selectors/transactionPayController', () => ({
   selectTransactionPayQuotesByTransactionId: jest.fn(),
 }));
+jest.mock('../selectors/musdConversionStatus', () => ({
+  selectPendingMusdConversionsForRelayMatch: jest.fn(),
+}));
 
 import { useSelector } from 'react-redux';
 import { selectERC20TokensByChain } from '../../../../selectors/tokenListController';
@@ -71,11 +74,15 @@ import {
   TransactionPayStrategy,
   type TransactionPayQuote,
 } from '@metamask/transaction-pay-controller';
+import { selectPendingMusdConversionsForRelayMatch } from '../selectors/musdConversionStatus';
 
 const mockTrace = trace as jest.MockedFunction<typeof trace>;
 const mockEndTrace = endTrace as jest.MockedFunction<typeof endTrace>;
 const mockSelectTransactionPayQuotesByTransactionId = jest.mocked(
   selectTransactionPayQuotesByTransactionId,
+);
+const mockSelectPendingMusdConversionsForRelayMatch = jest.mocked(
+  selectPendingMusdConversionsForRelayMatch,
 );
 
 const mockUseSelector = jest.mocked(useSelector);
@@ -212,6 +219,7 @@ describe('useMusdConversionStatus', () => {
       showToast: mockShowToast,
       EarnToastOptions: mockEarnToastOptions,
     });
+    mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([]);
 
     // Setup useSelector to return different values based on selector
     mockUseSelector.mockImplementation((selector) => {
@@ -466,7 +474,7 @@ describe('useMusdConversionStatus', () => {
   });
 
   describe('confirmed transaction status', () => {
-    it('shows success toast when transactionConfirmed event fires with confirmed status', () => {
+    it('ignores transactionConfirmed event when type is musdConversion', () => {
       renderHook(() => useMusdConversionStatus());
 
       const handler = getConfirmedHandler();
@@ -477,10 +485,7 @@ describe('useMusdConversionStatus', () => {
       // transactionConfirmed event receives transactionMeta directly (not wrapped)
       handler(transactionMeta);
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).toHaveBeenCalledWith(
-        mockEarnToastOptions.mUsdConversion.success,
-      );
+      expect(mockShowToast).not.toHaveBeenCalled();
     });
 
     it('ignores transactionConfirmed event when status is failed', () => {
@@ -496,37 +501,107 @@ describe('useMusdConversionStatus', () => {
       expect(mockShowToast).not.toHaveBeenCalled();
     });
 
-    it('prevents duplicate success toast for same transaction', () => {
+    it('prevents duplicate success toast for same relayDeposit match', () => {
+      const inFlightMusdConversionMeta = createTransactionMeta(
+        TransactionStatus.signed,
+        'musd-in-flight-dedupe',
+        TransactionType.musdConversion,
+        {
+          chainId: '0x1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        },
+      );
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightMusdConversionMeta,
+      ]);
+
       renderHook(() => useMusdConversionStatus());
 
       const handler = getConfirmedHandler();
-      const transactionMeta = createTransactionMeta(
+      const relayDepositMeta = createTransactionMeta(
         TransactionStatus.confirmed,
+        'relay-deposit-dedupe',
+        TransactionType.relayDeposit,
       );
 
-      handler(transactionMeta);
-      handler(transactionMeta);
+      handler(relayDepositMeta);
+      handler(relayDepositMeta);
 
       expect(mockShowToast).toHaveBeenCalledTimes(1);
     });
 
-    it('cleans up toast tracking entries after 5 seconds for confirmed status', () => {
+    it('shows success toast when relayDeposit confirms and single in-flight mUSD conversion matches by from address', () => {
+      setupTokensCacheMock({
+        '0x1': {
+          data: {
+            '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': {
+              symbol: 'USDC',
+              name: 'USD Coin',
+            },
+          },
+        },
+      });
+
+      const inFlightMusdConversionMeta = createTransactionMeta(
+        TransactionStatus.signed,
+        'musd-in-flight-1',
+        TransactionType.musdConversion,
+        {
+          chainId: '0x1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        },
+      );
+
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightMusdConversionMeta,
+      ]);
+
       renderHook(() => useMusdConversionStatus());
 
-      const statusHandler = getSubscribedHandler();
       const confirmedHandler = getConfirmedHandler();
+      const relayDepositConfirmedMeta = createTransactionMeta(
+        TransactionStatus.confirmed,
+        'relay-deposit-1',
+        TransactionType.relayDeposit,
+      );
+
+      confirmedHandler(relayDepositConfirmedMeta);
+
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(mockShowToast).toHaveBeenCalledWith(
+        mockEarnToastOptions.mUsdConversion.success,
+      );
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transaction_id: 'musd-in-flight-1',
+          transaction_status: TransactionStatus.signed,
+          transaction_type: TransactionType.musdConversion,
+        }),
+      );
+    });
+
+    it('cleans up toast tracking entries after 5 seconds for confirmed status', () => {
       const transactionId = 'test-transaction-1';
       const approvedMeta = createTransactionMeta(
         TransactionStatus.approved,
         transactionId,
       );
-      const confirmedMeta = createTransactionMeta(
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        approvedMeta,
+      ]);
+
+      renderHook(() => useMusdConversionStatus());
+
+      const statusHandler = getSubscribedHandler();
+      const confirmedHandler = getConfirmedHandler();
+      const relayDepositConfirmedMeta = createTransactionMeta(
         TransactionStatus.confirmed,
-        transactionId,
+        'relay-deposit-cleanup',
+        TransactionType.relayDeposit,
       );
 
       statusHandler({ transactionMeta: approvedMeta });
-      confirmedHandler(confirmedMeta);
+      confirmedHandler(relayDepositConfirmedMeta);
 
       expect(mockShowToast).toHaveBeenCalledTimes(2);
 
@@ -534,7 +609,7 @@ describe('useMusdConversionStatus', () => {
 
       // After cleanup, should be able to show toasts again for same transaction
       statusHandler({ transactionMeta: approvedMeta });
-      confirmedHandler(confirmedMeta);
+      confirmedHandler(relayDepositConfirmedMeta);
 
       expect(mockShowToast).toHaveBeenCalledTimes(4);
     });
@@ -598,18 +673,23 @@ describe('useMusdConversionStatus', () => {
 
   describe('transaction flow from approved to final status', () => {
     it('shows both in-progress and success toasts for transaction flow', () => {
-      renderHook(() => useMusdConversionStatus());
-
-      const statusHandler = getSubscribedHandler();
-      const confirmedHandler = getConfirmedHandler();
       const transactionId = 'test-transaction-3';
       const approvedMeta = createTransactionMeta(
         TransactionStatus.approved,
         transactionId,
       );
-      const confirmedMeta = createTransactionMeta(
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        approvedMeta,
+      ]);
+
+      renderHook(() => useMusdConversionStatus());
+
+      const statusHandler = getSubscribedHandler();
+      const confirmedHandler = getConfirmedHandler();
+      const relayDepositConfirmedMeta = createTransactionMeta(
         TransactionStatus.confirmed,
-        transactionId,
+        'relay-deposit-flow',
+        TransactionType.relayDeposit,
       );
 
       statusHandler({ transactionMeta: approvedMeta });
@@ -617,7 +697,7 @@ describe('useMusdConversionStatus', () => {
       expect(mockShowToast).toHaveBeenCalledTimes(1);
       expect(mockShowToast).toHaveBeenCalledWith(mockInProgressToast);
 
-      confirmedHandler(confirmedMeta);
+      confirmedHandler(relayDepositConfirmedMeta);
 
       expect(mockShowToast).toHaveBeenCalledTimes(2);
       expect(mockShowToast).toHaveBeenCalledWith(
@@ -739,72 +819,77 @@ describe('useMusdConversionStatus', () => {
     });
   });
 
-  describe('multiple concurrent transactions', () => {
-    it('tracks and shows toasts for different transactions independently', () => {
+  describe('relay matching guardrails', () => {
+    it('does not show success toast when more than one in-flight conversion exists for same sender', () => {
+      const inFlightConversionOne = createTransactionMeta(
+        TransactionStatus.signed,
+        'transaction-1',
+        TransactionType.musdConversion,
+        {
+          chainId: '0x1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        },
+      );
+      const inFlightConversionTwo = createTransactionMeta(
+        TransactionStatus.signed,
+        'transaction-2',
+        TransactionType.musdConversion,
+        {
+          chainId: '0x1',
+          tokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        },
+      );
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightConversionOne,
+        inFlightConversionTwo,
+      ]);
+
       renderHook(() => useMusdConversionStatus());
 
-      const statusHandler = getSubscribedHandler();
       const confirmedHandler = getConfirmedHandler();
-      const transaction1Approved = createTransactionMeta(
-        TransactionStatus.approved,
-        'transaction-1',
-      );
-      const transaction2Approved = createTransactionMeta(
-        TransactionStatus.approved,
-        'transaction-2',
-      );
-      const transaction1Confirmed = createTransactionMeta(
+      const relayDepositConfirmedMeta = createTransactionMeta(
         TransactionStatus.confirmed,
-        'transaction-1',
-      );
-      const transaction2Failed = createTransactionMeta(
-        TransactionStatus.failed,
-        'transaction-2',
+        'relay-deposit-ambiguous',
+        TransactionType.relayDeposit,
       );
 
-      statusHandler({ transactionMeta: transaction1Approved });
-      statusHandler({ transactionMeta: transaction2Approved });
-      confirmedHandler(transaction1Confirmed);
-      statusHandler({ transactionMeta: transaction2Failed });
+      confirmedHandler(relayDepositConfirmedMeta);
 
-      expect(mockShowToast).toHaveBeenCalledTimes(4);
-      expect(mockShowToast).toHaveBeenNthCalledWith(1, mockInProgressToast);
-      expect(mockShowToast).toHaveBeenNthCalledWith(2, mockInProgressToast);
-      expect(mockShowToast).toHaveBeenNthCalledWith(
-        3,
-        mockEarnToastOptions.mUsdConversion.success,
-      );
-      expect(mockShowToast).toHaveBeenNthCalledWith(
-        4,
-        mockEarnToastOptions.mUsdConversion.failed,
-      );
+      expect(mockShowToast).not.toHaveBeenCalled();
     });
 
-    it('cleans up only entries for specific transaction after timeout', () => {
+    it('cleans up relay-matched success toast entries after timeout', () => {
+      const inFlightMusdConversion = createTransactionMeta(
+        TransactionStatus.signed,
+        'transaction-1',
+        TransactionType.musdConversion,
+        {
+          chainId: '0x1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        },
+      );
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightMusdConversion,
+      ]);
+
       renderHook(() => useMusdConversionStatus());
 
       const handler = getConfirmedHandler();
-      const transaction1Confirmed = createTransactionMeta(
+      const relayDepositConfirmed = createTransactionMeta(
         TransactionStatus.confirmed,
-        'transaction-1',
-      );
-      const transaction2Confirmed = createTransactionMeta(
-        TransactionStatus.confirmed,
-        'transaction-2',
+        'relay-deposit-1',
+        TransactionType.relayDeposit,
       );
 
-      handler(transaction1Confirmed);
-      handler(transaction2Confirmed);
+      handler(relayDepositConfirmed);
 
-      expect(mockShowToast).toHaveBeenCalledTimes(2);
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
 
       jest.advanceTimersByTime(5000);
 
-      // Both transactions should be cleaned up after 5 seconds
-      handler(transaction1Confirmed);
-      handler(transaction2Confirmed);
+      handler(relayDepositConfirmed);
 
-      expect(mockShowToast).toHaveBeenCalledTimes(4);
+      expect(mockShowToast).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -823,14 +908,29 @@ describe('useMusdConversionStatus', () => {
     });
 
     it('uses EarnToastOptions from useEarnToasts hook', () => {
+      const inFlightMusdConversion = createTransactionMeta(
+        TransactionStatus.signed,
+        'hook-deps-in-flight',
+        TransactionType.musdConversion,
+        {
+          chainId: '0x1',
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        },
+      );
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightMusdConversion,
+      ]);
+
       renderHook(() => useMusdConversionStatus());
 
       const handler = getConfirmedHandler();
-      const transactionMeta = createTransactionMeta(
+      const relayDepositMeta = createTransactionMeta(
         TransactionStatus.confirmed,
+        'hook-deps-relay',
+        TransactionType.relayDeposit,
       );
 
-      handler(transactionMeta);
+      handler(relayDepositMeta);
 
       expect(mockShowToast).toHaveBeenCalledWith(
         mockEarnToastOptions.mUsdConversion.success,
@@ -889,7 +989,7 @@ describe('useMusdConversionStatus', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'mock-built-event' });
     });
 
-    it('tracks status updated event when transaction status is confirmed', () => {
+    it('tracks status updated event when relayDeposit confirms with matched in-flight mUSD conversion', () => {
       const tokenAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
       const chainId = '0x1';
       setupTokensCacheMock({
@@ -899,18 +999,26 @@ describe('useMusdConversionStatus', () => {
           },
         },
       });
-
-      renderHook(() => useMusdConversionStatus());
-
-      const handler = getConfirmedHandler();
-      const transactionMeta = createTransactionMeta(
-        TransactionStatus.confirmed,
+      const inFlightMusdConversionMeta = createTransactionMeta(
+        TransactionStatus.signed,
         'test-tx-metrics-confirmed',
         TransactionType.musdConversion,
         { chainId, tokenAddress },
       );
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightMusdConversionMeta,
+      ]);
 
-      handler(transactionMeta);
+      renderHook(() => useMusdConversionStatus());
+
+      const handler = getConfirmedHandler();
+      const relayDepositConfirmedMeta = createTransactionMeta(
+        TransactionStatus.confirmed,
+        'relay-metrics-confirmed',
+        TransactionType.relayDeposit,
+      );
+
+      handler(relayDepositConfirmedMeta);
 
       expect(mockCreateEventBuilder).toHaveBeenCalledTimes(1);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
@@ -921,7 +1029,7 @@ describe('useMusdConversionStatus', () => {
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({
           transaction_id: 'test-tx-metrics-confirmed',
-          transaction_status: TransactionStatus.confirmed,
+          transaction_status: TransactionStatus.signed,
           transaction_type: TransactionType.musdConversion,
           asset_symbol: 'USDC',
           network_chain_id: '0x1',
@@ -1197,16 +1305,26 @@ describe('useMusdConversionStatus', () => {
       );
     });
 
-    it('ends confirmation trace with success when transaction is confirmed', () => {
+    it('ends confirmation trace with success when relayDeposit confirms with matched in-flight mUSD conversion', () => {
+      const inFlightMusdConversion = createTransactionMeta(
+        TransactionStatus.signed,
+        'test-trace-confirmed',
+        TransactionType.musdConversion,
+      );
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        inFlightMusdConversion,
+      ]);
+
       renderHook(() => useMusdConversionStatus());
 
       const handler = getConfirmedHandler();
-      const transactionMeta = createTransactionMeta(
+      const relayDepositMeta = createTransactionMeta(
         TransactionStatus.confirmed,
-        'test-trace-confirmed',
+        'relay-trace-confirmed',
+        TransactionType.relayDeposit,
       );
 
-      handler(transactionMeta);
+      handler(relayDepositMeta);
 
       expect(mockEndTrace).toHaveBeenCalledWith({
         name: TraceName.MusdConversionConfirm,
@@ -1338,6 +1456,11 @@ describe('useMusdConversionStatus', () => {
       const statusHandler = getSubscribedHandler();
       const confirmedHandler = getConfirmedHandler();
       const transactionId = 'test-lifecycle-tx';
+      const relayDepositMeta = createTransactionMeta(
+        TransactionStatus.confirmed,
+        'relay-lifecycle-tx',
+        TransactionType.relayDeposit,
+      );
 
       // Transaction approved - starts trace
       statusHandler({
@@ -1346,6 +1469,13 @@ describe('useMusdConversionStatus', () => {
           transactionId,
         ),
       });
+      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+        createTransactionMeta(
+          TransactionStatus.signed,
+          transactionId,
+          TransactionType.musdConversion,
+        ),
+      ]);
 
       expect(mockTrace).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1355,9 +1485,7 @@ describe('useMusdConversionStatus', () => {
       );
 
       // Transaction confirmed - ends trace (via transactionConfirmed event)
-      confirmedHandler(
-        createTransactionMeta(TransactionStatus.confirmed, transactionId),
-      );
+      confirmedHandler(relayDepositMeta);
 
       expect(mockEndTrace).toHaveBeenCalledWith({
         name: TraceName.MusdConversionConfirm,

--- a/app/components/UI/Earn/hooks/useMusdConversionStatus.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionStatus.test.ts
@@ -54,7 +54,8 @@ jest.mock('../../../../selectors/transactionPayController', () => ({
   selectTransactionPayQuotesByTransactionId: jest.fn(),
 }));
 jest.mock('../selectors/musdConversionStatus', () => ({
-  selectPendingMusdConversionsForRelayMatch: jest.fn(),
+  selectMusdConversions: jest.fn(),
+  selectMusdConversionStatuses: jest.fn(),
 }));
 
 import { useSelector } from 'react-redux';
@@ -74,15 +75,19 @@ import {
   TransactionPayStrategy,
   type TransactionPayQuote,
 } from '@metamask/transaction-pay-controller';
-import { selectPendingMusdConversionsForRelayMatch } from '../selectors/musdConversionStatus';
+import {
+  selectMusdConversions,
+  selectMusdConversionStatuses,
+} from '../selectors/musdConversionStatus';
 
 const mockTrace = trace as jest.MockedFunction<typeof trace>;
 const mockEndTrace = endTrace as jest.MockedFunction<typeof endTrace>;
 const mockSelectTransactionPayQuotesByTransactionId = jest.mocked(
   selectTransactionPayQuotesByTransactionId,
 );
-const mockSelectPendingMusdConversionsForRelayMatch = jest.mocked(
-  selectPendingMusdConversionsForRelayMatch,
+const mockSelectMusdConversions = jest.mocked(selectMusdConversions);
+const mockSelectMusdConversionStatuses = jest.mocked(
+  selectMusdConversionStatuses,
 );
 
 const mockUseSelector = jest.mocked(useSelector);
@@ -219,7 +224,8 @@ describe('useMusdConversionStatus', () => {
       showToast: mockShowToast,
       EarnToastOptions: mockEarnToastOptions,
     });
-    mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([]);
+    mockSelectMusdConversions.mockReturnValue([]);
+    mockSelectMusdConversionStatuses.mockReturnValue({});
 
     // Setup useSelector to return different values based on selector
     mockUseSelector.mockImplementation((selector) => {
@@ -244,6 +250,24 @@ describe('useMusdConversionStatus', () => {
       }
       return {};
     });
+  };
+
+  const setPendingRelayMatchCandidates = (transactions: TransactionMeta[]) => {
+    mockSelectMusdConversions.mockReturnValue(transactions);
+    mockSelectMusdConversionStatuses.mockReturnValue(
+      Object.fromEntries(
+        transactions.map((transactionMeta, index) => [
+          `pending-${index}`,
+          {
+            txId: transactionMeta.id,
+            status: transactionMeta.status,
+            isPending: true,
+            isConfirmed: false,
+            isFailed: false,
+          },
+        ]),
+      ),
+    );
   };
 
   afterEach(() => {
@@ -511,9 +535,7 @@ describe('useMusdConversionStatus', () => {
           tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         },
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        inFlightMusdConversionMeta,
-      ]);
+      setPendingRelayMatchCandidates([inFlightMusdConversionMeta]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -552,9 +574,7 @@ describe('useMusdConversionStatus', () => {
         },
       );
 
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        inFlightMusdConversionMeta,
-      ]);
+      setPendingRelayMatchCandidates([inFlightMusdConversionMeta]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -586,9 +606,7 @@ describe('useMusdConversionStatus', () => {
         TransactionStatus.approved,
         transactionId,
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        approvedMeta,
-      ]);
+      setPendingRelayMatchCandidates([approvedMeta]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -678,9 +696,7 @@ describe('useMusdConversionStatus', () => {
         TransactionStatus.approved,
         transactionId,
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        approvedMeta,
-      ]);
+      setPendingRelayMatchCandidates([approvedMeta]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -839,7 +855,7 @@ describe('useMusdConversionStatus', () => {
           tokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
         },
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+      setPendingRelayMatchCandidates([
         inFlightConversionOne,
         inFlightConversionTwo,
       ]);
@@ -868,9 +884,7 @@ describe('useMusdConversionStatus', () => {
           tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         },
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        inFlightMusdConversion,
-      ]);
+      setPendingRelayMatchCandidates([inFlightMusdConversion]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -917,9 +931,7 @@ describe('useMusdConversionStatus', () => {
           tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         },
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        inFlightMusdConversion,
-      ]);
+      setPendingRelayMatchCandidates([inFlightMusdConversion]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -1005,9 +1017,7 @@ describe('useMusdConversionStatus', () => {
         TransactionType.musdConversion,
         { chainId, tokenAddress },
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        inFlightMusdConversionMeta,
-      ]);
+      setPendingRelayMatchCandidates([inFlightMusdConversionMeta]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -1311,9 +1321,7 @@ describe('useMusdConversionStatus', () => {
         'test-trace-confirmed',
         TransactionType.musdConversion,
       );
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
-        inFlightMusdConversion,
-      ]);
+      setPendingRelayMatchCandidates([inFlightMusdConversion]);
 
       renderHook(() => useMusdConversionStatus());
 
@@ -1469,7 +1477,7 @@ describe('useMusdConversionStatus', () => {
           transactionId,
         ),
       });
-      mockSelectPendingMusdConversionsForRelayMatch.mockReturnValue([
+      setPendingRelayMatchCandidates([
         createTransactionMeta(
           TransactionStatus.signed,
           transactionId,

--- a/app/components/UI/Earn/hooks/useMusdConversionStatus.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionStatus.ts
@@ -24,7 +24,10 @@ import {
 import { store } from '../../../../store';
 import { selectTransactionPayQuotesByTransactionId } from '../../../../selectors/transactionPayController';
 import { getNetworkName } from '../utils/network';
-import { selectPendingMusdConversionsForRelayMatch } from '../selectors/musdConversionStatus';
+import {
+  selectMusdConversions,
+  selectMusdConversionStatuses,
+} from '../selectors/musdConversionStatus';
 import Logger from '../../../../util/Logger';
 
 type PayQuote = TransactionPayQuote<unknown>;
@@ -36,9 +39,10 @@ function chainIdsMatch(a?: Hex, b?: Hex): boolean | undefined {
 }
 
 /**
- * Resolves the single in-flight mUSD conversion tied to a confirmed relay deposit.
+ * Resolves the single pending mUSD conversion tied to a confirmed relay deposit.
  * Current production relay payloads do not include deterministic linkage fields,
- * so we match by sender address and only proceed when there is exactly one candidate.
+ * so we derive pending candidates from the shared relay-aware status selector,
+ * then match by sender address and only proceed when there is exactly one candidate.
  */
 export function findSingleInFlightMusdConversionForRelayDeposit(
   relayDepositTransactionMeta: TransactionMeta,
@@ -53,29 +57,28 @@ export function findSingleInFlightMusdConversionForRelayDeposit(
   }
 
   const state = store.getState();
-  const inFlightMusdConversions =
-    selectPendingMusdConversionsForRelayMatch(state);
+  const conversionStatusesByTokenChainKey = selectMusdConversionStatuses(state);
+  const pendingConversionStatuses = Object.values(
+    conversionStatusesByTokenChainKey,
+  ).filter((conversionStatus) => conversionStatus.isPending);
 
-  const sortedInFlightMusdConversions = [...inFlightMusdConversions].sort(
-    (firstTransaction, secondTransaction) => {
-      const firstTransactionTime = firstTransaction.time ?? 0;
-      const secondTransactionTime = secondTransaction.time ?? 0;
-      return secondTransactionTime - firstTransactionTime;
-    },
-  );
-
-  const inFlightMusdConversionsForFromAddress =
-    sortedInFlightMusdConversions.filter(
-      (transactionMeta) =>
-        transactionMeta.txParams?.from?.toLowerCase() ===
-        relayFromAddress.toLowerCase(),
-    );
-
-  if (inFlightMusdConversionsForFromAddress.length !== 1) {
+  if (pendingConversionStatuses.length !== 1) {
     return undefined;
   }
 
-  const [matchedMusdConversion] = inFlightMusdConversionsForFromAddress;
+  const relayFromAddressLowercase = relayFromAddress.toLowerCase();
+  const pendingTransactionId = pendingConversionStatuses[0].txId;
+  const matchedMusdConversion = selectMusdConversions(state).find(
+    (transactionMeta) =>
+      transactionMeta.id === pendingTransactionId &&
+      transactionMeta.txParams?.from?.toLowerCase() ===
+        relayFromAddressLowercase,
+  );
+
+  if (!matchedMusdConversion) {
+    return undefined;
+  }
+
   Logger.log(
     `${MUSD_TOAST_LOG_PREFIX} matched relay by single from-address fallback`,
     {

--- a/app/components/UI/Earn/hooks/useMusdConversionStatus.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionStatus.ts
@@ -24,12 +24,66 @@ import {
 import { store } from '../../../../store';
 import { selectTransactionPayQuotesByTransactionId } from '../../../../selectors/transactionPayController';
 import { getNetworkName } from '../utils/network';
+import { selectPendingMusdConversionsForRelayMatch } from '../selectors/musdConversionStatus';
+import Logger from '../../../../util/Logger';
 
 type PayQuote = TransactionPayQuote<unknown>;
+const MUSD_TOAST_LOG_PREFIX = '[mUSD Conversion Toast]';
 
 function chainIdsMatch(a?: Hex, b?: Hex): boolean | undefined {
   if (!a || !b) return undefined;
   return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Resolves the single in-flight mUSD conversion tied to a confirmed relay deposit.
+ * Current production relay payloads do not include deterministic linkage fields,
+ * so we match by sender address and only proceed when there is exactly one candidate.
+ */
+export function findSingleInFlightMusdConversionForRelayDeposit(
+  relayDepositTransactionMeta: TransactionMeta,
+): TransactionMeta | undefined {
+  if (relayDepositTransactionMeta.type !== TransactionType.relayDeposit) {
+    return undefined;
+  }
+
+  const relayFromAddress = relayDepositTransactionMeta.txParams?.from;
+  if (!relayFromAddress) {
+    return undefined;
+  }
+
+  const state = store.getState();
+  const inFlightMusdConversions =
+    selectPendingMusdConversionsForRelayMatch(state);
+
+  const sortedInFlightMusdConversions = [...inFlightMusdConversions].sort(
+    (firstTransaction, secondTransaction) => {
+      const firstTransactionTime = firstTransaction.time ?? 0;
+      const secondTransactionTime = secondTransaction.time ?? 0;
+      return secondTransactionTime - firstTransactionTime;
+    },
+  );
+
+  const inFlightMusdConversionsForFromAddress =
+    sortedInFlightMusdConversions.filter(
+      (transactionMeta) =>
+        transactionMeta.txParams?.from?.toLowerCase() ===
+        relayFromAddress.toLowerCase(),
+    );
+
+  if (inFlightMusdConversionsForFromAddress.length !== 1) {
+    return undefined;
+  }
+
+  const [matchedMusdConversion] = inFlightMusdConversionsForFromAddress;
+  Logger.log(
+    `${MUSD_TOAST_LOG_PREFIX} matched relay by single from-address fallback`,
+    {
+      relayDepositTransactionId: relayDepositTransactionMeta.id,
+      musdConversionTransactionId: matchedMusdConversion.id,
+    },
+  );
+  return matchedMusdConversion;
 }
 
 function getTransactionPayQuotes(transactionId: string): PayQuote[] {
@@ -360,32 +414,55 @@ export const useMusdConversionStatus = () => {
     // ensuring the success toast appears in sync with the balance change in the UI
     // Note: transactionConfirmed can fire with failed status (see useCardDelegation.ts pattern)
     const handleTransactionConfirmed = (transactionMeta: TransactionMeta) => {
-      // Only handle confirmed status - failed status is handled by transactionStatusUpdated
+      // Only handles confirmed status - failed status is handled by transactionStatusUpdated
       if (transactionMeta.status !== TransactionStatus.confirmed) {
         return;
       }
 
-      const data = getConversionData(
-        transactionMeta,
+      if (transactionMeta.type !== TransactionType.relayDeposit) {
+        return;
+      }
+
+      const matchingMusdConversionTransactionMeta =
+        findSingleInFlightMusdConversionForRelayDeposit(transactionMeta);
+
+      if (!matchingMusdConversionTransactionMeta) {
+        return;
+      }
+
+      const matchingMusdConversionData = getConversionData(
+        matchingMusdConversionTransactionMeta,
         TransactionStatus.confirmed,
       );
-      if (!data) return;
 
-      const { transactionId, tokenData, toastKey } = data;
+      if (!matchingMusdConversionData) {
+        return;
+      }
 
-      submitConversionEvent(transactionMeta, tokenData);
+      const {
+        transactionId: matchingMusdConversionTransactionId,
+        tokenData: matchingMusdConversionTokenData,
+        toastKey: matchingMusdConversionToastKey,
+      } = matchingMusdConversionData;
+
+      submitConversionEvent(
+        matchingMusdConversionTransactionMeta,
+        matchingMusdConversionTokenData,
+      );
       showToast(EarnToastOptions.mUsdConversion.success);
-      shownToastsRef.current.add(toastKey);
-      // End confirmation trace on success
+      shownToastsRef.current.add(matchingMusdConversionToastKey);
       endTrace({
         name: TraceName.MusdConversionConfirm,
-        id: transactionId,
+        id: matchingMusdConversionTransactionId,
         data: {
           success: true,
           status: TransactionStatus.confirmed,
         },
       });
-      scheduleCleanup(transactionId, TransactionStatus.confirmed);
+      scheduleCleanup(
+        matchingMusdConversionTransactionId,
+        TransactionStatus.confirmed,
+      );
     };
 
     Engine.controllerMessenger.subscribe(

--- a/app/components/UI/Earn/selectors/musdConversionStatus.test.ts
+++ b/app/components/UI/Earn/selectors/musdConversionStatus.test.ts
@@ -7,7 +7,6 @@ import {
   selectMusdConversions,
   selectHasPendingMusdConversion,
   createTokenChainKey,
-  selectPendingMusdConversionsForRelayMatch,
   selectMusdConversionStatuses,
 } from './musdConversionStatus';
 
@@ -162,42 +161,6 @@ describe('musdConversionStatus selectors', () => {
       const result = createTokenChainKey(tokenAddress, chainId);
 
       expect(result).toBe('0xabcdef-0xabcd');
-    });
-  });
-
-  describe('selectPendingMusdConversionsForRelayMatch', () => {
-    it('returns only pending musdConversion transactions', () => {
-      const transactions = [
-        {
-          id: 'pending-1',
-          type: TransactionType.musdConversion,
-          status: TransactionStatus.approved,
-        },
-        {
-          id: 'pending-2',
-          type: TransactionType.musdConversion,
-          status: TransactionStatus.submitted,
-        },
-        {
-          id: 'confirmed-1',
-          type: TransactionType.musdConversion,
-          status: TransactionStatus.confirmed,
-        },
-        {
-          id: 'failed-1',
-          type: TransactionType.musdConversion,
-          status: TransactionStatus.failed,
-        },
-      ];
-      const state = createState(transactions);
-
-      const result = selectPendingMusdConversionsForRelayMatch(state);
-
-      expect(result).toHaveLength(2);
-      expect(result.map((transactionMeta) => transactionMeta.id)).toEqual([
-        'pending-1',
-        'pending-2',
-      ]);
     });
   });
 

--- a/app/components/UI/Earn/selectors/musdConversionStatus.test.ts
+++ b/app/components/UI/Earn/selectors/musdConversionStatus.test.ts
@@ -5,8 +5,9 @@ import {
 import { RootState } from '../../../../reducers';
 import {
   selectMusdConversions,
-  selectHasInFlightMusdConversion,
+  selectHasPendingMusdConversion,
   createTokenChainKey,
+  selectPendingMusdConversionsForRelayMatch,
   selectMusdConversionStatuses,
 } from './musdConversionStatus';
 
@@ -65,18 +66,22 @@ describe('musdConversionStatus selectors', () => {
     });
   });
 
-  describe('selectHasInFlightMusdConversion', () => {
+  describe('selectHasPendingMusdConversion', () => {
     it('returns true when at least one conversion has unapproved status', () => {
       const transactions = [
         {
           id: '1',
           type: TransactionType.musdConversion,
           status: TransactionStatus.unapproved,
+          metamaskPay: {
+            tokenAddress: '0xTokenA',
+            chainId: '0x1',
+          },
         },
       ];
       const state = createState(transactions);
 
-      const result = selectHasInFlightMusdConversion(state);
+      const result = selectHasPendingMusdConversion(state);
 
       expect(result).toBe(true);
     });
@@ -87,11 +92,15 @@ describe('musdConversionStatus selectors', () => {
           id: '1',
           type: TransactionType.musdConversion,
           status: TransactionStatus.submitted,
+          metamaskPay: {
+            tokenAddress: '0xTokenA',
+            chainId: '0x1',
+          },
         },
       ];
       const state = createState(transactions);
 
-      const result = selectHasInFlightMusdConversion(state);
+      const result = selectHasPendingMusdConversion(state);
 
       expect(result).toBe(true);
     });
@@ -106,7 +115,7 @@ describe('musdConversionStatus selectors', () => {
       ];
       const state = createState(transactions);
 
-      const result = selectHasInFlightMusdConversion(state);
+      const result = selectHasPendingMusdConversion(state);
 
       expect(result).toBe(false);
     });
@@ -121,7 +130,7 @@ describe('musdConversionStatus selectors', () => {
       ];
       const state = createState(transactions);
 
-      const result = selectHasInFlightMusdConversion(state);
+      const result = selectHasPendingMusdConversion(state);
 
       expect(result).toBe(false);
     });
@@ -130,7 +139,7 @@ describe('musdConversionStatus selectors', () => {
       const transactions = [{ id: '1', type: TransactionType.simpleSend }];
       const state = createState(transactions);
 
-      const result = selectHasInFlightMusdConversion(state);
+      const result = selectHasPendingMusdConversion(state);
 
       expect(result).toBe(false);
     });
@@ -153,6 +162,42 @@ describe('musdConversionStatus selectors', () => {
       const result = createTokenChainKey(tokenAddress, chainId);
 
       expect(result).toBe('0xabcdef-0xabcd');
+    });
+  });
+
+  describe('selectPendingMusdConversionsForRelayMatch', () => {
+    it('returns only pending musdConversion transactions', () => {
+      const transactions = [
+        {
+          id: 'pending-1',
+          type: TransactionType.musdConversion,
+          status: TransactionStatus.approved,
+        },
+        {
+          id: 'pending-2',
+          type: TransactionType.musdConversion,
+          status: TransactionStatus.submitted,
+        },
+        {
+          id: 'confirmed-1',
+          type: TransactionType.musdConversion,
+          status: TransactionStatus.confirmed,
+        },
+        {
+          id: 'failed-1',
+          type: TransactionType.musdConversion,
+          status: TransactionStatus.failed,
+        },
+      ];
+      const state = createState(transactions);
+
+      const result = selectPendingMusdConversionsForRelayMatch(state);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((transactionMeta) => transactionMeta.id)).toEqual([
+        'pending-1',
+        'pending-2',
+      ]);
     });
   });
 

--- a/app/components/UI/Earn/selectors/musdConversionStatus.ts
+++ b/app/components/UI/Earn/selectors/musdConversionStatus.ts
@@ -36,6 +36,7 @@ const IN_FLIGHT_STATUSES: TransactionStatus[] = [
 /**
  * Selects all mUSD conversion transactions.
  */
+// TODO: Remove if not in use anymore.
 export const selectMusdConversions = createSelector(
   [selectTransactions],
   (transactions): TransactionMeta[] =>
@@ -43,24 +44,15 @@ export const selectMusdConversions = createSelector(
 );
 
 /**
- * Selects in-flight mUSD conversions (for loading states).
- * These are conversions that have been submitted/approved and not yet terminal.
+ * Selects pending mUSD conversion intents that can still be matched
+ * when a relay confirmation event arrives.
  */
-const selectInFlightMusdConversions = createSelector(
+export const selectPendingMusdConversionsForRelayMatch = createSelector(
   [selectMusdConversions],
   (conversions): TransactionMeta[] =>
     conversions.filter((tx) =>
       IN_FLIGHT_STATUSES.includes(tx.status as TransactionStatus),
     ),
-);
-
-/**
- * True when any in-flight mUSD conversion exists.
- * Used to globally disable quick-convert actions.
- */
-export const selectHasInFlightMusdConversion = createSelector(
-  [selectInFlightMusdConversions],
-  (inFlight): boolean => inFlight.length > 0,
 );
 
 /**
@@ -80,10 +72,40 @@ export const createTokenChainKey = (
  * Useful for efficiently rendering status indicators on a list of tokens.
  */
 export const selectMusdConversionStatuses = createSelector(
-  [selectMusdConversions],
-  (conversions): Record<string, ConversionStatusInfo> => {
+  [selectTransactions],
+  (transactions): Record<string, ConversionStatusInfo> => {
+    const conversions = transactions.filter(
+      (tx) => tx.type === TransactionType.musdConversion,
+    );
     const statusMap: Record<string, ConversionStatusInfo> = {};
     const latestTimeByKey: Record<string, number> = {};
+    const latestConfirmedRelayTimeByFromAddress: Record<string, number> = {};
+
+    for (const tx of transactions) {
+      if (tx.type !== TransactionType.relayDeposit) {
+        continue;
+      }
+
+      if (tx.status !== TransactionStatus.confirmed) {
+        continue;
+      }
+
+      const fromAddress = tx.txParams?.from?.toLowerCase();
+      if (!fromAddress) {
+        continue;
+      }
+
+      const relayConfirmedTime = tx.time ?? 0;
+      const existingRelayConfirmedTime =
+        latestConfirmedRelayTimeByFromAddress[fromAddress];
+
+      if (
+        existingRelayConfirmedTime === undefined ||
+        relayConfirmedTime > existingRelayConfirmedTime
+      ) {
+        latestConfirmedRelayTimeByFromAddress[fromAddress] = relayConfirmedTime;
+      }
+    }
 
     for (const tx of conversions) {
       const tokenAddress = tx.metamaskPay?.tokenAddress?.toLowerCase();
@@ -106,11 +128,21 @@ export const selectMusdConversionStatuses = createSelector(
       latestTimeByKey[key] = txTime;
 
       const status = tx.status as TransactionStatus;
+      const transactionFromAddress = tx.txParams?.from?.toLowerCase();
+      const latestConfirmedRelayTime = transactionFromAddress
+        ? latestConfirmedRelayTimeByFromAddress[transactionFromAddress]
+        : undefined;
+      const relayConfirmedAfterConversionStarted =
+        latestConfirmedRelayTime !== undefined &&
+        latestConfirmedRelayTime >= txTime;
+      const isPending =
+        IN_FLIGHT_STATUSES.includes(status) &&
+        !relayConfirmedAfterConversionStarted;
 
       statusMap[key] = {
         txId: tx.id,
         status,
-        isPending: IN_FLIGHT_STATUSES.includes(status),
+        isPending,
         isConfirmed: status === TransactionStatus.confirmed,
         isFailed: status === TransactionStatus.failed,
       };
@@ -118,4 +150,16 @@ export const selectMusdConversionStatuses = createSelector(
 
     return statusMap;
   },
+);
+
+/**
+ * True when any conversion is pending in the UI.
+ * This is relay-aware and should be used for loading/disable states.
+ */
+export const selectHasPendingMusdConversion = createSelector(
+  [selectMusdConversionStatuses],
+  (conversionStatusesByTokenChainKey): boolean =>
+    Object.values(conversionStatusesByTokenChainKey).some(
+      (conversionStatus) => conversionStatus.isPending,
+    ),
 );

--- a/app/components/UI/Earn/selectors/musdConversionStatus.ts
+++ b/app/components/UI/Earn/selectors/musdConversionStatus.ts
@@ -10,8 +10,7 @@ interface ConversionStatusInfo {
   txId: string;
   status: TransactionStatus;
   /**
-   * True when the conversion is in-flight (not yet in a terminal state).
-   * Used to drive loading UI and disable actions.
+   * Single source of truth for pending state.
    */
   isPending: boolean;
   isConfirmed: boolean;
@@ -36,23 +35,10 @@ const IN_FLIGHT_STATUSES: TransactionStatus[] = [
 /**
  * Selects all mUSD conversion transactions.
  */
-// TODO: Remove if not in use anymore.
 export const selectMusdConversions = createSelector(
   [selectTransactions],
   (transactions): TransactionMeta[] =>
     transactions.filter((tx) => tx.type === TransactionType.musdConversion),
-);
-
-/**
- * Selects pending mUSD conversion intents that can still be matched
- * when a relay confirmation event arrives.
- */
-export const selectPendingMusdConversionsForRelayMatch = createSelector(
-  [selectMusdConversions],
-  (conversions): TransactionMeta[] =>
-    conversions.filter((tx) =>
-      IN_FLIGHT_STATUSES.includes(tx.status as TransactionStatus),
-    ),
 );
 
 /**
@@ -67,7 +53,9 @@ export const createTokenChainKey = (
 /**
  * Selects all mUSD conversion statuses as a map.
  * Key is "tokenAddress-chainId" to handle same token on different chains.
- * Important:Only includes the most recent conversion for each token + chain combination.
+ * Only includes the most recent conversion for each token + chain combination.
+ * Pending is relay-aware: a conversion is no longer pending once a newer
+ * confirmed relay deposit exists for the same sender address.
  *
  * Useful for efficiently rendering status indicators on a list of tokens.
  */
@@ -153,8 +141,8 @@ export const selectMusdConversionStatuses = createSelector(
 );
 
 /**
- * True when any conversion is pending in the UI.
- * This is relay-aware and should be used for loading/disable states.
+ * True when any conversion is pending.
+ * Uses the same relay-aware pending logic as selectMusdConversionStatuses.
  */
 export const selectHasPendingMusdConversion = createSelector(
   [selectMusdConversionStatuses],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
### Problem:
After mUSD conversion effectively completes (relay confirms), the success toast appears late and for UI states (spinner and disabled Max/Edit actions) to remain disabled for longer than expected.. The delay occurred because we were waiting on `musdConversion` transaction confirmation. Switching success handling to `relay_deposit` confirmation is faster since that relay transaction confirms earlier in the real execution flow.

### Fix:
We now resolve success and pending state using relay-confirm-aware conversion status handling, so UI feedback is synchronized:
- success toast is shown as soon as the relay-confirm path maps to the pending mUSD conversion
- pending row spinner clears promptly
- Max/Edit actions re-enable promptly
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed delayed mUSD Max conversion success toast

## **Related issues**

Fixes:
- [MUSD-318: Confirmation toast is delayed after quick convert "max" tx is confirmed. ](https://consensyssoftware.atlassian.net/browse/MUSD-318)
- [MUSD-343: After converting, when my USDC has already disappeared from the list and musd balance is updated, the “Converting…” loader is still spinning](https://consensyssoftware.atlassian.net/browse/MUSD-343)

## **Manual testing steps**

```gherkin
Feature: Timely mUSD conversion completion feedback

  Scenario: user completes a conversion and sees immediate completion state
    Given user has a pending mUSD conversion in Quick Convert

    When the relay deposit confirms for that conversion
    Then the conversion success toast is shown promptly
    And the token row no longer shows a pending spinner
    And Max/Edit actions are enabled again
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
Success toast was incorrectly displayed for ~10 seconds after the conversion completed

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/4d4eed89-7e2f-44c6-b409-0f5cc1433135

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversion pending/confirmation logic to infer completion from `relayDeposit` transactions, which could affect toast timing and re-enabling actions if matching heuristics misfire; tests add guardrails but edge cases with multiple pending conversions remain possible.
> 
> **Overview**
> Fixes delayed mUSD conversion completion feedback by making the success toast, Sentry trace completion, and MetaMetrics “confirmed” tracking fire when a matching `relayDeposit` transaction confirms (instead of waiting for the `musdConversion` transaction).
> 
> Reworks mUSD conversion “pending” state to be *relay-aware* and renames the global disable selector from `selectHasInFlightMusdConversion` to `selectHasPendingMusdConversion`, updating Quick Convert UI to re-enable Max/Edit sooner and clear row spinners once a newer confirmed relay deposit exists. Also renames user-facing copy from “boost” to “bonus” across CTA/quick-convert UI and localization keys (including `percentage_bonus`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daaed1aee9beafb6580263cbe9d1db684db463cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->