### PR TITLE
chore: add Claude Code support and improve AGENTS.md clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ github-tools/
 temp/
 /temp/
 .agent/
+.claude/worktrees/
 
 # Reassure performance testing
 .reassure/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,17 +99,19 @@ scripts/                  # Build and automation scripts
 
 ## Development Guidelines
 
-**Detailed guidelines are in `.cursor/rules/`** - these are automatically applied by Cursor:
+**Detailed guidelines are in `.cursor/rules/`**. Cursor applies these automatically. All other AI agents MUST read the relevant rule file before performing the associated task:
 
-| Rule File                         | Scope                                                |
-| --------------------------------- | ---------------------------------------------------- |
-| `general-coding-guidelines.mdc`   | Always applied - coding standards, file organization |
-| `ui-development-guidelines.mdc`   | UI components - design system, Tailwind, styling     |
-| `unit-testing-guidelines.mdc`     | `*.test.*` files - test patterns, mocking, AAA       |
-| `e2e-testing-guidelines.mdc`      | Always applied - E2E patterns, Page Objects          |
-| `component-view-testing.mdc`      | Component testing with presets/renderers             |
-| `deeplink-handler-guidelines.mdc` | Deeplink handler implementation                      |
-| `pr-creation-guidelines.mdc`      | Pull request standards                               |
+| Rule File                         | When to read                                 |
+| --------------------------------- | -------------------------------------------- |
+| `general-coding-guidelines.mdc`   | Before writing or modifying any code         |
+| `ui-development-guidelines.mdc`   | Before working on UI components or styling   |
+| `unit-testing-guidelines.mdc`     | Before writing or modifying `*.test.*` files |
+| `e2e-testing-guidelines.mdc`      | Before writing or modifying E2E tests        |
+| `component-view-testing.mdc`      | Before writing component view tests          |
+| `deeplink-handler-guidelines.mdc` | Before implementing deeplink handlers        |
+| `pr-creation-guidelines.mdc`      | Before creating any pull request             |
+
+These files are the canonical source of truth. Read them from `.cursor/rules/<filename>`.
 
 ### Quick Reference
 
@@ -192,5 +194,6 @@ If the user asks to implement a ticket directly from Jira:
 | Troubleshooting           | `/docs/readme/troubleshooting.md`            |
 | MetaMask Contributor Docs | https://github.com/MetaMask/contributor-docs |
 
-## Test Guidelines
+## Test Guidelines
+
 When working on tests, read tests/AGENTS.md for testing conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Treat @AGENTS.md the same way you would CLAUDE.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` that points Claude Code to `AGENTS.md` as its canonical instructions
- Update the guidelines table in `AGENTS.md` to be explicitly actionable for non-Cursor AI agents (clear "when to read" column, canonical source note)
- Add `.claude/worktrees/` to `.gitignore` to ignore Claude Code worktree artifacts

## Test plan
- [ ] Verify `CLAUDE.md` is picked up by Claude Code and correctly delegates to `AGENTS.md`
- [ ] Confirm `.gitignore` entry prevents `.claude/worktrees/` from being tracked
- [ ] Review `AGENTS.md` table renders correctly in GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a new ignore pattern; minimal risk aside from possibly affecting which Claude worktree artifacts are excluded from git.
> 
> **Overview**
> Adds `CLAUDE.md` to direct Claude Code to use `AGENTS.md` as the canonical agent instructions.
> 
> Clarifies `AGENTS.md` by making the `.cursor/rules/` table explicitly actionable for non-Cursor agents (when each rule should be read) and fixes the `Test Guidelines` heading formatting. Updates `.gitignore` to ignore `.claude/worktrees/` artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b77abd9b755f8990f06c1b1c3a10016da0a3616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->