### PR TITLE
refactor(confirmations): remove unnecessary useNavigation generic types

### DIFF
--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
@@ -3,13 +3,12 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { useEffect } from 'react';
 import { BackHandler } from 'react-native';
 import Device from '../../../../../util/device';
-import { StakeNavigationParamsList } from '../../../../UI/Stake/types';
 import { useConfirmActions } from '../useConfirmActions';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
+import type { RootStackParamList } from '../../../../../core/NavigationService/types';
 
 const useClearConfirmationOnBackSwipe = () => {
-  const navigation =
-    useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const { onReject } = useConfirmActions();
 

--- a/app/components/Views/confirmations/hooks/ui/useNavbar.ts
+++ b/app/components/Views/confirmations/hooks/ui/useNavbar.ts
@@ -1,8 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import { useEffect } from 'react';
 import { useTheme } from '../../../../../util/theme';
-import { StakeNavigationParamsList } from '../../../../UI/Stake/types';
 import {
   getModalNavigationOptions,
   getNavbar,
@@ -16,8 +14,7 @@ const useNavbar = (
   addBackButton = true,
   overrides?: NavbarOverrides,
 ) => {
-  const navigation =
-    useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const navigation = useNavigation();
   const { onReject } = useConfirmActions();
   const theme = useTheme();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
@@ -46,8 +43,7 @@ const useNavbar = (
 };
 
 export function useModalNavbar() {
-  const navigation =
-    useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const navigation = useNavigation();
 
   const { onReject } = useConfirmActions();
 


### PR DESCRIPTION
## **Description**

**Reason for the change:**
This is a preparatory change for upgrading the React Navigation library to v6. With global default types now applied to the navigation API, we no longer need to apply generic types to the `useNavigation` hook in most cases.

**Improvement/Solution:**
- Removed generic types from `useNavigation` hook invocations (now uses default global navigation types)
- Applied `NavigationProp<NavigatableRootParamList>` where deeply nested navigation is required
- Part of a series of PRs splitting the cleanup by codebase ownership

**Note on exceptions:**
Generic types may still be needed when navigating to deeper nested stacks. For those instances, we apply a recursive navigation type pattern.

**References:**
- Parent issue: #23763
- React Navigation nesting docs: https://reactnavigation.org/docs/nesting-navigators/

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23763 (partial)

## **Manual testing steps**

```gherkin
Feature: Navigation functionality after useNavigation cleanup

  Scenario: Confirmations navigation works correctly
    Given the app is running
    And the user is viewing confirmations

    When user navigates through confirmation flows
    Then the navigation should complete successfully
    And no TypeScript errors should occur
```

**Additional verification:**
- Run `yarn lint:tsc` to verify no TypeScript errors are introduced
- Run unit tests for affected components

## **Screenshots/Recordings**

N/A - No visual changes (internal refactoring/type cleanup)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no behavioral changes; risk is limited to potential TypeScript/navigation typing mismatches causing build errors.
> 
> **Overview**
> Updates confirmations UI hooks to rely on default `useNavigation` typing instead of `StakeNavigationParamsList` generics, as prep for a React Navigation v6 upgrade.
> 
> `useClearConfirmationOnBackSwipe` now types navigation against `RootStackParamList`, while `useNavbar`/`useModalNavbar` drop the explicit `StackNavigationProp` generic and use `useNavigation()` directly; runtime behavior is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db9c6de8226bd47306de06010b7e51c91a7aadb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->