### PR TITLE
fix: avoid logging full FiatOrder on deposit order failure

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -163,7 +163,7 @@ const OrderDetails = () => {
       } catch (fetchError) {
         Logger.error(fetchError as Error, {
           message: 'FiatOrders::OrderDetails error while processing order',
-          order,
+          orderId: order.id,
         });
         setError((fetchError as Error).message || 'An error as occurred');
       } finally {

--- a/app/components/UI/Ramp/Aggregator/orderProcessor/aggregator.ts
+++ b/app/components/UI/Ramp/Aggregator/orderProcessor/aggregator.ts
@@ -138,6 +138,10 @@ export async function processAggregatorOrder(
     Logger.error(error as Error, {
       message: 'FiatOrders::AggregatorProcessor error while processing order',
       orderId: order.id,
+      provider: order.provider,
+      orderType: order.orderType,
+      state: order.state,
+      network: order.network,
     });
     return order as FiatOrder;
   }

--- a/app/components/UI/Ramp/Aggregator/orderProcessor/aggregator.ts
+++ b/app/components/UI/Ramp/Aggregator/orderProcessor/aggregator.ts
@@ -137,7 +137,7 @@ export async function processAggregatorOrder(
   } catch (error) {
     Logger.error(error as Error, {
       message: 'FiatOrders::AggregatorProcessor error while processing order',
-      order,
+      orderId: order.id,
     });
     return order as FiatOrder;
   }

--- a/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/DepositOrderDetails.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/DepositOrderDetails.tsx
@@ -88,7 +88,7 @@ const DepositOrderDetails = () => {
         Logger.error(fetchError as Error, {
           message:
             'FiatOrders::DepositOrderDetails error while processing order',
-          order,
+          orderId: order.id,
         });
         setError(
           fetchError instanceof Error && fetchError.message

--- a/app/components/UI/Ramp/Deposit/orderProcessor/index.ts
+++ b/app/components/UI/Ramp/Deposit/orderProcessor/index.ts
@@ -96,7 +96,7 @@ export async function processDepositOrder(
   } catch (error) {
     Logger.error(error as Error, {
       message: 'DepositOrder::Processor error while processing order',
-      order,
+      orderId: order.id,
     });
     return order;
   }

--- a/app/components/UI/Ramp/Deposit/orderProcessor/index.ts
+++ b/app/components/UI/Ramp/Deposit/orderProcessor/index.ts
@@ -97,6 +97,10 @@ export async function processDepositOrder(
     Logger.error(error as Error, {
       message: 'DepositOrder::Processor error while processing order',
       orderId: order.id,
+      provider: order.provider,
+      orderType: order.orderType,
+      state: order.state,
+      network: order.network,
     });
     return order;
   }

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -121,6 +121,9 @@ const OrderDetails = () => {
     } catch (fetchError) {
       Logger.error(fetchError as Error, {
         message: 'FiatOrders::RampsOrderDetails error while refreshing order',
+        orderId: order.providerOrderId,
+        provider: order.provider?.id,
+        status: order.status,
       });
       setError(
         fetchError instanceof Error && fetchError.message

--- a/app/components/UI/Ramp/orderProcessor/index.test.ts
+++ b/app/components/UI/Ramp/orderProcessor/index.test.ts
@@ -111,7 +111,7 @@ describe('processOrder', () => {
     );
     expect(Logger.error).toHaveBeenCalledWith(
       new Error('FiatOrders::ProcessOrder unrecognized provider'),
-      unsupportedProviderOrder,
+      { orderId: unsupportedProviderOrder.id },
     );
   });
 

--- a/app/components/UI/Ramp/orderProcessor/index.test.ts
+++ b/app/components/UI/Ramp/orderProcessor/index.test.ts
@@ -111,7 +111,13 @@ describe('processOrder', () => {
     );
     expect(Logger.error).toHaveBeenCalledWith(
       new Error('FiatOrders::ProcessOrder unrecognized provider'),
-      { orderId: unsupportedProviderOrder.id },
+      {
+        orderId: unsupportedProviderOrder.id,
+        provider: unsupportedProviderOrder.provider,
+        orderType: unsupportedProviderOrder.orderType,
+        state: unsupportedProviderOrder.state,
+        network: unsupportedProviderOrder.network,
+      },
     );
   });
 

--- a/app/components/UI/Ramp/orderProcessor/index.ts
+++ b/app/components/UI/Ramp/orderProcessor/index.ts
@@ -29,7 +29,7 @@ function processOrder(
       const unrecognizedProviderError = new Error(
         'FiatOrders::ProcessOrder unrecognized provider',
       );
-      Logger.error(unrecognizedProviderError, order);
+      Logger.error(unrecognizedProviderError, { orderId: order.id });
       return order;
     }
   }

--- a/app/components/UI/Ramp/orderProcessor/index.ts
+++ b/app/components/UI/Ramp/orderProcessor/index.ts
@@ -29,7 +29,13 @@ function processOrder(
       const unrecognizedProviderError = new Error(
         'FiatOrders::ProcessOrder unrecognized provider',
       );
-      Logger.error(unrecognizedProviderError, { orderId: order.id });
+      Logger.error(unrecognizedProviderError, {
+        orderId: order.id,
+        provider: order.provider,
+        orderType: order.orderType,
+        state: order.state,
+        network: order.network,
+      });
       return order;
     }
   }


### PR DESCRIPTION
## **Description**

When a deposit order fails to process, the catch block in `processDepositOrder` was logging the full `FiatOrder` object to Sentry via `Logger.error`. This object can contain sensitive payment details (e.g. `paymentDetails`).

This fix replaces `order` with `order.id` in the log context so only the order identifier is sent to Sentry, not the full order payload.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/TRAM/boards/1568?assignee=712020%3Aff625c85-a003-41f4-9b73-e2af164f8214&selectedIssue=TRAM-3260

https://github.com/MetaMask/pm-security/issues/583

## **Manual testing steps**

\`\`\`gherkin
Feature: Deposit order error logging

  Scenario: user triggers a deposit order processing failure
    Given the user has an in-progress deposit order
    When the SDK call to fetch the order fails
    Then the error is logged to Sentry with only the order ID
    And no sensitive paymentDetails are included in the log
\`\`\`

## **Screenshots/Recordings**

### **Before**

Logger.error sends the full FiatOrder object (including paymentDetails) to Sentry.

### **After**

Logger.error sends only `{ message, orderId }` to Sentry.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust `Logger.error` context fields and update a unit test, with no impact to order processing or UI behavior.
> 
> **Overview**
> Redacts potentially sensitive `FiatOrder` data from Sentry logs by **replacing full `order` objects with minimal metadata** (e.g., `orderId`, `provider`, `orderType`, `state`, `network`) in multiple ramp order processing and order-details error paths.
> 
> Updates the `processOrder` unit test to assert the new structured logging payload for unsupported providers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f138be7a81d22b35af0f7a15e1b3325298b12a43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->