### PR TITLE
feat(predict): add Permit2 fee authorization support

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -14,6 +14,8 @@ export const DEFAULT_FEE_COLLECTION_FLAG = {
   metamaskFee: 0.02, // 2%
   providerFee: 0.02, // 2%
   waiveList: [],
+  executors: [],
+  permit2Enabled: false,
 } satisfies PredictFeeCollection;
 
 export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -45,12 +45,15 @@ import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
   computeProxyAddress,
+  createPermit2FeeAuthorization,
   createSafeFeeAuthorization,
   getClaimTransaction,
   getDeployProxyWalletTransaction,
   getProxyWalletAllowancesTransaction,
   hasAllowances,
+  hasPermit2Allowance,
 } from './safe/utils';
+import { PERMIT2_ADDRESS } from './safe/constants';
 import {
   createApiKey,
   encodeClaim,
@@ -115,11 +118,13 @@ jest.mock('./utils', () => {
 
 jest.mock('./safe/utils', () => ({
   computeProxyAddress: jest.fn(),
+  createPermit2FeeAuthorization: jest.fn(),
   createSafeFeeAuthorization: jest.fn(),
   getClaimTransaction: jest.fn(),
   getDeployProxyWalletTransaction: jest.fn(),
   getProxyWalletAllowancesTransaction: jest.fn(),
   hasAllowances: jest.fn(),
+  hasPermit2Allowance: jest.fn(),
   getWithdrawTransactionCallData: jest
     .fn()
     .mockResolvedValue('0xsignedcalldata'),
@@ -209,9 +214,12 @@ const mockCreateApiKey = createApiKey as jest.Mock;
 const mockSubmitClobOrder = submitClobOrder as jest.Mock;
 const mockEncodeClaim = encodeClaim as jest.Mock;
 const mockComputeProxyAddress = computeProxyAddress as jest.Mock;
+const mockCreatePermit2FeeAuthorization =
+  createPermit2FeeAuthorization as jest.Mock;
 const mockCreateSafeFeeAuthorization = createSafeFeeAuthorization as jest.Mock;
 const mockGetClaimTransaction = getClaimTransaction as jest.Mock;
 const mockHasAllowances = hasAllowances as jest.Mock;
+const mockHasPermit2Allowance = hasPermit2Allowance as jest.Mock;
 const mockQuery = query as jest.Mock;
 const mockPreviewOrder = previewOrder as jest.Mock;
 const mockGetBalance = getBalance as jest.Mock;
@@ -877,6 +885,22 @@ describe('PolymarketProvider', () => {
           value: '0',
         },
         sig: '0xsig',
+      },
+    });
+    mockHasPermit2Allowance.mockResolvedValue(false);
+    mockCreatePermit2FeeAuthorization.mockResolvedValue({
+      type: 'safe-permit2',
+      authorization: {
+        permit: {
+          permitted: {
+            token: '0xCollateralAddress',
+            amount: '40000',
+          },
+          nonce: '0',
+          deadline: '1700000000',
+        },
+        spender: '0x1111111111111111111111111111111111111111',
+        signature: '0xpermit2sig',
       },
     });
 
@@ -1620,6 +1644,123 @@ describe('PolymarketProvider', () => {
       expect(mockCreateSafeFeeAuthorization).toHaveBeenCalledWith(
         expect.objectContaining({
           to: '0x100c7b833bbd604a77890783439bbb9d65e31de7',
+        }),
+      );
+    });
+
+    it('uses Permit2 fee authorization when permit2Enabled and allowance is set', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: ['0x1111111111111111111111111111111111111111'],
+          permit2Enabled: true,
+        },
+      });
+      mockHasPermit2Allowance.mockResolvedValueOnce(true);
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockCreatePermit2FeeAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          safeAddress: '0x9999999999999999999999999999999999999999',
+          spender: '0x1111111111111111111111111111111111111111',
+        }),
+      );
+      expect(mockCreateSafeFeeAuthorization).not.toHaveBeenCalled();
+      expect(mockSubmitClobOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executor: '0x1111111111111111111111111111111111111111',
+          feeAuthorization: expect.objectContaining({ type: 'safe-permit2' }),
+        }),
+      );
+    });
+
+    it('falls back to Safe fee authorization when Permit2 allowance is not set', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: ['0x1111111111111111111111111111111111111111'],
+          permit2Enabled: true,
+        },
+      });
+      mockHasPermit2Allowance.mockResolvedValueOnce(false);
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockCreatePermit2FeeAuthorization).not.toHaveBeenCalled();
+      expect(mockCreateSafeFeeAuthorization).toHaveBeenCalled();
+    });
+
+    it('falls back to Safe fee authorization when permit2Enabled is false', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: ['0x1111111111111111111111111111111111111111'],
+          permit2Enabled: false,
+        },
+      });
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockHasPermit2Allowance).not.toHaveBeenCalled();
+      expect(mockCreatePermit2FeeAuthorization).not.toHaveBeenCalled();
+      expect(mockCreateSafeFeeAuthorization).toHaveBeenCalled();
+    });
+
+    it('falls back to Safe fee authorization when executors are missing', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: [],
+          permit2Enabled: true,
+        },
+      });
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockHasPermit2Allowance).not.toHaveBeenCalled();
+      expect(mockCreatePermit2FeeAuthorization).not.toHaveBeenCalled();
+      expect(mockCreateSafeFeeAuthorization).toHaveBeenCalled();
+    });
+
+    it('always submits orders with FOK type', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest();
+      const preview = createMockOrderPreview({ side: Side.BUY });
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockSubmitClobOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clobOrder: expect.objectContaining({ orderType: 'FOK' }),
         }),
       );
     });
