### PR TITLE
refactor(earn): remove unnecessary useNavigation generic types

### DIFF
--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
@@ -4,7 +4,6 @@ import {
   useNavigation,
   useRoute,
 } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import React, {
   useCallback,
   useEffect,
@@ -40,7 +39,6 @@ import {
   EVENT_PROVIDERS,
 } from '../../constants/events/earnEvents';
 import usePoolStakedUnstake from '../../../Stake/hooks/usePoolStakedUnstake';
-import { StakeNavigationParamsList } from '../../../Stake/types';
 import EarnTokenSelector from '../../components/EarnTokenSelector';
 import InputDisplay from '../../components/InputDisplay';
 import { EARN_EXPERIENCES } from '../../constants/experiences';
@@ -140,8 +138,7 @@ const EarnWithdrawInputView = () => {
     return undefined;
   }, [receiptTokenToUse, earnTokenFromMap]);
 
-  const navigation =
-    useNavigation<StackNavigationProp<StakeNavigationParamsList>>();
+  const navigation = useNavigation();
   const { styles, theme } = useStyles(styleSheet, {});
   const { attemptUnstakeTransaction } = usePoolStakedUnstake();
   const selectedAccount = useSelector(selectSelectedInternalAccountByScope)(
@@ -338,7 +335,6 @@ const EarnWithdrawInputView = () => {
       : `${strings('stake.unstake')} ${tokenLabel}`;
 
     navigation.setOptions(
-      // @ts-expect-error - React Native style type mismatch due to outdated @types/react-native
       getStakingNavbar(
         title,
         navigation,


### PR DESCRIPTION
## **Description**

**Reason for the change:**
This is a preparatory change for upgrading the React Navigation library to v6. With global default types now applied to the navigation API, we no longer need to apply generic types to the `useNavigation` hook in most cases.

**Improvement/Solution:**
- Removed generic types from `useNavigation` hook invocations (now uses default global navigation types)
- Applied `NavigationProp<NavigatableRootParamList>` where deeply nested navigation is required
- Part of a series of PRs splitting the cleanup by codebase ownership

**Note on exceptions:**
Generic types may still be needed when navigating to deeper nested stacks. For those instances, we apply a recursive navigation type pattern.

**References:**
- Parent issue: #23763
- React Navigation nesting docs: https://reactnavigation.org/docs/nesting-navigators/

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23763 (partial)

## **Manual testing steps**

```gherkin
Feature: Navigation functionality after useNavigation cleanup

  Scenario: Earn navigation works correctly
    Given the app is running
    And the user is on the Earn section

    When user navigates to withdraw input view
    Then the navigation should complete successfully
    And no TypeScript errors should occur
```

**Additional verification:**
- Run `yarn lint:tsc` to verify no TypeScript errors are introduced
- Run unit tests for affected components

## **Screenshots/Recordings**

N/A - No visual changes (internal refactoring/type cleanup)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor in an Earn UI screen; no logic or data-flow changes beyond TypeScript annotations.
> 
> **Overview**
> Removes explicit React Navigation type annotations from `EarnWithdrawInputView` by dropping the `StackNavigationProp<StakeNavigationParamsList>` generic and switching to the default `useNavigation()` typing.
> 
> Also removes now-unneeded imports and a `@ts-expect-error` comment around `navigation.setOptions(getStakingNavbar(...))`, keeping runtime behavior unchanged while preparing for the React Navigation v6 typing model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52373e9168c5061908f8bc234ef1a689661e98cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->