### PR TITLE
refactor(predict): migrate usePredictMarket to React Query

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -128,11 +128,11 @@ describe('PredictMarketSportCardWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePredictMarket.mockReturnValue({
-      market: null,
+      data: null,
       isFetching: false,
       error: null,
       refetch: jest.fn(),
-    });
+    } as unknown as ReturnType<typeof usePredictMarket>);
   });
 
   afterEach(() => {
@@ -142,11 +142,11 @@ describe('PredictMarketSportCardWrapper', () => {
   describe('loading state', () => {
     it('returns null when fetching market data', () => {
       mockUsePredictMarket.mockReturnValue({
-        market: null,
+        data: null,
         isFetching: true,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       const { toJSON } = renderWithProvider(
         <PredictMarketSportCardWrapper marketId="test-market-id" />,
@@ -160,11 +160,11 @@ describe('PredictMarketSportCardWrapper', () => {
   describe('error state', () => {
     it('returns null when error occurs', () => {
       mockUsePredictMarket.mockReturnValue({
-        market: null,
+        data: null,
         isFetching: false,
-        error: 'Failed to fetch market',
+        error: new Error('Failed to fetch market'),
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       const { toJSON } = renderWithProvider(
         <PredictMarketSportCardWrapper marketId="test-market-id" />,
@@ -178,11 +178,11 @@ describe('PredictMarketSportCardWrapper', () => {
   describe('no market data', () => {
     it('returns null when market is null', () => {
       mockUsePredictMarket.mockReturnValue({
-        market: null,
+        data: null,
         isFetching: false,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       const { toJSON } = renderWithProvider(
         <PredictMarketSportCardWrapper marketId="test-market-id" />,
@@ -196,11 +196,11 @@ describe('PredictMarketSportCardWrapper', () => {
   describe('successful render', () => {
     beforeEach(() => {
       mockUsePredictMarket.mockReturnValue({
-        market: mockMarket,
+        data: mockMarket,
         isFetching: false,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
     });
 
     it('renders PredictMarketSportCard when market data is available', () => {
@@ -333,11 +333,11 @@ describe('PredictMarketSportCardWrapper', () => {
     it('calls onLoad when market data is available', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
-        market: mockMarket,
+        data: mockMarket,
         isFetching: false,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       renderWithProvider(
         <PredictMarketSportCardWrapper
@@ -353,11 +353,11 @@ describe('PredictMarketSportCardWrapper', () => {
     it('does not call onLoad when fetching', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
-        market: null,
+        data: null,
         isFetching: true,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       renderWithProvider(
         <PredictMarketSportCardWrapper
@@ -373,11 +373,11 @@ describe('PredictMarketSportCardWrapper', () => {
     it('does not call onLoad when error occurs', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
-        market: null,
+        data: null,
         isFetching: false,
-        error: 'Failed to fetch',
+        error: new Error('Failed to fetch'),
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       renderWithProvider(
         <PredictMarketSportCardWrapper
@@ -393,11 +393,11 @@ describe('PredictMarketSportCardWrapper', () => {
     it('does not call onLoad when market is null', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
-        market: null,
+        data: null,
         isFetching: false,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       renderWithProvider(
         <PredictMarketSportCardWrapper
@@ -412,11 +412,11 @@ describe('PredictMarketSportCardWrapper', () => {
 
     it('does not call onLoad when onLoad is not provided', () => {
       mockUsePredictMarket.mockReturnValue({
-        market: mockMarket,
+        data: mockMarket,
         isFetching: false,
         error: null,
         refetch: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof usePredictMarket>);
 
       renderWithProvider(
         <PredictMarketSportCardWrapper marketId="test-market-id" />,

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -129,7 +129,7 @@ describe('PredictMarketSportCardWrapper', () => {
     jest.clearAllMocks();
     mockUsePredictMarket.mockReturnValue({
       data: null,
-      isFetching: false,
+      isLoading: false,
       error: null,
       refetch: jest.fn(),
     } as unknown as ReturnType<typeof usePredictMarket>);
@@ -143,7 +143,7 @@ describe('PredictMarketSportCardWrapper', () => {
     it('returns null when fetching market data', () => {
       mockUsePredictMarket.mockReturnValue({
         data: null,
-        isFetching: true,
+        isLoading: true,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -161,7 +161,7 @@ describe('PredictMarketSportCardWrapper', () => {
     it('returns null when error occurs', () => {
       mockUsePredictMarket.mockReturnValue({
         data: null,
-        isFetching: false,
+        isLoading: false,
         error: new Error('Failed to fetch market'),
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -179,7 +179,7 @@ describe('PredictMarketSportCardWrapper', () => {
     it('returns null when market is null', () => {
       mockUsePredictMarket.mockReturnValue({
         data: null,
-        isFetching: false,
+        isLoading: false,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -197,7 +197,7 @@ describe('PredictMarketSportCardWrapper', () => {
     beforeEach(() => {
       mockUsePredictMarket.mockReturnValue({
         data: mockMarket,
-        isFetching: false,
+        isLoading: false,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -334,7 +334,7 @@ describe('PredictMarketSportCardWrapper', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
         data: mockMarket,
-        isFetching: false,
+        isLoading: false,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -354,7 +354,7 @@ describe('PredictMarketSportCardWrapper', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
         data: null,
-        isFetching: true,
+        isLoading: true,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -374,7 +374,7 @@ describe('PredictMarketSportCardWrapper', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
         data: null,
-        isFetching: false,
+        isLoading: false,
         error: new Error('Failed to fetch'),
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -394,7 +394,7 @@ describe('PredictMarketSportCardWrapper', () => {
       const mockOnLoad = jest.fn();
       mockUsePredictMarket.mockReturnValue({
         data: null,
-        isFetching: false,
+        isLoading: false,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);
@@ -413,7 +413,7 @@ describe('PredictMarketSportCardWrapper', () => {
     it('does not call onLoad when onLoad is not provided', () => {
       mockUsePredictMarket.mockReturnValue({
         data: mockMarket,
-        isFetching: false,
+        isLoading: false,
         error: null,
         refetch: jest.fn(),
       } as unknown as ReturnType<typeof usePredictMarket>);

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -15,7 +15,11 @@ interface PredictMarketSportCardWrapperProps {
 const PredictMarketSportCardWrapper: React.FC<
   PredictMarketSportCardWrapperProps
 > = ({ marketId, testID, entryPoint, onDismiss, onLoad }) => {
-  const { market, isFetching, error } = usePredictMarket({
+  const {
+    data: market,
+    isFetching,
+    error,
+  } = usePredictMarket({
     id: marketId,
     enabled: Boolean(marketId),
   });

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.tsx
@@ -17,7 +17,7 @@ const PredictMarketSportCardWrapper: React.FC<
 > = ({ marketId, testID, entryPoint, onDismiss, onLoad }) => {
   const {
     data: market,
-    isFetching,
+    isLoading,
     error,
   } = usePredictMarket({
     id: marketId,
@@ -26,13 +26,13 @@ const PredictMarketSportCardWrapper: React.FC<
   const hasCalledOnLoad = useRef(false);
 
   useEffect(() => {
-    if (!isFetching && !error && market && onLoad && !hasCalledOnLoad.current) {
+    if (!isLoading && !error && market && onLoad && !hasCalledOnLoad.current) {
       hasCalledOnLoad.current = true;
       onLoad();
     }
-  }, [isFetching, error, market, onLoad]);
+  }, [isLoading, error, market, onLoad]);
 
-  if (isFetching || error || !market) {
+  if (isLoading || error || !market) {
     return null;
   }
 

--- a/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
@@ -14,16 +14,6 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-jest.mock('../../../../util/Logger', () => ({
-  __esModule: true,
-  default: { error: jest.fn() },
-}));
-
-jest.mock('../utils/predictErrorHandler', () => ({
-  ensureError: (err: unknown) =>
-    err instanceof Error ? err : new Error(String(err)),
-}));
-
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -187,8 +177,7 @@ describe('usePredictMarket', () => {
       });
 
       expect(result.current.data).toBeUndefined();
-      expect(result.current.error).toBeInstanceOf(Error);
-      expect(result.current.error?.message).toBe('String error');
+      expect(result.current.error).toBe('String error');
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
@@ -1,87 +1,107 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import Engine from '../../../../core/Engine';
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePredictMarket } from './usePredictMarket';
 import { PredictMarket, Recurrence } from '../types';
-
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
-// Mock dependencies
+
+const mockGetMarket = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
-      getMarket: jest.fn(),
+      getMarket: (...args: unknown[]) => mockGetMarket(...args),
     },
   },
 }));
 
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+jest.mock('../utils/predictErrorHandler', () => ({
+  ensureError: (err: unknown) =>
+    err instanceof Error ? err : new Error(String(err)),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+
+const mockMarket: PredictMarket = {
+  id: 'market-1',
+  providerId: POLYMARKET_PROVIDER_ID,
+  slug: 'bitcoin-price-prediction',
+  title: 'Will Bitcoin reach $200k by end of 2025?',
+  description: 'Bitcoin price prediction market',
+  endDate: '2025-12-31T23:59:59Z',
+  image: 'https://example.com/btc.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'crypto',
+  tags: ['trending'],
+  outcomes: [
+    {
+      id: 'outcome-1',
+      providerId: POLYMARKET_PROVIDER_ID,
+      marketId: 'market-1',
+      title: 'Yes',
+      description: 'Bitcoin will reach $200k',
+      image: '',
+      status: 'open',
+      tokens: [
+        {
+          id: 'token-1',
+          title: 'Yes',
+          price: 0.65,
+        },
+      ],
+      volume: 1000000,
+      groupItemTitle: 'Yes/No',
+    },
+    {
+      id: 'outcome-2',
+      providerId: POLYMARKET_PROVIDER_ID,
+      marketId: 'market-1',
+      title: 'No',
+      description: 'Bitcoin will not reach $200k',
+      image: '',
+      status: 'open',
+      tokens: [
+        {
+          id: 'token-2',
+          title: 'No',
+          price: 0.35,
+        },
+      ],
+      volume: 1000000,
+      groupItemTitle: 'Yes/No',
+    },
+  ],
+  liquidity: 1000000,
+  volume: 1000000,
+};
+
 describe('usePredictMarket', () => {
-  const mockGetMarket = jest.fn();
-
-  const mockMarket: PredictMarket = {
-    id: 'market-1',
-    providerId: POLYMARKET_PROVIDER_ID,
-    slug: 'bitcoin-price-prediction',
-    title: 'Will Bitcoin reach $200k by end of 2025?',
-    description: 'Bitcoin price prediction market',
-    endDate: '2025-12-31T23:59:59Z',
-    image: 'https://example.com/btc.png',
-    status: 'open',
-    recurrence: Recurrence.NONE,
-    category: 'crypto',
-    tags: ['trending'],
-    outcomes: [
-      {
-        id: 'outcome-1',
-        providerId: POLYMARKET_PROVIDER_ID,
-        marketId: 'market-1',
-        title: 'Yes',
-        description: 'Bitcoin will reach $200k',
-        image: '',
-        status: 'open',
-        tokens: [
-          {
-            id: 'token-1',
-            title: 'Yes',
-            price: 0.65,
-          },
-        ],
-        volume: 1000000,
-        groupItemTitle: 'Yes/No',
-      },
-      {
-        id: 'outcome-2',
-        providerId: POLYMARKET_PROVIDER_ID,
-        marketId: 'market-1',
-        title: 'No',
-        description: 'Bitcoin will not reach $200k',
-        image: '',
-        status: 'open',
-        tokens: [
-          {
-            id: 'token-2',
-            title: 'No',
-            price: 0.35,
-          },
-        ],
-        volume: 1000000,
-        groupItemTitle: 'Yes/No',
-      },
-    ],
-    liquidity: 1000000,
-    volume: 1000000,
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
-    (Engine.context.PredictController.getMarket as jest.Mock) = mockGetMarket;
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   describe('initial state', () => {
     it('returns null market and not fetching when no id provided', () => {
-      const { result } = renderHook(() => usePredictMarket());
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => usePredictMarket(), {
+        wrapper: Wrapper,
+      });
 
       expect(result.current.market).toBe(null);
       expect(result.current.isFetching).toBe(false);
@@ -90,7 +110,10 @@ describe('usePredictMarket', () => {
     });
 
     it('returns null market and not fetching when id is undefined', () => {
-      const { result } = renderHook(() => usePredictMarket({ id: undefined }));
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => usePredictMarket({ id: undefined }), {
+        wrapper: Wrapper,
+      });
 
       expect(result.current.market).toBe(null);
       expect(result.current.isFetching).toBe(false);
@@ -98,7 +121,10 @@ describe('usePredictMarket', () => {
     });
 
     it('returns null market and not fetching when id is empty string', () => {
-      const { result } = renderHook(() => usePredictMarket({ id: '' }));
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => usePredictMarket({ id: '' }), {
+        wrapper: Wrapper,
+      });
 
       expect(result.current.market).toBe(null);
       expect(result.current.isFetching).toBe(false);
@@ -108,37 +134,41 @@ describe('usePredictMarket', () => {
 
   describe('successful market fetching', () => {
     it('fetches market data successfully with string id', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
+      const { result } = renderHook(
+        () => usePredictMarket({ id: 'market-1' }),
+        { wrapper: Wrapper },
       );
 
-      // Initially loading
+      // Initially fetching
       expect(result.current.isFetching).toBe(true);
       expect(result.current.market).toBe(null);
       expect(result.current.error).toBe(null);
 
-      // Wait for data to load
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.market).toEqual(mockMarket);
       expect(result.current.error).toBe(null);
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
-        providerId: undefined,
       });
     });
 
     it('fetches market data successfully with number id', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 123 }),
-      );
+      const { result } = renderHook(() => usePredictMarket({ id: 123 }), {
+        wrapper: Wrapper,
+      });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(result.current.market).toEqual(mockMarket);
       expect(mockGetMarket).toHaveBeenCalledWith({
@@ -146,31 +176,19 @@ describe('usePredictMarket', () => {
       });
     });
 
-    it('fetches market data with string id', async () => {
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
-      );
-
-      await waitForNextUpdate();
-
-      expect(result.current.market).toEqual(mockMarket);
-      expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: 'market-1',
-      });
-    });
-
     it('handles null market response', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(null);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
+      const { result } = renderHook(
+        () => usePredictMarket({ id: 'market-1' }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.market).toBe(null);
       expect(result.current.error).toBe(null);
     });
@@ -178,53 +196,64 @@ describe('usePredictMarket', () => {
 
   describe('error handling', () => {
     it('handles API error with Error instance', async () => {
+      const { Wrapper } = createWrapper();
       const errorMessage = 'Network error occurred';
       mockGetMarket.mockRejectedValue(new Error(errorMessage));
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
+      const { result } = renderHook(
+        () => usePredictMarket({ id: 'market-1' }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.market).toBe(null);
       expect(result.current.error).toBe(errorMessage);
     });
 
     it('handles API error with non-Error instance', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockRejectedValue('String error');
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
+      const { result } = renderHook(
+        () => usePredictMarket({ id: 'market-1' }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.market).toBe(null);
-      expect(result.current.error).toBe('Failed to fetch market');
+      expect(result.current.error).toBe('String error');
     });
   });
 
   describe('enabled option', () => {
     it('does not fetch when enabled is false', () => {
-      renderHook(() => usePredictMarket({ id: 'market-1', enabled: false }));
+      const { Wrapper } = createWrapper();
+      renderHook(() => usePredictMarket({ id: 'market-1', enabled: false }), {
+        wrapper: Wrapper,
+      });
 
       expect(mockGetMarket).not.toHaveBeenCalled();
     });
 
     it('clears state when disabled after being enabled', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { result, rerender, waitForNextUpdate } = renderHook(
-        ({ enabled }) => usePredictMarket({ id: 'market-1', enabled }),
-        { initialProps: { enabled: true } },
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          usePredictMarket({ id: 'market-1', enabled }),
+        { wrapper: Wrapper, initialProps: { enabled: true } },
       );
 
-      await waitForNextUpdate();
-
-      expect(result.current.market).toEqual(mockMarket);
+      await waitFor(() => {
+        expect(result.current.market).toEqual(mockMarket);
+      });
 
       // Disable the hook
       rerender({ enabled: false });
@@ -235,11 +264,13 @@ describe('usePredictMarket', () => {
     });
 
     it('fetches when enabled changes from false to true', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { result, rerender, waitForNextUpdate } = renderHook(
-        ({ enabled }) => usePredictMarket({ id: 'market-1', enabled }),
-        { initialProps: { enabled: false } },
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          usePredictMarket({ id: 'market-1', enabled }),
+        { wrapper: Wrapper, initialProps: { enabled: false } },
       );
 
       expect(mockGetMarket).not.toHaveBeenCalled();
@@ -247,7 +278,9 @@ describe('usePredictMarket', () => {
       // Enable the hook
       rerender({ enabled: true });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(result.current.market).toEqual(mockMarket);
       expect(mockGetMarket).toHaveBeenCalledWith({
@@ -258,13 +291,17 @@ describe('usePredictMarket', () => {
 
   describe('refetch functionality', () => {
     it('refetches data when calling refetch', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
+      const { result } = renderHook(
+        () => usePredictMarket({ id: 'market-1' }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(mockGetMarket).toHaveBeenCalledTimes(1);
 
@@ -276,44 +313,46 @@ describe('usePredictMarket', () => {
       expect(mockGetMarket).toHaveBeenCalledTimes(2);
     });
 
-    it('maintains stable refetch function reference', () => {
+    it('maintains a callable refetch function across rerenders', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { result, rerender } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
+      const { result, rerender } = renderHook(
+        () => usePredictMarket({ id: 'market-1' }),
+        { wrapper: Wrapper },
       );
 
-      const firstRefetch = result.current.refetch;
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       // Trigger a re-render
-      rerender();
+      rerender({});
 
-      expect(result.current.refetch).toBe(firstRefetch);
-    });
+      expect(typeof result.current.refetch).toBe('function');
 
-    it('does not refetch when disabled', async () => {
-      const { result } = renderHook(() =>
-        usePredictMarket({ id: 'market-1', enabled: false }),
-      );
-
+      // Ensure refetch still works after rerender
       await act(async () => {
         await result.current.refetch();
       });
 
-      expect(mockGetMarket).not.toHaveBeenCalled();
+      expect(mockGetMarket).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('dependency changes', () => {
     it('refetches when id changes', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { rerender, waitForNextUpdate } = renderHook(
-        ({ id }) => usePredictMarket({ id }),
-        { initialProps: { id: 'market-1' } },
+      const { result, rerender } = renderHook(
+        ({ id }: { id: string }) => usePredictMarket({ id }),
+        { wrapper: Wrapper, initialProps: { id: 'market-1' } },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
@@ -322,32 +361,9 @@ describe('usePredictMarket', () => {
       // Change id
       rerender({ id: 'market-2' });
 
-      await waitForNextUpdate();
-
-      expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: 'market-2',
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
       });
-      expect(mockGetMarket).toHaveBeenCalledTimes(2);
-    });
-
-    it('refetches when id changes across rerenders', async () => {
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { rerender, waitForNextUpdate } = renderHook(
-        ({ id }) => usePredictMarket({ id }),
-        { initialProps: { id: 'market-1' } },
-      );
-
-      await waitForNextUpdate();
-
-      expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: 'market-1',
-      });
-
-      // Change id
-      rerender({ id: 'market-2' });
-
-      await waitForNextUpdate();
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-2',
@@ -356,119 +372,24 @@ describe('usePredictMarket', () => {
     });
   });
 
-  describe('component unmounting', () => {
-    it('does not update state after component unmounts', async () => {
-      mockGetMarket.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            setTimeout(() => resolve(mockMarket), 100);
-          }),
-      );
-
-      const { result, unmount } = renderHook(() =>
-        usePredictMarket({ id: 'market-1' }),
-      );
-
-      // Start the fetch
-      expect(result.current.isFetching).toBe(true);
-
-      // Unmount before fetch completes
-      unmount();
-
-      // Wait for the promise to resolve
-      await new Promise((resolve) => setTimeout(resolve, 150));
-
-      // The hook should not have updated state after unmount
-      // We can't test this directly since the hook is unmounted,
-      // but we can verify the mock was called
-      expect(mockGetMarket).toHaveBeenCalled();
-    });
-  });
-
-  describe('edge cases', () => {
-    it('handles id conversion from number to string', async () => {
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: 0 }),
-      );
-
-      await waitForNextUpdate();
-
-      expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: '0',
-      });
-    });
-
-    it('handles id conversion from negative number to string', async () => {
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({ id: -1 }),
-      );
-
-      await waitForNextUpdate();
-
-      expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: '-1',
-      });
-    });
-
-    it('handles multiple rapid id changes', async () => {
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { rerender } = renderHook(({ id }) => usePredictMarket({ id }), {
-        initialProps: { id: 'market-1' },
-      });
-
-      // Rapidly change id multiple times
-      rerender({ id: 'market-2' });
-      rerender({ id: 'market-3' });
-      rerender({ id: 'market-4' });
-
-      // Wait for all promises to settle
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      // Should have been called for each change
-      expect(mockGetMarket).toHaveBeenCalledTimes(4);
-    });
-  });
-
-  describe('integration with controller', () => {
+  describe('integration', () => {
     it('calls getMarket with correct parameters', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarket.mockResolvedValue(mockMarket);
 
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictMarket({
-          id: 'test-market-id',
-        }),
+      const { result } = renderHook(
+        () => usePredictMarket({ id: 'test-market-id' }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'test-market-id',
       });
       expect(mockGetMarket).toHaveBeenCalledTimes(1);
-    });
-
-    it('handles controller method throwing synchronously', async () => {
-      mockGetMarket.mockImplementation(() => {
-        throw new Error('Synchronous error');
-      });
-
-      const { result } = renderHook(() => usePredictMarket({ id: 'market-1' }));
-
-      // Wait a bit for the error to be processed
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      expect(result.current.isFetching).toBe(false);
-      expect(result.current.market).toBe(null);
-      expect(result.current.error).toBe('Synchronous error');
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.test.tsx
@@ -97,36 +97,13 @@ describe('usePredictMarket', () => {
   });
 
   describe('initial state', () => {
-    it('returns null market and not fetching when no id provided', () => {
-      const { Wrapper } = createWrapper();
-      const { result } = renderHook(() => usePredictMarket(), {
-        wrapper: Wrapper,
-      });
-
-      expect(result.current.market).toBe(null);
-      expect(result.current.isFetching).toBe(false);
-      expect(result.current.error).toBe(null);
-      expect(typeof result.current.refetch).toBe('function');
-    });
-
-    it('returns null market and not fetching when id is undefined', () => {
-      const { Wrapper } = createWrapper();
-      const { result } = renderHook(() => usePredictMarket({ id: undefined }), {
-        wrapper: Wrapper,
-      });
-
-      expect(result.current.market).toBe(null);
-      expect(result.current.isFetching).toBe(false);
-      expect(result.current.error).toBe(null);
-    });
-
-    it('returns null market and not fetching when id is empty string', () => {
+    it('does not fetch when id is empty string', () => {
       const { Wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictMarket({ id: '' }), {
         wrapper: Wrapper,
       });
 
-      expect(result.current.market).toBe(null);
+      expect(result.current.data).toBeUndefined();
       expect(result.current.isFetching).toBe(false);
       expect(result.current.error).toBe(null);
     });
@@ -144,35 +121,17 @@ describe('usePredictMarket', () => {
 
       // Initially fetching
       expect(result.current.isFetching).toBe(true);
-      expect(result.current.market).toBe(null);
+      expect(result.current.data).toBeUndefined();
       expect(result.current.error).toBe(null);
 
       await waitFor(() => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(result.current.market).toEqual(mockMarket);
+      expect(result.current.data).toEqual(mockMarket);
       expect(result.current.error).toBe(null);
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
-      });
-    });
-
-    it('fetches market data successfully with number id', async () => {
-      const { Wrapper } = createWrapper();
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { result } = renderHook(() => usePredictMarket({ id: 123 }), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isFetching).toBe(false);
-      });
-
-      expect(result.current.market).toEqual(mockMarket);
-      expect(mockGetMarket).toHaveBeenCalledWith({
-        marketId: '123',
       });
     });
 
@@ -189,7 +148,7 @@ describe('usePredictMarket', () => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(result.current.market).toBe(null);
+      expect(result.current.data).toBe(null);
       expect(result.current.error).toBe(null);
     });
   });
@@ -209,8 +168,9 @@ describe('usePredictMarket', () => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(result.current.market).toBe(null);
-      expect(result.current.error).toBe(errorMessage);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe(errorMessage);
     });
 
     it('handles API error with non-Error instance', async () => {
@@ -226,8 +186,9 @@ describe('usePredictMarket', () => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(result.current.market).toBe(null);
-      expect(result.current.error).toBe('String error');
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('String error');
     });
   });
 
@@ -239,28 +200,6 @@ describe('usePredictMarket', () => {
       });
 
       expect(mockGetMarket).not.toHaveBeenCalled();
-    });
-
-    it('clears state when disabled after being enabled', async () => {
-      const { Wrapper } = createWrapper();
-      mockGetMarket.mockResolvedValue(mockMarket);
-
-      const { result, rerender } = renderHook(
-        ({ enabled }: { enabled: boolean }) =>
-          usePredictMarket({ id: 'market-1', enabled }),
-        { wrapper: Wrapper, initialProps: { enabled: true } },
-      );
-
-      await waitFor(() => {
-        expect(result.current.market).toEqual(mockMarket);
-      });
-
-      // Disable the hook
-      rerender({ enabled: false });
-
-      expect(result.current.market).toBe(null);
-      expect(result.current.error).toBe(null);
-      expect(result.current.isFetching).toBe(false);
     });
 
     it('fetches when enabled changes from false to true', async () => {
@@ -282,7 +221,7 @@ describe('usePredictMarket', () => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(result.current.market).toEqual(mockMarket);
+      expect(result.current.data).toEqual(mockMarket);
       expect(mockGetMarket).toHaveBeenCalledWith({
         marketId: 'market-1',
       });

--- a/app/components/UI/Predict/hooks/usePredictMarket.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.tsx
@@ -1,8 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import Engine from '../../../../core/Engine';
-import Logger from '../../../../util/Logger';
-import { PREDICT_CONSTANTS } from '../constants/errors';
-import { ensureError } from '../utils/predictErrorHandler';
+import { useQuery } from '@tanstack/react-query';
+import { predictQueries } from '../queries';
 import { PredictMarket } from '../types';
 
 export interface UsePredictMarketOptions {
@@ -18,109 +15,30 @@ export interface UsePredictMarketResult {
 }
 
 /**
- * Hook to fetch detailed Predict market information
+ * Hook to fetch detailed Predict market information.
+ *
+ * Backed by React Query — results are cached, deduplicated, and
+ * automatically revalidated on stale-while-revalidate semantics.
  */
 export const usePredictMarket = (
   options: UsePredictMarketOptions = {},
 ): UsePredictMarketResult => {
   const { id, enabled = true } = options;
-  const [market, setMarket] = useState<PredictMarket | null>(null);
-  const [isFetching, setIsFetching] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const marketId = id !== undefined && id !== null ? String(id) : '';
 
-  const isMountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
-    },
-    [],
-  );
+  const isEnabled = enabled && !!marketId;
 
-  useEffect(() => {
-    if (!enabled && isMountedRef.current) {
-      setMarket(null);
-      setError(null);
-      setIsFetching(false);
-    }
-  }, [enabled]);
-
-  const fetchMarket = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
-
-    const marketId = id !== undefined && id !== null ? String(id) : '';
-    if (!marketId) {
-      if (isMountedRef.current) {
-        setMarket(null);
-        setError(null);
-        setIsFetching(false);
-      }
-      return;
-    }
-
-    if (isMountedRef.current) {
-      setIsFetching(true);
-      setError(null);
-    }
-
-    try {
-      if (!Engine || !Engine.context) {
-        throw new Error('Engine not initialized');
-      }
-
-      const controller = Engine.context.PredictController;
-      if (!controller) {
-        throw new Error('Predict controller not available');
-      }
-
-      const marketData = await controller.getMarket({
-        marketId,
-      });
-
-      if (isMountedRef.current) {
-        setMarket(marketData ?? null);
-      }
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Failed to fetch market';
-
-      // Capture exception with market loading context
-      Logger.error(ensureError(err), {
-        tags: {
-          feature: PREDICT_CONSTANTS.FEATURE_NAME,
-          component: 'usePredictMarket',
-        },
-        context: {
-          name: 'usePredictMarket',
-          data: {
-            method: 'loadMarket',
-            action: 'market_load',
-            operation: 'data_fetching',
-            marketId: id,
-          },
-        },
-      });
-
-      if (isMountedRef.current) {
-        setError(errorMessage);
-        setMarket(null);
-      }
-    } finally {
-      if (isMountedRef.current) {
-        setIsFetching(false);
-      }
-    }
-  }, [enabled, id]);
-
-  useEffect(() => {
-    fetchMarket();
-  }, [fetchMarket]);
+  const { data, isFetching, error, refetch } = useQuery({
+    ...predictQueries.market.options({ marketId }),
+    enabled: isEnabled,
+  });
 
   return {
-    market,
+    market: isEnabled ? (data ?? null) : null,
     isFetching,
-    error,
-    refetch: fetchMarket,
+    error: isEnabled ? (error?.message ?? null) : null,
+    refetch: async () => {
+      await refetch();
+    },
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictMarket.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.tsx
@@ -1,18 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { predictQueries } from '../queries';
-import { PredictMarket } from '../types';
-
-export interface UsePredictMarketOptions {
-  id?: string | number;
-  enabled?: boolean;
-}
-
-export interface UsePredictMarketResult {
-  market: PredictMarket | null;
-  isFetching: boolean;
-  error: string | null;
-  refetch: () => Promise<void>;
-}
 
 /**
  * Hook to fetch detailed Predict market information.
@@ -20,25 +7,14 @@ export interface UsePredictMarketResult {
  * Backed by React Query — results are cached, deduplicated, and
  * automatically revalidated on stale-while-revalidate semantics.
  */
-export const usePredictMarket = (
-  options: UsePredictMarketOptions = {},
-): UsePredictMarketResult => {
-  const { id, enabled = true } = options;
-  const marketId = id !== undefined && id !== null ? String(id) : '';
-
-  const isEnabled = enabled && !!marketId;
-
-  const { data, isFetching, error, refetch } = useQuery({
-    ...predictQueries.market.options({ marketId }),
-    enabled: isEnabled,
+export const usePredictMarket = ({
+  id,
+  enabled = true,
+}: {
+  id: string;
+  enabled?: boolean;
+}) =>
+  useQuery({
+    ...predictQueries.market.options({ marketId: id }),
+    enabled: enabled && !!id,
   });
-
-  return {
-    market: isEnabled ? (data ?? null) : null,
-    isFetching,
-    error: isEnabled ? (error?.message ?? null) : null,
-    refetch: async () => {
-      await refetch();
-    },
-  };
-};

--- a/app/components/UI/Predict/hooks/usePredictMarket.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarket.tsx
@@ -1,4 +1,8 @@
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import Logger from '../../../../util/Logger';
+import { PREDICT_CONSTANTS } from '../constants/errors';
+import { ensureError } from '../utils/predictErrorHandler';
 import { predictQueries } from '../queries';
 
 /**
@@ -13,8 +17,31 @@ export const usePredictMarket = ({
 }: {
   id: string;
   enabled?: boolean;
-}) =>
-  useQuery({
+}) => {
+  const queryResult = useQuery({
     ...predictQueries.market.options({ marketId: id }),
     enabled: enabled && !!id,
   });
+
+  useEffect(() => {
+    if (!queryResult.error) return;
+
+    Logger.error(ensureError(queryResult.error), {
+      tags: {
+        feature: PREDICT_CONSTANTS.FEATURE_NAME,
+        component: 'usePredictMarket',
+      },
+      context: {
+        name: 'usePredictMarket',
+        data: {
+          method: 'queryFn',
+          action: 'market_load',
+          operation: 'data_fetching',
+          marketId: id,
+        },
+      },
+    });
+  }, [queryResult.error, id]);
+
+  return queryResult;
+};

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,5 +1,6 @@
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
+import { predictMarketKeys, predictMarketOptions } from './market';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
 
 export const predictQueries = {
@@ -10,6 +11,10 @@ export const predictQueries = {
   balance: {
     keys: predictBalanceKeys,
     options: predictBalanceOptions,
+  },
+  market: {
+    keys: predictMarketKeys,
+    options: predictMarketOptions,
   },
   positions: {
     keys: predictPositionsKeys,

--- a/app/components/UI/Predict/queries/market.ts
+++ b/app/components/UI/Predict/queries/market.ts
@@ -1,0 +1,47 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { PREDICT_CONSTANTS } from '../constants/errors';
+import { ensureError } from '../utils/predictErrorHandler';
+import type { PredictMarket } from '../types';
+
+/**
+ * Query key factory for Predict single-market queries.
+ *
+ * - `all()` — prefix key for invalidating every market entry at once.
+ * - `detail(marketId)` — unique key for a specific market.
+ */
+export const predictMarketKeys = {
+  all: () => ['predict', 'market'] as const,
+  detail: (marketId: string) => [...predictMarketKeys.all(), marketId] as const,
+};
+
+export const predictMarketOptions = ({ marketId }: { marketId: string }) =>
+  queryOptions({
+    queryKey: predictMarketKeys.detail(marketId),
+    queryFn: async (): Promise<PredictMarket | null> => {
+      try {
+        const controller = Engine.context.PredictController;
+        const marketData = await controller.getMarket({ marketId });
+        return marketData ?? null;
+      } catch (err) {
+        Logger.error(ensureError(err), {
+          tags: {
+            feature: PREDICT_CONSTANTS.FEATURE_NAME,
+            component: 'usePredictMarket',
+          },
+          context: {
+            name: 'usePredictMarket',
+            data: {
+              method: 'loadMarket',
+              action: 'market_load',
+              operation: 'data_fetching',
+              marketId,
+            },
+          },
+        });
+        throw ensureError(err);
+      }
+    },
+    staleTime: 10_000,
+  });

--- a/app/components/UI/Predict/queries/market.ts
+++ b/app/components/UI/Predict/queries/market.ts
@@ -1,8 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
-import Logger from '../../../../util/Logger';
-import { PREDICT_CONSTANTS } from '../constants/errors';
-import { ensureError } from '../utils/predictErrorHandler';
 import type { PredictMarket } from '../types';
 
 /**
@@ -20,28 +17,9 @@ export const predictMarketOptions = ({ marketId }: { marketId: string }) =>
   queryOptions({
     queryKey: predictMarketKeys.detail(marketId),
     queryFn: async (): Promise<PredictMarket | null> => {
-      try {
-        const controller = Engine.context.PredictController;
-        const marketData = await controller.getMarket({ marketId });
-        return marketData ?? null;
-      } catch (err) {
-        Logger.error(ensureError(err), {
-          tags: {
-            feature: PREDICT_CONSTANTS.FEATURE_NAME,
-            component: 'usePredictMarket',
-          },
-          context: {
-            name: 'usePredictMarket',
-            data: {
-              method: 'loadMarket',
-              action: 'market_load',
-              operation: 'data_fetching',
-              marketId,
-            },
-          },
-        });
-        throw ensureError(err);
-      }
+      const controller = Engine.context.PredictController;
+      const marketData = await controller.getMarket({ marketId });
+      return marketData ?? null;
     },
     staleTime: 10_000,
   });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -169,6 +169,7 @@ jest.mock('../../utils/format', () => ({
 jest.mock('../../hooks/usePredictMarket', () => ({
   usePredictMarket: jest.fn(() => ({
     data: null,
+    isLoading: false,
     isFetching: false,
     refetch: jest.fn(),
   })),
@@ -502,6 +503,7 @@ function setupPredictMarketDetailsTest(
 
   usePredictMarket.mockReturnValue({
     data: mockMarket,
+    isLoading: false,
     isFetching: false,
     refetch: jest.fn(),
     ...hookOverrides.market,
@@ -669,7 +671,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(
         {},
         {},
-        { market: { isFetching: true, data: null } },
+        { market: { isLoading: true, isFetching: true, data: null } },
       );
 
       // Check that skeleton loaders appear
@@ -719,7 +721,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(
         {},
         {},
-        { market: { isFetching: true, data: null } },
+        { market: { isLoading: true, isFetching: true, data: null } },
       );
 
       expect(
@@ -3389,6 +3391,7 @@ describe('PredictMarketDetails', () => {
 
       usePredictMarket.mockReturnValue({
         data: marketWithoutMiddleEastTag,
+        isLoading: false,
         isFetching: false,
         refetch: jest.fn(),
       });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -168,7 +168,7 @@ jest.mock('../../utils/format', () => ({
 
 jest.mock('../../hooks/usePredictMarket', () => ({
   usePredictMarket: jest.fn(() => ({
-    market: null,
+    data: null,
     isFetching: false,
     refetch: jest.fn(),
   })),
@@ -501,7 +501,7 @@ function setupPredictMarketDetailsTest(
   });
 
   usePredictMarket.mockReturnValue({
-    market: mockMarket,
+    data: mockMarket,
     isFetching: false,
     refetch: jest.fn(),
     ...hookOverrides.market,
@@ -669,7 +669,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(
         {},
         {},
-        { market: { isFetching: true, market: null } },
+        { market: { isFetching: true, data: null } },
       );
 
       // Check that skeleton loaders appear
@@ -685,7 +685,7 @@ describe('PredictMarketDetails', () => {
     });
 
     it('displays fallback title when market data is unavailable', () => {
-      setupPredictMarketDetailsTest({}, {}, { market: { market: null } });
+      setupPredictMarketDetailsTest({}, {}, { market: { data: null } });
 
       // Screen renders without a title; other sections may still show loading keys
       expect(
@@ -719,7 +719,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(
         {},
         {},
-        { market: { isFetching: true, market: null } },
+        { market: { isFetching: true, data: null } },
       );
 
       expect(
@@ -756,7 +756,9 @@ describe('PredictMarketDetails', () => {
       expect(
         screen.getByText('predict.market_details.end_date'),
       ).toBeOnTheScreen();
-      expect(screen.getByText('12/31/2024')).toBeOnTheScreen();
+      expect(
+        screen.getByText(new Date('2024-12-31T23:59:59Z').toLocaleDateString()),
+      ).toBeOnTheScreen();
     });
 
     it('displays resolution details information', () => {
@@ -3386,7 +3388,7 @@ describe('PredictMarketDetails', () => {
       });
 
       usePredictMarket.mockReturnValue({
-        market: marketWithoutMiddleEastTag,
+        data: marketWithoutMiddleEastTag,
         isFetching: false,
         refetch: jest.fn(),
       });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -75,6 +75,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
   const {
     data: market,
+    isLoading: isMarketLoading,
     isFetching: isMarketFetching,
     refetch: refetchMarket,
   } = usePredictMarket({
@@ -95,11 +96,11 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
   // calculate sticky header indices based on content structure
   const stickyHeaderIndices = useMemo(() => {
-    if (isMarketFetching && !market) {
+    if (isMarketLoading) {
       return [];
     }
     return [1];
-  }, [isMarketFetching, market]);
+  }, [isMarketLoading]);
 
   const titleLineCount = useMemo(
     () => estimateLineCount(title ?? market?.title),
@@ -114,7 +115,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   } = usePredictPositions({
     marketId: resolvedMarketId,
     claimable: false,
-    enabled: !isMarketFetching && Boolean(resolvedMarketId),
+    enabled: !isMarketLoading && Boolean(resolvedMarketId),
   });
 
   // "claimable" positions
@@ -125,7 +126,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   } = usePredictPositions({
     marketId: resolvedMarketId,
     claimable: true,
-    enabled: !isMarketFetching && Boolean(resolvedMarketId),
+    enabled: !isMarketLoading && Boolean(resolvedMarketId),
   });
 
   // check if market has fee exemption (note: worth moveing to a const or util at some point))
@@ -134,10 +135,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   // Tabs become ready when both market and positions queries have resolved
   const tabsReady = useMemo(
     () =>
-      !isMarketFetching &&
+      !isMarketLoading &&
       !isActivePositionsLoading &&
       !isClaimablePositionsLoading,
-    [isMarketFetching, isActivePositionsLoading, isClaimablePositionsLoading],
+    [isMarketLoading, isActivePositionsLoading, isClaimablePositionsLoading],
   );
 
   const {
@@ -165,7 +166,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
   const { closedOutcomes, openOutcomes, yesPercentage } = useOpenOutcomes({
     market,
-    isMarketFetching,
+    isMarketFetching: isMarketLoading,
   });
 
   const handleBackPress = () => {
@@ -356,7 +357,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     >
       <Box twClassName="px-3 gap-4">
         <PredictMarketDetailsHeader
-          isLoading={isMarketFetching && !market}
+          isLoading={isMarketLoading}
           market={market}
           title={title}
           image={image}
@@ -403,7 +404,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         </Box>
 
         {/* Show content skeleton while initial market data is fetching */}
-        {isMarketFetching && !market ? (
+        {isMarketLoading ? (
           <Box twClassName="px-3">
             <PredictDetailsContentSkeleton />
           </Box>
@@ -417,7 +418,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         )}
 
         {/* Tab content - only show when market is loaded */}
-        {!isMarketFetching && market && (
+        {!isMarketLoading && market && (
           <PredictMarketDetailsTabContent
             activeTab={activeTab}
             tabsReady={tabsReady}

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -74,7 +74,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   });
 
   const {
-    data: market,
+    data: marketData,
     isLoading: isMarketLoading,
     isFetching: isMarketFetching,
     refetch: refetchMarket,
@@ -82,6 +82,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     id: resolvedMarketId ?? '',
     enabled: Boolean(resolvedMarketId),
   });
+  const market = marketData ?? null;
 
   // Track screen load performance (market details + chart)
   usePredictMeasurement({
@@ -166,7 +167,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
   const { closedOutcomes, openOutcomes, yesPercentage } = useOpenOutcomes({
     market,
-    isMarketFetching: isMarketLoading,
+    isMarketFetching,
   });
 
   const handleBackPress = () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -452,7 +452,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           hasPositivePnl={hasPositivePnl}
           marketStatus={market?.status as PredictMarketStatus | undefined}
           singleOutcomeMarket={singleOutcomeMarket}
-          isMarketFetching={isMarketFetching}
+          isMarketLoading={isMarketLoading}
           market={market}
           openOutcomes={openOutcomes}
           yesPercentage={yesPercentage}

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -74,11 +74,11 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   });
 
   const {
-    market,
+    data: market,
     isFetching: isMarketFetching,
     refetch: refetchMarket,
   } = usePredictMarket({
-    id: resolvedMarketId,
+    id: resolvedMarketId ?? '',
     enabled: Boolean(resolvedMarketId),
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
@@ -31,7 +31,7 @@ export interface PredictMarketDetailsActionsProps {
   hasPositivePnl: boolean;
   marketStatus: PredictMarketStatus | undefined;
   singleOutcomeMarket: boolean;
-  isMarketFetching: boolean;
+  isMarketLoading: boolean;
   market: PredictMarket | null;
   openOutcomes: PredictOutcome[];
   yesPercentage: number;
@@ -45,7 +45,7 @@ const PredictMarketDetailsActions = memo(
     hasPositivePnl,
     marketStatus,
     singleOutcomeMarket,
-    isMarketFetching,
+    isMarketLoading,
     market,
     openOutcomes,
     yesPercentage,
@@ -134,7 +134,7 @@ const PredictMarketDetailsActions = memo(
           }
 
           // Show skeleton buttons while loading
-          if (isMarketFetching && !market) {
+          if (isMarketLoading) {
             return <PredictDetailsButtonsSkeleton />;
           }
 


### PR DESCRIPTION
## **Description**

Replace manual `useState`/`useEffect`/`useRef` data-fetching in `usePredictMarket` with React Query's `useQuery`, backed by a new `predictMarketOptions` query factory.

**Why:** The existing implementation manually manages loading, error, and mounted-ref state which is error-prone and duplicates logic that React Query handles out of the box (caching, deduplication, stale-while-revalidate, automatic cleanup on unmount).

**What changed:**
- New `queries/market.ts` — query key factory and `queryOptions` for fetching a single market
- `queries/index.ts` — registered `market` entry in the `predictQueries` object
- `usePredictMarket.tsx` — replaced ~100 lines of manual state management with a single `useQuery` call
- `usePredictMarket.test.tsx` — updated tests to use `QueryClientProvider` wrapper and `@testing-library/react-native` APIs (`waitFor` instead of `waitForNextUpdate`)

## **Changelog**

## **Related issues**

## **Manual testing steps**

```gherkin
Feature: Predict market detail loading

  Scenario: user navigates to a market detail screen
    Given user is on the Predict markets list

    When user taps on a market card
    Then market detail screen loads with market data
    And loading indicator is shown while fetching
    And error state is shown if the fetch fails
```

## **Screenshots/Recordings**

N/A — no UI changes, internal refactor only.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the market-fetching hook’s behavior (loading/error semantics, caching/staleness, and return shape) and updates multiple UI call sites/tests that depend on it.
> 
> **Overview**
> Refactors `usePredictMarket` to be React Query-backed (new `predictQueries.market` with `predictMarketKeys`/`predictMarketOptions`), replacing manual `useState`/`useEffect` fetching with a cached `useQuery` result and centralized error logging.
> 
> Updates Predict UI consumers/tests to the new hook shape (`data`, `isLoading`, `Error`-typed errors) and adjusts loading gating in `PredictMarketSportCardWrapper`, `PredictMarketDetails`, and `PredictMarketDetailsActions` (including enabling downstream queries only after market load). Tests are migrated to a `QueryClientProvider` harness and assertions are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edb615eff8b17e91e9be466e807d620a744a5c46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->