### PR TITLE
feat: add Previously used tag to Ramps provider selection

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.test.tsx
@@ -80,7 +80,22 @@ const transakProvider: Provider = {
   },
 };
 
-const mockProviders: Provider[] = [transakProvider];
+const stripeProvider: Provider = {
+  id: '/providers/stripe',
+  name: 'Stripe',
+  environmentType: 'PRODUCTION',
+  description: 'Test provider',
+  hqAddress: 'Test Address',
+  links: [],
+  logos: {
+    light: 'https://example.com/logo-light.png',
+    dark: 'https://example.com/logo-dark.png',
+    height: 24,
+    width: 90,
+  },
+};
+
+const mockProviders: Provider[] = [transakProvider, stripeProvider];
 
 function createMockQuote(
   providerId: string,
@@ -106,6 +121,7 @@ interface RenderOptions {
   quotes?: QuotesResponse | null;
   quotesLoading?: boolean;
   quotesError?: string | null;
+  ordersProviders?: string[];
 }
 
 function renderWithProvider(
@@ -113,7 +129,12 @@ function renderWithProvider(
   selectedProvider: Provider | null = mockProviders[0],
   options: RenderOptions = {},
 ) {
-  const { quotes = null, quotesLoading = false, quotesError = null } = options;
+  const {
+    quotes = null,
+    quotesLoading = false,
+    quotesError = null,
+    ordersProviders = [],
+  } = options;
 
   jest.mocked(useRampsController).mockReturnValue({
     ...defaultMockController,
@@ -137,6 +158,16 @@ function renderWithProvider(
       state: {
         engine: {
           backgroundState,
+        },
+        fiatOrders: {
+          orders: ordersProviders.map((providerId) => ({
+            id: `order-${providerId}`,
+            provider: 'RAMPS_V2',
+            state: 'COMPLETED',
+            data: {
+              provider: { id: providerId },
+            },
+          })),
         },
       },
     },
@@ -239,5 +270,62 @@ describe('ProviderSelection', () => {
       expect(getByText('Transak')).toBeTruthy();
     });
     expect(queryByText('Stripe')).toBeNull();
+  });
+
+  describe('Previously used tag', () => {
+    it('displays "Previously used" tag for providers in order history', async () => {
+      jest.mocked(useRampsController).mockReturnValue({
+        ...defaultMockController,
+        userRegion: mockUserRegion,
+        selectedToken: mockSelectedToken,
+        providers: mockProviders,
+        selectedProvider: null,
+      });
+
+      const { getByText } = renderWithProvider(mockProviders, null, {
+        ordersProviders: ['/providers/transak'],
+      });
+
+      await waitFor(() => {
+        expect(getByText('Previously used')).toBeOnTheScreen();
+      });
+    });
+
+    it('does not display tag for providers not in order history', async () => {
+      jest.mocked(useRampsController).mockReturnValue({
+        ...defaultMockController,
+        userRegion: mockUserRegion,
+        selectedToken: mockSelectedToken,
+        providers: mockProviders,
+        selectedProvider: null,
+      });
+
+      const { queryByText } = renderWithProvider(mockProviders, null, {
+        ordersProviders: [],
+      });
+
+      await waitFor(() => {
+        expect(queryByText('Previously used')).toBeNull();
+      });
+    });
+
+    it('displays tag for multiple previously used providers', async () => {
+      jest.mocked(useRampsController).mockReturnValue({
+        ...defaultMockController,
+        userRegion: mockUserRegion,
+        selectedToken: mockSelectedToken,
+        providers: mockProviders,
+        selectedProvider: null,
+      });
+
+      const { getAllByText } = renderWithProvider(mockProviders, null, {
+        ordersProviders: ['/providers/transak', '/providers/stripe'],
+      });
+
+      await waitFor(() => {
+        const tags = getAllByText('Previously used');
+        expect(tags).toHaveLength(2);
+      });
+    });
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
+import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import ListItemSelect from '../../../../../../component-library/components/List/ListItemSelect';
@@ -22,6 +23,8 @@ import { useFormatters } from '../../../../../hooks/useFormatters';
 import QuoteDisplay from '../PaymentSelectionModal/QuoteDisplay';
 import PaymentSelectionAlert from '../PaymentSelectionModal/PaymentSelectionAlert';
 import { BannerAlertSeverity } from '../../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
+import TagColored from '../../../../../../component-library/components-temp/TagColored';
+import { getOrdersProviders } from '../../../../../../reducers/fiatOrders';
 
 const styles = StyleSheet.create({
   list: { flex: 1, minHeight: 0 },
@@ -56,6 +59,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
 
   const providers = providersOverride ?? controllerProviders;
   const { formatToken, formatCurrency } = useFormatters();
+  const ordersProviders = useSelector(getOrdersProviders);
 
   const currency = userRegion?.country?.currency ?? 'USD';
   const symbol = selectedToken?.symbol ?? '';
@@ -91,6 +95,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
           ? formatCurrency(Number(matchedQuote.quote.amountOutInFiat), currency)
           : null;
       const isSelected = selectedProvider?.id === provider.id;
+      const isPreviouslyUsed = ordersProviders.includes(provider.id);
 
       return (
         <ListItemSelect
@@ -101,6 +106,13 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
         >
           <ListItemColumn widthType={WidthType.Fill}>
             <Text variant={TextVariant.BodyLGMedium}>{provider.name}</Text>
+            {isPreviouslyUsed && (
+              <Box twClassName="mt-1">
+                <TagColored>
+                  {strings('fiat_on_ramp_aggregator.previously_used')}
+                </TagColored>
+              </Box>
+            )}
           </ListItemColumn>
           {showQuotes ? (
             <ListItemColumn widthType={WidthType.Auto}>
@@ -134,6 +146,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
       handleProviderSelect,
       formatToken,
       formatCurrency,
+      ordersProviders,
     ],
   );
 

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelection.test.tsx.snap
@@ -486,6 +486,20 @@ exports[`ProviderSelection matches snapshot when no quotes are available 1`] = `
                               },
                               "name": "Transak",
                             },
+                            {
+                              "description": "Test provider",
+                              "environmentType": "PRODUCTION",
+                              "hqAddress": "Test Address",
+                              "id": "/providers/stripe",
+                              "links": [],
+                              "logos": {
+                                "dark": "https://example.com/logo-dark.png",
+                                "height": 24,
+                                "light": "https://example.com/logo-light.png",
+                                "width": 90,
+                              },
+                              "name": "Stripe",
+                            },
                           ]
                         }
                         getItem={[Function]}
@@ -639,6 +653,114 @@ exports[`ProviderSelection matches snapshot when no quotes are available 1`] = `
                                   }
                                 }
                               />
+                            </TouchableOpacity>
+                          </View>
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          >
+                            <TouchableOpacity
+                              accessibilityRole="button"
+                              accessible={true}
+                              disabled={false}
+                              onPress={[Function]}
+                              style={
+                                {
+                                  "backgroundColor": "#ffffff",
+                                  "borderRadius": 4,
+                                  "opacity": 1,
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityRole="none"
+                                accessible={true}
+                                style={
+                                  {
+                                    "padding": 16,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 18,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
+                                      }
+                                    >
+                                      Stripe
+                                    </Text>
+                                  </View>
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 16,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "flex-end",
+                                            "display": "flex",
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        style={
+                                          {
+                                            "color": "#686e7d",
+                                            "fontFamily": "Geist-Regular",
+                                            "fontSize": 14,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 22,
+                                          }
+                                        }
+                                      >
+                                        Quote unavailable.
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </TouchableOpacity>
                           </View>
                         </View>
@@ -1142,6 +1264,20 @@ exports[`ProviderSelection matches snapshot when quotes are loading 1`] = `
                               },
                               "name": "Transak",
                             },
+                            {
+                              "description": "Test provider",
+                              "environmentType": "PRODUCTION",
+                              "hqAddress": "Test Address",
+                              "id": "/providers/stripe",
+                              "links": [],
+                              "logos": {
+                                "dark": "https://example.com/logo-dark.png",
+                                "height": 24,
+                                "light": "https://example.com/logo-light.png",
+                                "width": 90,
+                              },
+                              "name": "Stripe",
+                            },
                           ]
                         }
                         getItem={[Function]}
@@ -1341,6 +1477,160 @@ exports[`ProviderSelection matches snapshot when quotes are loading 1`] = `
                                   }
                                 }
                               />
+                            </TouchableOpacity>
+                          </View>
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          >
+                            <TouchableOpacity
+                              accessibilityRole="button"
+                              accessible={true}
+                              disabled={false}
+                              onPress={[Function]}
+                              style={
+                                {
+                                  "backgroundColor": "#ffffff",
+                                  "borderRadius": 4,
+                                  "opacity": 1,
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityRole="none"
+                                accessible={true}
+                                style={
+                                  {
+                                    "padding": 16,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 18,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
+                                      }
+                                    >
+                                      Stripe
+                                    </Text>
+                                  </View>
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 16,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "flex-end",
+                                            "display": "flex",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <View
+                                        style={
+                                          {
+                                            "borderRadius": 4,
+                                            "height": 16,
+                                            "overflow": "hidden",
+                                            "width": 80,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          collapsable={false}
+                                          pointerEvents="none"
+                                          style={
+                                            {
+                                              "backgroundColor": "#686e7d",
+                                              "borderRadius": 4,
+                                              "bottom": 0,
+                                              "left": 0,
+                                              "opacity": 0.2,
+                                              "position": "absolute",
+                                              "right": 0,
+                                              "top": 0,
+                                            }
+                                          }
+                                        />
+                                      </View>
+                                      <View
+                                        style={
+                                          {
+                                            "height": 6,
+                                          }
+                                        }
+                                      />
+                                      <View
+                                        style={
+                                          {
+                                            "borderRadius": 4,
+                                            "height": 16,
+                                            "overflow": "hidden",
+                                            "width": 60,
+                                          }
+                                        }
+                                      >
+                                        <View
+                                          collapsable={false}
+                                          pointerEvents="none"
+                                          style={
+                                            {
+                                              "backgroundColor": "#686e7d",
+                                              "borderRadius": 4,
+                                              "bottom": 0,
+                                              "left": 0,
+                                              "opacity": 0.2,
+                                              "position": "absolute",
+                                              "right": 0,
+                                              "top": 0,
+                                            }
+                                          }
+                                        />
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </TouchableOpacity>
                           </View>
                         </View>
@@ -1915,6 +2205,20 @@ exports[`ProviderSelection matches snapshot when quotes fail to load 1`] = `
                               },
                               "name": "Transak",
                             },
+                            {
+                              "description": "Test provider",
+                              "environmentType": "PRODUCTION",
+                              "hqAddress": "Test Address",
+                              "id": "/providers/stripe",
+                              "links": [],
+                              "logos": {
+                                "dark": "https://example.com/logo-dark.png",
+                                "height": 24,
+                                "light": "https://example.com/logo-light.png",
+                                "width": 90,
+                              },
+                              "name": "Stripe",
+                            },
                           ]
                         }
                         getItem={[Function]}
@@ -2068,6 +2372,114 @@ exports[`ProviderSelection matches snapshot when quotes fail to load 1`] = `
                                   }
                                 }
                               />
+                            </TouchableOpacity>
+                          </View>
+                          <View
+                            onFocusCapture={[Function]}
+                            onLayout={[Function]}
+                            style={null}
+                          >
+                            <TouchableOpacity
+                              accessibilityRole="button"
+                              accessible={true}
+                              disabled={false}
+                              onPress={[Function]}
+                              style={
+                                {
+                                  "backgroundColor": "#ffffff",
+                                  "borderRadius": 4,
+                                  "opacity": 1,
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityRole="none"
+                                accessible={true}
+                                style={
+                                  {
+                                    "padding": 16,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 18,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
+                                      }
+                                    >
+                                      Stripe
+                                    </Text>
+                                  </View>
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 16,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "flex-end",
+                                            "display": "flex",
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        style={
+                                          {
+                                            "color": "#686e7d",
+                                            "fontFamily": "Geist-Regular",
+                                            "fontSize": 14,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 22,
+                                          }
+                                        }
+                                      >
+                                        Quote unavailable.
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </TouchableOpacity>
                           </View>
                         </View>


### PR DESCRIPTION
## Description

This PR adds a "Previously used" tag to the Ramps unified buy v2 provider selection modal. The tag appears below provider names for providers that have been used in completed orders.

The implementation:
- Uses the existing `getOrdersProviders` Redux selector to identify previously used providers
- Displays a `TagColored` component below the provider name with proper spacing
- Only shows the tag for providers that appear in the user's completed order history
- Includes comprehensive test coverage with 3 new test cases

The "Most reliable" tag mentioned in the Figma design is intentionally **not implemented** in this PR and will be added in a future update when API support is available.

## Changelog

### Added
- Added "Previously used" tag to provider list items in Ramps unified buy v2 provider selection modal

## Related issues

Refs: [Add Figma link or JIRA ticket if available]

## Manual testing steps

### Given: User has completed orders with specific providers
1. Open MetaMask Mobile app
2. Navigate to Buy flow (Ramps unified buy v2)
3. Enter an amount and proceed to provider selection
4. **When**: Provider selection modal opens
5. **Then**: Providers that have been used in completed orders display a gray "Previously used" tag below their name

### Given: User has no order history
1. Fresh install or user with no completed orders
2. Navigate to provider selection
3. **When**: Provider selection modal opens
4. **Then**: No "Previously used" tags are displayed

### Given: User has multiple completed orders from different providers
1. Complete orders with Transak and Stripe
2. Navigate to provider selection
3. **When**: Provider selection modal opens
4. **Then**: Both Transak and Stripe show "Previously used" tags

## Screenshots/Recordings

<!-- Required for UI changes - please add before/after screenshots or screen recording -->
_Screenshots to be added_

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors
- [x] I've properly set the pull request status:
  - [ ] In case there's a PR with relevant styling changes, I've opened a PR on [MetaMask/metamask-mobile-storybook](https://github.com/MetaMask/metamask-mobile-storybook) (see [Storybook guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/docs/readme/storybook.md))

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots