### PR TITLE
feat(tests): use performance fixture in mm-connect tests

### DIFF
--- a/tests/performance/mm-connect/connection-evm.spec.js
+++ b/tests/performance/mm-connect/connection-evm.spec.js
@@ -1,4 +1,4 @@
-import { test } from 'appwright';
+import { test } from '../../framework/fixtures/performance';
 
 import { login } from '../../framework/utils/Flows.js';
 import {

--- a/tests/performance/mm-connect/connection-multichain.spec.js
+++ b/tests/performance/mm-connect/connection-multichain.spec.js
@@ -1,4 +1,4 @@
-import { test } from 'appwright';
+import { test } from '../../framework/fixtures/performance';
 
 import { login } from '../../framework/utils/Flows.js';
 import {

--- a/tests/performance/mm-connect/connection-wagmi.spec.js
+++ b/tests/performance/mm-connect/connection-wagmi.spec.js
@@ -1,4 +1,4 @@
-import { test } from 'appwright';
+import { test } from '../../framework/fixtures/performance';
 
 import { login } from '../../framework/utils/Flows.js';
 import {


### PR DESCRIPTION
## **Description**

The mm-connect tests (EVM, Wagmi, Multichain) were importing `test` directly from `appwright`, bypassing the shared performance fixture used by all other tests under `tests/performance/`. This meant they had no performance tracking, metric attachment, quality gate validation, or session data capture.

This PR switches the import in all three mm-connect test files from `appwright` to `../../framework/fixtures/performance`, aligning them with the rest of the performance test suite and enabling the `performanceTracker` fixture for future use.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: mm-connect performance fixture integration

  Scenario: user runs mm-connect EVM test
    Given the mm-connect EVM test suite is configured

    When user runs the connection-evm.spec.js test
    Then the test executes successfully with the performance fixture
    And performance metrics are attached to the test report

  Scenario: user runs mm-connect Wagmi test
    Given the mm-connect Wagmi test suite is configured

    When user runs the connection-wagmi.spec.js test
    Then the test executes successfully with the performance fixture
    And performance metrics are attached to the test report

  Scenario: user runs mm-connect Multichain test
    Given the mm-connect Multichain test suite is configured

    When user runs the connection-multichain.spec.js test
    Then the test executes successfully with the performance fixture
    And performance metrics are attached to the test report
```

## **Screenshots/Recordings**

N/A — import-only change with no UI impact.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the linked issue and target all platforms that should be supported
