### PR TITLE
refactor(platform): remove unnecessary useNavigation generic types

### DIFF
--- a/app/components/UI/BrowserBottomBar/index.test.tsx
+++ b/app/components/UI/BrowserBottomBar/index.test.tsx
@@ -216,7 +216,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalledWith(
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
         'AddBookmarkView',
         expect.objectContaining({
           screen: 'AddBookmark',
@@ -255,7 +255,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalled();
     });
   });
 
@@ -388,7 +388,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalledWith(
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
         'AddBookmarkView',
         expect.objectContaining({
           params: expect.objectContaining({
@@ -406,7 +406,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalled();
     });
   });
 
@@ -492,7 +492,7 @@ describe('BrowserBottomBar', () => {
       expect(mockDispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({ type: 'REMOVE_BOOKMARK' }),
       );
-      expect(mockNavigation.push).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalled();
     });
 
     it('does not dispatch removeBookmark when bookmarkToRemove is undefined', () => {
@@ -534,7 +534,7 @@ describe('BrowserBottomBar', () => {
 
       // Should return early due to isBookmarkDisabled check
       expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockNavigation.push).not.toHaveBeenCalled();
+      expect(mockNavigation.navigate).not.toHaveBeenCalled();
     });
 
     it('does not dispatch removeBookmark when activeUrl contains only whitespace', () => {
@@ -552,7 +552,7 @@ describe('BrowserBottomBar', () => {
 
       // Should return early due to isBookmarkDisabled check
       expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockNavigation.push).not.toHaveBeenCalled();
+      expect(mockNavigation.navigate).not.toHaveBeenCalled();
     });
 
     it('finds bookmark using masked URL from getMaskedUrl', () => {
@@ -635,7 +635,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).not.toHaveBeenCalled();
+      expect(mockNavigation.navigate).not.toHaveBeenCalled();
     });
   });
 
@@ -648,7 +648,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalledWith(
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
         'AddBookmarkView',
         expect.objectContaining({
           screen: 'AddBookmark',
@@ -689,7 +689,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalled();
     });
 
     it('does not call dispatch when bookmark to remove is not found', () => {
@@ -708,7 +708,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalled();
     });
   });
 
