### PR TITLE
fix: perps verbose when clearing subscriptions cp-7.67.0

### DIFF
--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -32,6 +32,7 @@ import type {
   OrderBookData,
   OrderBookLevel,
   PerpsPlatformDependencies,
+  PerpsLogger,
 } from '../types';
 import type { HyperLiquidClientService } from './HyperLiquidClientService';
 import type { HyperLiquidWalletService } from './HyperLiquidWalletService';
@@ -256,6 +257,24 @@ export class HyperLiquidSubscriptionService {
   }
 
   /**
+   * Conditionally log an error to Sentry, suppressing during intentional disconnect.
+   * When `clearAll()` is called, pending subscription promises reject with
+   * `WebSocketRequestError` — these are expected and must not pollute Sentry.
+   *
+   * @param error - The error to log
+   * @param context - Sentry context from #getErrorContext()
+   */
+  #logErrorUnlessClearing(
+    error: Error,
+    context: Parameters<PerpsLogger['error']>[1],
+  ): void {
+    if (this.#isClearing) {
+      return;
+    }
+    this.#deps.logger.error(error, context);
+  }
+
+  /**
    * Get error context for logging with searchable tags and context.
    * Enables Sentry dashboard filtering by feature, provider, and network.
    *
@@ -476,7 +495,7 @@ export class HyperLiquidSubscriptionService {
             try {
               await this.#ensureAssetCtxsSubscription(dex);
             } catch (error) {
-              this.#deps.logger.error(
+              this.#logErrorUnlessClearing(
                 ensureError(
                   error,
                   'HyperLiquidSubscriptionService.updateFeatureFlags',
@@ -517,7 +536,7 @@ export class HyperLiquidSubscriptionService {
                   `Established user data subscriptions for new DEX: ${dex}`,
                 );
               } catch (error) {
-                this.#deps.logger.error(
+                this.#logErrorUnlessClearing(
                   ensureError(
                     error,
                     'HyperLiquidSubscriptionService.updateFeatureFlags',
@@ -531,7 +550,7 @@ export class HyperLiquidSubscriptionService {
             }),
           );
         } catch (error) {
-          this.#deps.logger.error(
+          this.#logErrorUnlessClearing(
             ensureError(
               error,
               'HyperLiquidSubscriptionService.updateFeatureFlags',
@@ -954,7 +973,7 @@ export class HyperLiquidSubscriptionService {
       dexsNeeded.forEach((dex) => {
         const dexName = dex ?? '';
         this.#ensureAssetCtxsSubscription(dexName).catch((error) => {
-          this.#deps.logger.error(
+          this.#logErrorUnlessClearing(
             ensureError(
               error,
               'HyperLiquidSubscriptionService.subscribeToPrices',
@@ -1186,7 +1205,7 @@ export class HyperLiquidSubscriptionService {
                 );
               }
             } catch (error) {
-              this.#deps.logger.error(
+              this.#logErrorUnlessClearing(
                 ensureError(
                   error,
                   'HyperLiquidSubscriptionService.createUserDataSubscription',
@@ -1207,7 +1226,7 @@ export class HyperLiquidSubscriptionService {
             return undefined;
           })
           .catch((error) => {
-            this.#deps.logger.error(
+            this.#logErrorUnlessClearing(
               ensureError(
                 error,
                 'HyperLiquidSubscriptionService.createUserDataSubscription',
@@ -1231,7 +1250,7 @@ export class HyperLiquidSubscriptionService {
             return undefined;
           })
           .catch((error) => {
-            this.#deps.logger.error(
+            this.#logErrorUnlessClearing(
               ensureError(
                 error,
                 'HyperLiquidSubscriptionService.createUserDataSubscription',
@@ -1331,7 +1350,7 @@ export class HyperLiquidSubscriptionService {
                 );
               }
             } catch (error) {
-              this.#deps.logger.error(
+              this.#logErrorUnlessClearing(
                 ensureError(
                   error,
                   'HyperLiquidSubscriptionService.createUserDataSubscription',
@@ -1356,7 +1375,7 @@ export class HyperLiquidSubscriptionService {
             return undefined;
           })
           .catch((error) => {
-            this.#deps.logger.error(
+            this.#logErrorUnlessClearing(
               ensureError(
                 error,
                 'HyperLiquidSubscriptionService.createUserDataSubscription',
@@ -1504,7 +1523,7 @@ export class HyperLiquidSubscriptionService {
       // Remove this DEX from expected set so it doesn't block notifications for other DEXs
       this.#expectedDexs.delete(dexName);
 
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(
           error,
           'HyperLiquidSubscriptionService.createClearinghouseSubscription',
@@ -1632,7 +1651,7 @@ export class HyperLiquidSubscriptionService {
       // Remove this DEX from expected set so it doesn't block notifications for other DEXs
       this.#expectedDexs.delete(dexName);
 
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(
           error,
           'HyperLiquidSubscriptionService.createOpenOrdersSubscription',
@@ -1736,20 +1755,18 @@ export class HyperLiquidSubscriptionService {
       if (this.#webData3Subscriptions.size > 0) {
         this.#webData3Subscriptions.forEach((subscription, dexName) => {
           subscription.unsubscribe().catch((error: Error) => {
-            if (!this.#isClearing) {
-              this.#deps.logger.error(
-                ensureError(
-                  error,
-                  'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
-                ),
-                this.#getErrorContext(
-                  'cleanupSharedWebData3ISubscription.webData3',
-                  {
-                    dex: dexName,
-                  },
-                ),
-              );
-            }
+            this.#logErrorUnlessClearing(
+              ensureError(
+                error,
+                'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
+              ),
+              this.#getErrorContext(
+                'cleanupSharedWebData3ISubscription.webData3',
+                {
+                  dex: dexName,
+                },
+              ),
+            );
           });
         });
         this.#webData3Subscriptions.clear();
@@ -1761,20 +1778,18 @@ export class HyperLiquidSubscriptionService {
         this.#clearinghouseStateSubscriptions.forEach(
           (subscription, dexName) => {
             subscription.unsubscribe().catch((error: Error) => {
-              if (!this.#isClearing) {
-                this.#deps.logger.error(
-                  ensureError(
-                    error,
-                    'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
-                  ),
-                  this.#getErrorContext(
-                    'cleanupSharedWebData3ISubscription.clearinghouseState',
-                    {
-                      dex: dexName,
-                    },
-                  ),
-                );
-              }
+              this.#logErrorUnlessClearing(
+                ensureError(
+                  error,
+                  'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
+                ),
+                this.#getErrorContext(
+                  'cleanupSharedWebData3ISubscription.clearinghouseState',
+                  {
+                    dex: dexName,
+                  },
+                ),
+              );
             });
           },
         );
@@ -1784,20 +1799,18 @@ export class HyperLiquidSubscriptionService {
       if (this.#openOrdersSubscriptions.size > 0) {
         this.#openOrdersSubscriptions.forEach((subscription, dexName) => {
           subscription.unsubscribe().catch((error: Error) => {
-            if (!this.#isClearing) {
-              this.#deps.logger.error(
-                ensureError(
-                  error,
-                  'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
-                ),
-                this.#getErrorContext(
-                  'cleanupSharedWebData3ISubscription.openOrders',
-                  {
-                    dex: dexName,
-                  },
-                ),
-              );
-            }
+            this.#logErrorUnlessClearing(
+              ensureError(
+                error,
+                'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
+              ),
+              this.#getErrorContext(
+                'cleanupSharedWebData3ISubscription.openOrders',
+                {
+                  dex: dexName,
+                },
+              ),
+            );
           });
         });
         this.#openOrdersSubscriptions.clear();
@@ -1863,7 +1876,7 @@ export class HyperLiquidSubscriptionService {
 
     // Ensure shared subscription is active
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(
           error,
           'HyperLiquidSubscriptionService.subscribeToPositions',
@@ -1905,7 +1918,7 @@ export class HyperLiquidSubscriptionService {
 
     // Ensure webData3 subscription is active (OI caps come from webData3)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(error, 'HyperLiquidSubscriptionService.subscribeToOICaps'),
         this.#getErrorContext('subscribeToOICaps'),
       );
@@ -1947,7 +1960,7 @@ export class HyperLiquidSubscriptionService {
 
     // Ensure subscription is established for this accountId
     this.#ensureOrderFillISubscription(accountId).catch((error) => {
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(
           error,
           'HyperLiquidSubscriptionService.subscribeToOrderFills',
@@ -1966,7 +1979,7 @@ export class HyperLiquidSubscriptionService {
           this.#orderFillSubscriptions.get(normalizedAccountId);
         if (subscription) {
           subscription.unsubscribe().catch((error: Error) => {
-            this.#deps.logger.error(
+            this.#logErrorUnlessClearing(
               ensureError(
                 error,
                 'HyperLiquidSubscriptionService.subscribeToOrderFills',
@@ -2092,7 +2105,7 @@ export class HyperLiquidSubscriptionService {
 
     // Ensure shared subscription is active
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(error, 'HyperLiquidSubscriptionService.subscribeToOrders'),
         this.#getErrorContext('subscribeToOrders'),
       );
@@ -2129,7 +2142,7 @@ export class HyperLiquidSubscriptionService {
 
     // Ensure shared subscription is active (reuses existing connection)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
-      this.#deps.logger.error(
+      this.#logErrorUnlessClearing(
         ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
         this.#getErrorContext('subscribeToAccount'),
       );
@@ -2401,7 +2414,7 @@ export class HyperLiquidSubscriptionService {
         // Clear the promise on error so it can be retried
         this.#globalAllMidsPromise = undefined;
 
-        this.#deps.logger.error(
+        this.#logErrorUnlessClearing(
           ensureError(
             error,
             'HyperLiquidSubscriptionService.ensureGlobalAllMidsSubscription',
@@ -2506,7 +2519,7 @@ export class HyperLiquidSubscriptionService {
         return undefined;
       })
       .catch((error) => {
-        this.#deps.logger.error(
+        this.#logErrorUnlessClearing(
           ensureError(
             error,
             'HyperLiquidSubscriptionService.ensureActiveAssetSubscription',
@@ -2701,7 +2714,7 @@ export class HyperLiquidSubscriptionService {
           return undefined;
         })
         .catch((error) => {
-          this.#deps.logger.error(
+          this.#logErrorUnlessClearing(
             ensureError(
               error,
               'HyperLiquidSubscriptionService.createAssetCtxsSubscription',
@@ -2736,7 +2749,7 @@ export class HyperLiquidSubscriptionService {
 
       if (subscription) {
         subscription.unsubscribe().catch((error: Error) => {
-          this.#deps.logger.error(
+          this.#logErrorUnlessClearing(
             ensureError(
               error,
               'HyperLiquidSubscriptionService.cleanupAssetCtxsSubscription',
@@ -2799,7 +2812,7 @@ export class HyperLiquidSubscriptionService {
         return undefined;
       })
       .catch((error) => {
-        this.#deps.logger.error(
+        this.#logErrorUnlessClearing(
           ensureError(
             error,
             'HyperLiquidSubscriptionService.ensureBboSubscription',
@@ -2890,7 +2903,7 @@ export class HyperLiquidSubscriptionService {
           try {
             await sub.unsubscribe();
           } catch (unsubError: unknown) {
-            this.#deps.logger.error(
+            this.#logErrorUnlessClearing(
               ensureError(
                 unsubError,
                 'HyperLiquidSubscriptionService.subscribeToOrderBook',
@@ -2907,7 +2920,7 @@ export class HyperLiquidSubscriptionService {
         return undefined;
       })
       .catch((error) => {
-        this.#deps.logger.error(
+        this.#logErrorUnlessClearing(
           ensureError(
             error,
             'HyperLiquidSubscriptionService.subscribeToOrderBook',
@@ -2926,7 +2939,7 @@ export class HyperLiquidSubscriptionService {
       cancelled = true;
       if (subscription) {
         subscription.unsubscribe().catch((error: Error) => {
-          this.#deps.logger.error(
+          this.#logErrorUnlessClearing(
             ensureError(
               error,
               'HyperLiquidSubscriptionService.subscribeToOrderBook',
@@ -3278,14 +3291,12 @@ export class HyperLiquidSubscriptionService {
     if (this.#clearinghouseStateSubscriptions.size > 0) {
       this.#clearinghouseStateSubscriptions.forEach((subscription, dexName) => {
         subscription.unsubscribe().catch((error: Error) => {
-          if (!this.#isClearing) {
-            this.#deps.logger.error(
-              ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
-              this.#getErrorContext('clearAll.clearinghouseState', {
-                dex: dexName,
-              }),
-            );
-          }
+          this.#logErrorUnlessClearing(
+            ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+            this.#getErrorContext('clearAll.clearinghouseState', {
+              dex: dexName,
+            }),
+          );
         });
       });
       this.#clearinghouseStateSubscriptions.clear();
@@ -3294,14 +3305,12 @@ export class HyperLiquidSubscriptionService {
     if (this.#openOrdersSubscriptions.size > 0) {
       this.#openOrdersSubscriptions.forEach((subscription, dexName) => {
         subscription.unsubscribe().catch((error: Error) => {
-          if (!this.#isClearing) {
-            this.#deps.logger.error(
-              ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
-              this.#getErrorContext('clearAll.openOrders', {
-                dex: dexName,
-              }),
-            );
-          }
+          this.#logErrorUnlessClearing(
+            ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+            this.#getErrorContext('clearAll.openOrders', {
+              dex: dexName,
+            }),
+          );
         });
       });
       this.#openOrdersSubscriptions.clear();


### PR DESCRIPTION
## **Description**

During account switches, network changes, or app backgrounding, the Perps WebSocket connection is intentionally torn down via `clearAll()`. This causes pending subscription operations (subscribe/unsubscribe) to reject with `WebSocketRequestError` from the HyperLiquid SDK — which is expected behavior.

However, 25 out of 30 error handlers in `HyperLiquidSubscriptionService` were unconditionally calling `Logger.error()`, sending these expected cleanup errors to Sentry. Only 5 handlers checked the `#isClearing` flag before logging.

This PR:
- Adds a `#logErrorUnlessClearing()` private helper that checks the `#isClearing` flag before forwarding to `Logger.error()` (Sentry)
- Routes all 30 error handlers through this helper (previously only 5 were guarded)
- Removes redundant inline `if (!this.#isClearing)` checks that are now handled by the helper
- Imports `PerpsLogger` type for proper parameter typing

**Net effect**: During intentional disconnects, `WebSocketRequestError` errors from pending subscription operations are suppressed from Sentry. Genuine connection failures (when `#isClearing` is false) are still reported.

## **Changelog**

CHANGELOG entry: Fixed: Suppressed expected WebSocket cleanup errors from being reported to Sentry during intentional Perps disconnections

## **Related issues**

Fixes: Excessive `WebSocketRequestError: Failed to establish WebSocket connection` errors on Sentry during account switches and reconnections

## **Manual testing steps**

```gherkin
Feature: Perps WebSocket error suppression during cleanup

  Scenario: user switches accounts while on Perps tab
    Given the user is on the Perps tab with an active WebSocket connection

    When user switches to a different account
    Then the Perps connection reconnects successfully
    And no WebSocketRequestError errors are logged to Sentry during the transition

  Scenario: user navigates away from Perps and returns
    Given the user is on the Perps tab with an active WebSocket connection

    When user navigates to the Wallet tab and back to Perps
    Then the connection is re-established without Sentry error noise
```

## **Screenshots/Recordings**

N/A — No UI changes. This is an internal error logging improvement.

### **Before**

Expected `WebSocketRequestError` errors during cleanup were sent to Sentry (25 out of 30 error handlers were unguarded).

### **After**

All 30 error handlers now check `#isClearing` via the `#logErrorUnlessClearing()` helper — expected errors during intentional disconnect are suppressed.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only refactor gated by an existing `#isClearing` flag; primary risk is accidentally suppressing real errors if `#isClearing` is set unexpectedly.
> 
> **Overview**
> Reduces Sentry noise in `HyperLiquidSubscriptionService` by adding a `#logErrorUnlessClearing()` helper that skips `logger.error` while `#isClearing` is true (set during `clearAll()` intentional disconnects).
> 
> Routes all subscription setup/teardown `catch` paths (subscribe/unsubscribe callbacks, feature-flag updates, and cleanup flows) through this helper and removes the remaining inline `if (!#isClearing)` guards; also imports `PerpsLogger` to type the helper’s context parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 315a553a5b78609b7ac6d095d3fb0b6e3786577f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->