### PR TITLE
feat: add lightweight v2 toast notifications for Ramps orders

### DIFF
--- a/app/components/UI/Ramp/Deposit/hooks/useHandleNewOrder.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useHandleNewOrder.ts
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
+import { InteractionManager } from 'react-native';
 import stateHasOrder from '../../utils/stateHasOrder';
 import { addFiatOrder, FiatOrder } from '../../../../../reducers/fiatOrders';
 import NotificationManager from '../../../../../core/NotificationManager';
 import useThunkDispatch from '../../../../hooks/useThunkDispatch';
 import { getNotificationDetails } from '../utils';
+import { selectRampsUnifiedBuyV2ActiveFlag } from '../../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
+import { showV2OrderToast } from '../../utils/v2OrderToast';
 
 function useHandleNewOrder() {
   const dispatchThunk = useThunkDispatch();
@@ -16,10 +19,22 @@ function useHandleNewOrder() {
           return;
         }
         _dispatch(addFiatOrder(order));
-        const notificationDetails = getNotificationDetails(order);
-        if (notificationDetails) {
-          NotificationManager.showSimpleNotification(notificationDetails);
-        }
+        InteractionManager.runAfterInteractions(() => {
+          const isV2 = selectRampsUnifiedBuyV2ActiveFlag(state);
+          if (isV2) {
+            showV2OrderToast({
+              orderId: order.id,
+              cryptocurrency: order.cryptocurrency,
+              cryptoAmount: order.cryptoAmount,
+              state: order.state,
+            });
+          } else {
+            const notificationDetails = getNotificationDetails(order);
+            if (notificationDetails) {
+              NotificationManager.showSimpleNotification(notificationDetails);
+            }
+          }
+        });
       });
     },
     [dispatchThunk],

--- a/app/components/UI/Ramp/Deposit/hooks/useHandleNewOrder.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useHandleNewOrder.ts
@@ -5,11 +5,12 @@ import { addFiatOrder, FiatOrder } from '../../../../../reducers/fiatOrders';
 import NotificationManager from '../../../../../core/NotificationManager';
 import useThunkDispatch from '../../../../hooks/useThunkDispatch';
 import { getNotificationDetails } from '../utils';
