### PR TITLE
DO NOT MERGE - fix: MUSD-319 max convert bottom sheet convert button disabled but reason is not conveyed to user

### DIFF
--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.styles.ts
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.styles.ts
@@ -14,13 +14,12 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 12,
       paddingHorizontal: 16,
       paddingVertical: 8,
-      marginBottom: 16,
     },
     buttonContainer: {
-      paddingTop: 16,
+      paddingTop: 32,
     },
-    errorText: {
-      textAlign: 'center',
+    errorTextContainer: {
+      paddingTop: 32,
     },
   });
 };

--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.test.tsx
@@ -8,11 +8,7 @@ import {
 } from './musd-max-conversion-info';
 import { AssetType } from '../../../types/token';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import {
-  useIsTransactionPayLoading,
-  useTransactionPayQuotes,
-} from '../../../hooks/pay/useTransactionPayData';
-import { useNoPayTokenQuotesAlert } from '../../../hooks/alerts/useNoPayTokenQuotesAlert';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import { useAlerts } from '../../../context/alert-system-context';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
@@ -54,11 +50,6 @@ jest.mock('../../../hooks/transactions/useTransactionMetadataRequest', () => ({
 
 jest.mock('../../../hooks/pay/useTransactionPayData', () => ({
   useIsTransactionPayLoading: jest.fn(),
-  useTransactionPayQuotes: jest.fn(),
-}));
-
-jest.mock('../../../hooks/alerts/useNoPayTokenQuotesAlert', () => ({
-  useNoPayTokenQuotesAlert: jest.fn(),
 }));
 
 jest.mock('../../../hooks/transactions/useTransactionConfirm', () => ({
@@ -97,8 +88,6 @@ const mockUseTransactionMetadataRequest = jest.mocked(
   useTransactionMetadataRequest,
 );
 const mockUseIsTransactionPayLoading = jest.mocked(useIsTransactionPayLoading);
-const mockUseTransactionPayQuotes = jest.mocked(useTransactionPayQuotes);
-const mockUseNoPayTokenQuotesAlert = jest.mocked(useNoPayTokenQuotesAlert);
 const mockUseTransactionConfirm = jest.mocked(useTransactionConfirm);
 const mockUseAlerts = jest.mocked(useAlerts);
 const mockUseFiatFormatter = jest.mocked(useFiatFormatter);
@@ -109,13 +98,9 @@ function setupMocksForSuccessPath() {
     chainId: '0x1',
   } as unknown as ReturnType<typeof useTransactionMetadataRequest>);
   mockUseIsTransactionPayLoading.mockReturnValue(false);
-  mockUseTransactionPayQuotes.mockReturnValue([
-    { strategy: 'test' },
-  ] as ReturnType<typeof useTransactionPayQuotes>);
-  mockUseNoPayTokenQuotesAlert.mockReturnValue([]);
   mockUseTransactionConfirm.mockReturnValue({ onConfirm: jest.fn() });
   mockUseAlerts.mockReturnValue({
-    hasBlockingAlerts: false,
+    alerts: [],
   } as ReturnType<typeof useAlerts>);
   mockUseFiatFormatter.mockReturnValue((value: { toString: () => string }) =>
     value.toString(),
@@ -143,25 +128,62 @@ describe('MusdMaxConversionInfo', () => {
     });
   });
 
-  describe('noPayTokenQuotesAlert', () => {
-    it('displays error text when noPayTokenQuotesAlert has items', () => {
-      mockUseNoPayTokenQuotesAlert.mockReturnValue([
-        {
-          key: 'NoPayTokenQuotes',
-          message: 'No quotes available',
-          title: 'Error',
-          severity: 'danger',
-          isBlocking: true,
-        },
-      ] as never);
+  describe('blocking alert', () => {
+    it('displays blocking alert message when provided', () => {
+      mockUseAlerts.mockReturnValue({
+        alerts: [
+          {
+            key: 'BlockingAlert',
+            message: 'Cannot proceed with this conversion',
+            title: 'Review',
+            severity: 'danger',
+            isBlocking: true,
+          },
+        ],
+      } as ReturnType<typeof useAlerts>);
 
       renderWithProvider(<MusdMaxConversionInfo />, { state: {} });
 
       expect(
-        screen.getByText(
-          'Failed to get quotes. Please close this modal and try again.',
-        ),
+        screen.getByText('Cannot proceed with this conversion'),
       ).toBeOnTheScreen();
+    });
+
+    it('uses blocking alert title as button label', () => {
+      mockUseAlerts.mockReturnValue({
+        alerts: [
+          {
+            key: 'BlockingAlert',
+            message: 'Blocked',
+            title: 'Acknowledge First',
+            severity: 'danger',
+            isBlocking: true,
+          },
+        ],
+      } as ReturnType<typeof useAlerts>);
+
+      renderWithProvider(<MusdMaxConversionInfo />, { state: {} });
+
+      expect(screen.getByText('Acknowledge First')).toBeOnTheScreen();
+    });
+
+    it('does not render blocking alert text when message missing', () => {
+      mockUseAlerts.mockReturnValue({
+        alerts: [
+          {
+            key: 'BlockingAlert',
+            title: 'Review',
+            severity: 'danger',
+            isBlocking: true,
+          },
+        ],
+      } as ReturnType<typeof useAlerts>);
+
+      renderWithProvider(<MusdMaxConversionInfo />, { state: {} });
+
+      expect(
+        screen.queryByText('Cannot proceed with this conversion'),
+      ).toBeNull();
     });
   });
 
@@ -202,20 +224,17 @@ describe('MusdMaxConversionInfo', () => {
       expect(confirmButton.props.disabled).toBe(true);
     });
 
-    it('disables confirm button when quotes array is empty', () => {
-      mockUseTransactionPayQuotes.mockReturnValue([]);
-
-      renderWithProvider(<MusdMaxConversionInfo />, { state: {} });
-
-      const confirmButton = screen.getByTestId(
-        MusdMaxConversionInfoTestIds.CONFIRM_BUTTON,
-      );
-      expect(confirmButton.props.disabled).toBe(true);
-    });
-
-    it('disables confirm button when hasBlockingAlerts is true', () => {
+    it('disables confirm button when alerts contain isBlocking entry', () => {
       mockUseAlerts.mockReturnValue({
-        hasBlockingAlerts: true,
+        alerts: [
+          {
+            key: 'BlockingAlert',
+            message: 'Blocked',
+            title: 'Review',
+            severity: 'danger',
+            isBlocking: true,
+          },
+        ],
       } as ReturnType<typeof useAlerts>);
 
       renderWithProvider(<MusdMaxConversionInfo />, { state: {} });

--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useStyles } from '../../../../../hooks/useStyles';
@@ -11,20 +11,16 @@ import Button, {
 } from '../../../../../../component-library/components/Buttons/Button';
 import { selectNetworkName } from '../../../../../../selectors/networkInfos';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import {
-  useIsTransactionPayLoading,
-  useTransactionPayQuotes,
-} from '../../../hooks/pay/useTransactionPayData';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import { useAlerts } from '../../../context/alert-system-context';
 import { TotalRow } from '../../rows/total-row';
 import { BridgeFeeRow } from '../../rows/bridge-fee-row';
 import { AssetType } from '../../../types/token';
-import musdMaxConversionInfoStyleSheet from './musd-max-conversion-info.styles';
+import stylesheet from './musd-max-conversion-info.styles';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { PercentageRow } from '../../rows/percentage-row';
 import { MusdMaxConversionAssetHeader } from './musd-max-conversion-asset-header';
-import { useNoPayTokenQuotesAlert } from '../../../hooks/alerts/useNoPayTokenQuotesAlert';
 import Text, {
   TextColor,
   TextVariant,
@@ -76,66 +72,68 @@ export const MusdMaxConversionInfoTestIds = {
 } as const;
 
 export const MusdMaxConversionInfo = () => {
-  const { styles } = useStyles(musdMaxConversionInfoStyleSheet, {});
+  const { styles } = useStyles(stylesheet, {});
   const networkName = useSelector(selectNetworkName);
 
   const { token } = useParams<MusdMaxConversionParams>();
 
-  const quotes = useTransactionPayQuotes();
-
   const transactionMetadata = useTransactionMetadataRequest();
   const isQuoteLoading = useIsTransactionPayLoading();
-  const noPayTokenQuotesAlert = useNoPayTokenQuotesAlert();
 
   const { onConfirm } = useTransactionConfirm();
-  const { hasBlockingAlerts } = useAlerts();
+  const { alerts } = useAlerts();
+
+  const blockingAlert = alerts.find(
+    (confirmationAlert) => confirmationAlert.isBlocking,
+  );
 
   const formatFiat = useFiatFormatter();
 
-  const isLoading =
-    !transactionMetadata || isQuoteLoading || quotes?.length === 0;
+  const isLoading = !transactionMetadata || isQuoteLoading;
 
-  const isConfirmDisabled = isLoading || hasBlockingAlerts;
+  const isConfirmDisabled = isLoading || Boolean(blockingAlert);
+
+  const buttonLabel = useMemo(() => {
+    if (blockingAlert) {
+      return blockingAlert.title;
+    }
+    return strings('earn.musd_conversion.convert');
+  }, [blockingAlert]);
 
   return (
     <View
       style={styles.container}
       testID={MusdMaxConversionInfoTestIds.CONTAINER}
     >
-      {noPayTokenQuotesAlert.length > 0 ? (
-        <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Error}
-          style={styles.errorText}
-        >
-          {strings('earn.musd_conversion.quick_convert.failed_to_get_quotes')}
-        </Text>
-      ) : (
-        <>
-          <MusdMaxConversionAssetHeader
-            token={token}
-            networkName={networkName}
-            formatFiat={formatFiat}
-          />
-          <View style={styles.detailsSection}>
-            <RateRow tokenSymbol={token.symbol} isLoading={isLoading} />
-            <BridgeFeeRow />
-            <TotalRow />
-            <PercentageRow />
-          </View>
-          <View style={styles.buttonContainer}>
-            <Button
-              onPress={onConfirm}
-              label={strings('earn.musd_conversion.convert')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
-              size={ButtonSize.Lg}
-              isDisabled={isConfirmDisabled}
-              testID={MusdMaxConversionInfoTestIds.CONFIRM_BUTTON}
-            />
-          </View>
-        </>
+      <MusdMaxConversionAssetHeader
+        token={token}
+        networkName={networkName}
+        formatFiat={formatFiat}
+      />
+      <View style={styles.detailsSection}>
+        <RateRow tokenSymbol={token.symbol} isLoading={isLoading} />
+        <BridgeFeeRow />
+        <TotalRow />
+        <PercentageRow />
+      </View>
+      {blockingAlert?.message && (
+        <View style={styles.errorTextContainer}>
+          <Text variant={TextVariant.BodyMD} color={TextColor.Error}>
+            {blockingAlert?.message}
+          </Text>
+        </View>
       )}
+      <View style={styles.buttonContainer}>
+        <Button
+          onPress={onConfirm}
+          label={buttonLabel}
+          variant={ButtonVariants.Primary}
+          width={ButtonWidthTypes.Full}
+          size={ButtonSize.Lg}
+          isDisabled={isConfirmDisabled}
+          testID={MusdMaxConversionInfoTestIds.CONFIRM_BUTTON}
+        />
+      </View>
     </View>
   );
 };

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -22,7 +22,10 @@ import { Severity } from '../../types/alerts';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { Hex } from '@metamask/utils';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../transactions/useTransactionMetadataRequest');
@@ -300,6 +303,35 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       ]);
     });
 
+    it('returns mUSD-specific alert when source gas insufficient for musdConversion', () => {
+      useTokenWithBalanceMock.mockReturnValue({
+        ...NATIVE_TOKEN_MOCK,
+        balanceRaw: '99',
+      } as ReturnType<typeof useTokenWithBalance>);
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.musdConversion,
+      } as TransactionMeta);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([
+        {
+          key: AlertKeys.InsufficientPayTokenNative,
+          field: RowAlertKey.Amount,
+          isBlocking: true,
+          title: strings(
+            'alert_system.insufficient_pay_token_native_musd_conversion.title',
+          ),
+          message: strings(
+            'alert_system.insufficient_pay_token_native_musd_conversion.message',
+            { ticker: 'ETH' },
+          ),
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
     it('returns no alert if pay token is native', () => {
       useTokenWithBalanceMock.mockReturnValue({
         ...NATIVE_TOKEN_MOCK,
@@ -462,6 +494,36 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
             'alert_system.insufficient_pay_token_native.message',
+            { ticker: 'POL' },
+          ),
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
+    it('returns mUSD-specific alert when source gas insufficient in post-quote musdConversion', () => {
+      useTokenWithBalanceMock.mockReturnValue({
+        ...NATIVE_TOKEN_MOCK,
+        balanceRaw: '50',
+      } as ReturnType<typeof useTokenWithBalance>);
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        chainId: SOURCE_CHAIN_ID,
+        type: TransactionType.musdConversion,
+      } as TransactionMeta);
+
+      const { result } = runHook({}, polygonNetworkState);
+
+      expect(result.current).toStrictEqual([
+        {
+          key: AlertKeys.InsufficientPayTokenNative,
+          field: RowAlertKey.Amount,
+          isBlocking: true,
+          title: strings(
+            'alert_system.insufficient_pay_token_native_musd_conversion.title',
+          ),
+          message: strings(
+            'alert_system.insufficient_pay_token_native_musd_conversion.message',
             { ticker: 'POL' },
           ),
           severity: Severity.Danger,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -18,6 +18,8 @@ import { RootState } from '../../../../../reducers';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../utils/transaction';
 
 export function useInsufficientPayTokenBalanceAlert({
   pendingAmountUsd,
@@ -173,6 +175,24 @@ export function useInsufficientPayTokenBalanceAlert({
     }
 
     if (isInsufficientForSourceNetwork) {
+      if (
+        hasTransactionType(transactionMeta, [TransactionType.musdConversion])
+      ) {
+        return [
+          {
+            ...baseAlert,
+            key: AlertKeys.InsufficientPayTokenNative,
+            title: strings(
+              'alert_system.insufficient_pay_token_native_musd_conversion.title',
+            ),
+            message: strings(
+              'alert_system.insufficient_pay_token_native_musd_conversion.message',
+              { ticker },
+            ),
+          },
+        ];
+      }
+
       return [
         {
           ...baseAlert,
@@ -191,6 +211,7 @@ export function useInsufficientPayTokenBalanceAlert({
     isInsufficientForInput,
     isInsufficientForFees,
     isInsufficientForSourceNetwork,
+    transactionMeta,
     ticker,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -19,9 +19,12 @@ import {
   TransactionPayQuote,
   TransactionPaySourceAmount,
 } from '@metamask/transaction-pay-controller';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
 
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/useTransactionPayData');
+jest.mock('../transactions/useTransactionMetadataRequest');
 
 const STATE_MOCK = merge(
   {},
@@ -49,6 +52,9 @@ describe('useNoPayTokenQuotesAlert', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -65,9 +71,12 @@ describe('useNoPayTokenQuotesAlert', () => {
     useTransactionPaySourceAmountsMock.mockReturnValue([
       {} as TransactionPaySourceAmount,
     ]);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.simpleSend,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
   });
 
-  it('returns alert if pay token selected and no quotes available', () => {
+  it('returns generic alert when pay token selected and no quotes available', () => {
     const { result } = runHook();
 
     expect(result.current).toEqual([
@@ -82,12 +91,36 @@ describe('useNoPayTokenQuotesAlert', () => {
     ]);
   });
 
+  it('returns mUSD-specific alert when musdConversion type and no quotes available', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.musdConversion,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([
+      {
+        key: AlertKeys.NoPayTokenQuotes,
+        field: RowAlertKey.PayWith,
+        message: strings(
+          'alert_system.no_pay_token_quotes_musd_conversion.message',
+        ),
+        title: strings(
+          'alert_system.no_pay_token_quotes_musd_conversion.title',
+        ),
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ]);
+  });
+
   it('returns no alerts if quotes available', () => {
     useTransactionPayQuotesMock.mockReturnValue([
       {} as TransactionPayQuote<Json>,
     ]);
 
     const { result } = runHook();
+
     expect(result.current).toStrictEqual([]);
   });
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -10,6 +10,9 @@ import {
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { hasTransactionType } from '../../utils/transaction';
+import { TransactionType } from '@metamask/transaction-controller';
 
 export function useNoPayTokenQuotesAlert() {
   const { payToken } = useTransactionPayToken();
@@ -17,6 +20,7 @@ export function useNoPayTokenQuotesAlert() {
   const isQuotesLoading = useIsTransactionPayLoading();
   const sourceAmounts = useTransactionPaySourceAmounts();
   const requiredTokens = useTransactionPayRequiredTokens();
+  const transactionMetadata = useTransactionMetadataRequest();
 
   const isOptionalOnly = (sourceAmounts ?? []).every(
     (t) =>
@@ -36,15 +40,26 @@ export function useNoPayTokenQuotesAlert() {
       return [];
     }
 
-    return [
-      {
-        key: AlertKeys.NoPayTokenQuotes,
-        field: RowAlertKey.PayWith,
-        message: strings('alert_system.no_pay_token_quotes.message'),
-        title: strings('alert_system.no_pay_token_quotes.title'),
-        severity: Severity.Danger,
-        isBlocking: true,
-      },
-    ];
-  }, [showAlert]);
+    const baseAlert = {
+      key: AlertKeys.NoPayTokenQuotes,
+      field: RowAlertKey.PayWith,
+      message: strings('alert_system.no_pay_token_quotes.message'),
+      title: strings('alert_system.no_pay_token_quotes.title'),
+      severity: Severity.Danger,
+      isBlocking: true,
+    };
+
+    if (
+      hasTransactionType(transactionMetadata, [TransactionType.musdConversion])
+    ) {
+      baseAlert.message = strings(
+        'alert_system.no_pay_token_quotes_musd_conversion.message',
+      );
+      baseAlert.title = strings(
+        'alert_system.no_pay_token_quotes_musd_conversion.title',
+      );
+    }
+
+    return [baseAlert];
+  }, [showAlert, transactionMetadata]);
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -103,8 +103,16 @@
       "message": "Not enough {{ticker}} to cover fees. Use a token on another network or add more {{ticker}} to continue.",
       "title": "Insufficient funds"
     },
+    "insufficient_pay_token_native_musd_conversion": {
+      "message": "Not enough {{ticker}} to cover fees. Add more {{ticker}} to continue.",
+      "title": "Insufficient funds"
+    },
     "no_pay_token_quotes": {
       "message": "This payment route isn't available right now. Try changing the amount, network, or token and we'll find the best option.",
+      "title": "No quotes"
+    },
+    "no_pay_token_quotes_musd_conversion": {
+      "message": "We couldn't find any quotes for this conversion at this time. Please try again later.",
       "title": "No quotes"
     },
     "perps_hardware_account": {
@@ -5942,8 +5950,7 @@
         "inline_failed_message": "Conversion failed. Try again.",
         "confirmation": {
           "title": "Convert Max"
-        },
-        "failed_to_get_quotes": "Failed to get quotes. Please close this modal and try again."
+        }
       },
       "percentage_boost": "{{percentage}}% boost",
       "rate": "Rate"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates the mUSD Quick Convert bottom sheet to display blocking alerts (e.g. No quotes). This way the user knows why the "Convert" button is disabled.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated the mUSD Quick Convert bottom sheet to display blocking alerts (e.g. No Quotes)

## **Related issues**

Fixes: [MUSD-319: Max convert bottom sheet "convert" button disabled but reason isn't conveyed to user (Improve Alerts)](https://consensyssoftware.atlassian.net/browse/MUSD-319)

## **Manual testing steps**

```gherkin
Feature: mUSD max conversion blocking alerts

  Scenario: user sees clear reason when conversion is blocked
    Given user opens mUSD max conversion confirmation
    When a blocking alert exists
    Then the Convert button is disabled and shows the blocking alert title/message

  Scenario: user sees mUSD-specific quote and fee messaging
    Given user is in mUSD max conversion
    When no quotes are available or native gas is insufficient
    Then mUSD-specific blocking alert copy is shown instead of generic pay-token guidance
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A - The "Convert" button is disabled without telling the user why.
### **After**

<!-- [screenshots/recordings] -->
<img width="494" height="1047" alt="Screenshot 2026-02-24 at 2 03 30 PM" src="https://github.com/user-attachments/assets/d662d12a-833e-46bc-a049-1e9bcac4504c" />

<img width="494" height="974" alt="image" src="https://github.com/user-attachments/assets/f1cbb5f3-04dc-4dbd-9553-1f3ecc88598f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
