### PR TITLE
chore(homepage): homepage session summary segment event

### DIFF
--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -17,6 +17,7 @@ import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../UI/Predict/selectors/featureFlags';
 import { selectAssetsDefiPositionsEnabled } from '../../../selectors/featureFlagController/assetsDefiPositions';
 import { HomeSectionNames, HomeSectionName } from './hooks/useHomeViewedEvent';
+import useHomeSessionSummary from './hooks/useHomeSessionSummary';
 
 /**
  * Homepage component - Main view for the redesigned wallet homepage.
@@ -52,6 +53,8 @@ const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
   );
 
   const totalSectionsLoaded = enabledSections.length;
+
+  useHomeSessionSummary({ totalSectionsLoaded });
 
   const getSectionIndex = useCallback(
     (name: HomeSectionName) =>

--- a/app/components/Views/Homepage/context/HomepageScrollContext.ts
+++ b/app/components/Views/Homepage/context/HomepageScrollContext.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react';
+import type { HomeSectionName } from '../hooks/useHomeViewedEvent';
 
 export const HomepageEntryPoints = {
   APP_OPENED: 'app_opened',
@@ -36,6 +37,16 @@ interface HomepageScrollContextValue {
    * this to reset their "has fired" state and re-fire on every visit.
    */
   visitId: number;
