### PR TITLE
refactor: simplify useRampsQuotes hook

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -182,45 +182,27 @@ function BuildQuote() {
 
   const debouncedPollingAmount = useDebouncedValue(amountAsNumber, 500);
 
-  const quoteFetchEnabled = !!(
-    isOnBuildQuoteScreen &&
-    walletAddress &&
-    selectedPaymentMethod &&
-    selectedProvider &&
-    selectedToken?.assetId &&
-    debouncedPollingAmount > 0
-  );
-
-  const quoteFetchParams = useMemo(
-    () =>
-      selectedToken?.assetId &&
-      walletAddress &&
-      selectedPaymentMethod &&
-      selectedProvider
-        ? {
-            assetId: selectedToken.assetId,
-            amount: debouncedPollingAmount,
-            walletAddress,
-            redirectUrl: getRampCallbackBaseUrl(),
-            paymentMethods: [selectedPaymentMethod.id],
-            providers: [selectedProvider.id],
-            forceRefresh: true,
-          }
-        : null,
-    [
-      selectedToken?.assetId,
-      debouncedPollingAmount,
-      walletAddress,
-      selectedPaymentMethod,
-      selectedProvider,
-    ],
-  );
-
   const {
     data: quotesResponse,
     loading: selectedQuoteLoading,
     error: quoteFetchError,
-  } = useRampsQuotes(quoteFetchEnabled ? quoteFetchParams : null);
+  } = useRampsQuotes({
+    assetId: selectedToken?.assetId ?? '',
+    amount: debouncedPollingAmount,
+    walletAddress: walletAddress ?? '',
+    redirectUrl: getRampCallbackBaseUrl(),
+    paymentMethods: selectedPaymentMethod ? [selectedPaymentMethod.id] : [],
+    providers: selectedProvider ? [selectedProvider.id] : [],
+    forceRefresh: true,
+    enableFetching: !!(
+      isOnBuildQuoteScreen &&
+      walletAddress &&
+      selectedPaymentMethod &&
+      selectedProvider &&
+      selectedToken?.assetId &&
+      debouncedPollingAmount > 0
+    ),
+  });
 
   const selectedQuote = useMemo(() => {
     if (!quotesResponse?.success || !selectedProvider || !selectedPaymentMethod)

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
@@ -347,6 +347,7 @@ describe('PaymentSelectionModal', () => {
         '/payments/debit-credit-card-2',
       ],
       forceRefresh: true,
+      enableFetching: true,
     });
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -77,33 +77,20 @@ function PaymentSelectionModal() {
     [paymentMethods],
   );
 
-  const quoteFetchParams = useMemo(
-    () =>
+  const { data: quotes, loading: quotesLoading } = useRampsQuotes({
+    amount,
+    walletAddress,
+    assetId,
+    providers: selectedProvider ? [selectedProvider.id] : undefined,
+    paymentMethods: paymentMethodIds,
+    forceRefresh: true,
+    enableFetching: !!(
       walletAddress &&
       assetId &&
       !paymentMethodsLoading &&
       paymentMethodIds.length > 0
-        ? {
-            amount,
-            walletAddress,
-            assetId,
-            providers: selectedProvider ? [selectedProvider.id] : undefined,
-            paymentMethods: paymentMethodIds,
-            forceRefresh: true,
-          }
-        : null,
-    [
-      amount,
-      walletAddress,
-      assetId,
-      selectedProvider,
-      paymentMethodIds,
-      paymentMethodsLoading,
-    ],
-  );
-
-  const { data: quotes, loading: quotesLoading } =
-    useRampsQuotes(quoteFetchParams);
+    ),
+  });
 
   const handleChangeProviderPress = useCallback(() => {
     navigation.navigate(Routes.RAMP.MODALS.PROVIDER_SELECTION, { amount });

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
@@ -68,35 +68,21 @@ function ProviderSelectionModal() {
     [displayProviders],
   );
 
-  const quoteFetchParams = useMemo(
-    () =>
-      !skipQuotes && walletAddress && assetId
-        ? {
-            amount,
-            walletAddress,
-            assetId,
-            providers: providerIds,
-            paymentMethods: selectedPaymentMethod
-              ? [selectedPaymentMethod.id]
-              : undefined,
-            forceRefresh: true,
-          }
-        : null,
-    [
-      skipQuotes,
-      amount,
-      walletAddress,
-      assetId,
-      providerIds,
-      selectedPaymentMethod,
-    ],
-  );
-
   const {
     data: quotes,
     loading: quotesLoading,
     error: quotesError,
-  } = useRampsQuotes(quoteFetchParams);
+  } = useRampsQuotes({
+    amount,
+    walletAddress,
+    assetId,
+    providers: providerIds,
+    paymentMethods: selectedPaymentMethod
+      ? [selectedPaymentMethod.id]
+      : undefined,
+    forceRefresh: true,
+    enableFetching: !skipQuotes && !!walletAddress && !!assetId,
+  });
 
   const handleBack = useCallback(() => {
     navigation.goBack();

--- a/app/components/UI/Ramp/hooks/useRampTokens.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampTokens.test.ts
@@ -129,12 +129,11 @@ describe('useRampTokens', () => {
         expect(mockHandleFetch).toHaveBeenCalledWith(
           'https://on-ramp-cache.uat-api.cx.metamask.io/regions/us-ca/tokens?action=buy&sdk=2.1.5',
         );
+        expect(result.current.topTokens).toEqual(mockTopTokens);
+        expect(result.current.allTokens).toEqual(mockAllTokens);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toBeNull();
       });
-
-      expect(result.current.topTokens).toEqual(mockTopTokens);
-      expect(result.current.allTokens).toEqual(mockAllTokens);
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBeNull();
     });
 
     it('fetches tokens for DEPOSIT routing decision', async () => {
@@ -154,12 +153,11 @@ describe('useRampTokens', () => {
         expect(mockHandleFetch).toHaveBeenCalledWith(
           'https://on-ramp-cache.uat-api.cx.metamask.io/regions/uk/tokens?action=deposit&sdk=2.1.5',
         );
+        expect(result.current.topTokens).toEqual(mockTopTokens);
+        expect(result.current.allTokens).toEqual(mockAllTokens);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toBeNull();
       });
-
-      expect(result.current.topTokens).toEqual(mockTopTokens);
-      expect(result.current.allTokens).toEqual(mockAllTokens);
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBeNull();
     });
 
     it('includes SDK version in query parameters', async () => {
@@ -374,11 +372,10 @@ describe('useRampTokens', () => {
 
       await waitFor(() => {
         expect(result.current.error).toEqual(mockError);
+        expect(result.current.topTokens).toBeNull();
+        expect(result.current.allTokens).toBeNull();
+        expect(result.current.isLoading).toBe(false);
       });
-
-      expect(result.current.topTokens).toBeNull();
-      expect(result.current.allTokens).toBeNull();
-      expect(result.current.isLoading).toBe(false);
     });
 
     it('logs error when fetch fails', async () => {
@@ -416,10 +413,9 @@ describe('useRampTokens', () => {
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
+        expect(result.current.topTokens).toEqual(mockResponse.topTokens);
+        expect(result.current.allTokens).toEqual(mockResponse.allTokens);
       });
-
-      expect(result.current.topTokens).toEqual(mockResponse.topTokens);
-      expect(result.current.allTokens).toEqual(mockResponse.allTokens);
     });
   });
 
@@ -437,10 +433,9 @@ describe('useRampTokens', () => {
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
+        expect(result.current.topTokens).toEqual(mockResponse.topTokens);
+        expect(result.current.allTokens).toEqual(mockResponse.allTokens);
       });
-
-      expect(result.current.topTokens).toEqual(mockResponse.topTokens);
-      expect(result.current.allTokens).toEqual(mockResponse.allTokens);
     });
 
     it('sets loading to false after failed fetch', async () => {
@@ -453,9 +448,8 @@ describe('useRampTokens', () => {
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toEqual(mockError);
       });
-
-      expect(result.current.error).toEqual(mockError);
     });
   });
 
