### PR TITLE
fix(homepage): update styling for perp tile cards for homepage

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
@@ -20,8 +20,8 @@ import styleSheet from './PerpsMarketTileCard.styles';
 import type { PerpsMarketTileCardProps } from './PerpsMarketTileCard.types';
 
 const DEFAULT_CARD_WIDTH = 180;
-const DEFAULT_CARD_HEIGHT = 140;
-const SPARKLINE_HEIGHT = 48;
+const DEFAULT_CARD_HEIGHT = 180;
+const SPARKLINE_HEIGHT = 80;
 const TOKEN_LOGO_SIZE = 40;
 const SHIMMER_PULSE_DURATION = 900;
 const LIVE_PRICES_THROTTLE_MS = 3000;
@@ -152,6 +152,7 @@ const TileCardInner: React.FC<
             color={sparklineColor}
             gradientId={`sparkline-${market.symbol}`}
             revealColor={theme.colors.background.section}
+            showGradient={false}
           />
         )}
       </View>

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.types.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.types.ts
@@ -9,7 +9,7 @@ export interface PerpsMarketTileCardProps {
   onPress?: (market: PerpsMarketData) => void;
   /** Card width in pixels (default: 180) */
   cardWidth?: number;
-  /** Card height in pixels (default: 140) */
+  /** Card height in pixels (default: 180) */
   cardHeight?: number;
   /** Skip live price WebSocket subscription (use static market data instead) */
   disableLivePrices?: boolean;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates the Perpetuals homepage section empty state (trending markets carousel) tile card styling to match the Figma design:

- 1:1 aspect ratio — `DEFAULT_CARD_HEIGHT` updated from 140 → 180px to match `DEFAULT_CARD_WIDTH`, making tiles square.
- Line chart — `showGradient={false}` passed to `SparklineChart`, replacing the area graph with a clean line chart.
- `SPARKLINE_HEIGHT` increased from 48 → 80px to better utilize the additional vertical space.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-489

## **Manual testing steps**

```gherkin
Feature: Perpetuals homepage empty state tile cards

  Scenario: user views the Perpetuals section with no open positions
    Given the user has no open perps positions or orders
    And the user is on the Homepage

    When the user views the Perpetuals section
    Then trending market tiles display as square (1:1 aspect ratio)
    And each tile shows a line chart instead of an area graph
```

## **Screenshots/Recordings**

| before | after |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/8075fd5f-2098-46e3-8515-31624c3acfca) | ![after](https://github.com/user-attachments/assets/d09561f1-0904-447c-92a9-8bb03cfceda6) |

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to the Perps homepage market tiles (layout and chart presentation) with no impact to data fetching or business logic.
> 
> **Overview**
> Updates the Perpetuals homepage trending-market tile cards to match the latest design by making the default card square (`DEFAULT_CARD_HEIGHT` 140→180) and increasing sparkline height (48→80).
> 
> Switches the embedded `SparklineChart` rendering to a line-only style by passing `showGradient={false}`, removing the area/gradient fill.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36b796c6554b8fc98b342753aea42266dbfee76d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->