### PR TITLE
refactor(predict): migrate feature flags to unwrapRemoteFeatureFlag utility

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -114,6 +114,7 @@ import {
   VersionGatedFeatureFlag,
   validatedVersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
+import { unwrapRemoteFeatureFlag } from '../utils/flags';
 
 /**
  * State shape for PredictController
@@ -470,17 +471,18 @@ export class PredictController extends BaseController<
         'RemoteFeatureFlagController:getState',
       );
       const liveSportsFlag =
-        (remoteFeatureFlagState.remoteFeatureFlags
-          .predictLiveSports as unknown as PredictLiveSportsFlag | undefined) ??
-        DEFAULT_LIVE_SPORTS_FLAG;
+        unwrapRemoteFeatureFlag<PredictLiveSportsFlag>(
+          remoteFeatureFlagState.remoteFeatureFlags.predictLiveSports,
+        ) ?? DEFAULT_LIVE_SPORTS_FLAG;
+
       const liveSportsLeagues = liveSportsFlag.enabled
         ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
         : [];
 
-      const rawMarketHighlightsFlag = remoteFeatureFlagState.remoteFeatureFlags
-        .predictMarketHighlights as unknown as
-        | PredictMarketHighlightsFlag
-        | undefined;
+      const rawMarketHighlightsFlag =
+        unwrapRemoteFeatureFlag<PredictMarketHighlightsFlag>(
+          remoteFeatureFlagState.remoteFeatureFlags.predictMarketHighlights,
+        );
 
       const isHighlightsFlagValid = validatedVersionGatedFeatureFlag(
         rawMarketHighlightsFlag as unknown as VersionGatedFeatureFlag,
@@ -611,9 +613,9 @@ export class PredictController extends BaseController<
         'RemoteFeatureFlagController:getState',
       );
       const liveSportsFlag =
-        (remoteFeatureFlagState.remoteFeatureFlags
-          .predictLiveSports as unknown as PredictLiveSportsFlag | undefined) ??
-        DEFAULT_LIVE_SPORTS_FLAG;
+        unwrapRemoteFeatureFlag<PredictLiveSportsFlag>(
+          remoteFeatureFlagState.remoteFeatureFlags.predictLiveSports,
+        ) ?? DEFAULT_LIVE_SPORTS_FLAG;
       const liveSportsLeagues = liveSportsFlag.enabled
         ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
         : [];
@@ -1372,10 +1374,9 @@ export class PredictController extends BaseController<
         'RemoteFeatureFlagController:getState',
       );
       const feeCollection =
-        (remoteFeatureFlagState.remoteFeatureFlags
-          .predictFeeCollection as unknown as
-          | PredictFeeCollection
-          | undefined) ?? DEFAULT_FEE_COLLECTION_FLAG;
+        unwrapRemoteFeatureFlag<PredictFeeCollection>(
+          remoteFeatureFlagState.remoteFeatureFlags.predictFeeCollection,
+        ) ?? DEFAULT_FEE_COLLECTION_FLAG;
 
       const signer = this.getSigner();
 

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../../util/remoteFeatureFlag';
 import { PredictHotTabFlag } from '../../types/flags';
 import { DEFAULT_HOT_TAB_FLAG } from '../../constants/flags';
+import { unwrapRemoteFeatureFlag } from '../../utils/flags';
 
 /**
  * Selector for Predict trading feature enablement
@@ -20,8 +21,9 @@ import { DEFAULT_HOT_TAB_FLAG } from '../../constants/flags';
 export const selectPredictEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    const remoteFlag =
-      remoteFeatureFlags?.predictTradingEnabled as unknown as VersionGatedFeatureFlag;
+    const remoteFlag = unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(
+      remoteFeatureFlags?.predictTradingEnabled,
+    );
 
     // Default to `true` if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? true;
@@ -32,8 +34,9 @@ export const selectPredictGtmOnboardingModalEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
     const localFlag = process.env.MM_PREDICT_GTM_MODAL_ENABLED === 'true';
-    const remoteFlag =
-      remoteFeatureFlags?.predictGtmOnboardingModalEnabled as unknown as VersionGatedFeatureFlag;
+    const remoteFlag = unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(
+      remoteFeatureFlags?.predictGtmOnboardingModalEnabled,
+    );
 
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
@@ -65,8 +68,9 @@ export interface PredictHomeFeaturedVariantFlag
 export const selectPredictHomeFeaturedVariant = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): PredictHomeFeaturedVariant => {
-    const remoteFlag =
-      remoteFeatureFlags?.predictHomeFeaturedVariant as unknown as PredictHomeFeaturedVariantFlag;
+    const remoteFlag = unwrapRemoteFeatureFlag<PredictHomeFeaturedVariantFlag>(
+      remoteFeatureFlags?.predictHomeFeaturedVariant,
+    );
 
     const isEnabled = validatedVersionGatedFeatureFlag(remoteFlag);
 
@@ -85,14 +89,11 @@ export const selectPredictHomeFeaturedVariant = createSelector(
 export const selectPredictHotTabFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): PredictHotTabFlag => {
-    const flag =
-      remoteFeatureFlags?.predictHotTab as unknown as PredictHotTabFlag;
+    const flag = unwrapRemoteFeatureFlag<PredictHotTabFlag>(
+      remoteFeatureFlags?.predictHotTab,
+    );
 
-    if (
-      !validatedVersionGatedFeatureFlag(
-        flag as unknown as VersionGatedFeatureFlag,
-      )
-    ) {
+    if (!flag || !validatedVersionGatedFeatureFlag(flag)) {
       return DEFAULT_HOT_TAB_FLAG;
     }
 

--- a/app/components/UI/Predict/utils/flags.test.ts
+++ b/app/components/UI/Predict/utils/flags.test.ts
@@ -1,0 +1,132 @@
+import { VersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
+import { PredictHotTabFlag, PredictLiveSportsFlag } from '../types/flags';
+import { unwrapRemoteFeatureFlag } from './flags';
+
+describe('unwrapRemoteFeatureFlag', () => {
+  describe('direct shape (flag is the object itself)', () => {
+    it('returns the flag object for a version-gated flag', () => {
+      const flag = { enabled: true, minimumVersion: '7.65.0' };
+
+      const result = unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(flag);
+
+      expect(result).toEqual(flag);
+    });
+
+    it('returns the flag object with extra properties intact', () => {
+      const flag: PredictHotTabFlag = {
+        enabled: true,
+        minimumVersion: '7.64.0',
+        queryParams: 'tag_id=149&order=volume24hr',
+      };
+
+      const result = unwrapRemoteFeatureFlag<PredictHotTabFlag>(flag);
+
+      expect(result).toEqual(flag);
+      expect(result?.queryParams).toBe('tag_id=149&order=volume24hr');
+    });
+
+    it('returns non-version-gated flag objects unchanged', () => {
+      const flag: PredictLiveSportsFlag = {
+        enabled: true,
+        leagues: ['soccer_epl', 'soccer_laliga'],
+      };
+
+      const result = unwrapRemoteFeatureFlag<PredictLiveSportsFlag>(flag);
+
+      expect(result).toEqual(flag);
+      expect(result?.leagues).toEqual(['soccer_epl', 'soccer_laliga']);
+    });
+  });
+
+  describe('progressive rollout shape ({ name, value })', () => {
+    it('extracts .value from a wrapped version-gated flag', () => {
+      const input = {
+        name: 'group-a',
+        value: { enabled: true, minimumVersion: '7.65.0' },
+      };
+
+      const result = unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(input);
+
+      expect(result).toEqual({ enabled: true, minimumVersion: '7.65.0' });
+    });
+
+    it('extracts .value preserving extra flag properties', () => {
+      const input = {
+        name: 'exp-1',
+        value: {
+          enabled: true,
+          minimumVersion: '0.0.0',
+          queryParams: 'tag_id=149',
+        },
+      };
+
+      const result = unwrapRemoteFeatureFlag<PredictHotTabFlag>(input);
+
+      expect(result?.queryParams).toBe('tag_id=149');
+      expect(result?.enabled).toBe(true);
+    });
+
+    it('extracts .value when name property is absent', () => {
+      const input = {
+        value: { enabled: true, minimumVersion: '1.0.0' },
+      };
+
+      const result = unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(input);
+
+      expect(result).toEqual({ enabled: true, minimumVersion: '1.0.0' });
+    });
+  });
+
+  describe('returns undefined for non-object inputs', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['string', 'some-string'],
+      ['number', 42],
+      ['boolean', true],
+    ] as const)('returns undefined for %s', (_label, input) => {
+      const result = unwrapRemoteFeatureFlag(input);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('returns undefined for wrapped shape with non-object .value', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['string', 'not-an-object'],
+      ['number', 42],
+      ['boolean', false],
+    ] as const)('returns undefined when .value is %s', (_label, value) => {
+      const input = { value };
+
+      const result = unwrapRemoteFeatureFlag(input);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('enabled property takes precedence over value property', () => {
+    it('treats flag as direct shape when both enabled and value are present', () => {
+      const input = {
+        enabled: true,
+        minimumVersion: '1.0.0',
+        value: { enabled: false, minimumVersion: '2.0.0' },
+      };
+
+      const result = unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(input);
+
+      expect(result).toEqual(input);
+    });
+
+    it('returns the full direct flag even when it has a value property', () => {
+      const input = { enabled: true, value: 42, customProp: 'test' };
+
+      const result = unwrapRemoteFeatureFlag<Record<string, unknown>>(input);
+
+      expect(result).toEqual(input);
+      expect(result?.value).toBe(42);
+    });
+  });
+});

--- a/app/components/UI/Predict/utils/flags.ts
+++ b/app/components/UI/Predict/utils/flags.ts
@@ -1,0 +1,40 @@
+/**
+ * Generic utility to unwrap a remote feature flag from either of two runtime shapes:
+ *
+ * 1) Direct shape (flag value is the object itself):
+ * { enabled: true, minimumVersion: '7.65.0', variant: 'list' }
+ *
+ * 2) Progressive rollout / A/B test shape (flag value is nested inside `.value`):
+ * { name: 'group-a', value: { enabled: true, minimumVersion: '7.65.0', variant: 'list' } }
+ *
+ * This function only normalizes the shape — it does NOT validate version gating.
+ * Use `validatedVersionGatedFeatureFlag()` separately for version checks.
+ *
+ * Works for any flag type, including non-version-gated flags like PredictFeeCollection.
+ *
+ * @param remoteFlag - The raw remote feature flag value (unknown shape)
+ * @returns The unwrapped flag value typed as T, or undefined if the input is not a valid object
+ */
+export function unwrapRemoteFeatureFlag<T>(remoteFlag: unknown): T | undefined {
+  if (typeof remoteFlag !== 'object' || remoteFlag === null) {
+    return undefined;
+  }
+
+  // Direct shape: if the object has an `enabled` property, treat it as the flag itself.
+  // This check runs first to avoid misinterpreting a direct-shape flag that happens
+  // to have a `value` property as a progressive rollout wrapper.
+  if ('enabled' in remoteFlag) {
+    return remoteFlag as T;
+  }
+
+  // Progressive rollout shape: extract the nested value
+  if ('value' in remoteFlag) {
+    const wrapped = (remoteFlag as { value?: unknown }).value;
+    if (typeof wrapped === 'object' && wrapped !== null) {
+      return wrapped as T;
+    }
+    return undefined;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## **Description**

The Predict feature flags are currently using `as unknown as` type casts to access flag properties from `RemoteFeatureFlagController` state. This breaks when the controller delivers flags in the progressive rollout (A/B test) wrapper shape `{ name: string, value: <flag> }` instead of the direct shape.

This PR introduces a generic `unwrapRemoteFeatureFlag<T>()` utility that transparently handles both runtime shapes:
1. **Direct shape**: `{ enabled: true, minimumVersion: '7.65.0', ... }` — returned as-is
2. **Progressive rollout shape**: `{ name: 'group-a', value: { enabled: true, minimumVersion: '7.65.0', ... } }` — extracts `.value`

All Predict selectors and PredictController flag access points now use this utility instead of `as unknown as` casts, making them forward-compatible with the new feature flag format.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict feature flag compatibility

  Scenario: Predict features work with direct-shape feature flags
    Given the app is running with remote feature flags in direct shape
    When user navigates to Predict
    Then all Predict features behave normally (trading, hot tab, home featured variant, market highlights, live sports, fee collection)

  Scenario: Predict features work with progressive rollout feature flags
    Given the app is running with remote feature flags in wrapped shape ({ name, value })
    When user navigates to Predict
    Then all Predict features behave normally with no regressions
```

## **Screenshots/Recordings**

### **Before**

N/A — internal refactor, no UI changes.

### **After**

N/A — internal refactor, no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor limited to feature-flag parsing with added unit tests; main risk is unexpected flag-shape edge cases changing which defaults apply.
> 
> **Overview**
> Improves Predict’s remote feature flag handling to support both direct flag values and progressive-rollout wrappers by introducing `unwrapRemoteFeatureFlag<T>()`.
> 
> Updates `PredictController` and Predict feature-flag selectors to use the new unwrapping helper instead of `as unknown as` casts when reading `predictLiveSports`, `predictMarketHighlights`, `predictFeeCollection`, and other version-gated flags, and adds unit coverage for the helper across valid/invalid input shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b85c3fca81daf23903af7aa581569e51d191611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->