### PR TITLE
feat(homepage): adopt TokenListItemV2 via feature flag in TokensSection

### DIFF
--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -112,18 +112,35 @@ jest.mock(
   }),
 );
 
+const MockTokenListItemV2 = ({
+  assetKey,
+}: {
+  assetKey: { address: string };
+}) => {
+  const ReactActual = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return ReactActual.createElement(
+    Text,
+    { testID: `token-item-v2-${assetKey.address}` },
+    `TokenV2 ${assetKey.address}`,
+  );
+};
+
 jest.mock(
   '../../../../UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2',
   () => ({
     TokenListItemV2: (props: { assetKey: { address: string } }) =>
-      MockTokenListItem(props),
+      MockTokenListItemV2(props),
   }),
 );
+
+const mockSelectTokenListLayoutV2Enabled = jest.fn(() => false);
 
 jest.mock(
   '../../../../../selectors/featureFlagController/tokenListLayout',
   () => ({
-    selectTokenListLayoutV2Enabled: () => false,
+    selectTokenListLayoutV2Enabled: (state: unknown) =>
+      mockSelectTokenListLayoutV2Enabled(state),
   }),
 );
 

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -134,13 +134,12 @@ jest.mock(
   }),
 );
 
-const mockSelectTokenListLayoutV2Enabled = jest.fn(() => false);
+const mockSelectTokenListLayoutV2Enabled = jest.fn().mockReturnValue(false);
 
 jest.mock(
   '../../../../../selectors/featureFlagController/tokenListLayout',
   () => ({
-    selectTokenListLayoutV2Enabled: (state: unknown) =>
-      mockSelectTokenListLayoutV2Enabled(state),
+    selectTokenListLayoutV2Enabled: () => mockSelectTokenListLayoutV2Enabled(),
   }),
 );
 
