### PR TITLE
test: enforce color-no-hex

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -183,7 +183,6 @@ module.exports = {
       files: [
         'app/components/**/*.{js,jsx,ts,tsx}',
         'app/component-library/**/*.{js,jsx,ts,tsx}',
-        'app/vi',
       ],
       rules: {
         '@metamask/design-tokens/color-no-hex': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,18 +168,6 @@ module.exports = {
       },
     },
     {
-      // Temporary rollout strategy:
-      // Keep color-no-hex disabled for all tests by default, then re-enable it
-      // for specific folders in small PR batches. Once migration is complete,
-      // remove this override and enforce across all tests in:
-      // - app/components/
-      // - app/component-library/
-      files: ['**/*.test.{js,ts,tsx}', '**/*.stories.{js,ts,tsx}'],
-      rules: {
-        '@metamask/design-tokens/color-no-hex': 'off',
-      },
-    },
-    {
       files: [
         'app/components/**/*.{js,jsx,ts,tsx}',
         'app/component-library/**/*.{js,jsx,ts,tsx}',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,6 +168,29 @@ module.exports = {
       },
     },
     {
+      // Temporary rollout strategy:
+      // Keep color-no-hex disabled for all tests by default, then re-enable it
+      // for specific folders in small PR batches. Once migration is complete,
+      // remove this override and enforce across all tests in:
+      // - app/components/
+      // - app/component-library/
+      files: ['**/*.test.{js,ts,tsx}', '**/*.stories.{js,ts,tsx}'],
+      rules: {
+        '@metamask/design-tokens/color-no-hex': 'off',
+      },
+    },
+    {
+      files: [
+        'app/components/**/*.{js,jsx,ts,tsx}',
+        'app/component-library/**/*.{js,jsx,ts,tsx}',
+        'app/vi',
+      ],
+      rules: {
+        '@metamask/design-tokens/color-no-hex': 'error',
+      },
+    },
+
+    {
       files: [
         'app/components/UI/Name/**/*.{js,ts,tsx}',
         'app/components/UI/SimulationDetails/**/*.{js,ts,tsx}',
@@ -593,7 +616,7 @@ module.exports = {
     'react/no-string-refs': 'error',
     'react/no-unused-prop-types': 'error',
     'react/prefer-es6-class': 'error',
-    '@metamask/design-tokens/color-no-hex': 'error',
+    '@metamask/design-tokens/color-no-hex': 'warn',
     radix: 'off',
 
     // These rule modifications are removing changes to our shared ESLint config made after

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,87 +168,6 @@ module.exports = {
       },
     },
     {
-      // Temporary rollout strategy:
-      // Keep color-no-hex disabled for all tests by default, then re-enable it
-      // for specific folders in small PR batches. Once migration is complete,
-      // remove this override and enforce across all tests in:
-      // - app/components/
-      // - app/component-library/
-      files: ['**/*.test.{js,ts,tsx}', '**/*.stories.{js,ts,tsx}'],
-      rules: {
-        '@metamask/design-tokens/color-no-hex': 'off',
-      },
-    },
-    {
-      files: [
-        // @MetaMask/card
-        'app/components/UI/Card/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/core-platform
-        'app/components/Snaps/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/predict
-        'app/components/UI/Predict/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/ramp
-        'app/components/UI/Ramp/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/rewards
-        'app/components/UI/Rewards/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/perps
-        'app/components/UI/Perps/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/metamask-earn
-        'app/components/UI/Earn/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/Stake/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/metamask-assets
-        'app/components/UI/Assets/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/Tokens/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/AssetOverview/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/Collectibles/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleContractElement/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleContractInformation/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleContractOverview/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleContracts/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleDetectionModal/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleMedia/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleModal/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/CollectibleOverview/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/ConfirmAddAsset/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/DeFiPositions/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/TokenDetails/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AddAsset/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/Asset/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AssetDetails/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AssetHideConfirmation/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AssetOptions/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/Collectible/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/CollectibleView/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/DetectedTokens/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/NFTAutoDetectionModal/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/NftDetails/**/*.{js,jsx,ts,tsx}',
-        // @MetaMask/mobile-core-ux
-        'app/components/Views/AccountActions/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AccountSelector/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AccountsMenu/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/AddressQRCode/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/EditAccountName/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/LockScreen/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/Login/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/MultichainTransactionsView/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/NetworkConnect/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/NetworkSelector/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/QRAccountDisplay/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/QRScanner/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/Settings/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/TermsAndConditions/**/*.{js,jsx,ts,tsx}',
-        'app/components/Views/UnifiedTransactionsView/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/MultichainTransactionListItem/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/TransactionActionModal/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/TransactionElement/**/*.{js,jsx,ts,tsx}',
-        'app/components/UI/Transactions/**/*.{js,jsx,ts,tsx}',
-      ],
-      rules: {
-        '@metamask/design-tokens/color-no-hex': 'error',
-      },
-    },
-
-    {
       files: [
         'app/components/UI/Name/**/*.{js,ts,tsx}',
         'app/components/UI/SimulationDetails/**/*.{js,ts,tsx}',
@@ -674,7 +593,7 @@ module.exports = {
     'react/no-string-refs': 'error',
     'react/no-unused-prop-types': 'error',
     'react/prefer-es6-class': 'error',
-    '@metamask/design-tokens/color-no-hex': 'warn',
+    '@metamask/design-tokens/color-no-hex': 'error',
     radix: 'off',
 
     // These rule modifications are removing changes to our shared ESLint config made after

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -230,6 +230,7 @@ module.exports = {
       ],
       plugins: ['tailwindcss'],
       rules: {
+        '@metamask/design-tokens/color-no-hex': 'error',
         'tailwindcss/classnames-order': 'error',
         'tailwindcss/enforces-negative-arbitrary-values': 'error',
         'tailwindcss/enforces-shorthand': 'error',
@@ -615,7 +616,7 @@ module.exports = {
     'react/no-string-refs': 'error',
     'react/no-unused-prop-types': 'error',
     'react/prefer-es6-class': 'error',
-    '@metamask/design-tokens/color-no-hex': 'warn',
+    '@metamask/design-tokens/color-no-hex': 'off',
     radix: 'off',
 
     // These rule modifications are removing changes to our shared ESLint config made after

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -230,7 +230,6 @@ module.exports = {
       ],
       plugins: ['tailwindcss'],
       rules: {
-        '@metamask/design-tokens/color-no-hex': 'error',
         'tailwindcss/classnames-order': 'error',
         'tailwindcss/enforces-negative-arbitrary-values': 'error',
         'tailwindcss/enforces-shorthand': 'error',

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.test.tsx
@@ -5,13 +5,17 @@ import { strings } from '../../../../../../locales/i18n';
 import { BridgeToken } from '../../types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn(() => ({
-    colors: {
-      success: { default: '#28A745' },
-    },
-  })),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const actualTheme = jest.requireActual('../../../../../util/theme');
+  return {
+    ...actualTheme,
+    useTheme: jest.fn(() => ({
+      colors: {
+        success: { default: actualTheme.mockTheme.colors.success.default },
+      },
+    })),
+  };
+});
 
 const mockDestToken: BridgeToken = {
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/AnimatedGradientBorder.constants.ts
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/AnimatedGradientBorder.constants.ts
@@ -1,3 +1,5 @@
+import { brandColor } from '@metamask/design-tokens';
+
 /** Duration of the sweep traveling around the border in ms */
 export const BORDER_SWEEP_DURATION_MS = 1000;
 
@@ -23,7 +25,10 @@ export const BORDER_FADE_IN_FRACTION = 0.8;
 export const BORDER_FADE_OUT_FRACTION = 0.8;
 
 /** Gradient stop colors: pink/purple → orange */
-export const BORDER_GRADIENT_COLORS = ['#D075FF', '#FF5C16'] as const;
+export const BORDER_GRADIENT_COLORS = [
+  brandColor.purple300,
+  brandColor.orange400,
+] as const;
 
 /** Fraction of the card that must be visible on-screen to trigger the animation (1 = fully visible) */
 export const VISIBILITY_THRESHOLD = 1;

--- a/app/components/UI/Navbar/index.test.jsx
+++ b/app/components/UI/Navbar/index.test.jsx
@@ -286,10 +286,10 @@ describe('getBridgeNavbar', () => {
   };
   const mockThemeColors = {
     background: {
-      default: '#FFFFFF',
+      default: mockTheme.colors.background.default,
     },
     primary: {
-      default: '#037DD6',
+      default: mockTheme.colors.primary.default,
     },
   };
 

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -265,7 +265,10 @@ const SecurityTrustScreen: React.FC = () => {
                   : 'bg-[rgba(133,139,154,0.77)]'
               }`}
             >
-              <Box twClassName="h-full bg-[#6B7FFF]" style={barFillStyle} />
+              <Box
+                twClassName="h-full bg-primary-default"
+                style={barFillStyle}
+              />
             </Box>
           </Box>
         )}
@@ -282,7 +285,7 @@ const SecurityTrustScreen: React.FC = () => {
               gap={2}
               twClassName="flex-1"
             >
-              <Box twClassName="w-3 h-3 rounded-full bg-[#6B7FFF]" />
+              <Box twClassName="w-3 h-3 rounded-full bg-primary-default" />
               <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
                 {strings('security_trust.top_10_holders')}
               </Text>

--- a/app/components/Views/ManualBackupStep1/index.test.tsx
+++ b/app/components/Views/ManualBackupStep1/index.test.tsx
@@ -48,13 +48,21 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   Theme: { Light: 'light', Dark: 'dark' },
 }));
 
+const { mockTheme } = jest.requireActual('../../../util/theme');
+
 const mockUseTheme = jest.fn().mockReturnValue({
   colors: {
-    text: { default: '#000000' },
-    background: { default: '#FFFFFF', muted: '#F2F4F6' },
-    icon: { default: '#24272A' },
-    border: { default: '#BBC0C5', muted: '#D6D9DC' },
-    error: { default: '#D73A49' },
+    text: { default: mockTheme.colors.text.default },
+    background: {
+      default: mockTheme.colors.background.default,
+      muted: mockTheme.colors.background.muted,
+    },
+    icon: { default: mockTheme.colors.icon.default },
+    border: {
+      default: mockTheme.colors.border.default,
+      muted: mockTheme.colors.border.muted,
+    },
+    error: { default: mockTheme.colors.error.default },
   },
   themeAppearance: 'dark',
 });
@@ -318,11 +326,17 @@ describe('ManualBackupStep1', () => {
     afterEach(() => {
       mockUseTheme.mockReturnValue({
         colors: {
-          text: { default: '#000000' },
-          background: { default: '#FFFFFF', muted: '#F2F4F6' },
-          icon: { default: '#24272A' },
-          border: { default: '#BBC0C5', muted: '#D6D9DC' },
-          error: { default: '#D73A49' },
+          text: { default: mockTheme.colors.text.default },
+          background: {
+            default: mockTheme.colors.background.default,
+            muted: mockTheme.colors.background.muted,
+          },
+          icon: { default: mockTheme.colors.icon.default },
+          border: {
+            default: mockTheme.colors.border.default,
+            muted: mockTheme.colors.border.muted,
+          },
+          error: { default: mockTheme.colors.error.default },
         },
         themeAppearance: 'dark',
       });
@@ -338,11 +352,17 @@ describe('ManualBackupStep1', () => {
       Platform.OS = 'android';
       mockUseTheme.mockReturnValue({
         colors: {
-          text: { default: '#000000' },
-          background: { default: '#FFFFFF', muted: '#F2F4F6' },
-          icon: { default: '#24272A' },
-          border: { default: '#BBC0C5', muted: '#D6D9DC' },
-          error: { default: '#D73A49' },
+          text: { default: mockTheme.colors.text.default },
+          background: {
+            default: mockTheme.colors.background.default,
+            muted: mockTheme.colors.background.muted,
+          },
+          icon: { default: mockTheme.colors.icon.default },
+          border: {
+            default: mockTheme.colors.border.default,
+            muted: mockTheme.colors.border.muted,
+          },
+          error: { default: mockTheme.colors.error.default },
         },
         themeAppearance: 'light',
       });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcFormFields.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcFormFields.test.tsx
@@ -25,7 +25,7 @@ const defaultProps = {
   onRpcUrlValidationChange: jest.fn(),
   styles,
   themeAppearance: 'light' as const,
-  placeholderTextColor: '#999',
+  placeholderTextColor: mockTheme.colors.text.muted,
 };
 
 describe('RpcFormFields', () => {

--- a/app/components/Views/RestoreWallet/WalletRestored.test.tsx
+++ b/app/components/Views/RestoreWallet/WalletRestored.test.tsx
@@ -30,18 +30,22 @@ jest.mock('../../../util/Logger', () => ({
   error: jest.fn(),
   log: jest.fn(),
 }));
-jest.mock('../../../util/theme', () => ({
-  useAppThemeFromContext: jest.fn(() => ({
-    colors: {
-      primary: {
-        inverse: '#FFFFFF',
+jest.mock('../../../util/theme', () => {
+  const actualTheme = jest.requireActual('../../../util/theme');
+  return {
+    ...actualTheme,
+    useAppThemeFromContext: jest.fn(() => ({
+      colors: {
+        primary: {
+          inverse: actualTheme.mockTheme.colors.primary.inverse,
+        },
+        background: {
+          default: actualTheme.mockTheme.colors.background.default,
+        },
       },
-      background: {
-        default: '#000000',
-      },
-    },
-  })),
-}));
+    })),
+  };
+});
 jest.mock('../../../components/hooks/useAnalytics/useAnalytics');
 jest.mock('../../../util/metrics');
 jest.mock('react-native/Libraries/Linking/Linking', () => ({

--- a/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
+++ b/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
@@ -129,6 +129,7 @@ describe('HeroNft', () => {
 
     expect(getByText('Sending')).toBeOnTheScreen();
     expect(getByText('Test Dapp NFTs')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex -- false positive: '#12345' is a token-id display prefix, not a color literal
     expect(getByText('#12345')).toBeOnTheScreen();
     expect(getByTestId('nft-image')).toBeOnTheScreen();
   });


### PR DESCRIPTION
## **Description**

Removes static hex color values from tests and replaces them with theme-aware color lookups.

Why: hardcoded hex values are brittle.
- In production UI, hex literals can drift from the active theme, become incorrect as the color system evolves, and regress when token/theme mappings change.
- In tests, hex literals in mocks/assertions can fail just because a token’s underlying value changed (noise during token upgrades; see PR #27825).

Goal: no static hex colors anywhere inside app/components/ or app/component-library/ (including their tests and Storybook stories).

Enforcement:
- ESLint: @metamask/design-tokens/color-no-hex is turned on as error only for app/components/** and app/component-library/**.
- Cursor rule: .cursor/rules/unit-testing-guidelines.mdc explicitly calls out “Never hardcode design token hex values” (backed by the eslint rule).

Notable changes in this PR:
- Tests: update theme mocks to reference mockTheme/design tokens instead of literals.
- UI: replace a couple of production hex literals with token-backed values (e.g. SecurityTrustScreen, MarketInsights gradient).

Related: https://github.com/MetaMask/metamask-mobile/pull/26639
Related: https://github.com/MetaMask/metamask-mobile/pull/27825

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: static hex prevention in tests

  Scenario: tests pass after design token upgrade
    Given the design tokens package is upgraded
    When the test suite runs
    Then tests that check colors should not fail due to hex value changes
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="813" height="226" alt="Screenshot 2026-03-25 at 10 05 41 PM" src="https://github.com/user-attachments/assets/e3bdd558-b3f0-4b37-93a7-ae946382d75d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly lint configuration and test mock updates, with minor UI color token substitutions that could slightly change appearance if token mappings differ.
> 
> **Overview**
> Removes hardcoded hex colors in multiple tests by switching mocks/props to mockTheme/design-token values, reducing flakiness when design tokens change; adds a targeted eslint disable for a #12345 token-id false positive.
> 
> Updates UI constants/components to use design tokens instead of hex literals (e.g., Market Insights gradient border colors and Security Trust distribution bar/dot). Also tightens linting by enabling @metamask/design-tokens/color-no-hex as an error across all app/components and app/component-library while turning the rule off globally (removing the prior test-only override).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d8241e3ee3caa2d1430327a21cd4f92a75be06c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
