### PR TITLE
chore: new environment variable to builds with gh actions

### DIFF
--- a/app/components/UI/Card/util/mapBaanxApiUrl.test.ts
+++ b/app/components/UI/Card/util/mapBaanxApiUrl.test.ts
@@ -3,8 +3,8 @@ import { getDefaultBaanxApiBaseUrlForMetaMaskEnv } from './mapBaanxApiUrl';
 
 describe('getDefaultBaanxApiBaseUrlForMetaMaskEnv', () => {
   const originalBaanxUrl = process.env.BAANX_API_URL;
-  const originalGitHubActions = process.env.GITHUB_ACTIONS;
-  const originalE2e = process.env.E2E;
+  const originalBuildsEnabled =
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
 
   afterEach(() => {
     if (originalBaanxUrl !== undefined) {
@@ -12,22 +12,17 @@ describe('getDefaultBaanxApiBaseUrlForMetaMaskEnv', () => {
     } else {
       delete process.env.BAANX_API_URL;
     }
-    if (originalGitHubActions !== undefined) {
-      process.env.GITHUB_ACTIONS = originalGitHubActions;
+    if (originalBuildsEnabled !== undefined) {
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY =
+        originalBuildsEnabled;
     } else {
-      delete process.env.GITHUB_ACTIONS;
-    }
-    if (originalE2e !== undefined) {
-      process.env.E2E = originalE2e;
-    } else {
-      delete process.env.E2E;
+      delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
     }
   });
 
-  describe('when GITHUB_ACTIONS (builds.yml path)', () => {
+  describe('when BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (builds.yml path)', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'true';
-      delete process.env.E2E;
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
     });
 
     it('returns BAANX_API_URL from environment when set', () => {
@@ -53,23 +48,11 @@ describe('getDefaultBaanxApiBaseUrlForMetaMaskEnv', () => {
       const result2 = getDefaultBaanxApiBaseUrlForMetaMaskEnv('production');
       expect(result1).toBe(result2);
     });
-
-    it('uses metaMaskEnv when E2E is true (E2E path)', () => {
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.E2E = 'true';
-      process.env.BAANX_API_URL = 'https://build-time.api';
-      expect(getDefaultBaanxApiBaseUrlForMetaMaskEnv('production')).toBe(
-        AppConstants.BAANX_API_URL.PRD,
-      );
-      expect(getDefaultBaanxApiBaseUrlForMetaMaskEnv('dev')).toBe(
-        AppConstants.BAANX_API_URL.DEV,
-      );
-    });
   });
 
-  describe('when not GITHUB_ACTIONS (Bitrise / .js.env path)', () => {
+  describe('when not BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (Bitrise / .js.env path)', () => {
     beforeEach(() => {
-      delete process.env.GITHUB_ACTIONS;
+      delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
     });
 
     it('returns AppConstants.BAANX_API_URL.PRD for production/rc', () => {

--- a/app/components/UI/Card/util/mapBaanxApiUrl.ts
+++ b/app/components/UI/Card/util/mapBaanxApiUrl.ts
@@ -2,13 +2,13 @@ import AppConstants from '../../../../core/AppConstants';
 
 /**
  * Returns the Baanx API base URL for the given MetaMask environment.
- * When GITHUB_ACTIONS (and not E2E), uses process.env.BAANX_API_URL (set by builds.yml).
+ * When BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (and not E2E), uses process.env.BAANX_API_URL (set by builds.yml).
  * When not (Bitrise / .js.env / E2E), uses AppConstants.BAANX_API_URL per env.
  */
 export const getDefaultBaanxApiBaseUrlForMetaMaskEnv = (
   metaMaskEnv: string | undefined,
 ): string => {
-  if (process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true') {
+  if (process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY === 'true') {
     return process.env.BAANX_API_URL as string;
   }
   switch (metaMaskEnv) {

--- a/app/components/UI/Ramp/Aggregator/sdk/getSdkEnvironment.test.ts
+++ b/app/components/UI/Ramp/Aggregator/sdk/getSdkEnvironment.test.ts
@@ -3,12 +3,12 @@ import { getSdkEnvironment } from './getSdkEnvironment';
 
 describe('getSdkEnvironment', () => {
   const originalProcessEnv = process.env;
-  const originalGithubActions = process.env.GITHUB_ACTIONS;
+  const originalBuildsEnabled =
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
   const originalRampsEnvironment = process.env.RAMPS_ENVIRONMENT;
-  const originalE2e = process.env.E2E;
 
   beforeEach(() => {
-    process.env.GITHUB_ACTIONS = 'false';
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'false';
   });
 
   afterAll(() => {
@@ -16,27 +16,22 @@ describe('getSdkEnvironment', () => {
   });
 
   afterEach(() => {
-    if (originalGithubActions !== undefined) {
-      process.env.GITHUB_ACTIONS = originalGithubActions;
+    if (originalBuildsEnabled !== undefined) {
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY =
+        originalBuildsEnabled;
     } else {
-      delete process.env.GITHUB_ACTIONS;
+      delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
     }
     if (originalRampsEnvironment !== undefined) {
       process.env.RAMPS_ENVIRONMENT = originalRampsEnvironment;
     } else {
       delete process.env.RAMPS_ENVIRONMENT;
     }
-    if (originalE2e !== undefined) {
-      process.env.E2E = originalE2e;
-    } else {
-      delete process.env.E2E;
-    }
   });
 
-  describe('when GITHUB_ACTIONS (builds.yml path)', () => {
+  describe('when BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (builds.yml path)', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'true';
-      delete process.env.E2E;
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
     });
 
     it('returns Production when RAMPS_ENVIRONMENT is production', () => {
@@ -58,14 +53,6 @@ describe('getSdkEnvironment', () => {
       process.env.METAMASK_ENVIRONMENT = 'production';
       process.env.RAMPS_ENVIRONMENT = 'staging';
       expect(getSdkEnvironment()).toBe(Environment.Staging);
-    });
-
-    it('uses METAMASK_ENVIRONMENT when E2E is true (E2E path)', () => {
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.E2E = 'true';
-      process.env.RAMPS_ENVIRONMENT = 'staging';
-      process.env.METAMASK_ENVIRONMENT = 'production';
-      expect(getSdkEnvironment()).toBe(Environment.Production);
     });
   });
 

--- a/app/components/UI/Ramp/Aggregator/sdk/getSdkEnvironment.ts
+++ b/app/components/UI/Ramp/Aggregator/sdk/getSdkEnvironment.ts
@@ -1,11 +1,11 @@
 import { Environment } from '@consensys/on-ramp-sdk';
 
 /**
- * When GITHUB_ACTIONS (and not E2E), uses RAMPS_ENVIRONMENT (set by builds.yml).
+ * When BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (and not E2E), uses RAMPS_ENVIRONMENT (set by builds.yml).
  * When not (Bitrise / .js.env / E2E), uses METAMASK_ENVIRONMENT switch.
  */
 export function getSdkEnvironment() {
-  if (process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true') {
+  if (process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY === 'true') {
     const rampsEnv = process.env.RAMPS_ENVIRONMENT;
     return rampsEnv === 'production'
       ? Environment.Production

--- a/app/components/UI/Ramp/Deposit/sdk/getSdkEnvironment.test.ts
+++ b/app/components/UI/Ramp/Deposit/sdk/getSdkEnvironment.test.ts
@@ -3,37 +3,32 @@ import { getSdkEnvironment } from './getSdkEnvironment';
 
 describe('getSdkEnvironment', () => {
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
-  const originalGithubActions = process.env.GITHUB_ACTIONS;
+  const originalBuildsEnabled =
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
   const originalRampsEnvironment = process.env.RAMPS_ENVIRONMENT;
-  const originalE2e = process.env.E2E;
 
   beforeEach(() => {
-    process.env.GITHUB_ACTIONS = 'false';
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'false';
   });
 
   afterEach(() => {
     process.env.METAMASK_ENVIRONMENT = originalEnv;
-    if (originalGithubActions !== undefined) {
-      process.env.GITHUB_ACTIONS = originalGithubActions;
+    if (originalBuildsEnabled !== undefined) {
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY =
+        originalBuildsEnabled;
     } else {
-      delete process.env.GITHUB_ACTIONS;
+      delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
     }
     if (originalRampsEnvironment !== undefined) {
       process.env.RAMPS_ENVIRONMENT = originalRampsEnvironment;
     } else {
       delete process.env.RAMPS_ENVIRONMENT;
     }
-    if (originalE2e !== undefined) {
-      process.env.E2E = originalE2e;
-    } else {
-      delete process.env.E2E;
-    }
   });
 
-  describe('when GITHUB_ACTIONS (builds.yml path)', () => {
+  describe('when BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (builds.yml path)', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'true';
-      delete process.env.E2E;
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
     });
 
     it('returns Production when RAMPS_ENVIRONMENT is production', () => {
@@ -55,14 +50,6 @@ describe('getSdkEnvironment', () => {
       process.env.METAMASK_ENVIRONMENT = 'production';
       process.env.RAMPS_ENVIRONMENT = 'staging';
       expect(getSdkEnvironment()).toBe(SdkEnvironment.Staging);
-    });
-
-    it('uses METAMASK_ENVIRONMENT when E2E is true (E2E path)', () => {
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.E2E = 'true';
-      process.env.RAMPS_ENVIRONMENT = 'staging';
-      process.env.METAMASK_ENVIRONMENT = 'production';
-      expect(getSdkEnvironment()).toBe(SdkEnvironment.Production);
     });
   });
 

--- a/app/components/UI/Ramp/Deposit/sdk/getSdkEnvironment.ts
+++ b/app/components/UI/Ramp/Deposit/sdk/getSdkEnvironment.ts
@@ -1,11 +1,11 @@
 import { SdkEnvironment } from '@consensys/native-ramps-sdk';
 
 /**
- * When GITHUB_ACTIONS (and not E2E), uses RAMPS_ENVIRONMENT (set by builds.yml).
+ * When BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (and not E2E), uses RAMPS_ENVIRONMENT (set by builds.yml).
  * When not (Bitrise / .js.env / E2E), uses METAMASK_ENVIRONMENT switch.
  */
 export function getSdkEnvironment() {
-  if (process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true') {
+  if (process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY === 'true') {
     const rampsEnv = process.env.RAMPS_ENVIRONMENT;
     return rampsEnv === 'production'
       ? SdkEnvironment.Production

--- a/app/core/Engine/controllers/ramps-controller/ramps-service-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-service-init.test.ts
@@ -27,37 +27,32 @@ jest.mock('@metamask/ramps-controller', () => {
 
 describe('getRampsEnvironment', () => {
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
-  const originalGithubActions = process.env.GITHUB_ACTIONS;
+  const originalBuildsEnabled =
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
   const originalRampsEnvironment = process.env.RAMPS_ENVIRONMENT;
-  const originalE2e = process.env.E2E;
 
   beforeEach(() => {
-    process.env.GITHUB_ACTIONS = 'false';
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'false';
   });
 
   afterEach(() => {
     process.env.METAMASK_ENVIRONMENT = originalEnv;
-    if (originalGithubActions !== undefined) {
-      process.env.GITHUB_ACTIONS = originalGithubActions;
+    if (originalBuildsEnabled !== undefined) {
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY =
+        originalBuildsEnabled;
     } else {
-      delete process.env.GITHUB_ACTIONS;
+      delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
     }
     if (originalRampsEnvironment !== undefined) {
       process.env.RAMPS_ENVIRONMENT = originalRampsEnvironment;
     } else {
       delete process.env.RAMPS_ENVIRONMENT;
     }
-    if (originalE2e !== undefined) {
-      process.env.E2E = originalE2e;
-    } else {
-      delete process.env.E2E;
-    }
   });
 
-  describe('when GITHUB_ACTIONS (builds.yml path)', () => {
+  describe('when BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (builds.yml path)', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'true';
-      delete process.env.E2E;
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
     });
 
     it('returns Production when RAMPS_ENVIRONMENT is production', () => {
@@ -79,14 +74,6 @@ describe('getRampsEnvironment', () => {
       process.env.METAMASK_ENVIRONMENT = 'production';
       process.env.RAMPS_ENVIRONMENT = 'staging';
       expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
-    });
-
-    it('uses METAMASK_ENVIRONMENT when E2E is true (E2E path)', () => {
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.E2E = 'true';
-      process.env.RAMPS_ENVIRONMENT = 'staging';
-      process.env.METAMASK_ENVIRONMENT = 'production';
-      expect(getRampsEnvironment()).toBe(RampsEnvironment.Production);
     });
   });
 
@@ -167,13 +154,13 @@ describe('rampsServiceInit', () => {
   >;
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
   const originalOS = Platform.OS;
-  const originalGithubActions = process.env.GITHUB_ACTIONS;
+  const originalBuildsEnabled =
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
   const originalRampsEnvironment = process.env.RAMPS_ENVIRONMENT;
-  const originalE2e = process.env.E2E;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    process.env.GITHUB_ACTIONS = 'false';
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'false';
     const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
       namespace: MOCK_ANY_NAMESPACE,
     });
@@ -183,20 +170,16 @@ describe('rampsServiceInit', () => {
   afterEach(() => {
     process.env.METAMASK_ENVIRONMENT = originalEnv;
     Platform.OS = originalOS;
-    if (originalGithubActions !== undefined) {
-      process.env.GITHUB_ACTIONS = originalGithubActions;
+    if (originalBuildsEnabled !== undefined) {
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY =
+        originalBuildsEnabled;
     } else {
-      delete process.env.GITHUB_ACTIONS;
+      delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
     }
     if (originalRampsEnvironment !== undefined) {
       process.env.RAMPS_ENVIRONMENT = originalRampsEnvironment;
     } else {
       delete process.env.RAMPS_ENVIRONMENT;
-    }
-    if (originalE2e !== undefined) {
-      process.env.E2E = originalE2e;
-    } else {
-      delete process.env.E2E;
     }
   });
 
@@ -305,9 +288,9 @@ describe('rampsServiceInit', () => {
     });
   });
 
-  describe('when GITHUB_ACTIONS (builds.yml path)', () => {
+  describe('when BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (builds.yml path)', () => {
     beforeEach(() => {
-      process.env.GITHUB_ACTIONS = 'true';
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
       delete process.env.E2E;
     });
 

--- a/app/core/Engine/controllers/ramps-controller/ramps-service-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-service-init.ts
@@ -7,11 +7,11 @@ import {
 } from '@metamask/ramps-controller';
 
 /**
- * When GITHUB_ACTIONS (and not E2E), uses RAMPS_ENVIRONMENT (set by builds.yml).
+ * When BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (and not E2E), uses RAMPS_ENVIRONMENT (set by builds.yml).
  * When not (Bitrise / .js.env / E2E), uses METAMASK_ENVIRONMENT switch.
  */
 export function getRampsEnvironment(): RampsEnvironment {
-  if (process.env.GITHUB_ACTIONS === 'true' && process.env.E2E !== 'true') {
+  if (process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY === 'true') {
     const rampsEnv = process.env.RAMPS_ENVIRONMENT;
     return rampsEnv === 'production'
       ? RampsEnvironment.Production

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -76,7 +76,7 @@ describe('RewardsDataService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
-    process.env.GITHUB_ACTIONS = 'false';
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'false';
 
     // Allow env overrides by default (canChange = true).
     // getRewardsEnvUrl reads canChange from the tuple, so the second element

--- a/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.test.ts
@@ -38,18 +38,17 @@ describe('getDefaultRewardsApiBaseUrlForMetaMaskEnv', () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env.REWARDS_API_URL;
-    delete process.env.GITHUB_ACTIONS;
-    delete process.env.E2E;
+    delete process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY;
   });
 
   afterEach(() => {
     process.env = originalEnv;
   });
 
-  describe('GITHUB_ACTIONS override', () => {
-    it('returns custom URL when REWARDS_API_URL is set and GITHUB_ACTIONS is true and E2E is not true', () => {
+  describe('BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY override', () => {
+    it('returns custom URL when REWARDS_API_URL is set and BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY is true', () => {
       process.env.REWARDS_API_URL = 'https://custom.api';
-      process.env.GITHUB_ACTIONS = 'true';
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
 
       const [apiUrl, canChange] =
         getDefaultRewardsApiBaseUrlForMetaMaskEnv('dev');
@@ -59,7 +58,7 @@ describe('getDefaultRewardsApiBaseUrlForMetaMaskEnv', () => {
 
     it('preserves canChange based on env when returning custom URL', () => {
       process.env.REWARDS_API_URL = 'https://custom.api';
-      process.env.GITHUB_ACTIONS = 'true';
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
 
       const [apiUrl, canChange] =
         getDefaultRewardsApiBaseUrlForMetaMaskEnv('production');
@@ -67,25 +66,16 @@ describe('getDefaultRewardsApiBaseUrlForMetaMaskEnv', () => {
       expect(canChange).toBe(false);
     });
 
-    it('falls through to switch when E2E is true', () => {
+    it('falls through to switch when BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY is not true', () => {
       process.env.REWARDS_API_URL = 'https://custom.api';
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.E2E = 'true';
-
-      const [apiUrl] = getDefaultRewardsApiBaseUrlForMetaMaskEnv('dev');
-      expect(apiUrl).toEqual('https://api.uat');
-    });
-
-    it('falls through to switch when GITHUB_ACTIONS is not true', () => {
-      process.env.REWARDS_API_URL = 'https://custom.api';
-      process.env.GITHUB_ACTIONS = 'false';
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'false';
 
       const [apiUrl] = getDefaultRewardsApiBaseUrlForMetaMaskEnv('dev');
       expect(apiUrl).toEqual('https://api.uat');
     });
 
     it('falls through to switch when REWARDS_API_URL is not set', () => {
-      process.env.GITHUB_ACTIONS = 'true';
+      process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY = 'true';
 
       const [apiUrl] = getDefaultRewardsApiBaseUrlForMetaMaskEnv('dev');
       expect(apiUrl).toEqual('https://api.uat');

--- a/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts
@@ -17,7 +17,7 @@ export const canChangeRewardsEnvUrl = (
 
 /**
  * Returns the rewards API base URL for the given MetaMask environment.
- * When GITHUB_ACTIONS (and not E2E), uses process.env.REWARDS_API_URL (set by builds.yml).
+ * When BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY (and not E2E), uses process.env.REWARDS_API_URL (set by builds.yml).
  * When not (Bitrise / .js.env / E2E), uses AppConstants.REWARDS_API_URL per env.
  */
 export const getDefaultRewardsApiBaseUrlForMetaMaskEnv = (
@@ -27,8 +27,7 @@ export const getDefaultRewardsApiBaseUrlForMetaMaskEnv = (
 
   if (
     process.env.REWARDS_API_URL &&
-    process.env.GITHUB_ACTIONS === 'true' &&
-    process.env.E2E !== 'true'
+    process.env.BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY === 'true'
   ) {
     return [process.env.REWARDS_API_URL, canChange];
   }

--- a/builds.yml
+++ b/builds.yml
@@ -41,6 +41,8 @@ _public_envs: &public_envs # Servers (production)
   MM_PERPS_HIP3_ALLOWLIST_MARKETS: ''
   MM_PERPS_HIP3_BLOCKLIST_MARKETS: ''
   MM_PERPS_HIP3_ENABLED: 'true'
+  # Temporary flag to enable builds with GitHub Actions, remove it when deprecating bitrise
+  BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY: 'true'
 
 # Common secrets (shared across ALL builds - same names, GitHub Environment determines values)
 _secrets: &secrets # Infrastructure
@@ -580,4 +582,3 @@ builds:
       MM_CARD_BAANX_API_CLIENT_KEY: MM_CARD_BAANX_API_CLIENT_KEY_UAT
     code_fencing: *code_fencing_main
     remote_feature_flags: *remote_feature_flags
-


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
OTA was broken with old environment variables check. This PR aims to solve that by introdocing a new environment variable.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how several services choose API endpoints/environments by switching from `GITHUB_ACTIONS`/`E2E` checks to a new `BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY` flag, which could route builds to different backend environments if misconfigured.
> 
> **Overview**
> Introduces a new build-time env flag, `BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY`, and uses it to decide when to take **build-provided** URLs/environments (from `builds.yml`) versus deriving them from `METAMASK_ENVIRONMENT`.
> 
> Updates Baanx Card URL mapping, ramps SDK environment selection (Aggregator + Deposit), ramps controller init, and rewards API URL override logic to key off this flag, and refreshes/adjusts tests accordingly (including removing the previous special-casing tied to `E2E`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42499186e37db0ce7ff8459c282c8494a31bd982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->