### PR TITLE
chore: Revert built in default feature flag feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,9 +113,9 @@ jobs:
       - name: Apply build config
         run: |
           # Load env vars from builds.yml (this step only)
-          eval "$(node scripts/apply-build-config.js "${{ inputs.build_name }}" --export)"
+          eval "$(node scripts/apply-build-config.js ${{ inputs.build_name }} --export)"
           # Persist to GITHUB_ENV so later steps (e.g. Build) see CONFIGURATION, IS_SIM_BUILD, etc.
-          node scripts/apply-build-config.js "${{ inputs.build_name }}" --export-github-env >> "$GITHUB_ENV"
+          node scripts/apply-build-config.js ${{ inputs.build_name }} --export-github-env >> "$GITHUB_ENV"
 
       - name: Validate secrets
         env:

--- a/app/components/UI/Earn/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.test.ts
@@ -14,7 +14,6 @@ import {
   selectMusdConversionBlockedCountries,
   parseBlockedCountriesEnv,
   selectMusdConversionMinAssetBalanceRequired,
-  selectMerklCampaignClaimingEnabledFlag,
 } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import type { Json } from '@metamask/utils';
@@ -1056,44 +1055,6 @@ describe('Earn Feature Flag Selectors', () => {
       );
 
       expect(result).toBe(true);
-    });
-  });
-
-  describe('selectMerklCampaignClaimingEnabledFlag', () => {
-    afterEach(() => {
-      delete process.env.MM_EARN_MERKL_CAMPAIGN_CLAIMING;
-    });
-
-    it('returns true when remote flag is valid and enabled', () => {
-      const state = createStateWithRemoteFlags({
-        earnMerklCampaignClaiming: {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(selectMerklCampaignClaimingEnabledFlag(state)).toBe(true);
-    });
-
-    it('returns false when remote flag is valid and disabled', () => {
-      const state = createStateWithRemoteFlags({
-        earnMerklCampaignClaiming: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(selectMerklCampaignClaimingEnabledFlag(state)).toBe(false);
-    });
-
-    it('falls back to local env when remote flag is missing and not GITHUB_ACTIONS', () => {
-      process.env.MM_EARN_MERKL_CAMPAIGN_CLAIMING = 'true';
-      const state = createStateWithRemoteFlags({});
-      expect(selectMerklCampaignClaimingEnabledFlag(state)).toBe(true);
-    });
-
-    it('falls back to false when remote flag is missing and env is false', () => {
-      process.env.MM_EARN_MERKL_CAMPAIGN_CLAIMING = 'false';
-      const state = createStateWithRemoteFlags({});
-      expect(selectMerklCampaignClaimingEnabledFlag(state)).toBe(false);
     });
   });
 

--- a/app/components/UI/Earn/selectors/featureFlags/index.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.ts
@@ -17,6 +17,7 @@ export const selectPooledStakingEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnPooledStakingEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -29,6 +30,7 @@ export const selectPooledStakingServiceInterruptionBannerEnabledFlag =
     const remoteFlag =
       remoteFeatureFlags?.earnPooledStakingServiceInterruptionBannerEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   });
 
@@ -39,6 +41,7 @@ export const selectStablecoinLendingEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnStablecoinLendingEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -50,6 +53,7 @@ export const selectStablecoinLendingServiceInterruptionBannerEnabledFlag =
     const remoteFlag =
       remoteFeatureFlags?.earnStablecoinLendingServiceInterruptionBannerEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   });
 
@@ -60,6 +64,7 @@ export const selectIsMusdConversionFlowEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnMusdConversionFlowEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -77,10 +82,12 @@ export const selectIsMusdGetBuyCtaEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnMusdCtaEnabled as unknown as VersionGatedFeatureFlag;
 
+    // mUSD conversion flow must be enabled to show the mUSD CTA
     if (!isMusdConversionFlowEnabled) {
       return false;
     }
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -99,10 +106,12 @@ export const selectIsMusdConversionAssetOverviewEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnMusdConversionAssetOverviewCtaEnabled as unknown as VersionGatedFeatureFlag;
 
+    // mUSD conversion flow must be enabled to show the mUSD CTA
     if (!isMusdConversionFlowEnabled) {
       return false;
     }
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -121,10 +130,12 @@ export const selectIsMusdConversionTokenListItemCtaEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnMusdConversionTokenListItemCtaEnabled as unknown as VersionGatedFeatureFlag;
 
+    // mUSD conversion flow must be enabled to show the mUSD CTA
     if (!isMusdConversionFlowEnabled) {
       return false;
     }
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -352,6 +363,7 @@ export const selectMerklCampaignClaimingEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.earnMerklCampaignClaiming as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );

