### PR TITLE
fix: redact SDK related URLs

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -249,7 +249,7 @@ describe('ConnectionRegistry', () => {
 
       // @ts-expect-error test non-string input
       await expect(registry.handleMwpDeeplink(null)).rejects.toThrow(
-        'Invalid MWP deeplink: null',
+        'Invalid MWP deeplink: [invalid URL]',
       );
     });
   });

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -11,7 +11,7 @@ import { IConnectionStore } from '../types/connection-store';
 import { IHostApplicationAdapter } from '../types/host-application-adapter';
 import { Connection } from './connection';
 import { ConnectionInfo } from '../types/connection-info';
-import logger from './logger';
+import logger, { redactUrl } from './logger';
 import { ACTIONS, PREFIXES } from '../../../constants/deeplinks';
 import { decompressPayloadB64 } from '../utils/compression-utils';
 import { whenStoreReady } from '../utils/when-store-ready';
@@ -89,7 +89,7 @@ export class ConnectionRegistry {
 
   public async handleMwpDeeplink(url: string): Promise<void> {
     if (!this.isMwpDeeplink(url)) {
-      throw new Error(`Invalid MWP deeplink: ${url}`);
+      throw new Error(`Invalid MWP deeplink: ${redactUrl(url)}`);
     }
 
     try {
@@ -164,7 +164,7 @@ export class ConnectionRegistry {
     if (this.deeplinks.has(url)) return;
     this.deeplinks.add(url);
 
-    logger.debug('Handling connect deeplink:', url);
+    logger.debug('Handling connect deeplink:', redactUrl(url));
 
     let conn: Connection | undefined;
     let connInfo: ConnectionInfo | undefined;
@@ -194,9 +194,9 @@ export class ConnectionRegistry {
       this.connections.set(conn.id, conn);
       await this.store.save(connInfo);
       this.hostapp.syncConnectionList(Array.from(this.connections.values()));
-      logger.debug('Handled connect deeplink.', connInfo);
+      logger.debug('Handled connect deeplink.', connInfo?.id);
     } catch (error) {
-      logger.error('Failed to handle connect deeplink:', error, url);
+      logger.error('Failed to handle connect deeplink:', error, redactUrl(url));
       this.hostapp.showConnectionError();
       if (conn) await this.disconnect(conn.id);
     } finally {

--- a/app/core/SDKConnectV2/services/connection.ts
+++ b/app/core/SDKConnectV2/services/connection.ts
@@ -39,7 +39,14 @@ export class Connection {
     this.bridge = new RPCBridgeAdapter(this.info);
 
     this.client.on('message', async (payload) => {
-      logger.debug('Received message:', this.id, payload);
+      const data =
+        payload && typeof payload === 'object' && 'data' in payload
+          ? (payload.data as Record<string, unknown>)
+          : undefined;
+      logger.debug('Received message:', this.id, {
+        method: data?.method,
+        id: data?.id,
+      });
 
       const isWalletCreateSessionRequest =
         payload &&
@@ -76,7 +83,14 @@ export class Connection {
     });
 
     this.bridge.on('response', (payload) => {
-      logger.debug('Sending message:', this.id, payload);
+      const responseData =
+        'data' in payload
+          ? (payload.data as Record<string, unknown>)
+          : (payload as Record<string, unknown>);
+      logger.debug('Sending message:', this.id, {
+        method: responseData?.method,
+        id: responseData?.id,
+      });
 
       // If the payload includes an id, its a JSON-RPC response, otherwise its a notification
       if ('data' in payload && 'id' in payload.data) {

--- a/app/core/SDKConnectV2/services/logger.ts
+++ b/app/core/SDKConnectV2/services/logger.ts
@@ -5,6 +5,20 @@ const prettify = (...args: unknown[]) =>
     .map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : String(arg)))
     .join(' ');
 
+/**
+ * Redacts query and fragment parameters from a URL to prevent
+ * leaking sensitive connection parameters (channel ID, public key)
+ * in logs.
+ */
+export const redactUrl = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}?[REDACTED]`;
+  } catch {
+    return '[invalid URL]';
+  }
+};
+
 export default {
   debug: (...args: unknown[]) => {
     if (process.env.SDK_CONNECT_V2_DEBUG === 'true') {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Redact sensitive data from SDKConnectV2 / MWP debug and error logs
- Add `redactUrl` utility to strip query/fragment params from deeplink URLs before logging
- Reduce message payload logging to method + id metadata only

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: [WAPI-1117](https://consensyssoftware.atlassian.net/browse/WAPI-1117)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WAPI-1117]: https://consensyssoftware.atlassian.net/browse/WAPI-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging/error messages in SDKConnectV2, with minimal behavioral impact aside from altered log output and one test expectation.
> 
> **Overview**
> Prevents sensitive SDKConnectV2/MWP connection parameters from being written to logs by introducing `redactUrl()` and using it when throwing/logging deeplink handling errors.
> 
> Reduces verbosity of connection message logging by logging only JSON-RPC `method` and `id` (instead of full payloads), and adjusts connect-deeplink success logging to avoid dumping full `ConnectionInfo`. Updates the `handleMwpDeeplink` non-string URL test to expect the new redacted/invalid URL message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd3a3d031f2970f6b83e3ee7760e5acfaaa3cf3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->