### PR TITLE
Input default amount reset

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -330,6 +330,14 @@ describe('BuildQuote', () => {
     expect(getByText('$100123')).toBeOnTheScreen();
   });
 
+  it('clears the prefilled amount when delete button is pressed first', () => {
+    const { getByTestId, getByText } = renderWithTheme(<BuildQuote />);
+
+    fireEvent.press(getByTestId('keypad-delete-button'));
+
+    expect(getByText('$0')).toBeOnTheScreen();
+  });
+
   it('deletes last digit when delete button is pressed', () => {
     const { getByText, getByTestId } = renderWithTheme(<BuildQuote />);
 

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -11,7 +11,7 @@ import type { CaipChainId } from '@metamask/utils';
 
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
 import { getRampCallbackBaseUrl } from '../../utils/getRampCallbackBaseUrl';
-import Keypad, { type KeypadChangeData } from '../../../../Base/Keypad';
+import Keypad, { Keys, type KeypadChangeData } from '../../../../Base/Keypad';
 import PaymentMethodPill from '../../components/PaymentMethodPill';
 import QuickAmounts from '../../components/QuickAmounts';
 import Text, {
@@ -107,6 +107,7 @@ function BuildQuote() {
   const [amount, setAmount] = useState<string>(() => String(DEFAULT_AMOUNT));
   const [amountAsNumber, setAmountAsNumber] = useState<number>(DEFAULT_AMOUNT);
   const [userHasEnteredAmount, setUserHasEnteredAmount] = useState(false);
+  const [hasEditedAmount, setHasEditedAmount] = useState(false);
   const [isOnBuildQuoteScreen, setIsOnBuildQuoteScreen] =
     useState<boolean>(true);
   const [isContinueLoading, setIsContinueLoading] = useState(false);
@@ -358,13 +359,23 @@ function BuildQuote() {
   }, [navigation, selectedToken, networkInfo, trackEvent, createEventBuilder]);
 
   const handleKeypadChange = useCallback(
-    ({ value, valueAsNumber }: KeypadChangeData) => {
+    ({ value, valueAsNumber, pressedKey }: KeypadChangeData) => {
+      if (!hasEditedAmount && pressedKey === Keys.Back && amountAsNumber > 0) {
+        setAmount('0');
+        setAmountAsNumber(0);
+        setUserHasEnteredAmount(true);
+        setNativeFlowError(null);
+        setHasEditedAmount(true);
+        return;
+      }
+
       setAmount(value || '0');
       setAmountAsNumber(valueAsNumber || 0);
       setUserHasEnteredAmount(true);
       setNativeFlowError(null);
+      setHasEditedAmount(true);
     },
-    [],
+    [amountAsNumber, hasEditedAmount],
   );
 
   const handleQuickAmountPress = useCallback(
@@ -373,6 +384,7 @@ function BuildQuote() {
       setAmountAsNumber(quickAmount);
       setUserHasEnteredAmount(true);
       setNativeFlowError(null);
+      setHasEditedAmount(true);
       trackEvent(
         createEventBuilder(MetaMetricsEvents.RAMPS_QUICK_AMOUNT_CLICKED)
           .addProperties({


### PR DESCRIPTION
Clear the default `100` in the unified buy amount field with a single backspace press to improve user experience.

---
[Slack Thread](https://consensys.slack.com/archives/C09TEE4TL8M/p1772210109201709?thread_ts=1772210109.201709&cid=C09TEE4TL8M)

<p><a href="https://cursor.com/agents/bc-02126604-2dd1-5d24-8708-1a7024ef9fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02126604-2dd1-5d24-8708-1a7024ef9fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

