### PR TITLE
test: use unique BrowserStack Local identifier per job to prevent mm-connect tunnel routing conflicts

### DIFF
--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -98,12 +98,19 @@ jobs:
           username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: ${{ github.repository }}
-      
+
+      - name: Compute BrowserStack Local Identifier
+        id: bs-local-id
+        run: |
+          # Replace spaces with underscores so the identifier is safe for the BrowserStack Local binary
+          DEVICE_SAFE=$(echo "${{ matrix.device.name }}" | tr ' ' '_')
+          echo "value=${{ github.run_id }}-${{ inputs.build_type }}-${DEVICE_SAFE}" >> "$GITHUB_OUTPUT"
+
       - name: Setup BrowserStack Local
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
         with:
           local-testing: start
-          local-identifier: ${{ github.run_id }}-${{ inputs.build_type }}-${{ matrix.device.name }}
+          local-identifier: ${{ steps.bs-local-id.outputs.value }}
           # Use same args for all build types. Do not use --include-hosts for mm-connect:
           # bs-local.com requests must be forwarded to localhost; --include-hosts can block them.
           local-args: '--force-local --verbose'
@@ -147,7 +154,7 @@ jobs:
       - name: Run Tests
         env:
           BROWSERSTACK_LOCAL: 'true'
-          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ inputs.build_type }}-${{ matrix.device.name }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ steps.bs-local-id.outputs.value }}
           BROWSERSTACK_BUILD_NAME: ${{ inputs.browserstack_build_name }}
         working-directory: '.'
         run: |

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -104,6 +104,10 @@ jobs:
         run: |
           # Replace spaces with underscores so the identifier is safe for the BrowserStack Local binary
           DEVICE_SAFE=$(echo "${{ matrix.device.name }}" | tr ' ' '_')
+          if [ -z "$DEVICE_SAFE" ]; then
+            echo "❌ Error: matrix.device.name is empty — cannot build a valid BrowserStack Local identifier"
+            exit 1
+          fi
           echo "value=${{ github.run_id }}-${{ inputs.build_type }}-${DEVICE_SAFE}" >> "$GITHUB_OUTPUT"
 
       - name: Setup BrowserStack Local

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -103,7 +103,7 @@ jobs:
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
         with:
           local-testing: start
-          local-identifier: ${{ github.run_id }}
+          local-identifier: ${{ github.run_id }}-${{ inputs.build_type }}-${{ matrix.device.name }}
           # Use same args for all build types. Do not use --include-hosts for mm-connect:
           # bs-local.com requests must be forwarded to localhost; --include-hosts can block them.
           local-args: '--force-local --verbose'
@@ -147,7 +147,7 @@ jobs:
       - name: Run Tests
         env:
           BROWSERSTACK_LOCAL: 'true'
-          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ inputs.build_type }}-${{ matrix.device.name }}
           BROWSERSTACK_BUILD_NAME: ${{ inputs.browserstack_build_name }}
         working-directory: '.'
         run: |

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -102,8 +102,8 @@ jobs:
       - name: Compute BrowserStack Local Identifier
         id: bs-local-id
         run: |
-          # Replace spaces with underscores so the identifier is safe for the BrowserStack Local binary
-          DEVICE_SAFE=$(echo "${{ matrix.device.name }}" | tr ' ' '_')
+          # Strip any character that is not alphanumeric or a hyphen (covers spaces, /, \, @, etc.)
+          DEVICE_SAFE=$(printf '%s' "${{ matrix.device.name }}" | tr -c 'a-zA-Z0-9-' '_')
           if [ -z "$DEVICE_SAFE" ]; then
             echo "❌ Error: matrix.device.name is empty — cannot build a valid BrowserStack Local identifier"
             exit 1

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -103,12 +103,17 @@ jobs:
         id: bs-local-id
         run: |
           # Strip any character that is not alphanumeric or a hyphen (covers spaces, /, \, @, etc.)
+          BUILD_TYPE_SAFE=$(printf '%s' "${{ inputs.build_type }}" | tr -c 'a-zA-Z0-9-' '_')
           DEVICE_SAFE=$(printf '%s' "${{ matrix.device.name }}" | tr -c 'a-zA-Z0-9-' '_')
+          if [ -z "$BUILD_TYPE_SAFE" ]; then
+            echo "❌ Error: inputs.build_type is empty — cannot build a valid BrowserStack Local identifier"
+            exit 1
+          fi
           if [ -z "$DEVICE_SAFE" ]; then
             echo "❌ Error: matrix.device.name is empty — cannot build a valid BrowserStack Local identifier"
             exit 1
           fi
