### PR TITLE
feat: add @deprecated JSDoc comments to component library replacements

### DIFF
--- a/app/component-library/components/Avatars/Avatar/foundation/AvatarBase/AvatarBase.tsx
+++ b/app/component-library/components/Avatars/Avatar/foundation/AvatarBase/AvatarBase.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `AvatarBase` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `AvatarBase` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarBase/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Avatars/Avatar/foundation/AvatarBase/AvatarBase.tsx
+++ b/app/component-library/components/Avatars/Avatar/foundation/AvatarBase/AvatarBase.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `AvatarBase` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarBase/README.md}
- */
-
 // Third party dependencies.
 import React from 'react';
 import { View } from 'react-native';
@@ -18,6 +12,11 @@ import { AvatarBaseProps } from './AvatarBase.types';
 import styleSheet from './AvatarBase.styles';
 import { DEFAULT_AVATARBASE_SIZE } from './AvatarBase.constants';
 
+/**
+ * @deprecated Please update your code to use `AvatarBase` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarBase/README.md}
+ */
 const AvatarBase: React.FC<AvatarBaseProps> = ({
   size = DEFAULT_AVATARBASE_SIZE,
   style,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable react/prop-types */
 
+/**
+ * @deprecated Please update your code to use `AvatarAccount` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md}
+ */
+
 // Third party dependencies.
 import React, { useMemo } from 'react';
 import { Image as RNImage } from 'react-native';

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `AvatarAccount` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md}
- */
-
 // Third party dependencies.
 import React, { useMemo } from 'react';
 import { Image as RNImage } from 'react-native';
@@ -35,6 +29,11 @@ function getJazziconSeed(address: string) {
   return parseInt(address.slice(2, 10), 16);
 }
 
+/**
+ * @deprecated Please update your code to use `AvatarAccount` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md}
+ */
 const AvatarAccount = ({
   type: avatarType = DEFAULT_AVATARACCOUNT_TYPE,
   accountAddress,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable react/prop-types */
 
+/**
+ * @deprecated Please update your code to use `AvatarFavicon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarFavicon/README.md}
+ */
+
 // Third party dependencies.
 import React, { useCallback, useEffect, useState } from 'react';
 import { Image, ImageErrorEventData, NativeSyntheticEvent } from 'react-native';

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `AvatarFavicon` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarFavicon/README.md}
- */
-
 // Third party dependencies.
 import React, { useCallback, useEffect, useState } from 'react';
 import { Image, ImageErrorEventData, NativeSyntheticEvent } from 'react-native';
@@ -28,6 +22,11 @@ import {
 import stylesheet from './AvatarFavicon.styles';
 import { AvatarFaviconProps } from './AvatarFavicon.types';
 
+/**
+ * @deprecated Please update your code to use `AvatarFavicon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarFavicon/README.md}
+ */
 const AvatarFavicon = ({
   imageSource,
   size = DEFAULT_AVATARFAVICON_SIZE,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/AvatarIcon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/AvatarIcon.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `AvatarIcon` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarIcon/README.md}
- */
-
 // Third party dependencies.
 import React from 'react';
 
@@ -20,6 +14,11 @@ import stylesheet from './AvatarIcon.styles';
 import { AvatarIconProps } from './AvatarIcon.types';
 import { DEFAULT_AVATARICON_SIZE } from './AvatarIcon.constants';
 
+/**
+ * @deprecated Please update your code to use `AvatarIcon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarIcon/README.md}
+ */
 const AvatarIcon = ({
   size = DEFAULT_AVATARICON_SIZE,
   name,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/AvatarIcon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/AvatarIcon.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `AvatarIcon` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `AvatarIcon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarIcon/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `AvatarNetwork` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarNetwork/README.md}
- */
-
 // Third party dependencies.
 import React, { useCallback, useEffect, useState } from 'react';
 import { Image, ImageSourcePropType } from 'react-native';
@@ -24,6 +18,11 @@ import {
   AVATARNETWORK_IMAGE_TESTID,
 } from './AvatarNetwork.constants';
 
+/**
+ * @deprecated Please update your code to use `AvatarNetwork` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarNetwork/README.md}
+ */
 const AvatarNetwork = ({
   size = DEFAULT_AVATARNETWORK_SIZE,
   style,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `AvatarNetwork` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `AvatarNetwork` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarNetwork/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx
@@ -1,9 +1,3 @@
-/**
- * @deprecated Please update your code to use `AvatarToken` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarToken/README.md}
- */
-
 // Third party dependencies.
 import { isNumber } from 'lodash';
 import React, { useState } from 'react';
@@ -27,6 +21,11 @@ import {
   AVATARTOKEN_IMAGE_TESTID,
 } from './AvatarToken.constants';
 
+/**
+ * @deprecated Please update your code to use `AvatarToken` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarToken/README.md}
+ */
 const AvatarToken = ({
   size = DEFAULT_AVATARTOKEN_SIZE,
   style,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx
@@ -1,5 +1,7 @@
 /**
- * @deprecated Please update your code to use `AvatarToken` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `AvatarToken` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarToken/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/app/component-library/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -1,3 +1,9 @@
+/**
+ * @deprecated Please update your code to use `AvatarGroup` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarGroup/README.md}
+ */
+
 // Third party dependencies.
 import React, { useCallback } from 'react';
 import { View } from 'react-native';

--- a/app/component-library/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/app/component-library/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -1,9 +1,3 @@
-/**
- * @deprecated Please update your code to use `AvatarGroup` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarGroup/README.md}
- */
-
 // Third party dependencies.
 import React, { useCallback } from 'react';
 import { View } from 'react-native';
@@ -28,6 +22,11 @@ import {
   AVATARGROUP_CONTAINER_TESTID,
 } from './AvatarGroup.constants';
 
+/**
+ * @deprecated Please update your code to use `AvatarGroup` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarGroup/README.md}
+ */
 const AvatarGroup = ({
   avatarPropsList,
   size = DEFAULT_AVATARGROUP_AVATARSIZE,

--- a/app/component-library/components/Badges/Badge/foundation/BadgeBase/BadgeBase.tsx
+++ b/app/component-library/components/Badges/Badge/foundation/BadgeBase/BadgeBase.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `BadgeCount`, `BadgeIcon`, `BadgeNetwork` or `BadgeStatus` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `BadgeCount`, `BadgeIcon`, `BadgeNetwork` or `BadgeStatus` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react-native/src/components}
  */
 
 // Third library dependencies.

--- a/app/component-library/components/Badges/Badge/foundation/BadgeBase/BadgeBase.tsx
+++ b/app/component-library/components/Badges/Badge/foundation/BadgeBase/BadgeBase.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `BadgeCount`, `BadgeIcon`, `BadgeNetwork` or `BadgeStatus` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react-native/src/components}
- */
-
 // Third library dependencies.
 import React from 'react';
 import { View } from 'react-native';
@@ -18,6 +12,11 @@ import { BADGE_BASE_TEST_ID } from './BadgeBase.constants';
 import { BadgeBaseProps } from './BadgeBase.types';
 import styleSheet from './BadgeBase.styles';
 
+/**
+ * @deprecated Please update your code to use `BadgeCount`, `BadgeIcon`, `BadgeNetwork` or `BadgeStatus` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react-native/src/components}
+ */
 const BadgeBase: React.FC<BadgeBaseProps> = ({ children, style, ...props }) => {
   const { styles } = useStyles(styleSheet, {
     style,

--- a/app/component-library/components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `BadgeNetwork` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeNetwork/README.md}
- */
-
 // Third library dependencies.
 import React from 'react';
 
@@ -22,6 +16,11 @@ import {
   DEFAULT_BADGENETWORK_NETWORKICON_SIZE,
 } from './BadgeNetwork.constants';
 
+/**
+ * @deprecated Please update your code to use `BadgeNetwork` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeNetwork/README.md}
+ */
 const BadgeNetwork = ({
   style,
   name,

--- a/app/component-library/components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable react/prop-types */
 
+/**
+ * @deprecated Please update your code to use `BadgeNetwork` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeNetwork/README.md}
+ */
+
 // Third library dependencies.
 import React from 'react';
 

--- a/app/component-library/components/Badges/Badge/variants/BadgeNotifications/BadgeNotifications.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNotifications/BadgeNotifications.tsx
@@ -1,9 +1,3 @@
-/**
- * @deprecated Please update your code to use `BadgeIcon` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeIcon/README.md}
- */
-
 // Third library dependencies.
 import React from 'react';
 
@@ -16,6 +10,11 @@ import Icon, { IconSize, IconColor } from '../../../../Icons/Icon';
 import { BadgeNotificationsProps } from './BadgeNotifications.types';
 import styleSheet from './BadgeNotifications.styles';
 
+/**
+ * @deprecated Please update your code to use `BadgeIcon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeIcon/README.md}
+ */
 const BadgeNotifications = ({
   style,
   iconName,

--- a/app/component-library/components/Badges/Badge/variants/BadgeNotifications/BadgeNotifications.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNotifications/BadgeNotifications.tsx
@@ -1,3 +1,9 @@
+/**
+ * @deprecated Please update your code to use `BadgeIcon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeIcon/README.md}
+ */
+
 // Third library dependencies.
 import React from 'react';
 

--- a/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.tsx
+++ b/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `BadgeWrapper` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeWrapper/README.md}
- */
-
 // Third library dependencies.
 import React from 'react';
 import { View } from 'react-native';
@@ -22,6 +16,11 @@ import {
   BADGE_WRAPPER_BADGE_TEST_ID,
 } from './BadgeWrapper.constants';
 
+/**
+ * @deprecated Please update your code to use `BadgeWrapper` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeWrapper/README.md}
+ */
 const BadgeWrapper: React.FC<BadgeWrapperProps> = ({
   anchorElementShape = DEFAULT_BADGEWRAPPER_BADGEANCHORELEMENTSHAPE,
   badgePosition = DEFAULT_BADGEWRAPPER_BADGEPOSITION,

--- a/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.tsx
+++ b/app/component-library/components/Badges/BadgeWrapper/BadgeWrapper.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `BadgeWrapper` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `BadgeWrapper` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeWrapper/README.md}
  */
 
 // Third library dependencies.

--- a/app/component-library/components/Buttons/Button/Button.tsx
+++ b/app/component-library/components/Buttons/Button/Button.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
- */
-
 import React from 'react';
 
 // External dependencies.
@@ -16,6 +10,11 @@ import ButtonSecondary from './variants/ButtonSecondary';
 // Internal dependencies.
 import { ButtonProps, ButtonVariants } from './Button.types';
 
+/**
+ * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
+ */
 const Button = (buttonProps: ButtonProps) => {
   const { variant, ...restProps } = buttonProps;
 

--- a/app/component-library/components/Buttons/Button/Button.tsx
+++ b/app/component-library/components/Buttons/Button/Button.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
  */
 
 import React from 'react';

--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `TextButton` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `TextButton` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextButton/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `TextButton` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextButton/README.md}
- */
-
 // Third party dependencies.
 import React, { useState, useCallback } from 'react';
 import { GestureResponderEvent, StyleProp, TextStyle } from 'react-native';
@@ -28,6 +22,11 @@ import {
   DEFAULT_BUTTONLINK_LABEL_COLOR_ERROR_PRESSED,
 } from './ButtonLink.constants';
 
+/**
+ * @deprecated Please update your code to use `TextButton` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextButton/README.md}
+ */
 const ButtonLink: React.FC<ButtonLinkProps> = ({
   style,
   onPressIn,

--- a/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Primary`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
- */
-
 // Third party dependencies.
 import React, { useCallback, useState } from 'react';
 import { ActivityIndicator, GestureResponderEvent } from 'react-native';
@@ -21,6 +15,11 @@ import { ButtonPrimaryProps } from './ButtonPrimary.types';
 import styleSheet from './ButtonPrimary.styles';
 import { DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT } from './ButtonPrimary.constants';
 
+/**
+ * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Primary`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
+ */
 const ButtonPrimary = ({
   style,
   onPressIn,

--- a/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Primary`
+ * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Primary`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Secondary`
+ * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Secondary`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Secondary`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
- */
-
 // Third party dependencies.
 import React, { useCallback, useState } from 'react';
 import { ActivityIndicator, GestureResponderEvent } from 'react-native';
@@ -21,6 +15,11 @@ import { ButtonSecondaryProps } from './ButtonSecondary.types';
 import styleSheet from './ButtonSecondary.styles';
 import { DEFAULT_BUTTONSECONDARY_LABEL_TEXTVARIANT } from './ButtonSecondary.constants';
 
+/**
+ * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Secondary`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
+ */
 const ButtonSecondary = ({
   style,
   onPressIn,

--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.tsx
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `ButtonIcon` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `ButtonIcon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonIcon/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.tsx
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `ButtonIcon` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonIcon/README.md}
- */
-
 // Third party dependencies.
 import React, { useCallback, useState } from 'react';
 import { GestureResponderEvent, TouchableOpacity } from 'react-native';
@@ -23,6 +17,11 @@ import {
   ICONSIZE_BY_BUTTONICONSIZE,
 } from './ButtonIcon.constants';
 
+/**
+ * @deprecated Please update your code to use `ButtonIcon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonIcon/README.md}
+ */
 const ButtonIcon = ({
   iconName,
   onPress,

--- a/app/component-library/components/Checkbox/Checkbox.tsx
+++ b/app/component-library/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `Checkbox` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `Checkbox` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Checkbox/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Checkbox/Checkbox.tsx
+++ b/app/component-library/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `Checkbox` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Checkbox/README.md}
- */
-
 // Third party dependencies.
 import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
@@ -27,6 +21,11 @@ import {
   DEFAULT_CHECKBOX_ISINDETERMINATE_ICONNAME,
 } from './Checkbox.constants';
 
+/**
+ * @deprecated Please update your code to use `Checkbox` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Checkbox/README.md}
+ */
 const Checkbox = ({
   style,
   label,

--- a/app/component-library/components/Form/TextField/TextField.tsx
+++ b/app/component-library/components/Form/TextField/TextField.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable react/prop-types */
 
+/**
+ * @deprecated Please update your code to use `TextField` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextField/README.md}
+ */
+
 // Third party dependencies.
 import React, {
   useCallback,

--- a/app/component-library/components/Form/TextField/TextField.tsx
+++ b/app/component-library/components/Form/TextField/TextField.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `TextField` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextField/README.md}
- */
-
 // Third party dependencies.
 import React, {
   useCallback,
@@ -29,6 +23,11 @@ import {
   TEXTFIELD_ENDACCESSORY_TEST_ID,
 } from './TextField.constants';
 
+/**
+ * @deprecated Please update your code to use `TextField` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextField/README.md}
+ */
 const TextField = React.forwardRef<TextInput | null, TextFieldProps>(
   (
     {

--- a/app/component-library/components/Icons/Icon/Icon.tsx
+++ b/app/component-library/components/Icons/Icon/Icon.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types, react/jsx-pascal-case */
 
 /**
- * @deprecated Please update your code to use `Icon` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `Icon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Icon/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Icons/Icon/Icon.tsx
+++ b/app/component-library/components/Icons/Icon/Icon.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types, react/jsx-pascal-case */
 
-/**
- * @deprecated Please update your code to use `Icon` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Icon/README.md}
- */
-
 // Third party dependencies.
 import React from 'react';
 
@@ -18,6 +12,11 @@ import styleSheet from './Icon.styles';
 import { assetByIconName } from './Icon.assets';
 import { DEFAULT_ICON_SIZE, DEFAULT_ICON_COLOR } from './Icon.constants';
 
+/**
+ * @deprecated Please update your code to use `Icon` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Icon/README.md}
+ */
 const Icon = ({
   size = DEFAULT_ICON_SIZE,
   style,

--- a/app/component-library/components/Texts/Text/Text.tsx
+++ b/app/component-library/components/Texts/Text/Text.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 /**
- * @deprecated Please update your code to use `Text` from `@metamask/design-system-react-native`
+ * @deprecated Please update your code to use `Text` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Text/README.md}
  */
 
 // Third party dependencies.

--- a/app/component-library/components/Texts/Text/Text.tsx
+++ b/app/component-library/components/Texts/Text/Text.tsx
@@ -1,11 +1,5 @@
 /* eslint-disable react/prop-types */
 
-/**
- * @deprecated Please update your code to use `Text` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Text/README.md}
- */
-
 // Third party dependencies.
 import React from 'react';
 import { Text as RNText } from 'react-native';
@@ -18,6 +12,11 @@ import { TextProps } from './Text.types';
 import styleSheet from './Text.styles';
 import { DEFAULT_TEXT_COLOR, DEFAULT_TEXT_VARIANT } from './Text.constants';
 
+/**
+ * @deprecated Please update your code to use `Text` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Text/README.md}
+ */
 const Text: React.FC<TextProps> = ({
   variant = DEFAULT_TEXT_VARIANT,
   color = DEFAULT_TEXT_COLOR,

--- a/index.js
+++ b/index.js
@@ -99,16 +99,16 @@ if (IGNORE_BOXLOGS_DEVELOPMENT === 'true') {
 }
 
 /* Uncomment and comment regular registration below */
-import Storybook from './.storybook';
-AppRegistry.registerComponent(name, () => Storybook);
+// import Storybook from './.storybook';
+// AppRegistry.registerComponent(name, () => Storybook);
 
 /**
  * Application entry point responsible for registering root component
  */
-// AppRegistry.registerComponent(name, () =>
-//   // Disable Sentry for E2E tests
-//   isE2E ? Root : Sentry.wrap(Root),
-// );
+AppRegistry.registerComponent(name, () =>
+  // Disable Sentry for E2E tests
+  isE2E ? Root : Sentry.wrap(Root),
+);
 
 function setupGlobalErrorHandler() {
   const reactNativeDefaultHandler = global.ErrorUtils.getGlobalHandler();

--- a/index.js
+++ b/index.js
@@ -99,16 +99,16 @@ if (IGNORE_BOXLOGS_DEVELOPMENT === 'true') {
 }
 
 /* Uncomment and comment regular registration below */
-// import Storybook from './.storybook';
-// AppRegistry.registerComponent(name, () => Storybook);
+import Storybook from './.storybook';
+AppRegistry.registerComponent(name, () => Storybook);
 
 /**
  * Application entry point responsible for registering root component
  */
-AppRegistry.registerComponent(name, () =>
-  // Disable Sentry for E2E tests
-  isE2E ? Root : Sentry.wrap(Root),
-);
+// AppRegistry.registerComponent(name, () =>
+//   // Disable Sentry for E2E tests
+//   isE2E ? Root : Sentry.wrap(Root),
+// );
 
 function setupGlobalErrorHandler() {
   const reactNativeDefaultHandler = global.ErrorUtils.getGlobalHandler();


### PR DESCRIPTION
## **Description**

This PR adds `@deprecated` JSDoc comments with README links to 20 component library files that have replacements in the MetaMask Design System (MMDS).

The deprecation messages provide clear migration paths for developers by:
1. Indicating which MMDS component to use as a replacement
2. Warning that the API may have changed
3. Linking directly to the component's README in the MMDS repository

This work improves developer experience by making it easier to migrate from legacy component library components to the standardized MMDS components.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-494

## **Manual testing steps**

```gherkin
Feature: JSDoc deprecation comments

  Scenario: developer views deprecated component
    Given a developer opens a component library file
    
    When developer hovers over a deprecated component import
    Then the IDE should display the @deprecated JSDoc comment with migration guidance
    And the comment should include a link to the MMDS component README
```

## **Screenshots/Recordings**

N/A - Documentation-only changes

### **Before**

Components had either no deprecation messages or minimal ones without full context.

### **After**

All 20 components now have consistent deprecation messages following this pattern:

```javascript
/**
 * @deprecated Please update your code to use `ComponentName` from `@metamask/design-system-react-native`.
 * The API may have changed — compare props before migrating.
 * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ComponentName/README.md}
 */
```

**Components updated:**
- Avatar components: AvatarAccount, AvatarBase, AvatarFavicon, AvatarGroup, AvatarIcon, AvatarNetwork, AvatarToken
- Badge components: BadgeBase, BadgeNetwork, BadgeNotifications, BadgeWrapper
- Button components: Button, ButtonIcon, ButtonLink, ButtonPrimary, ButtonSecondary
- Form components: Checkbox, TextField
- Other components: Card, Icon, Text

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - documentation only)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds/standardizes `@deprecated` JSDoc blocks and external README links without altering component runtime behavior. Main risk is minor lint/formatting or tooling differences in how IDEs surface these comments.
> 
> **Overview**
> Adds consistent `@deprecated` JSDoc annotations across legacy component-library UI components (avatars, badges, buttons, checkbox, text field, icon, text), pointing developers to the equivalent `@metamask/design-system-react-native` replacements.
> 
> Each deprecation notice now includes a migration caution about potential API differences and a direct link to the relevant MMDS README for the replacement component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 167e357235a33ee19c06a46ca229a26f0074df69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->