### PR TITLE
refactor(predict): consolidate feature flag resolution and provider interface

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -498,7 +498,6 @@ describe('PredictController', () => {
         expect(controller.state.lastUpdateTimestamp).toBeGreaterThan(0);
         expect(mockPolymarketProvider.getMarketDetails).toHaveBeenCalledWith({
           marketId: 'market-1',
-          liveSportsLeagues: [],
         });
       });
     });
@@ -522,7 +521,6 @@ describe('PredictController', () => {
         expect(result).toEqual(mockMarket);
         expect(mockPolymarketProvider.getMarketDetails).toHaveBeenCalledWith({
           marketId: 'market-2',
-          liveSportsLeagues: [],
         });
       });
     });
@@ -580,7 +578,6 @@ describe('PredictController', () => {
         expect(result).toEqual(mockMarket);
         expect(mockPolymarketProvider.getMarketDetails).toHaveBeenCalledWith({
           marketId: '123',
-          liveSportsLeagues: [],
         });
       });
     });
@@ -1403,10 +1400,10 @@ describe('PredictController', () => {
           expect(result[1].id).toBe('highlight-2');
           expect(result[2].id).toBe('regular-1');
           expect(result[3].id).toBe('regular-2');
-          expect(mockPolymarketProvider.getMarketsByIds).toHaveBeenCalledWith(
-            ['highlight-1', 'highlight-2'],
-            [],
-          );
+          expect(mockPolymarketProvider.getMarketsByIds).toHaveBeenCalledWith([
+            'highlight-1',
+            'highlight-2',
+          ]);
         },
         {
           mocks: {
@@ -4200,12 +4197,6 @@ describe('PredictController', () => {
               address: '0x1234567890123456789012345678901234567890',
               signTypedMessage: expect.any(Function),
               signPersonalMessage: expect.any(Function),
-            }),
-            feeCollection: expect.objectContaining({
-              enabled: true,
-              collector: expect.any(String),
-              metamaskFee: expect.any(Number),
-              providerFee: expect.any(Number),
             }),
           }),
         );

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -106,7 +106,7 @@ import {
 } from '../constants/flags';
 import { filterSupportedLeagues } from '../constants/sports';
 import {
-  PredictFeeCollection,
+  PredictFeatureFlags,
   PredictLiveSportsFlag,
   PredictMarketHighlightsFlag,
 } from '../types/flags';
@@ -327,7 +327,9 @@ export class PredictController extends BaseController<
       state: { ...getDefaultPredictControllerState(), ...state },
     });
 
-    this.provider = new PolymarketProvider();
+    this.provider = new PolymarketProvider({
+      getFeatureFlags: () => this.resolveFeatureFlags(),
+    });
 
     this.messenger.subscribe(
       'TransactionController:transactionStatusUpdated',
@@ -410,6 +412,39 @@ export class PredictController extends BaseController<
     };
   }
 
