### PR TITLE
feat(predict): add FAK order type support

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -442,7 +442,19 @@ export class PredictController extends BaseController<
         flags.predictFeeCollection,
       ) ?? DEFAULT_FEE_COLLECTION_FLAG;
 
-    return { feeCollection, liveSportsLeagues, marketHighlightsFlag };
+    const fakOrdersEnabled =
+      validatedVersionGatedFeatureFlag(
+        unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(
+          flags.predictFakOrders,
+        ),
+      ) ?? false;
+
+    return {
+      feeCollection,
+      liveSportsLeagues,
+      marketHighlightsFlag,
+      fakOrdersEnabled,
+    };
   }
 
   private getEvmAccountAddress(): string {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -233,6 +233,7 @@ describe('PolymarketProvider', () => {
       highlights: [],
       minimumVersion: '7.64.0',
     },
+    fakOrdersEnabled: false,
   };
   const createProvider = (
     featureFlagsOverride?: Partial<PredictFeatureFlags>,
@@ -837,7 +838,9 @@ describe('PolymarketProvider', () => {
   }
 
   // Helper function to setup place order test environment
-  function setupPlaceOrderTest() {
+  function setupPlaceOrderTest(
+    featureFlagsOverride?: Partial<PredictFeatureFlags>,
+  ) {
     const mockAddress = '0x1234567890123456789012345678901234567890';
     const mockSigner = {
       address: mockAddress,
@@ -845,7 +848,7 @@ describe('PolymarketProvider', () => {
       signPersonalMessage: mockSignPersonalMessage,
     };
 
-    const provider = createProvider();
+    const provider = createProvider(featureFlagsOverride);
 
     const mockMarket = {
       id: 'market-1',
@@ -1751,7 +1754,7 @@ describe('PolymarketProvider', () => {
       expect(mockCreateSafeFeeAuthorization).toHaveBeenCalled();
     });
 
-    it('always submits orders with FOK type', async () => {
+    it('submits FOK order type when fakOrdersEnabled is false', async () => {
       jest.clearAllMocks();
       const { provider, mockSigner } = setupPlaceOrderTest();
       const preview = createMockOrderPreview({ side: Side.BUY });
@@ -1764,8 +1767,106 @@ describe('PolymarketProvider', () => {
         }),
       );
     });
-  });
 
+    it('submits FAK order type when Permit2 is used and fakOrdersEnabled is true', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest({
+        feeCollection: {
+          ...DEFAULT_FEE_COLLECTION_FLAG,
+          permit2Enabled: true,
+          executors: ['0xexecutor1'],
+        },
+        fakOrdersEnabled: true,
+      });
+      mockHasPermit2Allowance.mockResolvedValue(true);
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: ['0xexecutor1'],
+          permit2Enabled: true,
+        },
+      });
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockSubmitClobOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clobOrder: expect.objectContaining({ orderType: 'FAK' }),
+        }),
+      );
+    });
+
+    it('submits FOK order type when Permit2 is used but fakOrdersEnabled is false', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest({
+        feeCollection: {
+          ...DEFAULT_FEE_COLLECTION_FLAG,
+          permit2Enabled: true,
+          executors: ['0xexecutor1'],
+        },
+        fakOrdersEnabled: false,
+      });
+      mockHasPermit2Allowance.mockResolvedValue(true);
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: ['0xexecutor1'],
+          permit2Enabled: true,
+        },
+      });
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockSubmitClobOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clobOrder: expect.objectContaining({ orderType: 'FOK' }),
+        }),
+      );
+    });
+
+    it('submits FOK order type when falling back to Safe tx regardless of fakOrdersEnabled', async () => {
+      jest.clearAllMocks();
+      const { provider, mockSigner } = setupPlaceOrderTest({
+        feeCollection: {
+          ...DEFAULT_FEE_COLLECTION_FLAG,
+          permit2Enabled: true,
+          executors: ['0xexecutor1'],
+        },
+        fakOrdersEnabled: true,
+      });
+      mockHasPermit2Allowance.mockResolvedValue(false);
+      const preview = createMockOrderPreview({
+        side: Side.BUY,
+        fees: {
+          metamaskFee: 0.02,
+          providerFee: 0.02,
+          totalFee: 0.04,
+          totalFeePercentage: 0.04,
+          collector: DEFAULT_FEE_COLLECTION_FLAG.collector,
+          executors: ['0xexecutor1'],
+          permit2Enabled: true,
+        },
+      });
+
+      await provider.placeOrder({ preview, signer: mockSigner });
+
+      expect(mockSubmitClobOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clobOrder: expect.objectContaining({ orderType: 'FOK' }),
+        }),
+      );
+    });
+  });
   describe('placeOrder edge cases', () => {
     it('places order without fee authorization when totalFee is zero', async () => {
       // Clear mock to ensure clean state for this test

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -1143,24 +1143,8 @@ export class PolymarketProvider implements PredictProvider {
 
       const signerApiKey = await this.getApiKey({ address: signer.address });
 
-      const clobOrder = {
-        order: { ...signedOrder, side, salt: parseInt(signedOrder.salt) },
-        owner: signerApiKey.apiKey,
-        orderType: OrderType.FOK,
-      };
-
-      const body = JSON.stringify(clobOrder);
-
-      const headers = await getL2Headers({
-        l2HeaderArgs: {
-          method: 'POST',
-          requestPath: `/order`,
-          body,
-        },
-        address: clobOrder.order.signer ?? '',
-        apiKey: signerApiKey,
-      });
-
+      // Determine fees, permit2, and order type BEFORE building clobOrder
+      // so the HMAC signature covers the correct orderType.
       const { fakOrdersEnabled } = this.#getFeatureFlags();
       const shouldUsePermit2 =
         fees?.permit2Enabled === true &&
@@ -1213,11 +1197,27 @@ export class PolymarketProvider implements PredictProvider {
         }
       }
 
+      const clobOrder = {
+        order: { ...signedOrder, side, salt: parseInt(signedOrder.salt) },
+        owner: signerApiKey.apiKey,
+        orderType: shouldUseFakOrderType ? OrderType.FAK : OrderType.FOK,
+      };
+
+      const body = JSON.stringify(clobOrder);
+
+      const headers = await getL2Headers({
+        l2HeaderArgs: {
+          method: 'POST',
+          requestPath: `/order`,
+          body,
+        },
+        address: clobOrder.order.signer ?? '',
+        apiKey: signerApiKey,
+      });
+
       const { success, response, error } = await submitClobOrder({
         headers,
-        clobOrder: shouldUseFakOrderType
-          ? { ...clobOrder, orderType: OrderType.FAK }
-          : clobOrder,
+        clobOrder,
         feeAuthorization,
         executor,
       });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -1161,6 +1161,7 @@ export class PolymarketProvider implements PredictProvider {
         apiKey: signerApiKey,
       });
 
+      const { fakOrdersEnabled } = this.#getFeatureFlags();
       const shouldUsePermit2 =
         fees?.permit2Enabled === true &&
         Array.isArray(fees.executors) &&
@@ -1171,6 +1172,7 @@ export class PolymarketProvider implements PredictProvider {
         | Permit2FeeAuthorization
         | undefined;
       let executor: string | undefined;
+      let shouldUseFakOrderType = false;
 
       if (fees !== undefined && fees.totalFee > 0) {
         const safeAddress = computeProxyAddress(signer.address);
@@ -1192,6 +1194,7 @@ export class PolymarketProvider implements PredictProvider {
               amount: feeAmountInUsdc,
               spender: executor,
             });
+            shouldUseFakOrderType = fakOrdersEnabled === true;
           } else {
             feeAuthorization = await createSafeFeeAuthorization({
               safeAddress,
@@ -1212,7 +1215,9 @@ export class PolymarketProvider implements PredictProvider {
 
       const { success, response, error } = await submitClobOrder({
         headers,
-        clobOrder,
+        clobOrder: shouldUseFakOrderType
+          ? { ...clobOrder, orderType: OrderType.FAK }
+          : clobOrder,
         feeAuthorization,
         executor,
       });

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -29,6 +29,7 @@ export interface PredictFeatureFlags {
   feeCollection: PredictFeeCollection;
   liveSportsLeagues: string[];
   marketHighlightsFlag: PredictMarketHighlightsFlag;
+  fakOrdersEnabled: boolean;
 }
 
 export interface PredictHotTabFlag extends VersionGatedFeatureFlag {


### PR DESCRIPTION
## **Description**

Adds Fill-and-Kill (FAK) order type support, feature-flagged OFF by default via the `predictFakOrders` version-gated remote flag.

**How it works**:
When both conditions are met:
1. Permit2 fee authorization is active (Permit2 allowance exists AND being used)
2. `fakOrdersEnabled` flag is true (via `predictFakOrders` remote flag)

→ The order is submitted with `OrderType.FAK` instead of `OrderType.FOK`.

In all other cases (no Permit2, fallback to Safe tx, or `fakOrdersEnabled` false), orders continue to use `OrderType.FOK`.

### Changes (~20 lines of logic):
- Add `fakOrdersEnabled: boolean` to `PredictFeatureFlags`
- Resolve `predictFakOrders` version-gated remote flag in `resolveFeatureFlags()`
- In `placeOrder()`: when Permit2 path is taken AND `fakOrdersEnabled` → `OrderType.FAK`
- 4 new test cases covering FAK/FOK selection logic

**Double-gated safety**: FAK requires both Permit2 AND the FAK flag. The `predictFakOrders` flag is version-gated, so old app versions won't get FAK even if the remote flag is enabled.

**Depends on**: #26711 (Permit2 fee authorization)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-715

## **Manual testing steps**

```gherkin
Feature: FAK order type support (feature-flagged OFF)

  Scenario: user places orders with FAK disabled (default)
    Given user has Predict feature enabled
    And fakOrdersEnabled remote flag is false (default)

    When user places a buy order (even with Permit2 active)
    Then order type is FOK

  Scenario: user places orders with FAK enabled and Permit2 active
    Given user has Predict feature enabled
    And fakOrdersEnabled remote flag is true
    And permit2Enabled is true with executors configured
    And user's Safe has Permit2 USDC allowance

    When user places a buy order
    Then order type is FAK
    And Permit2 fee authorization is used

  Scenario: user places orders with FAK enabled but no Permit2
    Given user has Predict feature enabled
    And fakOrdersEnabled remote flag is true
    And Permit2 conditions are NOT met (no allowance or flag off)

    When user places a buy order
    Then order type is FOK (fallback)
    And Safe transaction fee authorization is used
```

## **Screenshots/Recordings**

N/A — backend logic, no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Polymarket order submission to conditionally use a new `FAK` order type, which can affect trade execution semantics and request signing when enabled. Risk is mitigated by a version-gated remote flag and only applying the behavior on the Permit2 fee-authorization path.
> 
> **Overview**
> Adds a new `fakOrdersEnabled` feature flag (resolved from the version-gated remote flag `predictFakOrders`) to control whether Predict orders may be submitted as *Fill-and-Kill*.
> 
> Updates Polymarket `placeOrder` to choose `OrderType.FAK` **only** when Permit2 fee authorization is actually used and `fakOrdersEnabled` is true (otherwise it remains `FOK`), and restructures header signing so the HMAC covers the selected `orderType`.
> 
> Expands Polymarket provider tests to cover `FAK` vs `FOK` selection across Permit2, Safe fallback, and flag combinations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 054dccc2f9fce3bb2734bd93f9c131b20e570649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->