-          echo "value=${{ github.run_id }}-${{ inputs.build_type }}-${DEVICE_SAFE}" >> "$GITHUB_OUTPUT"
+          echo "value=${{ github.run_id }}-${BUILD_TYPE_SAFE}-${DEVICE_SAFE}" >> "$GITHUB_OUTPUT"
 
       - name: Setup BrowserStack Local
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3


### PR DESCRIPTION
## **Description**

All MM-Connect performance tests on CI were consistently failing with "not able to connect to bs-local.com:8090", and after the initial fix a second issue surfaced causing `BROWSERSTACK_LOCAL_CONNECTION_FAILED` for all appwright tests.

### Root cause 1: localIdentifier tunnel group conflict

Every job in a workflow run — `imported-wallet` (Android), `imported-wallet` (iOS), and `mm-connect` (Android) — calls the reusable `performance-test-runner.yml` and starts a BrowserStack Local tunnel using `local-identifier: ${{ github.run_id }}`. Because all concurrent jobs share the same `run_id`, BrowserStack treats their tunnel binaries as a **tunnel group** and may route any session's request to any binary in the group. The appwright patch hardcodes `local: true` for all sessions, so imported-wallet sessions also participate in the group. When a mm-connect session navigates to `http://bs-local.com:8090`, BrowserStack can route the request to an imported-wallet runner — where no dapp server is listening on port 8090 — causing a consistent connection failure.

**Fix:** Append `build_type` and `matrix.device.name` to the `local-identifier` so each job registers an isolated tunnel that only its own session uses.

### Root cause 2: unsafe characters in localIdentifier breaking BrowserStack Local binary

Device names (e.g. `"Samsung Galaxy S23 Ultra"`) contain spaces. When passed directly as `--local-identifier` to the BrowserStack Local binary, the spaces caused argument misparsing — the tunnel registered with a truncated identifier. The session then sent the full string as `localIdentifier`, found no matching tunnel, and threw `BROWSERSTACK_LOCAL_CONNECTION_FAILED` for every test.

**Fix:** Add a dedicated "Compute BrowserStack Local Identifier" step that sanitizes both `inputs.build_type` and `matrix.device.name` using `tr -c 'a-zA-Z0-9-' '_'`, replacing every unsafe character (spaces, `/`, `\`, `@`, etc.) with an underscore. Uses `printf` instead of `echo` to avoid a trailing newline becoming a trailing underscore. Both values are validated to be non-empty and fail fast with a clear error if not, preventing malformed identifiers with trailing hyphens. The sanitized value is stored as a step output and referenced consistently in both `setup-local` and `BROWSERSTACK_LOCAL_IDENTIFIER`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1488

## **Manual testing steps**

```gherkin
Feature: MM-Connect performance tests on CI

  Scenario: mm-connect tests run without tunnel routing conflicts
    Given the performance E2E workflow is triggered
    And imported-wallet and mm-connect jobs run concurrently
    When BrowserStack Local is started with a unique sanitized identifier per job
    Then each BrowserStack session routes bs-local.com traffic to its own runner
    And mm-connect tests can reach the dapp server on port 8090
    And all three mm-connect specs pass on BrowserStack
    And no BROWSERSTACK_LOCAL_CONNECTION_FAILED errors appear for any test
```

## **Screenshots/Recordings**

### **Before**

- MM-Connect specs: "not able to connect to bs-local.com:8090"
- All appwright tests after initial fix: `BROWSERSTACK_LOCAL_CONNECTION_FAILED`

### **After**

[BrowserStack Build Results](https://app-automate.browserstack.com/dashboard/v2/public-build/Tjh6Y3N1b3pwYXNxSmtvQjAwNkV0TFA4ekNVOFZxdXBQMmNka041OC9XbDVHc1JHVVJabzczb254Qmc3SThYVjVybWlhYW5qbXA1RTZOZHk2TjM2Y0E5PS0tV0VIMEh3U2tUbnUrZGw5WmppWCt0UT09--74149fd798c3d43122ccbfd107c699ad988d74e1)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change limited to BrowserStack Local tunnel configuration; main risk is mis-sanitization or identifier formatting causing tunnels not to match sessions.
> 
> **Overview**
> Prevents BrowserStack Local tunnel collisions in the reusable performance test workflow by generating a **unique per-job** `local-identifier` from `github.run_id`, `inputs.build_type`, and `matrix.device.name`.
> 
> Adds a dedicated step to **sanitize** identifier components (replace non-alphanumeric/hyphen chars with `_`) and fail fast if inputs are empty, then reuses the computed value for both `setup-local` and `BROWSERSTACK_LOCAL_IDENTIFIER` during test execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d9ba634cbad2de1f233bd54378bcec8c4337ea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->