@@ -484,14 +478,12 @@ describe('useRampTokens', () => {
 
       await waitFor(() => {
         expect(result.current.topTokens).toEqual(mockTopTokens);
+        expect(result.current.allTokens).toHaveLength(4);
+        expect(result.current.topTokens?.[0].tokenSupported).toBe(true);
+        expect(result.current.topTokens?.[1].tokenSupported).toBe(true);
+        expect(result.current.allTokens?.[2].tokenSupported).toBe(false);
+        expect(result.current.allTokens?.[3].tokenSupported).toBe(false);
       });
-
-      // All 4 tokens pass network filter (ETH, BTC, USDC on eip155:1, SOL on solana)
-      expect(result.current.allTokens).toHaveLength(4);
-      expect(result.current.topTokens?.[0].tokenSupported).toBe(true);
-      expect(result.current.topTokens?.[1].tokenSupported).toBe(true);
-      expect(result.current.allTokens?.[2].tokenSupported).toBe(false);
-      expect(result.current.allTokens?.[3].tokenSupported).toBe(false);
     });
   });
 
@@ -521,12 +513,9 @@ describe('useRampTokens', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.topTokens).toBeDefined();
+        expect(result.current.topTokens).toHaveLength(2);
+        expect(result.current.allTokens).toHaveLength(3);
       });