+  private resolveFeatureFlags(): PredictFeatureFlags {
+    const remoteFeatureFlagState = this.messenger.call(
+      'RemoteFeatureFlagController:getState',
+    );
+    const flags = remoteFeatureFlagState.remoteFeatureFlags;
+
+    const liveSportsFlag =
+      unwrapRemoteFeatureFlag<PredictLiveSportsFlag>(flags.predictLiveSports) ??
+      DEFAULT_LIVE_SPORTS_FLAG;
+    const liveSportsLeagues = liveSportsFlag.enabled
+      ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
+      : [];
+
+    const rawMarketHighlightsFlag =
+      unwrapRemoteFeatureFlag<PredictMarketHighlightsFlag>(
+        flags.predictMarketHighlights,
+      );
+    const isHighlightsFlagValid = validatedVersionGatedFeatureFlag(
+      rawMarketHighlightsFlag as unknown as VersionGatedFeatureFlag,
+    );
+    const marketHighlightsFlag =
+      isHighlightsFlagValid && rawMarketHighlightsFlag
+        ? rawMarketHighlightsFlag
+        : DEFAULT_MARKET_HIGHLIGHTS_FLAG;
+
+    const feeCollection =
+      unwrapRemoteFeatureFlag<PredictFeatureFlags['feeCollection']>(
+        flags.predictFeeCollection,
+      ) ?? DEFAULT_FEE_COLLECTION_FLAG;
+
+    return { feeCollection, liveSportsLeagues, marketHighlightsFlag };
+  }
+
   private getEvmAccountAddress(): string {
     const accounts = this.messenger.call(
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
@@ -467,35 +502,9 @@ export class PredictController extends BaseController<
     });
 
     try {
-      const remoteFeatureFlagState = this.messenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      const liveSportsFlag =
-        unwrapRemoteFeatureFlag<PredictLiveSportsFlag>(
-          remoteFeatureFlagState.remoteFeatureFlags.predictLiveSports,
-        ) ?? DEFAULT_LIVE_SPORTS_FLAG;
+      const featureFlags = this.resolveFeatureFlags();
 
-      const liveSportsLeagues = liveSportsFlag.enabled
-        ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
-        : [];
-
-      const rawMarketHighlightsFlag =
-        unwrapRemoteFeatureFlag<PredictMarketHighlightsFlag>(
-          remoteFeatureFlagState.remoteFeatureFlags.predictMarketHighlights,
-        );
-
-      const isHighlightsFlagValid = validatedVersionGatedFeatureFlag(
-        rawMarketHighlightsFlag as unknown as VersionGatedFeatureFlag,
-      );
-
-      const marketHighlightsFlag: PredictMarketHighlightsFlag =
-        isHighlightsFlagValid && rawMarketHighlightsFlag
-          ? rawMarketHighlightsFlag
-          : DEFAULT_MARKET_HIGHLIGHTS_FLAG;
-
-      const paramsWithLiveSports = { ...params, liveSportsLeagues };
-
-      const allMarkets = await this.provider.getMarkets(paramsWithLiveSports);
+      const allMarkets = await this.provider.getMarkets(params);
 
       let markets = allMarkets.filter(
         (market): market is PredictMarket => market !== undefined,
@@ -503,11 +512,16 @@ export class PredictController extends BaseController<
 
       const isFirstPage = !params.offset || params.offset === 0;
       const shouldFetchHighlights =
-        isHighlightsFlagValid && isFirstPage && params.category && !params.q;
+        validatedVersionGatedFeatureFlag(
+          featureFlags.marketHighlightsFlag as unknown as VersionGatedFeatureFlag,
+        ) &&
+        isFirstPage &&
+        params.category &&
+        !params.q;
 
       if (shouldFetchHighlights) {
         const highlightedMarketIds =
-          (marketHighlightsFlag.highlights ?? []).find(
+          (featureFlags.marketHighlightsFlag.highlights ?? []).find(
             (h) => h.category === params.category,
           )?.markets ?? [];
 
@@ -515,10 +529,7 @@ export class PredictController extends BaseController<
           const provider = this.provider;
 
           const fetchedHighlightedMarkets =
-            (await provider.getMarketsByIds?.(
-              highlightedMarketIds,
-              liveSportsLeagues,
-            )) ?? [];
+            (await provider.getMarketsByIds?.(highlightedMarketIds)) ?? [];
 
           const highlightedMarkets = fetchedHighlightedMarkets.filter(
             (market) => market.status === 'open',
@@ -608,21 +619,8 @@ export class PredictController extends BaseController<
 
     try {
       const provider = this.provider;
-
-      const remoteFeatureFlagState = this.messenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      const liveSportsFlag =
-        unwrapRemoteFeatureFlag<PredictLiveSportsFlag>(
-          remoteFeatureFlagState.remoteFeatureFlags.predictLiveSports,
-        ) ?? DEFAULT_LIVE_SPORTS_FLAG;
-      const liveSportsLeagues = liveSportsFlag.enabled
-        ? filterSupportedLeagues(liveSportsFlag.leagues ?? [])
-        : [];
-
       const market = await provider.getMarketDetails({
         marketId: resolvedMarketId,
-        liveSportsLeagues,
       });
 
       this.update((state) => {
@@ -1370,17 +1368,9 @@ export class PredictController extends BaseController<
     try {
       const provider = this.provider;
 
-      const remoteFeatureFlagState = this.messenger.call(
-        'RemoteFeatureFlagController:getState',
-      );
-      const feeCollection =
-        unwrapRemoteFeatureFlag<PredictFeeCollection>(
-          remoteFeatureFlagState.remoteFeatureFlags.predictFeeCollection,
-        ) ?? DEFAULT_FEE_COLLECTION_FLAG;
-
       const signer = this.getSigner();
 
-      return provider.previewOrder({ ...params, signer, feeCollection });
+      return provider.previewOrder({ ...params, signer });
     } catch (error) {
       // Log to Sentry with preview context (no sensitive amounts)
       Logger.error(

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -512,9 +512,7 @@ export class PredictController extends BaseController<
 
       const isFirstPage = !params.offset || params.offset === 0;
       const shouldFetchHighlights =
-        validatedVersionGatedFeatureFlag(
-          featureFlags.marketHighlightsFlag as unknown as VersionGatedFeatureFlag,
-        ) &&
+        featureFlags.marketHighlightsFlag.highlights.length > 0 &&
         isFirstPage &&
         params.category &&
         !params.q;

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -511,17 +511,13 @@ export class PredictController extends BaseController<
       );
 
       const isFirstPage = !params.offset || params.offset === 0;
+      const highlights = featureFlags.marketHighlightsFlag.highlights ?? [];
       const shouldFetchHighlights =
-        featureFlags.marketHighlightsFlag.highlights.length > 0 &&
-        isFirstPage &&
-        params.category &&
-        !params.q;
+        highlights.length > 0 && isFirstPage && params.category && !params.q;
 
       if (shouldFetchHighlights) {
         const highlightedMarketIds =
-          (featureFlags.marketHighlightsFlag.highlights ?? []).find(
-            (h) => h.category === params.category,
-          )?.markets ?? [];
+          highlights.find((h) => h.category === params.category)?.markets ?? [];
 
         if (highlightedMarketIds.length > 0) {
           const provider = this.provider;

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -40,6 +40,7 @@ import {
 } from '../../types';
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
+import type { PredictFeatureFlags } from '../../types/flags';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -216,7 +217,24 @@ const mockPreviewOrder = previewOrder as jest.Mock;
 const mockGetBalance = getBalance as jest.Mock;
 
 describe('PolymarketProvider', () => {
-  const createProvider = () => new PolymarketProvider();
+  const defaultFeatureFlags: PredictFeatureFlags = {
+    feeCollection: DEFAULT_FEE_COLLECTION_FLAG,
+    liveSportsLeagues: [],
+    marketHighlightsFlag: {
+      enabled: false,
+      highlights: [],
+      minimumVersion: '7.64.0',
+    },
+  };
+  const createProvider = (
+    featureFlagsOverride?: Partial<PredictFeatureFlags>,
+  ) =>
+    new PolymarketProvider({
+      getFeatureFlags: () => ({
+        ...defaultFeatureFlags,
+        ...featureFlagsOverride,
+      }),
+    });
 
   it('exposes the correct providerId', () => {
     const provider = createProvider();
@@ -224,8 +242,6 @@ describe('PolymarketProvider', () => {
   });
 
   it('getMarkets returns an array with some length', async () => {
-    const provider = createProvider();
-
     const mockMarkets = [
       {
         id: 'market-1',
@@ -279,7 +295,9 @@ describe('PolymarketProvider', () => {
 
     mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
 
-    const markets = await provider.getMarkets({ liveSportsLeagues: ['nfl'] });
+    const markets = await createProvider({
+      liveSportsLeagues: ['nfl'],
+    }).getMarkets();
     expect(Array.isArray(markets)).toBe(true);
     expect(markets.length).toBeGreaterThan(0);
     expect(markets.length).toBe(2);
@@ -289,11 +307,12 @@ describe('PolymarketProvider', () => {
   });
 
   it('getMarkets returns empty array when API fails', async () => {
-    const provider = createProvider();
     const apiError = new Error('API request failed');
     mockGetMarketsFromPolymarketApi.mockRejectedValue(apiError);
 
-    const result = await provider.getMarkets({ liveSportsLeagues: ['nfl'] });
+    const result = await createProvider({
+      liveSportsLeagues: ['nfl'],
+    }).getMarkets();
 
     expect(result).toEqual([]);
     expect(mockGetMarketsFromPolymarketApi).toHaveBeenCalledWith(
@@ -1336,7 +1355,10 @@ describe('PolymarketProvider', () => {
 
       await provider.previewOrder(mockParams);
 
-      expect(mockPreviewOrder).toHaveBeenCalledWith(mockParams);
+      expect(mockPreviewOrder).toHaveBeenCalledWith({
+        ...mockParams,
+        feeCollection: DEFAULT_FEE_COLLECTION_FLAG,
+      });
     });
   });
 
@@ -1358,7 +1380,7 @@ describe('PolymarketProvider', () => {
         signPersonalMessage: mockSignPersonalMessage,
       };
 
-      const provider = createProvider();
+      const provider = createProvider({ liveSportsLeagues: ['nfl'] });
 
       // Setup minimal mocks needed for placeOrder
       mockSignTypedMessage.mockResolvedValue('0xsignature');
@@ -2463,13 +2485,12 @@ describe('PolymarketProvider', () => {
     };
 
     it('get market details successfully', async () => {
-      const provider = createProvider();
+      const provider = createProvider({ liveSportsLeagues: ['nfl'] });
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
       const result = await provider.getMarketDetails({
         marketId: 'market-1',
-        liveSportsLeagues: ['nfl'],
       });
 
       expect(result).toEqual(mockParsedMarket);
@@ -2643,10 +2664,9 @@ describe('PolymarketProvider', () => {
       expect(result[0].id).toBe('market-1');
     });
 
-    it('passes liveSportsLeagues to getMarketDetails for each market', async () => {
-      const provider = createProvider();
+    it('calls getMarketDetails for each market id', async () => {
+      const provider = createProvider({ liveSportsLeagues: ['nfl'] });
       const marketIds = ['market-1', 'market-2'];
-      const liveSportsLeagues = ['nfl'];
 
       const getMarketDetailsSpy = jest.spyOn(provider, 'getMarketDetails');
       mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
@@ -2656,22 +2676,20 @@ describe('PolymarketProvider', () => {
         events.map((event: { id: string }) => createMockParsedMarket(event.id)),
       );
 
-      await provider.getMarketsByIds(marketIds, liveSportsLeagues);
+      await provider.getMarketsByIds(marketIds);
 
       expect(getMarketDetailsSpy).toHaveBeenCalledTimes(2);
       expect(getMarketDetailsSpy).toHaveBeenCalledWith({
         marketId: 'market-1',
-        liveSportsLeagues: ['nfl'],
       });
       expect(getMarketDetailsSpy).toHaveBeenCalledWith({
         marketId: 'market-2',
-        liveSportsLeagues: ['nfl'],
       });
 
       getMarketDetailsSpy.mockRestore();
     });
 
-    it('uses empty liveSportsLeagues by default', async () => {
+    it('calls getMarketDetails without extra params by default', async () => {
       const provider = createProvider();
       const marketIds = ['market-1'];
 
@@ -2687,7 +2705,6 @@ describe('PolymarketProvider', () => {
 
       expect(getMarketDetailsSpy).toHaveBeenCalledWith({
         marketId: 'market-1',
-        liveSportsLeagues: [],
       });
 
       getMarketDetailsSpy.mockRestore();
@@ -6619,19 +6636,19 @@ describe('PolymarketProvider', () => {
 
   describe('provider interface properties', () => {
     it('exposes chainId property with value 137', () => {
-      const provider = new PolymarketProvider();
+      const provider = createProvider();
 
       expect(provider.chainId).toBe(137);
     });
 
     it('exposes name property with value Polymarket', () => {
-      const provider = new PolymarketProvider();
+      const provider = createProvider();
 
       expect(provider.name).toBe('Polymarket');
     });
 
     it('exposes providerId property with value polymarket', () => {
-      const provider = new PolymarketProvider();
+      const provider = createProvider();
 
       expect(provider.providerId).toBe(POLYMARKET_PROVIDER_ID);
     });
@@ -6649,23 +6666,23 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarkets', () => {
-      it('applies GameCache overlay to fetched markets when liveSportsLeagues is provided', async () => {
-        const provider = new PolymarketProvider();
+      it('applies GameCache overlay to fetched markets when live sports are enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         const mockMarkets = [
           { id: 'market-1', title: 'Test Market 1' },
           { id: 'market-2', title: 'Test Market 2' },
         ];
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
 
-        await provider.getMarkets({ liveSportsLeagues: ['nfl'] });
+        await provider.getMarkets();
 
         expect(mockGameCacheInstance.overlayOnMarkets).toHaveBeenCalledWith(
           mockMarkets,
         );
       });
 
-      it('returns markets with cached game data overlay applied when liveSportsLeagues is provided', async () => {
-        const provider = new PolymarketProvider();
+      it('returns markets with cached game data overlay applied when live sports are enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         const mockMarkets = [{ id: 'market-1', title: 'Test Market' }];
         const overlaidMarkets = [
           {
@@ -6677,22 +6694,18 @@ describe('PolymarketProvider', () => {
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
         mockGameCacheInstance.overlayOnMarkets.mockReturnValue(overlaidMarkets);
 
-        const result = await provider.getMarkets({
-          liveSportsLeagues: ['nfl'],
-        });
+        const result = await provider.getMarkets();
 
         expect(result).toEqual(overlaidMarkets);
       });
 
       it('returns empty array when API fails without calling GameCache overlay', async () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         mockGetMarketsFromPolymarketApi.mockRejectedValue(
           new Error('API error'),
         );
 
-        const result = await provider.getMarkets({
-          liveSportsLeagues: ['nfl'],
-        });
+        const result = await provider.getMarkets();
 
         expect(result).toEqual([]);
         expect(mockGameCacheInstance.overlayOnMarkets).not.toHaveBeenCalled();
@@ -6700,8 +6713,8 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarketDetails', () => {
-      it('applies GameCache overlay to fetched market details when liveSportsLeagues is provided', async () => {
-        const provider = new PolymarketProvider();
+      it('applies GameCache overlay to fetched market details when live sports are enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = {
           id: 'market-1',
@@ -6711,18 +6724,15 @@ describe('PolymarketProvider', () => {
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
         mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
 
-        await provider.getMarketDetails({
-          marketId: 'market-1',
-          liveSportsLeagues: ['nfl'],
-        });
+        await provider.getMarketDetails({ marketId: 'market-1' });
 
         expect(mockGameCacheInstance.overlayOnMarket).toHaveBeenCalledWith(
           parsedMarket,
         );
       });
 
-      it('returns market with cached game data overlay applied when liveSportsLeagues is provided', async () => {
-        const provider = new PolymarketProvider();
+      it('returns market with cached game data overlay applied when live sports are enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = { id: 'market-1', title: 'Test Market' };
         const overlaidMarket = {
@@ -6736,22 +6746,18 @@ describe('PolymarketProvider', () => {
 
         const result = await provider.getMarketDetails({
           marketId: 'market-1',
-          liveSportsLeagues: ['nfl'],
         });
 
         expect(result).toEqual(overlaidMarket);
       });
 
       it('throws error when parsing fails without calling GameCache overlay', async () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         mockGetMarketDetailsFromGammaApi.mockResolvedValue({});
         mockParsePolymarketEvents.mockReturnValue([]);
 
         await expect(
-          provider.getMarketDetails({
-            marketId: 'market-1',
-            liveSportsLeagues: ['nfl'],
-          }),
+          provider.getMarketDetails({ marketId: 'market-1' }),
         ).rejects.toThrow('Failed to parse market details');
         expect(mockGameCacheInstance.overlayOnMarket).not.toHaveBeenCalled();
       });
@@ -6765,7 +6771,7 @@ describe('PolymarketProvider', () => {
 
     describe('subscribeToGameUpdates', () => {
       it('delegates to WebSocketManager.subscribeToGame', () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider();
         const mockCallback = jest.fn();
         const mockUnsubscribe = jest.fn();
         mockWebSocketManagerInstance.subscribeToGame.mockReturnValue(
@@ -6784,7 +6790,7 @@ describe('PolymarketProvider', () => {
       });
 
       it('returns unsubscribe function from WebSocketManager', () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider();
         const mockUnsubscribe = jest.fn();
         mockWebSocketManagerInstance.subscribeToGame.mockReturnValue(
           mockUnsubscribe,
@@ -6803,7 +6809,7 @@ describe('PolymarketProvider', () => {
 
     describe('subscribeToMarketPrices', () => {
       it('delegates to WebSocketManager.subscribeToMarketPrices', () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider();
         const mockCallback = jest.fn();
         const mockUnsubscribe = jest.fn();
         mockWebSocketManagerInstance.subscribeToMarketPrices.mockReturnValue(
@@ -6822,7 +6828,7 @@ describe('PolymarketProvider', () => {
       });
 
       it('returns unsubscribe function from WebSocketManager', () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider();
         const mockUnsubscribe = jest.fn();
         mockWebSocketManagerInstance.subscribeToMarketPrices.mockReturnValue(
           mockUnsubscribe,
@@ -6841,7 +6847,7 @@ describe('PolymarketProvider', () => {
 
     describe('getConnectionStatus', () => {
       it('returns connection status from WebSocketManager', () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider();
         mockWebSocketManagerInstance.getConnectionStatus.mockReturnValue({
           sportsConnected: true,
           marketConnected: false,
@@ -6858,7 +6864,7 @@ describe('PolymarketProvider', () => {
       });
 
       it('maps WebSocketManager status to ConnectionStatus interface', () => {
-        const provider = new PolymarketProvider();
+        const provider = createProvider();
         mockWebSocketManagerInstance.getConnectionStatus.mockReturnValue({
           sportsConnected: false,
           marketConnected: true,
@@ -6878,50 +6884,47 @@ describe('PolymarketProvider', () => {
     });
   });
 
-  describe('Live sports disabled (empty liveSportsLeagues)', () => {
+  describe('Live sports disabled', () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
     describe('getMarkets', () => {
-      it('skips TeamsCache loading when liveSportsLeagues is empty', async () => {
-        const provider = new PolymarketProvider();
+      it('skips TeamsCache loading when live sports leagues are empty', async () => {
+        const provider = createProvider();
         mockGetMarketsFromPolymarketApi.mockResolvedValue([]);
 
-        await provider.getMarkets({ liveSportsLeagues: [] });
+        await provider.getMarkets();
 
         expect(
           mockTeamsCacheInstance.ensureLeaguesLoaded,
         ).not.toHaveBeenCalled();
       });
 
-      it('skips GameCache overlay when liveSportsLeagues is empty', async () => {
-        const provider = new PolymarketProvider();
+      it('skips GameCache overlay when live sports leagues are empty', async () => {
+        const provider = createProvider();
         const mockMarkets = [{ id: 'market-1', title: 'Test Market' }];
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
 
-        const result = await provider.getMarkets({ liveSportsLeagues: [] });
+        const result = await provider.getMarkets();
 
         expect(mockGameCacheInstance.overlayOnMarkets).not.toHaveBeenCalled();
         expect(result).toEqual(mockMarkets);
       });
 
-      it('does not pass teamLookup when liveSportsLeagues is empty', async () => {
-        const provider = new PolymarketProvider();
+      it('does not pass teamLookup when live sports leagues are empty', async () => {
+        const provider = createProvider();
         mockGetMarketsFromPolymarketApi.mockResolvedValue([]);
 
-        await provider.getMarkets({
-          category: 'sports',
-          liveSportsLeagues: [],
-        });
+        await provider.getMarkets({ category: 'sports' });
 
         expect(mockGetMarketsFromPolymarketApi).toHaveBeenCalledWith(
           expect.objectContaining({ teamLookup: undefined }),
         );
       });
 
-      it('skips TeamsCache loading when liveSportsLeagues is undefined (default)', async () => {
-        const provider = new PolymarketProvider();
+      it('skips TeamsCache loading when live sports config is defaulted', async () => {
+        const provider = createProvider();
         mockGetMarketsFromPolymarketApi.mockResolvedValue([]);
 
         await provider.getMarkets();
@@ -6933,25 +6936,22 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarketDetails', () => {
-      it('skips TeamsCache loading when liveSportsLeagues is empty', async () => {
-        const provider = new PolymarketProvider();
+      it('skips TeamsCache loading when live sports leagues are empty', async () => {
+        const provider = createProvider();
         const mockEvent = { id: 'market-1', question: 'Test?' };
         const parsedMarket = { id: 'market-1', title: 'Test' };
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
         mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
 
-        await provider.getMarketDetails({
-          marketId: 'market-1',
-          liveSportsLeagues: [],
-        });
+        await provider.getMarketDetails({ marketId: 'market-1' });
 
         expect(
           mockTeamsCacheInstance.ensureLeaguesLoaded,
         ).not.toHaveBeenCalled();
       });
 
-      it('skips GameCache overlay when liveSportsLeagues is empty', async () => {
-        const provider = new PolymarketProvider();
+      it('skips GameCache overlay when live sports leagues are empty', async () => {
+        const provider = createProvider();
         const mockEvent = { id: 'market-1', question: 'Test?' };
         const parsedMarket = { id: 'market-1', title: 'Test' };
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
@@ -6959,24 +6959,20 @@ describe('PolymarketProvider', () => {
 
         const result = await provider.getMarketDetails({
           marketId: 'market-1',
-          liveSportsLeagues: [],
         });
 
         expect(mockGameCacheInstance.overlayOnMarket).not.toHaveBeenCalled();
         expect(result).toEqual(parsedMarket);
       });
 
-      it('does not pass teamLookup when liveSportsLeagues is empty', async () => {
-        const provider = new PolymarketProvider();
+      it('does not pass teamLookup when live sports leagues are empty', async () => {
+        const provider = createProvider();
         const mockEvent = { id: 'market-1', question: 'Test?' };
         const parsedMarket = { id: 'market-1', title: 'Test' };
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
         mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
 
-        await provider.getMarketDetails({
-          marketId: 'market-1',
-          liveSportsLeagues: [],
-        });
+        await provider.getMarketDetails({ marketId: 'market-1' });
 
         expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
           [mockEvent],

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -101,7 +101,7 @@ import {
   roundOrderAmount,
   submitClobOrder,
 } from './utils';
-import { PredictFeeCollection } from '../../types/flags';
+import { PredictFeatureFlags } from '../../types/flags';
 import { GameCache } from './GameCache';
 import { TeamsCache } from './TeamsCache';
 import { WebSocketManager } from './WebSocketManager';
@@ -135,6 +135,7 @@ export class PolymarketProvider implements PredictProvider {
   readonly providerId = POLYMARKET_PROVIDER_ID;
   readonly name = 'Polymarket';
   readonly chainId = POLYGON_MAINNET_CHAIN_ID;
+  readonly #getFeatureFlags: () => PredictFeatureFlags;
 
   #apiKeysByAddress: Map<string, ApiKeyCreds> = new Map();
   #accountStateByAddress: Map<string, AccountState> = new Map();
@@ -146,6 +147,14 @@ export class PolymarketProvider implements PredictProvider {
   >();
 
   private static readonly FALLBACK_CATEGORY: PredictCategory = 'trending';
+
+  constructor({
+    getFeatureFlags,
+  }: {
+    getFeatureFlags: () => PredictFeatureFlags;
+  }) {
+    this.#getFeatureFlags = getFeatureFlags;
+  }
 
   /**
    * Generate standard error context for Logger.error calls with searchable tags and context.
@@ -176,16 +185,15 @@ export class PolymarketProvider implements PredictProvider {
 
   public async getMarketDetails({
     marketId,
-    liveSportsLeagues = [],
   }: {
     marketId: string;
-    liveSportsLeagues?: string[];
   }): Promise<PredictMarket> {
     if (!marketId) {
       throw new Error('marketId is required');
     }
 
     try {
+      const { liveSportsLeagues } = this.#getFeatureFlags();
       const event = await getMarketDetailsFromGammaApi({
         marketId,
       });
@@ -223,25 +231,20 @@ export class PolymarketProvider implements PredictProvider {
     }
   }
 
-  public async getMarketsByIds(
-    marketIds: string[],
-    liveSportsLeagues: string[] = [],
-  ): Promise<PredictMarket[]> {
+  public async getMarketsByIds(marketIds: string[]): Promise<PredictMarket[]> {
     if (!marketIds || marketIds.length === 0) {
       return [];
     }
 
     try {
       const marketPromises = marketIds.map((marketId) =>
-        this.getMarketDetails({ marketId, liveSportsLeagues }).catch(
-          (error) => {
-            DevLogger.log(
-              `PolymarketProvider: Failed to fetch market ${marketId}`,
-              error,
-            );
-            return null;
-          },
-        ),
+        this.getMarketDetails({ marketId }).catch((error) => {
+          DevLogger.log(
+            `PolymarketProvider: Failed to fetch market ${marketId}`,
+            error,
+          );
+          return null;
+        }),
       );
 
       const results = await Promise.all(marketPromises);
@@ -301,7 +304,7 @@ export class PolymarketProvider implements PredictProvider {
 
   public async getMarkets(params?: GetMarketsParams): Promise<PredictMarket[]> {
     try {
-      const liveSportsLeagues = params?.liveSportsLeagues ?? [];
+      const { liveSportsLeagues } = this.#getFeatureFlags();
       const liveSportsEnabled = liveSportsLeagues.length > 0;
 
       if (liveSportsEnabled) {
@@ -968,10 +971,10 @@ export class PolymarketProvider implements PredictProvider {
   public async previewOrder(
     params: PreviewOrderParams & {
       signer: Signer;
-      feeCollection?: PredictFeeCollection;
     },
   ): Promise<OrderPreview> {
-    const basePreview = await previewOrder(params);
+    const { feeCollection } = this.#getFeatureFlags();
+    const basePreview = await previewOrder({ ...params, feeCollection });
 
     if (params.signer) {
       if (this.isRateLimited(params.signer.address)) {

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -24,7 +24,7 @@ import {
 } from '../types';
 import { Hex } from '@metamask/utils';
 import { TransactionType } from '@metamask/transaction-controller';
-import { PredictFeeCollection } from '../types/flags';
+import { PredictFeatureFlags } from '../types/flags';
 
 // Re-export shared types so existing provider-layer imports continue to work
 export type {
@@ -42,6 +42,7 @@ export type {
   PreviewOrderParams,
   PriceUpdateCallback,
 };
+export type { PredictFeatureFlags };
 
 export interface Signer {
   address: string;
@@ -121,14 +122,8 @@ export interface PredictProvider {
   readonly chainId: number;
 
   getMarkets(params: GetMarketsParams): Promise<PredictMarket[]>;
-  getMarketsByIds?(
-    marketIds: string[],
-    liveSportsLeagues?: string[],
-  ): Promise<PredictMarket[]>;
-  getMarketDetails(params: {
-    marketId: string;
-    liveSportsLeagues?: string[];
-  }): Promise<PredictMarket>;
+  getMarketsByIds?(marketIds: string[]): Promise<PredictMarket[]>;
+  getMarketDetails(params: { marketId: string }): Promise<PredictMarket>;
   getPriceHistory(
     params: GetPriceHistoryParams,
   ): Promise<PredictPriceHistoryPoint[]>;
@@ -143,7 +138,6 @@ export interface PredictProvider {
   previewOrder(
     params: PreviewOrderParams & {
       signer: Signer;
-      feeCollection?: PredictFeeCollection;
     },
   ): Promise<OrderPreview>;
   placeOrder(

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -23,6 +23,12 @@ export interface PredictMarketHighlightsFlag extends VersionGatedFeatureFlag {
   highlights: PredictMarketHighlight[];
 }
 
+export interface PredictFeatureFlags {
+  feeCollection: PredictFeeCollection;
+  liveSportsLeagues: string[];
+  marketHighlightsFlag: PredictMarketHighlightsFlag;
+}
+
 export interface PredictHotTabFlag extends VersionGatedFeatureFlag {
   queryParams?: string; // Raw query params WITHOUT leading &: "tag_id=149&tag_id=100995&order=volume24hr"
 }

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -420,7 +420,6 @@ export interface GetMarketsParams {
   sortDirection?: 'asc' | 'desc';
   offset?: number;
   limit?: number;
-  liveSportsLeagues?: string[];
   customQueryParams?: string;
 }
 
@@ -540,3 +539,5 @@ export interface GetAccountStateParams {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PrepareWithdrawParams {}
+
+export type { PredictFeatureFlags } from './flags';


### PR DESCRIPTION
## **Description**

Consolidates scattered feature flag resolution in PredictController into a single `resolveFeatureFlags()` method and injects flags into PolymarketProvider via a constructor callback.

**Problem**: Feature flags (liveSportsLeagues, feeCollection, marketHighlights) were resolved independently in 3 separate PredictController methods (`getMarkets`, `getMarket`, `previewOrder`), each calling `RemoteFeatureFlagController:getState` and unwrapping flags ad-hoc. These flags were then passed as method parameters to PolymarketProvider.

**Solution**:
- New `PredictFeatureFlags` type consolidating all predict feature flags
- New `resolveFeatureFlags()` private method on PredictController — single resolution point
- PolymarketProvider now takes a `getFeatureFlags` callback in constructor and reads flags internally
- Cleaned `PredictProvider` interface — removed per-method flag parameters (`liveSportsLeagues`, `feeCollection`)
- Removed `liveSportsLeagues` from `GetMarketsParams` (internal concern, not caller-facing)

This is a **pure refactor** — zero behavior changes. Foundation for upcoming Permit2 fee authorization support.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-715

## **Manual testing steps**

```gherkin
Feature: Predict feature flag resolution refactor

  Scenario: user places prediction market orders as before
    Given user has Predict feature enabled and is in a supported region

    When user browses markets, views market details, and previews/places orders
    Then all functionality works identically to before (no behavior changes)
```

## **Screenshots/Recordings**

N/A — pure refactor, no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict market fetching and order preview paths by changing how feature flags are resolved and threaded into the Polymarket provider. Risk is mainly around mismatched defaults or missing flag injection impacting live sports overlays, highlights ordering, or fee collection in previews.
> 
> **Overview**
> **Refactors Predict feature-flag plumbing** by introducing `PredictFeatureFlags` and a single `PredictController.resolveFeatureFlags()` that reads remote flags (live sports leagues, market highlights, fee collection) and supplies them to `PolymarketProvider` via a `getFeatureFlags` constructor callback.
> 
> `PolymarketProvider` now consumes flags internally (no longer accepts `liveSportsLeagues`/`feeCollection` as method params), and the `PredictProvider`/`GetMarketsParams` types are simplified accordingly. Tests are updated to match the new provider constructor + method signatures and to assert fee collection defaults are applied during `previewOrder` and highlight fetching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdb4a95c313b141cdf5e58767c7cd4cf55e2d57a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->