### PR TITLE
feat(STX-355): add gasless bridge with 7702 behind feature flag

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -12,13 +12,15 @@ import {
   selectSelectedDestChainId,
   selectSlippage,
   selectDestAddress,
-  selectGasIncludedQuoteParams,
 } from '../../../../../core/redux/slices/bridge';
+import {
+  selectGasIncludedQuoteParams,
+  selectSourceWalletAddress,
+} from '../../../../../selectors/bridge';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { calcTokenValue } from '../../../../../util/transactions';
 import { debounce } from 'lodash';
 import { useUnifiedSwapBridgeContext } from '../useUnifiedSwapBridgeContext';
-import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import useIsInsufficientBalance from '../useInsufficientBalance';
 import { useLatestBalance } from '../useLatestBalance';
 

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -56,6 +56,7 @@ jest.mock('../useUnifiedSwapBridgeContext', () => ({
 
 // Mock the bridge selector
 jest.mock('../../../../../selectors/bridge', () => ({
+  ...jest.requireActual('../../../../../selectors/bridge'),
   selectSourceWalletAddress: jest.fn(),
 }));
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -12,7 +12,6 @@ import reducer, {
   setIsDestTokenManuallySet,
   selectIsDestTokenManuallySet,
   selectBip44DefaultPair,
-  selectGasIncludedQuoteParams,
   selectIsBridgeEnabledSource,
   selectAllowedChainRanking,
   setTokenSelectorNetworkFilter,
@@ -466,70 +465,6 @@ describe('bridge slice', () => {
       const result = selectBip44DefaultPair(mockState as unknown as RootState);
 
       expect(result).toBeUndefined();
-    });
-  });
-
-  describe('selectGasIncludedQuoteParams', () => {
-    it('returns gasIncluded true with 7702 false when STX send bundle is supported', () => {
-      const mockState = {
-        bridge: {
-          ...initialState,
-          isGasIncludedSTXSendBundleSupported: true,
-          isGasIncluded7702Supported: true,
-        },
-      } as RootState;
-
-      const result = selectGasIncludedQuoteParams(mockState);
-
-      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: false });
-    });
-
-    it('returns gasIncluded true with 7702 true for swap when 7702 is supported', () => {
-      const mockState = {
-        bridge: {
-          ...initialState,
-          sourceToken: mockToken,
-          destToken: { ...mockDestToken, chainId: mockToken.chainId },
-          isGasIncludedSTXSendBundleSupported: false,
-          isGasIncluded7702Supported: true,
-        },
-      } as RootState;
-
-      const result = selectGasIncludedQuoteParams(mockState);
-
-      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: true });
-    });
-
-    it('returns gasIncluded false with 7702 false for swap without 7702 support', () => {
-      const mockState = {
-        bridge: {
-          ...initialState,
-          sourceToken: mockToken,
-          destToken: { ...mockDestToken, chainId: mockToken.chainId },
-          isGasIncludedSTXSendBundleSupported: false,
-          isGasIncluded7702Supported: false,
-        },
-      } as RootState;
-
-      const result = selectGasIncludedQuoteParams(mockState);
-
-      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
-    });
-
-    it('returns gasIncluded false with 7702 false for bridge mode', () => {
-      const mockState = {
-        bridge: {
-          ...initialState,
-          sourceToken: mockToken,
-          destToken: mockDestToken,
-          isGasIncludedSTXSendBundleSupported: false,
-          isGasIncluded7702Supported: true,
-        },
-      } as RootState;
-
-      const result = selectGasIncludedQuoteParams(mockState);
-
-      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
     });
   });
 

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -529,34 +529,6 @@ export const selectIsSwap = createSelector(
     sourceToken.chainId === destToken.chainId,
 );
 
