### PR TITLE
test: reduces timeout to allow for multiple retries

### DIFF
--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -41,19 +41,20 @@ class TabBarComponent {
     await Gestures.waitAndTap(homeButton);
   }
 
-  async tapWallet(options?: { timeout?: number }): Promise<void> {
-    const timeout = options?.timeout ?? 2000;
+  async tapWallet(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
         await Gestures.waitAndTap(this.tabBarWalletButton, {
-          timeout,
+          timeout: 2000,
         });
         await Assertions.expectElementToBeVisible(WalletView.container, {
-          timeout,
+          timeout: 500,
         });
       },
       {
-        maxRetries: 30,
+        // Each attempt: ~2.5s (2s tap + 0.5s assertion). 15 retries ≈ ~37s total budget.
+        maxRetries: 15,
+        timeout: 45000,
         description: 'Tap Wallet Button with Validation',
       },
     );
@@ -100,20 +101,21 @@ class TabBarComponent {
     );
   }
 
-  async tapActivity(options?: { timeout?: number }): Promise<void> {
-    const timeout = options?.timeout ?? 2000;
+  async tapActivity(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
         await Gestures.waitAndTap(this.tabBarActivityButton, {
-          timeout,
+          timeout: 2000,
         });
         await Assertions.expectElementToBeVisible(ActivitiesView.title, {
           description: 'Activity View Title',
-          timeout,
+          timeout: 500,
         });
       },
       {
-        maxRetries: 30,
+        // Each attempt: ~2.5s (2s tap + 0.5s assertion). 15 retries ≈ ~37s total budget.
+        maxRetries: 15,
+        timeout: 45000,
         description: 'Tap Activity Button',
       },
     );

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -42,14 +42,18 @@ class TabBarComponent {
   }
 
   async tapWallet(options?: { timeout?: number }): Promise<void> {
-    const timeout = options?.timeout ?? 10000;
+    const timeout = options?.timeout ?? 2000;
     await Utilities.executeWithRetry(
       async () => {
-        await Gestures.waitAndTap(this.tabBarWalletButton);
-        await Assertions.expectElementToBeVisible(WalletView.container);
+        await Gestures.waitAndTap(this.tabBarWalletButton, {
+          timeout,
+        });
+        await Assertions.expectElementToBeVisible(WalletView.container, {
+          timeout,
+        });
       },
       {
-        timeout,
+        maxRetries: 30,
         description: 'Tap Wallet Button with Validation',
       },
     );
@@ -97,18 +101,19 @@ class TabBarComponent {
   }
 
   async tapActivity(options?: { timeout?: number }): Promise<void> {
-    const timeout = options?.timeout ?? 10000;
+    const timeout = options?.timeout ?? 2000;
     await Utilities.executeWithRetry(
       async () => {
         await Gestures.waitAndTap(this.tabBarActivityButton, {
-          delay: 3500,
+          timeout,
         });
         await Assertions.expectElementToBeVisible(ActivitiesView.title, {
           description: 'Activity View Title',
+          timeout,
         });
       },
       {
-        timeout,
+        maxRetries: 30,
         description: 'Tap Activity Button',
       },
     );

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -75,13 +75,20 @@ class TabBarComponent {
   async tapSettings(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        // Ensure we're on WalletView where the hamburger menu is located
-        await this.tapWallet();
+        // Navigate to Wallet first (where the hamburger menu lives)
+        await Gestures.waitAndTap(this.tabBarWalletButton, { timeout: 2000 });
+        await Assertions.expectElementToBeVisible(WalletView.container, {
+          timeout: 500,
+        });
         await WalletView.tapHamburgerMenu();
-        await Assertions.expectElementToBeVisible(SettingsView.title);
+        await Assertions.expectElementToBeVisible(SettingsView.title, {
+          timeout: 500,
+        });
       },
       {
-        timeout: 10000,
+        // Each attempt: ~3s (2s tap + 0.5s wallet check + hamburger + 0.5s settings check).
+        maxRetries: 15,
+        timeout: 45000,
         description: 'Tap Settings Button',
       },
     );

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -76,20 +76,12 @@ class TabBarComponent {
     await Utilities.executeWithRetry(
       async () => {
         // Navigate to Wallet first (where the hamburger menu lives)
-        await Gestures.waitAndTap(this.tabBarWalletButton, { timeout: 2000 });
-        await Assertions.expectElementToBeVisible(WalletView.container, {
-          timeout: 500,
-        });
-        await Gestures.waitAndTap(WalletView.hamburgerMenuButton, {
-          timeout: 2000,
-        });
-        await Assertions.expectElementToBeVisible(SettingsView.title, {
-          timeout: 500,
-        });
+        await Gestures.waitAndTap(this.tabBarWalletButton);
+        await Assertions.expectElementToBeVisible(WalletView.container);
+        await Gestures.waitAndTap(WalletView.hamburgerMenuButton);
+        await Assertions.expectElementToBeVisible(SettingsView.title);
       },
       {
-        // Each attempt: ~5s (2s wallet tap + 0.5s wallet check + 2s hamburger tap + 0.5s settings check).
-        maxRetries: 15,
         timeout: 45000,
         description: 'Tap Settings Button',
       },
@@ -140,11 +132,10 @@ class TabBarComponent {
       async () => {
         await Gestures.waitAndTap(this.tabBarRewardsButton, {
           timeout: 2000,
-          delay: 2500,
         });
       },
       {
-        // Each attempt: ~4.5s (2.5s delay + 2s tap). 15 retries ≈ ~67s total budget.
+        // Each attempt: ~2.5s (2s tap + 0.5s default delay) + 500ms retry interval ≈ 3s/cycle → ~15 retries within 45s.
         maxRetries: 15,
         timeout: 45000,
         description: 'Tap Rewards Button',

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -80,13 +80,15 @@ class TabBarComponent {
         await Assertions.expectElementToBeVisible(WalletView.container, {
           timeout: 500,
         });
-        await WalletView.tapHamburgerMenu();
+        await Gestures.waitAndTap(WalletView.hamburgerMenuButton, {
+          timeout: 2000,
+        });
         await Assertions.expectElementToBeVisible(SettingsView.title, {
           timeout: 500,
         });
       },
       {
-        // Each attempt: ~3s (2s tap + 0.5s wallet check + hamburger + 0.5s settings check).
+        // Each attempt: ~5s (2s wallet tap + 0.5s wallet check + 2s hamburger tap + 0.5s settings check).
         maxRetries: 15,
         timeout: 45000,
         description: 'Tap Settings Button',
@@ -96,13 +98,18 @@ class TabBarComponent {
   async tapExploreButton(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await Gestures.waitAndTap(this.tabBarExploreButton);
+        await Gestures.waitAndTap(this.tabBarExploreButton, {
+          timeout: 2000,
+        });
         await Assertions.expectElementToBeVisible(TrendingView.searchButton, {
           description: 'Trending view search button should be visible',
+          timeout: 500,
         });
       },
       {
-        timeout: 10000,
+        // Each attempt: ~2.5s (2s tap + 0.5s assertion). 15 retries ≈ ~37s total budget.
+        maxRetries: 15,
+        timeout: 45000,
         description: 'Tap Explore Button with Validation',
       },
     );
@@ -132,11 +139,14 @@ class TabBarComponent {
     await Utilities.executeWithRetry(
       async () => {
         await Gestures.waitAndTap(this.tabBarRewardsButton, {
+          timeout: 2000,
           delay: 2500,
         });
       },
       {
-        timeout: 10000,
+        // Each attempt: ~4.5s (2.5s delay + 2s tap). 15 retries ≈ ~67s total budget.
+        maxRetries: 15,
+        timeout: 45000,
         description: 'Tap Rewards Button',
       },
     );

--- a/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
+++ b/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
@@ -174,10 +174,10 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
         });
 
         // Go to Activity and verify mUSD conversion is confirmed
-        await TabBarComponent.tapActivity({ timeout: 30000 });
+        await TabBarComponent.tapActivity();
         await ActivitiesView.verifyMusdConversionConfirmed(0);
         // gets back to wallet to avoid waiting fora rpc updated in the activity view
-        await TabBarComponent.tapWallet({ timeout: 30000 });
+        await TabBarComponent.tapWallet();
       },
     );
   });
@@ -234,10 +234,10 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
         });
 
         // Go to Activity and verify mUSD conversion is confirmed