@@ -3626,6 +3767,27 @@ describe('PolymarketProvider', () => {
       expect(result.transactions[1].type).toBe('predictDeposit');
     });
 
+    it('passes Permit2 spender when creating allowance transaction and permit2Enabled is true', async () => {
+      const provider = createProvider({
+        feeCollection: {
+          ...DEFAULT_FEE_COLLECTION_FLAG,
+          permit2Enabled: true,
+        },
+      });
+      (isSmartContractAddress as jest.Mock).mockResolvedValue(true);
+      (hasAllowances as jest.Mock).mockResolvedValue(false);
+      (getProxyWalletAllowancesTransaction as jest.Mock).mockResolvedValue({
+        params: { to: '0xSafe', data: '0xallowances' },
+      });
+
+      await provider.prepareDeposit({ signer: mockSigner });
+
+      expect(getProxyWalletAllowancesTransaction).toHaveBeenCalledWith({
+        signer: mockSigner,
+        extraUsdcSpenders: [PERMIT2_ADDRESS],
+      });
+    });
+
     it('prepares only deposit transaction when wallet deployed and has allowances', async () => {
       // Given a fully set up wallet
       const provider = createProvider();
@@ -4042,6 +4204,25 @@ describe('PolymarketProvider', () => {
       );
       expect(hasAllowances).toHaveBeenCalledWith({
         address: '0xSafeAddress',
+        extraUsdcSpenders: [],
+      });
+    });
+
+    it('passes Permit2 spender to hasAllowances when permit2Enabled is true', async () => {
+      const provider = createProvider({
+        feeCollection: {
+          ...DEFAULT_FEE_COLLECTION_FLAG,
+          permit2Enabled: true,
+        },
+      });
+      (isSmartContractAddress as jest.Mock).mockResolvedValue(true);
+      (hasAllowances as jest.Mock).mockResolvedValue(true);
+
+      await provider.getAccountState({ ownerAddress: '0x123' });
+
+      expect(hasAllowances).toHaveBeenCalledWith({
+        address: '0xSafeAddress',
+        extraUsdcSpenders: [PERMIT2_ADDRESS],
       });
     });
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -63,8 +63,10 @@ import {
   ROUNDING_CONFIG,
   SAFE_EXEC_GAS_LIMIT,
 } from './constants';
+import { PERMIT2_ADDRESS } from './safe/constants';
 import {
   computeProxyAddress,
+  createPermit2FeeAuthorization,
   createSafeFeeAuthorization,
   getClaimTransaction,
   getDeployProxyWalletTransaction,
@@ -72,7 +74,9 @@ import {
   getSafeUsdcAmount,
   getWithdrawTransactionCallData,
   hasAllowances,
+  hasPermit2Allowance,
 } from './safe/utils';
+import { Permit2FeeAuthorization, SafeFeeAuthorization } from './safe/types';
 import {
   ApiKeyCreds,
   OrderData,
@@ -1157,24 +1161,60 @@ export class PolymarketProvider implements PredictProvider {
         apiKey: signerApiKey,
       });
 
-      let feeAuthorization;
+      const shouldUsePermit2 =
+        fees?.permit2Enabled === true &&
+        Array.isArray(fees.executors) &&
+        fees.executors.length > 0;
+
+      let feeAuthorization:
+        | SafeFeeAuthorization
+        | Permit2FeeAuthorization
+        | undefined;
+      let executor: string | undefined;
+
       if (fees !== undefined && fees.totalFee > 0) {
         const safeAddress = computeProxyAddress(signer.address);
         const feeAmountInUsdc = BigInt(
           parseUnits(fees.totalFee.toString(), 6).toString(),
         );
-        feeAuthorization = await createSafeFeeAuthorization({
-          safeAddress,
-          signer,
-          amount: feeAmountInUsdc,
-          to: fees.collector,
-        });
+
+        if (shouldUsePermit2 && fees.executors) {
+          const permit2Ready = await hasPermit2Allowance({
+            address: safeAddress,
+          });
+
+          if (permit2Ready) {
+            executor =
+              fees.executors[Math.floor(Math.random() * fees.executors.length)];
+            feeAuthorization = await createPermit2FeeAuthorization({
+              safeAddress,
+              signer,
+              amount: feeAmountInUsdc,
+              spender: executor,
+            });
+          } else {
+            feeAuthorization = await createSafeFeeAuthorization({
+              safeAddress,
+              signer,
+              amount: feeAmountInUsdc,
+              to: fees.collector,
+            });
+          }
+        } else {
+          feeAuthorization = await createSafeFeeAuthorization({
+            safeAddress,
+            signer,
+            amount: feeAmountInUsdc,
+            to: fees.collector,
+          });
+        }
       }
 
       const { success, response, error } = await submitClobOrder({
         headers,
         clobOrder,
         feeAuthorization,
+        executor,
       });
 
       if (!success) {
@@ -1467,8 +1507,13 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     if (!accountState.hasAllowances) {
+      const { feeCollection: depositFeeCollection } = this.#getFeatureFlags();
+      const extraUsdcSpenders = depositFeeCollection.permit2Enabled
+        ? [PERMIT2_ADDRESS]
+        : [];
       const allowanceTransaction = await getProxyWalletAllowancesTransaction({
         signer,
+        extraUsdcSpenders,
       });
 
       if (!allowanceTransaction) {
@@ -1540,13 +1585,17 @@ export class PolymarketProvider implements PredictProvider {
       // Check deployment status and allowances
       let isDeployed: boolean;
       let hasAllowancesResult: boolean;
+      const { feeCollection: flagFeeCollection } = this.#getFeatureFlags();
+      const extraUsdcSpenders = flagFeeCollection.permit2Enabled
+        ? [PERMIT2_ADDRESS]
+        : [];
       try {
         [isDeployed, hasAllowancesResult] = await Promise.all([
           isSmartContractAddress(
             address,
             numberToHex(POLYGON_MAINNET_CHAIN_ID),
           ),
-          hasAllowances({ address }),
+          hasAllowances({ address, extraUsdcSpenders }),
         ]);
       } catch (error) {
         throw new Error(

--- a/app/components/UI/Predict/providers/polymarket/safe/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/constants.ts
@@ -11,8 +11,11 @@ export const SAFE_MULTISEND_ADDRESS =
 // Constants from the contract
 export const SAFE_TX_TYPEHASH =
   '0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8';
+export const SAFE_MSG_TYPEHASH =
+  '0x60b3cbf8b4a223d68d641b3b6ddf9a298e7f33710cf3d3a9d1146b5a6150fbca';
 export const DOMAIN_SEPARATOR_TYPEHASH =
   '0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218';
+export const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
 
 export const usdcSpenders = [
   MATIC_CONTRACTS.conditionalTokens, // Conditional Tokens Framework

--- a/app/components/UI/Predict/providers/polymarket/safe/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/types.ts
@@ -23,3 +23,16 @@ export interface SafeFeeAuthorization {
     sig: string; // Signature of the Safe transaction
   };
 }
+
+export interface Permit2FeeAuthorization {
+  type: 'safe-permit2';
+  authorization: {
+    permit: {
+      permitted: { token: string; amount: string };
+      nonce: string;
+      deadline: string;
+    };
+    spender: string;
+    signature: string;
+  };
+}

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
@@ -5,10 +5,17 @@ import {
   POLYGON_MAINNET_CHAIN_ID,
   POLYMARKET_PROVIDER_ID,
 } from '../constants';
-import { SAFE_FACTORY_ADDRESS, SAFE_MULTISEND_ADDRESS } from './constants';
+import {
+  PERMIT2_ADDRESS,
+  SAFE_FACTORY_ADDRESS,
+  SAFE_MULTISEND_ADDRESS,
+  usdcSpenders,
+} from './constants';
 import {
   computeProxyAddress,
+  createPermit2FeeAuthorization,
   createSafeFeeAuthorization,
+  getPermit2Nonce,
   getDeployProxyWalletTypedData,
   encodeCreateProxy,
   getDeployProxyWalletTransaction,
@@ -18,6 +25,7 @@ import {
   aggregateTransaction,
   createAllowancesSafeTransaction,
   hasAllowances,
+  hasPermit2Allowance,
   createClaimSafeTransaction,
   getSafeTransactionCallData,
   getProxyWalletAllowancesTransaction,
@@ -405,6 +413,102 @@ describe('safe utils', () => {
     });
   });
 
+  describe('getPermit2Nonce', () => {
+    it('returns 0 when nonce bitmap call returns 0x', async () => {
+      mockNetworkController();
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce('0x');
+
+      const nonce = await getPermit2Nonce({ safeAddress: TEST_SAFE_ADDRESS });
+
+      expect(nonce).toBe('0');
+    });
+
+    it('returns first available nonce when bitmap is 0x7', async () => {
+      mockNetworkController();
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce('0x7');
+
+      const nonce = await getPermit2Nonce({ safeAddress: TEST_SAFE_ADDRESS });
+
+      expect(nonce).toBe('3');
+    });
+
+    it('returns first available nonce when bitmap is 0x5', async () => {
+      mockNetworkController();
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce('0x5');
+
+      const nonce = await getPermit2Nonce({ safeAddress: TEST_SAFE_ADDRESS });
+
+      expect(nonce).toBe('1');
+    });
+
+    it('throws when nonce bitmap word 0 is fully used', async () => {
+      mockNetworkController();
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce(`0x${'f'.repeat(64)}`);
+
+      await expect(
+        getPermit2Nonce({ safeAddress: TEST_SAFE_ADDRESS }),
+      ).rejects.toThrow(
+        'No available Permit2 nonce found in nonce bitmap word 0',
+      );
+    });
+  });
+
+  describe('hasPermit2Allowance', () => {
+    it('returns true when Permit2 allowance is greater than zero', async () => {
+      mockGetAllowance.mockResolvedValueOnce(1n);
+
+      const result = await hasPermit2Allowance({ address: TEST_SAFE_ADDRESS });
+
+      expect(result).toBe(true);
+      expect(mockGetAllowance).toHaveBeenCalledWith({
+        tokenAddress: MATIC_CONTRACTS.collateral,
+        owner: TEST_SAFE_ADDRESS,
+        spender: PERMIT2_ADDRESS,
+      });
+    });
+
+    it('returns false when Permit2 allowance is zero', async () => {
+      mockGetAllowance.mockResolvedValueOnce(0n);
+
+      const result = await hasPermit2Allowance({ address: TEST_SAFE_ADDRESS });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createPermit2FeeAuthorization', () => {
+    it('creates safe-permit2 authorization payload', async () => {
+      mockNetworkController();
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce('0x0');
+      mockSignPersonalMessage.mockResolvedValue(
+        '0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900',
+      );
+
+      const authorization = await createPermit2FeeAuthorization({
+        safeAddress: TEST_SAFE_ADDRESS,
+        signer: buildSigner(),
+        amount: 1_000_000n,
+        spender: TEST_TO_ADDRESS,
+      });
+
+      expect(authorization.type).toBe('safe-permit2');
+      expect(authorization.authorization.permit.permitted.token).toBe(
+        MATIC_CONTRACTS.collateral,
+      );
+      expect(authorization.authorization.permit.permitted.amount).toBe(
+        '1000000',
+      );
+      expect(authorization.authorization.permit.nonce).toBe('0');
+      expect(authorization.authorization.spender).toBe(TEST_TO_ADDRESS);
+      expect(authorization.authorization.signature).toMatch(/^0x[a-f0-9]+$/);
+    });
+  });
+
   describe('getDeployProxyWalletTypedData', () => {
     it('returns correct typed data structure', async () => {
       const typedData = await getDeployProxyWalletTypedData();
@@ -660,6 +764,18 @@ describe('safe utils', () => {
       expect(safeTxn.data).toBeDefined();
       expect(typeof safeTxn.data).toBe('string');
     });
+
+    it('includes extra USDC spenders when provided', () => {
+      const defaultSafeTxn = createAllowancesSafeTransaction();
+      const safeTxnWithExtra = createAllowancesSafeTransaction({
+        extraUsdcSpenders: [PERMIT2_ADDRESS],
+      });
+
+      expect(safeTxnWithExtra.data).toBeDefined();
+      expect(safeTxnWithExtra.data.length).toBeGreaterThan(
+        defaultSafeTxn.data.length,
+      );
+    });
   });
 
   describe('hasAllowances', () => {
@@ -692,6 +808,22 @@ describe('safe utils', () => {
       const result = await hasAllowances({ address: TEST_ADDRESS });
 
       expect(result).toBe(false);
+    });
+
+    it('checks allowances for extra USDC spenders', async () => {
+      mockGetAllowance.mockResolvedValue(100n);
+      mockGetIsApprovedForAll.mockResolvedValue(true);
+
+      const result = await hasAllowances({
+        address: TEST_ADDRESS,
+        extraUsdcSpenders: [PERMIT2_ADDRESS],
+      });
+
+      expect(result).toBe(true);
+      expect(mockGetAllowance).toHaveBeenCalledWith(
+        expect.objectContaining({ spender: PERMIT2_ADDRESS }),
+      );
+      expect(mockGetAllowance).toHaveBeenCalledTimes(usdcSpenders.length + 1);
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.ts
@@ -44,15 +44,18 @@ import {
   DOMAIN_SEPARATOR_TYPEHASH,
   MASTER_COPY_ADDRESS,
   outcomeTokenSpenders,
+  PERMIT2_ADDRESS,
   PROXY_CREATION_CODE,
   SAFE_FACTORY_ADDRESS,
   SAFE_FACTORY_NAME,
+  SAFE_MSG_TYPEHASH,
   SAFE_MULTISEND_ADDRESS,
   SAFE_TX_TYPEHASH,
   usdcSpenders,
 } from './constants';
 import {
   OperationType,
+  Permit2FeeAuthorization,
   SafeFeeAuthorization,
   SafeTransaction,
   SplitSignature,
@@ -169,6 +172,41 @@ const getNonce = async ({
   }
 
   return BigInt(res);
+};
+
+export const getPermit2Nonce = async ({
+  safeAddress,
+}: {
+  safeAddress: string;
+}): Promise<string> => {
+  const { NetworkController } = Engine.context;
+  const networkClientId = NetworkController.findNetworkClientIdByChainId(
+    numberToHex(POLYGON_MAINNET_CHAIN_ID),
+  );
+  const ethQuery = new EthQuery(
+    NetworkController.getNetworkClientById(networkClientId).provider,
+  );
+  const nonceBitmapInterface = new Interface([
+    'function nonceBitmap(address, uint256) view returns (uint256)',
+  ]);
+  const res = (await query(ethQuery, 'call', [
+    {
+      to: PERMIT2_ADDRESS,
+      data: nonceBitmapInterface.encodeFunctionData('nonceBitmap', [
+        safeAddress,
+        0,
+      ]),
+    },
+  ])) as Hex;
+  const bitmap = res === '0x' ? 0n : BigInt(res);
+  let bitPos = 0n;
+  while (bitPos < 256n && ((bitmap >> bitPos) & 1n) === 1n) {
+    bitPos += 1n;
+  }
+  if (bitPos === 256n) {
+    throw new Error('No available Permit2 nonce found in nonce bitmap word 0');
+  }
+  return ((0n << 8n) | bitPos).toString();
 };
 
 const getTransactionHash = ({
@@ -309,6 +347,91 @@ export const createSafeFeeAuthorization = async ({
     authorization: {
       tx,
       sig,
+    },
+  };
+};
+
+export const createPermit2FeeAuthorization = async ({
+  safeAddress,
+  signer,
+  amount,
+  spender,
+}: {
+  safeAddress: Hex;
+  signer: Signer;
+  amount: bigint;
+  spender: string;
+}): Promise<Permit2FeeAuthorization> => {
+  const nonce = await getPermit2Nonce({ safeAddress });
+  const deadline = (Math.floor(Date.now() / 1000) + 3600).toString();
+  const token = MATIC_CONTRACTS.collateral;
+
+  const domain = {
+    name: 'Permit2',
+    chainId: POLYGON_MAINNET_CHAIN_ID,
+    verifyingContract: PERMIT2_ADDRESS,
+  };
+  const types = {
+    PermitTransferFrom: [
+      { name: 'permitted', type: 'TokenPermissions' },
+      { name: 'spender', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ],
+    TokenPermissions: [
+      { name: 'token', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+  };
+  const message = {
+    permitted: { token, amount: amount.toString() },
+    spender,
+    nonce,
+    deadline,
+  };
+
+  const { _TypedDataEncoder } = ethers.utils;
+  const permit2Hash = _TypedDataEncoder.hash(domain, types, message);
+
+  const safeDomainSeparator = keccak256(
+    new AbiCoder().encode(
+      ['bytes32', 'uint256', 'address'],
+      [DOMAIN_SEPARATOR_TYPEHASH, POLYGON_MAINNET_CHAIN_ID, safeAddress],
+    ),
+  );
+
+  const encodedPermit2Hash = new AbiCoder().encode(['bytes32'], [permit2Hash]);
+  const safeMessageHash = keccak256(
+    new AbiCoder().encode(
+      ['bytes32', 'bytes32'],
+      [SAFE_MSG_TYPEHASH, keccak256(encodedPermit2Hash)],
+    ),
+  );
+
+  const finalHash = keccak256(
+    solidityPack(
+      ['bytes1', 'bytes1', 'bytes32', 'bytes32'],
+      ['0x19', '0x01', safeDomainSeparator, safeMessageHash],
+    ),
+  ) as Hex;
+
+  const rsvSignature = await signTransactionHash(signer, finalHash);
+  const signature = abiEncodePacked(
+    { type: 'uint256', value: rsvSignature.r },
+    { type: 'uint256', value: rsvSignature.s },
+    { type: 'uint8', value: rsvSignature.v },
+  );
+
+  return {
+    type: 'safe-permit2',
+    authorization: {
+      permit: {
+        permitted: { token, amount: amount.toString() },
+        nonce,
+        deadline,
+      },
+      spender,
+      signature,
     },
   };
 };
@@ -482,10 +605,16 @@ export const aggregateTransaction = (
   return transaction;
 };
 
-export const createAllowancesSafeTransaction = () => {
+export const createAllowancesSafeTransaction = (options?: {
+  extraUsdcSpenders?: string[];
+}) => {
   const safeTxns: SafeTransaction[] = [];
+  const allUsdcSpenders = [
+    ...usdcSpenders,
+    ...(options?.extraUsdcSpenders ?? []),
+  ];
 
-  for (const spender of usdcSpenders) {
+  for (const spender of allUsdcSpenders) {
     safeTxns.push({
       to: MATIC_CONTRACTS.collateral,
       data: encodeApprove({
@@ -576,12 +705,14 @@ export const getSafeTransactionCallData = async ({
 
 export const getProxyWalletAllowancesTransaction = async ({
   signer,
+  extraUsdcSpenders,
 }: {
   signer: Signer;
+  extraUsdcSpenders?: string[];
 }) => {
   try {
     const safeAddress = computeProxyAddress(signer.address);
-    const safeTxn = createAllowancesSafeTransaction();
+    const safeTxn = createAllowancesSafeTransaction({ extraUsdcSpenders });
     const callData = await getSafeTransactionCallData({
       signer,
       safeAddress,
@@ -624,10 +755,17 @@ export const getProxyWalletAllowancesTransaction = async ({
   }
 };
 
-export const hasAllowances = async ({ address }: { address: string }) => {
+export const hasAllowances = async ({
+  address,
+  extraUsdcSpenders = [],
+}: {
+  address: string;
+  extraUsdcSpenders?: string[];
+}) => {
   const allowanceCalls = [];
   const isApprovedForAllCalls = [];
-  for (const spender of usdcSpenders) {
+  const allUsdcSpenders = [...usdcSpenders, ...extraUsdcSpenders];
+  for (const spender of allUsdcSpenders) {
     allowanceCalls.push(
       getAllowance({
         tokenAddress: MATIC_CONTRACTS.collateral,
@@ -650,6 +788,19 @@ export const hasAllowances = async ({ address }: { address: string }) => {
     allowanceResults.every((allowance) => allowance > 0) &&
     isApprovedForAllResults.every((isApproved) => isApproved)
   );
+};
+
+export const hasPermit2Allowance = async ({
+  address,
+}: {
+  address: string;
+}): Promise<boolean> => {
+  const allowance = await getAllowance({
+    tokenAddress: MATIC_CONTRACTS.collateral,
+    owner: address,
+    spender: PERMIT2_ADDRESS,
+  });
+  return allowance > 0;
 };
 
 export const createClaimSafeTransaction = (

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -1,5 +1,5 @@
 import { PredictGamePeriod, Side } from '../../types';
-import { SafeFeeAuthorization } from './safe/types';
+import { Permit2FeeAuthorization, SafeFeeAuthorization } from './safe/types';
 
 export interface PolymarketPosition {
   conditionId: string;
@@ -119,7 +119,7 @@ export type ClobHeaders = {
 export interface PolymarketOffchainTradeParams {
   clobOrder: ClobOrderObject;
   headers: ClobHeaders;
-  feeAuthorization?: SafeFeeAuthorization;
+  feeAuthorization?: SafeFeeAuthorization | Permit2FeeAuthorization;
 }
 
 // Polymarket API response types

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -976,6 +976,52 @@ describe('polymarket utils', () => {
         },
       );
     });
+
+    it('includes executor in request body when provided', async () => {
+      await submitClobOrder({
+        headers: mockHeaders,
+        clobOrder: mockClobOrder,
+        executor: '0x1111111111111111111111111111111111111111',
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const bodyString = callArgs[1].body;
+      const parsedBody = JSON.parse(bodyString);
+
+      expect(parsedBody.executor).toBe(
+        '0x1111111111111111111111111111111111111111',
+      );
+    });
+
+    it('supports Permit2 fee authorization payload in request body', async () => {
+      const feeAuthorization = {
+        type: 'safe-permit2' as const,
+        authorization: {
+          permit: {
+            permitted: {
+              token: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+              amount: '1000000',
+            },
+            nonce: '0',
+            deadline: '1700000000',
+          },
+          spender: '0x1111111111111111111111111111111111111111',
+          signature: '0xabc',
+        },
+      };
+
+      await submitClobOrder({
+        headers: mockHeaders,
+        clobOrder: mockClobOrder,
+        feeAuthorization,
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const bodyString = callArgs[1].body;
+      const parsedBody = JSON.parse(bodyString);
+
+      expect(parsedBody.feeAuthorization).toEqual(feeAuthorization);
+    });
   });
 
   describe('parsePolymarketEvents', () => {
@@ -2787,6 +2833,8 @@ describe('polymarket utils', () => {
       expect(fees.metamaskFee).toBe(expectedMetamaskFee);
       expect(fees.totalFeePercentage).toBe(totalFeePercentage);
       expect(fees.collector).toBe(feeCollection.collector);
+      expect(fees.executors).toEqual(feeCollection.executors ?? []);
+      expect(fees.permit2Enabled).toBe(feeCollection.permit2Enabled ?? false);
     });
 
     it('calculates fees correctly for various amounts', async () => {
@@ -2863,6 +2911,8 @@ describe('polymarket utils', () => {
       expect(fees.totalFee).toBe(0);
       expect(fees.totalFeePercentage).toBe(0);
       expect(fees.collector).toBe('0x0');
+      expect(fees.executors).toEqual([]);
+      expect(fees.permit2Enabled).toBe(false);
     });
 
     it('waives fees for markets in waiveList', async () => {
@@ -2893,6 +2943,27 @@ describe('polymarket utils', () => {
       expect(fees.totalFee).toBe(0);
       expect(fees.totalFeePercentage).toBe(0);
       expect(fees.collector).toBe('0x0');
+      expect(fees.executors).toEqual([]);
+      expect(fees.permit2Enabled).toBe(false);
+    });
+
+    it('returns executors and permit2Enabled from feeCollection config', async () => {
+      const params = {
+        feeCollection: {
+          ...feeCollection,
+          executors: ['0x1111111111111111111111111111111111111111'],
+          permit2Enabled: true,
+        },
+        marketId: 'market-1',
+        userBetAmount: 100,
+      };
+
+      const fees = await calculateFees(params);
+
+      expect(fees.executors).toEqual([
+        '0x1111111111111111111111111111111111111111',
+      ]);
+      expect(fees.permit2Enabled).toBe(true);
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -45,7 +45,7 @@ import {
   SLIPPAGE_SELL,
   POLYMARKET_PROVIDER_ID,
 } from './constants';
-import { SafeFeeAuthorization } from './safe/types';
+import { Permit2FeeAuthorization, SafeFeeAuthorization } from './safe/types';
 import {
   ApiKeyCreds,
   ClobHeaders,
@@ -394,16 +394,22 @@ export const submitClobOrder = async ({
   headers,
   clobOrder,
   feeAuthorization,
+  executor,
 }: {
   headers: ClobHeaders;
   clobOrder: ClobOrderObject;
-  feeAuthorization?: SafeFeeAuthorization;
+  feeAuthorization?: SafeFeeAuthorization | Permit2FeeAuthorization;
+  executor?: string;
 }): Promise<Result<OrderResponse>> => {
   const { CLOB_RELAYER } = getPolymarketEndpoints();
   const url = `${CLOB_RELAYER}/order`;
-  const body: ClobOrderObject & { feeAuthorization?: SafeFeeAuthorization } = {
+  const body: ClobOrderObject & {
+    feeAuthorization?: SafeFeeAuthorization | Permit2FeeAuthorization;
+    executor?: string;
+  } = {
     ...clobOrder,
     feeAuthorization,
+    ...(executor && { executor }),
   };
 
   // For our relayer, we need to replace the underscores with dashes
@@ -1091,6 +1097,8 @@ export async function calculateFees({
       totalFee: 0,
       totalFeePercentage: 0,
       collector: '0x0',
+      executors: [],
+      permit2Enabled: false,
     };
   }
 
@@ -1113,6 +1121,8 @@ export async function calculateFees({
     totalFee,
     totalFeePercentage,
     collector: feeCollection.collector,
+    executors: feeCollection.executors ?? [],
+    permit2Enabled: feeCollection.permit2Enabled ?? false,
   };
 }
 

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -7,6 +7,8 @@ export interface PredictFeeCollection {
   metamaskFee: number;
   providerFee: number;
   waiveList: string[];
+  executors?: string[];
+  permit2Enabled?: boolean;
 }
 
 export interface PredictLiveSportsFlag {

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -433,6 +433,8 @@ export interface PredictFees {
   totalFee: number;
   totalFeePercentage: number;
   collector: Hex;
+  executors?: string[];
+  permit2Enabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
## **Description**

Adds Permit2 SignatureTransfer fee authorization as an alternative to Safe `execTransaction` for fee collection. Feature-flagged OFF by default via `permit2Enabled` and `executors` fields on the fee collection remote config.

**How it works**:
When `permit2Enabled` is true, executors are configured, AND the user's Safe has approved USDC to the Permit2 contract:
1. A Permit2 `PermitTransferFrom` signature is created (EIP-1271 wrapped for Safe)
2. A random executor is selected from the configured list
3. Both are sent to the relayer alongside the CLOB order

**Fallback behavior**: If any condition is not met (flag off, no executors, no Permit2 allowance), the existing Safe transaction fee authorization is used. Zero behavior change for existing users.

**Conditional approval**: The Permit2 USDC approval is only bundled into deposit transactions when `permit2Enabled` is true — existing users without the flag don't get an extra approval transaction.

### Key additions:
- `Permit2FeeAuthorization` type with `safe-permit2` discriminator
- `getPermit2Nonce()` — bitmap-based nonce reading from Permit2 contract
- `createPermit2FeeAuthorization()` — EIP-1271 wrapped Permit2 SignatureTransfer signature
- `hasPermit2Allowance()` — checks Safe USDC approval to Permit2
- `extraUsdcSpenders` parameter on `createAllowancesSafeTransaction`, `hasAllowances`, `getProxyWalletAllowancesTransaction` for conditional approval
- `calculateFees` passes through `executors` and `permit2Enabled`
- `submitClobOrder` accepts Permit2 auth union type and `executor` param
- `placeOrder` branching: Permit2 → Safe tx fallback
- `getAccountState` and `prepareDeposit` conditionally include Permit2 approval

**Still uses FOK orders** — FAK support comes in the next PR.

**Depends on**: #26703 (feature flag refactor)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-715

## **Manual testing steps**

```gherkin
Feature: Permit2 fee authorization (feature-flagged OFF)

  Scenario: user places orders with Permit2 disabled (default)
    Given user has Predict feature enabled
    And permit2Enabled remote flag is false (default)

    When user places a buy order
    Then fee authorization uses Safe transaction (existing behavior)
    And order type is FOK

  Scenario: user places orders with Permit2 enabled
    Given user has Predict feature enabled
    And permit2Enabled remote flag is true with executors configured
    And user's Safe has approved USDC to Permit2 contract

    When user places a buy order
    Then fee authorization uses Permit2 SignatureTransfer
    And a random executor is selected and sent with the order
    And order type is still FOK

  Scenario: user places orders with Permit2 enabled but no allowance
    Given user has Predict feature enabled
    And permit2Enabled remote flag is true
    And user's Safe has NOT approved USDC to Permit2 contract

    When user places a buy order
    Then fee authorization falls back to Safe transaction
```

## **Screenshots/Recordings**

N/A — backend logic, no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new, feature-flagged fee authorization path that changes how trade fees are signed and submitted (Permit2 + executor selection) and conditionally alters allowance/approval behavior for Safe wallets. While gated off by default with fallbacks, it touches trading flow, signing, and on-chain allowance checks.
> 
> **Overview**
> Adds an alternative *Permit2 SignatureTransfer* fee authorization path for Polymarket order placement: when `permit2Enabled` is true, `executors` are configured, and the Safe has a Permit2 USDC allowance, `placeOrder` selects a random executor, creates a `safe-permit2` authorization payload, and submits it alongside the order (otherwise it falls back to the existing `safe-transaction` authorization).
> 
> Extends fee/flag types and defaults to include `executors` and `permit2Enabled`, updates relayer payloads to accept `executor` and the new authorization union, and conditionally includes Permit2 as an extra USDC spender in allowance checks/approval transaction generation. Adds comprehensive unit tests for nonce calculation, Permit2 authorization creation, fallback behavior, and request-body changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db73a13e26fc1766a168ade394df1834709d12bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->