### PR TITLE
fix: formatting remove territory for unified formatting

### DIFF
--- a/app/components/hooks/useFormatters.test.ts
+++ b/app/components/hooks/useFormatters.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useFormatters } from './useFormatters';
+import I18n from '../../../locales/i18n';
+
+jest.mock('../../../locales/i18n', () => ({
+  __esModule: true,
+  default: { locale: 'en' },
+}));
+
+const mockI18n = jest.mocked(I18n);
+
+describe('useFormatters', () => {
+  beforeEach(() => {
+    mockI18n.locale = 'en';
+  });
+
+  describe('formatCurrency', () => {
+    const enLocales = ['en', 'en-US', 'en-GB', 'en-CA', 'en-AU', 'en-NZ'];
+    const tests = [
+      { value: 100, currency: 'USD', expected: '$100.00' },
+      { value: 0.5, currency: 'USD', expected: '$0.50' },
+      { value: 1234.56, currency: 'USD', expected: '$1,234.56' },
+    ];
+    const localeTestCases = enLocales.flatMap((locale) =>
+      tests.map((testCase) => ({ ...testCase, locale })),
+    );
+
+    it.each(localeTestCases)(
+      'returns $ prefix for $value $currency, never US$ (using locale $locale)',
+      ({ value, currency, expected, locale }) => {
+        mockI18n.locale = locale;
+        const { result } = renderHook(() => useFormatters());
+
+        const formatted = result.current.formatCurrency(value, currency);
+
+        expect(formatted).toBe(expected);
+        expect(formatted).not.toContain('US$');
+      },
+    );
+  });
+});

--- a/app/components/hooks/useFormatters.ts
+++ b/app/components/hooks/useFormatters.ts
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 import { createFormatters } from '@metamask/assets-controllers';
 import I18n from '../../../locales/i18n';
 
+export const getLocaleLanguageCode = () => I18n.locale.split('-')[0];
+
 export function useFormatters() {
-  const locale = I18n.locale;
+  const locale = getLocaleLanguageCode();
   return useMemo(() => createFormatters({ locale }), [locale]);
 }

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -16,6 +16,13 @@ import {
   selectSortedAssetsBySelectedAccountGroup,
   selectTronResourcesBySelectedAccountGroup,
 } from './assets-list';
+import I18n from '../../../locales/i18n';
+
+jest.mock('../../../locales/i18n', () => ({
+  __esModule: true,
+  default: { locale: 'en' },
+}));
+const mockI18n = jest.mocked(I18n);
 
 const mockState = ({
   filterNetwork,
@@ -683,6 +690,10 @@ describe('selectSortedAssetsBySelectedAccountGroup', () => {
 });
 
 describe('selectAsset', () => {
+  beforeEach(() => {
+    mockI18n.locale = 'en';
+  });
+
   it('returns formatted evm native asset based on filter criteria', () => {
     const state = mockState();
     const result = selectAsset(state, {
@@ -973,6 +984,46 @@ describe('selectAsset', () => {
     // Assert - isStaked should be false instead of undefined
     expect(result?.isStaked).toBe(false);
     expect(result?.isStaked).not.toBeUndefined();
+  });
+
+  describe('balanceFiat locale formatting', () => {
+    beforeEach(() => {
+      const actualNumberFormat = Intl.NumberFormat;
+      jest.spyOn(Intl, 'NumberFormat').mockImplementation((locale, options) => {
+        // Mobile (Android & IOS do not support currencyDisplay and are unable to use 'narrowSymbol')
+        // We can remove these mocks once this becomes supported.
+        delete options?.currencyDisplay;
+        return actualNumberFormat(locale, options);
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const enLocaleTestCases = [
+      'en',
+      'en-US',
+      'en-GB',
+      'en-CA',
+      'en-AU',
+      'en-NZ',
+    ];
+    it.each(enLocaleTestCases.map((locale) => [locale]))(
+      'returns $24,000.00, never US$ (locale: %s)',
+      (locale) => {
+        mockI18n.locale = locale;
+        const state = mockState();
+        const result = selectAsset(state, {
+          address: '0x0000000000000000000000000000000000000000',
+          chainId: '0x1',
+          isStaked: false,
+        });
+
+        expect(result?.balanceFiat).toBe('$24,000.00');
+        expect(result?.balanceFiat).not.toContain('US$');
+      },
+    );
   });
 });
 

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -35,6 +35,7 @@ import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAsse
 import { selectAllTokens } from '../tokensController';
 import { selectSelectedInternalAccountAddress } from '../accountsController';
 import { selectSelectedInternalAccountByScope } from '../multichainAccounts/accounts';
+import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
 
 /**
  * Structured map of Tron resources for efficient access.
@@ -396,10 +397,15 @@ function assetToToken(
       },
     ),
     balanceFiat: asset.fiat
-      ? formatWithThreshold(asset.fiat.balance, oneHundredths, I18n.locale, {
-          style: 'currency',
-          currency: asset.fiat.currency,
-        })
+      ? formatWithThreshold(
+          asset.fiat.balance,
+          oneHundredths,
+          getLocaleLanguageCode(),
+          {
+            style: 'currency',
+            currency: asset.fiat.currency,
+          },
+        )
       : undefined,
     logo:
       asset.accountType.startsWith('eip155') && asset.isNative


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We are removing the locale territory (e.g. 'en-US', 'en-GB') so we can have a unified currency experience.
Will need to sync with the ramps team who are using these shared utils.

I've also added a small test harness to prevent this regression in the future.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: formatting remove territory for unified formatting

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26428 https://consensyssoftware.atlassian.net/browse/ASSETS-2767

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="441" height="950" alt="Screenshot 2026-02-26 at 10 53 56" src="https://github.com/user-attachments/assets/6229d6f2-f018-4e3f-95cd-2789d85904ae" />


### **After**

<img width="811" height="940" alt="Screenshot 2026-02-26 at 12 08 56" src="https://github.com/user-attachments/assets/78dc2765-4ebf-48d0-853b-eab998ecf5e2" />




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes locale handling for all callers of `useFormatters`, which can affect currency/number formatting across the app; impact is broad but the logic change is small and covered by a new regression test.
> 
> **Overview**
> Forces `useFormatters` to *drop the locale territory* (e.g., `en-US` -> `en`) before creating formatters, to unify currency formatting output.
> 
> Adds a hook test that mocks `I18n.locale` across several English locales and asserts `formatCurrency` for USD uses the `$` prefix (and never `US$`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0cf303a8611a738fda26268abd2ef317a75e2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->