### PR TITLE
chore: upgrade @metamask/design-system-react-native to v0.8.0

### DIFF
--- a/app/component-library/components/RadioButton/RadioButton.tsx
+++ b/app/component-library/components/RadioButton/RadioButton.tsx
@@ -17,6 +17,12 @@ import {
   DEFAULT_RADIOBUTTON_LABEL_TEXTCOLOR,
 } from './RadioButton.constants';
 
+/**
+ * @deprecated Please update your code to use `RadioButton` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/RadioButton/README.md}
+ * @since @metamask/design-system-react-native@0.8.0
+ */
 const RadioButton = ({
   style,
   label,

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "@metamask/core-backend": "^5.0.0",
     "@metamask/delegation-controller": "^2.0.1",
     "@metamask/delegation-deployments": "^0.15.0",
-    "@metamask/design-system-react-native": "^0.7.0",
+    "@metamask/design-system-react-native": "^0.8.0",
     "@metamask/design-system-twrnc-preset": "^0.3.0",
     "@metamask/design-tokens": "^8.2.0",
     "@metamask/earn-controller": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8179,11 +8179,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@metamask/design-system-react-native@npm:0.7.0"
+"@metamask/design-system-react-native@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@metamask/design-system-react-native@npm:0.8.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.1.3"
+    "@metamask/design-system-shared": "npm:^0.2.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8196,16 +8196,16 @@ __metadata:
     react-native-gesture-handler: ">=1.10.3"
     react-native-reanimated: ">=3.3.0"
     react-native-safe-area-context: ">=4.0.0"
-  checksum: 10/abb97977d9bc6c2059c35adc1c056792d579442724722db0688121e4c1fdafe5f2a78da232ab92aafcb6e3adb3d375edf25188ffe135bdbfc162121ab77b01cf
+  checksum: 10/378572600ad2ac44d7522c2875585be80148ff51b6aa351143e55d69b102cf03823d3bc36b1c3531e1a5079944b0a88da1cff10a5383766fd6ff89258a4a900d
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@metamask/design-system-shared@npm:0.1.3"
+"@metamask/design-system-shared@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/design-system-shared@npm:0.2.0"
   dependencies:
     "@metamask/utils": "npm:^11.10.0"
-  checksum: 10/6e474dd5d1e45637e51ef1b1656d4717bc71e8a0b52f2822c66182fbde49f53c13a31d52988bb4c7587448d528d6f71bef11c3c4de97d29a353ef6ec59a0d484
+  checksum: 10/8b7436e4c1882495faa1ca402456dfb82247e517c718da0bed0c4daf7ec06ed0e6bfa7fa3c9fa6930b30e4e5f3f8576436f0de27d9a86f97169cab0423285612
   languageName: node
   linkType: hard
 
@@ -35385,7 +35385,7 @@ __metadata:
     "@metamask/core-backend": "npm:^5.0.0"
     "@metamask/delegation-controller": "npm:^2.0.1"
     "@metamask/delegation-deployments": "npm:^0.15.0"
-    "@metamask/design-system-react-native": "npm:^0.7.0"
+    "@metamask/design-system-react-native": "npm:^0.8.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.3.0"
     "@metamask/design-tokens": "npm:^8.2.0"
     "@metamask/earn-controller": "npm:^10.0.0"


### PR DESCRIPTION
## **Description**

Upgrades \`@metamask/design-system-react-native\` from \`^0.7.0\` to \`^0.8.0\` (design system monorepo [v21.0.0](https://github.com/MetaMask/metamask-design-system/releases/tag/v21.0.0)) and marks the legacy \`RadioButton\` component as deprecated.

This also updates the transitive dependency \`@metamask/design-system-shared\` from \`0.1.3\` → \`0.2.0\`.

**What's new in 0.8.0:**
- Added \`RadioButton\` component (checked, disabled, read-only, and danger states; full accessibility support)
- \`BadgeStatus\` migrated from TypeScript enums to string union types — no migration required, enum constants still work
- \`BottomSheetFooter\` refactored to top-level location — no import changes needed for package entry point consumers

**Deprecation:**
- Added \`@deprecated\` JSDoc tag to the legacy \`app/component-library\` \`RadioButton\` component, pointing consumers to \`RadioButton\` from \`@metamask/design-system-react-native\`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

\`\`\`gherkin
Feature: design system upgrade

  Scenario: app builds and runs normally after upgrade
    Given the app is built with the updated dependency

    When user navigates through the app
    Then existing components render correctly with no regressions
\`\`\`

## **Screenshots/Recordings**

### **After**

General smoke test to make sure mobile loads

https://github.com/user-attachments/assets/7e2f0181-a01a-4775-9a2d-cb290f5e24ab

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump plus a doc-only deprecation annotation; no functional code paths are changed in this repo beyond updated package resolution.
> 
> **Overview**
> Upgrades `@metamask/design-system-react-native` from `^0.7.0` to `^0.8.0` (and updates the lockfile, including `@metamask/design-system-shared` to `^0.2.0`).
> 
> Marks the legacy `app/component-library` `RadioButton` component as **deprecated** via JSDoc, directing consumers to migrate to the design-system `RadioButton` and linking to its docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f79730bda760c8b274b16dda8428eaa5e61ff898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->