### PR TITLE
refactor(predict): add React Query cache invalidation to usePredictWithdraw

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWithdraw.test.ts
@@ -1,8 +1,10 @@
 import { renderHook } from '@testing-library/react-native';
 import { usePredictWithdraw } from './usePredictWithdraw';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
-
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
+import Logger from '../../../../util/Logger';
+import { invalidatePredictCaches } from '../utils/invalidatePredictCaches';
+
 // Create mock functions
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -13,6 +15,13 @@ const mockPrepareWithdraw = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {},
+  },
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
   },
 }));
 
@@ -58,6 +67,22 @@ jest.mock('react', () => ({
   useContext: jest.fn(() => ({ toastRef: mockToastRef })),
 }));
 
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: jest.fn(() => ({
+    invalidateQueries: jest.fn(),
+  })),
+}));
+
+jest.mock('../utils/invalidatePredictCaches', () => ({
+  invalidatePredictCaches: jest.fn(),
+}));
+
+const mockInvalidatePredictCaches =
+  invalidatePredictCaches as jest.MockedFunction<
+    typeof invalidatePredictCaches
+  >;
+
 // Mock react-redux
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let mockState: any = {
@@ -89,6 +114,10 @@ jest.mock('../../../../../locales/i18n', () => ({
     return translations[key] || key;
   },
 }));