+  /**
+   * Called by each section immediately after its section_viewed event fires.
+   * Used to aggregate the total number of distinct sections viewed this visit.
+   */
+  notifySectionViewed: (sectionName: HomeSectionName) => void;
+  /**
+   * Returns the number of distinct sections viewed during the current visit.
+   * Intended for use in the session_summary event fired on blur.
+   */
+  getViewedSectionCount: () => number;
 }
 
 const noop = () => () => {
@@ -48,6 +59,8 @@ const defaultValue: HomepageScrollContextValue = {
   containerScreenY: 0,
   entryPoint: HomepageEntryPoints.APP_OPENED,
   visitId: 0,
+  notifySectionViewed: () => undefined,
+  getViewedSectionCount: () => 0,
 };
 
 export const HomepageScrollContext =

--- a/app/components/Views/Homepage/hooks/useHomeSessionSummary.test.ts
+++ b/app/components/Views/Homepage/hooks/useHomeSessionSummary.test.ts
@@ -1,0 +1,340 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { renderHook, act } from '@testing-library/react-hooks';
+import useHomeSessionSummary from './useHomeSessionSummary';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+
+// --- @react-navigation/native mock ---
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+  typeof useFocusEffect
+>;
+
+// --- Analytics mock ---
+const mockTrackEvent = jest.fn();
+const mockBuild = jest.fn(() => ({ builtEvent: true }));
+const mockAddProperties = jest.fn(() => ({ build: mockBuild }));
+const mockCreateEventBuilder = jest.fn(() => ({
+  addProperties: mockAddProperties,
+}));
+
+jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+// --- Scroll context mock ---
+const HomepageEntryPoints = {
+  APP_OPENED: 'app_opened',
+  HOME_TAB: 'home_tab',
+  NAVIGATED_BACK: 'navigated_back',
+} as const;
+
+let mockGetViewedSectionCount = jest.fn(() => 3);
+let mockNotifySectionViewed = jest.fn();
+
+let mockContextValue = {
+  subscribeToScroll: jest.fn(() => jest.fn()),
+  viewportHeight: 800,
+  containerScreenY: 0,
+  entryPoint: HomepageEntryPoints.APP_OPENED as string,
+  visitId: 1,
+  notifySectionViewed: mockNotifySectionViewed,
+  getViewedSectionCount: mockGetViewedSectionCount,
+};
+
+jest.mock('../context/HomepageScrollContext', () => ({
+  useHomepageScrollContext: () => mockContextValue,
+  HomepageEntryPoints: {
+    APP_OPENED: 'app_opened',
+    HOME_TAB: 'home_tab',
+    NAVIGATED_BACK: 'navigated_back',
+  },
+}));
+
+// --- Helpers ---
+
+/** Type for addProperties(firstArg) so mock.calls is safely indexable after toHaveBeenCalled(). */
+type AddPropertiesCall = [Record<string, unknown>];
+
+/**
+ * Simulate useFocusEffect: call the callback (focus) and return a function
+ * that invokes the cleanup (blur).
+ */
+const setupFocusBlur = () => {
+  let blurCleanup: (() => void) | undefined;
+  mockUseFocusEffect.mockImplementation((callback) => {
+    blurCleanup = (callback as () => (() => void) | undefined)();
+  });
+  return {
+    simulateBlur: () => blurCleanup?.(),
+  };
+};
+
+describe('useHomeSessionSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetViewedSectionCount = jest.fn(() => 3);
+    mockNotifySectionViewed = jest.fn();
+    mockContextValue = {
+      subscribeToScroll: jest.fn(() => jest.fn()),
+      viewportHeight: 800,
+      containerScreenY: 0,
+      entryPoint: HomepageEntryPoints.APP_OPENED,
+      visitId: 1,
+      notifySectionViewed: mockNotifySectionViewed,
+      getViewedSectionCount: mockGetViewedSectionCount,
+    };
+  });
+
+  describe('blur guard — visitId === 0', () => {
+    it('does not fire when visitId is 0 (pre-focus state)', () => {
+      mockContextValue = { ...mockContextValue, visitId: 0 };
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fires on blur only', () => {
+    it('does not fire on focus — only fires when the blur cleanup runs', () => {
+      // Track whether trackEvent is called during focus (render) phase
+      let calledDuringFocus = false;
+      mockUseFocusEffect.mockImplementation((callback) => {
+        // Call the focus callback and check if track was called before blur
+        (callback as () => void)();
+        calledDuringFocus = mockTrackEvent.mock.calls.length > 0;
+      });
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      expect(calledDuringFocus).toBe(false);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
+    it('fires exactly once on blur', () => {
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('event properties', () => {
+    it('uses the HOME_VIEWED MetaMetrics event', () => {
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.HOME_VIEWED,
+      );
+    });
+
+    it('fires with interaction_type: session_summary', () => {
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ interaction_type: 'session_summary' }),
+      );
+    });
+
+    it('fires with location: home', () => {
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ location: 'home' }),
+      );
+    });
+
+    it('uses getViewedSectionCount() for total_sections_viewed', () => {
+      mockGetViewedSectionCount = jest.fn(() => 4);
+      mockContextValue = {
+        ...mockContextValue,
+        getViewedSectionCount: mockGetViewedSectionCount,
+      };
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ total_sections_viewed: 4 }),
+      );
+    });
+
+    it('uses the totalSectionsLoaded prop for total_sections_loaded', () => {
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 3 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ total_sections_loaded: 3 }),
+      );
+    });
+
+    it('uses the entry_point from context', () => {
+      mockContextValue = {
+        ...mockContextValue,
+        entryPoint: HomepageEntryPoints.HOME_TAB,
+      };
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ entry_point: HomepageEntryPoints.HOME_TAB }),
+      );
+    });
+
+    it('includes a non-negative session_time (in seconds)', () => {
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalled();
+      const calls = mockAddProperties.mock
+        .calls as unknown as AddPropertiesCall[];
+      const props = calls[0][0];
+      expect(typeof props.session_time).toBe('number');
+      expect(props.session_time).toBeGreaterThanOrEqual(0);
+    });
+
+    it('passes the built event to trackEvent', () => {
+      const builtEvent = { builtEvent: true };
+      mockBuild.mockReturnValue(builtEvent);
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 5 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(builtEvent);
+    });
+
+    it('fires with all required properties', () => {
+      mockGetViewedSectionCount = jest.fn(() => 2);
+      mockContextValue = {
+        ...mockContextValue,
+        entryPoint: HomepageEntryPoints.NAVIGATED_BACK,
+        getViewedSectionCount: mockGetViewedSectionCount,
+      };
+      const { simulateBlur } = setupFocusBlur();
+
+      renderHook(() => useHomeSessionSummary({ totalSectionsLoaded: 4 }));
+
+      act(() => {
+        simulateBlur();
+      });
+
+      expect(mockAddProperties).toHaveBeenCalled();
+      const calls = mockAddProperties.mock
+        .calls as unknown as AddPropertiesCall[];
+      const props = calls[0][0];
+      expect(props).toMatchObject({
+        interaction_type: 'session_summary',
+        location: 'home',
+        total_sections_viewed: 2,
+        total_sections_loaded: 4,
+        entry_point: HomepageEntryPoints.NAVIGATED_BACK,
+      });
+      expect(typeof props.session_time).toBe('number');
+    });
+  });
+
+  describe('session timer resets on new visit', () => {
+    it('session_time reflects time since most recent visitId change', () => {
+      jest.useFakeTimers();
+
+      const { simulateBlur } = setupFocusBlur();
+      let currentVisitId = 1;
+      mockContextValue = { ...mockContextValue, visitId: currentVisitId };
+
+      const { rerender } = renderHook(() =>
+        useHomeSessionSummary({ totalSectionsLoaded: 5 }),
+      );
+
+      // Advance 10 seconds and blur — first visit
+      jest.advanceTimersByTime(10_000);
+
+      act(() => {
+        simulateBlur();
+      });
+
+      const addPropertiesCalls = mockAddProperties.mock
+        .calls as unknown as AddPropertiesCall[];
+      const firstSessionTime = addPropertiesCalls[0][0].session_time as number;
+      expect(firstSessionTime).toBeGreaterThanOrEqual(10);
+
+      // Simulate new visit: visitId increments
+      currentVisitId = 2;
+      mockContextValue = { ...mockContextValue, visitId: currentVisitId };
+
+      act(() => {
+        rerender();
+      });
+
+      // Only 2 seconds into the new visit before blur
+      jest.advanceTimersByTime(2_000);
+
+      act(() => {
+        simulateBlur();
+      });
+
+      const secondSessionTime = addPropertiesCalls[1][0].session_time as number;
+      // Second visit was only ~2 s, not ~12 s
+      expect(secondSessionTime).toBeLessThan(firstSessionTime);
+      expect(secondSessionTime).toBeGreaterThanOrEqual(2);
+
+      jest.useRealTimers();
+    });
+  });
+});

