### PR TITLE
refactor(predict): migrate usePredictActivity to React Query

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictActivity.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.test.ts
@@ -1,134 +1,114 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePredictActivity } from './usePredictActivity';
-import Engine from '../../../../core/Engine';
 
-// Mock Engine
+const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+const mockGetActivity = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
-      getActivity: jest.fn(),
+      getActivity: (...args: unknown[]) => mockGetActivity(...args),
     },
   },
 }));
 
-// Mock navigation focus effect without auto-invocation; provide manual trigger
-jest.mock('@react-navigation/native', () => {
-  let focusCb: (() => void) | null = null;
-  return {
-    useFocusEffect: (cb: () => void) => {
-      focusCb = cb;
-    },
-    __esModule: true,
-    __mock: {
-      invokeFocusEffect: () => {
-        focusCb?.();
-      },
-    },
-  };
-});
+jest.mock('../utils/accounts', () => ({
+  getEvmAccountFromSelectedAccountGroup: jest.fn(() => ({
+    address: MOCK_ADDRESS,
+  })),
+}));
+
+const mockEnsurePolygonNetworkExists = jest.fn<Promise<void>, []>();
+jest.mock('./usePredictNetworkManagement', () => ({
+  usePredictNetworkManagement: () => ({
+    ensurePolygonNetworkExists: mockEnsurePolygonNetworkExists,
+  }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return { Wrapper };
+};
 
 describe('usePredictActivity', () => {
-  const mockGetActivity = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
-    (Engine.context.PredictController.getActivity as jest.Mock) =
-      mockGetActivity;
+    mockGetActivity.mockResolvedValue([]);
+    mockEnsurePolygonNetworkExists.mockResolvedValue(undefined);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  it('fetches activity automatically on mount', async () => {
+    const { Wrapper } = createWrapper();
+    const activity = [{ id: '1' }];
+    mockGetActivity.mockResolvedValueOnce(activity);
 
-  it('initializes and auto-loads activity on mount', async () => {
-    const data = [{ id: '1' }];
-    mockGetActivity.mockResolvedValueOnce(data);
-
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictActivity(),
-    );
-
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.activity).toEqual([]);
-    expect(result.current.error).toBe(null);
-
-    await waitForNextUpdate();
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.activity).toEqual(data);
-    expect(result.current.error).toBe(null);
-    expect(mockGetActivity).toHaveBeenCalledWith({
-      providerId: undefined,
+    const { result } = renderHook(() => usePredictActivity(), {
+      wrapper: Wrapper,
     });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(activity);
+    expect(result.current.error).toBeNull();
+    expect(mockGetActivity).toHaveBeenCalledWith({ address: MOCK_ADDRESS });
   });
 
-  it('loads activity when hook is mounted', async () => {
-    mockGetActivity.mockResolvedValueOnce([]);
+  it('exposes error when activity fetch fails', async () => {
+    const { Wrapper } = createWrapper();
+    mockGetActivity.mockRejectedValueOnce(new Error('Boom'));
 
-    const { waitForNextUpdate } = renderHook(() => usePredictActivity());
+    const { result } = renderHook(() => usePredictActivity(), {
+      wrapper: Wrapper,
+    });
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
 
-    expect(mockGetActivity).toHaveBeenCalledWith({});
+    expect(result.current.error?.message).toBe('Boom');
   });
 
-  it('can refresh with isRefresh=true and sets isRefreshing flag', async () => {
+  it('uses refetch for refresh behavior', async () => {
+    const { Wrapper } = createWrapper();
     mockGetActivity.mockResolvedValueOnce([{ id: '1' }]);
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictActivity(),
-    );
 
-    await waitForNextUpdate();
+    const { result } = renderHook(() => usePredictActivity(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
 
     mockGetActivity.mockResolvedValueOnce([{ id: '2' }]);
     await act(async () => {
-      await result.current.loadActivity({ isRefresh: true });
-    });
-
-    expect(result.current.isRefreshing).toBe(false);
-    expect(result.current.activity).toEqual([{ id: '2' }]);
-  });
-
-  it('handles errors and sets error message', async () => {
-    mockGetActivity.mockRejectedValueOnce(new Error('Boom'));
-
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictActivity(),
-    );
-
-    await waitForNextUpdate();
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBe('Boom');
-    expect(result.current.activity).toEqual([]);
-  });
-
-  it('supports disabling auto-load via loadOnMount=false', () => {
-    const { result } = renderHook(() =>
-      usePredictActivity({ loadOnMount: false }),
-    );
-
-    expect(result.current.isLoading).toBe(true);
-    expect(result.current.activity).toEqual([]);
-    expect(mockGetActivity).not.toHaveBeenCalled();
-  });
-
-  it('triggers refresh on focus when refreshOnFocus=true', async () => {
-    mockGetActivity.mockResolvedValueOnce([]);
-
-    const { waitForNextUpdate } = renderHook(() =>
-      usePredictActivity({ refreshOnFocus: true }),
-    );
-
-    await waitForNextUpdate();
-
-    mockGetActivity.mockResolvedValueOnce([]);
-    const { __mock } = jest.requireMock('@react-navigation/native');
-    await act(async () => {
-      __mock.invokeFocusEffect();
-      await Promise.resolve();
+      await result.current.refetch();
     });
 
     expect(mockGetActivity).toHaveBeenCalledTimes(2);
+    expect(result.current.isRefetching).toBe(false);
+  });
+
+  it('ensures polygon network before running query', async () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePredictActivity(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockEnsurePolygonNetworkExists).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictActivity.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.ts
@@ -1,89 +1,43 @@
-import { useFocusEffect } from '@react-navigation/native';
-import { useCallback, useEffect, useState } from 'react';
-import Engine from '../../../../core/Engine';
+import { useEffect } from 'react';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import Logger from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import type { PredictActivity } from '../types';
+import { usePredictNetworkManagement } from './usePredictNetworkManagement';
+import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
+import { predictQueries } from '../queries';
 import { ensureError } from '../utils/predictErrorHandler';
 
-interface UsePredictActivityOptions {
-  loadOnMount?: boolean;
-  refreshOnFocus?: boolean;
-}
+export function usePredictActivity(): UseQueryResult<PredictActivity[], Error> {
+  const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
 
-interface UsePredictActivityReturn {
-  activity: PredictActivity[];
-  isLoading: boolean;
-  isRefreshing: boolean;
-  error: string | null;
-  loadActivity: (options?: { isRefresh?: boolean }) => Promise<void>;
-}
-
-export function usePredictActivity(
-  options: UsePredictActivityOptions = {},
-): UsePredictActivityReturn {
-  const { loadOnMount = true, refreshOnFocus = true } = options;
-
-  const [activity, setActivity] = useState<PredictActivity[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadActivity = useCallback(
-    async (loadOptions?: { isRefresh?: boolean }) => {
-      const { isRefresh = false } = loadOptions || {};
-      try {
-        if (isRefresh) {
-          setIsRefreshing(true);
-        } else {
-          setIsLoading(true);
-        }
-        setError(null);
-
-        const controller = Engine.context.PredictController;
-        const data = await controller.getActivity({});
-        setActivity(data ?? []);
-      } catch (err) {
-        const message =
-          err instanceof Error ? err.message : 'Failed to load activity';
-        setError(message);
-
-        // Capture exception with activity loading context (no user address)
-        Logger.error(ensureError(err), {
-          tags: {
-            feature: PREDICT_CONSTANTS.FEATURE_NAME,
-            component: 'usePredictActivity',
-          },
-          context: {
-            name: 'usePredictActivity',
-            data: {
-              method: 'loadActivity',
-              action: 'activity_load',
-              operation: 'data_fetching',
-            },
-          },
-        });
-      } finally {
-        setIsLoading(false);
-        setIsRefreshing(false);
-      }
-    },
-    [],
-  );
+  const evmAccount = getEvmAccountFromSelectedAccountGroup();
+  const address = evmAccount?.address ?? '0x0';
 
   useEffect(() => {
-    if (loadOnMount) {
-      loadActivity();
-    }
-  }, [loadOnMount, loadActivity]);
+    ensurePolygonNetworkExists().catch(() => undefined);
+  }, [ensurePolygonNetworkExists]);
 
-  useFocusEffect(
-    useCallback(() => {
-      if (refreshOnFocus) {
-        loadActivity({ isRefresh: true });
-      }
-    }, [refreshOnFocus, loadActivity]),
-  );
+  const queryResult = useQuery(predictQueries.activity.options({ address }));
 
-  return { activity, isLoading, isRefreshing, error, loadActivity };
+  useEffect(() => {
+    if (!queryResult.error) return;
+
+    Logger.error(ensureError(queryResult.error), {
+      tags: {
+        feature: PREDICT_CONSTANTS.FEATURE_NAME,
+        component: 'usePredictActivity',
+      },
+      context: {
+        name: 'usePredictActivity',
+        data: {
+          method: 'queryFn',
+          action: 'activity_load',
+          operation: 'data_fetching',
+        },
+      },
+    });
+  }, [queryResult.error]);
+
+  return queryResult;
 }

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -190,6 +190,10 @@ export function usePredictPlaceOrder(
           queryKey: predictQueries.positions.keys.all(),
         });
 
+        queryClient.invalidateQueries({
+          queryKey: predictQueries.activity.keys.all(),
+        });
+
         if (side === Side.BUY) {
           showOrderPlacedToast();
         } else {

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -147,6 +147,10 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
         queryClient.invalidateQueries({
           queryKey: predictQueries.balance.keys.all(),
         });
+
+        queryClient.invalidateQueries({
+          queryKey: predictQueries.activity.keys.all(),
+        });
       }
 
       if (type === 'deposit') {

--- a/app/components/UI/Predict/queries/activity.ts
+++ b/app/components/UI/Predict/queries/activity.ts
@@ -1,0 +1,17 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import type { PredictActivity } from '../types';
+
+export const predictActivityKeys = {
+  all: () => ['predict', 'activity'] as const,
+  byAddress: (address: string) =>
+    [...predictActivityKeys.all(), address] as const,
+};
+
+export const predictActivityOptions = ({ address }: { address: string }) =>
+  queryOptions({
+    queryKey: predictActivityKeys.byAddress(address),
+    queryFn: async (): Promise<PredictActivity[]> =>
+      Engine.context.PredictController.getActivity({ address }),
+    staleTime: 5_000,
+  });

--- a/app/components/UI/Predict/queries/activity.ts
+++ b/app/components/UI/Predict/queries/activity.ts
@@ -13,5 +13,4 @@ export const predictActivityOptions = ({ address }: { address: string }) =>
     queryKey: predictActivityKeys.byAddress(address),
     queryFn: async (): Promise<PredictActivity[]> =>
       Engine.context.PredictController.getActivity({ address }),
-    staleTime: 5_000,
   });

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,7 +1,12 @@
+import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
 
 export const predictQueries = {
+  activity: {
+    keys: predictActivityKeys,
+    options: predictActivityOptions,
+  },
   balance: {
     keys: predictBalanceKeys,
     options: predictBalanceOptions,

--- a/app/components/UI/Predict/views/PredictTransactionsView/PredictTransactionsView.test.tsx
+++ b/app/components/UI/Predict/views/PredictTransactionsView/PredictTransactionsView.test.tsx
@@ -69,10 +69,10 @@ jest.mock('../../components/PredictActivity/PredictActivity', () => {
 // Mock usePredictActivity hook - external data dependency
 jest.mock('../../hooks/usePredictActivity', () => ({
   usePredictActivity: jest.fn(() => ({
-    activity: [],
+    data: [],
     isLoading: false,
-    isRefreshing: false,
-    loadActivity: jest.fn(),
+    isRefetching: false,
+    refetch: jest.fn(),
   })),
 }));
 
@@ -85,29 +85,25 @@ describe('PredictTransactionsView', () => {
     jest.clearAllMocks();
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   const createUsePredictActivityValue = (
     overrides: Partial<{
-      activity: unknown[];
+      data: unknown[];
       isLoading: boolean;
-      isRefreshing: boolean;
-      loadActivity: jest.Mock;
+      isRefetching: boolean;
+      refetch: jest.Mock;
     }> = {},
   ) => ({
-    activity: [],
+    data: [],
     isLoading: false,
-    isRefreshing: false,
-    loadActivity: jest.fn(),
+    isRefetching: false,
+    refetch: jest.fn(),
     ...overrides,
   });
 
   it('displays loading indicator when activity data loads', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
-        activity: [],
+        data: [],
         isLoading: true,
       }),
     );
@@ -120,7 +116,7 @@ describe('PredictTransactionsView', () => {
   it('displays empty state message when activity list is empty', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
-        activity: [],
+        data: [],
         isLoading: false,
       }),
     );
@@ -135,7 +131,7 @@ describe('PredictTransactionsView', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
         isLoading: false,
-        activity: [
+        data: [
           {
             id: 'a1',
             title: 'Market A',
@@ -175,7 +171,7 @@ describe('PredictTransactionsView', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
         isLoading: false,
-        activity: [
+        data: [
           {
             id: 'a1',
             title: 'Market A',
@@ -215,7 +211,7 @@ describe('PredictTransactionsView', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
         isLoading: false,
-        activity: [
+        data: [
           {
             id: 'b2',
             title: 'Market B',
@@ -254,7 +250,7 @@ describe('PredictTransactionsView', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
         isLoading: false,
-        activity: [
+        data: [
           {
             id: 'c3',
             title: 'Market C',
@@ -289,7 +285,7 @@ describe('PredictTransactionsView', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
         isLoading: false,
-        activity: [
+        data: [
           {
             id: 'd4',
             title: 'Market D',
@@ -324,7 +320,7 @@ describe('PredictTransactionsView', () => {
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
         isLoading: true,
-        activity: [
+        data: [
           {
             id: 'refreshing-item',
             title: 'Market Refresh',
@@ -349,13 +345,13 @@ describe('PredictTransactionsView', () => {
   });
 
   it('passes refreshing state and triggers refresh handler on pull to refresh', async () => {
-    const mockLoadActivity = jest.fn().mockResolvedValue(undefined);
+    const mockRefetch = jest.fn().mockResolvedValue(undefined);
     const mockTimestamp = Math.floor(Date.now() / 1000);
     (usePredictActivity as jest.Mock).mockReturnValueOnce(
       createUsePredictActivityValue({
-        isRefreshing: true,
-        loadActivity: mockLoadActivity,
-        activity: [
+        isRefetching: true,
+        refetch: mockRefetch,
+        data: [
           {
             id: 'refreshable',
             title: 'Market Refreshable',
@@ -380,6 +376,6 @@ describe('PredictTransactionsView', () => {
       await sectionList.props.onRefresh();
     });
 
-    expect(mockLoadActivity).toHaveBeenCalledWith({ isRefresh: true });
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Predict/views/PredictTransactionsView/PredictTransactionsView.tsx
+++ b/app/components/UI/Predict/views/PredictTransactionsView/PredictTransactionsView.tsx
@@ -62,8 +62,12 @@ const PredictTransactionsView: React.FC<PredictTransactionsViewProps> = ({
   isVisible,
 }) => {
   const tw = useTailwind();
-  const { activity, isLoading, isRefreshing, loadActivity } =
-    usePredictActivity({});
+  const {
+    data: activity = [],
+    isLoading,
+    isRefetching,
+    refetch,
+  } = usePredictActivity();
 
   // Track screen load performance (activity data loaded)
   usePredictMeasurement({
@@ -270,8 +274,10 @@ const PredictTransactionsView: React.FC<PredictTransactionsViewProps> = ({
       showsVerticalScrollIndicator={false}
       style={tw.style('flex-1')}
       stickySectionHeadersEnabled
-      refreshing={isRefreshing}
-      onRefresh={() => loadActivity({ isRefresh: true })}
+      refreshing={isRefetching}
+      onRefresh={() => {
+        void refetch();
+      }}
       maxToRenderPerBatch={20}
       initialNumToRender={20}
       windowSize={12}


### PR DESCRIPTION
## **Description**

Migrated `usePredictActivity` from manual loading/refresh state to a React Query-based implementation and aligned transactions view + tests with the query-result contract. This removes legacy hook options/refresh plumbing and keeps activity data fresh by invalidating the new activity query after relevant Predict mutations.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict activity history uses React Query

  Scenario: user views and refreshes transaction history
    Given user is on the Predict Transactions tab with an account that has activity

    When user opens the Transactions tab
    Then activity rows are loaded from the query and rendered

    When user pulls to refresh
    Then the view calls query refetch and keeps rendering using query loading states
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a behavioral refactor of activity fetching/refresh semantics (React Query caching, address-scoped keys, and removal of focus-based refresh), which could affect when/which activity data is shown.
> 
> **Overview**
> Migrates `usePredictActivity` from manual state management + navigation focus refresh to a `@tanstack/react-query` `useQuery` implementation keyed by selected EVM `address`, with centralized query config in new `predictQueries.activity`.
> 
> Updates `PredictTransactionsView` (and its tests) to consume the query-result contract (`data`, `isRefetching`, `refetch`) and adds activity query invalidation after order placement and when Predict transactions are confirmed, keeping the activity list in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f1553fa0af0e68b2d02ee3d8111ea4bb6047d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->