### PR TITLE
feat: add transport metadata to `HardwareWalletAdapter` and clean up exports

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletEventHandlers.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletEventHandlers.test.tsx
@@ -42,6 +42,10 @@ describe('useDeviceEventHandlers', () => {
       stopDeviceDiscovery: jest.fn(),
       isTransportAvailable: jest.fn(() => Promise.resolve(true)),
       getRequiredAppName: jest.fn().mockReturnValue('Ethereum'),
+      getTransportDisabledErrorCode: jest
+        .fn()
+        .mockReturnValue(ErrorCode.BluetoothDisabled),
+      getConnectionTips: jest.fn().mockReturnValue([]),
     };
 
     // Create mock refs

--- a/app/core/HardwareWallet/HardwareWalletEventHandlers.tsx
+++ b/app/core/HardwareWallet/HardwareWalletEventHandlers.tsx
@@ -16,7 +16,7 @@ import { parseErrorByType, createHardwareWalletError } from './errors';
 import DevLogger from '../SDKConnect/utils/DevLogger';
 
 /** Options for the {@link useDeviceEventHandlers} hook. */
-export interface UseDeviceEventHandlersOptions {
+interface UseDeviceEventHandlersOptions {
   /** Mutable refs shared across the hardware wallet system. */
   refs: HardwareWalletRefs;
   /** State setter functions for connection state, device ID, etc. */
@@ -26,7 +26,7 @@ export interface UseDeviceEventHandlersOptions {
 }
 
 /** Return value of the {@link useDeviceEventHandlers} hook. */
-export interface DeviceEventHandlersResult {
+interface DeviceEventHandlersResult {
   /** Directly sets the connection state (no dedup — callers control when to update). */
   updateConnectionState: (newState: HardwareWalletConnectionState) => void;
   /** Routes a device event payload to the appropriate state transition. */
@@ -212,5 +212,3 @@ export const useDeviceEventHandlers = ({
     clearError,
   };
 };
-
-export default useDeviceEventHandlers;

--- a/app/core/HardwareWallet/HardwareWalletStateManager.tsx
+++ b/app/core/HardwareWallet/HardwareWalletStateManager.tsx
@@ -11,7 +11,7 @@ import { getHardwareWalletTypeForAddress } from './helpers';
 import { HardwareWalletAdapter } from './types';
 
 /** Core state managed by the hardware wallet state manager. */
-export interface HardwareWalletManagedState {
+interface HardwareWalletManagedState {
   /** Current connection state (discriminated union keyed on status). */
   connectionState: HardwareWalletConnectionState;
   /** Device ID of the connected hardware wallet, or null if none. */
@@ -44,7 +44,7 @@ export interface HardwareWalletStateSetters {
 }
 
 /** Return value of the {@link useHardwareWalletStateManager} hook. */
-export interface HardwareWalletStateManagerResult {
+interface HardwareWalletStateManagerResult {
   /** Current hardware wallet state (connection, device, wallet type). */
   state: HardwareWalletManagedState;
   /** Mutable refs for adapter, connection guard, and abort controller. */
@@ -135,5 +135,3 @@ export const useHardwareWalletStateManager =
       resetState,
     };
   };
-
-export default useHardwareWalletStateManager;

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -8,6 +8,7 @@ import {
   HardwareWalletType,
   DeviceEvent,
   DeviceEventPayload,
+  ErrorCode,
 } from '@metamask/hw-wallet-sdk';
 import {
   DiscoveredDevice,
@@ -306,6 +307,19 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
 
   getRequiredAppName(): string {
     return 'Ethereum';
+  }
+
+  getTransportDisabledErrorCode(): ErrorCode {
+    return ErrorCode.BluetoothDisabled;
+  }
+
+  getConnectionTips(): string[] {
+    return [
+      'hardware_wallet.connecting.tip_unlock',
+      'hardware_wallet.connecting.tip_open_app',
+      'hardware_wallet.connecting.tip_enable_bluetooth',
+      'hardware_wallet.connecting.tip_dnd_off',
+    ];
   }
 
   /**

--- a/app/core/HardwareWallet/adapters/NonHardwareAdapter.ts
+++ b/app/core/HardwareWallet/adapters/NonHardwareAdapter.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-empty-function, @typescript-eslint/no-unused-vars, @typescript-eslint/no-useless-constructor */
 
+import { ErrorCode } from '@metamask/hw-wallet-sdk';
 import {
   DiscoveredDevice,
   HardwareWalletAdapter,
@@ -72,5 +73,13 @@ export class NonHardwareAdapter implements HardwareWalletAdapter {
 
   getRequiredAppName(): string | undefined {
     return undefined;
+  }
+
+  getTransportDisabledErrorCode(): ErrorCode | null {
+    return null;
+  }
+
+  getConnectionTips(): string[] {
+    return [];
   }
 }

--- a/app/core/HardwareWallet/adapters/factory.test.ts
+++ b/app/core/HardwareWallet/adapters/factory.test.ts
@@ -28,8 +28,8 @@ jest.mock('@ledgerhq/hw-app-eth', () => ({
   })),
 }));
 
-import { createAdapter, requiresBluetooth } from './factory';
-import { HardwareWalletType } from '@metamask/hw-wallet-sdk';
+import { createAdapter } from './factory';
+import { HardwareWalletType, ErrorCode } from '@metamask/hw-wallet-sdk';
 import { HardwareWalletAdapterOptions } from '../types';
 import { LedgerBluetoothAdapter } from './LedgerBluetoothAdapter';
 import { NonHardwareAdapter } from './NonHardwareAdapter';
@@ -66,12 +66,21 @@ describe('createAdapter', () => {
   });
 });
 
-describe('requiresBluetooth', () => {
-  it('returns true for Ledger', () => {
-    expect(requiresBluetooth(HardwareWalletType.Ledger)).toBe(true);
+describe('adapter transport properties', () => {
+  const mockOptions: HardwareWalletAdapterOptions = {
+    onDisconnect: jest.fn(),
+    onDeviceEvent: jest.fn(),
+  };
+
+  it('LedgerBluetoothAdapter returns BluetoothDisabled error code for transport', () => {
+    const adapter = createAdapter(HardwareWalletType.Ledger, mockOptions);
+    expect(adapter.getTransportDisabledErrorCode()).toBe(
+      ErrorCode.BluetoothDisabled,
+    );
   });
 
-  it('returns false for null', () => {
-    expect(requiresBluetooth(null)).toBe(false);
+  it('NonHardwareAdapter returns null for transport error code', () => {
+    const adapter = createAdapter(null, mockOptions);
+    expect(adapter.getTransportDisabledErrorCode()).toBeNull();
   });
 });

--- a/app/core/HardwareWallet/adapters/factory.ts
+++ b/app/core/HardwareWallet/adapters/factory.ts
@@ -27,12 +27,3 @@ export function createAdapter(
       return new NonHardwareAdapter(options);
   }
 }
-
-/**
- * Check if a wallet type requires Bluetooth
- */
-export function requiresBluetooth(
-  walletType: HardwareWalletType | null,
-): boolean {
-  return walletType === HardwareWalletType.Ledger;
-}

--- a/app/core/HardwareWallet/adapters/index.ts
+++ b/app/core/HardwareWallet/adapters/index.ts
@@ -1,1 +1,1 @@
-export { createAdapter, requiresBluetooth } from './factory';
+export { createAdapter } from './factory';

--- a/app/core/HardwareWallet/contexts/index.ts
+++ b/app/core/HardwareWallet/contexts/index.ts
@@ -2,7 +2,4 @@
  * Single hardware wallet context: config, state, and actions.
  */
 
-export {
-  useHardwareWallet,
-  type HardwareWalletContextValue,
-} from './HardwareWalletContext';
+export { useHardwareWallet } from './HardwareWalletContext';

--- a/app/core/HardwareWallet/index.ts
+++ b/app/core/HardwareWallet/index.ts
@@ -1,0 +1,4 @@
+export { HardwareWalletProvider } from './HardwareWalletProvider';
+
+export { useHardwareWallet } from './contexts';
+export { isUserCancellation } from './errors';

--- a/app/core/HardwareWallet/index.ts
+++ b/app/core/HardwareWallet/index.ts
@@ -1,4 +1,2 @@
-export { HardwareWalletProvider } from './HardwareWalletProvider';
-
 export { useHardwareWallet } from './contexts';
 export { isUserCancellation } from './errors';

--- a/app/core/HardwareWallet/types.ts
+++ b/app/core/HardwareWallet/types.ts
@@ -1,6 +1,7 @@
 import {
   HardwareWalletType,
   DeviceEventPayload,
+  ErrorCode,
 } from '@metamask/hw-wallet-sdk';
 
 /**
@@ -127,6 +128,24 @@ export interface HardwareWalletAdapter {
    * For QR/others: undefined (no app concept)
    */
   getRequiredAppName?(): string | undefined;
+
+  /**
+   * Get the ErrorCode to use when this adapter's transport is unavailable,
+   * or null if this adapter does not require persistent transport monitoring.
+   *
+   * Returning a non-null value means the provider will monitor transport
+   * availability and show an error if it becomes unavailable during an
+   * active operation.
+   */
+  getTransportDisabledErrorCode(): ErrorCode | null;
+
+  /**
+   * Get connection tips relevant to this adapter's transport mechanism.
+   * Returns an array of i18n string keys.
+   * For Ledger: BLE-specific tips (unlock, open app, enable bluetooth, DND)
+   * For QR: camera-specific tips
+   */
+  getConnectionTips(): string[];
 }
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Part "3.5" of the hardware wallet connection & error management overhaul. This does not introduce user facing changes.

Final implementation will look like this ([Figma designs](https://www.figma.com/design/1F3yNWYLOVPFpTPeJugH20/SWAP?node-id=11110-19571&t=tPMZNNiwCgbDfegd-0)):
<img width="1404" height="631" alt="image" src="https://github.com/user-attachments/assets/68850711-f53b-4060-8b47-6faceb67f82f" />

Reference feature branch: https://github.com/MetaMask/metamask-mobile/pull/25519

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

no manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to an interface change affecting all adapter implementations and downstream imports/exports; runtime behavior change is limited to additional transport metadata on Ledger.
> 
> **Overview**
> Extends the `HardwareWalletAdapter` interface with `getTransportDisabledErrorCode()` and `getConnectionTips()` so callers can surface transport-specific errors and UX guidance; implements these for `LedgerBluetoothAdapter` (BLE tips + `BluetoothDisabled`) and no-ops for `NonHardwareAdapter`, with tests updated accordingly.
> 
> Removes the `requiresBluetooth` helper and tightens module exports by dropping default exports for `useDeviceEventHandlers`/`useHardwareWalletStateManager` and narrowing context exports, plus adds a top-level `app/core/HardwareWallet` index exporting `useHardwareWallet` and `isUserCancellation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 010da70b43971ac6d268fd0f185bcc200f2c05b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->