### PR TITLE
refactor(predict): add React Query cache invalidation to usePredictClaim

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -1,6 +1,7 @@
 import { NavigationProp } from '@react-navigation/native';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
@@ -10,6 +11,7 @@ import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConf
 import { usePredictClaim } from './usePredictClaim';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import { predictQueries } from '../queries';
 
 // Create mock functions
 const mockNavigate = jest.fn();
@@ -102,19 +104,29 @@ describe('usePredictClaim', () => {
     jest.clearAllMocks();
   });
 
-  const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(
-      ToastContext.Provider,
-      {
-        value: {
-          toastRef: mockToastRef as React.RefObject<{
-            showToast: jest.Mock;
-            closeToast: jest.Mock;
-          }>,
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        ToastContext.Provider,
+        {
+          value: {
+            toastRef: mockToastRef as React.RefObject<{
+              showToast: jest.Mock;
+              closeToast: jest.Mock;
+            }>,
+          },
         },
-      },
-      children,
+        children,
+      ),
     );
+  };
 
   describe('initialization', () => {
     it('returns claim function', () => {
@@ -370,15 +382,22 @@ describe('usePredictClaim', () => {
       const mockError = new Error('Claim failed');
       mockClaimWinnings.mockRejectedValue(mockError);
 
+      const noToastQueryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       const noToastWrapper = ({ children }: { children: React.ReactNode }) =>
         React.createElement(
-          ToastContext.Provider,
-          {
-            value: {
-              toastRef: undefined,
+          QueryClientProvider,
+          { client: noToastQueryClient },
+          React.createElement(
+            ToastContext.Provider,
+            {
+              value: {
+                toastRef: undefined,
+              },
             },
-          },
-          children,
+            children,
+          ),
         );
 
       const { result } = renderHook(() => usePredictClaim(), {
@@ -408,6 +427,47 @@ describe('usePredictClaim', () => {
         }),
       );
       expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cache invalidation', () => {
+    it('invalidates balance, positions, and activity caches after successful claim', async () => {
+      // Arrange
+      mockClaimWinnings.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Spy on the queryClient instance
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+      // Act
+      await result.current.claim();
+
+      // Assert
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: predictQueries.balance.keys.all(),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: predictQueries.positions.keys.all(),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: predictQueries.activity.keys.all(),
+      });
+    });
+
+    it('does not invalidate caches when claim fails', async () => {
+      // Arrange
+      mockClaimWinnings.mockRejectedValue(new Error('Claim failed'));
+
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+      // Act
+      await result.current.claim();
+
+      // Assert
+      expect(invalidateSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -104,33 +104,34 @@ describe('usePredictClaim', () => {
     jest.clearAllMocks();
   });
 
-  let queryClient: QueryClient;
-
-  const wrapper = ({ children }: { children: React.ReactNode }) => {
-    queryClient = new QueryClient({
+  const createWrapper = () => {
+    const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    return React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
+    const Wrapper = ({ children }: { children: React.ReactNode }) =>
       React.createElement(
-        ToastContext.Provider,
-        {
-          value: {
-            toastRef: mockToastRef as React.RefObject<{
-              showToast: jest.Mock;
-              closeToast: jest.Mock;
-            }>,
+        QueryClientProvider,
+        { client: qc },
+        React.createElement(
+          ToastContext.Provider,
+          {
+            value: {
+              toastRef: mockToastRef as React.RefObject<{
+                showToast: jest.Mock;
+                closeToast: jest.Mock;
+              }>,
+            },
           },
-        },
-        children,
-      ),
-    );
+          children,
+        ),
+      );
+    return { wrapper: Wrapper, queryClient: qc };
   };
 
   describe('initialization', () => {
     it('returns claim function', () => {
       // Arrange & Act
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Assert
@@ -142,7 +143,7 @@ describe('usePredictClaim', () => {
     it('navigates to confirmation and claims winnings', async () => {
       // Arrange
       mockClaimWinnings.mockResolvedValue(undefined);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
@@ -161,7 +162,7 @@ describe('usePredictClaim', () => {
     it('calls claim without provider argument', async () => {
       // Arrange
       mockClaimWinnings.mockResolvedValue(undefined);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
@@ -177,7 +178,7 @@ describe('usePredictClaim', () => {
       // Arrange
       const mockError = new Error('Claim failed');
       mockClaimWinnings.mockRejectedValue(mockError);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
@@ -229,7 +230,7 @@ describe('usePredictClaim', () => {
       mockClaimWinnings
         .mockRejectedValueOnce(mockError)
         .mockResolvedValueOnce(undefined);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act - first claim attempt fails
@@ -285,7 +286,7 @@ describe('usePredictClaim', () => {
       // Arrange
       const mockError = new Error('Network error');
       mockClaimWinnings.mockRejectedValue(mockError);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
@@ -316,7 +317,7 @@ describe('usePredictClaim', () => {
       // Arrange
       const mockErrorString = 'String error message';
       mockClaimWinnings.mockRejectedValue(mockErrorString);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
@@ -348,7 +349,7 @@ describe('usePredictClaim', () => {
       // Arrange
       const mockErrorObject = { code: 'NETWORK_ERROR', message: 'Failed' };
       mockClaimWinnings.mockRejectedValue(mockErrorObject);
-
+      const { wrapper } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Act
@@ -434,10 +435,8 @@ describe('usePredictClaim', () => {
     it('invalidates balance, positions, and activity caches after successful claim', async () => {
       // Arrange
       mockClaimWinnings.mockResolvedValue(undefined);
-
+      const { wrapper, queryClient } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
-      // Spy on the queryClient instance
       const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
       // Act
@@ -458,9 +457,8 @@ describe('usePredictClaim', () => {
     it('does not invalidate caches when claim fails', async () => {
       // Arrange
       mockClaimWinnings.mockRejectedValue(new Error('Claim failed'));
-
+      const { wrapper, queryClient } = createWrapper();
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
       const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
       // Act

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useContext } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
@@ -12,6 +13,7 @@ import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import Routes from '../../../../constants/navigation/Routes';
+import { predictQueries } from '../queries';
 
 export const usePredictClaim = () => {
   const { navigateToConfirmation } = useConfirmNavigation();
@@ -19,6 +21,7 @@ export const usePredictClaim = () => {
   const theme = useAppThemeFromContext();
   const { toastRef } = useContext(ToastContext);
   const navigation = useNavigation();
+  const queryClient = useQueryClient();
 
   const claim = useCallback(async () => {
     try {
@@ -29,6 +32,18 @@ export const usePredictClaim = () => {
         stack: Routes.PREDICT.ROOT,
       });
       await claimWinnings({});
+
+      // Invalidate caches after successful claim so balance,
+      // positions, and activity reflect the updated state.
+      queryClient.invalidateQueries({
+        queryKey: predictQueries.balance.keys.all(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: predictQueries.positions.keys.all(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: predictQueries.activity.keys.all(),
+      });
     } catch (err) {
       // Log error with claim context
       Logger.error(ensureError(err), {
@@ -75,6 +90,7 @@ export const usePredictClaim = () => {
     claimWinnings,
     navigateToConfirmation,
     navigation,
+    queryClient,
     theme.colors.accent04.normal,
     theme.colors.error.default,
     toastRef,

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -13,7 +13,7 @@ import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import Routes from '../../../../constants/navigation/Routes';
-import { predictQueries } from '../queries';
+import { invalidatePredictCaches } from '../utils/invalidatePredictCaches';
 
 export const usePredictClaim = () => {
   const { navigateToConfirmation } = useConfirmNavigation();
@@ -33,17 +33,7 @@ export const usePredictClaim = () => {
       });
       await claimWinnings({});
 
-      // Invalidate caches after successful claim so balance,
-      // positions, and activity reflect the updated state.
-      queryClient.invalidateQueries({
-        queryKey: predictQueries.balance.keys.all(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: predictQueries.positions.keys.all(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: predictQueries.activity.keys.all(),
-      });
+      invalidatePredictCaches(queryClient);
     } catch (err) {
       // Log error with claim context
       Logger.error(ensureError(err), {

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -20,7 +20,7 @@ import { formatPrice } from '../utils/format';
 import { ensureError, parseErrorMessage } from '../utils/predictErrorHandler';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import { usePredictBalance } from './usePredictBalance';
-import { predictQueries } from '../queries';
+import { invalidatePredictCaches } from '../utils/invalidatePredictCaches';
 import { usePredictDeposit } from './usePredictDeposit';
 import { PredictEventValues } from '../constants/eventNames';
 
@@ -182,17 +182,7 @@ export function usePredictPlaceOrder(
 
         setResult(orderResult);
 
-        queryClient.invalidateQueries({
-          queryKey: predictQueries.balance.keys.all(),
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: predictQueries.positions.keys.all(),
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: predictQueries.activity.keys.all(),
-        });
+        invalidatePredictCaches(queryClient);
 
         if (side === Side.BUY) {
           showOrderPlacedToast();

--- a/app/components/UI/Predict/utils/invalidatePredictCaches.ts
+++ b/app/components/UI/Predict/utils/invalidatePredictCaches.ts
@@ -1,0 +1,18 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { predictQueries } from '../queries';
+
+/**
+ * Invalidates balance, positions, and activity caches so the UI
+ * reflects the latest state after a mutation (e.g. claim, place order).
+ */
+export function invalidatePredictCaches(queryClient: QueryClient) {
+  queryClient.invalidateQueries({
+    queryKey: predictQueries.balance.keys.all(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: predictQueries.positions.keys.all(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: predictQueries.activity.keys.all(),
+  });
+}


### PR DESCRIPTION
## **Description**

Adds React Query cache invalidation to `usePredictClaim` so that after a successful claim, the balance, positions, and activity query caches are invalidated. This ensures the UI reflects the updated state without requiring a manual refresh.

## **Related issues**

N/A

## **Manual testing steps**

1. Open a Predict market with a claimable position
2. Tap "Claim"
3. Verify balance, positions, and activity views update automatically after claim completes

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/contributor-docs/blob/main/docs/metamask-mobile-coding-standards.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [Labeling Guideline](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING.md)).
- [x] I've properly set the PR status:
  - [x] In case of a ongoing work, I've set the PR as draft
- [x] I confirm this PR addresses all acceptance criteria described in the ticket and includes the necessary testing evidence such as recordings and or parties can verify

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and run branch, verify suggested testing steps, test determine if the fix addresses the original issue, etc.)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket and includes the necessary testing evidence such as recordings and/or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds post-mutation React Query cache invalidation and corresponding tests; main risk is over/under-invalidating queries causing stale UI or extra refetches.
> 
> **Overview**
> After a successful `usePredictClaim` mutation, the hook now invalidates the Predict React Query caches for **balance**, **positions**, and **activity** so the UI refreshes automatically.
> 
> Cache invalidation logic is centralized in a new `invalidatePredictCaches` utility and `usePredictPlaceOrder` is refactored to use it instead of duplicating `invalidateQueries` calls. Tests for `usePredictClaim` are updated to provide a `QueryClientProvider` and to assert caches are invalidated only on success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa5c0859689dcc512a4dcf6ffa6eae1238c0a27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->