### PR TITLE
test: use mockTheme instead of hardcoded hex values in amount-keyboard assertions

### DIFF
--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
@@ -162,7 +162,7 @@ describe('Amount', () => {
     const { getByRole } = renderComponent(undefined, '');
     expect(
       getByRole('button', { name: 'Next' }).props.style.backgroundColor,
-    ).toEqual('#b7bbc8');
+    ).toEqual(mockTheme.colors.text.muted);
   });
 
   it('call updateValue with MaxMode true when Max button is pressed', () => {
@@ -225,9 +225,17 @@ describe('Amount', () => {
 
 describe('getBackgroundColor', () => {
   it('return correct color depending on amount value and error', () => {
-    expect(getBackgroundColor(mockTheme, false, false)).toEqual('#121314');
-    expect(getBackgroundColor(mockTheme, true, false)).toEqual('#ca3542');
-    expect(getBackgroundColor(mockTheme, false, true)).toEqual('#b7bbc8');
-    expect(getBackgroundColor(mockTheme, true, true)).toEqual('#ca3542');
+    expect(getBackgroundColor(mockTheme, false, false)).toEqual(
+      mockTheme.colors.text.default,
+    );
+    expect(getBackgroundColor(mockTheme, true, false)).toEqual(
+      mockTheme.colors.error.default,
+    );
+    expect(getBackgroundColor(mockTheme, false, true)).toEqual(
+      mockTheme.colors.text.muted,
+    );
+    expect(getBackgroundColor(mockTheme, true, true)).toEqual(
+      mockTheme.colors.error.default,
+    );
   });
 });


### PR DESCRIPTION
## **Description**

Updates `amount-keyboard.test.tsx` to use `mockTheme` design token references instead of hardcoded hex values in test assertions, unblocking the design tokens upgrade to v8.2.1 (#26639).

**What this PR does:**
- Replaces hardcoded color hex values (`#b7bbc8`, `#121314`, `#ca3542`) with `mockTheme.colors.*` references in test assertions for `getBackgroundColor` and the disabled Next button

**Why this is an improvement:**
- Makes tests resilient to design token value changes
- Ensures tests validate correct token usage rather than specific hex values
- Aligns with design system best practices
- Follows the same pattern established in #26657

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Dependency of: #26639
Related: #26657

## **Manual testing steps**

```gherkin
Scenario: Verify updated tests pass
  Given the repository with design tokens v8.2.1
  When I run app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
  Then all 6 tests should pass
```

## **Screenshots/Recordings**

N/A - Test-only changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only updates that swap fixed hex assertions for `mockTheme` token references, reducing brittleness during design token upgrades. No production logic changes; risk limited to potential mismatches with token names/structure.
> 
> **Overview**
> Updates `amount-keyboard.test.tsx` to stop asserting on hardcoded hex colors for the disabled Next/Continue button and `getBackgroundColor` output.
> 
> Assertions now reference `mockTheme.colors.text.*` and `mockTheme.colors.error.*`, making the tests resilient to design token value changes while still verifying the correct token is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95e250e8f312b9dbe004140b64cfb8bc76086edf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->