### PR TITLE
chore: add new event props for MM pay

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -245,6 +245,29 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
+  it('includes predict withdraw properties', async () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: noop,
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
+
+    runHook({ type: TransactionType.predictWithdraw });
+
+    await act(async () => noop());
+
+    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+      id: transactionIdMock,
+      params: {
+        properties: expect.objectContaining({
+          mm_pay_use_case: 'predict_withdraw',
+        }),
+        sensitiveProperties: {},
+      },
+    });
+  });
+
   it('includes dust property for non-native quote', async () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,
@@ -314,6 +337,118 @@ describe('useTransactionPayMetrics', () => {
         }),
         sensitiveProperties: {},
       },
+    });
+  });
+
+  describe('mm_pay_sending_value_usd', () => {
+    it('tracks USD value from required token amountUsd', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          amountHuman: '1.5',
+          amountUsd: '3000.50',
+        } as TransactionPayRequiredToken,
+      ]);
+
+      runHook();
+
+      await act(async () => noop());
+
+      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+        id: transactionIdMock,
+        params: {
+          properties: expect.objectContaining({
+            mm_pay_sending_value_usd: 3000.5,
+          }),
+          sensitiveProperties: {},
+        },
+      });
+    });
+
+    it('defaults to 0 when amountUsd is not available', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          amountHuman: '1.5',
+        } as TransactionPayRequiredToken,
+      ]);
+
+      runHook();
+
+      await act(async () => noop());
+
+      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+        id: transactionIdMock,
+        params: {
+          properties: expect.objectContaining({
+            mm_pay_sending_value_usd: 0,
+          }),
+          sensitiveProperties: {},
+        },
+      });
+    });
+  });
+
+  describe('mm_pay_receiving_value_usd', () => {
+    it('tracks USD value from totals targetAmount', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayTotalsMock.mockReturnValue({
+        fees: {
+          sourceNetwork: { estimate: { usd: '1', fiat: '1' } },
+          targetNetwork: { usd: '1', fiat: '1' },
+          provider: { usd: '0', fiat: '0' },
+        },
+        targetAmount: { usd: '2950.25', fiat: '2950.25' },
+      } as ReturnType<typeof useTransactionPayTotals>);
+
+      runHook();
+
+      await act(async () => noop());
+
+      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+        id: transactionIdMock,
+        params: {
+          properties: expect.objectContaining({
+            mm_pay_receiving_value_usd: 2950.25,
+          }),
+          sensitiveProperties: {},
+        },
+      });
+    });
+
+    it('is null when totals are not available', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayTotalsMock.mockReturnValue(undefined);
+
+      runHook();
+
+      await act(async () => noop());
+
+      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+        id: transactionIdMock,
+        params: {
+          properties: expect.objectContaining({
+            mm_pay_receiving_value_usd: null,
+          }),
+          sensitiveProperties: {},
+        },
+      });
     });
   });
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -99,6 +99,22 @@ export function useTransactionPayMetrics() {
     properties.simulation_sending_assets_total_value = sendingValue;
   }
 
+  if (
+    payToken &&
+    hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])
+  ) {
+    properties.mm_pay_use_case = 'predict_withdraw';
+  }
+
+  if (payToken) {
+    const sendingAmountUsd = Number(primaryRequiredToken?.amountUsd ?? '0');
+    properties.mm_pay_sending_value_usd = sendingAmountUsd;
+
+    properties.mm_pay_receiving_value_usd = totals
+      ? Number(totals.targetAmount.usd)
+      : null;
+  }
+
   const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
 
   const nonGasQuote = quotes?.find(

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -78,6 +78,17 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
+  it('returns nothing if predict_withdraw', () => {
+    request.transactionMeta.type = TransactionType.predictWithdraw;
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {},
+      sensitiveProperties: {},
+    });
+  });
+
   it('copies properties from parent transaction if bridge', () => {
     getUIMetricsMock.mockReturnValue({
       properties: {
@@ -103,6 +114,40 @@ describe('Metamask Pay Metrics', () => {
         mm_pay: true,
         mm_pay_use_case: 'test_use_case',
         mm_pay_transaction_step_total: 3,
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
+  it('copies USD value metrics from predictWithdraw parent to child', () => {
+    getUIMetricsMock.mockReturnValue({
+      properties: {
+        mm_pay: true,
+        mm_pay_use_case: 'predict_withdraw',
+        mm_pay_transaction_step_total: 2,
+        mm_pay_sending_value_usd: 1500.5,
+        mm_pay_receiving_value_usd: 1495.25,
+      },
+      sensitiveProperties: {},
+    });
+
+    request.allTransactions = [
+      {
+        id: 'parent-1',
+        type: TransactionType.predictWithdraw,
+        requiredTransactionIds: ['child-1'],
+      } as TransactionMeta,
+    ];
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay: true,
+        mm_pay_use_case: 'predict_withdraw',
+        mm_pay_transaction_step_total: 2,
+        mm_pay_sending_value_usd: 1500.5,
+        mm_pay_receiving_value_usd: 1495.25,
       }),
       sensitiveProperties: {},
     });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -22,11 +22,14 @@ const COPY_METRICS = [
   'mm_pay',
   'mm_pay_use_case',
   'mm_pay_transaction_step_total',
+  'mm_pay_sending_value_usd',
+  'mm_pay_receiving_value_usd',
 ] as const;
 
 const PAY_TYPES = [
   TransactionType.perpsDeposit,
   TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
 ];
 
 export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({


### PR DESCRIPTION
## **Description**

Adds metrics for predict withdraw transactions as part of the MM Pay metrics framework.

## **Changelog**

CHANGELOG entry: Adds metrics for predict withdraw transactions as part of the MM Pay metrics

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7033

## **Manual testing steps**

```gherkin
Feature: Predict withdraw metrics

  Scenario: user initiates a predict withdraw
    Given user has funds in their predict account

    When user initiates a predict withdraw to any token
    Then transaction events include mm_pay_use_case = 'predict_withdraw'
    And transaction events include mm_pay_sending_value_usd with the USD value of the withdraw amount
    And transaction events include mm_pay_receiving_value_usd with the USD value of the expected receive amount
    And child transactions (relay deposits) inherit the USD value metrics from the parent
```

## **Screenshots/Recordings**

### **Before**

N/A — metrics-only change

### **After**

N/A — metrics-only change

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only changes that add new event properties and copy logic without affecting transaction execution or user-facing flows.
> 
> **Overview**
> Adds **MetaMask Pay metrics support for `TransactionType.predictWithdraw`** by emitting `mm_pay_use_case: "predict_withdraw"` from `useTransactionPayMetrics`.
> 
> When a pay token is selected, the hook now also records USD-denominated amounts via `mm_pay_sending_value_usd` (from required token `amountUsd`, defaulting to `0`) and `mm_pay_receiving_value_usd` (from quote totals `targetAmount.usd`, or `null` if unavailable).
> 
> Extends engine-side MetaMetrics copying so child bridge/swap transactions can inherit `mm_pay_sending_value_usd` and `mm_pay_receiving_value_usd` from a `predictWithdraw` parent, with new/updated unit tests covering these cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bfbabe5518fa6dabd835d99363d5913dab4ae76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->