-/**
- * Selector that returns the gas included quote params for bridge and swap transactions.
- * Combines isSwap, STX/SendBundle support, and 7702 support to determine the correct
- * gas included parameters.
- */
-export const selectGasIncludedQuoteParams = createSelector(
-  [
-    selectIsSwap,
-    selectIsGasIncludedSTXSendBundleSupported,
-    selectIsGasIncluded7702Supported,
-  ],
-  (isSwap, gasIncludedSTXSendBundleSupport, gasIncluded7702Support) => {
-    // If STX send bundle support is true, we favor it over 7702.
-    if (gasIncludedSTXSendBundleSupport) {
-      return { gasIncluded: true, gasIncluded7702: false };
-    }
-
-    // If 7702 support is true, we use it for swap transactions.
-    const gasIncludedWith7702Enabled =
-      Boolean(isSwap) && gasIncluded7702Support;
-
-    return {
-      gasIncluded: gasIncludedWith7702Enabled,
-      gasIncluded7702: gasIncludedWith7702Enabled,
-    };
-  },
-);
-
 export const selectIsEvmSwap = createSelector(
   selectIsSwap,
   selectIsSolanaSwap,

--- a/app/selectors/bridge.test.ts
+++ b/app/selectors/bridge.test.ts
@@ -1,0 +1,232 @@
+import { getGaslessBridgeWith7702EnabledForChain } from './smartTransactionsController';
+
+jest.mock('./smartTransactionsController', () => ({
+  getGaslessBridgeWith7702EnabledForChain: jest.fn().mockReturnValue(false),
+}));
+
+import { initialState } from '../core/redux/slices/bridge';
+import {
+  selectGasIncludedQuoteParams,
+  selectIsGasIncluded7702BridgeEnabled,
+} from './bridge';
+import { BridgeToken } from '../components/UI/Bridge/types';
+import { Hex } from '@metamask/utils';
+import { RootState } from '../reducers';
+
+const mockToken: BridgeToken = {
+  address: '0x123',
+  symbol: 'ETH',
+  decimals: 18,
+  image: 'https://example.com/eth.png',
+  chainId: '0x1' as Hex,
+  name: 'Ethereum',
+  balance: '100',
+  balanceFiat: '100',
+};
+
+const mockDestToken: BridgeToken = {
+  address: '0x456',
+  symbol: 'USDC',
+  decimals: 6,
+  image: 'https://example.com/usdc.png',
+  chainId: '0x2' as Hex,
+  name: 'USDC',
+  balance: '100',
+  balanceFiat: '100',
+};
+
+describe('bridge selectors', () => {
+  describe('selectIsGasIncluded7702BridgeEnabled', () => {
+    beforeEach(() => {
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(false);
+    });
+
+    it('returns false when sourceToken is undefined', () => {
+      const mockState = {
+        bridge: { ...initialState, sourceToken: undefined },
+      } as RootState;
+
+      expect(selectIsGasIncluded7702BridgeEnabled(mockState)).toBe(false);
+    });
+
+    it('returns false when sourceToken has no chainId', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: { ...mockToken, chainId: undefined },
+        },
+      } as unknown as RootState;
+
+      expect(selectIsGasIncluded7702BridgeEnabled(mockState)).toBe(false);
+    });
+
+    it('delegates to getGaslessBridgeWith7702EnabledForChain for EVM chains', () => {
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(true);
+
+      const mockState = {
+        bridge: { ...initialState, sourceToken: mockToken },
+      } as RootState;
+
+      expect(selectIsGasIncluded7702BridgeEnabled(mockState)).toBe(true);
+      expect(getGaslessBridgeWith7702EnabledForChain).toHaveBeenCalledWith(
+        mockState,
+        mockToken.chainId,
+      );
+    });
+  });
+
+  describe('selectGasIncludedQuoteParams', () => {
+    beforeEach(() => {
+      selectGasIncludedQuoteParams.resetRecomputations();
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(false);
+    });
+
+    it('returns gasIncluded true with 7702 false when STX send bundle is supported', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          isGasIncludedSTXSendBundleSupported: true,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: false });
+    });
+
+    it('returns gasIncluded true with 7702 true for swap when 7702 is supported', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: { ...mockDestToken, chainId: mockToken.chainId },
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: true });
+    });
+
+    it('returns gasIncluded false with 7702 false for swap without 7702 support', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: { ...mockDestToken, chainId: mockToken.chainId },
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: false,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
+    });
+
+    it('returns gasIncluded false with 7702 false for bridge mode if disabled via flag', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: mockDestToken,
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
+    });
+
+    it('returns gasIncluded and gasIncluded7702 true for bridge when gaslessBridgeWith7702Enabled flag is true and 7702 relay supported', () => {
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(true);
+
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: mockDestToken,
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: true });
+    });
+
+    it('returns gasIncluded false for bridge when flag is true but 7702 relay not supported', () => {
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(true);
+
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: mockDestToken,
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: false,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
+    });
+
+    it('returns gasIncluded false for bridge when flag is false even with 7702 relay supported', () => {
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(false);
+
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: mockDestToken,
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
+    });
+
+    it('STX send bundle takes priority over bridge flag', () => {
+      jest
+        .mocked(getGaslessBridgeWith7702EnabledForChain)
+        .mockReturnValue(true);
+
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: mockDestToken,
+          isGasIncludedSTXSendBundleSupported: true,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: false });
+    });
+  });
+});