-import { selectRampsUnifiedBuyV2ActiveFlag } from '../../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
+import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
 
 function useHandleNewOrder() {
   const dispatchThunk = useThunkDispatch();
+  const isV2Enabled = useRampsUnifiedV2Enabled();
 
   return useCallback(
     async (order: FiatOrder) => {
@@ -20,8 +21,7 @@ function useHandleNewOrder() {
         }
         _dispatch(addFiatOrder(order));
         InteractionManager.runAfterInteractions(() => {
-          const isV2 = selectRampsUnifiedBuyV2ActiveFlag(state);
-          if (isV2) {
+          if (isV2Enabled) {
             showV2OrderToast({
               orderId: order.id,
               cryptocurrency: order.cryptocurrency,
@@ -37,7 +37,7 @@ function useHandleNewOrder() {
         });
       });
     },
-    [dispatchThunk],
+    [dispatchThunk, isV2Enabled],
   );
 }
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -38,6 +38,8 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
+import { showV2OrderToast } from '../../utils/v2OrderToast';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -216,6 +218,7 @@ const Checkout = () => {
   const params = useParams<CheckoutParams>();
   const theme = useTheme();
   const { styles } = useStyles(styleSheet, {});
+  const isV2Enabled = useRampsUnifiedV2Enabled();
 
   const {
     url: uri,
@@ -286,9 +289,18 @@ const Checkout = () => {
           return;
         }
         _dispatch(addFiatOrder(order));
-        const notificationDetails = getNotificationDetails(order);
-        if (notificationDetails) {
-          NotificationManager.showSimpleNotification(notificationDetails);
+        if (isV2Enabled) {
+          showV2OrderToast({
+            orderId: order.id,
+            cryptocurrency: order.cryptocurrency,
+            cryptoAmount: order.cryptoAmount,
+            state: order.state,
+          });
+        } else {
+          const notificationDetails = getNotificationDetails(order);
+          if (notificationDetails) {
+            NotificationManager.showSimpleNotification(notificationDetails);
+          }
         }
       });
 
@@ -311,7 +323,7 @@ const Checkout = () => {
         navigation.dangerouslyGetParent()?.pop();
       }
     },
-    [dispatch, dispatchThunk, navigation, providerType],
+    [dispatch, dispatchThunk, navigation, providerType, isV2Enabled],
   );
 
   const handleNavigationStateChange = useCallback(

--- a/app/components/UI/Ramp/index.tsx
+++ b/app/components/UI/Ramp/index.tsx
@@ -36,6 +36,8 @@ import { NativeRampsSdk } from '@consensys/native-ramps-sdk';
 import useDetectGeolocation from './hooks/useDetectGeolocation';
 import useHydrateRampsController from './hooks/useHydrateRampsController';
 import useRampsSmartRouting from './hooks/useRampsSmartRouting';
+import { selectRampsUnifiedBuyV2ActiveFlag } from '../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
+import { showV2OrderToast } from './utils/v2OrderToast';
 
 const POLLING_FREQUENCY = AppConstants.FIAT_ORDERS.POLLING_FREQUENCY;
 
@@ -60,9 +62,19 @@ export async function processFiatOrder(
         trackEvent(event, params);
       }
       InteractionManager.runAfterInteractions(() => {
-        const notificationDetails = getNotificationDetails(updatedOrder);
-        if (notificationDetails) {
-          NotificationManager.showSimpleNotification(notificationDetails);
+        const isV2 = selectRampsUnifiedBuyV2ActiveFlag(state);
+        if (isV2) {
+          showV2OrderToast({
+            orderId: updatedOrder.id,
+            cryptocurrency: updatedOrder.cryptocurrency,
+            cryptoAmount: updatedOrder.cryptoAmount,
+            state: updatedOrder.state,
+          });
+        } else {
+          const notificationDetails = getNotificationDetails(updatedOrder);
+          if (notificationDetails) {
+            NotificationManager.showSimpleNotification(notificationDetails);
+          }
         }
       });
     }
@@ -96,9 +108,19 @@ async function processCustomOrderId(
       }
       dispatchAddFiatOrder(fiatOrder);
       InteractionManager.runAfterInteractions(() => {
-        const notificationDetails = getNotificationDetails(fiatOrder);
-        if (notificationDetails) {
-          NotificationManager.showSimpleNotification(notificationDetails);
+        const isV2 = selectRampsUnifiedBuyV2ActiveFlag(state);
+        if (isV2) {
+          showV2OrderToast({
+            orderId: fiatOrder.id,
+            cryptocurrency: fiatOrder.cryptocurrency,
+            cryptoAmount: fiatOrder.cryptoAmount,
+            state: fiatOrder.state,
+          });
+        } else {
+          const notificationDetails = getNotificationDetails(fiatOrder);
+          if (notificationDetails) {
+            NotificationManager.showSimpleNotification(notificationDetails);
+          }
         }
       });
     });

--- a/app/components/UI/Ramp/index.tsx
+++ b/app/components/UI/Ramp/index.tsx
@@ -36,7 +36,7 @@ import { NativeRampsSdk } from '@consensys/native-ramps-sdk';
 import useDetectGeolocation from './hooks/useDetectGeolocation';
 import useHydrateRampsController from './hooks/useHydrateRampsController';
 import useRampsSmartRouting from './hooks/useRampsSmartRouting';
-import { selectRampsUnifiedBuyV2ActiveFlag } from '../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
+import { isRampsUnifiedV2Enabled } from './utils/isRampsUnifiedV2Enabled';
 import { showV2OrderToast } from './utils/v2OrderToast';
 
 const POLLING_FREQUENCY = AppConstants.FIAT_ORDERS.POLLING_FREQUENCY;
@@ -62,7 +62,7 @@ export async function processFiatOrder(
         trackEvent(event, params);
       }
       InteractionManager.runAfterInteractions(() => {
-        const isV2 = selectRampsUnifiedBuyV2ActiveFlag(state);
+        const isV2 = isRampsUnifiedV2Enabled(state);
         if (isV2) {
           showV2OrderToast({
             orderId: updatedOrder.id,
@@ -108,7 +108,7 @@ async function processCustomOrderId(
       }
       dispatchAddFiatOrder(fiatOrder);
       InteractionManager.runAfterInteractions(() => {
-        const isV2 = selectRampsUnifiedBuyV2ActiveFlag(state);
+        const isV2 = isRampsUnifiedV2Enabled(state);
         if (isV2) {
           showV2OrderToast({
             orderId: fiatOrder.id,

--- a/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.test.ts
+++ b/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.test.ts
@@ -1,0 +1,124 @@
+import initialRootState, {
+  backgroundState,
+} from '../../../../util/test/initial-root-state';
+import { isRampsUnifiedV2Enabled } from './isRampsUnifiedV2Enabled';
+import { getVersion } from 'react-native-device-info';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(),
+}));
+
+function buildState({
+  active = true,
+  minimumVersion,
+}: {
+  active?: boolean;
+  minimumVersion?: string | null;
+} = {}) {
+  return {
+    ...initialRootState,
+    engine: {
+      backgroundState: {
+        ...backgroundState,
+        RemoteFeatureFlagController: {
+          ...backgroundState.RemoteFeatureFlagController,
+          remoteFeatureFlags: {
+            rampsUnifiedBuyV2: {
+              active,
+              ...(minimumVersion !== undefined && { minimumVersion }),
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('isRampsUnifiedV2Enabled', () => {
+  const mockGetVersion = jest.mocked(getVersion);
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('build flag precedence', () => {
+    it('returns true when build flag is "true" regardless of remote flags', () => {
+      process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'true';
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: false, minimumVersion: '99.0.0' }),
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when build flag is "false" regardless of remote flags', () => {
+      process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'false';
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: true, minimumVersion: '1.0.0' }),
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('remote feature flag behavior when build flag is not set', () => {
+    it('returns true when active and version meets minimum requirement', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: true, minimumVersion: '7.63.0' }),
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when active flag is false', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: false, minimumVersion: '7.63.0' }),
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version does not meet minimum requirement', () => {
+      mockGetVersion.mockReturnValue('7.0.0');
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: true, minimumVersion: '7.63.0' }),
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when minimumVersion is not configured', () => {
+      mockGetVersion.mockReturnValue('8.0.0');
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: true, minimumVersion: null }),
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when version exactly equals minimum version', () => {
+      mockGetVersion.mockReturnValue('7.63.0');
+
+      const result = isRampsUnifiedV2Enabled(
+        buildState({ active: true, minimumVersion: '7.63.0' }),
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.ts
+++ b/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.ts
@@ -1,0 +1,22 @@
+import {
+  selectRampsUnifiedBuyV2ActiveFlag,
+  selectRampsUnifiedBuyV2MinimumVersionFlag,
+} from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
+import { hasMinimumRequiredVersion } from './hasMinimumRequiredVersion';
+import { RootState } from '../../../../reducers';
+
+/**
+ * Non-hook equivalent of useRampsUnifiedV2Enabled.
+ * Checks build flag override, active flag, and minimum version gate.
+ * Use this in thunks / plain functions where hooks aren't available.
+ */
+export function isRampsUnifiedV2Enabled(state: RootState): boolean {
+  const buildFlag = process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED;
+  if (buildFlag === 'true' || buildFlag === 'false') {
+    return buildFlag === 'true';
+  }
+
+  const activeFlag = selectRampsUnifiedBuyV2ActiveFlag(state);
+  const minimumVersion = selectRampsUnifiedBuyV2MinimumVersionFlag(state);
+  return hasMinimumRequiredVersion(minimumVersion, activeFlag);
+}

--- a/app/components/UI/Ramp/utils/v2OrderToast.test.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.test.ts
@@ -1,0 +1,226 @@
+import { FIAT_ORDER_STATES } from '../../../../constants/on-ramp';
+import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
+import {
+  buildV2OrderToastOptions,
+  showV2OrderToast,
+  V2OrderToastParams,
+} from './v2OrderToast';
+import ToastService from '../../../../core/ToastService';
+import NavigationService from '../../../../core/NavigationService';
+import Routes from '../../../../constants/navigation/Routes';
+import { strings } from '../../../../../locales/i18n';
+
+jest.mock('../../../../core/ToastService');
+jest.mock('../../../../core/NavigationService', () => ({
+  navigation: {
+    navigate: jest.fn(),
+  },
+}));
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn(),
+}));
+
+describe('v2OrderToast', () => {
+  const mockToastService = ToastService as jest.Mocked<typeof ToastService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildV2OrderToastOptions', () => {
+    it('returns toast options for PENDING state with spinner and Track button', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Processing your purchase of ETH')
+        .mockReturnValueOnce('This should only take a few minutes...')
+        .mockReturnValueOnce('Track');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        cryptoAmount: 1.5,
+        state: FIAT_ORDER_STATES.PENDING,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(result).not.toBeNull();
+      expect(result?.variant).toBe(ToastVariants.Plain);
+      expect(result?.hasNoTimeout).toBe(false);
+      expect(result?.startAccessory).toBeDefined();
+      expect(result?.labelOptions?.[0]?.label).toBe(
+        'Processing your purchase of ETH',
+      );
+      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
+      expect(result?.descriptionOptions?.description).toBe(
+        'This should only take a few minutes...',
+      );
+      expect(result?.linkButtonOptions?.label).toBe('Track');
+      expect(result?.linkButtonOptions?.onPress).toBeDefined();
+    });
+
+    it('navigates to order details when Track button is pressed', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Processing your purchase of ETH')
+        .mockReturnValueOnce('This should only take a few minutes...')
+        .mockReturnValueOnce('Track');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        state: FIAT_ORDER_STATES.PENDING,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+      result?.linkButtonOptions?.onPress();
+
+      expect(mockToastService.closeToast).toHaveBeenCalled();
+      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+        Routes.RAMP.RAMPS_ORDER_DETAILS,
+        { orderId: 'test-order-id', showCloseButton: true },
+      );
+    });
+
+    it('returns toast options for COMPLETED state with success icon', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Your purchase of 100.5 USDC was successful!')
+        .mockReturnValueOnce('Your USDC is now available');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'USDC',
+        cryptoAmount: 100.5,
+        state: FIAT_ORDER_STATES.COMPLETED,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(result).not.toBeNull();
+      expect(result?.variant).toBe(ToastVariants.Plain);
+      expect(result?.hasNoTimeout).toBe(false);
+      expect(result?.startAccessory).toBeDefined();
+      expect(result?.labelOptions?.[0]?.label).toBe(
+        'Your purchase of 100.5 USDC was successful!',
+      );
+      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
+      expect(result?.descriptionOptions?.description).toBe(
+        'Your USDC is now available',
+      );
+      expect(result?.linkButtonOptions).toBeUndefined();
+    });
+
+    it('returns toast options for FAILED state with error icon', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Purchase of BTC failed')
+        .mockReturnValueOnce('Please try again momentarily');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'BTC',
+        state: FIAT_ORDER_STATES.FAILED,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(result).not.toBeNull();
+      expect(result?.variant).toBe(ToastVariants.Plain);
+      expect(result?.hasNoTimeout).toBe(false);
+      expect(result?.startAccessory).toBeDefined();
+      expect(result?.labelOptions?.[0]?.label).toBe('Purchase of BTC failed');
+      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
+      expect(result?.descriptionOptions?.description).toBe(
+        'Please try again momentarily',
+      );
+    });
+
+    it('returns toast options for CANCELLED state with warning icon', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Your purchase was cancelled')
+        .mockReturnValueOnce('Your purchase of DAI has been cancelled');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'DAI',
+        state: FIAT_ORDER_STATES.CANCELLED,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(result).not.toBeNull();
+      expect(result?.variant).toBe(ToastVariants.Plain);
+      expect(result?.hasNoTimeout).toBe(false);
+      expect(result?.startAccessory).toBeDefined();
+      expect(result?.labelOptions?.[0]?.label).toBe(
+        'Your purchase was cancelled',
+      );
+      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
+      expect(result?.descriptionOptions?.description).toBe(
+        'Your purchase of DAI has been cancelled',
+      );
+    });
+
+    it('returns null for CREATED state', () => {
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        state: FIAT_ORDER_STATES.CREATED,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(result).toBeNull();
+    });
+
+    it('handles missing cryptoAmount for COMPLETED state', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Your purchase of  ETH was successful!')
+        .mockReturnValueOnce('Your ETH is now available');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        state: FIAT_ORDER_STATES.COMPLETED,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(result).not.toBeNull();
+      expect(result?.labelOptions?.[0]?.label).toBe(
+        'Your purchase of  ETH was successful!',
+      );
+    });
+  });
+
+  describe('showV2OrderToast', () => {
+    it('calls ToastService.showToast with valid toast options', () => {
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Your purchase of 1.5 ETH was successful!')
+        .mockReturnValueOnce('Your ETH is now available');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        cryptoAmount: 1.5,
+        state: FIAT_ORDER_STATES.COMPLETED,
+      };
+
+      showV2OrderToast(params);
+
+      expect(mockToastService.showToast).toHaveBeenCalledTimes(1);
+      const callArg = mockToastService.showToast.mock.calls[0][0];
+      expect(callArg.variant).toBe(ToastVariants.Plain);
+      expect(callArg.startAccessory).toBeDefined();
+    });
+
+    it('does not call ToastService.showToast for CREATED state', () => {
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        state: FIAT_ORDER_STATES.CREATED,
+      };
+
+      showV2OrderToast(params);
+
+      expect(mockToastService.showToast).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/UI/Ramp/utils/v2OrderToast.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.ts
@@ -1,0 +1,213 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import {
+  IconColor as ReactNativeDsIconColor,
+  IconSize as ReactNativeDsIconSize,
+} from '@metamask/design-system-react-native';
+import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
+import { lightTheme } from '@metamask/design-tokens';
+import { strings } from '../../../../../locales/i18n';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import {
+  ToastOptions,
+  ToastVariants,
+} from '../../../../component-library/components/Toast/Toast.types';
+import { FIAT_ORDER_STATES } from '../../../../constants/on-ramp';
+import Routes from '../../../../constants/navigation/Routes';
+import NavigationService from '../../../../core/NavigationService';
+import ToastService from '../../../../core/ToastService';
+import { renderNumber } from '../../../../util/number';
+import Avatar, {
+  AvatarSize,
+  AvatarVariant,
+} from '../../../../component-library/components/Avatars/Avatar';
+
+export interface V2OrderToastParams {
+  orderId: string;
+  cryptocurrency: string;
+  cryptoAmount?: string | number;
+  state: FIAT_ORDER_STATES;
+}
+
+const toastStyles = StyleSheet.create({
+  spinnerContainer: {
+    paddingTop: 4,
+    marginRight: 12,
+    alignSelf: 'flex-start',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+  iconContainer: {
+    paddingTop: 0,
+    marginRight: 12,
+    alignSelf: 'flex-start',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+});
+
+/**
+ * Builds toast options for V2 Ramps orders based on order state.
+ * Returns null for CREATED state (no toast shown).
+ */
+export function buildV2OrderToastOptions(
+  params: V2OrderToastParams,
+): ToastOptions | null {
+  const { orderId, cryptocurrency, cryptoAmount, state } = params;
+
+  switch (state) {
+    case FIAT_ORDER_STATES.PENDING: {
+      return {
+        variant: ToastVariants.Plain,
+        hasNoTimeout: false,
+        startAccessory: React.createElement(
+          View,
+          { style: toastStyles.spinnerContainer },
+          React.createElement(Spinner, {
+            color: ReactNativeDsIconColor.PrimaryDefault,
+            spinnerIconProps: { size: ReactNativeDsIconSize.Xl },
+          }),
+        ),
+        labelOptions: [
+          {
+            label: strings('ramps_v2.notifications.purchase_pending_title', {
+              cryptocurrency,
+            }),
+            isBold: true,
+          },
+        ],
+        descriptionOptions: {
+          description: strings(
+            'ramps_v2.notifications.purchase_pending_description',
+          ),
+        },
+        linkButtonOptions: {
+          label: strings('ramps_v2.notifications.track'),
+          onPress: () => {
+            ToastService.closeToast();
+            NavigationService.navigation.navigate(
+              Routes.RAMP.RAMPS_ORDER_DETAILS,
+              { orderId, showCloseButton: true },
+            );
+          },
+        },
+      };
+    }
+
+    case FIAT_ORDER_STATES.COMPLETED: {
+      const formattedAmount = cryptoAmount
+        ? renderNumber(String(cryptoAmount))
+        : '';
+      return {
+        variant: ToastVariants.Plain,
+        hasNoTimeout: false,
+        startAccessory: React.createElement(
+          View,
+          { style: toastStyles.iconContainer },
+          React.createElement(Avatar, {
+            variant: AvatarVariant.Icon,
+            name: IconName.Confirmation,
+            size: AvatarSize.Lg,
+            iconColor: lightTheme.colors.success.default,
+            backgroundColor: 'transparent',
+          }),
+        ),
+        labelOptions: [
+          {
+            label: strings('ramps_v2.notifications.purchase_completed_title', {
+              amount: formattedAmount,
+              cryptocurrency,
+            }),
+            isBold: true,
+          },
+        ],
+        descriptionOptions: {
+          description: strings(
+            'ramps_v2.notifications.purchase_completed_description',
+            {
+              cryptocurrency,
+            },
+          ),
+        },
+      };
+    }
+
+    case FIAT_ORDER_STATES.FAILED: {
+      return {
+        variant: ToastVariants.Plain,
+        hasNoTimeout: false,
+        startAccessory: React.createElement(
+          View,
+          { style: toastStyles.iconContainer },
+          React.createElement(Avatar, {
+            variant: AvatarVariant.Icon,
+            name: IconName.Warning,
+            size: AvatarSize.Lg,
+            iconColor: lightTheme.colors.error.default,
+            backgroundColor: 'transparent',
+          }),
+        ),
+        labelOptions: [
+          {
+            label: strings('ramps_v2.notifications.purchase_failed_title', {
+              cryptocurrency,
+            }),
+            isBold: true,
+          },
+        ],
+        descriptionOptions: {
+          description: strings(
+            'ramps_v2.notifications.purchase_failed_description',
+          ),
+        },
+      };
+    }
+
+    case FIAT_ORDER_STATES.CANCELLED: {
+      return {
+        variant: ToastVariants.Plain,
+        hasNoTimeout: false,
+        startAccessory: React.createElement(
+          View,
+          { style: toastStyles.iconContainer },
+          React.createElement(Avatar, {
+            variant: AvatarVariant.Icon,
+            name: IconName.Warning,
+            size: AvatarSize.Lg,
+            iconColor: lightTheme.colors.warning.default,
+            backgroundColor: 'transparent',
+          }),
+        ),
+        labelOptions: [
+          {
+            label: strings('ramps_v2.notifications.purchase_cancelled_title'),
+            isBold: true,
+          },
+        ],
+        descriptionOptions: {
+          description: strings(
+            'ramps_v2.notifications.purchase_cancelled_description',
+            {
+              cryptocurrency,
+            },
+          ),
+        },
+      };
+    }
+
+    case FIAT_ORDER_STATES.CREATED:
+    default:
+      return null;
+  }
+}
+
+/**
+ * Shows a toast notification for V2 Ramps orders.
+ * No-op if toast options are null (e.g., CREATED state).
+ */
+export function showV2OrderToast(params: V2OrderToastParams): void {
+  const toastOptions = buildV2OrderToastOptions(params);
+  if (toastOptions) {
+    ToastService.showToast(toastOptions);
+  }
+}

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -32,6 +32,8 @@ const newOverrides = [
       'app/components/UI/Ramp/hooks/useRampsUnifiedV1Enabled.test.ts',
       'app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.ts',
       'app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.test.ts',
+      'app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.ts',
+      'app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.test.ts',
       'app/components/UI/Ramp/hooks/useRampsSmartRouting.ts',
       'app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts',
       'app/components/UI/Ramp/hooks/useRampTokens.ts',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5189,6 +5189,19 @@
     "try_again": "Try again",
     "close": "Close"
   },
+  "ramps_v2": {
+    "notifications": {
+      "purchase_pending_title": "Processing your purchase of {{cryptocurrency}}",
+      "purchase_pending_description": "This should only take a few minutes...",
+      "purchase_completed_title": "Your purchase of {{amount}} {{cryptocurrency}} was successful!",
+      "purchase_completed_description": "Your {{cryptocurrency}} is now available",
+      "purchase_failed_title": "Purchase of {{cryptocurrency}} failed",
+      "purchase_failed_description": "Please try again momentarily",
+      "purchase_cancelled_title": "Your purchase was cancelled",
+      "purchase_cancelled_description": "Your purchase of {{cryptocurrency}} has been cancelled",
+      "track": "Track"
+    }
+  },
   "swaps": {
     "title": "Swap",
     "onboarding": {


### PR DESCRIPTION
## **Description**

Introduces new lightweight toast notifications for Ramps orders behind the `unifiedBuyV2` feature flag. When enabled, orders display modern Toast-based notifications instead of the legacy `NotificationManager.showSimpleNotification` approach.

The new toasts accept simple parameters (`orderId`, `cryptocurrency`, `cryptoAmount`, `state`) rather than the full `FiatOrder` object, keeping them decoupled from legacy aggregator/deposit code. This makes them easy to maintain and eventually replace the old notifications entirely.

**What changed:**
- Created `v2OrderToast.ts` utility with `buildV2OrderToastOptions` and `showV2OrderToast` functions
- All four order states are covered: pending (with spinner + Track button), completed (green checkmark), failed (red warning), cancelled (orange warning)
- Icons use `AvatarSize.Lg` with transparent backgrounds and semantic colors from design tokens
- Gated behind `selectRampsUnifiedBuyV2ActiveFlag` / `useRampsUnifiedV2Enabled` - falls back to old notifications when flag is off
- Updated three notification entry points: `processFiatOrder`, `processCustomOrderId` (in `index.tsx`), `handleOrderCreated` (in `Checkout.tsx`), and `useHandleNewOrder` (Deposit flow)
- Added translation strings under `ramps_v2.notifications`

## **Changelog**

CHANGELOG entry: Added new toast-style notifications for buy order status updates (processing, completed, failed, cancelled) behind the Unified Buy V2 feature flag

## **Related issues**

Refs: Unified Buy V2

## **Manual testing steps**

```gherkin
Feature: V2 Ramps Order Toast Notifications

  Scenario: user sees processing toast when order is created (flag on)
    Given the unifiedBuyV2 feature flag is enabled
    And the user initiates a buy order

    When the order is created
    Then a toast notification appears with a spinner and "Processing your purchase of <crypto>"
    And a "Track" button is visible
    When user taps "Track"
    Then the order details screen opens

  Scenario: user sees success toast when order completes (flag on)
    Given the unifiedBuyV2 feature flag is enabled
    And the user has a pending buy order

    When the order completes
    Then a toast notification appears with a green checkmark and "Your purchase of <amount> <crypto> was successful!"
    And the toast auto-dismisses after a few seconds

  Scenario: user sees old notifications when flag is off
    Given the unifiedBuyV2 feature flag is disabled
    And the user initiates a buy order

    When the order status changes
    Then the legacy NotificationManager notification is shown
```

## **Screenshots/Recordings**

### **Before**

Legacy `NotificationManager.showSimpleNotification` banners

### **After**

New Toast notifications with semantic icon colors, and Track navigation button

Aggregator:

https://github.com/user-attachments/assets/b52282ee-fbf0-4260-9e78-2f560a9f642d

Native:

https://github.com/user-attachments/assets/c1c6a6f1-0f2b-4c27-9409-0a757ecf4966


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing order status notifications in multiple Ramps entry points (checkout, deposit, polling) and adds navigation from a toast action; regressions could affect notification delivery/timing, though behavior is gated and falls back to legacy notifications when disabled.
> 
> **Overview**
> Adds new `v2OrderToast` utility to show Toast-based Ramps V2 order status notifications (pending/completed/failed/cancelled), including a pending-state *Track* action that navigates to `Routes.RAMP.RAMPS_ORDER_DETAILS`.
> 
> Updates the main order-notification emitters (`Checkout.handleOrderCreated`, deposit `useHandleNewOrder`, and `processFiatOrder`/`processCustomOrderId` in `Ramp/index.tsx`) to conditionally use the new toasts when Unified Buy V2 is enabled, otherwise keeping the existing `NotificationManager.showSimpleNotification` behavior (some calls deferred with `InteractionManager.runAfterInteractions`).
> 
> Introduces a non-hook `isRampsUnifiedV2Enabled(state)` helper (with tests) for thunk/plain-function contexts, extends test Babel config to avoid inlining the related env var, and adds new `en.json` strings under `ramps_v2.notifications`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d84e5fd65317a5a835f0dddfab231be143c0cff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->