### PR TITLE
fix: Use `withKeyring` for accessing keyring entropy for Snaps

### DIFF
--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -12,7 +12,6 @@ import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import {
   KeyringControllerLockEvent,
   KeyringControllerUnlockEvent,
-  KeyringControllerGetKeyringsByTypeAction,
 } from '@metamask/keyring-controller';
 import { store, runSaga } from '../../../../store';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
@@ -146,60 +145,6 @@ describe('SnapControllerInit', () => {
     baseMessenger.publish('KeyringController:unlock');
 
     expect(spy).toHaveBeenCalledWith('SnapController:setClientActive', true);
-  });
-
-  describe('getMnemonicSeed', () => {
-    it('returns the mnemonic seed', async () => {
-      const messenger = new ExtendedMessenger<
-        MockAnyNamespace,
-        KeyringControllerGetKeyringsByTypeAction,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-
-      snapControllerInit(getInitRequestMock(messenger));
-
-      const mock = jest.mocked(SnapController);
-      const getMnemonicSeed = mock.mock.calls[0][0].getMnemonicSeed;
-
-      const seed = new Uint8Array([1, 2, 3, 4]);
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringsByType',
-        () => [
-          {
-            type: 'HD Key Tree',
-            seed,
-          },
-        ],
-      );
-
-      await expect(getMnemonicSeed()).resolves.toBe(seed);
-    });
-
-    it('throws an error if the keyring is not available', async () => {
-      const messenger = new ExtendedMessenger<
-        MockAnyNamespace,
-        KeyringControllerGetKeyringsByTypeAction,
-        never
-      >({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
-
-      snapControllerInit(getInitRequestMock(messenger));
-
-      const controllerMock = jest.mocked(SnapController);
-      const getMnemonicSeed = controllerMock.mock.calls[0][0].getMnemonicSeed;
-
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringsByType',
-        () => [],
-      );
-
-      await expect(getMnemonicSeed()).rejects.toThrow(
-        'Primary keyring mnemonic unavailable.',
-      );
-    });
   });
 
   describe('getFeatureFlags', () => {

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -1,5 +1,5 @@
 import { SnapController } from '@metamask/snaps-controllers';
-import { Duration, hasProperty, inMilliseconds } from '@metamask/utils';
+import { Duration, inMilliseconds } from '@metamask/utils';
 import { hmacSha512 } from '@metamask/native-utils';
 import { ControllerInitFunction } from '../../types';
 import {
@@ -17,7 +17,6 @@ import {
   LEGACY_DERIVATION_OPTIONS,
   pbkdf2,
 } from '../../../Encryptor';
-import { KeyringTypes } from '@metamask/keyring-controller';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
 import { store, runSaga } from '../../../../store';
 import PREINSTALLED_SNAPS from '../../../../lib/snaps/preinstalled-snaps';
@@ -30,6 +29,7 @@ import {
   SetCompletedOnboardingAction,
 } from '../../../../actions/onboarding';
 import { SagaIterator } from 'redux-saga';
+import { getMnemonicSeed } from '../../../Snaps/permissions/utils';
 
 /**
  * Initialize the Snap controller.
@@ -60,24 +60,6 @@ export const snapControllerInit: ControllerInitFunction<
   const encryptor = new Encryptor({
     keyDerivationOptions: LEGACY_DERIVATION_OPTIONS,
   });
-
-  // Async because `SnapController` expects a promise.
-  async function getMnemonicSeed() {
-    const keyrings = initMessenger.call(
-      'KeyringController:getKeyringsByType',
-      KeyringTypes.hd,
-    );
-
-    if (
-      !keyrings[0] ||
-      !hasProperty(keyrings[0], 'seed') ||
-      !(keyrings[0].seed instanceof Uint8Array)
-    ) {
-      throw new Error('Primary keyring mnemonic unavailable.');
-    }
-
-    return keyrings[0].seed;
-  }
 
   /**
    * Get the feature flags for the `SnapController.
@@ -153,7 +135,7 @@ export const snapControllerInit: ControllerInitFunction<
     // TODO: Look into the type mismatch.
     encryptor,
 
-    getMnemonicSeed,
+    getMnemonicSeed: getMnemonicSeed.bind(null, initMessenger, undefined),
 
     // @ts-expect-error: `PREINSTALLED_SNAPS` is readonly, but the controller
     // expects a mutable array.

--- a/app/core/Engine/messengers/snaps/snap-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-controller-messenger.ts
@@ -36,9 +36,9 @@ import {
   UpdateRequestState,
 } from '@metamask/approval-controller';
 import {
-  KeyringControllerGetKeyringsByTypeAction,
   KeyringControllerLockEvent,
   KeyringControllerUnlockEvent,
+  KeyringControllerWithKeyringAction,
 } from '@metamask/keyring-controller';
 import { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
 import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
@@ -160,7 +160,7 @@ export function getSnapControllerMessenger(rootMessenger: RootMessenger) {
 }
 
 type InitActions =
-  | KeyringControllerGetKeyringsByTypeAction
+  | KeyringControllerWithKeyringAction
   | PreferencesControllerGetStateAction
   | SetClientActive
   | AnalyticsControllerActions;
@@ -190,7 +190,7 @@ export function getSnapControllerInitMessenger(rootMessenger: RootMessenger) {
   });
   rootMessenger.delegate({
     actions: [
-      'KeyringController:getKeyringsByType',
+      'KeyringController:withKeyring',
       'PreferencesController:getState',
       'SnapController:setClientActive',
       'AnalyticsController:trackEvent',

--- a/app/core/Snaps/permissions/specifications.ts
+++ b/app/core/Snaps/permissions/specifications.ts
@@ -26,7 +26,6 @@ import {
 } from '@metamask/keyring-controller';
 import { MaybeUpdateState, TestOrigin } from '@metamask/phishing-controller';
 import { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
-import { HdKeyring } from '@metamask/eth-hd-keyring';
 import { DialogType, EnumToUnion } from '@metamask/snaps-sdk';
 import {
   AddApprovalOptions,
@@ -37,10 +36,8 @@ import { HasPermission } from '@metamask/permission-controller';
 import { hmacSha512 } from '@metamask/native-utils';
 import { pbkdf2 } from '../../Encryptor';
 import I18n from '../../../../locales/i18n';
-import {
-  ExcludedSnapEndowments,
-  ExcludedSnapPermissions,
-} from './permissions.ts';
+import { ExcludedSnapEndowments, ExcludedSnapPermissions } from './permissions';
+import { getMnemonic, getMnemonicSeed } from './utils';
 
 export type SnapPermissionSpecificationsActions =
   | AddApprovalRequest
@@ -81,35 +78,6 @@ export const getSnapPermissionSpecifications = (
   >,
   { addNewKeyring }: SnapPermissionSpecificationsHooks,
 ) => {
-  /**
-   * Gets the mnemonic of the user's primary keyring.
-   */
-  const getPrimaryKeyringMnemonic = () => {
-    const [keyring] = messenger.call(
-      'KeyringController:getKeyringsByType',
-      KeyringTypes.hd,
-    ) as HdKeyring[];
-
-    if (!keyring.mnemonic) {
-      throw new Error('Primary keyring mnemonic unavailable.');
-    }
-
-    return keyring.mnemonic;
-  };
-
-  const getPrimaryKeyringMnemonicSeed = () => {
-    const [keyring] = messenger.call(
-      'KeyringController:getKeyringsByType',
-      KeyringTypes.hd,
-    ) as HdKeyring[];
-
-    if (!keyring.seed) {
-      throw new Error('Primary keyring mnemonic unavailable.');
-    }
-
-    return keyring.seed;
-  };
-
   const getUnlockPromise = () => {
     if (messenger.call('KeyringController:getState').isUnlocked) {
       return Promise.resolve();
@@ -130,64 +98,8 @@ export const getSnapPermissionSpecifications = (
       messenger,
       'SnapController:clearSnapState',
     ),
-    getMnemonic: async (source?: string) => {
-      if (!source) {
-        return getPrimaryKeyringMnemonic();
-      }
-
-      try {
-        const { type, mnemonic } = (await messenger.call(
-          'KeyringController:withKeyring',
-          {
-            id: source,
-          },
-          async ({ keyring }) => ({
-            type: keyring.type,
-            mnemonic: (keyring as unknown as HdKeyring).mnemonic,
-          }),
-        )) as { type: string; mnemonic?: Uint8Array };
-
-        if (type !== KeyringTypes.hd || !mnemonic) {
-          // The keyring isn't guaranteed to have a mnemonic (e.g.,
-          // hardware wallets, which can't be used as entropy sources),
-          // so we throw an error if it doesn't.
-          throw new Error(`Entropy source with ID "${source}" not found.`);
-        }
-
-        return mnemonic;
-      } catch {
-        throw new Error(`Entropy source with ID "${source}" not found.`);
-      }
-    },
-    getMnemonicSeed: async (source?: string) => {
-      if (!source) {
-        return getPrimaryKeyringMnemonicSeed();
-      }
-
-      try {
-        const { type, seed } = (await messenger.call(
-          'KeyringController:withKeyring',
-          {
-            id: source,
-          },
-          async ({ keyring }) => ({
-            type: keyring.type,
-            seed: (keyring as unknown as HdKeyring).seed,
-          }),
-        )) as { type: string; seed?: Uint8Array };
-
-        if (type !== KeyringTypes.hd || !seed) {
-          // The keyring isn't guaranteed to have a seed (e.g.,
-          // hardware wallets, which can't be used as entropy sources),
-          // so we throw an error if it doesn't.
-          throw new Error(`Entropy source with ID "${source}" not found.`);
-        }
-
-        return seed;
-      } catch {
-        throw new Error(`Entropy source with ID "${source}" not found.`);
-      }
-    },
+    getMnemonic: getMnemonic.bind(null, messenger),
+    getMnemonicSeed: getMnemonicSeed.bind(null, messenger),
     getUnlockPromise: getUnlockPromise.bind(this),
     getSnap: messenger.call.bind(messenger, 'SnapController:get'),
     handleSnapRpcRequest: messenger.call.bind(

--- a/app/core/Snaps/permissions/utils.test.ts
+++ b/app/core/Snaps/permissions/utils.test.ts
@@ -1,0 +1,136 @@
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+import { getMnemonic, getMnemonicSeed } from './utils';
+import { KeyringControllerWithKeyringAction } from '@metamask/keyring-controller';
+import { HdKeyring } from '@metamask/eth-hd-keyring';
+import { hexToBytes } from '@metamask/utils';
+import { mnemonicPhraseToBytes } from '@metamask/key-tree';
+import { mnemonicToSeed } from 'ethers/lib/utils';
+import { Keyring } from '@metamask/keyring-utils';
+import { LedgerKeyring } from '@metamask/eth-ledger-bridge-keyring';
+
+const TEST_MNEMONIC =
+  'test test test test test test test test test test test ball';
+const TEST_MNEMONIC_BYTES = mnemonicPhraseToBytes(TEST_MNEMONIC);
+const TEST_MNEMONIC_SEED = hexToBytes(mnemonicToSeed(TEST_MNEMONIC));
+
+/**
+ * Setup the messenger and mock `KeyringController:withKeyring`.
+ *
+ * @param deserialize - Whether to deserialize the HD keyring state before returning.
+ * @returns The messenger.
+ */
+async function getMessenger(deserialize = true) {
+  const hdKeyring = new HdKeyring();
+
+  if (deserialize) {
+    await hdKeyring.deserialize({
+      mnemonic: TEST_MNEMONIC,
+    });
+  }
+
+  // @ts-expect-error Intentionally not passing in the bridge.
+  const ledgerKeyring = new LedgerKeyring({ bridge: {} });
+
+  const keyrings: Record<string, Keyring> = {
+    main: hdKeyring,
+    ledger: ledgerKeyring,
+  };
+
+  const messenger = new Messenger<
+    string,
+    KeyringControllerWithKeyringAction,
+    never
+  >({ namespace: MOCK_ANY_NAMESPACE });
+  messenger.registerActionHandler(
+    'KeyringController:withKeyring',
+    (selector, operation) => {
+      if ('type' in selector) {
+        const [id, keyring] = Object.entries(keyrings).filter(
+          ([_, instance]) => instance.type === selector.type,
+        )[selector.index ?? 0];
+        return operation({ keyring, metadata: { id, name: id } });
+      }
+
+      if ('id' in selector && keyrings[selector.id]) {
+        return operation({
+          keyring: keyrings[selector.id],
+          metadata: { id: selector.id, name: selector.id },
+        });
+      }
+
+      throw new Error('Keyring not found.');
+    },
+  );
+
+  return messenger;
+}
+
+describe('getMnemonic', () => {
+  it('uses the primary keyring when no source is passed', async () => {
+    const messenger = await getMessenger();
+    expect(await getMnemonic(messenger)).toStrictEqual(TEST_MNEMONIC_BYTES);
+  });
+
+  it('throws if the primary keyring is unavailable', async () => {
+    const messenger = await getMessenger(false);
+    await expect(getMnemonic(messenger)).rejects.toThrow(
+      'Primary keyring mnemonic unavailable.',
+    );
+  });
+
+  it('finds the source by ID', async () => {
+    const messenger = await getMessenger();
+    expect(await getMnemonic(messenger, 'main')).toStrictEqual(
+      TEST_MNEMONIC_BYTES,
+    );
+  });
+
+  it('throws if the source is not the right type', async () => {
+    const messenger = await getMessenger();
+    await expect(getMnemonic(messenger, 'ledger')).rejects.toThrow(
+      'Entropy source with ID "ledger" not found.',
+    );
+  });
+
+  it('throws if the keyring cannot be found', async () => {
+    const messenger = await getMessenger();
+    await expect(getMnemonic(messenger, 'foo')).rejects.toThrow(
+      'Entropy source with ID "foo" not found.',
+    );
+  });
+});
+
+describe('getMnemonicSeed', () => {
+  it('uses the primary keyring when no source is passed', async () => {
+    const messenger = await getMessenger();
+    expect(await getMnemonicSeed(messenger)).toStrictEqual(TEST_MNEMONIC_SEED);
+  });
+
+  it('throws if the primary keyring is unavailable', async () => {
+    const messenger = await getMessenger(false);
+    await expect(getMnemonicSeed(messenger)).rejects.toThrow(
+      'Primary keyring mnemonic unavailable.',
+    );
+  });
+
+  it('finds the source by ID', async () => {
+    const messenger = await getMessenger();
+    expect(await getMnemonicSeed(messenger, 'main')).toStrictEqual(
+      TEST_MNEMONIC_SEED,
+    );
+  });
+
+  it('throws if the source is not the right type', async () => {
+    const messenger = await getMessenger();
+    await expect(getMnemonicSeed(messenger, 'ledger')).rejects.toThrow(
+      'Entropy source with ID "ledger" not found.',
+    );
+  });
+
+  it('throws if the keyring cannot be found', async () => {
+    const messenger = await getMessenger();
+    await expect(getMnemonicSeed(messenger, 'foo')).rejects.toThrow(
+      'Entropy source with ID "foo" not found.',
+    );
+  });
+});

--- a/app/core/Snaps/permissions/utils.ts
+++ b/app/core/Snaps/permissions/utils.ts
@@ -1,0 +1,121 @@
+import {
+  KeyringControllerWithKeyringAction,
+  KeyringTypes,
+} from '@metamask/keyring-controller';
+import type { HdKeyring } from '@metamask/eth-hd-keyring';
+import { Messenger } from '@metamask/messenger';
+
+/**
+ * Get the mnemonic for a given entropy source. If no source is
+ * provided, the primary HD keyring's mnemonic will be returned.
+ *
+ * @param messenger - The messenger.
+ * @param source - The ID of the entropy source keyring.
+ * @returns The mnemonic.
+ */
+export async function getMnemonic(
+  messenger: Messenger<string, KeyringControllerWithKeyringAction, never>,
+  source?: string | undefined,
+): Promise<Uint8Array> {
+  if (!source) {
+    const mnemonic = (await messenger.call(
+      'KeyringController:withKeyring',
+      {
+        type: KeyringTypes.hd,
+        index: 0,
+      },
+      async ({ keyring }) => (keyring as HdKeyring).mnemonic,
+    )) as Uint8Array | null;
+
+    if (!mnemonic) {
+      throw new Error('Primary keyring mnemonic unavailable.');
+    }
+
+    return mnemonic;
+  }
+
+  try {
+    const keyringData = await messenger.call(
+      'KeyringController:withKeyring',
+      {
+        id: source,
+      },
+      async ({ keyring }) => ({
+        type: keyring.type,
+        mnemonic: (keyring as HdKeyring).mnemonic,
+      }),
+    );
+
+    const { type, mnemonic } = keyringData as {
+      type: string;
+      mnemonic?: Uint8Array;
+    };
+
+    if (type !== KeyringTypes.hd || !mnemonic) {
+      // The keyring isn't guaranteed to have a mnemonic (e.g.,
+      // hardware wallets, which can't be used as entropy sources),
+      // so we throw an error if it doesn't.
+      throw new Error(`Entropy source with ID "${source}" not found.`);
+    }
+
+    return mnemonic;
+  } catch {
+    throw new Error(`Entropy source with ID "${source}" not found.`);
+  }
+}
+
+/**
+ * Get the mnemonic seed for a given entropy source. If no source is
+ * provided, the primary HD keyring's mnemonic seed will be returned.
+ *
+ * @param messenger - The messenger.
+ * @param source - The ID of the entropy source keyring.
+ * @returns The mnemonic seed.
+ */
+export async function getMnemonicSeed(
+  messenger: Messenger<string, KeyringControllerWithKeyringAction, never>,
+  source?: string | undefined,
+): Promise<Uint8Array> {
+  if (!source) {
+    const seed = (await messenger.call(
+      'KeyringController:withKeyring',
+      {
+        type: KeyringTypes.hd,
+        index: 0,
+      },
+      async ({ keyring }) => (keyring as HdKeyring).seed,
+    )) as Uint8Array | null;
+
+    if (!seed) {
+      throw new Error('Primary keyring mnemonic unavailable.');
+    }
+
+    return seed;
+  }
+
+  try {
+    const keyringData = await messenger.call(
+      'KeyringController:withKeyring',
+      {
+        id: source,
+      },
+      async ({ keyring }) => ({
+        type: keyring.type,
+        seed: (keyring as HdKeyring).seed,
+      }),
+    );
+
+    const { type, seed } = keyringData as { type: string; seed?: Uint8Array };
+
+    if (type !== KeyringTypes.hd || !seed) {
+      // The keyring isn't guaranteed to have a mnemonic (e.g.,
+      // hardware wallets, which can't be used as entropy sources),
+      // so we throw an error if it doesn't.
+      throw new Error(`Entropy source with ID "${source}" not found.`);
+    }
+
+    return seed;
+  } catch {
+    throw new Error(`Entropy source with ID "${source}" not found.`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "@metamask/keyring-controller": "^25.0.0",
     "@metamask/keyring-internal-api": "^10.0.0",
     "@metamask/keyring-snap-client": "^8.1.0",
+    "@metamask/keyring-utils": "^3.2.0",
     "@metamask/logging-controller": "^7.0.0",
     "@metamask/message-signing-snap": "^1.1.2",
     "@metamask/messenger": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35365,6 +35365,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^25.0.0"
     "@metamask/keyring-internal-api": "npm:^10.0.0"
     "@metamask/keyring-snap-client": "npm:^8.1.0"
+    "@metamask/keyring-utils": "npm:^3.2.0"
     "@metamask/logging-controller": "npm:^7.0.0"
     "@metamask/message-signing-snap": "npm:^1.1.2"
     "@metamask/messenger": "npm:^0.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Use `withKeyring` instead of `getKeyringsByType` for accessing the mnemonic for Snaps. `withKeyring` has more guarantees that should prevent race conditions and `getKeyringsByType` is deprecated for that same reason.

Additionally, move `getMnemonic` and `getMnemonicSeed` to utility functions that can be re-used.

Mirror extension implementation: https://github.com/MetaMask/metamask-extension/pull/40296/

https://consensyssoftware.atlassian.net/browse/WPC-508

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Snaps entropy/mnemonic retrieval paths and keyring controller messaging, so mistakes could break Snap permissions or produce unexpected errors, though changes are mostly a refactor to a safer API with added unit coverage.
> 
> **Overview**
> Switches Snaps entropy access from deprecated `KeyringController:getKeyringsByType` to `KeyringController:withKeyring` to reduce race conditions when retrieving the primary HD keyring mnemonic/seed.
> 
> Introduces reusable permission utilities (`getMnemonic`, `getMnemonicSeed`) and wires them into both `SnapController` initialization (`getMnemonicSeed`) and snap restricted methods, updating the init messenger’s allowed actions accordingly. Adds dedicated unit tests for the new utilities and removes the old controller-init seed test, plus adds `@metamask/keyring-utils` dependency for test typing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db8fe87fecc57bcecbc61fd23091b45e7f8e272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->