### PR TITLE
fix: use streaming decompression with size limit for deeplink payloads

### DIFF
--- a/app/core/SDKConnectV2/utils/compression-utils.ts
+++ b/app/core/SDKConnectV2/utils/compression-utils.ts
@@ -1,15 +1,38 @@
-import { inflate } from 'pako';
+import { Inflate } from 'pako';
+
+export const MAX_DECOMPRESSED_PAYLOAD_SIZE = 5 * 1024 * 1024; // 5 MB
 
 /**
- * Decompress a base64-encoded compressed string
+ * Decompress a base64-encoded compressed string using streaming inflation.
+ * Aborts early if cumulative output exceeds MAX_DECOMPRESSED_PAYLOAD_SIZE,
+ * preventing decompression bomb attacks from exhausting heap memory.
  */
 export function decompressPayloadB64(compressedBase64: string): string {
   const binaryString = atob(compressedBase64);
-  // Convert string back to Uint8Array
   const compressed = new Uint8Array(binaryString.length);
   for (let i = 0; i < binaryString.length; i++) {
     compressed[i] = binaryString.charCodeAt(i);
   }
-  const decompressed = inflate(compressed);
-  return new TextDecoder().decode(decompressed);
+
+  const inflator = new Inflate();
+  let outputSize = 0;
+  const collectChunk = inflator.onData;
+
+  inflator.onData = (chunk) => {
+    outputSize += chunk.byteLength;
+    if (outputSize > MAX_DECOMPRESSED_PAYLOAD_SIZE) {
+      throw new Error(
+        `Decompressed payload too large (max ${MAX_DECOMPRESSED_PAYLOAD_SIZE} bytes)`,
+      );
+    }
+    collectChunk.call(inflator, chunk);
+  };
+
+  inflator.push(compressed, true);
+
+  if (inflator.err) {
+    throw new Error(`Decompression failed: ${inflator.msg}`);
+  }
+
+  return new TextDecoder().decode(inflator.result as Uint8Array);
 }

--- a/app/core/SDKConnectV2/utils/compression.utils.test.ts
+++ b/app/core/SDKConnectV2/utils/compression.utils.test.ts
@@ -1,31 +1,42 @@
-import { decompressPayloadB64 } from './compression-utils';
-import { inflate } from 'pako';
+import { deflate } from 'pako';
+import {
+  decompressPayloadB64,
+  MAX_DECOMPRESSED_PAYLOAD_SIZE,
+} from './compression-utils';
 
-jest.mock('pako', () => ({
-  inflate: jest.fn(),
-}));
+function compressAndEncode(data: string | Uint8Array): string {
+  const input =
+    typeof data === 'string' ? new TextEncoder().encode(data) : data;
+  const compressed = deflate(input);
+  let binary = '';
+  for (const byte of compressed) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
 
-const mockInflate = inflate as jest.MockedFunction<typeof inflate>;
+describe('decompressPayloadB64', () => {
+  it('round-trips a valid JSON payload', () => {
+    const original = JSON.stringify({
+      session: { id: 'abc-123' },
+      metadata: { name: 'Test dApp' },
+    });
 
-describe('compression-utils', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+    expect(decompressPayloadB64(compressAndEncode(original))).toBe(original);
   });
 
-  describe('decompressPayloadB64', () => {
-    it('decompresses a valid base64-encoded compressed string', () => {
-      const originalText = 'Hello, World!';
-      const compressedBase64 = btoa('compressed-data');
-      const mockDecompressed = new Uint8Array([
-        72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33,
-      ]); // "Hello, World!" in bytes
+  it('aborts decompression when output exceeds the size limit', () => {
+    const oversized = new Uint8Array(MAX_DECOMPRESSED_PAYLOAD_SIZE + 1024);
+    const encoded = compressAndEncode(oversized);
 
-      mockInflate.mockReturnValue(mockDecompressed);
+    expect(() => decompressPayloadB64(encoded)).toThrow(
+      'Decompressed payload too large',
+    );
+  });
 
-      const result = decompressPayloadB64(compressedBase64);
-
-      expect(result).toBe(originalText);
-      expect(mockInflate).toHaveBeenCalledWith(expect.any(Uint8Array));
-    });
+  it('throws on corrupt compressed data', () => {
+    expect(() => decompressPayloadB64(btoa('not-valid-deflate'))).toThrow(
+      'Decompression failed',
+    );
   });
 });


### PR DESCRIPTION
## **Description**

The deeplink connection flow (`metamask://connect/mwp?p=<payload>&c=1`) checks payload size only on the compressed, base64-encoded input (1 MB limit) but not on the decompressed output. A crafted compressed payload within this limit can expand to hundreds of megabytes during decompression, exhausting heap memory and crashing the app.

This was identified as a finding in the Cyfrin security audit: [Cyfrin audit issue #4](https://github.com/Cyfrin/audit-2026-02-metamask-connect/issues/4)

The fix switches from pako's one-shot `inflate()` to the streaming `Inflate` class, wrapping the default `onData` handler with a size guard that tracks cumulative output bytes and throws as soon as output exceeds 5 MB. This aborts decompression early without ever allocating the full bomb payload in memory. The 5 MB limit is generous (real connection request payloads are well under 10 KB) and the existing 1 MB pre-decompression check remains in place as a first line of defense.

## **Changelog**

CHANGELOG entry: Fixed a potential decompression bomb vulnerability in the deeplink connection flow by adding streaming output size limits

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1131
Refs: https://github.com/Cyfrin/audit-2026-02-metamask-connect/issues/4

## **Manual testing steps**

Not applicable.

## **Screenshots/Recordings**

Not applicable.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
