### PR TITLE
refactor(predict): defer sports detection to after event fetch in getMarketDetails

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -2557,6 +2557,24 @@ describe('PolymarketProvider', () => {
         provider.getMarketDetails({ marketId: 'market-1' }),
       ).rejects.toThrow('Failed to parse market details');
     });
+
+    it('does not load TeamsCache when detected league is not in enabled leagues list', async () => {
+      mockTeamsCacheInstance.ensureLeaguesLoaded.mockClear();
+      const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+      mockGetEventLeague.mockReturnValue('nba');
+      mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
+      mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+      await provider.getMarketDetails({ marketId: 'market-1' });
+
+      expect(mockTeamsCacheInstance.ensureLeaguesLoaded).not.toHaveBeenCalled();
+      expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+        [mockEvent],
+        expect.objectContaining({
+          teamLookup: undefined,
+        }),
+      );
+    });
   });
 
   describe('getMarketsByIds', () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -41,6 +41,7 @@ import {
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import type { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -181,6 +182,11 @@ jest.mock('./WebSocketManager', () => ({
   },
 }));
 
+jest.mock('../../utils/gameParser', () => ({
+  ...jest.requireActual('../../utils/gameParser'),
+  getEventLeague: jest.fn(),
+}));
+
 jest.mock('../../../../../util/transactions', () => ({
   generateTransferData: jest.fn(),
   isSmartContractAddress: jest.fn(),
@@ -215,6 +221,7 @@ const mockHasAllowances = hasAllowances as jest.Mock;
 const mockQuery = query as jest.Mock;
 const mockPreviewOrder = previewOrder as jest.Mock;
 const mockGetBalance = getBalance as jest.Mock;
+const mockGetEventLeague = getEventLeague as jest.Mock;
 
 describe('PolymarketProvider', () => {
   const defaultFeatureFlags: PredictFeatureFlags = {
@@ -2486,6 +2493,7 @@ describe('PolymarketProvider', () => {
 
     it('get market details successfully', async () => {
       const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+      mockGetEventLeague.mockReturnValue('nfl');
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
@@ -6713,8 +6721,9 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarketDetails', () => {
-      it('applies GameCache overlay to fetched market details when live sports are enabled', async () => {
+      it('applies GameCache overlay to fetched market details when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = {
           id: 'market-1',
@@ -6731,8 +6740,9 @@ describe('PolymarketProvider', () => {
         );
       });
 
-      it('returns market with cached game data overlay applied when live sports are enabled', async () => {
+      it('returns market with cached game data overlay applied when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = { id: 'market-1', title: 'Test Market' };
         const overlaidMarket = {
@@ -6749,6 +6759,25 @@ describe('PolymarketProvider', () => {
         });
 
         expect(result).toEqual(overlaidMarket);
+      });
+
+      it('skips GameCache overlay when event is not a sports event despite leagues being enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue(null);
+        const mockEvent = { id: 'market-1', question: 'Will BTC hit 100k?' };
+        const parsedMarket = { id: 'market-1', title: 'Will BTC hit 100k?' };
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
+        mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
+
+        const result = await provider.getMarketDetails({
+          marketId: 'market-1',
+        });
+
+        expect(mockGameCacheInstance.overlayOnMarket).not.toHaveBeenCalled();
+        expect(
+          mockTeamsCacheInstance.ensureLeaguesLoaded,
+        ).not.toHaveBeenCalled();
+        expect(result).toEqual(parsedMarket);
       });
 
       it('throws error when parsing fails without calling GameCache overlay', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -102,6 +102,7 @@ import {
   submitClobOrder,
 } from './utils';
 import { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { GameCache } from './GameCache';
 import { TeamsCache } from './TeamsCache';
 import { WebSocketManager } from './WebSocketManager';
@@ -193,20 +194,22 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     try {
-      const { liveSportsLeagues } = this.#getFeatureFlags();
       const event = await getMarketDetailsFromGammaApi({
         marketId,
       });
 
-      const liveSportsEnabled = liveSportsLeagues.length > 0;
+      const { liveSportsLeagues } = this.#getFeatureFlags();
+      const eventLeague = getEventLeague(event);
+      const isSportsEvent =
+        eventLeague !== null && liveSportsLeagues.length > 0;
 
-      if (liveSportsEnabled) {
+      if (isSportsEvent) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(
           liveSportsLeagues as typeof SUPPORTED_SPORTS_LEAGUES,
         );
       }
 
-      const teamLookup = liveSportsEnabled
+      const teamLookup = isSportsEvent
         ? (
             league: (typeof SUPPORTED_SPORTS_LEAGUES)[number],
             abbreviation: string,
@@ -222,7 +225,7 @@ export class PolymarketProvider implements PredictProvider {
         throw new Error('Failed to parse market details');
       }
 
-      return liveSportsEnabled
+      return isSportsEvent
         ? GameCache.getInstance().overlayOnMarket(parsedMarket)
         : parsedMarket;
     } catch (error) {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -201,7 +201,7 @@ export class PolymarketProvider implements PredictProvider {
       const { liveSportsLeagues } = this.#getFeatureFlags();
       const eventLeague = getEventLeague(event);
       const isSportsEvent =
-        eventLeague !== null && liveSportsLeagues.length > 0;
+        eventLeague !== null && liveSportsLeagues.includes(eventLeague);
 
       if (isSportsEvent) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(


### PR DESCRIPTION
## Summary
- Reorders `getMarketDetails()` to fetch the event from API first, then inspect it with `getEventLeague()` to determine if it's a sports event
- Only loads `TeamsCache` and applies `GameCache` overlay for actual sports events
- Non-sports market details (and non-sports highlighted markets via `getMarketsByIds`) skip the sports pipeline entirely

## Test plan
- [x] Updated existing tests to mock `getEventLeague` for sports event detection
- [x] Added new test verifying non-sports events skip TeamsCache and GameCache even when leagues are configured
- [x] All 399 PolymarketProvider tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when `TeamsCache` loading and `GameCache` overlays occur; incorrect `getEventLeague` detection could cause sports markets to miss team parsing/overlays or change output shape.
> 
> **Overview**
> Polymarket `getMarketDetails` now fetches the event first, then uses `getEventLeague(event)` to decide if it’s a sports event **and** in the enabled `liveSportsLeagues` list before loading `TeamsCache`, providing `teamLookup`, and applying the `GameCache` overlay.
> 
> Tests were updated to mock `getEventLeague` and expanded to assert that non-sports (or non-enabled-league) events skip `TeamsCache` loading and `GameCache` overlay even when sports leagues are configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42a873723efabfcb874c54fed61a82641be4963f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->