### PR TITLE
chore: validate secrets building with gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,12 @@ jobs:
           # Persist to GITHUB_ENV so later steps (e.g. Build) see CONFIGURATION, IS_SIM_BUILD, etc.
           node scripts/apply-build-config.js ${{ inputs.build_name }} --export-github-env >> "$GITHUB_ENV"
 
+      - name: Validate secrets
+        env:
+          CONFIG_SECRETS: ${{ needs.prepare.outputs.secrets_json }}
+          SECRETS_JSON: ${{ toJSON(secrets) }}
+        run: node scripts/validate-secrets-from-config.js
+
       - name: Set secrets
         env:
           CONFIG_SECRETS: ${{ needs.prepare.outputs.secrets_json }}

--- a/scripts/validate-secrets-from-config.js
+++ b/scripts/validate-secrets-from-config.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Validates that all secrets required by the current build (from builds.yml)
+ * are defined and applied. Used in CI before "Set secrets" to fail fast and
+ * cancel the build if any required secret is missing or empty.
+ *
+ * CI-agnostic: secrets are resolved from process.env by default. Pass
+ * SECRETS_JSON (a JSON object mapping secret name → value) to override,
+ * e.g. when the CI platform exposes all secrets as a single JSON blob rather
+ * than individual env vars.
+ *
+ * Fails when:
+ * - A secret is absent (not in env / not in SECRETS_JSON).
+ * - A secret is present but empty (defined but not set in the CI environment).
+ *
+ * Reads CONFIG_SECRETS (same format as set-secrets-from-config.js):
+ *   { "ENV_VAR_NAME": "SECRET_NAME", ... }
+ *
+ * Exits 0 if every secret has a non-empty value; exits 1 otherwise.
+ */
+
+const secretsMapping = JSON.parse(process.env.CONFIG_SECRETS || '{}');
+// SECRETS_JSON lets callers pass all secrets as a JSON blob (e.g. GitHub's
+// toJSON(secrets)); falls back to individual process.env lookups so the script
+// works on any CI without extra wiring.
+const secretsSource = process.env.SECRETS_JSON
+  ? JSON.parse(process.env.SECRETS_JSON)
+  : process.env;
+const missing = [];
+const notApplied = [];
+
+for (const [envVar, secretName] of Object.entries(secretsMapping)) {
+  const value = secretsSource[secretName];
+  if (value === undefined || value === null) {
+    missing.push({ envVar, secretName });
+  } else if (String(value).trim() === '') {
+    notApplied.push({ envVar, secretName });
+  }
+}
+
+const invalid = missing.length + notApplied.length;
+if (invalid > 0) {
+  console.error(
+    'Build validation failed: required secrets are not defined or not applied from GitHub.',
+  );
+  if (missing.length > 0) {
+    console.error('Not in environment:');
+    missing.forEach(({ envVar, secretName }) => {
+      console.error(`  - ${secretName} (for ${envVar})`);
+    });
+  }
+  if (notApplied.length > 0) {
+    console.error('In environment but empty (not set in GitHub Environment):');
+    notApplied.forEach(({ envVar, secretName }) => {
+      console.error(`  - ${secretName} (for ${envVar})`);
+    });
+  }
+  console.error(
+    'Ensure these secrets are set in the GitHub Environment for this build.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `All ${Object.keys(secretsMapping).length} required secret(s) are defined and applied.`,
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

GH ACTIONS test proof - https://github.com/MetaMask/metamask-mobile/actions/runs/22361836820/job/64717546937

CI builds currently fail late — after cloning, installing dependencies, and starting the build — if a required secret is missing or not set in the GitHub Environment. This PR adds a fast-fail validation step that runs **before** secrets are injected, aborting the build immediately with a clear, actionable error message.

### What changed

**`scripts/validate-secrets-from-config.js`** (new)

A CI-agnostic Node.js script that reads `CONFIG_SECRETS` (the `{ ENV_VAR_NAME: SECRET_NAME }` map defined in `builds.yml`, same format used by `set-secrets-from-config.js`) and verifies every required secret is present and non-empty before the build proceeds.

- Distinguishes two failure modes with separate error lists:
  - **Absent** — secret is not in the source at all (e.g. missing from `builds.yml` or not passed to the step)
  - **Empty** — secret is present but has no value (e.g. not configured in the GitHub Environment for this build)
- CI-agnostic by default: resolves secrets from `process.env` individually, so it works on any CI platform (Bitrise, CircleCI, etc.) without extra wiring
- Accepts an optional `SECRETS_JSON` env var (a JSON blob) as an override, allowing callers to pass all secrets at once — used by the GitHub Actions step via `toJSON(secrets)`

**`.github/workflows/build.yml`**

Adds a **"Validate secrets"** step between "Apply build config" and "Set secrets":

```yaml
- name: Validate secrets
  env:
    CONFIG_SECRETS: ${{ needs.prepare.outputs.secrets_json }}
    SECRETS_JSON: ${{ toJSON(secrets) }}
  run: node scripts/validate-secrets-from-config.js
```

The GitHub-specific `toJSON(secrets)` wiring stays in the YAML; the script itself has no GitHub-specific dependencies.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a preflight CI validation step and a new script without changing build outputs or secret injection logic; primary risk is only increased CI failures when environments are misconfigured.
> 
> **Overview**
> CI now fails fast when a build’s required secrets (as defined in `builds.yml`) are missing or empty, instead of failing later during the build.
> 
> This adds a new `scripts/validate-secrets-from-config.js` validator and wires it into `.github/workflows/build.yml` as a dedicated **Validate secrets** step that runs before `set-secrets-from-config.js`, emitting actionable errors for missing vs. empty secrets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ab10fb1832833dd6c7e466196a65e7781dd641f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->