### PR TITLE
Rewards toast mock theme

### DIFF
--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -36,6 +36,7 @@ jest.mock('../../../../../locales/i18n', () => ({
 jest.mock('../../../../util/theme', () => {
   const actualTheme = jest.requireActual('../../../../util/theme');
   return {
+    ...actualTheme,
     useAppThemeFromContext: () => actualTheme.mockTheme,
   };
 });


### PR DESCRIPTION
Fix `useRewardsToast` test mock to correctly re-export `mockTheme`, resolving `TypeError`s due to undefined access.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only change that fixes a Jest mock to include the real theme exports, preventing `mockTheme` from being `undefined`. No production logic is modified.
> 
> **Overview**
> Fixes `useRewardsToast.test.tsx` by updating the `../../../../util/theme` Jest mock to spread `jest.requireActual` exports, ensuring `mockTheme` and other module exports remain available while still overriding `useAppThemeFromContext`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3032f9806f9f9f9253d26a0e62e4e7b4f777560b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->