### PR TITLE
ci: fix setup-e2e-env tag in mobile workflows

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Setup Android Build Environment
         timeout-minutes: 15
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1.7
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: android
           setup-simulator: false

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -100,7 +100,7 @@ jobs:
       # Install Node.js, Xcode tools, and other iOS development dependencies
       - name: Installing iOS Environment Setup
         timeout-minutes: 15
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1.7
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: ios
           setup-simulator: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Installing iOS Environment Setup
         if: matrix.platform == 'ios'
         timeout-minutes: 15
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1.7
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: ios
           configure-keystores: false

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup iOS Environment
         timeout-minutes: 15
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1.7
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: ios
           setup-simulator: false

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Set up E2E environment
         timeout-minutes: 15
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1.7
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@v1
         with:
           platform: ${{ inputs.platform }}
           setup-simulator: ${{ inputs.platform == 'ios' }}


### PR DESCRIPTION
## **Description**

Fixes mobile CI build failures caused by invalid action tag references in workflow files.

Several workflows were using `MetaMask/github-tools/.github/actions/setup-e2e-env@v1.7`, but `v1.7` does not exist in `MetaMask/github-tools` (valid refs include `v1` and `v1.7.0`).  
This PR updates those references to `@v1` to restore build job setup resolution.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: CI workflow setup action reference

  Scenario: Build jobs resolve setup-e2e-env action
    Given workflow files reference setup-e2e-env@v1
    When CI runs Build Android E2E APKs and Build iOS E2E Apps jobs
    Then job setup resolves the action successfully
    And CI no longer fails with "unable to find version v1.7"