### PR TITLE
feat: add bottom fade overlay to Wallet component for improved scroll experience

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1428,13 +1428,13 @@ const Wallet = ({
               scrollViewProps={{
                 contentContainerStyle: scrollViewContentStyle,
                 showsVerticalScrollIndicator: false,
-                onScroll: shouldEnableParentScroll
+                onScroll: isHomepageSectionsV1Enabled
                   ? handleVerticalScroll
                   : undefined,
-                onContentSizeChange: shouldEnableParentScroll
+                onContentSizeChange: isHomepageSectionsV1Enabled
                   ? handleScrollContentSizeChange
                   : undefined,
-                onLayout: shouldEnableParentScroll
+                onLayout: isHomepageSectionsV1Enabled
                   ? handleScrollLayout
                   : undefined,
                 scrollEventThrottle: 16,

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -17,11 +17,14 @@ import {
   ActivityIndicator,
   DeviceEventEmitter,
   Linking,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
   RefreshControl,
   ScrollView,
   StyleSheet as RNStyleSheet,
   View,
 } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import {
@@ -108,6 +111,7 @@ import {
 } from '../../../util/networks';
 import NotificationsService from '../../../util/notifications/services/NotificationService';
 import { useTheme } from '../../../util/theme';
+import { colorWithOpacity } from '../../../util/colors';
 import { useAccountGroupName } from '../../hooks/multichainAccounts/useAccountGroupName';
 import { useAccountName } from '../../hooks/useAccountName';
 import usePrevious from '../../hooks/usePrevious';
@@ -205,6 +209,14 @@ const createStyles = ({ colors }: Theme) =>
     },
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
+    },
+    bottomFadeOverlay: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: 40,
+      pointerEvents: 'none',
     },
   });
 
