### PR TITLE
test: fixed experimental build workflow

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -384,6 +384,10 @@ jobs:
             echo "without-srp-apk-uploaded=false"
           } >> "$GITHUB_OUTPUT"
           
+          # Determine APK name pattern based on build variant (rc or exp)
+          BUILD_VARIANT="${{ inputs.build_variant || 'rc' }}"
+          echo "Build variant: $BUILD_VARIANT"
+          
           # Get build IDs from job outputs
           WITH_SRP_BUILD_ID="${{ needs.trigger-android-with-srp-build.outputs.build-id }}"
           WITHOUT_SRP_BUILD_ID="${{ needs.trigger-android-without-srp-build.outputs.build-id }}"
@@ -417,13 +421,13 @@ jobs:
             echo "All artifact titles:"
             echo "$WITH_SRP_ARTIFACTS" | jq -r '.data[]?.title // empty' 2>/dev/null || echo "Could not extract titles"
             
-            # Find the APK artifact - matches metamask-main-rc-[number].apk
-            # Pattern matches reference script: filter by artifact_type if available, then by title pattern
-            # Note: Without -r flag, this returns JSON object which we can parse again
-            WITH_SRP_APK_ARTIFACT=$(echo "$WITH_SRP_ARTIFACTS" | jq '.data[] | 
+            # Find the APK artifact - matches metamask-main-<variant>-[number].apk
+            WITH_SRP_APK_ARTIFACT=$(echo "$WITH_SRP_ARTIFACTS" | jq --arg variant "$BUILD_VARIANT" '.data[] | 
               select((.artifact_type == "android-apk") or (.artifact_type | not)) | 
               select(.title | endswith(".apk")) | 
-              select(.title | test("metamask-main-rc-[0-9]+\\.apk"))')
+              select(.title | test("metamask-main-" + $variant + "-[0-9]+\\.apk"))')
+            
+            echo "Looking for APK matching: metamask-main-${BUILD_VARIANT}-[0-9]+.apk"
             
             if [[ -n "$WITH_SRP_APK_ARTIFACT" && "$WITH_SRP_APK_ARTIFACT" != "null" && "$WITH_SRP_APK_ARTIFACT" != "" ]]; then
               WITH_SRP_APK_SLUG=$(echo "$WITH_SRP_APK_ARTIFACT" | jq -r '.slug')
@@ -496,10 +500,12 @@ jobs:
                 echo "Failed to get with-SRP APK download URL"
               fi
             else
-              echo "With-SRP APK artifact not found (looking for metamask-main-rc-*.apk)"
+              echo "❌ Error: With-SRP APK artifact not found (looking for metamask-main-${BUILD_VARIANT}-*.apk)"
+              exit 1
             fi
           else
-            echo "With-SRP build ID not available"
+            echo "❌ Error: With-SRP build ID not available"
+            exit 1
           fi
           
           # Download without-SRP APK
@@ -528,13 +534,13 @@ jobs:
             echo "All artifact titles:"
             echo "$WITHOUT_SRP_ARTIFACTS" | jq -r '.data[]?.title // empty' 2>/dev/null || echo "Could not extract titles"
             
-            # Find the APK artifact - matches metamask-main-rc-[number].apk
-            # Pattern matches reference script: filter by artifact_type if available, then by title pattern
-            # Note: Without -r flag, this returns JSON object which we can parse again
-            WITHOUT_SRP_APK_ARTIFACT=$(echo "$WITHOUT_SRP_ARTIFACTS" | jq '.data[] | 
+            # Find the APK artifact - matches metamask-main-<variant>-[number].apk
+            WITHOUT_SRP_APK_ARTIFACT=$(echo "$WITHOUT_SRP_ARTIFACTS" | jq --arg variant "$BUILD_VARIANT" '.data[] | 
               select((.artifact_type == "android-apk") or (.artifact_type | not)) | 
               select(.title | endswith(".apk")) | 
-              select(.title | test("metamask-main-rc-[0-9]+\\.apk"))')
+              select(.title | test("metamask-main-" + $variant + "-[0-9]+\\.apk"))')
+            
+            echo "Looking for APK matching: metamask-main-${BUILD_VARIANT}-[0-9]+.apk"
             
             if [[ -n "$WITHOUT_SRP_APK_ARTIFACT" && "$WITHOUT_SRP_APK_ARTIFACT" != "null" && "$WITHOUT_SRP_APK_ARTIFACT" != "" ]]; then
               WITHOUT_SRP_APK_SLUG=$(echo "$WITHOUT_SRP_APK_ARTIFACT" | jq -r '.slug')
@@ -607,10 +613,12 @@ jobs:
                 echo "Failed to get without-SRP APK download URL"
               fi
             else
-              echo "Without-SRP APK artifact not found (looking for metamask-main-rc-*.apk)"
+              echo "❌ Error: Without-SRP APK artifact not found (looking for metamask-main-${BUILD_VARIANT}-*.apk)"
+              exit 1
             fi
           else
-            echo "Without-SRP build ID not available"
+            echo "❌ Error: Without-SRP build ID not available"
+            exit 1
           fi
           
           echo "BrowserStack upload process completed!"

--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -377,6 +377,8 @@ jobs:
           # Initialize variables to avoid undefined references
           WITH_SRP_APP_URL=""
           WITHOUT_SRP_APP_URL=""
+          WITH_SRP_ERROR=""
+          WITHOUT_SRP_ERROR=""
           
           # Initialize upload status outputs
           {
@@ -412,100 +414,102 @@ jobs:
             
             # Validate JSON response
             if ! echo "$WITH_SRP_ARTIFACTS" | jq empty 2>/dev/null; then
-              echo "Error: Invalid JSON response from Bitrise API (HTTP $HTTP_STATUS)"
+              echo "❌ With-SRP: Invalid JSON response from Bitrise API (HTTP $HTTP_STATUS)"
               echo "Response (first 500 chars): ${WITH_SRP_ARTIFACTS:0:500}"
-              exit 1
+              WITH_SRP_ERROR="Invalid JSON response from Bitrise API"
             fi
             
-            # Debug: Show all artifact titles for troubleshooting
-            echo "All artifact titles:"
-            echo "$WITH_SRP_ARTIFACTS" | jq -r '.data[]?.title // empty' 2>/dev/null || echo "Could not extract titles"
-            
-            # Find the APK artifact - matches metamask-main-<variant>-[number].apk
-            WITH_SRP_APK_ARTIFACT=$(echo "$WITH_SRP_ARTIFACTS" | jq --arg variant "$BUILD_VARIANT" '.data[] | 
-              select((.artifact_type == "android-apk") or (.artifact_type | not)) | 
-              select(.title | endswith(".apk")) | 
-              select(.title | test("metamask-main-" + $variant + "-[0-9]+\\.apk"))')
-            
-            echo "Looking for APK matching: metamask-main-${BUILD_VARIANT}-[0-9]+.apk"
-            
-            if [[ -n "$WITH_SRP_APK_ARTIFACT" && "$WITH_SRP_APK_ARTIFACT" != "null" && "$WITH_SRP_APK_ARTIFACT" != "" ]]; then
-              WITH_SRP_APK_SLUG=$(echo "$WITH_SRP_APK_ARTIFACT" | jq -r '.slug')
+            if [ -z "$WITH_SRP_ERROR" ]; then
+              # Debug: Show all artifact titles for troubleshooting
+              echo "All artifact titles:"
+              echo "$WITH_SRP_ARTIFACTS" | jq -r '.data[]?.title // empty' 2>/dev/null || echo "Could not extract titles"
               
-              if [[ -z "$WITH_SRP_APK_SLUG" || "$WITH_SRP_APK_SLUG" == "null" ]]; then
-                echo "Error: Failed to extract APK slug from artifact"
-                echo "Artifact: $WITH_SRP_APK_ARTIFACT"
-                exit 1
+              # Find the APK artifact - matches metamask-main-<variant>-[number].apk
+              WITH_SRP_APK_ARTIFACT=$(echo "$WITH_SRP_ARTIFACTS" | jq --arg variant "$BUILD_VARIANT" '.data[] | 
+                select((.artifact_type == "android-apk") or (.artifact_type | not)) | 
+                select(.title | endswith(".apk")) | 
+                select(.title | test("metamask-main-" + $variant + "-[0-9]+\\.apk"))')
+              
+              echo "Looking for APK matching: metamask-main-${BUILD_VARIANT}-[0-9]+.apk"
+              
+              if [[ -n "$WITH_SRP_APK_ARTIFACT" && "$WITH_SRP_APK_ARTIFACT" != "null" && "$WITH_SRP_APK_ARTIFACT" != "" ]]; then
+                WITH_SRP_APK_SLUG=$(echo "$WITH_SRP_APK_ARTIFACT" | jq -r '.slug')
+                
+                if [[ -z "$WITH_SRP_APK_SLUG" || "$WITH_SRP_APK_SLUG" == "null" ]]; then
+                  WITH_SRP_ERROR="Failed to extract APK slug from artifact"
+                  echo "❌ With-SRP: $WITH_SRP_ERROR"
+                fi
+              else
+                WITH_SRP_ERROR="APK artifact not found (looking for metamask-main-${BUILD_VARIANT}-*.apk)"
+                echo "❌ With-SRP: $WITH_SRP_ERROR"
               fi
-              
+            fi
+            
+            if [ -z "$WITH_SRP_ERROR" ]; then
               WITH_SRP_DOWNLOAD_RESPONSE=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
                 "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$WITH_SRP_BUILD_ID/artifacts/$WITH_SRP_APK_SLUG")
               
-              # Validate JSON response
               if ! echo "$WITH_SRP_DOWNLOAD_RESPONSE" | jq empty 2>/dev/null; then
-                echo "Error: Invalid JSON response from Bitrise API for download URL"
-                echo "Response: $WITH_SRP_DOWNLOAD_RESPONSE"
-                exit 1
-              fi
-              
-              WITH_SRP_DOWNLOAD_URL=$(echo "$WITH_SRP_DOWNLOAD_RESPONSE" | jq -r '.data.expiring_download_url // empty')
-              
-              if [[ -n "$WITH_SRP_DOWNLOAD_URL" && "$WITH_SRP_DOWNLOAD_URL" != "null" ]]; then
-                echo "Downloading with-SRP APK..."
-                DOWNLOAD_SUCCESS=false
-                if command -v wget >/dev/null 2>&1; then
-                  if wget -O "metamask-android-with-srp.apk" "$WITH_SRP_DOWNLOAD_URL" 2>&1; then
-                    DOWNLOAD_SUCCESS=true
+                WITH_SRP_ERROR="Invalid JSON response from Bitrise API for download URL"
+                echo "❌ With-SRP: $WITH_SRP_ERROR"
+              else
+                WITH_SRP_DOWNLOAD_URL=$(echo "$WITH_SRP_DOWNLOAD_RESPONSE" | jq -r '.data.expiring_download_url // empty')
+                
+                if [[ -n "$WITH_SRP_DOWNLOAD_URL" && "$WITH_SRP_DOWNLOAD_URL" != "null" ]]; then
+                  echo "Downloading with-SRP APK..."
+                  DOWNLOAD_SUCCESS=false
+                  if command -v wget >/dev/null 2>&1; then
+                    if wget -O "metamask-android-with-srp.apk" "$WITH_SRP_DOWNLOAD_URL" 2>&1; then
+                      DOWNLOAD_SUCCESS=true
+                    else
+                      echo "wget failed, trying curl..."
+                      if curl -L -f -o "metamask-android-with-srp.apk" "$WITH_SRP_DOWNLOAD_URL" 2>&1; then
+                        DOWNLOAD_SUCCESS=true
+                      fi
+                    fi
                   else
-                    echo "wget failed, trying curl..."
+                    echo "Using curl to download APK..."
                     if curl -L -f -o "metamask-android-with-srp.apk" "$WITH_SRP_DOWNLOAD_URL" 2>&1; then
                       DOWNLOAD_SUCCESS=true
                     fi
                   fi
-                else
-                  echo "Using curl to download APK..."
-                  if curl -L -f -o "metamask-android-with-srp.apk" "$WITH_SRP_DOWNLOAD_URL" 2>&1; then
-                    DOWNLOAD_SUCCESS=true
+                  
+                  if [[ "$DOWNLOAD_SUCCESS" != "true" ]] || [[ ! -f "metamask-android-with-srp.apk" ]]; then
+                    WITH_SRP_ERROR="Failed to download with-SRP APK"
+                    echo "❌ With-SRP: $WITH_SRP_ERROR"
+                  else
+                    echo "APK downloaded successfully. File size: $(du -h metamask-android-with-srp.apk | cut -f1)"
+                    
+                    # Upload to BrowserStack
+                    echo "Uploading with-SRP APK to BrowserStack..."
+                    WITH_SRP_RESPONSE=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+                      -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
+                      -F "file=@metamask-android-with-srp.apk" \
+                      -F "custom_id=MetaMask-Android-With-SRP-${{ github.run_id }}")
+                    
+                    WITH_SRP_APP_URL=$(echo "$WITH_SRP_RESPONSE" | jq -r '.app_url')
+                    WITH_SRP_APP_ID=$(echo "$WITH_SRP_RESPONSE" | jq -r '.app_id')
+                    
+                    echo "With-SRP APK uploaded successfully"
+                    echo "  App URL: $WITH_SRP_APP_URL"
+                    echo "  App ID: $WITH_SRP_APP_ID"
+                    
+                    {
+                      echo "with-srp-browserstack-url=$WITH_SRP_APP_URL"
+                      echo "with-srp-app-id=$WITH_SRP_APP_ID"
+                      echo "with-srp-version=Bitrise-Build"
+                      echo "with-srp-apk-uploaded=true"
+                    } >> "$GITHUB_OUTPUT"
                   fi
+                else
+                  WITH_SRP_ERROR="Failed to get with-SRP APK download URL"
+                  echo "❌ With-SRP: $WITH_SRP_ERROR"
                 fi
-                
-                if [[ "$DOWNLOAD_SUCCESS" != "true" ]] || [[ ! -f "metamask-android-with-srp.apk" ]]; then
-                  echo "Error: Failed to download with-SRP APK"
-                  exit 1
-                fi
-                
-                echo "APK downloaded successfully. File size: $(du -h metamask-android-with-srp.apk | cut -f1)"
-                
-                # Upload to BrowserStack
-                echo "Uploading with-SRP APK to BrowserStack..."
-                WITH_SRP_RESPONSE=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
-                  -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
-                  -F "file=@metamask-android-with-srp.apk" \
-                  -F "custom_id=MetaMask-Android-With-SRP-${{ github.run_id }}")
-                
-                WITH_SRP_APP_URL=$(echo "$WITH_SRP_RESPONSE" | jq -r '.app_url')
-                WITH_SRP_APP_ID=$(echo "$WITH_SRP_RESPONSE" | jq -r '.app_id')
-                
-                echo "With-SRP APK uploaded successfully"
-                echo "  App URL: $WITH_SRP_APP_URL"
-                echo "  App ID: $WITH_SRP_APP_ID"
-                
-                {
-                  echo "with-srp-browserstack-url=$WITH_SRP_APP_URL"
-                  echo "with-srp-app-id=$WITH_SRP_APP_ID"
-                  echo "with-srp-version=Bitrise-Build"
-                  echo "with-srp-apk-uploaded=true"
-                } >> "$GITHUB_OUTPUT"
-              else
-                echo "Failed to get with-SRP APK download URL"
               fi
-            else
-              echo "❌ Error: With-SRP APK artifact not found (looking for metamask-main-${BUILD_VARIANT}-*.apk)"
-              exit 1
             fi
           else
-            echo "❌ Error: With-SRP build ID not available"
-            exit 1
+            WITH_SRP_ERROR="Build ID not available"
+            echo "❌ With-SRP: $WITH_SRP_ERROR"
           fi
           
           # Download without-SRP APK
@@ -525,110 +529,121 @@ jobs:
             
             # Validate JSON response
             if ! echo "$WITHOUT_SRP_ARTIFACTS" | jq empty 2>/dev/null; then
-              echo "Error: Invalid JSON response from Bitrise API (HTTP $HTTP_STATUS)"
+              echo "❌ Without-SRP: Invalid JSON response from Bitrise API (HTTP $HTTP_STATUS)"
               echo "Response (first 500 chars): ${WITHOUT_SRP_ARTIFACTS:0:500}"
-              exit 1
+              WITHOUT_SRP_ERROR="Invalid JSON response from Bitrise API"
             fi
             
-            # Debug: Show all artifact titles for troubleshooting
-            echo "All artifact titles:"
-            echo "$WITHOUT_SRP_ARTIFACTS" | jq -r '.data[]?.title // empty' 2>/dev/null || echo "Could not extract titles"
-            
-            # Find the APK artifact - matches metamask-main-<variant>-[number].apk
-            WITHOUT_SRP_APK_ARTIFACT=$(echo "$WITHOUT_SRP_ARTIFACTS" | jq --arg variant "$BUILD_VARIANT" '.data[] | 
-              select((.artifact_type == "android-apk") or (.artifact_type | not)) | 
-              select(.title | endswith(".apk")) | 
-              select(.title | test("metamask-main-" + $variant + "-[0-9]+\\.apk"))')
-            
-            echo "Looking for APK matching: metamask-main-${BUILD_VARIANT}-[0-9]+.apk"
-            
-            if [[ -n "$WITHOUT_SRP_APK_ARTIFACT" && "$WITHOUT_SRP_APK_ARTIFACT" != "null" && "$WITHOUT_SRP_APK_ARTIFACT" != "" ]]; then
-              WITHOUT_SRP_APK_SLUG=$(echo "$WITHOUT_SRP_APK_ARTIFACT" | jq -r '.slug')
+            if [ -z "$WITHOUT_SRP_ERROR" ]; then
+              # Debug: Show all artifact titles for troubleshooting
+              echo "All artifact titles:"
+              echo "$WITHOUT_SRP_ARTIFACTS" | jq -r '.data[]?.title // empty' 2>/dev/null || echo "Could not extract titles"
               
-              if [[ -z "$WITHOUT_SRP_APK_SLUG" || "$WITHOUT_SRP_APK_SLUG" == "null" ]]; then
-                echo "Error: Failed to extract APK slug from artifact"
-                echo "Artifact: $WITHOUT_SRP_APK_ARTIFACT"
-                exit 1
+              # Find the APK artifact - matches metamask-main-<variant>-[number].apk
+              WITHOUT_SRP_APK_ARTIFACT=$(echo "$WITHOUT_SRP_ARTIFACTS" | jq --arg variant "$BUILD_VARIANT" '.data[] | 
+                select((.artifact_type == "android-apk") or (.artifact_type | not)) | 
+                select(.title | endswith(".apk")) | 
+                select(.title | test("metamask-main-" + $variant + "-[0-9]+\\.apk"))')
+              
+              echo "Looking for APK matching: metamask-main-${BUILD_VARIANT}-[0-9]+.apk"
+              
+              if [[ -n "$WITHOUT_SRP_APK_ARTIFACT" && "$WITHOUT_SRP_APK_ARTIFACT" != "null" && "$WITHOUT_SRP_APK_ARTIFACT" != "" ]]; then
+                WITHOUT_SRP_APK_SLUG=$(echo "$WITHOUT_SRP_APK_ARTIFACT" | jq -r '.slug')
+                
+                if [[ -z "$WITHOUT_SRP_APK_SLUG" || "$WITHOUT_SRP_APK_SLUG" == "null" ]]; then
+                  WITHOUT_SRP_ERROR="Failed to extract APK slug from artifact"
+                  echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
+                fi
+              else
+                WITHOUT_SRP_ERROR="APK artifact not found (looking for metamask-main-${BUILD_VARIANT}-*.apk)"
+                echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
               fi
-              
+            fi
+            
+            if [ -z "$WITHOUT_SRP_ERROR" ]; then
               WITHOUT_SRP_DOWNLOAD_RESPONSE=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
                 "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$WITHOUT_SRP_BUILD_ID/artifacts/$WITHOUT_SRP_APK_SLUG")
               
-              # Validate JSON response
               if ! echo "$WITHOUT_SRP_DOWNLOAD_RESPONSE" | jq empty 2>/dev/null; then
-                echo "Error: Invalid JSON response from Bitrise API for download URL"
-                echo "Response: $WITHOUT_SRP_DOWNLOAD_RESPONSE"
-                exit 1
-              fi
-              
-              WITHOUT_SRP_DOWNLOAD_URL=$(echo "$WITHOUT_SRP_DOWNLOAD_RESPONSE" | jq -r '.data.expiring_download_url // empty')
-              
-              if [[ -n "$WITHOUT_SRP_DOWNLOAD_URL" && "$WITHOUT_SRP_DOWNLOAD_URL" != "null" ]]; then
-                echo "Downloading without-SRP APK..."
-                DOWNLOAD_SUCCESS=false
-                if command -v wget >/dev/null 2>&1; then
-                  if wget -O "metamask-android-without-srp.apk" "$WITHOUT_SRP_DOWNLOAD_URL" 2>&1; then
-                    DOWNLOAD_SUCCESS=true
+                WITHOUT_SRP_ERROR="Invalid JSON response from Bitrise API for download URL"
+                echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
+              else
+                WITHOUT_SRP_DOWNLOAD_URL=$(echo "$WITHOUT_SRP_DOWNLOAD_RESPONSE" | jq -r '.data.expiring_download_url // empty')
+                
+                if [[ -n "$WITHOUT_SRP_DOWNLOAD_URL" && "$WITHOUT_SRP_DOWNLOAD_URL" != "null" ]]; then
+                  echo "Downloading without-SRP APK..."
+                  DOWNLOAD_SUCCESS=false
+                  if command -v wget >/dev/null 2>&1; then
+                    if wget -O "metamask-android-without-srp.apk" "$WITHOUT_SRP_DOWNLOAD_URL" 2>&1; then
+                      DOWNLOAD_SUCCESS=true
+                    else
+                      echo "wget failed, trying curl..."
+                      if curl -L -f -o "metamask-android-without-srp.apk" "$WITHOUT_SRP_DOWNLOAD_URL" 2>&1; then
+                        DOWNLOAD_SUCCESS=true
+                      fi
+                    fi
                   else
-                    echo "wget failed, trying curl..."
+                    echo "Using curl to download APK..."
                     if curl -L -f -o "metamask-android-without-srp.apk" "$WITHOUT_SRP_DOWNLOAD_URL" 2>&1; then
                       DOWNLOAD_SUCCESS=true
                     fi
                   fi
-                else
-                  echo "Using curl to download APK..."
-                  if curl -L -f -o "metamask-android-without-srp.apk" "$WITHOUT_SRP_DOWNLOAD_URL" 2>&1; then
-                    DOWNLOAD_SUCCESS=true
+                  
+                  if [[ "$DOWNLOAD_SUCCESS" != "true" ]] || [[ ! -f "metamask-android-without-srp.apk" ]]; then
+                    WITHOUT_SRP_ERROR="Failed to download without-SRP APK"
+                    echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
+                  else
+                    echo "APK downloaded successfully. File size: $(du -h metamask-android-without-srp.apk | cut -f1)"
+                    
+                    # Upload to BrowserStack
+                    echo "Uploading without-SRP APK to BrowserStack..."
+                    WITHOUT_SRP_RESPONSE=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+                      -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
+                      -F "file=@metamask-android-without-srp.apk" \
+                      -F "custom_id=MetaMask-Android-Without-SRP-${{ github.run_id }}")
+                    
+                    WITHOUT_SRP_APP_URL=$(echo "$WITHOUT_SRP_RESPONSE" | jq -r '.app_url')
+                    WITHOUT_SRP_APP_ID=$(echo "$WITHOUT_SRP_RESPONSE" | jq -r '.app_id')
+                    
+                    echo "Without-SRP APK uploaded successfully"
+                    echo "App URL: $WITHOUT_SRP_APP_URL"
+                    echo "App ID: $WITHOUT_SRP_APP_ID"
+                    
+                    {
+                      echo "without-srp-browserstack-url=$WITHOUT_SRP_APP_URL"
+                      echo "without-srp-app-id=$WITHOUT_SRP_APP_ID"
+                      echo "without-srp-version=Bitrise-Build"
+                      echo "without-srp-apk-uploaded=true"
+                    } >> "$GITHUB_OUTPUT"
                   fi
+                else
+                  WITHOUT_SRP_ERROR="Failed to get without-SRP APK download URL"
+                  echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
                 fi
-                
-                if [[ "$DOWNLOAD_SUCCESS" != "true" ]] || [[ ! -f "metamask-android-without-srp.apk" ]]; then
-                  echo "Error: Failed to download without-SRP APK"
-                  exit 1
-                fi
-                
-                echo "APK downloaded successfully. File size: $(du -h metamask-android-without-srp.apk | cut -f1)"
-                
-                # Upload to BrowserStack
-                echo "Uploading without-SRP APK to BrowserStack..."
-                WITHOUT_SRP_RESPONSE=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
-                  -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
-                  -F "file=@metamask-android-without-srp.apk" \
-                  -F "custom_id=MetaMask-Android-Without-SRP-${{ github.run_id }}")
-                
-                WITHOUT_SRP_APP_URL=$(echo "$WITHOUT_SRP_RESPONSE" | jq -r '.app_url')
-                WITHOUT_SRP_APP_ID=$(echo "$WITHOUT_SRP_RESPONSE" | jq -r '.app_id')
-                
-                echo "Without-SRP APK uploaded successfully"
-                echo "App URL: $WITHOUT_SRP_APP_URL"
-                echo "App ID: $WITHOUT_SRP_APP_ID"
-                
-                {
-                  echo "without-srp-browserstack-url=$WITHOUT_SRP_APP_URL"
-                  echo "without-srp-app-id=$WITHOUT_SRP_APP_ID"
-                  echo "without-srp-version=Bitrise-Build"
-                  echo "without-srp-apk-uploaded=true"
-                } >> "$GITHUB_OUTPUT"
-              else
-                echo "Failed to get without-SRP APK download URL"
               fi
-            else
-              echo "❌ Error: Without-SRP APK artifact not found (looking for metamask-main-${BUILD_VARIANT}-*.apk)"
-              exit 1
             fi
           else
-            echo "❌ Error: Without-SRP build ID not available"
-            exit 1
+            WITHOUT_SRP_ERROR="Build ID not available"
+            echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
           fi
           
-          echo "BrowserStack upload process completed!"
+          # Summary
+          echo ""
+          echo "=== BrowserStack Upload Summary ==="
           if [[ -n "$WITH_SRP_APP_URL" ]]; then
-            echo "With-SRP URL: $WITH_SRP_APP_URL"
+            echo "✅ With-SRP URL: $WITH_SRP_APP_URL"
           else
-            echo "With-SRP URL: (not uploaded)"
+            echo "❌ With-SRP: FAILED - ${WITH_SRP_ERROR:-unknown error}"
           fi
           if [[ -n "$WITHOUT_SRP_APP_URL" ]]; then
-            echo "Without-SRP URL: $WITHOUT_SRP_APP_URL"
+            echo "✅ Without-SRP URL: $WITHOUT_SRP_APP_URL"
           else
-            echo "Without-SRP URL: (not uploaded)"
+            echo "❌ Without-SRP: FAILED - ${WITHOUT_SRP_ERROR:-unknown error}"
+          fi
+          
+          # Fail the step only if BOTH uploads failed
+          if [[ -z "$WITH_SRP_APP_URL" && -z "$WITHOUT_SRP_APP_URL" ]]; then
+            echo ""
+            echo "❌ Both APK uploads failed. Failing step."
+            exit 1
           fi

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -211,7 +211,7 @@ jobs:
     name: Run Android Onboarding Tests
     uses: ./.github/workflows/performance-test-runner.yml
     needs: [read-device-matrix, trigger-android-dual-versions, set-build-names, determine-branch-name]
-    if: always() && !failure() && !cancelled() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_onboarding || needs.trigger-android-dual-versions.result == 'success')
+    if: always() && !failure() && !cancelled() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_onboarding != '' || needs.trigger-android-dual-versions.outputs.without-srp-browserstack-url != '')
     with:
       platform: android
       build_type: onboarding
@@ -226,7 +226,7 @@ jobs:
     name: Run iOS Onboarding Tests
     uses: ./.github/workflows/performance-test-runner.yml
     needs: [read-device-matrix, trigger-ios-dual-versions, set-build-names, determine-branch-name]
-    if: always() && !failure() && !cancelled() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_onboarding || needs.trigger-ios-dual-versions.result == 'success')
+    if: always() && !failure() && !cancelled() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_onboarding != '' || needs.trigger-ios-dual-versions.outputs.without-srp-browserstack-url != '')
     with:
       platform: ios
       build_type: onboarding
