### PR TITLE
fix: musd e2e flaky due to toast

### DIFF
--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -41,14 +41,15 @@ class TabBarComponent {
     await Gestures.waitAndTap(homeButton);
   }
 
-  async tapWallet(): Promise<void> {
+  async tapWallet(options?: { timeout?: number }): Promise<void> {
+    const timeout = options?.timeout ?? 10000;
     await Utilities.executeWithRetry(
       async () => {
         await Gestures.waitAndTap(this.tabBarWalletButton);
         await Assertions.expectElementToBeVisible(WalletView.container);
       },
       {
-        timeout: 10000,
+        timeout,
         description: 'Tap Wallet Button with Validation',
       },
     );
@@ -95,7 +96,8 @@ class TabBarComponent {
     );
   }
 
-  async tapActivity(): Promise<void> {
+  async tapActivity(options?: { timeout?: number }): Promise<void> {
+    const timeout = options?.timeout ?? 10000;
     await Utilities.executeWithRetry(
       async () => {
         await Gestures.waitAndTap(this.tabBarActivityButton, {
@@ -106,7 +108,7 @@ class TabBarComponent {
         });
       },
       {
-        timeout: 10000,
+        timeout,
         description: 'Tap Activity Button',
       },
     );

--- a/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
+++ b/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
@@ -115,15 +115,15 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
         });
 
         // Go to Activity and verify mUSD conversion is confirmed (same pattern as send-native-token: no swipeDown)
-        await TabBarComponent.tapActivity();
+        await TabBarComponent.tapActivity({ timeout: 30000 });
         await ActivitiesView.verifyMusdConversionConfirmed(0);
         // gets back to wallet to avoid waiting fora rpc updated in the activity view
-        await TabBarComponent.tapWallet();
+        await TabBarComponent.tapWallet({ timeout: 30000 });
       },
     );
   });
 
-  it('converts USDC to mUSD from Token List (Returning User)', async () => {
+  it.only('converts USDC to mUSD from Token List (Returning User)', async () => {
     await withFixtures(
       withMusdFixturesOptions({
         musdConversionEducationSeen: true,
@@ -174,10 +174,10 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
         });
 
         // Go to Activity and verify mUSD conversion is confirmed
-        await TabBarComponent.tapActivity();
+        await TabBarComponent.tapActivity({ timeout: 30000 });
         await ActivitiesView.verifyMusdConversionConfirmed(0);
         // gets back to wallet to avoid waiting fora rpc updated in the activity view
-        await TabBarComponent.tapWallet();
+        await TabBarComponent.tapWallet({ timeout: 30000 });
       },
     );
   });
@@ -234,10 +234,10 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
         });
 
         // Go to Activity and verify mUSD conversion is confirmed
-        await TabBarComponent.tapActivity();
+        await TabBarComponent.tapActivity({ timeout: 30000 });
         await ActivitiesView.verifyMusdConversionConfirmed(0);
         // gets back to wallet to avoid waiting fora rpc updated in the activity view
-        await TabBarComponent.tapWallet();
+        await TabBarComponent.tapWallet({ timeout: 30000 });
       },
     );
   });

--- a/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
+++ b/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
@@ -123,7 +123,7 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
     );
   });
 
-  it.only('converts USDC to mUSD from Token List (Returning User)', async () => {
+  it('converts USDC to mUSD from Token List (Returning User)', async () => {
     await withFixtures(
       withMusdFixturesOptions({
         musdConversionEducationSeen: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

## E2E: Increase timeout for Activity/Wallet taps in mUSD conversion happy path

Toast visibility is unreliable: it may or may not be present, and can appear right when tapping Activity. Rather than adding toast-specific handling, we only increase the retry timeout for `tapActivity` and `tapWallet` in this flow. With a longer timeout (30s), retries have more time to succeed once the toast has dismissed or the UI has settled.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that only adjust retry timeouts/parameters; no production logic or data handling is affected.
> 
> **Overview**
> Reduces flakiness in the mUSD conversion happy-path smoke test by allowing `TabBarComponent.tapActivity` and `tapWallet` to accept an optional `timeout` and wiring those calls to use a longer 30s retry window.
> 
> This keeps the existing retry/validation behavior but makes the timeout configurable so the test can tolerate transient UI interference (e.g., toasts) when switching between Wallet and Activity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b797fe6d89fbaf0b7f0eb3f31d1c787af208e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->