### PR TITLE
chore: add Claude Code project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ github-tools/
 temp/
 /temp/
 .agent/
+.claude/worktrees/
 
 # Reassure performance testing
 .reassure/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,17 +99,19 @@ scripts/                  # Build and automation scripts
 
 ## Development Guidelines
 
-**Detailed guidelines are in `.cursor/rules/`** - these are automatically applied by Cursor:
+**Detailed guidelines are in `.cursor/rules/`**. Cursor applies these automatically. All other AI agents MUST read the relevant rule file before performing the associated task:
 
-| Rule File                         | Scope                                                |
-| --------------------------------- | ---------------------------------------------------- |
-| `general-coding-guidelines.mdc`   | Always applied - coding standards, file organization |
-| `ui-development-guidelines.mdc`   | UI components - design system, Tailwind, styling     |
-| `unit-testing-guidelines.mdc`     | `*.test.*` files - test patterns, mocking, AAA       |
-| `e2e-testing-guidelines.mdc`      | Always applied - E2E patterns, Page Objects          |
-| `component-view-testing.mdc`      | Component testing with presets/renderers             |
-| `deeplink-handler-guidelines.mdc` | Deeplink handler implementation                      |
-| `pr-creation-guidelines.mdc`      | Pull request standards                               |
+| Rule File                         | When to read                                 |
+| --------------------------------- | -------------------------------------------- |
+| `general-coding-guidelines.mdc`   | Before writing or modifying any code         |
+| `ui-development-guidelines.mdc`   | Before working on UI components or styling   |
+| `unit-testing-guidelines.mdc`     | Before writing or modifying `*.test.*` files |
+| `e2e-testing-guidelines.mdc`      | Before writing or modifying E2E tests        |
+| `component-view-testing.mdc`      | Before writing component view tests          |
+| `deeplink-handler-guidelines.mdc` | Before implementing deeplink handlers        |
+| `pr-creation-guidelines.mdc`      | Before creating any pull request             |
+
+These files are the canonical source of truth. Read them from `.cursor/rules/<filename>`.
 
 ### Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Treat @AGENTS.md the same way you would CLAUDE.md


### PR DESCRIPTION
## **Description**

Adds `CLAUDE.md` to direct Claude Code (and other AI agents that read `CLAUDE.md`) to follow the existing `AGENTS.md` instructions. Also updates `.gitignore` to ignore `.claude/worktrees/` so Claude Code worktree directories aren't committed.

No runtime behavior changes — documentation and gitignore only.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A — repository tooling improvement

## **Manual testing steps**

```gherkin
Feature: Claude Code agent configuration

  Scenario: Claude Code reads project instructions
    Given a developer opens the repo with Claude Code

    When Claude Code loads the project context
    Then it reads CLAUDE.md which directs it to AGENTS.md
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI changes

### **After**

N/A — no UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.