@@ -1080,6 +1092,28 @@ const Wallet = ({
   const shouldEnableParentScroll =
     isHomepageRedesignV1Enabled || isHomepageSectionsV1Enabled;
 
+  const [bottomFadeOpacity, setBottomFadeOpacity] = useState(1);
+
+  const handleVerticalScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const scrollableHeight = contentSize.height - layoutMeasurement.height;
+
+      if (scrollableHeight <= 0) {
+        setBottomFadeOpacity(0);
+        return;
+      }
+
+      const distanceFromEnd = scrollableHeight - contentOffset.y;
+      const fadeThreshold = 100;
+      setBottomFadeOpacity(
+        Math.min(1, Math.max(0, distanceFromEnd / fadeThreshold)),
+      );
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!selectedInternalAccount) return;
     navigation.setOptions(
@@ -1359,6 +1393,10 @@ const Wallet = ({
               scrollViewProps={{
                 contentContainerStyle: scrollViewContentStyle,
                 showsVerticalScrollIndicator: false,
+                onScroll: shouldEnableParentScroll
+                  ? handleVerticalScroll
+                  : undefined,
+                scrollEventThrottle: 16,
                 refreshControl: shouldEnableParentScroll ? (
                   <RefreshControl
                     colors={[colors.primary.default]}
@@ -1371,6 +1409,20 @@ const Wallet = ({
             >
               {content}
             </ConditionalScrollView>
+            {shouldEnableParentScroll && bottomFadeOpacity > 0 && (
+              <LinearGradient
+                colors={[
+                  colorWithOpacity(colors.background.default, 0),
+                  colors.background.default,
+                ]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 0, y: 1 }}
+                style={[
+                  styles.bottomFadeOverlay,
+                  { opacity: bottomFadeOpacity },
+                ]}
+              />
+            )}
           </View>
         ) : (
           renderLoader()

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -216,7 +216,6 @@ const createStyles = ({ colors }: Theme) =>
       right: 0,
       bottom: 0,
       height: 40,
-      pointerEvents: 'none',
     },
   });
 
@@ -1092,26 +1091,60 @@ const Wallet = ({
   const shouldEnableParentScroll =
     isHomepageRedesignV1Enabled || isHomepageSectionsV1Enabled;
 
-  const [bottomFadeOpacity, setBottomFadeOpacity] = useState(1);
+  const [bottomFadeOpacity, setBottomFadeOpacity] = useState(0);
 
-  const handleVerticalScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } =
-        event.nativeEvent;
-      const scrollableHeight = contentSize.height - layoutMeasurement.height;
+  const scrollContentHeight = useRef(0);
+  const scrollLayoutHeight = useRef(0);
 
+  const computeFadeOpacity = useCallback(
+    (contentH: number, layoutH: number, offsetY: number) => {
+      const scrollableHeight = contentH - layoutH;
       if (scrollableHeight <= 0) {
         setBottomFadeOpacity(0);
         return;
       }
-
-      const distanceFromEnd = scrollableHeight - contentOffset.y;
+      const distanceFromEnd = scrollableHeight - offsetY;
       const fadeThreshold = 100;
       setBottomFadeOpacity(
         Math.min(1, Math.max(0, distanceFromEnd / fadeThreshold)),
       );
     },
     [],
+  );
+
+  const handleVerticalScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      scrollContentHeight.current = contentSize.height;
+      scrollLayoutHeight.current = layoutMeasurement.height;
+      computeFadeOpacity(
+        contentSize.height,
+        layoutMeasurement.height,
+        contentOffset.y,
+      );
+    },
+    [computeFadeOpacity],
+  );
+
+  const handleScrollContentSizeChange = useCallback(
+    (_w: number, h: number) => {
+      scrollContentHeight.current = h;
+      computeFadeOpacity(h, scrollLayoutHeight.current, 0);
+    },
+    [computeFadeOpacity],
+  );
+
+  const handleScrollLayout = useCallback(
+    (event: { nativeEvent: { layout: { height: number } } }) => {
+      scrollLayoutHeight.current = event.nativeEvent.layout.height;
+      computeFadeOpacity(
+        scrollContentHeight.current,
+        event.nativeEvent.layout.height,
+        0,
+      );
+    },
+    [computeFadeOpacity],
   );
 
   useEffect(() => {
@@ -1396,6 +1429,12 @@ const Wallet = ({
                 onScroll: shouldEnableParentScroll
                   ? handleVerticalScroll
                   : undefined,
+                onContentSizeChange: shouldEnableParentScroll
+                  ? handleScrollContentSizeChange
+                  : undefined,
+                onLayout: shouldEnableParentScroll
+                  ? handleScrollLayout
+                  : undefined,
                 scrollEventThrottle: 16,
                 refreshControl: shouldEnableParentScroll ? (
                   <RefreshControl
@@ -1411,6 +1450,7 @@ const Wallet = ({
             </ConditionalScrollView>
             {shouldEnableParentScroll && bottomFadeOpacity > 0 && (
               <LinearGradient
+                pointerEvents="none"
                 colors={[
                   colorWithOpacity(colors.background.default, 0),
                   colors.background.default,

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1095,6 +1095,7 @@ const Wallet = ({
 
   const scrollContentHeight = useRef(0);
   const scrollLayoutHeight = useRef(0);
+  const scrollOffsetY = useRef(0);
 
   const computeFadeOpacity = useCallback(
     (contentH: number, layoutH: number, offsetY: number) => {
@@ -1118,6 +1119,7 @@ const Wallet = ({
         event.nativeEvent;
       scrollContentHeight.current = contentSize.height;
       scrollLayoutHeight.current = layoutMeasurement.height;
+      scrollOffsetY.current = contentOffset.y;
       computeFadeOpacity(
         contentSize.height,
         layoutMeasurement.height,
@@ -1130,7 +1132,7 @@ const Wallet = ({
   const handleScrollContentSizeChange = useCallback(
     (_w: number, h: number) => {
       scrollContentHeight.current = h;
-      computeFadeOpacity(h, scrollLayoutHeight.current, 0);
+      computeFadeOpacity(h, scrollLayoutHeight.current, scrollOffsetY.current);
     },
     [computeFadeOpacity],
   );
@@ -1141,7 +1143,7 @@ const Wallet = ({
       computeFadeOpacity(
         scrollContentHeight.current,
         event.nativeEvent.layout.height,
-        0,
+        scrollOffsetY.current,
       );
     },
     [computeFadeOpacity],

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1450,7 +1450,7 @@ const Wallet = ({
             >
               {content}
             </ConditionalScrollView>
-            {shouldEnableParentScroll && bottomFadeOpacity > 0 && (
+            {isHomepageSectionsV1Enabled && bottomFadeOpacity > 0 && (
               <LinearGradient
                 pointerEvents="none"
                 colors={[


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Added a bottom fade overlay (gradient) to the Wallet scroll view when the homepage redesign (isHomepageRedesignV1Enabled or isHomepageSectionsV1Enabled) is active. The gradient smoothly fades out as the user scrolls toward the bottom of the content, providing a visual cue that more content is available. The overlay is purely decorative (pointerEvents: 'none') and uses react-native-linear-gradient with the theme's background.default color transitioning from transparent to opaque.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a bottom fade overlay to the homepage wallet view indicating scrollable content

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-458

## **Manual testing steps**

```gherkin
Feature: Homepage scroll fade overlay

  Scenario: user sees fade overlay when content is scrollable
    Given the user is on the homepage with homepage redesign enabled
    And the wallet content exceeds the visible area

    When user views the wallet screen
    Then a subtle gradient fade is visible at the bottom of the screen

  Scenario: fade overlay disappears when scrolled to bottom
    Given the user is on the homepage with homepage redesign enabled
    And the wallet content exceeds the visible area

    When user scrolls to the bottom of the wallet content
    Then the bottom fade overlay gradually disappears

  Scenario: no fade overlay when content fits the screen
    Given the user is on the homepage with homepage redesign enabled
    And the wallet content fits within the visible area

    When user views the wallet screen
    Then no bottom fade overlay is displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/c8dbac51-d9b4-4010-b522-20ebf0743210


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/29a27de6-0778-4f95-a4db-ae73ab48e83a


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change gated behind a feature flag; main risk is minor scroll performance/regression due to new `onScroll`/layout handlers and gradient rendering.
> 
> **Overview**
> Adds a **bottom gradient fade overlay** to the `Wallet` screen when `selectHomepageSectionsV1Enabled` is on, giving a visual cue that more content is available.
> 
> The overlay is driven by new scroll/layout/content-size handlers that compute `bottomFadeOpacity` based on distance from the end of the scrollable content, and renders a `react-native-linear-gradient` (theme background from transparent to opaque) positioned absolutely at the bottom with `pointerEvents="none"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ddcf61c048af159402b06e36425e7c92ce778fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->