### PR TITLE
fix: avoid perps failure tightly coupled to trending feature

### DIFF
--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
@@ -35,6 +35,8 @@ interface PerpsConnectionProviderProps {
   children: React.ReactNode;
   isVisible?: boolean;
   isFullScreen?: boolean;
+  /** When true, silently renders children instead of showing the error view on connection failure. */
+  suppressErrorView?: boolean;
 }
 
 /**
@@ -46,7 +48,12 @@ interface PerpsConnectionProviderProps {
  */
 export const PerpsConnectionProvider: React.FC<
   PerpsConnectionProviderProps
-> = ({ children, isVisible, isFullScreen = false }) => {
+> = ({
+  children,
+  isVisible,
+  isFullScreen = false,
+  suppressErrorView = false,
+}) => {
   const [connectionState, setConnectionState] = useState(() =>
     PerpsConnectionManager.getConnectionState(),
   );
@@ -252,7 +259,9 @@ export const PerpsConnectionProvider: React.FC<
 
   // Environment-level error handling - show error screen if connection failed
   // This ensures NO Perps screen can render when there's a connection error
-  if (connectionState.error) {
+  // When suppressErrorView is true, skip the error view and render children normally
+  // so the consuming section can handle the empty state gracefully (e.g., hide itself)
+  if (connectionState.error && !suppressErrorView) {
     // Determine if back button should be shown based on navigation context
     // Always show back button when in full screen mode (e.g., stack navigator)
     // Also show it after retry attempts for other contexts

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx
@@ -33,7 +33,7 @@ const ExploreSearchScreen: React.FC = () => {
         />
       </Box>
 
-      <PerpsConnectionProvider>
+      <PerpsConnectionProvider suppressErrorView>
         <PerpsStreamProvider>
           <ExploreSearchResults searchQuery={searchQuery} />
         </PerpsStreamProvider>

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useMemo } from 'react';
+import React, { PropsWithChildren, useContext, useMemo } from 'react';
 import Fuse, { type FuseOptions } from 'fuse.js';
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import type { TrendingAsset } from '@metamask/assets-controllers';
@@ -19,7 +19,10 @@ import PredictMarketSkeleton from '../../UI/Predict/components/PredictMarketSkel
 import { usePredictMarketData } from '../../UI/Predict/hooks/usePredictMarketData';
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { usePerpsMarkets } from '../../UI/Perps/hooks';
-import { PerpsConnectionProvider } from '../../UI/Perps/providers/PerpsConnectionProvider';
+import {
+  PerpsConnectionProvider,
+  PerpsConnectionContext,
+} from '../../UI/Perps/providers/PerpsConnectionProvider';
 import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager';
 import { Box, IconName } from '@metamask/design-system-react-native';
 import type { SiteData } from '../../UI/Sites/components/SiteRowItem/SiteRowItem';
@@ -230,25 +233,27 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
     // Using trending skeleton cause PerpsMarketRowSkeleton has too much spacing
     Skeleton: TrendingTokensSkeleton,
     SectionWrapper: ({ children }) => (
-      <PerpsConnectionProvider>
+      <PerpsConnectionProvider suppressErrorView>
         <PerpsStreamProvider>{children}</PerpsStreamProvider>
       </PerpsConnectionProvider>
     ),
     Section: SectionCard,
     useSectionData: (searchQuery) => {
+      const connectionContext = useContext(PerpsConnectionContext);
       const { markets, isLoading, refresh, isRefreshing } = usePerpsMarkets();
 
       const filteredMarkets = useMemo(() => {
+        if (connectionContext?.error) return [];
         if (!searchQuery) {
           return markets;
         }
         const filteredByQuery = filterMarketsByQuery(markets, searchQuery);
         return fuseSearch(filteredByQuery, searchQuery, PERPS_FUSE_OPTIONS);
-      }, [markets, searchQuery]);
+      }, [markets, searchQuery, connectionContext?.error]);
 
       return {
         data: filteredMarkets,
-        isLoading: isLoading || isRefreshing,
+        isLoading: connectionContext?.error ? false : isLoading || isRefreshing,
         refetch: refresh,
       };
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a reported issue where the IAB feature does not work if Perps fails to connect in the Explore environment.
<img height="500" alt="image" src="https://github.com/user-attachments/assets/075e3d5f-b560-4392-860e-988af7e2c2c3" />

The fix:
- Hides the perps section if the perps connection fails
- Does not show the "Connection failed" error and "Try again" button anywhere in the explore page

To force a connection error, apply this git diff:
```
diff --git a/app/components/UI/Perps/services/PerpsConnectionManager.ts b/app/components/UI/Perps/services/PerpsConnectionManager.ts
index dff4bf9695..fa6efafd8d 100644
--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -412,6 +412,15 @@ class PerpsConnectionManagerClass {
   }
 
   async connect(): Promise<void> {
+    // TODO: Remove - Force connection failure for testing error UI
+    if (__DEV__) {
+      this.isConnecting = false;
+      this.isConnected = false;
+      this.isInitialized = false;
+      this.setError('Forced connection failure for testing');
+      throw new Error('Forced connection failure for testing');
+    }
+
     // Cancel any active grace period when reconnecting
     if (this.isInGracePeriod) {
       DevLogger.log(
@@ -696,6 +705,15 @@ class PerpsConnectionManagerClass {
    * Performs the actual reconnection logic
    */
   private async performReconnection(): Promise<void> {
+    // TODO: Remove - Force reconnection failure for testing error UI
+    if (__DEV__) {
+      this.isConnecting = false;
+      this.isConnected = false;
+      this.isInitialized = false;
+      this.setError('Forced connection failure for testing');
+      throw new Error('Forced connection failure for testing');
+    }
+
     const traceId = uuidv4();
     const reconnectionStartTime = performance.now();
     let traceData: Record<string, string | number | boolean> | undefined;

```
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: avoid perps failure tightly coupled to trending feature

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2762

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/1428fc8f-7bde-43fe-ade8-53e1b98ebb08


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/460ad8cd-9f0a-4316-a687-ad0a34d43d5e


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/UX behavior change around Perps connection error handling; main risk is masking Perps errors in Explore/Trending contexts and potentially hiding data when the connection is transient.
> 
> **Overview**
> Prevents Perps connection failures from blocking the Explore/Trending experience by adding `suppressErrorView` to `PerpsConnectionProvider`, allowing consumers to *silently* render without the global "connection failed" screen.
> 
> Explore search results and the Trending Perps section now opt into this behavior, and the Perps section’s data hook returns an empty dataset (and stops showing loading) when `PerpsConnectionContext.error` is set so the section can effectively hide instead of breaking the page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0269e0316d95db9d53b2af05bfe7cbf8a75301b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->