--- a/app/selectors/bridge.ts
+++ b/app/selectors/bridge.ts
@@ -1,16 +1,24 @@
 import { createSelector } from 'reselect';
-import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import {
+  formatChainIdToCaip,
+  isNonEvmChainId,
+  formatChainIdToHex,
+} from '@metamask/bridge-controller';
 import { selectSelectedInternalAccountByScope } from './multichainAccounts/accounts';
 import { RootState } from '../reducers';
 import {
   selectSourceToken,
   selectDestToken,
+  selectIsSwap,
+  selectIsGasIncludedSTXSendBundleSupported,
+  selectIsGasIncluded7702Supported,
 } from '../core/redux/slices/bridge';
 import { selectInternalAccountsByScope } from '../selectors/accountsController';
 import type { AccountId } from '@metamask/accounts-controller';
 import { EthScope } from '@metamask/keyring-api';
 import { createDeepEqualSelector } from './util';
 import { KnownCaipNamespace } from '@metamask/utils';
+import { getGaslessBridgeWith7702EnabledForChain } from './smartTransactionsController';
 
 /**
  * Gets the wallet address for a given source token by finding the selected account
@@ -50,5 +58,49 @@ export const selectValidDestInternalAccountIds = createDeepEqualSelector(
     return new Set<AccountId>(
       [...byDestScope, ...evmWildcard].map((a) => a.id),
     );
+  },
+);
+
+export const selectIsGasIncluded7702BridgeEnabled = (
+  state: RootState,
+): boolean => {
+  const sourceToken = selectSourceToken(state);
+  if (!sourceToken?.chainId || isNonEvmChainId(sourceToken.chainId))
+    return false;
+
+  const hexChainId = formatChainIdToHex(sourceToken.chainId);
+  return getGaslessBridgeWith7702EnabledForChain(state, hexChainId);
+};
+
+/**
+ * Selector that returns the gas included quote params for bridge and swap transactions.
+ * Combines isSwap, STX/SendBundle support, and 7702 support to determine the correct
+ * gas included parameters.
+ */
+export const selectGasIncludedQuoteParams = createSelector(
+  [
+    selectIsSwap,
+    selectIsGasIncludedSTXSendBundleSupported,
+    selectIsGasIncluded7702Supported,
+    selectIsGasIncluded7702BridgeEnabled,
+  ],
+  (
+    isSwap,
+    gasIncludedSTXSendBundleSupport,
+    gasIncluded7702Support,
+    gasIncluded7702BridgeEnabled,
+  ) => {
+    if (gasIncludedSTXSendBundleSupport) {
+      return { gasIncluded: true, gasIncluded7702: false };
+    }
+
+    const gasIncludedWith7702Enabled =
+      (Boolean(isSwap) || gasIncluded7702BridgeEnabled) &&
+      gasIncluded7702Support;
+
+    return {
+      gasIncluded: gasIncludedWith7702Enabled,
+      gasIncluded7702: gasIncludedWith7702Enabled,
+    };
   },
 );

--- a/app/selectors/smartTransactionsController.test.ts
+++ b/app/selectors/smartTransactionsController.test.ts
@@ -2,9 +2,9 @@ import {
   selectShouldUseSmartTransaction,
   selectSmartTransactionsEnabled,
   selectSmartTransactionsForCurrentChain,
-  // Add the pending selector to test it.
   selectPendingSmartTransactionsBySender,
   selectPendingSmartTransactionsForSelectedAccountGroup,
+  getGaslessBridgeWith7702EnabledForChain,
 } from './smartTransactionsController';
 import { backgroundState } from '../util/test/initial-root-state';
 import { isHardwareAccount } from '../util/address';
@@ -407,6 +407,35 @@ describe('SmartTransactionsController Selectors', () => {
             isSmartTransaction: true,
           },
         ]),