-        await TabBarComponent.tapActivity({ timeout: 30000 });
+        await TabBarComponent.tapActivity();
         await ActivitiesView.verifyMusdConversionConfirmed(0);
         // gets back to wallet to avoid waiting fora rpc updated in the activity view
-        await TabBarComponent.tapWallet({ timeout: 30000 });
+        await TabBarComponent.tapWallet();
       },
     );
   });

--- a/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
+++ b/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
@@ -115,10 +115,10 @@ describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
         });
 
         // Go to Activity and verify mUSD conversion is confirmed (same pattern as send-native-token: no swipeDown)
-        await TabBarComponent.tapActivity({ timeout: 30000 });
+        await TabBarComponent.tapActivity();
         await ActivitiesView.verifyMusdConversionConfirmed(0);
         // gets back to wallet to avoid waiting fora rpc updated in the activity view
-        await TabBarComponent.tapWallet({ timeout: 30000 });
+        await TabBarComponent.tapWallet();
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
 - Fix nested retry timeout mismatch in `TabBarComponent` where inner `expectElementToBeVisible` (15s default) exceeded the outer `executeWithRetry` timeout (10s), causing the outer loop to get only 1 attempt                                                                                                                                                                                           
- Both `tapWallet` and `tapActivity` now use fast-fail inner operations (2s timeout) with outer retry control (`maxRetries: 30`)     

Example with tapActivity:                                                                                                                                                                            
                                                                                                                                                                                                       
  executeWithRetry(maxRetries: 30)                 ← OUTER: retries up to 30 times
    ├─ waitAndTap(timeout: 2000ms)                 ← INNER: waits 2s for tap, fails fast if blocked
    └─ expectElementToBeVisible(timeout: 2000ms)   ← INNER: waits 2s for title, fails fast if not visible

  Per attempt: ~4s max (2s tap + 2s assertion). If either fails, control returns to the outer loop which retries the whole sequence. Total budget: ~2 min (30 attempts x ~4s).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Detox test page objects and smoke specs; main risk is altering retry/timing behavior which could affect test stability (better or worse) but not production code.
> 
> **Overview**
> Improves Detox tab-bar navigation reliability by making `tapWallet`, `tapActivity`, `tapExploreButton`, and `tapRewards` **fast-fail per attempt** (short tap/visibility timeouts) while shifting control to an outer `executeWithRetry` loop with explicit `maxRetries` and a larger overall timeout budget.
> 
> Simplifies `tapSettings` to navigate via the Wallet tab and hamburger menu directly (instead of calling `tapWallet`) and increases its retry timeout. Updates the mUSD conversion smoke tests to use the new `tapWallet()`/`tapActivity()` signatures (removing per-call timeout overrides).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f86844b9cc0c88dd4908576f06460a2169eb3151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->