### PR TITLE
chore: Add autoSign unit test to validate no call unless using ledger/QR

### DIFF
--- a/app/components/Nav/Main/RootRPCMethodsUI.test.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.test.js
@@ -34,14 +34,18 @@ jest.mock('../../../components/hooks/useAnalytics/useAnalytics', () => ({
   })),
 }));
 
+const mockIsHardwareAccount = jest.fn((_, types) =>
+  types.includes('Ledger Hardware'),
+);
 jest.mock('../../../util/address', () => ({
-  isHardwareAccount: jest.fn((_, types) => types.includes('Ledger Hardware')),
+  isHardwareAccount: (...args) => mockIsHardwareAccount(...args),
 }));
 
+const mockGetDeviceId = jest.fn(() => {
+  throw new Error('KeystoneError#Tx_canceled');
+});
 jest.mock('../../../core/Ledger/Ledger', () => ({
-  getDeviceId: jest.fn(() => {
-    throw new Error('KeystoneError#Tx_canceled');
-  }),
+  getDeviceId: (...args) => mockGetDeviceId(...args),
 }));
 
 jest.mock('../../Approvals/WatchAssetApproval', () => 'WatchAssetApproval');
@@ -71,6 +75,34 @@ describe('RootRPCMethodsUI', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedAutoSign = undefined;
+    mockIsHardwareAccount.mockImplementation((_, types) =>
+      types.includes('Ledger Hardware'),
+    );
+  });
+
+  describe('autoSign', () => {
+    it('does not navigate or open signing when from account is not Ledger or QR', async () => {
+      mockIsHardwareAccount.mockReturnValue(false);
+
+      const mockNavigate = jest.fn();
+      render(<RootRPCMethodsUI navigation={{ navigate: mockNavigate }} />);
+
+      const subscribeCall = controllerMessenger.subscribe.mock.calls[0];
+      const handleUnapprovedTransaction = subscribeCall[1];
+      handleUnapprovedTransaction({
+        id: 'tx-1',
+        txParams: { from: '0xSoftwareWalletAddress' },
+      });
+
+      await capturedAutoSign({
+        id: 'tx-1',
+        txParams: { from: '0xSoftwareWalletAddress' },
+      });
+
+      expect(mockIsHardwareAccount).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockGetDeviceId).not.toHaveBeenCalled();
+    });
   });
 
   it('calls trackEvent for DAPP_TRANSACTION_CANCELLED on keystone cancel', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a unit test for `autoSign` to validate that it does NOT get called unless using Ledger or QR account. This is an action item from the security team - https://docs.google.com/document/d/1yoaOLqVh0_WXxq3dGqi0dVFnMWaK05dhXYxFgvSOQvQ/edit?tab=t.0#heading=h.ngbwex5oz6hk

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-372

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage around `autoSign` early-return behavior; no production logic is modified.
> 
> **Overview**
> Adds a new unit test ensuring `autoSign` **does nothing** (no navigation and no `getDeviceId` call) when the transaction `from` address is not a Ledger/QR hardware account.
> 
> Refactors the existing Jest mocks for `isHardwareAccount` and `getDeviceId` to use reusable mock functions (`mockIsHardwareAccount`, `mockGetDeviceId`) so tests can override behavior and assert invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45715ce02ec8d6bcf6b9a2e183bfcdb818d3f186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->