+      );
+    });
+  });
+
+  describe('getGaslessBridgeWith7702EnabledForChain', () => {
+    it('returns false when flag is not set for chain', () => {
+      const state = getDefaultState();
+      expect(getGaslessBridgeWith7702EnabledForChain(state, '0x1')).toBe(false);
+    });
+
+    it('returns true when flag is true for chain', () => {
+      const state = getDefaultState();
+      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.smartTransactionsNetworks[
+        '0x1'
+      ].gaslessBridgeWith7702Enabled = true;
+      expect(getGaslessBridgeWith7702EnabledForChain(state, '0x1')).toBe(true);
+    });
+
+    it('returns false when smartTransactionsNetworks is undefined', () => {
+      const state = getDefaultState();
+      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.smartTransactionsNetworks =
+        undefined;
+      expect(getGaslessBridgeWith7702EnabledForChain(state, '0x1')).toBe(false);
+    });
+
+    it('returns false for a chain not in the config', () => {
+      const state = getDefaultState();
+      expect(getGaslessBridgeWith7702EnabledForChain(state, '0x89')).toBe(
+        false,
       );
     });
   });

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -41,6 +41,18 @@ export const getSmartTransactionsFeatureFlagsForChain = createDeepEqualSelector(
     selectSmartTransactionsFeatureFlagsForChain(featureFlagsState, chainId),
 );
 
+export const getGaslessBridgeWith7702EnabledForChain = createDeepEqualSelector(
+  selectSmartTransactionsFeatureFlagsState,
+  (_state: RootState, chainId: Hex | CaipChainId) => chainId,
+  (featureFlagsState, chainId): boolean => {
+    const featureFlags = selectSmartTransactionsFeatureFlagsForChain(
+      featureFlagsState,
+      chainId,
+    );
+    return featureFlags?.gaslessBridgeWith7702Enabled ?? false;
+  },
+);
+
 /**
  * Checks if smart transactions are enabled for the current device based on feature flags.
  * Uses device-specific flags (mobileActiveIOS, mobileActiveAndroid) with fallback to mobileActive.

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/signature-controller": "^35.0.0",
     "@metamask/slip44": "^4.2.0",
-    "@metamask/smart-transactions-controller": "^22.5.0",
+    "@metamask/smart-transactions-controller": "^22.6.0",
     "@metamask/snaps-controllers": "^18.0.1",
     "@metamask/snaps-execution-environments": "^11.0.0",
     "@metamask/snaps-rpc-methods": "^14.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9609,9 +9609,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^22.5.0":
-  version: 22.5.0
-  resolution: "@metamask/smart-transactions-controller@npm:22.5.0"
+"@metamask/smart-transactions-controller@npm:^22.6.0":
+  version: 22.6.0
+  resolution: "@metamask/smart-transactions-controller@npm:22.6.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -9645,7 +9645,7 @@ __metadata:
       optional: true
     "@metamask/gas-fee-controller":
       optional: true
-  checksum: 10/215c5fe21e5e1679e4e0bc247d4ace99d88464ae97fd8c75fcd3bb3dc8420e11752b18a8eddd481591fc97508cfa87e909f7defda6911027c95166e6f69c5ba5
+  checksum: 10/f8fc9b7b63f343d9e806cec8da14f5419af075aac0d751bff727f6c9380ee28710406a4deae7753bf55155cf0469089b6e1058d02f0e47a2bfbfa3128abb7cba
   languageName: node
   linkType: hard
 
@@ -35407,7 +35407,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/signature-controller": "npm:^35.0.0"
     "@metamask/slip44": "npm:^4.2.0"
-    "@metamask/smart-transactions-controller": "npm:^22.5.0"
+    "@metamask/smart-transactions-controller": "npm:^22.6.0"
     "@metamask/snaps-controllers": "npm:^18.0.1"
     "@metamask/snaps-execution-environments": "npm:^11.0.0"
     "@metamask/snaps-rpc-methods": "npm:^14.3.0"


### PR DESCRIPTION
add gasless bridge with 7702 behind feature flag

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add gasless bridge with 7702 behind feature flag

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote parameter selection for bridging/swapping and introduces new remote-flag-driven behavior; misconfiguration could toggle gasless quoting on unintended chains.
> 
> **Overview**
> Enables *gas-included bridging via 7702* behind a per-chain remote feature flag, extending existing 7702 gasless behavior beyond swap-only flows.
> 
> This moves `selectGasIncludedQuoteParams` out of the bridge Redux slice into `app/selectors/bridge`, adds `selectIsGasIncluded7702BridgeEnabled` (backed by new `getGaslessBridgeWith7702EnabledForChain` in `smartTransactionsController`), and updates quote requests to use the relocated selector.
> 
> Adds unit coverage for the new selectors/flag behavior and bumps `@metamask/smart-transactions-controller` to `^22.6.0` to support the new flag field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2724fb94c31c75994285f4561d4461a376d8ec5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->