### PR TITLE
refactor(predict): migrate usePredictMarketData to React Query

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictMarketData.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.test.tsx
@@ -150,7 +150,7 @@ describe('usePredictMarketData', () => {
     jest.restoreAllMocks();
   });
 
-  it('should fetch market data successfully', async () => {
+  it('fetches market data successfully', async () => {
     const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue(mockMarketData);
 
@@ -179,7 +179,7 @@ describe('usePredictMarketData', () => {
     );
   });
 
-  it('should handle null market data', async () => {
+  it('handles null market data', async () => {
     const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue(null);
 
@@ -195,7 +195,7 @@ describe('usePredictMarketData', () => {
     expect(result.current.error).toBe(null);
   });
 
-  it('should handle empty market data array', async () => {
+  it('handles empty market data array', async () => {
     const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue([]);
 
@@ -211,7 +211,7 @@ describe('usePredictMarketData', () => {
     expect(result.current.error).toBe(null);
   });
 
-  it('should refetch data when calling refetch', async () => {
+  it('refetches data when calling refetch', async () => {
     const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue(mockMarketData);
 
@@ -295,7 +295,7 @@ describe('usePredictMarketData', () => {
   });
 
   describe('pagination', () => {
-    it('should load next page via fetchMore and indicate when no more pages', async () => {
+    it('loads next page via fetchMore and indicates when no more pages', async () => {
       const { Wrapper } = createWrapper();
       const PAGE_SIZE = 20;
 

--- a/app/components/UI/Predict/hooks/usePredictMarketData.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.test.tsx
@@ -1,221 +1,230 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
-import Engine from '../../../../core/Engine';
+import React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePredictMarketData } from './usePredictMarketData';
 import { PredictMarket, Recurrence } from '../types';
-
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
-// Mock dependencies
-jest.mock('../../../../core/SDKConnect/utils/DevLogger');
+
+const mockGetMarkets = jest.fn();
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: { log: jest.fn() },
+}));
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
-      getMarkets: jest.fn(),
+      getMarkets: (...args: unknown[]) => mockGetMarkets(...args),
     },
   },
 }));
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+jest.mock('../utils/predictErrorHandler', () => ({
+  ensureError: (err: unknown) =>
+    err instanceof Error ? err : new Error(String(err)),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+
+const mockMarketData: PredictMarket[] = [
+  {
+    id: 'market-1',
+    providerId: POLYMARKET_PROVIDER_ID,
+    slug: 'bitcoin-price-prediction',
+    title: 'Will Bitcoin reach $100k by end of 2024?',
+    description: 'Bitcoin price prediction market',
+    image: 'https://example.com/btc.png',
+    status: 'open',
+    recurrence: Recurrence.NONE,
+    category: 'crypto',
+    tags: ['trending'],
+    outcomes: [
+      {
+        id: 'outcome-1',
+        providerId: POLYMARKET_PROVIDER_ID,
+        marketId: 'market-1',
+        title: 'Yes',
+        description: 'Bitcoin will reach $100k',
+        image: '',
+        status: 'open',
+        tokens: [
+          {
+            id: 'token-1',
+            title: 'Yes',
+            price: 0.65,
+          },
+        ],
+        volume: 1000000,
+        groupItemTitle: 'Yes/No',
+      },
+      {
+        id: 'outcome-2',
+        providerId: POLYMARKET_PROVIDER_ID,
+        marketId: 'market-1',
+        title: 'No',
+        description: 'Bitcoin will not reach $100k',
+        image: '',
+        status: 'open',
+        tokens: [
+          {
+            id: 'token-2',
+            title: 'No',
+            price: 0.35,
+          },
+        ],
+        volume: 1000000,
+        groupItemTitle: 'Yes/No',
+      },
+    ],
+    liquidity: 1000000,
+    volume: 1000000,
+  },
+  {
+    id: 'market-2',
+    providerId: POLYMARKET_PROVIDER_ID,
+    slug: 'ethereum-price-prediction',
+    title: 'Will Ethereum reach $100000 by end of 2025?',
+    description: 'Ethereum price prediction market',
+    image: 'https://example.com/eth.png',
+    status: 'open',
+    recurrence: Recurrence.NONE,
+    category: 'crypto',
+    tags: ['trending'],
+    outcomes: [
+      {
+        id: 'outcome-3',
+        providerId: POLYMARKET_PROVIDER_ID,
+        marketId: 'market-2',
+        title: 'Yes',
+        description: 'Ethereum will reach $100k',
+        image: '',
+        status: 'open',
+        tokens: [
+          {
+            id: 'token-3',
+            title: 'Yes',
+            price: 0.45,
+          },
+        ],
+        volume: 500000,
+        groupItemTitle: 'Yes/No',
+      },
+      {
+        id: 'outcome-4',
+        providerId: POLYMARKET_PROVIDER_ID,
+        marketId: 'market-2',
+        title: 'No',
+        description: 'Ethereum will not reach $100k',
+        image: '',
+        status: 'open',
+        tokens: [
+          {
+            id: 'token-4',
+            title: 'No',
+            price: 0.55,
+          },
+        ],
+        volume: 500000,
+        groupItemTitle: 'Yes/No',
+      },
+    ],
+    liquidity: 1000000,
+    volume: 1000000,
+  },
+];
 
 describe('usePredictMarketData', () => {
-  const mockGetMarkets = jest.fn();
-
-  const mockMarketData: PredictMarket[] = [
-    {
-      id: 'market-1',
-      providerId: POLYMARKET_PROVIDER_ID,
-      slug: 'bitcoin-price-prediction',
-      title: 'Will Bitcoin reach $100k by end of 2024?',
-      description: 'Bitcoin price prediction market',
-      image: 'https://example.com/btc.png',
-      status: 'open',
-      recurrence: Recurrence.NONE,
-      category: 'crypto',
-      tags: ['trending'],
-      outcomes: [
-        {
-          id: 'outcome-1',
-          providerId: POLYMARKET_PROVIDER_ID,
-          marketId: 'market-1',
-          title: 'Yes',
-          description: 'Bitcoin will reach $100k',
-          image: '',
-          status: 'open',
-          tokens: [
-            {
-              id: 'token-1',
-              title: 'Yes',
-              price: 0.65,
-            },
-          ],
-          volume: 1000000,
-          groupItemTitle: 'Yes/No',
-        },
-        {
-          id: 'outcome-2',
-          providerId: POLYMARKET_PROVIDER_ID,
-          marketId: 'market-1',
-          title: 'No',
-          description: 'Bitcoin will not reach $100k',
-          image: '',
-          status: 'open',
-          tokens: [
-            {
-              id: 'token-2',
-              title: 'No',
-              price: 0.35,
-            },
-          ],
-          volume: 1000000,
-          groupItemTitle: 'Yes/No',
-        },
-      ],
-      liquidity: 1000000,
-      volume: 1000000,
-    },
-    {
-      id: 'market-2',
-      providerId: POLYMARKET_PROVIDER_ID,
-      slug: 'ethereum-price-prediction',
-      title: 'Will Ethereum reach $100000 by end of 2025?',
-      description: 'Ethereum price prediction market',
-      image: 'https://example.com/eth.png',
-      status: 'open',
-      recurrence: Recurrence.NONE,
-      category: 'crypto',
-      tags: ['trending'],
-      outcomes: [
-        {
-          id: 'outcome-3',
-          providerId: POLYMARKET_PROVIDER_ID,
-          marketId: 'market-2',
-          title: 'Yes',
-          description: 'Ethereum will reach $100k',
-          image: '',
-          status: 'open',
-          tokens: [
-            {
-              id: 'token-3',
-              title: 'Yes',
-              price: 0.45,
-            },
-          ],
-          volume: 500000,
-          groupItemTitle: 'Yes/No',
-        },
-        {
-          id: 'outcome-4',
-          providerId: POLYMARKET_PROVIDER_ID,
-          marketId: 'market-2',
-          title: 'No',
-          description: 'Ethereum will not reach $100k',
-          image: '',
-          status: 'open',
-          tokens: [
-            {
-              id: 'token-4',
-              title: 'No',
-              price: 0.55,
-            },
-          ],
-          volume: 500000,
-          groupItemTitle: 'Yes/No',
-        },
-      ],
-      liquidity: 1000000,
-      volume: 1000000,
-    },
-  ];
-
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Setup Engine mocks
-    (Engine.context.PredictController.getMarkets as jest.Mock) = mockGetMarkets;
-
-    // Setup DevLogger mock
-    (DevLogger.log as jest.Mock).mockImplementation(() => {
-      // Mock implementation
-    });
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should fetch market data successfully', async () => {
+    const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue(mockMarketData);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketData(),
-    );
+    const { result } = renderHook(() => usePredictMarketData(), {
+      wrapper: Wrapper,
+    });
 
     // Initially loading
     expect(result.current.isFetching).toBe(true);
     expect(result.current.marketData).toEqual([]);
     expect(result.current.error).toBe(null);
 
-    // Wait for data to load
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
 
-    expect(result.current.isFetching).toBe(false);
     expect(result.current.marketData).toEqual(mockMarketData);
     expect(result.current.error).toBe(null);
     expect(mockGetMarkets).toHaveBeenCalledTimes(1);
-    expect(DevLogger.log).toHaveBeenCalledWith(
-      'Fetching market data for category:',
-      'trending',
-      'search:',
-      undefined,
-      'offset:',
-      0,
-      'limit:',
-      20,
-    );
-    expect(DevLogger.log).toHaveBeenCalledWith(
-      'Market data received:',
-      mockMarketData,
+    expect(mockGetMarkets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'trending',
+        limit: 20,
+        offset: 0,
+      }),
     );
   });
 
-  it('handle null market data', async () => {
+  it('should handle null market data', async () => {
+    const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue(null);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketData(),
-    );
+    const { result } = renderHook(() => usePredictMarketData(), {
+      wrapper: Wrapper,
+    });
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
 
-    expect(result.current.isFetching).toBe(false);
     expect(result.current.marketData).toEqual([]);
     expect(result.current.error).toBe(null);
   });
 
-  it('handle empty market data array', async () => {
+  it('should handle empty market data array', async () => {
+    const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue([]);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketData(),
-    );
+    const { result } = renderHook(() => usePredictMarketData(), {
+      wrapper: Wrapper,
+    });
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
 
-    expect(result.current.isFetching).toBe(false);
     expect(result.current.marketData).toEqual([]);
     expect(result.current.error).toBe(null);
   });
 
-  it('refetch data when calling refetch', async () => {
+  it('should refetch data when calling refetch', async () => {
+    const { Wrapper } = createWrapper();
     mockGetMarkets.mockResolvedValue(mockMarketData);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketData(),
-    );
+    const { result } = renderHook(() => usePredictMarketData(), {
+      wrapper: Wrapper,
+    });
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
 
     expect(mockGetMarkets).toHaveBeenCalledTimes(1);
 
-    // Call refetch
     await act(async () => {
       await result.current.refetch();
     });
@@ -223,31 +232,23 @@ describe('usePredictMarketData', () => {
     expect(mockGetMarkets).toHaveBeenCalledTimes(2);
   });
 
-  it('maintain stable refetch function reference', () => {
-    mockGetMarkets.mockResolvedValue(mockMarketData);
-
-    const { result, rerender } = renderHook(() => usePredictMarketData());
-
-    const firstRefetch = result.current.refetch;
-
-    // Trigger a re-render
-    rerender();
-
-    expect(result.current.refetch).toBe(firstRefetch);
-  });
-
   describe('customQueryParams option', () => {
     it('passes customQueryParams to getMarkets', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarkets.mockResolvedValue(mockMarketData);
 
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictMarketData({
-          category: 'hot',
-          customQueryParams: 'tag_id=149&order=volume24hr',
-        }),
+      const { result } = renderHook(
+        () =>
+          usePredictMarketData({
+            category: 'hot',
+            customQueryParams: 'tag_id=149&order=volume24hr',
+          }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(mockGetMarkets).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -258,52 +259,104 @@ describe('usePredictMarketData', () => {
     });
 
     it('refetches when customQueryParams changes', async () => {
+      const { Wrapper } = createWrapper();
       mockGetMarkets.mockResolvedValue(mockMarketData);
 
-      const { waitForNextUpdate, rerender } = renderHook(
-        ({ customQueryParams }) =>
+      const { result, rerender } = renderHook(
+        ({ customQueryParams }: { customQueryParams: string }) =>
           usePredictMarketData({
             category: 'hot',
             customQueryParams,
           }),
         {
+          wrapper: Wrapper,
           initialProps: { customQueryParams: 'tag_id=149' },
         },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(mockGetMarkets).toHaveBeenCalledTimes(1);
 
       rerender({ customQueryParams: 'tag_id=200' });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(mockGetMarkets).toHaveBeenCalledTimes(2);
+      });
 
-      expect(mockGetMarkets).toHaveBeenCalledTimes(2);
       expect(mockGetMarkets).toHaveBeenLastCalledWith(
         expect.objectContaining({
           customQueryParams: 'tag_id=200',
         }),
       );
     });
+  });
 
-    it('does not pass customQueryParams when undefined', async () => {
-      mockGetMarkets.mockResolvedValue(mockMarketData);
+  describe('pagination', () => {
+    it('should load next page via fetchMore and indicate when no more pages', async () => {
+      const { Wrapper } = createWrapper();
+      const PAGE_SIZE = 20;
 
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictMarketData({
-          category: 'trending',
+      // Generate first page: 20 items (full page, so hasMore = true)
+      const firstPage: PredictMarket[] = Array.from(
+        { length: PAGE_SIZE },
+        (_, i) => ({
+          ...mockMarketData[0],
+          id: `page1-market-${i}`,
+          slug: `page1-market-${i}`,
+          title: `Page 1 Market ${i}`,
         }),
       );
 
-      await waitForNextUpdate();
+      // Generate second page: fewer than 20 items (partial page, so hasMore = false)
+      const secondPage: PredictMarket[] = Array.from({ length: 5 }, (_, i) => ({
+        ...mockMarketData[0],
+        id: `page2-market-${i}`,
+        slug: `page2-market-${i}`,
+        title: `Page 2 Market ${i}`,
+      }));
 
+      mockGetMarkets
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      const { result } = renderHook(() => usePredictMarketData(), {
+        wrapper: Wrapper,
+      });
+
+      // Wait for first page to load
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(result.current.marketData).toHaveLength(PAGE_SIZE);
+      expect(result.current.hasMore).toBe(true);
+      expect(result.current.isFetchingMore).toBe(false);
       expect(mockGetMarkets).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: 'trending',
-          customQueryParams: undefined,
-        }),
+        expect.objectContaining({ offset: 0, limit: PAGE_SIZE }),
       );
+
+      // Fetch second page
+      await act(async () => {
+        await result.current.fetchMore();
+      });
+
+      // Wait for all items from both pages to be present
+      await waitFor(() => {
+        expect(result.current.marketData).toHaveLength(PAGE_SIZE + 5);
+      });
+
+      expect(result.current.isFetchingMore).toBe(false);
+
+      // Second call should use offset = 20 (total items from first page)
+      expect(mockGetMarkets).toHaveBeenCalledTimes(2);
+      expect(mockGetMarkets).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: PAGE_SIZE, limit: PAGE_SIZE }),
+      );
+
+      expect(result.current.hasMore).toBe(false);
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictMarketData.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.tsx
@@ -118,7 +118,7 @@ export const usePredictMarketData = ({
     marketData,
     isLoading: queryResult.isLoading,
     isFetching: queryResult.isFetching,
-    isFetchingMore,
+    isFetchingMore: isFetchingNextPage,
     error: queryResult.error,
     hasMore: hasNextPage ?? false,
     refetch: queryResult.refetch,

--- a/app/components/UI/Predict/hooks/usePredictMarketData.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.tsx
@@ -29,6 +29,7 @@ export const usePredictMarketData = ({
     queryKey: predictQueries.markets.keys.list({
       category,
       q,
+      pageSize,
       customQueryParams,
     }),
     queryFn: async ({ pageParam = 0 }) => {

--- a/app/components/UI/Predict/hooks/usePredictMarketData.tsx
+++ b/app/components/UI/Predict/hooks/usePredictMarketData.tsx
@@ -1,221 +1,127 @@
-/* eslint-disable react/prop-types */
-
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Logger from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { ensureError } from '../utils/predictErrorHandler';
+import { predictQueries } from '../queries';
 import { PredictCategory, PredictMarket } from '../types';
 
-export interface UsePredictMarketDataOptions {
+/**
+ * Hook to fetch and manage market data for a specific category with infinite scroll.
+ *
+ * Backed by React Query's `useInfiniteQuery` — handles pagination, retry with
+ * exponential back-off, caching, and deduplication automatically.
+ */
+export const usePredictMarketData = ({
+  category = 'trending',
+  q,
+  pageSize = 20,
+  customQueryParams,
+}: {
   q?: string;
   category?: PredictCategory;
   pageSize?: number;
   customQueryParams?: string;
-}
+} = {}) => {
+  const queryResult = useInfiniteQuery({
+    queryKey: predictQueries.markets.keys.list({
+      category,
+      q,
+      customQueryParams,
+    }),
+    queryFn: async ({ pageParam = 0 }) => {
+      DevLogger.log(
+        'Fetching market data for category:',
+        category,
+        'search:',
+        q,
+        'offset:',
+        pageParam,
+        'limit:',
+        pageSize,
+      );
 
-export interface UsePredictMarketDataResult {
-  marketData: PredictMarket[];
-  isFetching: boolean;
-  isFetchingMore: boolean;
-  error: string | null;
-  hasMore: boolean;
-  refetch: () => Promise<void>;
-  fetchMore: () => Promise<void>;
-}
+      const controller = Engine.context.PredictController;
+      const markets = await controller.getMarkets({
+        category,
+        q,
+        limit: pageSize,
+        offset: pageParam,
+        customQueryParams,
+      });
 
-/**
- * Hook to fetch and manage market data for a specific category with infinite scroll
- * @returns Market data, loading states, and pagination controls
- */
-export const usePredictMarketData = (
-  options: UsePredictMarketDataOptions = {},
-): UsePredictMarketDataResult => {
-  const {
-    category = 'trending',
-    q,
-    pageSize = 20,
-    customQueryParams,
-  } = options;
-  const [marketData, setMarketData] = useState<PredictMarket[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(true);
-  const [currentOffset, setCurrentOffset] = useState(0);
+      DevLogger.log('Market data received:', markets);
 
-  const currentCategoryRef = useRef(category);
-  const currentOffsetRef = useRef(currentOffset);
-
-  useEffect(() => {
-    currentCategoryRef.current = category;
-  }, [category]);
-
-  useEffect(() => {
-    currentOffsetRef.current = currentOffset;
-  }, [currentOffset]);
-
-  const fetchMarketData = useCallback(
-    async (isLoadMore = false) => {
-      try {
-        if (isLoadMore) {
-          setIsLoadingMore(true);
-        } else {
-          setIsLoading(true);
-          setCurrentOffset(0);
-          currentOffsetRef.current = 0;
-        }
-        setError(null);
-
-        const offset = isLoadMore ? currentOffsetRef.current : 0;
-
-        DevLogger.log(
-          'Fetching market data for category:',
-          category,
-          'search:',
-          q,
-          'offset:',
-          offset,
-          'limit:',
-          pageSize,
-        );
-
-        let retryCount = 0;
-        const maxRetries = 3;
-        const baseDelay = 1000;
-
-        while (retryCount < maxRetries) {
-          try {
-            if (!Engine || !Engine.context) {
-              throw new Error('Engine not initialized');
-            }
-
-            const controller = Engine.context.PredictController;
-            if (!controller) {
-              throw new Error('Predict controller not available');
-            }
-
-            const markets = await controller.getMarkets({
-              category,
-              q,
-              limit: pageSize,
-              offset,
-              customQueryParams,
-            });
-            DevLogger.log('Market data received:', markets);
-
-            if (!markets || !Array.isArray(markets)) {
-              if (isLoadMore) {
-                setHasMore(false);
-              } else {
-                setMarketData([]);
-              }
-              return;
-            }
-
-            const hasMoreData = markets.length >= pageSize;
-            setHasMore(hasMoreData);
-
-            if (isLoadMore) {
-              setMarketData((prevData) => {
-                // Use a Map to efficiently deduplicate by ID
-                const existingIds = new Set(prevData.map((event) => event.id));
-                const newEvents = markets.filter(
-                  (event) => !existingIds.has(event.id),
-                );
-                return [...prevData, ...newEvents];
-              });
-              setCurrentOffset((prev) => prev + pageSize);
-              currentOffsetRef.current += pageSize;
-            } else {
-              // Replace data for initial load or refresh
-              setMarketData(markets);
-              setCurrentOffset(pageSize);
-              currentOffsetRef.current = pageSize;
-            }
-
-            // Success - break out of retry loop
-            break;
-          } catch (engineError) {
-            retryCount++;
-            if (retryCount >= maxRetries) {
-              throw engineError;
-            }
-
-            // Exponential backoff with jitter
-            const delay =
-              baseDelay * Math.pow(2, retryCount - 1) + Math.random() * 1000;
-            DevLogger.log(
-              `Engine not ready, retrying in ${Math.round(
-                delay,
-              )}ms (attempt ${retryCount}/${maxRetries})`,
-            );
-            await new Promise((resolve) => setTimeout(resolve, delay));
-          }
-        }
-      } catch (err) {
-        DevLogger.log('Error fetching market data:', err);
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to fetch market data';
-        setError(errorMessage);
-
-        // Capture exception with market data loading context
-        Logger.error(ensureError(err), {
-          tags: {
-            feature: PREDICT_CONSTANTS.FEATURE_NAME,
-            component: 'usePredictMarketData',
-          },
-          context: {
-            name: 'usePredictMarketData',
-            data: {
-              method: 'loadMarketData',
-              action: 'market_data_load',
-              operation: 'data_fetching',
-              category,
-              hasSearchQuery: !!q,
-              pageSize,
-              isLoadMore,
-            },
-          },
-        });
-
-        if (!isLoadMore) {
-          setMarketData([]);
-        }
-      } finally {
-        setIsLoading(false);
-        setIsLoadingMore(false);
+      if (!markets || !Array.isArray(markets)) {
+        return [] as PredictMarket[];
       }
+
+      return markets as PredictMarket[];
     },
-    [category, q, pageSize, customQueryParams],
-  );
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length < pageSize) {
+        return undefined;
+      }
+      return allPages.reduce((total, page) => total + page.length, 0);
+    },
+    retry: 3,
+    retryDelay: (attemptIndex) =>
+      Math.min(1000 * Math.pow(2, attemptIndex), 30000) + Math.random() * 1000,
+    staleTime: 10_000,
+  });
 
-  const loadMore = useCallback(async () => {
-    if (isLoadingMore || !hasMore) return;
-    await fetchMarketData(true);
-  }, [fetchMarketData, isLoadingMore, hasMore]);
-
-  const refetch = useCallback(async () => {
-    await fetchMarketData(false);
-  }, [fetchMarketData]);
-
-  // Reset pagination when category or search changes
   useEffect(() => {
-    setCurrentOffset(0);
-    currentOffsetRef.current = 0;
-    setHasMore(true);
-    setMarketData([]);
-    fetchMarketData(false);
-  }, [category, q, customQueryParams, fetchMarketData]);
+    if (!queryResult.error) return;
+
+    Logger.error(ensureError(queryResult.error), {
+      tags: {
+        feature: PREDICT_CONSTANTS.FEATURE_NAME,
+        component: 'usePredictMarketData',
+      },
+      context: {
+        name: 'usePredictMarketData',
+        data: {
+          method: 'queryFn',
+          action: 'market_data_load',
+          operation: 'data_fetching',
+          category,
+          hasSearchQuery: !!q,
+          pageSize,
+        },
+      },
+    });
+  }, [queryResult.error, category, q, pageSize]);
+
+  // Flatten pages and deduplicate by ID
+  const marketData = useMemo(() => {
+    if (!queryResult.data?.pages) return [];
+    const seen = new Set<string>();
+    return queryResult.data.pages.flat().filter((market) => {
+      if (seen.has(market.id)) return false;
+      seen.add(market.id);
+      return true;
+    });
+  }, [queryResult.data?.pages]);
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = queryResult;
+
+  const fetchMore = useCallback(async () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      await fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return {
     marketData,
-    isFetching: isLoading,
-    isFetchingMore: isLoadingMore,
-    error,
-    hasMore,
-    refetch,
-    fetchMore: loadMore,
+    isLoading: queryResult.isLoading,
+    isFetching: queryResult.isFetching,
+    isFetchingMore,
+    error: queryResult.error,
+    hasMore: hasNextPage ?? false,
+    refetch: queryResult.refetch,
+    fetchMore,
   };
 };

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,6 +1,8 @@
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
+import { predictMarketsKeys } from './markets';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
+import { predictPricesKeys, predictPricesOptions } from './prices';
 
 export const predictQueries = {
   activity: {
@@ -11,8 +13,15 @@ export const predictQueries = {
     keys: predictBalanceKeys,
     options: predictBalanceOptions,
   },
+  markets: {
+    keys: predictMarketsKeys,
+  },
   positions: {
     keys: predictPositionsKeys,
     options: predictPositionsOptions,
+  },
+  prices: {
+    keys: predictPricesKeys,
+    options: predictPricesOptions,
   },
 };

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -2,7 +2,6 @@ import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
 import { predictMarketsKeys } from './markets';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
-import { predictPricesKeys, predictPricesOptions } from './prices';
 
 export const predictQueries = {
   activity: {
@@ -19,9 +18,5 @@ export const predictQueries = {
   positions: {
     keys: predictPositionsKeys,
     options: predictPositionsOptions,
-  },
-  prices: {
-    keys: predictPricesKeys,
-    options: predictPricesOptions,
   },
 };

--- a/app/components/UI/Predict/queries/markets.ts
+++ b/app/components/UI/Predict/queries/markets.ts
@@ -11,12 +11,14 @@ export const predictMarketsKeys = {
   list: (params: {
     category: PredictCategory;
     q?: string;
+    pageSize?: number;
     customQueryParams?: string;
   }) =>
     [
       ...predictMarketsKeys.all(),
       params.category,
       params.q ?? '',
+      params.pageSize ?? 20,
       params.customQueryParams ?? '',
     ] as const,
 };

--- a/app/components/UI/Predict/queries/markets.ts
+++ b/app/components/UI/Predict/queries/markets.ts
@@ -1,0 +1,22 @@
+import type { PredictCategory } from '../types';
+
+/**
+ * Query key factory for Predict market-list (infinite scroll) queries.
+ *
+ * - `all()` — prefix key for invalidating every market-list entry at once.
+ * - `list(params)` — unique key for a specific category + search + custom params combo.
+ */
+export const predictMarketsKeys = {
+  all: () => ['predict', 'markets'] as const,
+  list: (params: {
+    category: PredictCategory;
+    q?: string;
+    customQueryParams?: string;
+  }) =>
+    [
+      ...predictMarketsKeys.all(),
+      params.category,
+      params.q ?? '',
+      params.customQueryParams ?? '',
+    ] as const,
+};

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -252,6 +252,7 @@ describe('PredictFeed', () => {
         { id: '1', title: 'Test Market 1' },
         { id: '2', title: 'Test Market 2' },
       ],
+      isLoading: false,
       isFetching: false,
       isFetchingMore: false,
       error: null,
@@ -384,6 +385,7 @@ describe('PredictFeed', () => {
     it('renders skeleton loaders when fetching initial data', () => {
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: true,
         isFetching: true,
         isFetchingMore: false,
         error: null,
@@ -403,6 +405,7 @@ describe('PredictFeed', () => {
     it('renders offline component when fetch error occurs', () => {
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: false,
         error: new Error('Network error'),
@@ -421,6 +424,7 @@ describe('PredictFeed', () => {
     it('renders empty state message when no markets available', () => {
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: false,
         error: null,
@@ -450,6 +454,7 @@ describe('PredictFeed', () => {
     it('displays skeleton loaders while search is fetching', () => {
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: true,
         isFetching: true,
         isFetchingMore: false,
         error: null,
@@ -549,6 +554,7 @@ describe('PredictFeed', () => {
     it('displays no results message when search returns empty', () => {
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: false,
         error: null,
@@ -571,6 +577,7 @@ describe('PredictFeed', () => {
     it('displays error state in search when fetch fails', () => {
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: false,
         error: new Error('Search error'),
@@ -599,6 +606,7 @@ describe('PredictFeed', () => {
           { id: '1', title: 'Test Market 1' },
           { id: '2', title: 'Test Market 2' },
         ],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: true,
         error: null,
@@ -663,6 +671,7 @@ describe('PredictFeed', () => {
       mockUseDebouncedValue.mockReturnValue('');
       mockUsePredictMarketData.mockReturnValue({
         marketData: [],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: false,
         error: null,
@@ -686,6 +695,7 @@ describe('PredictFeed', () => {
           { id: '1', title: 'Bitcoin Market 1' },
           { id: '2', title: 'Bitcoin Market 2' },
         ],
+        isLoading: false,
         isFetching: false,
         isFetchingMore: false,
         error: null,

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -236,7 +236,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
 
   const {
     marketData,
-    isFetching,
+    isLoading,
     error,
     hasMore,
     refetch,
@@ -315,7 +315,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     [tw, contentInsetTop, headerHidden, tabBarHeight],
   );
 
-  if (!hasEverBeenActive || (isFetching && !isRefreshing && !isFetchingMore)) {
+  if (!hasEverBeenActive || (isLoading && !isRefreshing && !isFetchingMore)) {
     return (
       <Box twClassName="flex-1 px-4" style={{ paddingTop: currentPaddingTop }}>
         <PredictMarketSkeleton testID={`skeleton-loading-${category}-1`} />
@@ -470,13 +470,18 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
   );
   const isDebouncing = searchQuery !== debouncedSearchQuery;
 
-  const { marketData, isFetching, error, refetch } = usePredictMarketData({
+  const {
+    marketData,
+    isLoading: isSearchFetching,
+    error,
+    refetch,
+  } = usePredictMarketData({
     category: 'trending',
     q: debouncedSearchQuery,
     pageSize: 20,
   });
 
-  const isSearchLoading = isDebouncing || isFetching;
+  const isSearchLoading = isDebouncing || isSearchFetching;
 
   const renderItem = useCallback(
     (info: { item: PredictMarketType; index: number }) => (

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -236,7 +236,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
 
   const {
     marketData,
-    isLoading,
+    isFetching,
     error,
     hasMore,
     refetch,
@@ -315,7 +315,10 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     [tw, contentInsetTop, headerHidden, tabBarHeight],
   );
 
-  if (!hasEverBeenActive || (isLoading && !isRefreshing && !isFetchingMore)) {
+  if (
+    !hasEverBeenActive ||
+    (isFetching && !marketData.length && !isFetchingMore)
+  ) {
     return (
       <Box twClassName="flex-1 px-4" style={{ paddingTop: currentPaddingTop }}>
         <PredictMarketSkeleton testID={`skeleton-loading-${category}-1`} />
@@ -326,7 +329,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     );
   }
 
-  if (error) {
+  if (error && !isFetching) {
     return (
       <Box style={{ paddingTop: currentPaddingTop }}>
         <PredictOffline onRetry={handleRefresh} />
@@ -473,6 +476,7 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
   const {
     marketData,
     isLoading: isSearchFetching,
+    isFetching: isSearchRefetching,
     error,
     refetch,
   } = usePredictMarketData({
@@ -481,7 +485,10 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
     pageSize: 20,
   });
 
-  const isSearchLoading = isDebouncing || isSearchFetching;
+  const isSearchLoading =
+    isDebouncing ||
+    isSearchFetching ||
+    (isSearchRefetching && (!marketData || marketData.length === 0));
 
   const renderItem = useCallback(
     (info: { item: PredictMarketType; index: number }) => (

--- a/app/components/Views/TrendingView/components/Sections/Section.tsx
+++ b/app/components/Views/TrendingView/components/Sections/Section.tsx
@@ -24,7 +24,7 @@ const Section: React.FC<SectionProps> = ({
   toggleSectionLoadingState,
 }) => {
   const section = SECTIONS_CONFIG[sectionId];
-  const { data, isLoading, refetch } = section.useSectionData();
+  const { data, isLoading, isFetching, refetch } = section.useSectionData();
 
   // Notify parent when data is empty
   useEffect(() => {
@@ -45,7 +45,8 @@ const Section: React.FC<SectionProps> = ({
   }, [refreshConfig, refetch]);
 
   // Only show loading skeleton if refreshConfig allows it
-  const shouldShowSkeleton = isLoading && refreshConfig.silentRefresh;
+  const shouldShowSkeleton =
+    (isLoading || isFetching) && refreshConfig.silentRefresh;
 
   return (
     <section.Section

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -71,6 +71,7 @@ interface SectionConfig {
   useSectionData: (searchQuery?: string) => {
     data: unknown[];
     isLoading: boolean;
+    isFetching?: boolean;
     refetch: () => Promise<void> | void;
   };
   SectionWrapper?: React.ComponentType<PropsWithChildren>;
@@ -286,18 +287,19 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
     OverrideSkeletonSearch: SiteSkeleton,
     Section: SectionCarrousel,
     useSectionData: (searchQuery) => {
-      const { marketData, isLoading, refetch } = usePredictMarketData({
-        category: 'trending',
-        pageSize: searchQuery ? 20 : 6,
-        q: searchQuery || undefined,
-      });
+      const { marketData, isLoading, isFetching, refetch } =
+        usePredictMarketData({
+          category: 'trending',
+          pageSize: searchQuery ? 20 : 6,
+          q: searchQuery || undefined,
+        });
 
       const filteredData = useMemo(
         () => fuseSearch(marketData, searchQuery, PREDICTIONS_FUSE_OPTIONS),
         [marketData, searchQuery],
       );
 
-      return { data: filteredData, isLoading, refetch };
+      return { data: filteredData, isLoading, isFetching, refetch };
     },
   },
   sites: {

--- a/app/components/Views/TrendingView/sections.config.tsx
+++ b/app/components/Views/TrendingView/sections.config.tsx
@@ -286,7 +286,7 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
     OverrideSkeletonSearch: SiteSkeleton,
     Section: SectionCarrousel,
     useSectionData: (searchQuery) => {
-      const { marketData, isFetching, refetch } = usePredictMarketData({
+      const { marketData, isLoading, refetch } = usePredictMarketData({
         category: 'trending',
         pageSize: searchQuery ? 20 : 6,
         q: searchQuery || undefined,
@@ -297,7 +297,7 @@ export const SECTIONS_CONFIG: Record<SectionId, SectionConfig> = {
         [marketData, searchQuery],
       );
 
-      return { data: filteredData, isLoading: isFetching, refetch };
+      return { data: filteredData, isLoading, refetch };
     },
   },
   sites: {


### PR DESCRIPTION
## **Description**

Migrate `usePredictMarketData` from manual `useState`/`useEffect` state management to React Query's `useInfiniteQuery`, following the same patterns established in #26645 (`usePredictMarket` migration).

Key changes:
- Replace manual state management with `useInfiniteQuery` for pagination, caching, deduplication, and retry with exponential back-off
- Extract query keys to a dedicated factory in `queries/markets.ts`
- Move `Logger.error` from `queryFn` try/catch to a `useEffect` watching `error` — avoids duplicate Sentry reports on retries (`retry: 3` means up to 4 error logs per failure otherwise)
- Return stable `refetch` reference directly from React Query instead of wrapping in `async () => { await refetch() }`
- Expose both `isLoading` (for UI visibility guards) and `isFetching` (for refresh indicators) so consumers can pick the right one
- Remove custom `UsePredictMarketDataOptions` and `UsePredictMarketDataResult` interfaces — types are inlined
- Return raw `Error` object instead of mapping to `error?.message` string

## **Related issues**

Follows up on #26645

## **Manual testing steps**

```gherkin
Feature: Predict market data loading

  Scenario: user views trending markets
    Given the app is open on the Predict feed

    When user scrolls through the market list
    Then markets load with infinite scroll pagination
    And returning to the app after 10+ seconds does not cause UI flicker
```

## **Screenshots/Recordings**

N/A — internal refactor, no visual changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces custom fetching/pagination/error handling with `useInfiniteQuery`, which can change loading states, caching behavior, and pagination across Predict and Trending surfaces.
> 
> **Overview**
> Migrates `usePredictMarketData` from manual `useState`/`useEffect` fetching to React Query’s `useInfiniteQuery`, adding built-in pagination (`fetchMore`/`hasMore`), caching/stale-time, retry/backoff, and page flattening + dedupe.
> 
> Introduces `predictQueries.markets` query key factory (`queries/markets.ts`) and shifts error reporting to a `useEffect` watching `queryResult.error` to avoid duplicate logs during retries; the hook now exposes `isLoading` alongside `isFetching` and returns the raw `error` object.
> 
> Updates Predict UI/tests (`PredictFeed`, Trending `predictions` section, and hook tests) to consume the new hook shape and to refine skeleton/offline rendering so initial-load vs refetch/pagination states behave correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 983e3a7b1058426250ffd23afe17b6e683ecf64a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->