--- a/app/components/UI/Perps/selectors/featureFlags/index.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.ts
@@ -26,6 +26,7 @@ export const selectPerpsEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.perpsPerpTradingEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -38,6 +39,7 @@ export const selectPerpsServiceInterruptionBannerEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.perpsPerpTradingServiceInterruptionBannerEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -49,6 +51,7 @@ export const selectPerpsGtmOnboardingModalEnabledFlag = createSelector(
     const remoteFlag =
       remoteFeatureFlags?.perpsPerpGtmOnboardingModalEnabled as unknown as VersionGatedFeatureFlag;
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
@@ -62,6 +65,7 @@ export const selectPerpsGtmOnboardingModalEnabledFlag = createSelector(
 export const selectPerpsOrderBookEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
+    // Default to false if no flag is set (disabled by default)
     const localFlag = process.env.MM_PERPS_ORDER_BOOK_ENABLED === 'true';
     const remoteFlag =
       remoteFeatureFlags?.perpsOrderBookEnabled as unknown as VersionGatedFeatureFlag;

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1,8 +1,4 @@
-import {
-  selectPredictEnabledFlag,
-  selectPredictGtmOnboardingModalEnabledFlag,
-  selectPredictHotTabFlag,
-} from '.';
+import { selectPredictEnabledFlag, selectPredictHotTabFlag } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import {
   mockedState,
@@ -36,7 +32,6 @@ describe('Predict Feature Flag Selectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.MM_PREDICT_ENABLED;
-    delete process.env.MM_PREDICT_GTM_MODAL_ENABLED;
     mockHasMinimumRequiredVersion = jest.spyOn(
       remoteFeatureFlagModule,
       'hasMinimumRequiredVersion',
@@ -46,7 +41,6 @@ describe('Predict Feature Flag Selectors', () => {
 
   afterEach(() => {
     delete process.env.MM_PREDICT_ENABLED;
-    delete process.env.MM_PREDICT_GTM_MODAL_ENABLED;
     mockHasMinimumRequiredVersion?.mockRestore();
   });
 
@@ -189,79 +183,6 @@ describe('Predict Feature Flag Selectors', () => {
 
         expect(result).toBe(true);
       });
-    });
-  });
-
-  describe('selectPredictGtmOnboardingModalEnabledFlag', () => {
-    it('returns true when remote flag is enabled (VersionGated shape from builds.yml)', () => {
-      const state = {
-        engine: {
-          backgroundState: {
-            RemoteFeatureFlagController: {
-              remoteFeatureFlags: {
-                predictGtmOnboardingModalEnabled: {
-                  enabled: true,
-                  minimumVersion: '0.0.0',
-                },
-              },
-              cacheTimestamp: 0,
-            },
-          },
-        },
-      };
-      expect(selectPredictGtmOnboardingModalEnabledFlag(state)).toBe(true);
-    });
-
-    it('returns false when remote flag is disabled (VersionGated shape from builds.yml)', () => {
-      const state = {
-        engine: {
-          backgroundState: {
-            RemoteFeatureFlagController: {
-              remoteFeatureFlags: {
-                predictGtmOnboardingModalEnabled: {
-                  enabled: false,
-                  minimumVersion: '0.0.0',
-                },
-              },
-              cacheTimestamp: 0,
-            },
-          },
-        },
-      };
-      expect(selectPredictGtmOnboardingModalEnabledFlag(state)).toBe(false);
-    });
-
-    it('falls back to process.env.MM_PREDICT_GTM_MODAL_ENABLED when remote flag is absent', () => {
-      const emptyRemoteState = {
-        engine: {
-          backgroundState: {
-            RemoteFeatureFlagController: {
-              remoteFeatureFlags: {},
-              cacheTimestamp: 0,
-            },
-          },
-        },
-      };
-      const emptyRemoteState2 = {
-        engine: {
-          backgroundState: {
-            RemoteFeatureFlagController: {
-              remoteFeatureFlags: {},
-              cacheTimestamp: 1,
-            },
-          },
-        },
-      };
-
-      process.env.MM_PREDICT_GTM_MODAL_ENABLED = 'true';
-      expect(selectPredictGtmOnboardingModalEnabledFlag(emptyRemoteState)).toBe(
-        true,
-      );
-
-      process.env.MM_PREDICT_GTM_MODAL_ENABLED = 'false';
-      expect(
-        selectPredictGtmOnboardingModalEnabledFlag(emptyRemoteState2),
-      ).toBe(false);
     });
   });
 

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -38,6 +38,7 @@ export const selectPredictGtmOnboardingModalEnabledFlag = createSelector(
       remoteFeatureFlags?.predictGtmOnboardingModalEnabled,
     );
 
+    // Fallback to local flag if remote flag is not available
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );

--- a/app/core/Engine/controllers/remote-feature-flag-build-time-defaults-config.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-build-time-defaults-config.ts
@@ -1,9 +1,0 @@
-/**
- * Config for build-time defaults.
- * Production: uses GITHUB_ACTIONS and E2E. Tests: mock this module to control shouldApply().
- */
-export const buildTimeDefaultsConfig = {
-  shouldApply(): boolean {
-    return process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true';
-  },
-};

--- a/app/core/Engine/controllers/remote-feature-flag-controller-init.test.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller-init.test.ts
@@ -10,13 +10,6 @@ import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import Logger from '../../../util/Logger';
-import { buildTimeDefaultsConfig } from './remote-feature-flag-build-time-defaults-config';
-
-jest.mock('./remote-feature-flag-build-time-defaults-config', () => ({
-  buildTimeDefaultsConfig: {
-    shouldApply: jest.fn(),
-  },
-}));
 
 jest.mock('../../../util/Logger', () => ({
   log: jest.fn(),
@@ -29,12 +22,9 @@ jest.mock('@metamask/remote-feature-flag-controller', () => ({
   })),
 }));
 
-function getInitRequestMock(
-  overrides?: Partial<{
-    persistedState: ControllerInitRequest<RemoteFeatureFlagControllerMessenger>['persistedState'];
-    __testRemoteFeatureFlagDefaultsJson?: string;
-  }>,
-): jest.Mocked<ControllerInitRequest<RemoteFeatureFlagControllerMessenger>> {
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<RemoteFeatureFlagControllerMessenger>
+> {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,
   });
@@ -43,7 +33,6 @@ function getInitRequestMock(
     ...buildControllerInitRequestMock(baseMessenger),
     controllerMessenger: getRemoteFeatureFlagControllerMessenger(baseMessenger),
     initMessenger: undefined,
-    ...overrides,
   };
 
   // @ts-expect-error: Partial mock.
@@ -74,7 +63,6 @@ describe('remoteFeatureFlagControllerInit', () => {
     const controllerMock = jest.mocked(RemoteFeatureFlagController);
     expect(controllerMock).toHaveBeenCalledWith({
       messenger: expect.any(Object),
-      state: undefined,
       disabled: false,
       getMetaMetricsId: expect.any(Function),
       clientConfigApiService: expect.any(ClientConfigApiService),
@@ -148,128 +136,5 @@ describe('remoteFeatureFlagControllerInit', () => {
       'Feature flags update failed: ',
       mockError,
     );
-  });
-
-  describe('build-time feature flag defaults (builds.yml)', () => {
-    const originalGithubActions = process.env.GITHUB_ACTIONS;
-    const originalE2E = process.env.E2E;
-    const originalRemoteFeatureFlagDefaults =
-      process.env.REMOTE_FEATURE_FLAG_DEFAULTS;
-
-    beforeEach(() => {
-      jest.mocked(RemoteFeatureFlagController).mockClear();
-    });
-
-    afterEach(() => {
-      jest.mocked(buildTimeDefaultsConfig.shouldApply).mockReset();
-      if (originalGithubActions !== undefined) {
-        process.env.GITHUB_ACTIONS = originalGithubActions;
-      } else {
-        delete process.env.GITHUB_ACTIONS;
-      }
-      if (originalE2E !== undefined) {
-        process.env.E2E = originalE2E;
-      } else {
-        delete process.env.E2E;
-      }
-      if (originalRemoteFeatureFlagDefaults !== undefined) {
-        process.env.REMOTE_FEATURE_FLAG_DEFAULTS =
-          originalRemoteFeatureFlagDefaults;
-      } else {
-        delete process.env.REMOTE_FEATURE_FLAG_DEFAULTS;
-      }
-    });
-
-    it('passes persisted state as-is when not in GitHub Actions', () => {
-      jest.mocked(buildTimeDefaultsConfig.shouldApply).mockReturnValue(false);
-      process.env.GITHUB_ACTIONS = 'false';
-      delete process.env.E2E;
-      delete process.env.REMOTE_FEATURE_FLAG_DEFAULTS;
-
-      const persistedState = {
-        RemoteFeatureFlagController: {
-          remoteFeatureFlags: { customFlag: true },
-        },
-      };
-      remoteFeatureFlagControllerInit(
-        getInitRequestMock({
-          persistedState,
-        } as Parameters<typeof getInitRequestMock>[0]),
-      );
-
-      const controllerMock = jest.mocked(RemoteFeatureFlagController);
-      expect(controllerMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          state: persistedState.RemoteFeatureFlagController,
-        }),
-      );
-    });
-
-    it('merges REMOTE_FEATURE_FLAG_DEFAULTS when GITHUB_ACTIONS is true and E2E is not set', () => {
-      jest.mocked(buildTimeDefaultsConfig.shouldApply).mockReturnValue(true);
-
-      remoteFeatureFlagControllerInit(
-        getInitRequestMock({
-          __testRemoteFeatureFlagDefaultsJson: JSON.stringify({
-            perpsPerpTradingEnabled: true,
-            earnPooledStakingEnabled: false,
-          }),
-        } as Parameters<typeof getInitRequestMock>[0]),
-      );
-
-      const controllerMock = jest.mocked(RemoteFeatureFlagController);
-      const callArg = controllerMock.mock.calls[0][0];
-      expect(callArg.state).toBeDefined();
-      expect(callArg.state?.remoteFeatureFlags).toMatchObject({
-        perpsPerpTradingEnabled: true,
-        earnPooledStakingEnabled: false,
-      });
-    });
-
-    it('passes persisted state as-is when GITHUB_ACTIONS is true and E2E is true', () => {
-      jest.mocked(buildTimeDefaultsConfig.shouldApply).mockReturnValue(false);
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.E2E = 'true';
-      process.env.REMOTE_FEATURE_FLAG_DEFAULTS = JSON.stringify({
-        perpsPerpTradingEnabled: true,
-      });
-
-      remoteFeatureFlagControllerInit(getInitRequestMock());
-
-      const controllerMock = jest.mocked(RemoteFeatureFlagController);
-      expect(controllerMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          state: undefined,
-        }),
-      );
-    });
-
-    it('persisted state overrides build-time defaults when both present', () => {
-      jest.mocked(buildTimeDefaultsConfig.shouldApply).mockReturnValue(true);
-
-      const persistedState = {
-        RemoteFeatureFlagController: {
-          remoteFeatureFlags: {
-            perpsPerpTradingEnabled: true,
-          },
-        },
-      };
-      remoteFeatureFlagControllerInit(
-        getInitRequestMock({
-          persistedState,
-          __testRemoteFeatureFlagDefaultsJson: JSON.stringify({
-            perpsPerpTradingEnabled: false,
-            earnPooledStakingEnabled: true,
-          }),
-        } as Parameters<typeof getInitRequestMock>[0]),
-      );
-
-      const controllerMock = jest.mocked(RemoteFeatureFlagController);
-      const callArg = controllerMock.mock.calls[0][0];
-      expect(callArg.state?.remoteFeatureFlags).toMatchObject({
-        perpsPerpTradingEnabled: true,
-        earnPooledStakingEnabled: true,
-      });
-    });
   });
 });

