### PR TITLE
chore: set up nightly builds with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       platform:
         required: true
         type: string # android, ios, or both
+      skip_version_bump:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       build_name:
@@ -32,14 +36,20 @@ on:
         required: true
         type: choice
         options: [android, ios, both]
+      skip_version_bump:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  # Bump version in repo (bitrise.yml, package.json, ios/android) before building
+  # Bump version in repo (bitrise.yml, package.json, ios/android) before building.
+  # Skipped when skip_version_bump=true (e.g. nightly builds where Bitrise owns the bump).
   update-build-version:
+    if: ${{ !inputs.skip_version_bump }}
     uses: ./.github/workflows/update-latest-build-version.yml
     permissions:
       contents: write
@@ -52,6 +62,7 @@ jobs:
   # Load config
   prepare:
     needs: [update-build-version]
+    if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       github_environment: ${{ steps.config.outputs.github_environment }}
@@ -86,6 +97,7 @@ jobs:
   # Build
   build:
     needs: [prepare, update-build-version]
+    if: ${{ always() && !failure() && !cancelled() }}
     strategy:
       matrix:
         platform: ${{ inputs.platform == 'both' && fromJSON('["android", "ios"]') || fromJSON(format('["{0}"]', inputs.platform)) }}
@@ -94,6 +106,7 @@ jobs:
     environment: ${{ needs.prepare.outputs.github_environment }}
     steps:
       - name: Validate version-bump commit
+        if: ${{ !inputs.skip_version_bump }}
         run: |
           COMMIT_HASH="${{ needs.update-build-version.outputs.commit-hash }}"
           if [ -z "$COMMIT_HASH" ]; then
@@ -102,8 +115,11 @@ jobs:
           fi
           echo "Building at version-bump commit: $COMMIT_HASH"
       - uses: actions/checkout@v4
+        if: ${{ !inputs.skip_version_bump }}
         with:
           ref: ${{ needs.update-build-version.outputs.commit-hash }}
+      - uses: actions/checkout@v4
+        if: ${{ inputs.skip_version_bump }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,42 @@
+name: Nightly Build
+
+# Triggered by every push to chore/temp-nightly (which nightly-temp-branch-sync.yml
+# force-pushes daily at 4 AM UTC to match main).
+#
+# [skip ci] commits (e.g. version bumps pushed by Bitrise's bump_version_code job via
+# update-latest-build-version.yml) are automatically skipped by GitHub Actions, so
+# this workflow will NOT double-trigger on those commits.
+#
+# skip_version_bump=true is passed to build.yml because Bitrise already owns the
+# version bump for chore/temp-nightly during the parallel transition period.
+# When Bitrise is deprecated, remove skip_version_bump: true and the version bump
+# will be handled by build.yml as normal.
+
+on:
+  push:
+    branches:
+      - chore/temp-nightly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-exp:
+    name: Nightly exp build (main-exp)
+    uses: ./.github/workflows/build.yml
+    with:
+      build_name: main-exp
+      platform: both
+      skip_version_bump: true
+    secrets: inherit
+
+  build-rc:
+    name: Nightly RC build (main-rc)
+    uses: ./.github/workflows/build.yml
+    with:
+      build_name: main-rc
+      platform: both
+      skip_version_bump: true
+    secrets: inherit


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds GitHub Actions as a parallel nightly build system alongside Bitrise, enabling a gradual deprecation of Bitrise for nightly builds.

**Why**: The team wants to migrate nightly builds from Bitrise to GitHub Actions. To do this safely, both systems need to run in parallel for a testing/validation period before Bitrise is turned off.

**What changed**:

- **`build.yml`**: Added an optional `skip_version_bump` boolean input (default: `false`). When `true`, the `update-build-version` job is skipped and the build runs against the current HEAD of the branch. This is needed because Bitrise already owns the version bump for `chore/temp-nightly` (via its `bump_version_code` workflow, which dispatches `update-latest-build-version.yml` via the GitHub API). Without this flag, both systems would race to bump the version concurrently on the same branch. The `prepare` and `build` jobs use `always() && !failure() && !cancelled()` to correctly handle a skipped (not failed) `update-build-version` dependency.

- **`nightly-build.yml`** (new): A dedicated workflow that triggers on every push to `chore/temp-nightly` — the same event that triggers Bitrise via its dashboard webhook. It runs `main-exp` and `main-rc` builds for both platforms in parallel, mirroring Bitrise's `nightly_exp_builds_pipeline` and `nightly_rc_builds_pipeline`. `[skip ci]` commits (written back to the branch by Bitrise's version bump) are automatically ignored by GitHub Actions, preventing any re-trigger loop. A `workflow_dispatch` trigger is also included for manual testing from any branch.

**Transition path**: When Bitrise is deprecated, remove `skip_version_bump: true` from `nightly-build.yml` and GitHub Actions will take over the version bump as well.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI control flow (skipped dependencies, conditional checkouts) and adds a new automated nightly trigger, which could impact build reproducibility and job execution if misconfigured.
> 
> **Overview**
> Adds a `skip_version_bump` input to `.github/workflows/build.yml` to optionally skip `update-build-version`, adjust downstream `prepare`/`build` job gating to tolerate skipped dependencies, and conditionally build from either the bumped commit or the branch HEAD.
> 
> Introduces a new `.github/workflows/nightly-build.yml` that runs nightly `main-exp` and `main-rc` builds for both platforms on pushes to `chore/temp-nightly`, calling `build.yml` with `skip_version_bump: true` for parallel operation alongside Bitrise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e426099d02aeb08a037481dcdba1a8371ba07457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->