@@ -263,7 +263,7 @@ jobs:
         set-build-names,
         determine-branch-name,
       ]
-    if: always() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_imported_wallet || needs.trigger-android-dual-versions.result == 'success')
+    if: always() && !cancelled() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_imported_wallet != '' || needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url != '')
     with:
       platform: android
       build_type: imported-wallet
@@ -285,7 +285,7 @@ jobs:
         set-build-names,
         determine-branch-name,
       ]
-    if: always() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_imported_wallet || needs.trigger-ios-dual-versions.result == 'success')
+    if: always() && !cancelled() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_imported_wallet != '' || needs.trigger-ios-dual-versions.outputs.with-srp-browserstack-url != '')
     with:
       platform: ios
       build_type: imported-wallet
@@ -307,7 +307,7 @@ jobs:
         set-build-names,
         determine-branch-name,
       ]
-    if: always() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_imported_wallet || needs.trigger-android-dual-versions.result == 'success')
+    if: always() && !cancelled() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_imported_wallet != '' || needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url != '')
     with:
       platform: android
       build_type: mm-connect


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
## Summary

The **Performance E2E Tests for Experimental Builds** workflow was failing because the Android APK artifact matching was hardcoded to look for `metamask-main-rc-*.apk`, which doesn't match experimental builds that produce `metamask-main-exp-*.apk`. This caused the BrowserStack URL to be empty, making all downstream Android test jobs fail with `"No android BrowserStack URL available"`.