+
+const mockLoggerError = Logger.error as jest.MockedFunction<
+  typeof Logger.error
+>;
 
 // Helper to create mock withdraw transaction
 function createMockWithdrawTransaction(overrides = {}) {
@@ -216,20 +245,18 @@ describe('usePredictWithdraw', () => {
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
     });
 
-    it('calls prepareWithdraw with empty options object', async () => {
+    it('calls prepareWithdraw with explicit empty options object', async () => {
       mockPrepareWithdraw.mockResolvedValue({ success: true });
 
       const { result } = setupUsePredictWithdrawTest({});
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
@@ -247,34 +274,33 @@ describe('usePredictWithdraw', () => {
     });
 
     it('handles prepareWithdraw error gracefully', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       mockPrepareWithdraw.mockRejectedValue(new Error('Withdraw failed'));
 
       const { result } = setupUsePredictWithdrawTest();
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockGoBack).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to proceed with withdraw:',
-        expect.any(Error),
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        new Error('Withdraw failed'),
+        expect.objectContaining({
+          tags: {
+            feature: 'Predict',
+            component: 'usePredictWithdraw',
+          },
+        }),
       );
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('shows error toast when prepareWithdraw fails', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       mockPrepareWithdraw.mockRejectedValue(new Error('Withdraw failed'));
 
       const { result } = setupUsePredictWithdrawTest();
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockGoBack).toHaveBeenCalled();
@@ -295,19 +321,15 @@ describe('usePredictWithdraw', () => {
           hasNoTimeout: false,
         }),
       );
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('shows error toast with default message for non-Error exceptions', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       mockPrepareWithdraw.mockRejectedValue('String error');
 
       const { result } = setupUsePredictWithdrawTest();
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockGoBack).toHaveBeenCalled();
@@ -328,12 +350,9 @@ describe('usePredictWithdraw', () => {
           hasNoTimeout: false,
         }),
       );
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('shows error toast when prepareWithdraw returns failure result', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       mockPrepareWithdraw.mockRejectedValue(
         new Error('Provider not available'),
       );
@@ -342,7 +361,6 @@ describe('usePredictWithdraw', () => {
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockGoBack).toHaveBeenCalled();
@@ -363,12 +381,9 @@ describe('usePredictWithdraw', () => {
           hasNoTimeout: false,
         }),
       );
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('handles navigation error gracefully', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       mockNavigateToConfirmation.mockImplementationOnce(() => {
         throw new Error('Navigation failed');
       });
@@ -378,29 +393,28 @@ describe('usePredictWithdraw', () => {
       await result.current.withdraw();
 
       expect(mockGoBack).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to proceed with withdraw:',
-        expect.any(Error),
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        new Error('Navigation failed'),
+        expect.objectContaining({
+          tags: {
+            feature: 'Predict',
+            component: 'usePredictWithdraw',
+          },
+        }),
       );
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('returns undefined when error occurs', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       mockPrepareWithdraw.mockRejectedValue(new Error('Withdraw failed'));
 
       const { result } = setupUsePredictWithdrawTest();
 
       const response = await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockGoBack).toHaveBeenCalled();
       expect(response).toBeUndefined();
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -439,7 +453,6 @@ describe('usePredictWithdraw', () => {
 
       await result.current.withdraw();
 
-      // Wait for async operation
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(mockPrepareWithdraw).toHaveBeenCalledWith({});
@@ -484,28 +497,51 @@ describe('usePredictWithdraw', () => {
     });
 
     it('handles mixed success and failure withdraw calls', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { result } = setupUsePredictWithdrawTest();
+
       mockPrepareWithdraw
         .mockResolvedValueOnce({ success: true })
         .mockRejectedValueOnce(new Error('Withdraw failed'));
 
-      const { result } = setupUsePredictWithdrawTest();
-
       const firstResponse = await result.current.withdraw();
       const secondResponse = await result.current.withdraw();
 
-      // Wait for async operations
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(firstResponse).toEqual({ success: true });
       expect(secondResponse).toBeUndefined();
       expect(mockGoBack).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to proceed with withdraw:',
-        expect.any(Error),
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        new Error('Withdraw failed'),
+        expect.objectContaining({
+          tags: {
+            feature: 'Predict',
+            component: 'usePredictWithdraw',
+          },
+        }),
       );
+    });
+  });
 
-      consoleErrorSpy.mockRestore();
+  describe('cache invalidation', () => {
+    it('invalidates caches after successful withdraw', async () => {
+      mockPrepareWithdraw.mockResolvedValue(undefined);
+
+      const { result } = setupUsePredictWithdrawTest();
+
+      await result.current.withdraw();
+
+      expect(mockInvalidatePredictCaches).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invalidate caches when withdraw fails', async () => {
+      mockPrepareWithdraw.mockRejectedValue(new Error('Withdraw failed'));
+
+      const { result } = setupUsePredictWithdrawTest();
+
+      await result.current.withdraw();
+
+      expect(mockInvalidatePredictCaches).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictWithdraw.ts
+++ b/app/components/UI/Predict/hooks/usePredictWithdraw.ts
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useContext } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import { usePredictTrading } from './usePredictTrading';
@@ -10,13 +11,18 @@ import {
   ToastVariants,
 } from '../../../../component-library/components/Toast';
 import { strings } from '../../../../../locales/i18n';
+import Logger from '../../../../util/Logger';
 import { selectPredictWithdrawTransaction } from '../selectors/predictController';
+import { PREDICT_CONSTANTS } from '../constants/errors';
+import { ensureError } from '../utils/predictErrorHandler';
+import { invalidatePredictCaches } from '../utils/invalidatePredictCaches';
 
 export const usePredictWithdraw = () => {
   const { prepareWithdraw } = usePredictTrading();
   const { navigateToConfirmation } = useConfirmNavigation();
   const navigation = useNavigation();
   const { toastRef } = useContext(ToastContext);
+  const queryClient = useQueryClient();
 
   const withdrawTransaction = useSelector(selectPredictWithdrawTransaction);
 
@@ -28,13 +34,30 @@ export const usePredictWithdraw = () => {
 
       const response = await prepareWithdraw({});
 
+      invalidatePredictCaches(queryClient);
+
       return response;
     } catch (err) {
+      Logger.error(ensureError(err), {
+        tags: {
+          feature: PREDICT_CONSTANTS.FEATURE_NAME,
+          component: 'usePredictWithdraw',
+        },
+        context: {
+          name: 'usePredictWithdraw',
+          data: {
+            method: 'withdraw',
+            action: 'prepare_withdraw',
+            operation: 'position_management',
+          },
+        },
+      });
+
       navigation.goBack();
+
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to prepare withdraw';
 
-      // Show error toast to user
       toastRef?.current?.showToast({
         variant: ToastVariants.Icon,
         iconName: IconName.Danger,
@@ -48,10 +71,14 @@ export const usePredictWithdraw = () => {
         ],
         hasNoTimeout: false,
       });
-
-      console.error('Failed to proceed with withdraw:', err);
     }
-  }, [navigateToConfirmation, navigation, prepareWithdraw, toastRef]);
+  }, [
+    navigateToConfirmation,
+    navigation,
+    prepareWithdraw,
+    queryClient,
+    toastRef,
+  ]);
 
   return { withdraw, withdrawTransaction };
 };

--- a/app/components/UI/Predict/utils/invalidatePredictCaches.ts
+++ b/app/components/UI/Predict/utils/invalidatePredictCaches.ts
@@ -1,0 +1,18 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { predictQueries } from '../queries';
+
+/**
+ * Invalidates balance, positions, and activity caches so the UI
+ * reflects the latest state after a mutation (e.g. claim, withdraw).
+ */
+export function invalidatePredictCaches(queryClient: QueryClient) {
+  queryClient.invalidateQueries({
+    queryKey: predictQueries.balance.keys.all(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: predictQueries.positions.keys.all(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: predictQueries.activity.keys.all(),
+  });
+}


### PR DESCRIPTION
## Summary

- Add React Query cache invalidation to `usePredictWithdraw` so balance, positions, and activity caches are refreshed after a successful withdraw
- Replace `console.error` with structured `Logger.error` using `ensureError` for proper Sentry reporting
- Extract shared `invalidatePredictCaches` utility for reuse across mutation hooks (claim, withdraw)

## Test plan

- [x] `yarn jest app/components/UI/Predict/hooks/usePredictWithdraw --no-coverage` — 23/23 tests pass
- [ ] Verify withdraw flow invalidates stale data in balance/positions/activity views

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `usePredictWithdraw` mutation flow by adding React Query invalidations and changing error logging behavior, which could impact post-withdraw UI refresh timing and error handling paths.
> 
> **Overview**
> After a successful `withdraw`, `usePredictWithdraw` now invalidates Predict React Query caches (balance, positions, activity) via a new shared `invalidatePredictCaches(queryClient)` utility so the UI refetches fresh data.
> 
> Error handling in `usePredictWithdraw` is updated to use structured `Logger.error` with `ensureError` and Predict feature tags (instead of `console.error`), and tests are updated to mock/verify the new logging and cache invalidation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b10d1fe1d02111534b7f58fd7f1be4ae04afab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->