--- a/app/core/Engine/controllers/remote-feature-flag-controller-init.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller-init.ts
@@ -4,7 +4,6 @@ import {
   ClientType,
   RemoteFeatureFlagController,
   type RemoteFeatureFlagControllerMessenger,
-  type RemoteFeatureFlagControllerState,
 } from '@metamask/remote-feature-flag-controller';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 import AppConstants from '../../AppConstants';
@@ -15,67 +14,6 @@ import {
   isRemoteFeatureFlagOverrideActivated,
 } from './remote-feature-flag-controller';
 import { getBaseSemVerVersion } from '../../../util/version';
-import { buildTimeDefaultsConfig } from './remote-feature-flag-build-time-defaults-config';
-
-/**
- * Get build-time feature flag defaults from environment variable.
- * Set by apply-build-config.js from builds.yml (e.g. in GitHub Actions "Apply build config" step).
- *
- * @returns Parsed defaults object or empty object if unset/invalid.
- */
-function getBuildTimeFeatureFlagDefaults(): Record<string, unknown> {
-  try {
-    const defaults = process.env.REMOTE_FEATURE_FLAG_DEFAULTS;
-    if (defaults) {
-      return JSON.parse(defaults);
-    }
-  } catch (error) {
-    Logger.log('Failed to parse REMOTE_FEATURE_FLAG_DEFAULTS:', error);
-  }
-  return {};
-}
-
-/**
- * Merge build-time defaults with persisted state.
- * Build-time defaults (from builds.yml) are used as initial values; persisted state takes precedence.
- * Only applied when running in GitHub Actions (non-E2E); Bitrise/local unchanged.
- *
- * @param persistedState - Persisted RemoteFeatureFlagController state, if any.
- * @param buildTimeDefaultsJsonOverride - Optional JSON string (e.g. for tests) to use instead of REMOTE_FEATURE_FLAG_DEFAULTS env.
- * @returns State to pass to the controller (merged when GH Actions, else persisted as-is).
- */
-function getInitialState(
-  persistedState: RemoteFeatureFlagControllerState | undefined,
-  buildTimeDefaultsJsonOverride?: string,
-): RemoteFeatureFlagControllerState | undefined {
-  if (!buildTimeDefaultsConfig.shouldApply()) {
-    return persistedState;
-  }
-
-  let buildTimeDefaults: Record<string, unknown>;
-  if (buildTimeDefaultsJsonOverride !== undefined) {
-    try {
-      buildTimeDefaults = JSON.parse(buildTimeDefaultsJsonOverride);
-    } catch {
-      buildTimeDefaults = {};
-    }
-  } else {
-    buildTimeDefaults = getBuildTimeFeatureFlagDefaults();
-  }
-  if (Object.keys(buildTimeDefaults).length === 0) {
-    return persistedState;
-  }
-
-  const mergedRemoteFeatureFlags = {
-    ...buildTimeDefaults,
-    ...(persistedState?.remoteFeatureFlags ?? {}),
-  };
-
-  return {
-    ...persistedState,
-    remoteFeatureFlags: mergedRemoteFeatureFlags,
-  } as RemoteFeatureFlagControllerState;
-}
 
 /**
  * Initialize the remote feature flag controller.
@@ -87,24 +25,12 @@ function getInitialState(
 export const remoteFeatureFlagControllerInit: ControllerInitFunction<
   RemoteFeatureFlagController,
   RemoteFeatureFlagControllerMessenger
-> = (request) => {
-  const { controllerMessenger, persistedState, getState, analyticsId } =
-    request;
+> = ({ controllerMessenger, persistedState, getState, analyticsId }) => {
   const disabled = !selectBasicFunctionalityEnabled(getState());
-
-  // Test-only: inject build-time defaults JSON so tests need not rely on process.env
-  const testDefaultsJson = (request as Record<string, unknown>)
-    .__testRemoteFeatureFlagDefaultsJson as string | undefined;
-  const initialState = getInitialState(
-    persistedState.RemoteFeatureFlagController as
-      | RemoteFeatureFlagControllerState
-      | undefined,
-    testDefaultsJson,
-  );
 
   const controller = new RemoteFeatureFlagController({
     messenger: controllerMessenger,
-    state: initialState,
+    state: persistedState.RemoteFeatureFlagController,
     disabled,
     getMetaMetricsId: () => analyticsId,
     clientVersion: getBaseSemVerVersion(),

--- a/app/selectors/featureFlagController/legalNotices/index.test.ts
+++ b/app/selectors/featureFlagController/legalNotices/index.test.ts
@@ -48,47 +48,12 @@ function mockStateWithUndefinedController() {
 }
 
 describe('selectIsPna25FlagEnabled', () => {
-  const originalGithubActions = process.env.GITHUB_ACTIONS;
-  const originalE2E = process.env.E2E;
-
   afterEach(() => {
     jest.clearAllMocks();
-    if (originalGithubActions !== undefined) {
-      process.env.GITHUB_ACTIONS = originalGithubActions;
-    } else {
-      delete process.env.GITHUB_ACTIONS;
-    }
-    if (originalE2E !== undefined) {
-      process.env.E2E = originalE2E;
-    } else {
-      delete process.env.E2E;
-    }
-  });
-
-  describe('when GITHUB_ACTIONS uses only remote (no env)', () => {
-    beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'true';
-      delete process.env.E2E;
-    });
-
-    it('returns true when remote flag is true', () => {
-      const mockedState = mockStateWith(true);
-      const result = selectIsPna25FlagEnabled(mockedState);
-      expect(result).toBe(true);
-      expect(getFeatureFlagValue).not.toHaveBeenCalled();
-    });
-
-    it('returns false when remote flag is false', () => {
-      const mockedState = mockStateWith(false);
-      const result = selectIsPna25FlagEnabled(mockedState);
-      expect(result).toBe(false);
-      expect(getFeatureFlagValue).not.toHaveBeenCalled();
-    });
   });
 
   describe('without environment variable override', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'false';
       (getFeatureFlagValue as jest.Mock).mockImplementation(
         (_envValue: string | undefined, remoteValue: boolean) => remoteValue,
       );
@@ -129,7 +94,7 @@ describe('selectIsPna25FlagEnabled', () => {
 
   describe('with environment variable override to true', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'false';
+      // Mock behavior: always returns true (env override)
       (getFeatureFlagValue as jest.Mock).mockReturnValue(true);
     });
 
@@ -160,7 +125,7 @@ describe('selectIsPna25FlagEnabled', () => {
 
   describe('with environment variable override to false', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'false';
+      // Mock behavior: always returns false (env override)
       (getFeatureFlagValue as jest.Mock).mockReturnValue(false);
     });
 

--- a/app/selectors/featureFlagController/legalNotices/index.ts
+++ b/app/selectors/featureFlagController/legalNotices/index.ts
@@ -3,9 +3,8 @@ import { selectRemoteFeatureFlags } from '..';
 import { getFeatureFlagValue } from '../env';
 
 /**
- * Selector for PNA25 feature flag.
- * When GITHUB_ACTIONS (and not E2E): use only remote (builds.yml). Otherwise
- * MM_EXTENSION_UX_PNA25 can override the remote flag.
+ * Selector for PNA25 feature flag
+ * Checks the environment variable `MM_EXTENSION_UX_PNA25` to override the remote flag
  *
  * @returns {boolean} True if PNA25 feature is enabled
  */