--- a/app/components/Views/Homepage/hooks/useHomeSessionSummary.ts
+++ b/app/components/Views/Homepage/hooks/useHomeSessionSummary.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { useHomepageScrollContext } from '../context/HomepageScrollContext';
+
+interface UseHomeSessionSummaryParams {
+  totalSectionsLoaded: number;
+}
+
+/**
+ * Fires a `Home Viewed` Segment event with `interaction_type: 'session_summary'`
+ * when the user navigates away from the homepage. Captures:
+ *
+ * - `total_sections_viewed` — distinct sections that reached ≥50% visibility
+ * - `total_sections_loaded` — sections enabled via feature flags
+ * - `entry_point` — how the user arrived (app_opened, home_tab, navigated_back)
+ * - `session_time` — seconds spent on the homepage this visit
+ *
+ * All session state is held in refs — no re-renders occur on scroll or blur.
+ */
+const useHomeSessionSummary = ({
+  totalSectionsLoaded,
+}: UseHomeSessionSummaryParams) => {
+  const { visitId, entryPoint, getViewedSectionCount } =
+    useHomepageScrollContext();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const sessionStartRef = useRef<number>(Date.now());
+
+  // Reset session start time on each new visit (visitId increments on focus).
+  useEffect(() => {
+    sessionStartRef.current = Date.now();
+  }, [visitId]);
+
+  // Stable refs for the blur callback to avoid stale closure issues.
+  const visitIdRef = useRef(visitId);
+  const entryPointRef = useRef(entryPoint);
+  const totalSectionsLoadedRef = useRef(totalSectionsLoaded);
+
+  useEffect(() => {
+    visitIdRef.current = visitId;
+  }, [visitId]);
+  useEffect(() => {
+    entryPointRef.current = entryPoint;
+  }, [entryPoint]);
+  useEffect(() => {
+    totalSectionsLoadedRef.current = totalSectionsLoaded;
+  }, [totalSectionsLoaded]);
+
+  useFocusEffect(
+    useCallback(() => () => {
+        // Blur — user is leaving the homepage. Skip if never actually focused.
+        if (visitIdRef.current === 0) return;
+        const sessionTime = Math.round(
+          (Date.now() - sessionStartRef.current) / 1000,
+        );
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.HOME_VIEWED)
+            .addProperties({
+              interaction_type: 'session_summary',
+              location: 'home',
+              total_sections_viewed: getViewedSectionCount(),
+              total_sections_loaded: totalSectionsLoadedRef.current,
+              entry_point: entryPointRef.current,
+              session_time: sessionTime,
+            })
+            .build(),
+        );
+      }, [trackEvent, createEventBuilder, getViewedSectionCount]),
+  );
+};
+
+export default useHomeSessionSummary;

