### PR TITLE
Ci formatting and linting

### DIFF
--- a/app/components/UI/Perps/hooks/useWithdrawalRequests.test.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawalRequests.test.ts
@@ -4,7 +4,10 @@ import { useWithdrawalRequests } from './useWithdrawalRequests';
 import Engine from '../../../../core/Engine';
 import { usePerpsSelector } from './usePerpsSelector';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
-import type { PerpsControllerState , UserHistoryItem } from '@metamask/perps-controller';
+import type {
+  PerpsControllerState,
+  UserHistoryItem,
+} from '@metamask/perps-controller';
 import type { RootState } from '../../../../reducers';
 import {
   createMockInternalAccount,


### PR DESCRIPTION
Fixes `yarn format:check` by correcting an import statement in `useWithdrawalRequests.test.ts`.

Other `yarn lint:tsc` and `yarn lint` failures were due to local setup not mirroring CI (missing patches and generated files), which are resolved by running the CI setup script. The only actual code change required was this formatting fix.

---
<p><a href="https://cursor.com/agents/bc-ff753f38-0027-456a-9a4f-adf2d64a239f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff753f38-0027-456a-9a4f-adf2d64a239f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only change in a test file with no production logic impact.
> 
> **Overview**
> Fixes CI formatting by changing the `@metamask/perps-controller` type-only import in `useWithdrawalRequests.test.ts` from a single-line import to a multi-line, lint-compliant form.
> 
> No runtime or behavioral changes; this is a test-file formatting-only update intended to satisfy `yarn format:check`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da201abd0f9378df95ec070c6701c7110ad5c3cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->