### PR TITLE
refactor(predict): gate sports data pipeline by category in getMarkets

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -297,7 +297,7 @@ describe('PolymarketProvider', () => {
 
     const markets = await createProvider({
       liveSportsLeagues: ['nfl'],
-    }).getMarkets();
+    }).getMarkets({ category: 'sports' });
     expect(Array.isArray(markets)).toBe(true);
     expect(markets.length).toBeGreaterThan(0);
     expect(markets.length).toBe(2);
@@ -312,7 +312,7 @@ describe('PolymarketProvider', () => {
 
     const result = await createProvider({
       liveSportsLeagues: ['nfl'],
-    }).getMarkets();
+    }).getMarkets({ category: 'sports' });
 
     expect(result).toEqual([]);
     expect(mockGetMarketsFromPolymarketApi).toHaveBeenCalledWith(
@@ -6674,7 +6674,7 @@ describe('PolymarketProvider', () => {
         ];
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
 
-        await provider.getMarkets();
+        await provider.getMarkets({ category: 'sports' });
 
         expect(mockGameCacheInstance.overlayOnMarkets).toHaveBeenCalledWith(
           mockMarkets,
@@ -6694,7 +6694,7 @@ describe('PolymarketProvider', () => {
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
         mockGameCacheInstance.overlayOnMarkets.mockReturnValue(overlaidMarkets);
 
-        const result = await provider.getMarkets();
+        const result = await provider.getMarkets({ category: 'sports' });
 
         expect(result).toEqual(overlaidMarkets);
       });
@@ -6705,7 +6705,7 @@ describe('PolymarketProvider', () => {
           new Error('API error'),
         );
 
-        const result = await provider.getMarkets();
+        const result = await provider.getMarkets({ category: 'sports' });
 
         expect(result).toEqual([]);
         expect(mockGameCacheInstance.overlayOnMarkets).not.toHaveBeenCalled();
@@ -6932,6 +6932,23 @@ describe('PolymarketProvider', () => {
         expect(
           mockTeamsCacheInstance.ensureLeaguesLoaded,
         ).not.toHaveBeenCalled();
+      });
+
+      it('skips sports pipeline when category is not sports even if leagues are configured', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        const mockMarkets = [{ id: 'market-1', title: 'Test Market' }];
+        mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
+
+        const result = await provider.getMarkets({ category: 'trending' });
+
+        expect(
+          mockTeamsCacheInstance.ensureLeaguesLoaded,
+        ).not.toHaveBeenCalled();
+        expect(mockGameCacheInstance.overlayOnMarkets).not.toHaveBeenCalled();
+        expect(mockGetMarketsFromPolymarketApi).toHaveBeenCalledWith(
+          expect.objectContaining({ teamLookup: undefined }),
+        );
+        expect(result).toEqual(mockMarkets);
       });
     });
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -304,8 +304,10 @@ export class PolymarketProvider implements PredictProvider {
 
   public async getMarkets(params?: GetMarketsParams): Promise<PredictMarket[]> {
     try {
+      const isSportsCategory = params?.category === 'sports';
       const { liveSportsLeagues } = this.#getFeatureFlags();
-      const liveSportsEnabled = liveSportsLeagues.length > 0;
+      const liveSportsEnabled =
+        isSportsCategory && liveSportsLeagues.length > 0;
 
       if (liveSportsEnabled) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -700,7 +700,6 @@ export const parsePolymarketEvents = (
   const parsedMarkets: PredictMarket[] = events.map(
     (event: PolymarketApiEvent) => {
       const tags = Array.isArray(event.tags) ? event.tags : [];
-      const eventLeague = getEventLeague(event);
 
       const markets = sortMarkets(event, sortBy).filter(
         (market: PolymarketApiMarket) => market?.active !== false,
@@ -712,6 +711,8 @@ export const parsePolymarketEvents = (
             return apiTeam ? mapApiTeamToPredictTeam(apiTeam) : undefined;
           }
         : undefined;
+
+      const eventLeague = predictTeamLookup ? getEventLeague(event) : null;
 
       const game =
         eventLeague && predictTeamLookup


### PR DESCRIPTION
## Summary
- Gates `TeamsCache.ensureLeaguesLoaded()`, `teamLookup`, and `GameCache.overlayOnMarkets()` in `PolymarketProvider.getMarkets()` to only activate when `category === 'sports'`
- Skips `getEventLeague()` tag/slug checking in `parsePolymarketEvents` when `teamLookup` is absent
- Non-sports tabs (trending, crypto, politics, etc.) no longer trigger sports API calls or game data processing

## Test plan
- [x] Updated existing tests that use `liveSportsLeagues: ['nfl']` to pass `{ category: 'sports' }` to `.getMarkets()`
- [x] Added new test verifying non-sports categories skip the sports pipeline even when leagues are configured
- [x] All 399 PolymarketProvider tests pass
- [x] All 328 utils tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `PolymarketProvider.getMarkets` behavior so sports team/game enrichment only runs when `params.category === 'sports'`, which could alter results/caching for callers that omit or mis-set the category. Scope is limited and covered by updated/added unit tests.
> 
> **Overview**
> Non-sports `getMarkets` calls no longer trigger the live-sports pipeline: `TeamsCache.ensureLeaguesLoaded`, `teamLookup` injection, and `GameCache.overlayOnMarkets` are now **gated on** `params.category === 'sports'` (in addition to `liveSportsLeagues` being configured).
> 
> `parsePolymarketEvents` now skips `getEventLeague()`/game-data construction work when `teamLookup` is absent, reducing unnecessary sports parsing on non-sports categories. Tests were updated to pass `{ category: 'sports' }` where needed and a new case asserts non-sports categories bypass the sports pipeline even when leagues are configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc5659771d3943118ff03751c4037db466b73a1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->