@@ -721,7 +721,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalledWith(
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
         'AddBookmarkView',
         expect.objectContaining({
           screen: 'AddBookmark',
@@ -737,7 +737,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalledWith(
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
         'AddBookmarkView',
         expect.objectContaining({
           params: expect.objectContaining({
@@ -757,7 +757,7 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      expect(mockNavigation.push).toHaveBeenCalledWith(
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
         'AddBookmarkView',
         expect.objectContaining({
           params: expect.objectContaining({
@@ -775,9 +775,9 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      expect(pushCall[1].params.onAddBookmark).toBeDefined();
-      expect(typeof pushCall[1].params.onAddBookmark).toBe('function');
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      expect(navigateCall[1].params.onAddBookmark).toBeDefined();
+      expect(typeof navigateCall[1].params.onAddBookmark).toBe('function');
     });
   });
 
@@ -802,8 +802,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -840,8 +840,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -865,8 +865,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -894,8 +894,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -918,8 +918,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -937,8 +937,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark Name',
@@ -960,8 +960,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Custom Bookmark Name',
@@ -988,8 +988,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: '',
@@ -1011,8 +1011,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: '',
@@ -1034,8 +1034,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'My Bookmark',
@@ -1060,8 +1060,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -1083,8 +1083,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test Bookmark',
@@ -1105,8 +1105,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: '',
@@ -1128,8 +1128,8 @@ describe('BrowserBottomBar', () => {
 
       fireEvent.press(getByTestId(BrowserViewSelectorsIDs.BOOKMARK_BUTTON));
 
-      const pushCall = mockNavigation.push.mock.calls[0];
-      const onAddBookmark = pushCall[1].params.onAddBookmark;
+      const navigateCall = mockNavigation.navigate.mock.calls[0];
+      const onAddBookmark = navigateCall[1].params.onAddBookmark;
 
       await onAddBookmark({
         name: 'Test  Bookmark   Name',

--- a/app/components/UI/BrowserBottomBar/index.tsx
+++ b/app/components/UI/BrowserBottomBar/index.tsx
@@ -22,7 +22,6 @@ import SearchApi from '@metamask/react-native-search-api';
 import Logger from '../../../util/Logger';
 import { RootState } from '../../../reducers';
 import { SessionENSNames } from '../../Views/BrowserTab/types';
-import { StackNavigationProp } from '@react-navigation/stack';
 import { selectBrowserTabCount } from '../../../reducers/browser/selectors';
 
 interface BrowserBottomBarProps {
@@ -100,8 +99,7 @@ const BrowserBottomBar: React.FC<BrowserBottomBarProps> = ({
   const tw = useTailwind();
   const { trackEvent, createEventBuilder } = useMetrics();
   const dispatch = useDispatch();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const navigation = useNavigation<StackNavigationProp<any>>();
+  const navigation = useNavigation();
   const bookmarks = useSelector((state: RootState) => state.bookmarks);
   const tabCount = useSelector(selectBrowserTabCount);
 
@@ -136,7 +134,7 @@ const BrowserBottomBar: React.FC<BrowserBottomBarProps> = ({
    * Navigate to AddBookmarkView modal
    */
   const navigateToAddBookmark = useCallback(() => {
-    navigation.push('AddBookmarkView', {
+    navigation.navigate('AddBookmarkView', {
       screen: 'AddBookmark',
       params: {
         title: title || '',

--- a/app/components/UI/NftGrid/NftGrid.test.tsx
+++ b/app/components/UI/NftGrid/NftGrid.test.tsx
@@ -617,7 +617,7 @@ describe('NftGrid', () => {
     const addButton = getByTestId('import-token-button');
     fireEvent.press(addButton);
 
-    expect(mockPush).toHaveBeenCalledWith('AddAsset', {
+    expect(mockNavigate).toHaveBeenCalledWith('AddAsset', {
       assetType: 'collectible',
     });
     expect(mockTrackEvent).toHaveBeenCalled();

--- a/app/components/UI/NftGrid/NftGrid.tsx
+++ b/app/components/UI/NftGrid/NftGrid.tsx
@@ -25,7 +25,6 @@ import NftGridItemActionSheet from './NftGridItemActionSheet';
 import NftGridHeader from './NftGridHeader';
 import NftGridSkeleton from './NftGridSkeleton';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
 import { CollectiblesEmptyState } from '../CollectiblesEmptyState';
 import { WalletViewSelectorsIDs } from '../../Views/Wallet/WalletView.testIds';
@@ -45,11 +44,6 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../util/theme';
 import { selectHomepageRedesignV1Enabled } from '../../../selectors/featureFlagController/homepage';
 import { useNftDetection } from '../../hooks/useNftDetection';
-
-interface NFTNavigationParamList {
-  AddAsset: { assetType: string };
-  [key: string]: undefined | object;
-}
 
 interface NftGridProps {
   isFullView?: boolean;
@@ -91,8 +85,7 @@ const NftGridContent = ({
 
 const NftGrid = forwardRef<TabRefreshHandle, NftGridProps>(
   ({ isFullView = false }, ref) => {
-    const navigation =
-      useNavigation<StackNavigationProp<NFTNavigationParamList, 'AddAsset'>>();
+    const navigation = useNavigation();
     const { trackEvent, createEventBuilder } = useMetrics();
     const [isAddNFTEnabled, setIsAddNFTEnabled] = useState(true);
     const [longPressedCollectible, setLongPressedCollectible] =
@@ -181,7 +174,7 @@ const NftGrid = forwardRef<TabRefreshHandle, NftGridProps>(
 
     const goToAddCollectible = useCallback(() => {
       setIsAddNFTEnabled(false);
-      navigation.push('AddAsset', { assetType: 'collectible' });
+      navigation.navigate('AddAsset', { assetType: 'collectible' });
       trackEvent(
         createEventBuilder(MetaMetricsEvents.WALLET_ADD_COLLECTIBLES).build(),
       );

--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -51,7 +51,6 @@ import {
   type RouteProp,
   type ParamListBase,
 } from '@react-navigation/native';
-import type { StackNavigationProp } from '@react-navigation/stack';
 import type { RootState } from '../../../reducers';
 
 /**
@@ -59,7 +58,7 @@ import type { RootState } from '../../../reducers';
  */
 const OptinMetrics = () => {
   const dispatch = useDispatch();
-  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
+  const navigation = useNavigation();
   const route =
     useRoute<
       RouteProp<

--- a/app/components/UI/Sites/components/SitesList/SitesList.tsx
+++ b/app/components/UI/Sites/components/SitesList/SitesList.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation } from '@react-navigation/native';
-// eslint-disable-next-line no-duplicate-imports
-import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import SiteRowItemWrapper from '../SiteRowItemWrapper/SiteRowItemWrapper';
 import type { SiteData } from '../SiteRowItem/SiteRowItem';
 
@@ -17,7 +15,7 @@ const SitesList: React.FC<SitesListProps> = ({
   refreshControl,
   ListFooterComponent,
 }) => {
-  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const navigation = useNavigation();
 
   const renderSiteItem = ({ item }: { item: SiteData }) => (
     <SiteRowItemWrapper site={item} navigation={navigation} />

--- a/app/components/UI/Sites/components/SitesSearchFooter/SitesSearchFooter.tsx
+++ b/app/components/UI/Sites/components/SitesSearchFooter/SitesSearchFooter.tsx
@@ -10,11 +10,7 @@ import {
   BoxProps,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import {
-  NavigationProp,
-  ParamListBase,
-  useNavigation,
-} from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import { selectSearchEngine } from '../../../../../reducers/browser/selectors';
@@ -40,7 +36,7 @@ function looksLikeUrl(str: string): boolean {
 }
 
 export const useSearchFooterBrowserNavigation = () => {
-  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const navigation = useNavigation();
 
   const onPress = useCallback(
     (url: string) => {

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -87,7 +87,6 @@ import {
   type IpfsContentResult,
   WebViewNavigationEventName,
 } from './types';
-import { StackNavigationProp } from '@react-navigation/stack';
 import {
   WebViewNavigationEvent,
   WebViewErrorEvent,
@@ -141,9 +140,7 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
     fromTrending,
     fromPerps,
   }) => {
-    // This any can be removed when react navigation is bumped to v6 - issue https://github.com/react-navigation/react-navigation/issues/9037#issuecomment-735698288
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const navigation = useNavigation<StackNavigationProp<any>>();
+    const navigation = useNavigation();
     const { styles } = useStyles(styleSheet, {});
     const [backEnabled, setBackEnabled] = useState(false);
     const [forwardEnabled, setForwardEnabled] = useState(false);

--- a/app/components/Views/BrowserTab/components/Options/index.tsx
+++ b/app/components/Views/BrowserTab/components/Options/index.tsx
@@ -26,7 +26,6 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import Logger from '../../../../../util/Logger';
-import { StackNavigationProp } from '@react-navigation/stack';
 import { useNavigation } from '@react-navigation/native';
 import { SessionENSNames } from '../../types';
 import { useDispatch, useSelector } from 'react-redux';
@@ -64,9 +63,7 @@ const Options = ({
   favicon,
   icon,
 }: OptionsProps) => {
-  // This any can be removed when react navigation is bumped to v6 - issue https://github.com/react-navigation/react-navigation/issues/9037#issuecomment-735698288
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const navigation = useNavigation<StackNavigationProp<any>>();
+  const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
   const { trackEvent, createEventBuilder } = useAnalytics();
   const dispatch = useDispatch();
@@ -107,7 +104,7 @@ const Options = ({
    */
   const navigateToAddBookmark = () => {
     toggleOptionsIfNeeded();
-    navigation.push('AddBookmarkView', {
+    navigation.navigate('AddBookmarkView', {
       screen: 'AddBookmark',
       params: {
         title: title.current || '',

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -1322,7 +1322,7 @@ describe('ChoosePassword', () => {
       fireEvent.press(learnMoreLink);
     });
 
-    expect(mockNavigation.push).toHaveBeenCalledWith('Webview', {
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Webview', {
       screen: 'SimpleWebview',
       params: {
         url: 'https://support.metamask.io/managing-my-wallet/resetting-deleting-and-restoring/how-can-i-reset-my-password/',

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -87,13 +87,7 @@ import { AccountImportStrategy } from '@metamask/keyring-controller';
 import { setDataCollectionForMarketing } from '../../../actions/security';
 import createStyles from './ChoosePassword.styles';
 import { ChoosePasswordRouteParams } from './ChoosePassword.types';
-import {
-  useNavigation,
-  useRoute,
-  RouteProp,
-  ParamListBase,
-} from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 
 interface KeyringState {
   type: string;
@@ -119,7 +113,7 @@ const ChoosePassword = () => {
   const { colors, themeAppearance } = useContext(ThemeContext);
   const styles = createStyles(colors);
 
-  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
+  const navigation = useNavigation();
   const route =
     useRoute<RouteProp<{ params: ChoosePasswordRouteParams }, 'params'>>();
 
@@ -481,7 +475,7 @@ const ChoosePassword = () => {
       url: learnMoreUrl,
     });
 
-    navigation.push('Webview', {
+    navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {
         url: learnMoreUrl,

--- a/app/components/Views/DiscoveryTab/DiscoveryTab.tsx
+++ b/app/components/Views/DiscoveryTab/DiscoveryTab.tsx
@@ -14,7 +14,6 @@ import { useStyles } from '../../hooks/useStyles';
 import styleSheet from './styles';
 import { type RootState } from '../../../reducers';
 import { type DiscoveryTabProps } from './types';
-import { StackNavigationProp } from '@react-navigation/stack';
 import BrowserUrlBar, {
   BrowserUrlBarRef,
   ConnectionType,
@@ -42,9 +41,7 @@ const DiscoveryTabPure: React.FC<DiscoveryTabProps> = ({
   newTab,
   updateTabInfo,
 }) => {
-  // This any can be removed when react navigation is bumped to v6 - issue https://github.com/react-navigation/react-navigation/issues/9037#issuecomment-735698288
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const navigation = useNavigation<StackNavigationProp<any>>();
+  const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
   const [isUrlBarFocused, setIsUrlBarFocused] = useState(false);
   const urlBarRef = useRef<BrowserUrlBarRef>(null);

--- a/app/components/Views/LedgerSelectAccount/index.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.tsx
@@ -22,7 +22,6 @@ import { setReloadAccounts } from '../../../actions/accounts';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { KeyringController } from '@metamask/keyring-controller';
-import { StackNavigationProp } from '@react-navigation/stack';
 import createStyles from './index.styles';
 import { HardwareDeviceTypes } from '../../../constants/keyringTypes';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -62,7 +61,7 @@ interface OptionType {
 }
 
 const LedgerSelectAccount = () => {
-  const navigation = useNavigation<StackNavigationProp<never>>();
+  const navigation = useNavigation();
   const [selectedDevice, setSelectedDevice] = useState<LedgerDevice>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const dispatch = useDispatch();
@@ -288,7 +287,7 @@ const LedgerSelectAccount = () => {
             })
             .build(),
         );
-        navigation.pop(2);
+        navigation.dispatch(StackActions.pop(2));
       } catch (err) {
         trackEvent(
           createEventBuilder(MetaMetricsEvents.HARDWARE_WALLET_ERROR)

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -60,10 +60,7 @@ import {
   handleSkipBackup,
   showSeedphraseDefinition,
 } from '../../../util/onboarding/backupUtils';
-import type {
-  ManualBackupStep1NavigationProp,
-  ManualBackupStep1RouteProp,
-} from './ManualBackupStep1.types';
+import type { ManualBackupStep1RouteProp } from './ManualBackupStep1.types';
 
 import darkBlurImage from '../../../images/dark-blur.png';
 import lightBlurImage from '../../../images/blur.png';
@@ -73,7 +70,7 @@ import lightBlurImage from '../../../images/blur.png';
  * the backup seed phrase flow
  */
 const ManualBackupStep1 = () => {
-  const navigation = useNavigation<ManualBackupStep1NavigationProp>();
+  const navigation = useNavigation();
   const route = useRoute<ManualBackupStep1RouteProp>();
   const dispatch = useDispatch();
 

--- a/app/components/Views/SitesFullView/SitesFullView.tsx
+++ b/app/components/Views/SitesFullView/SitesFullView.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useState, useMemo } from 'react';
 import { Platform, StyleSheet, View, RefreshControl } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-// eslint-disable-next-line no-duplicate-imports
-import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -36,7 +34,7 @@ const SitesFullView: React.FC = () => {
   const theme = useAppThemeFromContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const insets = useSafeAreaInsets();
-  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const navigation = useNavigation();
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearchActive, setIsSearchActive] = useState(false);
   const [refreshing, setRefreshing] = useState(false);

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -11,16 +10,8 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
 import Tokens from '../../UI/Tokens';
 
-interface TokenListNavigationParamList {
-  AddAsset: { assetType: string };
-  [key: string]: undefined | object;
-}
-
 const TokensFullView = () => {
-  const navigation =
-    useNavigation<
-      StackNavigationProp<TokenListNavigationParamList, 'AddAsset'>
-    >();
+  const navigation = useNavigation();
   const tw = useTailwind();
 
   const handleBackPress = useCallback(() => {

--- a/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/Views/TrendingTokens/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -49,10 +48,6 @@ import EmptySearchResultState from '../../TrendingView/components/EmptyErrorStat
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import TrendingFeedSessionManager from '../../../UI/Trending/services/TrendingFeedSessionManager';
 import { useSearchTracking } from '../../../UI/Trending/hooks/useSearchTracking/useSearchTracking';
-
-interface TrendingTokensNavigationParamList {
-  [key: string]: undefined | object;
-}
 
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
@@ -203,8 +198,7 @@ export const TrendingTokensData = (props: TrendingTokensDataProps) => {
 };
 
 const TrendingTokensFullView = () => {
-  const navigation =
-    useNavigation<StackNavigationProp<TrendingTokensNavigationParamList>>();
+  const navigation = useNavigation();
   const theme = useAppThemeFromContext();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
## **Description**

**Reason for the change:**
This is a preparatory change for upgrading the React Navigation library to v6. With global default types now applied to the navigation API, we no longer need to apply generic types to the `useNavigation` hook in most cases.

**Improvement/Solution:**
- Removed generic types from `useNavigation` hook invocations (now uses default global navigation types)
- Applied `NavigationProp<NavigatableRootParamList>` where deeply nested navigation is required
- Part of a series of PRs splitting the cleanup by codebase ownership

**Note on exceptions:**
Generic types may still be needed when navigating to deeper nested stacks. For those instances, we apply a recursive navigation type pattern.

**References:**
- Parent issue: #23763
- React Navigation nesting docs: https://reactnavigation.org/docs/nesting-navigators/

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #23763 (partial)

## **Manual testing steps**

```gherkin
Feature: Navigation functionality after useNavigation cleanup

  Scenario: Platform navigation works correctly
    Given the app is running
    And the user is on Browser, Sites, ChoosePassword, or other platform screens

    When user navigates between screens
    Then the navigation should complete successfully
    And no TypeScript errors should occur
```

**Additional verification:**
- Run `yarn lint:tsc` to verify no TypeScript errors are introduced
- Run unit tests for affected components

## **Screenshots/Recordings**

N/A - No visual changes (internal refactoring/type cleanup)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a type/refactor change, but it touches navigation behavior (`push` vs `navigate` and stack popping) across multiple screens, which could subtly alter routing/history in edge cases.
> 
> **Overview**
> **Refactors React Navigation usage to rely on default typing** by removing most `useNavigation<...>` generics across several UI/views (Browser, Sites, NFTs, onboarding, metrics, trending, tokens, ledger).
> 
> Standardizes navigation calls by switching bookmark/add-asset related flows from `navigation.push(...)` to `navigation.navigate(...)`, updating corresponding unit tests. Also fixes Ledger account flow back navigation by replacing `navigation.pop(2)` with `navigation.dispatch(StackActions.pop(2))` for stack pop behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18aea0753a060bb3d95d796bf35bf37102d43c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->