-
-      // All networks from mock config are in the user's wallet
-      expect(result.current.topTokens).toHaveLength(2);
-      expect(result.current.allTokens).toHaveLength(3);
     });
 
     it('filters out tokens with empty chainId', async () => {
@@ -548,13 +537,10 @@ describe('useRampTokens', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.topTokens).toBeDefined();
+        expect(result.current.topTokens).toHaveLength(1);
+        expect(result.current.topTokens?.[0].symbol).toBe('ETH');
+        expect(result.current.allTokens).toHaveLength(1);
       });
-
-      // Should exclude token with empty chainId
-      expect(result.current.topTokens).toHaveLength(1);
-      expect(result.current.topTokens?.[0].symbol).toBe('ETH');
-      expect(result.current.allTokens).toHaveLength(1);
     });
   });
 });

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -2,7 +2,11 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import React from 'react';
-import { useRampsQuotes, type GetQuotesOptions } from './useRampsQuotes';
+import {
+  useRampsQuotes,
+  type GetQuotesOptions,
+  type UseRampsQuotesOptions,
+} from './useRampsQuotes';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 
@@ -275,6 +279,119 @@ describe('useRampsQuotes', () => {
       expect(result.current.data).toBeNull();
       expect(result.current.loading).toBe(false);
       expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('enableFetching', () => {
+    const baseOptions: UseRampsQuotesOptions = {
+      amount: 100,
+      walletAddress: '0x123',
+      assetId: 'eip155:1/slip44:60',
+    };
+
+    it('skips fetch when enableFetching is false', () => {
+      const store = createMockStore();
+      const { result } = renderHook(
+        () => useRampsQuotes({ ...baseOptions, enableFetching: false }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current.data).toBeNull();
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(Engine.context.RampsController.getQuotes).not.toHaveBeenCalled();
+    });
+
+    it('fetches when enableFetching is true', async () => {
+      const store = createMockStore();
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        mockQuotesResponse,
+      );
+
+      const { result } = renderHook(
+        () => useRampsQuotes({ ...baseOptions, enableFetching: true }),
+        { wrapper: wrapper(store) },
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data).toEqual(mockQuotesResponse);
+    });
+
+    it('does not pass enableFetching to the controller', async () => {
+      const store = createMockStore();
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        mockQuotesResponse,
+      );
+
+      renderHook(
+        () => useRampsQuotes({ ...baseOptions, enableFetching: true }),
+        { wrapper: wrapper(store) },
+      );
+
+      await waitFor(() => {
+        expect(Engine.context.RampsController.getQuotes).toHaveBeenCalledTimes(
+          1,
+        );
+      });
+
+      const calledWith = (Engine.context.RampsController.getQuotes as jest.Mock)
+        .mock.calls[0][0];
+      expect(calledWith).not.toHaveProperty('enableFetching');
+    });
+
+    it('clears data when enableFetching transitions from true to false', async () => {
+      const store = createMockStore();
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        mockQuotesResponse,
+      );
+
+      const { result, rerender } = renderHook(
+        ({ params }: { params: UseRampsQuotesOptions }) =>
+          useRampsQuotes(params),
+        {
+          wrapper: wrapper(store),
+          initialProps: {
+            params: { ...baseOptions, enableFetching: true },
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual(mockQuotesResponse);
+      });
+
+      rerender({ params: { ...baseOptions, enableFetching: false } });
+
+      expect(result.current.data).toBeNull();
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('does not re-fetch when options object is a new reference with same values', async () => {
+      const store = createMockStore();
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        mockQuotesResponse,
+      );
+
+      const { result, rerender } = renderHook(
+        ({ params }: { params: UseRampsQuotesOptions }) =>
+          useRampsQuotes(params),
+        {
+          wrapper: wrapper(store),
+          initialProps: { params: { ...baseOptions } },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      rerender({ params: { ...baseOptions } });
+
+      expect(Engine.context.RampsController.getQuotes).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { QuotesResponse } from '@metamask/ramps-controller';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
@@ -17,6 +17,14 @@ export interface GetQuotesOptions {
   redirectUrl?: string;
   forceRefresh?: boolean;
   ttl?: number;
+}
+
+/**
+ * Hook-level options that extend GetQuotesOptions with fetch control.
+ */
+export interface UseRampsQuotesOptions extends GetQuotesOptions {
+  /** When false, the hook skips fetching and clears data/error. Defaults to true. */
+  enableFetching?: boolean;
 }
 
 /**
@@ -46,14 +54,16 @@ export interface UseRampsQuotesResult {
  * Hook to get quote-related functions from RampsController.
  * Components call getQuotes() and manage quotes/selection locally.
  *
- * When options is provided, runs an effect to fetch quotes and returns data, loading, and error.
- * Loading is reset when the fetch settles unless the effect was cancelled (avoids setState on unmounted component).
+ * When options is provided (and enableFetching is not false), runs an effect
+ * to fetch quotes and returns data, loading, and error. Callers do not need
+ * to memoize options — the hook stabilizes the reference internally via
+ * serialization.
  *
- * @param options - GetQuotesOptions to fetch, or null/undefined to skip fetch.
+ * @param options - UseRampsQuotesOptions to fetch, or null/undefined to skip fetch.
  * @returns getQuotes, getWidgetUrl, and when options used: data, loading, error.
  */
 export function useRampsQuotes(
-  options?: GetQuotesOptions | null,
+  options?: UseRampsQuotesOptions | null,
 ): UseRampsQuotesResult {
   const getQuotes = useCallback(
     (opts: GetQuotesOptions) => Engine.context.RampsController.getQuotes(opts),
@@ -65,12 +75,24 @@ export function useRampsQuotes(
     [],
   );
 
+  const enableFetching = options?.enableFetching !== false;
+
+  const optionsKey = JSON.stringify(options ?? null);
+  const stableOptions = useMemo<GetQuotesOptions | null>(() => {
+    if (!enableFetching || options == null) {
+      return null;
+    }
+    const { enableFetching: _, ...fetchOptions } = options;
+    return fetchOptions;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optionsKey]);
+
   const [data, setData] = useState<QuotesResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (options == null) {
+    if (stableOptions == null) {
       setData(null);
       setLoading(false);
       setError(null);
@@ -82,7 +104,7 @@ export function useRampsQuotes(
     setData(null);
     setError(null);
 
-    getQuotes(options)
+    getQuotes(stableOptions)
       .then((response) => {
         if (!cancelled) {
           setData(response);
@@ -105,7 +127,7 @@ export function useRampsQuotes(
     return () => {
       cancelled = true;
     };
-  }, [options, getQuotes]);
+  }, [stableOptions, getQuotes]);
 
   return {
     getQuotes,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Refactors useRampsQuotes to memoize its own params so that the usage can be simplified.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quote-fetching behavior used across multiple Ramp screens; serialization-based memoization and the new `enableFetching` gating could change when/if refetches occur, impacting displayed quotes if edge cases slip through.
> 
> **Overview**
> Refactors `useRampsQuotes` so callers can pass an options object directly without memoizing it, and adds an `enableFetching` flag to explicitly gate fetching while ensuring `enableFetching` is not forwarded to `RampsController.getQuotes`.
> 
> Updates Ramp quote consumers (`BuildQuote`, `PaymentSelectionModal`, `ProviderSelectionModal`) to always provide options plus an `enableFetching` condition instead of building `null` params, and adjusts/extends tests to cover the new behavior (skip/clear on disabled fetch, stable options avoiding re-fetch, and updated call expectations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2c47f17d614a815e16bb9d7fede3b082d4723d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->