### PR TITLE
fix(homepage): add claim button to homepage Predictions section

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -5,6 +5,8 @@ import PredictionsSection from './PredictionsSection';
 import Routes from '../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
+const mockClaim = jest.fn();
+const mockRefreshClaimable = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -18,6 +20,10 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('../../../../UI/Predict/selectors/featureFlags', () => ({
   selectPredictEnabledFlag: jest.fn(() => true),
+}));
+
+jest.mock('../../../../UI/Predict/hooks/usePredictClaim', () => ({
+  usePredictClaim: () => ({ claim: mockClaim }),
 }));
 
 // Mock the hooks
@@ -41,9 +47,70 @@ const mockUsePredictMarketsForHomepage =
 const mockUsePredictPositionsForHomepage =
   jest.requireMock('./hooks').usePredictPositionsForHomepage;
 
+const mockActivePositions = [
+  {
+    outcomeId: 'outcome-1',
+    outcomeIndex: 0,
+    marketId: 'market-1',
+    title: 'Test Position 1',
+    outcome: 'Yes',
+    icon: 'https://example.com/icon1.png',
+    initialValue: 10,
+    currentValue: 12,
+    size: 15,
+    percentPnl: 20,
+    claimable: false,
+  },
+  {
+    outcomeId: 'outcome-2',
+    outcomeIndex: 0,
+    marketId: 'market-2',
+    title: 'Test Position 2',
+    outcome: 'No',
+    icon: 'https://example.com/icon2.png',
+    initialValue: 5,
+    currentValue: 3,
+    size: 8,
+    percentPnl: -40,
+    claimable: false,
+  },
+];
+
+const mockClaimablePositions = [
+  {
+    outcomeId: 'claimable-outcome-1',
+    outcomeIndex: 0,
+    marketId: 'claimable-market-1',
+    title: 'Claimable Position',
+    outcome: 'Yes',
+    icon: 'https://example.com/icon-claimable.png',
+    initialValue: 10,
+    currentValue: 75,
+    size: 75,
+    percentPnl: 650,
+    claimable: true,
+  },
+  {
+    outcomeId: 'claimable-outcome-2',
+    outcomeIndex: 0,
+    marketId: 'claimable-market-2',
+    title: 'Claimable Position 2',
+    outcome: 'Yes',
+    icon: 'https://example.com/icon-claimable2.png',
+    initialValue: 10,
+    currentValue: 125,
+    size: 125,
+    percentPnl: 1150,
+    claimable: true,
+  },
+];
+
 describe('PredictionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockClaim.mockResolvedValue(undefined);
+    mockRefreshClaimable.mockResolvedValue(undefined);
+
     // Reset mock return value to default (true) to ensure test isolation
     jest
       .requireMock('../../../../UI/Predict/selectors/featureFlags')
@@ -69,12 +136,16 @@ describe('PredictionsSection', () => {
       error: null,
       refresh: jest.fn(),
     });
-    mockUsePredictPositionsForHomepage.mockReturnValue({
-      positions: [],
-      isLoading: false,
-      error: null,
-      refresh: jest.fn(),
-    });
+
+    // Differentiate active vs claimable positions calls by second arg
+    mockUsePredictPositionsForHomepage.mockImplementation(
+      (_maxPositions?: number, claimable = false) => ({
+        positions: [],
+        isLoading: false,
+        error: null,
+        refresh: claimable ? mockRefreshClaimable : jest.fn(),
+      }),
+    );
   });
 
   it('renders section title when enabled', () => {
@@ -104,41 +175,18 @@ describe('PredictionsSection', () => {
   });
 
   describe('when user has positions', () => {
-    const mockPositions = [
-      {
-        outcomeId: 'outcome-1',
-        outcomeIndex: 0,
-        marketId: 'market-1',
-        title: 'Test Position 1',
-        outcome: 'Yes',
-        icon: 'https://example.com/icon1.png',
-        initialValue: 10,
-        currentValue: 12,
-        size: 15,
-        percentPnl: 20,
-      },
-      {
-        outcomeId: 'outcome-2',
-        outcomeIndex: 0,
-        marketId: 'market-2',
-        title: 'Test Position 2',
-        outcome: 'No',
-        icon: 'https://example.com/icon2.png',
-        initialValue: 5,
-        currentValue: 3,
-        size: 8,
-        percentPnl: -40,
-      },
-    ];
+    beforeEach(() => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: claimable ? [] : mockActivePositions,
+          isLoading: false,
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
+    });
 
     it('renders positions when user has them', async () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: mockPositions,
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
-
       renderWithProvider(<PredictionsSection />);
 
       await waitFor(() => {
@@ -148,16 +196,17 @@ describe('PredictionsSection', () => {
     });
 
     it('shows position skeletons when loading positions', () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: true,
-        error: null,
-        refresh: jest.fn(),
-      });
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: [],
+          isLoading: !claimable, // only active positions loading
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
 
       renderWithProvider(<PredictionsSection />);
 
-      // When loading positions, should not show markets
       expect(screen.queryByText('Test Position 1')).not.toBeOnTheScreen();
     });
   });
@@ -186,12 +235,6 @@ describe('PredictionsSection', () => {
     ];
 
     it('renders trending markets when user has no positions', async () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: mockMarkets,
         isLoading: false,
@@ -207,12 +250,6 @@ describe('PredictionsSection', () => {
     });
 
     it('shows market skeletons when loading markets', () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: true,
@@ -227,12 +264,6 @@ describe('PredictionsSection', () => {
     });
 
     it('returns null when markets are empty and not loading', () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: false,
@@ -248,12 +279,6 @@ describe('PredictionsSection', () => {
 
   describe('error state', () => {
     it('renders error state when markets fail to load', () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: false,
@@ -268,12 +293,6 @@ describe('PredictionsSection', () => {
     });
 
     it('does not render error state while still loading', () => {
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        error: null,
-        refresh: jest.fn(),
-      });
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: true,
@@ -289,56 +308,113 @@ describe('PredictionsSection', () => {
     });
   });
 
-  describe('refresh functionality', () => {
-    it('refreshes only markets when user has no positions', async () => {
-      const mockRefreshPositions = jest.fn();
-      const mockRefreshMarkets = jest.fn();
-
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [],
-        isLoading: false,
-        error: null,
-        refresh: mockRefreshPositions,
-      });
-      mockUsePredictMarketsForHomepage.mockReturnValue({
-        markets: [],
-        isLoading: false,
-        error: null,
-        refresh: mockRefreshMarkets,
-      });
-
-      const ref = React.createRef<{ refresh: () => Promise<void> }>();
-      renderWithProvider(<PredictionsSection ref={ref} />);
-
-      await ref.current?.refresh();
-
-      expect(mockRefreshPositions).not.toHaveBeenCalled();
-      expect(mockRefreshMarkets).toHaveBeenCalled();
+  describe('claim button', () => {
+    beforeEach(() => {
+      // Show positions so the positions branch renders
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: claimable ? [] : mockActivePositions,
+          isLoading: false,
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
     });
 
-    it('refreshes both positions and markets when user has positions', async () => {
-      const mockRefreshPositions = jest.fn();
-      const mockRefreshMarkets = jest.fn();
+    it('does not show claim button when there are no claimable positions', () => {
+      renderWithProvider(<PredictionsSection />);
 
-      mockUsePredictPositionsForHomepage.mockReturnValue({
-        positions: [
-          {
-            outcomeId: 'outcome-1',
-            outcomeIndex: 0,
-            marketId: 'market-1',
-            title: 'Test Position',
-            outcome: 'Yes',
-            icon: 'https://example.com/icon.png',
-            initialValue: 10,
-            currentValue: 12,
-            size: 15,
-            percentPnl: 20,
-          },
-        ],
-        isLoading: false,
-        error: null,
-        refresh: mockRefreshPositions,
+      expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
+    });
+
+    it('shows claim button with total amount when claimable positions exist', async () => {
+      // totalClaimable = 75 + 125 = 200
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: claimable ? mockClaimablePositions : mockActivePositions,
+          isLoading: false,
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
+
+      renderWithProvider(<PredictionsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
       });
+    });
+
+    it('does not show claim button while claimable positions are loading', () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: [],
+          isLoading: claimable, // claimable fetch still loading
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
+
+      renderWithProvider(<PredictionsSection />);
+
+      expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
+    });
+
+    it('does not show claim button while active positions are loading', () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: [],
+          isLoading: !claimable, // active fetch still loading
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
+
+      renderWithProvider(<PredictionsSection />);
+
+      expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
+    });
+
+    it('calls claim and then refreshes claimable positions on press', async () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: claimable ? mockClaimablePositions : mockActivePositions,
+          isLoading: false,
+          error: null,
+          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        }),
+      );
+
+      renderWithProvider(<PredictionsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+      });
+
+      fireEvent.press(screen.getByText('Claim $200.00'));
+
+      await waitFor(() => {
+        expect(mockClaim).toHaveBeenCalledTimes(1);
+        expect(mockRefreshClaimable).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('refreshes markets and claimable when user has no positions', async () => {
+      const mockRefreshActivePositions = jest.fn().mockResolvedValue(undefined);
+      const mockRefreshMarkets = jest.fn().mockResolvedValue(undefined);
+
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: [],
+          isLoading: false,
+          error: null,
+          refresh: claimable
+            ? mockRefreshClaimable
+            : mockRefreshActivePositions,
+        }),
+      );
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: false,
@@ -351,8 +427,40 @@ describe('PredictionsSection', () => {
 
       await ref.current?.refresh();
 
-      expect(mockRefreshPositions).toHaveBeenCalled();
+      expect(mockRefreshActivePositions).not.toHaveBeenCalled();
       expect(mockRefreshMarkets).toHaveBeenCalled();
+      expect(mockRefreshClaimable).toHaveBeenCalled();
+    });
+
+    it('refreshes positions, markets, and claimable when user has positions', async () => {
+      const mockRefreshActivePositions = jest.fn().mockResolvedValue(undefined);
+      const mockRefreshMarkets = jest.fn().mockResolvedValue(undefined);
+
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_maxPositions?: number, claimable = false) => ({
+          positions: claimable ? [] : mockActivePositions,
+          isLoading: false,
+          error: null,
+          refresh: claimable
+            ? mockRefreshClaimable
+            : mockRefreshActivePositions,
+        }),
+      );
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: [],
+        isLoading: false,
+        error: null,
+        refresh: mockRefreshMarkets,
+      });
+
+      const ref = React.createRef<{ refresh: () => Promise<void> }>();
+      renderWithProvider(<PredictionsSection ref={ref} />);
+
+      await ref.current?.refresh();
+
+      expect(mockRefreshActivePositions).toHaveBeenCalled();
+      expect(mockRefreshMarkets).toHaveBeenCalled();
+      expect(mockRefreshClaimable).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -39,6 +39,8 @@ import { colorWithOpacity } from '../../../../../util/colors';
 import type { PredictPosition } from '../../../../UI/Predict/types';
 import type { PredictNavigationParamList } from '../../../../UI/Predict/types/navigation';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
+import { PredictClaimButton } from '../../../../UI/Predict/components/PredictActionButtons';
+import { usePredictClaim } from '../../../../UI/Predict/hooks/usePredictClaim';
 
 const MAX_MARKETS_DISPLAYED = 5;
 
@@ -93,6 +95,7 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const title = strings('homepage.sections.predictions');
+  const { claim } = usePredictClaim();
 
   // Track scroll position for fade effect
   const [fadeOpacity, setFadeOpacity] = useState(1);
@@ -112,6 +115,22 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     refresh: refreshMarkets,
   } = usePredictMarketsForHomepage(MAX_MARKETS_DISPLAYED);
 
+  const {
+    positions: claimablePositions,
+    isLoading: isLoadingClaimable,
+    refresh: refreshClaimable,
+  } = usePredictPositionsForHomepage(undefined, true);
+
+  const handleClaim = useCallback(async () => {
+    await claim();
+    await refreshClaimable();
+  }, [claim, refreshClaimable]);
+
+  const totalClaimable = claimablePositions.reduce(
+    (sum, p) => sum + (p.currentValue ?? 0),
+    0,
+  );
+
   // Determine if user has positions
   const hasPositions = positions.length > 0;
 
@@ -119,14 +138,18 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const hasPositionsRef = useRef(hasPositions);
   hasPositionsRef.current = hasPositions;
 
-  // Refresh: only refresh positions if user has them, always refresh markets
+  // Refresh: only refresh positions if user has them, always refresh markets + claimable
   const refresh = useCallback(async () => {
     if (hasPositionsRef.current) {
-      await Promise.all([refreshPositions(), refreshMarkets()]);
+      await Promise.all([
+        refreshPositions(),
+        refreshMarkets(),
+        refreshClaimable(),
+      ]);
     } else {
-      await refreshMarkets();
+      await Promise.all([refreshMarkets(), refreshClaimable()]);
     }
-  }, [refreshPositions, refreshMarkets]);
+  }, [refreshPositions, refreshMarkets, refreshClaimable]);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
@@ -222,6 +245,14 @@ const PredictionsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
                 onPress={handlePositionPress}
               />
             ))
+          )}
+          {!isLoadingPositions && !isLoadingClaimable && totalClaimable > 0 && (
+            <Box paddingHorizontal={4} paddingTop={1} paddingBottom={3}>
+              <PredictClaimButton
+                amount={totalClaimable}
+                onPress={handleClaim}
+              />
+            </Box>
           )}
         </Box>
       </Box>

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
@@ -201,4 +201,84 @@ describe('usePredictPositionsForHomepage', () => {
 
     expect(mockGetPositions).toHaveBeenCalledTimes(2);
   });
+
+  describe('claimable parameter', () => {
+    it('passes claimable: false to getPositions by default', async () => {
+      const { waitForNextUpdate } = renderHook(() =>
+        usePredictPositionsForHomepage(5),
+      );
+
+      await waitForNextUpdate();
+
+      expect(mockGetPositions).toHaveBeenCalledWith({
+        address: '0xuser123',
+        claimable: false,
+      });
+    });
+
+    it('passes claimable: true to getPositions when specified', async () => {
+      const { waitForNextUpdate } = renderHook(() =>
+        usePredictPositionsForHomepage(undefined, true),
+      );
+
+      await waitForNextUpdate();
+
+      expect(mockGetPositions).toHaveBeenCalledWith({
+        address: '0xuser123',
+        claimable: true,
+      });
+    });
+
+    it('uses separate cache keys for claimable and non-claimable fetches', async () => {
+      // Fetch non-claimable
+      const { waitForNextUpdate: wait1, unmount: unmount1 } = renderHook(() =>
+        usePredictPositionsForHomepage(5, false),
+      );
+      await wait1();
+      unmount1();
+
+      expect(mockGetPositions).toHaveBeenCalledTimes(1);
+
+      // Fetch claimable — must hit the API again (different cache key)
+      const { waitForNextUpdate: wait2 } = renderHook(() =>
+        usePredictPositionsForHomepage(5, true),
+      );
+      await wait2();
+
+      expect(mockGetPositions).toHaveBeenCalledTimes(2);
+    });
+
+    it('serves claimable positions from cache independently of non-claimable', async () => {
+      const claimablePositions = [createMockPosition('c1')];
+      const nonClaimablePositions = [
+        createMockPosition('1'),
+        createMockPosition('2'),
+      ];
+
+      mockGetPositions
+        .mockResolvedValueOnce(nonClaimablePositions)
+        .mockResolvedValueOnce(claimablePositions);
+
+      // Populate both caches
+      const {
+        result: r1,
+        waitForNextUpdate: w1,
+        unmount: u1,
+      } = renderHook(() => usePredictPositionsForHomepage(undefined, false));
+      await w1();
+      u1();
+
+      const {
+        result: r2,
+        waitForNextUpdate: w2,
+        unmount: u2,
+      } = renderHook(() => usePredictPositionsForHomepage(undefined, true));
+      await w2();
+      u2();
+
+      // Each set has its own cached value
+      expect(r1.current.positions).toHaveLength(2);
+      expect(r2.current.positions).toHaveLength(1);
+    });
+  });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
@@ -44,13 +44,14 @@ export const _clearPositionsCache = (): void => {
  * Lightweight hook for fetching user prediction positions for the homepage.
  *
  * Uses module-level caching to avoid redundant API calls.
- * Returns active (non-claimable) positions only.
  *
  * @param maxPositions - Maximum number of positions to return (all if omitted)
+ * @param claimable - When true, returns only claimable positions; when false (default), returns only active positions
  * @returns Positions data, loading state, and refresh function
  */
 export const usePredictPositionsForHomepage = (
   maxPositions?: number,
+  claimable = false,
 ): UsePredictPositionsForHomepageResult => {
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const userAddress = useSelector(
@@ -64,7 +65,9 @@ export const usePredictPositionsForHomepage = (
   const maxPositionsRef = useRef(maxPositions);
   maxPositionsRef.current = maxPositions;
 
-  const cacheKey = userAddress ? `predict_positions_${userAddress}` : null;
+  const cacheKey = userAddress
+    ? `predict_positions_${userAddress}_${claimable}`
+    : null;
 
   const [state, setState] = useState<{
     positions: PredictPosition[];
@@ -121,7 +124,7 @@ export const usePredictPositionsForHomepage = (
       const controller = Engine.context.PredictController;
       const positionsData = await controller.getPositions({
         address: userAddress,
-        claimable: false, // Only active positions
+        claimable,
       });
 
       // Check if this request is still valid
@@ -157,7 +160,7 @@ export const usePredictPositionsForHomepage = (
         error: err instanceof Error ? err.message : 'Failed to fetch positions',
       });
     }
-  }, [isPredictEnabled, cacheKey, userAddress]);
+  }, [isPredictEnabled, cacheKey, userAddress, claimable]);
 
   const refresh = useCallback(async () => {
     // Clear cache and refetch


### PR DESCRIPTION
## **Description**

Adds back the blue "Claim $X.XX" button to the Predictions section on the homepage. The button appears below the positions list when the user has claimable winnings, summing currentValue across all claimable positions. Tapping it triggers the existing claim flow (`usePredictClaim`) and automatically refreshes the claimable positions to dismiss the button on success.

Changes:

- Extended `usePredictPositionsForHomepage` with a claimable parameter (default false) and separate cache key, enabling a second call to fetch only claimable positions
- Added `PredictClaimButton` + `usePredictClaim` to `PredictionsSection`, rendered below the positions list when `totalClaimable` > 0 and both position fetches have settled
- Updated section-level refresh to always include `refreshClaimable` alongside markets

## **Changelog**

CHANGELOG entry: Added blue claim button to the homepage Predictions section for users with claimable winnings

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-485

## **Manual testing steps**

```gherkin
Feature: Homepage Predictions claim button

  Scenario: user claims winnings from the homepage
    Given the user has resolved prediction positions with claimable winnings
    And the user is on the homepage

    When the user views the Predictions section
    Then a blue "Claim $X.XX" button appears below the positions list
    And the amount reflects the sum of all claimable position values

    When the user taps the claim button
    Then the claim confirmation flow is triggered
    And the button disappears after a successful claim
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/4e131f6a-f625-4423-be33-96f220b579b1

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
