### PR TITLE
refactor: extract slide-from-right animation and apply to full view screens

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -142,6 +142,22 @@ const styles = StyleSheet.create({
   },
 });
 
+const slideFromRightAnimation = {
+  animationEnabled: true,
+  cardStyleInterpolator: ({ current, layouts }) => ({
+    cardStyle: {
+      transform: [
+        {
+          translateX: current.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [layouts.screen.width, 0],
+          }),
+        },
+      ],
+    },
+  }),
+};
+
 const clearStackNavigatorOptions = {
   headerShown: false,
   cardStyle: {
@@ -954,91 +970,33 @@ const MainNavigator = () => {
       <Stack.Screen
         name={Routes.WALLET.TOKENS_FULL_VIEW}
         component={TokensFullView}
-        options={{ headerShown: false }}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
       />
       <Stack.Screen
         name={Routes.WALLET.DEFI_FULL_VIEW}
         component={DeFiFullView}
-        options={{ headerShown: false }}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
       />
       <Stack.Screen name="AddAsset" component={AddAsset} />
       <Stack.Screen
         name="ConfirmAddAsset"
         component={ConfirmAddAsset}
-        options={{
-          headerShown: true,
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={{ headerShown: true, ...slideFromRightAnimation }}
       />
       <Stack.Screen
         name={Routes.SETTINGS_VIEW}
         component={SettingsFlow}
-        options={{
-          headerShown: false,
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
       />
       <Stack.Screen
         name="Asset"
         component={AssetNavigator}
-        options={{
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={slideFromRightAnimation}
       />
       <Stack.Screen
         name="TrendingTokensFullView"
         component={TrendingTokensFullView}
-        options={{
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={slideFromRightAnimation}
       />
 
       <Stack.Screen name="Webview" component={Webview} />
@@ -1057,45 +1015,17 @@ const MainNavigator = () => {
       <Stack.Screen
         name="NftDetails"
         component={NftDetailsModeView}
-        options={{
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={slideFromRightAnimation}
       />
       <Stack.Screen
         name="NftDetailsFullImage"
         component={NftDetailsFullImageModeView}
-        options={{
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={slideFromRightAnimation}
       />
       <Stack.Screen
         name={Routes.WALLET.NFTS_FULL_VIEW}
         component={NftFullView}
-        options={{ headerShown: false }}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
       />
       <Stack.Screen name="PaymentRequestView" component={PaymentRequestView} />
       <Stack.Screen
@@ -1118,42 +1048,12 @@ const MainNavigator = () => {
       <Stack.Screen
         name="StakeScreens"
         component={StakeScreenStack}
-        options={{
-          headerShown: false,
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
       />
       <Stack.Screen
         name={Routes.EARN.ROOT}
         component={EarnScreenStack}
-        options={{
-          headerShown: false,
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
       />
       <Stack.Screen
         name={Routes.EARN.MODALS.ROOT}
@@ -1170,21 +1070,7 @@ const MainNavigator = () => {
           <Stack.Screen
             name={Routes.PERPS.ROOT}
             component={PerpsScreenStack}
-            options={{
-              animationEnabled: true,
-              cardStyleInterpolator: ({ current, layouts }) => ({
-                cardStyle: {
-                  transform: [
-                    {
-                      translateX: current.progress.interpolate({
-                        inputRange: [0, 1],
-                        outputRange: [layouts.screen.width, 0],
-                      }),
-                    },
-                  ],
-                },
-              }),
-            }}
+            options={slideFromRightAnimation}
           />
           <Stack.Screen
             name={Routes.PERPS.TUTORIAL}
@@ -1233,21 +1119,7 @@ const MainNavigator = () => {
           <Stack.Screen
             name={Routes.PREDICT.ROOT}
             component={PredictScreenStack}
-            options={{
-              animationEnabled: true,
-              cardStyleInterpolator: ({ current, layouts }) => ({
-                cardStyle: {
-                  transform: [
-                    {
-                      translateX: current.progress.interpolate({
-                        inputRange: [0, 1],
-                        outputRange: [layouts.screen.width, 0],
-                      }),
-                    },
-                  ],
-                },
-              }),
-            }}
+            options={slideFromRightAnimation}
           />
           <Stack.Screen
             name={Routes.PREDICT.MODALS.ROOT}
@@ -1260,84 +1132,24 @@ const MainNavigator = () => {
         <Stack.Screen
           name={Routes.MARKET_INSIGHTS.VIEW}
           component={MarketInsightsView}
-          options={{
-            headerShown: false,
-            animationEnabled: true,
-            cardStyleInterpolator: ({ current, layouts }) => ({
-              cardStyle: {
-                transform: [
-                  {
-                    translateX: current.progress.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [layouts.screen.width, 0],
-                    }),
-                  },
-                ],
-              },
-            }),
-          }}
+          options={{ headerShown: false, ...slideFromRightAnimation }}
         />
       )}
       <>
         <Stack.Screen
           name={Routes.EXPLORE_SEARCH}
           component={ExploreSearchScreen}
-          options={{
-            headerShown: false,
-            animationEnabled: true,
-            cardStyleInterpolator: ({ current, layouts }) => ({
-              cardStyle: {
-                transform: [
-                  {
-                    translateX: current.progress.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [layouts.screen.width, 0],
-                    }),
-                  },
-                ],
-              },
-            }),
-          }}
+          options={{ headerShown: false, ...slideFromRightAnimation }}
         />
         <Stack.Screen
           name={Routes.SITES_FULL_VIEW}
           component={SitesFullView}
-          options={{
-            headerShown: false,
-            animationEnabled: true,
-            cardStyleInterpolator: ({ current, layouts }) => ({
-              cardStyle: {
-                transform: [
-                  {
-                    translateX: current.progress.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [layouts.screen.width, 0],
-                    }),
-                  },
-                ],
-              },
-            }),
-          }}
+          options={{ headerShown: false, ...slideFromRightAnimation }}
         />
         <Stack.Screen
           name={Routes.BROWSER.HOME}
           component={BrowserFlow}
-          options={{
-            headerShown: false,
-            animationEnabled: true,
-            cardStyleInterpolator: ({ current, layouts }) => ({
-              cardStyle: {
-                transform: [
-                  {
-                    translateX: current.progress.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [layouts.screen.width, 0],
-                    }),
-                  },
-                ],
-              },
-            }),
-          }}
+          options={{ headerShown: false, ...slideFromRightAnimation }}
         />
       </>
       <Stack.Screen
@@ -1381,22 +1193,7 @@ const MainNavigator = () => {
       <Stack.Screen
         name="DeFiProtocolPositionDetails"
         component={DeFiProtocolPositionDetails}
-        options={{
-          headerShown: true,
-          animationEnabled: true,
-          cardStyleInterpolator: ({ current, layouts }) => ({
-            cardStyle: {
-              transform: [
-                {
-                  translateX: current.progress.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [layouts.screen.width, 0],
-                  }),
-                },
-              ],
-            },
-          }),
-        }}
+        options={{ headerShown: true, ...slideFromRightAnimation }}
       />
       {
         ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -43,6 +43,8 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
     name="TokensFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -52,6 +54,8 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
     name="DeFiFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -156,6 +160,8 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
     name="NftFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -411,6 +417,8 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
     name="TokensFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -420,6 +428,8 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
     name="DeFiFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -524,6 +534,8 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
     name="NftFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -779,6 +791,8 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
     name="TokensFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -788,6 +802,8 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
     name="DeFiFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }
@@ -892,6 +908,8 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
     name="NftFullView"
     options={
       {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
         "headerShown": false,
       }
     }


### PR DESCRIPTION
## **Description**

The Tokens, DeFi, and NFTs full view screens were using the default stack navigator animation (bottom-to-top slide). Design feedback requested they transition from the right instead.

Rather than copy-pasting the same `cardStyleInterpolator` block that was already duplicated across 15 other screens, this PR extracts a shared `slideFromRightAnimation` constant and applies it to:

- `TokensFullView`
- `DeFiFullView`
- `NftFullView`

All 15 existing screens that had the identical inline animation were also refactored to use the shared constant, resulting in a net reduction of ~185 lines.

## **Changelog**

CHANGELOG entry: Updated Tokens, DeFi, and NFTs full view pages to slide in from the right instead of from the bottom

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Full view screen transitions

  Scenario: user navigates to Tokens full view
    Given the user is on the Homepage

    When user taps "See All" on the Tokens section
    Then the Tokens full view slides in from the right

  Scenario: user navigates to DeFi full view
    Given the user is on the Homepage

    When user taps "See All" on the DeFi section
    Then the DeFi full view slides in from the right

  Scenario: user navigates to NFTs full view
    Given the user is on the Homepage

    When user taps "See All" on the NFTs section
    Then the NFTs full view slides in from the right

  Scenario: existing slide-from-right screens are unaffected
    Given the user is on the Homepage

    When user navigates to Settings
    Then the Settings screen slides in from the right as before
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a navigation animation refactor with no changes to business logic or data handling; risk is limited to potential regressions in screen transition behavior.
> 
> **Overview**
> Updates navigation transitions so `TokensFullView`, `DeFiFullView`, and `NftFullView` now slide in from the right (matching other screens) instead of using the default stack animation.
> 
> Refactors `MainNavigator` to extract a reusable `slideFromRightAnimation` option and replaces multiple duplicated inline `cardStyleInterpolator` blocks across several stack screens; Jest snapshots are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c94d846e83d69530c4f63a54a68d811153e463f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->