@@ -13,16 +12,10 @@ export const selectIsPna25FlagEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
     const remoteValue = remoteFeatureFlags?.extensionUxPna25;
-    const useRemoteOnly =
-      process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true';
-
-    if (useRemoteOnly) {
-      return remoteValue === true;
-    }
 
     return getFeatureFlagValue(
       process.env.MM_EXTENSION_UX_PNA25,
-      remoteValue === true,
+      Boolean(remoteValue),
     );
   },
 );

--- a/app/selectors/featureFlagController/networkBlacklist/index.test.ts
+++ b/app/selectors/featureFlagController/networkBlacklist/index.test.ts
@@ -20,13 +20,12 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
   });
 
   beforeEach(() => {
-    // Reset environment variables (ensure non-GH path for tests that use env)
+    // Reset environment variables
     process.env = { ...originalEnv };
-    delete process.env.GITHUB_ACTIONS;
-    delete process.env.E2E;
   });
 
   afterEach(() => {
+    // Restore original environment
     process.env = originalEnv;
   });
 
@@ -95,18 +94,5 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
 
     const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
     expect(result).toEqual(['0x8f', 123, null, '0x531']);
-  });
-
-  it('when GITHUB_ACTIONS uses only remote and ignores env override', () => {
-    process.env.GITHUB_ACTIONS = 'true';
-    delete process.env.E2E;
-    process.env.MM_ADDITIONAL_NETWORK_BLACKLIST = '0x1,0x2';
-
-    const state = createTestState({
-      additionalNetworksBlacklist: ['0x8f', '0x531'],
-    });
-
-    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
-    expect(result).toEqual(['0x8f', '0x531']);
   });
 });