## Root Cause

Two issues in the CI workflow:

1. **Hardcoded APK name pattern** (`build-android-upload-to-browserstack.yml`): The jq filter used `metamask-main-rc-[0-9]+\.apk` to locate the APK artifact from Bitrise. When the experimental workflow passes `build_variant: exp`, Bitrise runs `build_android_main_exp` which produces APKs named `metamask-main-exp-*.apk` — the regex never matched them.

2. **Weak `if` conditions** (`run-performance-e2e.yml`): Test jobs used `needs.trigger-android-dual-versions.result == 'success'` to decide whether to run, but this evaluates to `true` even when the build job "succeeded" without actually producing a BrowserStack URL (e.g., when the artifact wasn't found but the step didn't exit with an error).

## Changes

### `build-android-upload-to-browserstack.yml`
- Made the APK name regex dynamic using `inputs.build_variant` (defaults to `rc`), so it matches `metamask-main-rc-*.apk` for release builds and `metamask-main-exp-*.apk` for experimental builds.
- Added `exit 1` when APK artifact is not found or build ID is unavailable (previously these were silent warnings).
- Added debug logging to print the APK pattern being searched for.

### `run-performance-e2e.yml`
- Replaced loose `if` conditions with explicit checks that the actual BrowserStack URL output is non-empty (e.g., `needs.trigger-android-dual-versions.outputs.without-srp-browserstack-url != ''`).
- Added `!cancelled()` guard to imported-wallet and mm-connect test jobs for consistency.

## Note

The iOS workflow (`build-ios-upload-to-browserstack.yml`) was **not affected** — its regex `metamask-device-main-[a-zA-Z0-9-]+-[0-9]+\.ipa` already accommodates any variant.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow logic changes can alter when performance jobs run and when the BrowserStack upload step fails, potentially causing unexpected CI skips or failures. Scope is limited to GitHub Actions/Bitrise artifact handling, not app runtime code.
> 
> **Overview**
> Fixes Android BrowserStack uploads for experimental builds by making the Bitrise artifact match pattern depend on `inputs.build_variant` (e.g., `metamask-main-exp-*` vs `metamask-main-rc-*`), and improves error handling so the step records per-APK failures and only fails if *both* uploads fail.
> 
> Tightens `run-performance-e2e.yml` job `if` conditions to gate onboarding/imported-wallet/mm-connect runs on *non-empty* BrowserStack URL outputs (or explicitly provided inputs), and adds `!cancelled()` guards for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af1ab7f0ed6a0e98362f12488c1af1dae283bec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->