### PR TITLE
fix(bridge): cp-7.67.0 fix "View on block explorer" button for swap and bridge transactions

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
@@ -9,8 +9,25 @@ import { BridgeState } from '../../../../../core/redux/slices/bridge';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { initialState } from '../../_mocks_/initialState';
 import BlockExplorersModal from './BlockExplorersModal';
+import { fireEvent } from '@testing-library/react-native';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      setOptions: jest.fn(),
+    }),
+  };
+});
 
 describe('BlockExplorersModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const mockTx = {
     id: 'test-tx-id',
     chainId: '0x1',
@@ -114,5 +131,45 @@ describe('BlockExplorersModal', () => {
     );
     const etherscanButtons = getAllByText('Etherscan');
     expect(etherscanButtons).toHaveLength(1);
+  });
+
+  it('should navigate to webview when source chain explorer button is pressed', () => {
+    const { getAllByText } = renderScreen(
+      () => <BlockExplorersModal {...mockProps} />,
+      {
+        name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
+      },
+      { state: mockState },
+    );
+
+    const [srcExplorerButton] = getAllByText('Etherscan');
+    fireEvent.press(srcExplorerButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: expect.objectContaining({
+        url: expect.stringContaining('etherscan.io'),
+      }),
+    });
+  });
+
+  it('should navigate to webview when destination chain explorer button is pressed', () => {
+    const { getByText } = renderScreen(
+      () => <BlockExplorersModal {...mockProps} />,
+      {
+        name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
+      },
+      { state: mockState },
+    );
+
+    const destExplorerButton = getByText('Optimistic');
+    fireEvent.press(destExplorerButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: expect.objectContaining({
+        url: expect.stringContaining('optimistic.etherscan.io'),
+      }),
+    });
   });
 });

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -110,9 +110,11 @@ const BlockExplorersModal = (props: BlockExplorersModalProps) => {
               </Box>
             }
             onPress={() => {
-              navigation.navigate(Routes.BROWSER.VIEW, {
-                newTabUrl: srcExplorerData.explorerTxUrl,
-                timestamp: Date.now(),
+              navigation.navigate(Routes.WEBVIEW.MAIN, {
+                screen: Routes.WEBVIEW.SIMPLE,
+                params: {
+                  url: srcExplorerData.explorerTxUrl,
+                },
               });
             }}
           />
@@ -139,9 +141,11 @@ const BlockExplorersModal = (props: BlockExplorersModalProps) => {
               </Box>
             }
             onPress={() => {
-              navigation.navigate(Routes.BROWSER.VIEW, {
-                newTabUrl: bridgeDestExplorerData.explorerTxUrl,
-                timestamp: Date.now(),
+              navigation.navigate(Routes.WEBVIEW.MAIN, {
+                screen: Routes.WEBVIEW.SIMPLE,
+                params: {
+                  url: bridgeDestExplorerData.explorerTxUrl,
+                },
               });
             }}
           />

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
@@ -143,6 +143,31 @@ describe('BridgeTransactionDetails', () => {
     expect(getByText(/view on block explorer/i)).toBeTruthy();
   });
 
+  it('navigates to block explorer modal for cross-chain bridge with evmTxMeta', () => {
+    const { getByText } = renderScreen(
+      () => (
+        <BridgeTransactionDetails
+          route={{ params: { evmTxMeta: mockEVMTx } }}
+        />
+      ),
+      {
+        name: Routes.BRIDGE.BRIDGE_TRANSACTION_DETAILS,
+      },
+      { state: mockState },
+    );
+
+    const blockExplorerButton = getByText(/view on block explorer/i);
+    fireEvent.press(blockExplorerButton);
+
+    // Should navigate to bridge modal stack, not directly to webview
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
+      params: expect.objectContaining({
+        evmTxMeta: mockEVMTx,
+      }),
+    });
+  });
+
   it('navigates directly to browser for same-chain swaps with multiChainTx', () => {
     const { getByText } = renderScreen(
       () => (
@@ -159,12 +184,12 @@ describe('BridgeTransactionDetails', () => {
     const blockExplorerButton = getByText(/view on block explorer/i);
     fireEvent.press(blockExplorerButton);
 
-    // Should navigate to browser, not to the modal
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.BROWSER.VIEW,
-      expect.objectContaining({
-        newTabUrl: expect.stringContaining('solana-tx-hash-123'),
+    // Should navigate to webview, not to the modal
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: expect.objectContaining({
+        url: expect.stringContaining('solana-tx-hash-123'),
       }),
-    );
+    });
   });
 });

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -395,19 +395,22 @@ export const BridgeTransactionDetails = (
             onPress={() => {
               // For swaps, go directly to block explorer web view
               if (isSwap && swapSrcExplorerData?.explorerTxUrl) {
-                navigation.navigate(Routes.BROWSER.VIEW, {
-                  newTabUrl: swapSrcExplorerData.explorerTxUrl,
-                  timestamp: Date.now(),
+                navigation.navigate(Routes.WEBVIEW.MAIN, {
+                  screen: Routes.WEBVIEW.SIMPLE,
+                  params: {
+                    url: swapSrcExplorerData.explorerTxUrl,
+                  },
                 });
-              } else {
+              } else if (isBridge) {
                 // For bridges, show the modal with both explorers
-                navigation.navigate(
-                  Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
-                  {
+                navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+                  screen:
+                    Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
+                  params: {
                     evmTxMeta: props.route.params.evmTxMeta,
                     multiChainTx: props.route.params.multiChainTx,
                   },
-                );
+                });
               }
             }}
           />


### PR DESCRIPTION
## **Description**

The "View on block explorer" button on the Bridge/Swap Transaction Details screen was broken for both swaps and bridge transactions — pressing it did nothing.

Root causes:

- Swap transactions: `navigation.navigate(Routes.BROWSER.VIEW, ...)` was called directly, but `BROWSER.VIEW` is a nested screen inside the `BROWSER.HOME` tab navigator. React Navigation silently ignores navigation calls to nested screens made from outside their parent. Additionally, navigating to a tab navigator replaces the current stack, so the back button would return to the home screen instead of activities.

- Bridge transactions: `navigation.navigate(Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER, ...)` was called directly, but this screen is nested inside `BridgeModalStack` (registered as `Routes.BRIDGE.MODALS.ROOT`). Same silent failure.

Fix:

- Swap path now uses `Routes.WEBVIEW.MAIN` → `Routes.WEBVIEW.SIMPLE`, which pushes a `WebView` on top of the current stack (back button returns to Transaction Details correctly)
- Bridge path now navigates to `Routes.BRIDGE.MODALS.ROOT` with screen: `TRANSACTION_DETAILS_BLOCK_EXPLORER` as a nested param
- Tightened the condition from a bare else to else if (isBridge) to prevent a swap with an unresolved explorer URL from accidentally opening the bridge modal

## **Changelog**

CHANGELOG entry: Fixed "View on block explorer" button not working on Bridge/Swap Transaction Details screen

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26628

## **Manual testing steps**

```gherkin
Feature: View on block explorer from Transaction Details

  Scenario: user views a completed swap on block explorer
    Given user has a completed swap transaction (same-chain)
    When user taps the transaction in Activity to open Transaction Details
    And user taps "View on block explorer"
    Then a WebView opens showing the block explorer for that transaction
    And tapping back returns the user to Transaction Details

  Scenario: user views a completed bridge on block explorer
    Given user has a completed bridge transaction (cross-chain)
    When user taps the transaction in Activity to open Transaction Details
    And user taps "View on block explorer"
    Then a bottom sheet appears with source and destination chain explorer options
    When user taps one of the explorer options
    Then a WebView opens showing that chain's block explorer for the transaction
```

## **Screenshots/Recordings**

`~`

### **Before**

https://github.com/user-attachments/assets/9030e42a-32a5-4661-bc00-d4953ae17850

### **After**

https://github.com/user-attachments/assets/26da74e6-353b-4df9-9be2-7f45f00105fe

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes React Navigation targets for the “View on block explorer” flow and bridge explorer modal buttons, which is user-facing and could regress routing/back-stack behavior if route params or navigator structure differ across entry points.
> 
> **Overview**
> Fixes the broken “View on block explorer” actions in Bridge/Swap transaction details by updating navigation to valid parent/nested routes.
> 
> Swaps now open the in-app `WEBVIEW` (`Routes.WEBVIEW.MAIN` → `Routes.WEBVIEW.SIMPLE`) instead of `Routes.BROWSER.VIEW`, while bridges now navigate via `Routes.BRIDGE.MODALS.ROOT` to show the explorer-selection bottom sheet; the fallback logic is tightened to only open the modal for actual bridge transactions.
> 
> Updates/expands unit tests to mock navigation and assert the new webview/modal navigation behavior, including pressing source/destination explorer buttons in `BlockExplorersModal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77221e0bb11cbffff5b0629b398db3214177c829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->