--- a/app/selectors/featureFlagController/networkBlacklist/index.ts
+++ b/app/selectors/featureFlagController/networkBlacklist/index.ts
@@ -10,8 +10,8 @@ export interface AdditionalNetworksBlacklistFeatureFlag {
  * Allows to remove a network from the additional network selection.
  * Returns an array of chain IDs that should be hidden from the Additional Networks list.
  *
- * When GITHUB_ACTIONS (and not E2E): use only remote (builds.yml). Otherwise supports
- * local override via MM_ADDITIONAL_NETWORK_BLACKLIST (comma-separated chain IDs).
+ * Supports local environment variable override via MM_ADDITIONAL_NETWORK_BLACKLIST
+ * (comma-separated chain IDs, e.g., "0x8f,0x531")
  *
  * @param state - The Redux state
  * @returns Array of blacklisted chain IDs
@@ -23,11 +23,7 @@ export const selectAdditionalNetworksBlacklistFeatureFlag = createSelector(
       | string[]
       | undefined;
 
-    if (process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true') {
-      const value = remoteValue || [];
-      return Array.isArray(value) ? value : [];
-    }
-
+    // Parse environment variable override
     const envValue = process.env.MM_ADDITIONAL_NETWORK_BLACKLIST;
     let envArray: string[] = [];
 
@@ -38,7 +34,10 @@ export const selectAdditionalNetworksBlacklistFeatureFlag = createSelector(
         .filter((id) => id.length > 0);
     }
 
+    // Use environment variable if provided, otherwise use remote value, fallback to empty array
     const finalValue = envArray.length > 0 ? envArray : remoteValue || [];
+
+    // Ensure we return an array of strings
     return Array.isArray(finalValue) ? finalValue : [];
   },
 );

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -13,9 +13,6 @@ const newOverrides = [
     exclude: [
       'app/components/UI/Earn/selectors/featureFlags/index.ts',
       'app/components/UI/Perps/selectors/featureFlags/index.ts',
-      'app/components/UI/Predict/selectors/featureFlags/index.ts',
-      'app/selectors/featureFlagController/legalNotices/index.ts',
-      'app/selectors/featureFlagController/networkBlacklist/index.ts',
       'app/core/Engine/controllers/network-controller/utils.ts',
       'app/core/Engine/controllers/network-controller/utils.test.ts',
       'app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.ts',

--- a/builds.yml
+++ b/builds.yml
@@ -4,14 +4,12 @@
 # Usage:
 #   - CI reads this file to configure builds
 #   - Local dev can override via .js.env (takes precedence)
-#   - LaunchDarkly overrides remote_feature_flags at runtime
 #
 # Structure:
 #   - env: sets environment variables directly (servers, build config, etc.)
 #   - secrets: maps env var names to GitHub Secret names
 #   - signing: (optional) AWS role + secret for code signing (omit for dev/simulator builds)
 #   - code_fencing: features to include via code fencing
-#   - remote_feature_flags: build-time defaults for LaunchDarkly flags (seeded into RemoteFeatureFlagController)
 #
 # GitHub Environment determines actual secret values - builds.yml just maps the names.
 # Signing: AWS Secrets Manager (Account 363762752069) - see Mobile Signer Roles & Secrets doc.
@@ -156,29 +154,6 @@ _code_fencing_flask: &code_fencing_flask
   - tron
 
 # =============================================================================
-# Remote Feature Flags - Build-time defaults (seeded into RemoteFeatureFlagController)
-# LaunchDarkly will override these at runtime
-# Production (conservative) defaults - override in dev/exp builds as needed
-# =============================================================================
-_remote_feature_flags: &remote_feature_flags # Perps
-  perpsPerpTradingEnabled: false
-  perpsPerpTradingServiceInterruptionBannerEnabled: false
-  perpsPerpGtmOnboardingModalEnabled: false
-  perpsOrderBookEnabled: false
-  perpsFeedbackEnabled: false
-  # Earn/Staking
-  earnPooledStakingEnabled: true
-  earnPooledStakingServiceInterruptionBannerEnabled: false
-  earnStablecoinLendingEnabled: true
-  earnStablecoinLendingServiceInterruptionBannerEnabled: false
-  earnMusdConversionFlowEnabled: false
-  earnMusdCtaEnabled: false
-  earnMusdConversionAssetOverviewCtaEnabled: false
-  earnMusdConversionTokenListItemCtaEnabled: false
-  earnMusdConversionRewardsUiEnabled: false
-  earnMerklCampaignClaiming: false
-
-# =============================================================================
 # Build Configurations
 # =============================================================================
 # Based on client distribution matrix - see docs for full mapping
@@ -199,7 +174,6 @@ builds:
       METAMASK_BUILD_TYPE: 'main'
     secrets: *secrets
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
 
   # Beta (production APIs, RC signing; TestFlight / Play Store beta track)
   main-beta:
@@ -211,7 +185,6 @@ builds:
       METAMASK_BUILD_TYPE: 'main'
     secrets: *secrets
     code_fencing: *code_fencing_beta
-    remote_feature_flags: *remote_feature_flags
 
   # Release candidate
   main-rc:
@@ -223,7 +196,6 @@ builds:
       METAMASK_BUILD_TYPE: 'main'
     secrets: *secrets
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
 
   # Test builds (QA)
   main-test:
@@ -244,7 +216,6 @@ builds:
       IS_SIM_BUILD: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
 
   # E2E test builds (no Sentry)
   main-e2e:
@@ -265,7 +236,6 @@ builds:
       IS_SIM_BUILD: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
 
   # Experimental builds
   main-exp:
@@ -285,19 +255,6 @@ builds:
       MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_experimental
-    remote_feature_flags:
-      <<: *remote_feature_flags
-      # Override for experimental testing
-      perpsPerpTradingEnabled: true
-      perpsPerpGtmOnboardingModalEnabled: true
-      perpsOrderBookEnabled: true
-      perpsFeedbackEnabled: true
-      earnMusdConversionFlowEnabled: true
-      earnMusdCtaEnabled: true
-      earnMusdConversionAssetOverviewCtaEnabled: true
-      earnMusdConversionTokenListItemCtaEnabled: true
-      earnMusdConversionRewardsUiEnabled: true
-      earnMerklCampaignClaiming: true
 
   # Local development / Expo development build (Runway .app for simulator)
   main-dev:
@@ -319,19 +276,6 @@ builds:
       DEV_OAUTH_CONFIG: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_main
-    remote_feature_flags:
-      <<: *remote_feature_flags
-      # Override for dev testing
-      perpsPerpTradingEnabled: true
-      perpsPerpGtmOnboardingModalEnabled: true
-      perpsOrderBookEnabled: true
-      perpsFeedbackEnabled: true
-      earnMusdConversionFlowEnabled: true
-      earnMusdCtaEnabled: true
-      earnMusdConversionAssetOverviewCtaEnabled: true
-      earnMusdConversionTokenListItemCtaEnabled: true
-      earnMusdConversionRewardsUiEnabled: true
-      earnMerklCampaignClaiming: true
 
   # ---------------------------------------------------------------------------
   # FLASK BUILDS
@@ -347,7 +291,6 @@ builds:
       METAMASK_BUILD_TYPE: 'flask'
     secrets: *secrets
     code_fencing: *code_fencing_flask
-    remote_feature_flags: *remote_feature_flags
 
   # Flask test builds (QA)
   flask-test:
@@ -368,7 +311,6 @@ builds:
       IS_SIM_BUILD: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_flask
-    remote_feature_flags: *remote_feature_flags
 
   # Flask E2E test builds (no Sentry)
   flask-e2e:
@@ -389,7 +331,6 @@ builds:
       IS_SIM_BUILD: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_flask
-    remote_feature_flags: *remote_feature_flags
 
   # Flask local development / Expo development build (Runway .app for simulator)
   flask-dev:
@@ -411,19 +352,6 @@ builds:
       DEV_OAUTH_CONFIG: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_flask
-    remote_feature_flags:
-      <<: *remote_feature_flags
-      # Override for dev testing
-      perpsPerpTradingEnabled: true
-      perpsPerpGtmOnboardingModalEnabled: true
-      perpsOrderBookEnabled: true
-      perpsFeedbackEnabled: true
-      earnMusdConversionFlowEnabled: true
-      earnMusdCtaEnabled: true
-      earnMusdConversionAssetOverviewCtaEnabled: true
-      earnMusdConversionTokenListItemCtaEnabled: true
-      earnMusdConversionRewardsUiEnabled: true
-      earnMerklCampaignClaiming: true
 
   # ─────────────────────────────────────────────────────────────────────────────
   # QA Builds (legacy - for internal testing)
@@ -452,7 +380,6 @@ builds:
       ANDROID_GOOGLE_SERVER_CLIENT_ID: MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT
       MM_CARD_BAANX_API_CLIENT_KEY: MM_CARD_BAANX_API_CLIENT_KEY_UAT
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
 
   # QA dev build / Expo development build (Runway .app for simulator)
   qa-dev:
@@ -487,16 +414,3 @@ builds:
       ANDROID_GOOGLE_SERVER_CLIENT_ID: MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT
       MM_CARD_BAANX_API_CLIENT_KEY: MM_CARD_BAANX_API_CLIENT_KEY_UAT
     code_fencing: *code_fencing_main
-    remote_feature_flags:
-      <<: *remote_feature_flags
-      # Override for dev testing
-      perpsPerpTradingEnabled: true
-      perpsPerpGtmOnboardingModalEnabled: true
-      perpsOrderBookEnabled: true
-      perpsFeedbackEnabled: true
-      earnMusdConversionFlowEnabled: true
-      earnMusdCtaEnabled: true
-      earnMusdConversionAssetOverviewCtaEnabled: true
-      earnMusdConversionTokenListItemCtaEnabled: true
-      earnMusdConversionRewardsUiEnabled: true
-      earnMerklCampaignClaiming: true

--- a/builds.yml
+++ b/builds.yml
@@ -160,151 +160,23 @@ _code_fencing_flask: &code_fencing_flask
 # LaunchDarkly will override these at runtime
 # Production (conservative) defaults - override in dev/exp builds as needed
 # =============================================================================
-_remote_feature_flags: &remote_feature_flags
-  # Bitcoin/Tron/Multichain accounts (prod LD values — each uses a custom type-guard validator)
-  bitcoinAccounts:
-    enabled: true
-    minimumVersion: '7.59.0'
-  tronAccounts:
-    enabled: true
-    minimumVersion: '7.61.6'
-  # enableMultichainAccounts requires the extra featureVersion field (assertMultichainAccountsFeatureFlagType)
-  enableMultichainAccounts:
-    enabled: true
-    featureVersion: '1'
-    minimumVersion: '7.53.0'
-  enableMultichainAccountsState2:
-    enabled: true
-    featureVersion: '2'
-    minimumVersion: '7.57.0'
-  # Perps (prod LD values — version gates preserved for safety)
-  perpsPerpTradingEnabled:
-    enabled: true
-    minimumVersion: '7.56.2'
-  perpsPerpTradingServiceInterruptionBannerEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  perpsPerpGtmOnboardingModalEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  perpsOrderBookEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  perpsFeedbackEnabled:
-    enabled: true
-    minimumVersion: '7.62.0'
-  perpsHip3Enabled:
-    enabled: true
-    minimumVersion: '7.60.4'
-  # LD sends { enabled: false } without minimumVersion — keeping minimumVersion for selector type-guard
-  perpsTradeWithAnyTokenIsEnabled:
-    enabled: false
-    minimumVersion: '7.66.0'
-  perpsMyxProviderEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  rewardsReferralCodeEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
+_remote_feature_flags: &remote_feature_flags # Perps
+  perpsPerpTradingEnabled: false
+  perpsPerpTradingServiceInterruptionBannerEnabled: false
+  perpsPerpGtmOnboardingModalEnabled: false
+  perpsOrderBookEnabled: false
+  perpsFeedbackEnabled: false
   # Earn/Staking
-  earnPooledStakingEnabled:
-    enabled: true
-    minimumVersion: '7.47.0'
-  earnPooledStakingServiceInterruptionBannerEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  earnStablecoinLendingEnabled:
-    enabled: true
-    minimumVersion: '7.51.0'
-  earnStablecoinLendingServiceInterruptionBannerEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  earnMusdConversionFlowEnabled:
-    enabled: true
-    minimumVersion: '7.65.0'
-  earnMusdCtaEnabled:
-    enabled: true
-    minimumVersion: '7.65.0'
-  earnMusdConversionAssetOverviewCtaEnabled:
-    enabled: true
-    minimumVersion: '7.65.0'
-  earnMusdConversionTokenListItemCtaEnabled:
-    enabled: true
-    minimumVersion: '7.65.0'
-  earnMusdConversionRewardsUiEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  earnMerklCampaignClaiming:
-    enabled: false
-    minimumVersion: '0.0.0'
-  # Predict
-  predictHotTab:
-    enabled: false
-    minimumVersion: '0.0.0'
-  # predictHomeFeaturedVariant has an extended structure: variant controls which layout is shown
-  predictHomeFeaturedVariant:
-    enabled: true
-    minimumVersion: '7.65.0'
-    variant: 'carousel'
-  predictGtmOnboardingModalEnabled:
-    enabled: true
-    minimumVersion: '7.60.0'
-  predictTradingEnabled:
-    enabled: true
-    minimumVersion: '7.60.0'
-  # Market Insights
-  aiSocialMarketAnalysisEnabled:
-    enabled: true
-    minimumVersion: '7.66.0'
-  # Card Features
-  # displayCardButton is a phased rollout in LD (10% enabled) — conservative disabled default
-  displayCardButton:
-    enabled: false
-    minimumVersion: '0.0.0'
-  cardExperimentalSwitch2:
-    enabled: true
-    minimumVersion: '7.58.1'
-  metalCardCheckoutEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  galileoAppleWalletInAppProvisioningEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  galileoGoogleWalletInAppProvisioningEnabled:
-    enabled: false
-    minimumVersion: '0.0.0'
-  # Homepage
-  homepageRedesignV1:
-    enabled: true
-    minimumVersion: '7.59.0'
-  homepageSectionsV1:
-    enabled: false
-    minimumVersion: '0.0.0'
-  # OTA Updates
-  otaUpdatesEnabled:
-    enabled: true
-    minimumVersion: '7.63.90'
-  # Token Details
-  tokenDetailsV2ButtonLayout:
-    enabled: false
-    minimumVersion: '7.67.0'
-  tokenListItemV2AbtestVersioned:
-    enabled: false
-    minimumVersion: '7.67.0'
-  # Tron Staking
-  trxStakingEnabled:
-    enabled: true
-    minimumVersion: '7.61.6'
-  # Assets
-  assetsAccountApiBalances:
-    - '0x1'
-    - '0xe708'
-    - '0x2105'
-    - '0x89'
-    - '0xa4b1'
-    - '0xa'
-    - '0x38'
-  additionalNetworksBlacklist: []
+  earnPooledStakingEnabled: true
+  earnPooledStakingServiceInterruptionBannerEnabled: false
+  earnStablecoinLendingEnabled: true
+  earnStablecoinLendingServiceInterruptionBannerEnabled: false
+  earnMusdConversionFlowEnabled: false
+  earnMusdCtaEnabled: false
+  earnMusdConversionAssetOverviewCtaEnabled: false
+  earnMusdConversionTokenListItemCtaEnabled: false
+  earnMusdConversionRewardsUiEnabled: false
+  earnMerklCampaignClaiming: false
 
 # =============================================================================
 # Build Configurations
@@ -413,7 +285,19 @@ builds:
       MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_experimental
-    remote_feature_flags: *remote_feature_flags
+    remote_feature_flags:
+      <<: *remote_feature_flags
+      # Override for experimental testing
+      perpsPerpTradingEnabled: true
+      perpsPerpGtmOnboardingModalEnabled: true
+      perpsOrderBookEnabled: true
+      perpsFeedbackEnabled: true
+      earnMusdConversionFlowEnabled: true
+      earnMusdCtaEnabled: true
+      earnMusdConversionAssetOverviewCtaEnabled: true
+      earnMusdConversionTokenListItemCtaEnabled: true
+      earnMusdConversionRewardsUiEnabled: true
+      earnMerklCampaignClaiming: true
 
   # Local development / Expo development build (Runway .app for simulator)
   main-dev:
@@ -435,7 +319,19 @@ builds:
       DEV_OAUTH_CONFIG: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
+    remote_feature_flags:
+      <<: *remote_feature_flags
+      # Override for dev testing
+      perpsPerpTradingEnabled: true
+      perpsPerpGtmOnboardingModalEnabled: true
+      perpsOrderBookEnabled: true
+      perpsFeedbackEnabled: true
+      earnMusdConversionFlowEnabled: true
+      earnMusdCtaEnabled: true
+      earnMusdConversionAssetOverviewCtaEnabled: true
+      earnMusdConversionTokenListItemCtaEnabled: true
+      earnMusdConversionRewardsUiEnabled: true
+      earnMerklCampaignClaiming: true
 
   # ---------------------------------------------------------------------------
   # FLASK BUILDS
@@ -515,7 +411,19 @@ builds:
       DEV_OAUTH_CONFIG: 'true'
     secrets: *secrets
     code_fencing: *code_fencing_flask
-    remote_feature_flags: *remote_feature_flags
+    remote_feature_flags:
+      <<: *remote_feature_flags
+      # Override for dev testing
+      perpsPerpTradingEnabled: true
+      perpsPerpGtmOnboardingModalEnabled: true
+      perpsOrderBookEnabled: true
+      perpsFeedbackEnabled: true
+      earnMusdConversionFlowEnabled: true
+      earnMusdCtaEnabled: true
+      earnMusdConversionAssetOverviewCtaEnabled: true
+      earnMusdConversionTokenListItemCtaEnabled: true
+      earnMusdConversionRewardsUiEnabled: true
+      earnMerklCampaignClaiming: true
 
   # ─────────────────────────────────────────────────────────────────────────────
   # QA Builds (legacy - for internal testing)
@@ -579,5 +487,16 @@ builds:
       ANDROID_GOOGLE_SERVER_CLIENT_ID: MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT
       MM_CARD_BAANX_API_CLIENT_KEY: MM_CARD_BAANX_API_CLIENT_KEY_UAT
     code_fencing: *code_fencing_main
-    remote_feature_flags: *remote_feature_flags
-
+    remote_feature_flags:
+      <<: *remote_feature_flags
+      # Override for dev testing
+      perpsPerpTradingEnabled: true
+      perpsPerpGtmOnboardingModalEnabled: true
+      perpsOrderBookEnabled: true
+      perpsFeedbackEnabled: true
+      earnMusdConversionFlowEnabled: true
+      earnMusdCtaEnabled: true
+      earnMusdConversionAssetOverviewCtaEnabled: true
+      earnMusdConversionTokenListItemCtaEnabled: true
+      earnMusdConversionRewardsUiEnabled: true
+      earnMerklCampaignClaiming: true

--- a/scripts/apply-build-config.js
+++ b/scripts/apply-build-config.js
@@ -3,7 +3,7 @@
  * Loads build configuration from builds.yml and exports non-secret env vars.
  * Runs at workflow runtime (during the "Apply build config" step).
  *
- * Exports: env, code_fencing, remote_feature_flags. Does NOT handle secrets
+ * Exports: env, code_fencing. Does NOT handle secrets
  * (those are injected by the "Set secrets" step via set-secrets-from-config.js,
  * which reads all secrets via toJSON(secrets) — no explicit per-secret list needed).
  *
@@ -49,13 +49,6 @@ function applyConfig(buildName) {
     process.env.CODE_FENCING_FEATURES = JSON.stringify(config.code_fencing);
   }
 
-  // Set remote feature flag defaults (seeded into RemoteFeatureFlagController)
-  if (config.remote_feature_flags) {
-    process.env.REMOTE_FEATURE_FLAG_DEFAULTS = JSON.stringify(
-      config.remote_feature_flags,
-    );
-  }
-
   return config;
 }
 
@@ -73,12 +66,6 @@ function exportForShell(buildName) {
   if (config.code_fencing) {
     lines.push(
       `export CODE_FENCING_FEATURES='${JSON.stringify(config.code_fencing)}'`,
-    );
-  }
-
-  if (config.remote_feature_flags) {
-    lines.push(
-      `export REMOTE_FEATURE_FLAG_DEFAULTS='${JSON.stringify(config.remote_feature_flags)}'`,
     );
   }
 
@@ -114,13 +101,6 @@ function exportForGitHubEnv(buildName) {
 
   if (config.code_fencing) {
     appendVar('CODE_FENCING_FEATURES', JSON.stringify(config.code_fencing));
-  }
-
-  if (config.remote_feature_flags) {
-    appendVar(
-      'REMOTE_FEATURE_FLAG_DEFAULTS',
-      JSON.stringify(config.remote_feature_flags),
-    );
   }
 
   return lines.join('\n');

--- a/scripts/validate-build-config.js
+++ b/scripts/validate-build-config.js
@@ -48,40 +48,6 @@ function validate() {
     }
   });
 
-  // Detect which flags are VersionGatedFeatureFlag-shaped (objects with both
-  // `enabled` and `minimumVersion`) across all builds. Any build that overrides
-  // one of these flags MUST keep it as an object — plain booleans or other
-  // primitives mean the controller can't validate them as VersionGated flags.
-  const versionGatedFlagNames = new Set();
-  buildNames.forEach((name) => {
-    const flags = config.builds[name].remote_feature_flags;
-    if (!flags) return;
-    Object.entries(flags).forEach(([key, value]) => {
-      if (
-        value !== null &&
-        typeof value === 'object' &&
-        'enabled' in value &&
-        'minimumVersion' in value
-      ) {
-        versionGatedFlagNames.add(key);
-      }
-    });
-  });
-
-  buildNames.forEach((name) => {
-    const flags = config.builds[name].remote_feature_flags;
-    if (!flags) return;
-    Object.entries(flags).forEach(([key, value]) => {
-      if (versionGatedFlagNames.has(key) && (value === null || typeof value !== 'object' || Array.isArray(value))) {
-        errors.push(
-          `${name}: remote_feature_flags.${key} must be an object ` +
-            `{ enabled: bool, minimumVersion: string } but got ${JSON.stringify(value)}. ` +
-            `Use "enabled: true/false" + "minimumVersion: '0.0.0'" instead of a plain boolean.`,
-        );
-      }
-    });
-  });
-
   if (errors.length > 0) {
     console.error('❌ Validation errors:');
     errors.forEach((e) => console.error(`  - ${e}`));

--- a/scripts/verify-build-config.js
+++ b/scripts/verify-build-config.js
@@ -311,25 +311,6 @@ function verifyConfig(options = {}) {
     console.log(`   ❌ No code fencing defined in builds.yml`);
   }
 
-  // Verify remote feature flags
-  console.log('\n🚩 Checking remote feature flags...');
-  if (config.remote_feature_flags) {
-    const flags = Object.keys(config.remote_feature_flags);
-    if (verbose) {
-      Object.entries(config.remote_feature_flags).forEach(([flag, value]) => {
-        console.log(`   ✅ ${flag}: ${value}`);
-      });
-    } else {
-      console.log(`   ✅ ${flags.length} remote feature flags configured`);
-    }
-  } else {
-    warnings.push({
-      key: 'remote_feature_flags',
-      reason: 'Not defined in builds.yml',
-    });
-    console.log(`   ⚠️  No remote feature flags defined`);
-  }
-
   // REVERSE CHECK: Find Bitrise env vars NOT in builds.yml
   console.log('\n🔄 Checking for Bitrise env vars NOT in builds.yml...');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
After some consideration, we are taking a step back and reverting the built-in default feature flags for now. 
We measured the pros and cons, and the benefits of standardising a default value for feature flags were not enough to outweigh the cons, such as the friction for teams to implement them. 
 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote feature flags are initialized and overridden by removing build-time seeded defaults and re-enabling env-based overrides, which could alter feature availability across builds/environments. Also adjusts CI/build tooling and test behavior around `process.env`, so regressions may surface as unexpected flag values in builds/tests.
> 
> **Overview**
> Reverts the build-time seeding of LaunchDarkly defaults from `builds.yml`: removes the `remote_feature_flags` section, stops exporting `REMOTE_FEATURE_FLAG_DEFAULTS` in `apply-build-config.js`, and drops related validation/verification checks.
> 
> Simplifies remote feature flag controller init to use only persisted state (removing the GitHub Actions/E2E-specific merge logic and its tests), and updates selectors/tests to no longer treat `GITHUB_ACTIONS` as “remote-only” (env overrides like `MM_EXTENSION_UX_PNA25` and `MM_ADDITIONAL_NETWORK_BLACKLIST` now always apply when set). Test setup is adjusted accordingly, including enabling env var inlining for some selector files by removing them from `babel.config.tests.js` exclusions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 170eef5eea343e5aa29d95bfdfd06463ef40b136. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->