### PR TITLE
fix(perps): standardize percentage formatting in PerpsHeroCardView and related components

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.test.tsx
@@ -270,7 +270,7 @@ describe('PerpsHeroCardView', () => {
 
       const pnlText = getByTestId(getPerpsHeroCardViewSelector.pnlText(0));
 
-      expect(pnlText).toHaveTextContent('+10.0%');
+      expect(pnlText).toHaveTextContent('+10.00%');
     });
   });
 
@@ -627,7 +627,7 @@ describe('PerpsHeroCardView', () => {
 
       const pnlText = getByTestId(getPerpsHeroCardViewSelector.pnlText(0));
 
-      expect(pnlText).toHaveTextContent('-10.0%');
+      expect(pnlText).toHaveTextContent('-10.00%');
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
@@ -195,7 +195,7 @@ const PerpsHeroCardView: React.FC = () => {
   };
 
   const pnlSign = data.pnl >= 0 ? '+' : '';
-  const pnlDisplay = `${pnlSign}${data.roe.toFixed(1)}%`;
+  const pnlDisplay = `${pnlSign}${data.roe.toFixed(2)}%`;
   const directionText =
     data.direction.charAt(0).toUpperCase() + data.direction.slice(1);
   const directionBadgeText = data.leverage

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -120,7 +120,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
   const pnlNum = parseFloat(position.unrealizedPnl);
 
-  // ROE is always stored as a decimal (e.g., 0.171 for 17.1%)
+  // ROE is always stored as a decimal (e.g., 0.171 for 17.10%)
   // Convert to percentage for display
   const roeValue = parseFloat(position.returnOnEquity || '0');
   const roe = isNaN(roeValue) ? 0 : roeValue * 100;
@@ -203,7 +203,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
     const roeRaw = Number.parseFloat(position.returnOnEquity || '');
     const hasValidRoe = !Number.isNaN(roeRaw) && Number.isFinite(roeRaw);
     const roeDisplay = hasValidRoe
-      ? formatPercentage(roeRaw * 100, 1)
+      ? formatPercentage(roeRaw * 100, 2)
       : PERPS_CONSTANTS.FallbackPercentageDisplay;
 
     const isPositionVariant = compactVariant === 'position';

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -747,7 +747,7 @@ const usePerpsToasts = (): {
                         }}
                       >
                         {' '}
-                        {`${roeValue.toFixed(1)}%`}
+                        {`${roeValue.toFixed(2)}%`}
                       </Text>
                     </Text>,
                   ),
@@ -818,7 +818,7 @@ const usePerpsToasts = (): {
                         }}
                       >
                         {' '}
-                        {`${roeValue.toFixed(1)}%`}
+                        {`${roeValue.toFixed(2)}%`}
                       </Text>
                     </Text>,
                   ),

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -349,7 +349,7 @@ describe('PerpsSection', () => {
 
     renderWithProvider(<PerpsSection />);
 
-    const roeElements = screen.getAllByText('+9.4%');
+    const roeElements = screen.getAllByText('+9.40%');
     expect(roeElements.length).toBeGreaterThanOrEqual(2);
   });
 

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -18,6 +18,25 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+jest.mock('../../components/FadingScrollContainer', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      children,
+    }: {
+      children: (props: {
+        onScroll: () => void;
+        scrollEventThrottle: number;
+      }) => React.ReactNode;
+    }) => (
+      <View testID="fading-scroll-container">
+        {children({ onScroll: jest.fn(), scrollEventThrottle: 16 })}
+      </View>
+    ),
+  };
+});
+
 jest.mock('../../../../UI/Predict/selectors/featureFlags', () => ({
   selectPredictEnabledFlag: jest.fn(() => true),
 }));

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -3,23 +3,15 @@ import React, {
   useCallback,
   useImperativeHandle,
   useRef,
-  useState,
 } from 'react';
-import {
-  ScrollView,
-  NativeSyntheticEvent,
-  NativeScrollEvent,
-  View,
-  StyleSheet,
-} from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { ScrollView } from 'react-native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box } from '@metamask/design-system-react-native';
-import { useTheme } from '../../../../../util/theme';
+import { Box, TextVariant } from '@metamask/design-system-react-native';
 import SectionTitle from '../../components/SectionTitle';
 import ErrorState from '../../components/ErrorState';
+import FadingScrollContainer from '../../components/FadingScrollContainer';
 import Routes from '../../../../../constants/navigation/Routes';
 import { SectionRefreshHandle } from '../../types';
 import { selectPredictEnabledFlag } from '../../../../UI/Predict/selectors/featureFlags';
@@ -35,7 +27,6 @@ import {
   PredictPositionRowSkeleton,
 } from './components';
 import ViewMoreCard from '../../components/ViewMoreCard';
-import { colorWithOpacity } from '../../../../../util/colors';
 import type { PredictPosition } from '../../../../UI/Predict/types';
 import type { PredictNavigationParamList } from '../../../../UI/Predict/types/navigation';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
@@ -62,23 +53,6 @@ const SKELETON_KEYS = Array.from(
   (__, i) => `skeleton-${i}`,
 );
 
-// Fade overlay width
-const FADE_WIDTH = 40;
-
-const styles = StyleSheet.create({
-  scrollContainer: {
-    position: 'relative',
-  },
-  fadeOverlay: {
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    bottom: 0,
-    width: FADE_WIDTH,
-    pointerEvents: 'none',
-  },
-});
-
 /**
  * PredictionsSection - Displays prediction content on the homepage
  *
@@ -90,15 +64,11 @@ const styles = StyleSheet.create({
  */
 const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const tw = useTailwind();