@@ -221,6 +220,7 @@ describe('TokensSection', () => {
     // Default null: balance selectors not yet initialized (cold start).
     // Prevents the heuristic from firing in tests that don't set up balance data.
     mockAccountGroupBalance.mockReturnValue(null);
+    mockSelectTokenListLayoutV2Enabled.mockReturnValue(false);
     mockUsePopularTokens.mockReturnValue({
       tokens: mockPopularTokens,
       isInitialLoading: false,

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -93,19 +93,39 @@ jest.mock('./components/PopularTokensSkeleton', () => {
   };
 });
 
-// Mock TokenListItem to avoid complex import chains
-jest.mock('../../../../UI/Tokens/TokenList/TokenListItem/TokenListItem', () => {
+// Mock TokenListItem and TokenListItemV2 to avoid complex import chains
+const MockTokenListItem = ({ assetKey }: { assetKey: { address: string } }) => {
   const ReactActual = jest.requireActual('react');
   const { Text } = jest.requireActual('react-native');
-  return {
-    TokenListItem: ({ assetKey }: { assetKey: { address: string } }) =>
-      ReactActual.createElement(
-        Text,
-        { testID: `token-item-${assetKey.address}` },
-        `Token ${assetKey.address}`,
-      ),
-  };
-});
+  return ReactActual.createElement(
+    Text,
+    { testID: `token-item-${assetKey.address}` },
+    `Token ${assetKey.address}`,
+  );
+};
+
+jest.mock(
+  '../../../../UI/Tokens/TokenList/TokenListItem/TokenListItem',
+  () => ({
+    TokenListItem: (props: { assetKey: { address: string } }) =>
+      MockTokenListItem(props),
+  }),
+);
+
+jest.mock(
+  '../../../../UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2',
+  () => ({
+    TokenListItemV2: (props: { assetKey: { address: string } }) =>
+      MockTokenListItem(props),
+  }),
+);
+
+jest.mock(
+  '../../../../../selectors/featureFlagController/tokenListLayout',
+  () => ({
+    selectTokenListLayoutV2Enabled: () => false,
+  }),
+);
 
 // Mock PopularTokenRow to avoid deep import chains (AvatarToken uses selectors)
 jest.mock('./components/PopularTokenRow', () => {

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -18,6 +18,8 @@ import { useIsZeroBalanceAccount } from './hooks';
 import { selectSortedAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
 import { TokenListItem } from '../../../../UI/Tokens/TokenList/TokenListItem/TokenListItem';
+import { TokenListItemV2 } from '../../../../UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2';
+import { selectTokenListLayoutV2Enabled } from '../../../../../selectors/featureFlagController/tokenListLayout';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { SectionRefreshHandle } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
@@ -47,6 +49,8 @@ const TokensSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     selectAccountGroupBalanceForEmptyState,
   );
   const privacyMode = useSelector(selectPrivacyMode);
+  const isTokenListV2 = useSelector(selectTokenListLayoutV2Enabled);
+  const ListItemComponent = isTokenListV2 ? TokenListItemV2 : TokenListItem;
   const popularTokensListRef = useRef<SectionRefreshHandle>(null);
   const [hasTokensError, setHasTokensError] = useState(false);
 
@@ -136,7 +140,7 @@ const TokensSection = forwardRef<SectionRefreshHandle>((_, ref) => {
       ) : (
         <SectionRow>
           {displayTokenKeys.map((tokenKey, index) => (
-            <TokenListItem
+            <ListItemComponent
               key={`${tokenKey.chainId}-${tokenKey.address}-${tokenKey.isStaked ? 'staked' : 'unstaked'}-${index}`}
               assetKey={tokenKey}
               showRemoveMenu={noopShowRemoveMenu}


### PR DESCRIPTION
## **Description**

Adopts the `TokenListItemV2` component in the Homepage `TokensSection`, controlled by the existing `selectTokenListLayoutV2Enabled` feature flag.

This matches the same A/B test pattern already used in `TokenList.tsx`:
```typescript
const isTokenListV2 = useSelector(selectTokenListLayoutV2Enabled);
const ListItemComponent = isTokenListV2 ? TokenListItemV2 : TokenListItem;
```

**Changes:**
- Import both `TokenListItem` (V1) and `TokenListItemV2`
- Use `selectTokenListLayoutV2Enabled` selector to pick the active component
- Render via `ListItemComponent` (dynamic, based on feature flag)
- Update tests to mock both components

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-407

## **Manual testing steps**

```gherkin
Feature: TokenListItemV2 adoption in Homepage TokensSection

  Scenario: user sees V1 token list items when feature flag is off
    Given selectTokenListLayoutV2Enabled returns false
    And user has token balances

    When user views the Homepage Tokens section
    Then tokens are rendered using TokenListItem (V1 layout)

  Scenario: user sees V2 token list items when feature flag is on
    Given selectTokenListLayoutV2Enabled returns true
    And user has token balances

    When user views the Homepage Tokens section
    Then tokens are rendered using TokenListItemV2 (V2 layout)
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

<img width="300" src="https://github.com/user-attachments/assets/cb4d82da-e6cf-4640-908c-48670f28f70d" />


### **After**

<!-- [screenshots/recordings] -->

<img width="300" src="https://github.com/user-attachments/assets/83b9e117-d7da-4d87-adfd-908c155bc6d4" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only swaps the rendered token row component behind an existing feature flag; main risk is layout/prop compatibility differences between V1 and V2.
> 
> **Overview**
> Updates Homepage `TokensSection` to choose between `TokenListItem` (V1) and `TokenListItemV2` at render time using the existing `selectTokenListLayoutV2Enabled` feature flag, matching the A/B pattern used elsewhere.
> 
> Adjusts `TokensSection` tests to mock `TokenListItemV2` and the feature-flag selector so coverage remains stable when toggling the layout choice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b1aa73be333e07c7530935af7b1ccf3e9f6cac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->