--- a/app/components/Views/Homepage/hooks/useHomeSessionSummary.ts
+++ b/app/components/Views/Homepage/hooks/useHomeSessionSummary.ts
@@ -49,7 +49,8 @@ const useHomeSessionSummary = ({
   }, [totalSectionsLoaded]);
 
   useFocusEffect(
-    useCallback(() => () => {
+    useCallback(
+      () => () => {
         // Blur — user is leaving the homepage. Skip if never actually focused.
         if (visitIdRef.current === 0) return;
         const sessionTime = Math.round(
@@ -67,7 +68,9 @@ const useHomeSessionSummary = ({
             })
             .build(),
         );
-      }, [trackEvent, createEventBuilder, getViewedSectionCount]),
+      },
+      [trackEvent, createEventBuilder, getViewedSectionCount],
+    ),
   );
 };
 

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
@@ -34,12 +34,16 @@ const HomeEntryPointsValues = {
   NAVIGATED_BACK: 'navigated_back',
 } as const;
 
+const mockNotifySectionViewed = jest.fn();
+
 let mockContextValue = {
   subscribeToScroll: mockSubscribeToScroll,
   viewportHeight: 800,
   containerScreenY: 0,
   entryPoint: HomeEntryPointsValues.APP_OPENED as string,
   visitId: 0,
+  notifySectionViewed: mockNotifySectionViewed,
+  getViewedSectionCount: jest.fn(() => 0),
 };
 
 jest.mock('../context/HomepageScrollContext', () => ({
@@ -86,6 +90,8 @@ describe('useHomeViewedEvent', () => {
       containerScreenY: 0,
       entryPoint: HomeEntryPointsValues.APP_OPENED,
       visitId: 1, // Use 1 as default so "event fires" tests pass; 0 = pre-focus, no fire
+      notifySectionViewed: mockNotifySectionViewed,
+      getViewedSectionCount: jest.fn(() => 0),
     };
   });
 

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
@@ -63,6 +63,7 @@ const useHomeViewedEvent = ({
     containerScreenY,
     entryPoint,
     visitId,
+    notifySectionViewed,
   } = useHomepageScrollContext();
 
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -96,6 +97,7 @@ const useHomeViewedEvent = ({
         })
         .build(),
     );
+    notifySectionViewed(sectionName);
   }, [
     visitId,
     sectionName,
@@ -106,6 +108,7 @@ const useHomeViewedEvent = ({
     entryPoint,
     trackEvent,
     createEventBuilder,
+    notifySectionViewed,
   ]);
 
   // Reset on each homepage visit so the event re-fires.

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -639,6 +639,8 @@ const Wallet = ({
   // Callbacks registered by sections to be notified of scroll events.
   // Using a ref+Set avoids any React state updates (and re-renders) on scroll.
   const scrollSubscribersRef = useRef<Set<() => void>>(new Set());
+  // Tracks which sections have been viewed this visit (reset on each focus).
+  const viewedSectionsRef = useRef<Set<string>>(new Set());
   // ─────────────────────────────────────────────────────────────────────────
 
   const isPerpsFlagEnabled = useSelector(selectPerpsEnabledFlag);
@@ -1392,6 +1394,20 @@ const Wallet = ({
     return () => scrollSubscribersRef.current.delete(cb);
   }, []);
 
+  // Reset viewed sections on each new visit so session summary starts fresh.
+  useEffect(() => {
+    viewedSectionsRef.current.clear();
+  }, [visitId]);
+
+  const notifySectionViewed = useCallback((sectionName: string) => {
+    viewedSectionsRef.current.add(sectionName);
+  }, []);
+
+  const getViewedSectionCount = useCallback(
+    () => viewedSectionsRef.current.size,
+    [],
+  );
+
   const homepageScrollContextValue = useMemo(
     () => ({
       subscribeToScroll,
@@ -1399,8 +1415,18 @@ const Wallet = ({
       containerScreenY,
       entryPoint,
       visitId,
+      notifySectionViewed,
+      getViewedSectionCount,
     }),
-    [subscribeToScroll, viewportHeight, containerScreenY, entryPoint, visitId],
+    [
+      subscribeToScroll,
+      viewportHeight,
+      containerScreenY,
+      entryPoint,
+      visitId,
+      notifySectionViewed,
+      getViewedSectionCount,
+    ],
   );
 
   const content = (


### PR DESCRIPTION
## **Description**

Adds a `session_summary` analytics event that fires when a user navigates away from the homepage. This completes the homepage sections analytics suite alongside the existing `section_viewed` event.

The event reuses the `HOMEPAGE_SECTION_VIEWED` Segment event with `interaction_type: 'session_summary'` and captures:

- `total_sections_viewed`— how many sections reached ≥50% visibility this visit
- `total_sections_loaded` — how many sections were enabled via feature flags
- `entry_point` — how the user arrived (app_opened, home_tab, navigated_back)
- `session_time` — seconds spent on the homepage
location: 'home'

Implementation details:

- New `useHomepageSessionSummary` hook owns all session tracking. All state lives in refs — zero re-renders on scroll or blur path.
- Reacts to visitId increments from `useHomepageEntryPoint` to detect focus and reset per-visit state.
- Fires on navigation blur via a stable ref-wrapped callback to avoid stale closures.
- `notifySectionViewed` added to `HomepageScrollContext` so sections self-report views when their `section_viewed` event fires.

Segment Event PR: https://github.com/Consensys/segment-schema/pull/477

This PR needs to be merged first before review: https://github.com/MetaMask/metamask-mobile/pull/26529

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Homepage session summary analytics

  Scenario: user navigates away from the homepage
    Given the homepage sections feature flag is enabled
    And the user is on the homepage

    When user navigates to another screen (e.g. sends a transaction)
    Then a session_summary event fires with interaction_type "session_summary"
    And session_time reflects time spent on the homepage
    And total_sections_viewed reflects sections that entered the viewport

  Scenario: feature flag is disabled
    Given the homepage sections feature flag is disabled
    When user navigates away from the homepage
    Then no session_summary event is fired
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/573caf7a-3afe-4cee-a1e1-5f447f877bac

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new analytics firing on homepage blur and expands `HomepageScrollContext` contract, which could affect event volume/accuracy if focus/visit tracking is wrong. Runtime risk is limited since it uses refs/sets and doesn’t change wallet transaction or account logic.
> 
> **Overview**
> Adds a new homepage *session summary* analytics emission: `useHomeSessionSummary` fires `MetaMetricsEvents.HOME_VIEWED` with `interaction_type: 'session_summary'` when the homepage blurs, including `session_time`, `entry_point`, `total_sections_loaded`, and `total_sections_viewed`.
> 
> Extends `HomepageScrollContext` with `notifySectionViewed`/`getViewedSectionCount`; `Wallet` now tracks distinct viewed sections per `visitId` in a ref-backed `Set`, and `useHomeViewedEvent` reports section views into this aggregator. Includes new unit tests for the session-summary hook and updates existing section-view tests for the new context fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d91715f6f540153af765b33f7a9d979a94843bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->