-  const { colors } = useTheme();
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const title = strings('homepage.sections.predictions');
   const { claim } = usePredictClaim();
-
-  // Track scroll position for fade effect
-  const [fadeOpacity, setFadeOpacity] = useState(1);
 
   // Fetch both positions and markets
   const {
@@ -158,32 +128,6 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
       screen: Routes.PREDICT.MARKET_LIST,
     });
   }, [navigation]);
-
-  // Handle scroll to update fade opacity
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } =
-        event.nativeEvent;
-      const scrollableWidth = contentSize.width - layoutMeasurement.width;
-
-      // No scrollable content — hide fade
-      if (scrollableWidth <= 0) {
-        setFadeOpacity(0);
-        return;
-      }
-
-      const distanceFromEnd = scrollableWidth - contentOffset.x;
-
-      // Fade out the overlay as we approach the end (within 100px)
-      const fadeThreshold = 100;
-      const newOpacity = Math.min(
-        1,
-        Math.max(0, distanceFromEnd / fadeThreshold),
-      );
-      setFadeOpacity(newOpacity);
-    },
-    [],
-  );
 
   const handlePositionPress = useCallback(
     (position: PredictPosition) => {
@@ -268,43 +212,35 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   return (
     <Box gap={3}>
       <SectionTitle title={title} onPress={handleViewAllPredictions} />
-      <View style={styles.scrollContainer}>
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('px-4 gap-3')}
-          snapToOffsets={SNAP_OFFSETS}
-          decelerationRate="fast"
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-        >
-          {isLoadingMarkets ? (
-            SKELETON_KEYS.map((key) => <PredictMarketCardSkeleton key={key} />)
-          ) : (
-            <>
-              {markets.map((market) => (
-                <PredictMarketCard key={market.id} market={market} />
-              ))}
-              <ViewMoreCard
-                onPress={handleViewAllPredictions}
-                twClassName="w-[180px] flex-1"
-              />
-            </>
-          )}
-        </ScrollView>
-        {/* Fade overlay on the right edge */}
-        {fadeOpacity > 0 && (
-          <LinearGradient
-            colors={[
-              colorWithOpacity(colors.background.default, 0),
-              colors.background.default,
-            ]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 0 }}
-            style={[styles.fadeOverlay, { opacity: fadeOpacity }]}
-          />
+      <FadingScrollContainer>
+        {(scrollProps) => (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={tw.style('px-4 gap-3')}
+            snapToOffsets={SNAP_OFFSETS}
+            decelerationRate="fast"
+            {...scrollProps}
+          >
+            {isLoadingMarkets ? (
+              SKELETON_KEYS.map((key) => (
+                <PredictMarketCardSkeleton key={key} />
+              ))
+            ) : (
+              <>
+                {markets.map((market) => (
+                  <PredictMarketCard key={market.id} market={market} />
+                ))}
+                <ViewMoreCard
+                  onPress={handleViewAllPredictions}
+                  twClassName="w-[180px] h-[180px]"
+                  textVariant={TextVariant.BodyLg}
+                />
+              </>
+            )}
+          </ScrollView>
         )}
-      </View>
+      </FadingScrollContainer>
     </Box>
   );
 });


### PR DESCRIPTION


## **Description**

Follow-up improvements for the homepage perps and predictions sections:

- **Perps ROE precision**: Increased ROE (Return on Equity) percentage display from 1 decimal place to 2 decimal places across the hero card, position card, and toast notifications for consistency and more precise reporting.
- **PredictionsSection refactor**: Replaced the inline fade overlay implementation (LinearGradient + manual scroll tracking) with the reusable FadingScrollContainer component, reducing code duplication and simplifying the component.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed perps ROE percentage display to show 2 decimal places for improved precision

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps ROE precision

  Scenario: user views perps position ROE percentage
    Given user has an open perps position with ROE of 17.12%

    When user views the position on the hero card, position card, or toast
    Then the ROE displays as "17.12%" (2 decimal places, not "17.1%")

Feature: Predictions section fade scroll

  Scenario: user scrolls predictions section horizontally
    Given user is on the homepage with predictions section visible

    When user scrolls the predictions cards horizontally
    Then a fade overlay appears on the right edge and fades out near the end

Feature: Network management feature flag

  Scenario: network management flag resolves correctly
    Given the remote config has the mobile-ux-network-management flag set

    When the selector reads the feature flag
    Then it resolves correctly using the kebab-case key
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="378" height="182" alt="Screenshot 2026-02-25 at 22 02 46" src="https://github.com/user-attachments/assets/8d653db8-53f9-4005-86c8-17a02b891abc" />

### **After**
<img width="383" height="169" alt="Screenshot 2026-02-25 at 21 57 57" src="https://github.com/user-attachments/assets/75174384-feee-4932-8c6c-bb39445954a2" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: percentage formatting is adjusted from 1 to 2 decimals and the Predictions carousel fade behavior is refactored to a shared container, with tests updated accordingly.
> 
> **Overview**
> **Standardizes Perps ROE/percentage display to 2 decimal places** across `PerpsHeroCardView`, compact `PerpsPositionCard`, and close-position toasts (`usePerpsToasts`), updating snapshots/assertions in related tests.
> 
> **Refactors `PredictionsSection` horizontal carousel fade** by removing the inline `LinearGradient` + manual scroll tracking and wrapping the `ScrollView` in the reusable `FadingScrollContainer`; also tweaks the `ViewMoreCard` sizing and text variant, and updates tests to mock the new container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65b3cc967cf3e82a5f7304f35a8e4ac5befcda07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->