### PR TITLE
feat: enhance PerpsSection to display watchlist markets with favorite badges

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -91,23 +91,26 @@ jest.mock('./hooks/useHomepageSparklines', () => ({
 }));
 
 jest.mock('./components/PerpsMarketTileCard', () => {
-  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  const { TouchableOpacity, Text, View } = jest.requireActual('react-native');
   return {
     __esModule: true,
     default: ({
       market,
       testID,
       onPress,
+      showFavoriteTag,
     }: {
       market: { symbol: string };
       testID?: string;
       onPress?: (m: { symbol: string }) => void;
+      showFavoriteTag?: boolean;
     }) => (
       <TouchableOpacity
         testID={testID ?? `perps-market-tile-${market.symbol}`}
         onPress={() => onPress?.(market)}
       >
         <Text>{market.symbol}</Text>
+        {showFavoriteTag && <View testID={`favorite-badge-${market.symbol}`} />}
       </TouchableOpacity>
     ),
   };
@@ -684,6 +687,208 @@ describe('PerpsSection', () => {
       expect(
         screen.queryByTestId('homepage-trending-perps-carousel'),
       ).toBeNull();
+    });
+  });
+
+  describe('Watchlist Markets in Carousel', () => {
+    const makeTrendingMarket = (overrides: Record<string, unknown> = {}) => ({
+      symbol: 'BTC',
+      name: 'Bitcoin',
+      maxLeverage: '50x',
+      price: '$52,000',
+      change24h: '+$2,000',
+      change24hPercent: '+4.00%',
+      volume: '$2.5B',
+      volumeNumber: 2500000000,
+      ...overrides,
+    });
+
+    const watchlistState = (symbols: string[]) => ({
+      engine: {
+        backgroundState: {
+          PerpsController: {
+            watchlistMarkets: { mainnet: symbols, testnet: [] },
+          },
+        },
+      },
+    });
+
+    it('shows watchlist market first in carousel with favorite badge', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+          makeTrendingMarket({ symbol: 'ETH', volumeNumber: 3000000000 }),
+          makeTrendingMarket({ symbol: 'SOL', volumeNumber: 1000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState(['SOL']),
+      });
+
+      expect(
+        screen.getByTestId('homepage-trending-perps-carousel'),
+      ).toBeOnTheScreen();
+
+      const allTiles = screen.getAllByTestId(/^perps-market-tile-/);
+      expect(allTiles[0].props.testID).toBe('perps-market-tile-SOL');
+
+      expect(screen.getByTestId('favorite-badge-SOL')).toBeOnTheScreen();
+      expect(screen.queryByTestId('favorite-badge-BTC')).toBeNull();
+      expect(screen.queryByTestId('favorite-badge-ETH')).toBeNull();
+    });
+
+    it('shows multiple watchlist markets before trending markets', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+          makeTrendingMarket({ symbol: 'ETH', volumeNumber: 3000000000 }),
+          makeTrendingMarket({ symbol: 'SOL', volumeNumber: 1000000000 }),
+          makeTrendingMarket({ symbol: 'DOGE', volumeNumber: 500000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState(['SOL', 'DOGE']),
+      });
+
+      const allTiles = screen.getAllByTestId(/^perps-market-tile-/);
+      const symbols = allTiles.map((t) =>
+        t.props.testID.replace('perps-market-tile-', ''),
+      );
+
+      expect(symbols.indexOf('SOL')).toBeLessThan(symbols.indexOf('BTC'));
+      expect(symbols.indexOf('DOGE')).toBeLessThan(symbols.indexOf('BTC'));
+
+      expect(screen.getByTestId('favorite-badge-SOL')).toBeOnTheScreen();
+      expect(screen.getByTestId('favorite-badge-DOGE')).toBeOnTheScreen();
+    });
+
+    it('excludes watchlist markets from trending to avoid duplicates', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+          makeTrendingMarket({ symbol: 'ETH', volumeNumber: 3000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState(['BTC']),
+      });
+
+      const allTiles = screen.getAllByTestId(/^perps-market-tile-/);
+      const symbols = allTiles.map((t) =>
+        t.props.testID.replace('perps-market-tile-', ''),
+      );
+
+      const btcOccurrences = symbols.filter((s) => s === 'BTC').length;
+      expect(btcOccurrences).toBe(1);
+    });
+
+    it('respects max 5 total tiles including watchlist', () => {
+      const markets = Array.from({ length: 8 }, (_, i) =>
+        makeTrendingMarket({
+          symbol: `MKT${i}`,
+          volumeNumber: 10000000 - i * 1000000,
+        }),
+      );
+      usePerpsMarkets.mockReturnValue({
+        markets,
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState(['MKT5', 'MKT6']),
+      });
+
+      const allTiles = screen.getAllByTestId(/^perps-market-tile-/);
+      expect(allTiles).toHaveLength(5);
+
+      expect(screen.getByText('MKT5')).toBeOnTheScreen();
+      expect(screen.getByText('MKT6')).toBeOnTheScreen();
+    });
+
+    it('renders only trending when watchlist is empty', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+          makeTrendingMarket({ symbol: 'ETH', volumeNumber: 3000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState([]),
+      });
+
+      expect(screen.getByText('BTC')).toBeOnTheScreen();
+      expect(screen.getByText('ETH')).toBeOnTheScreen();
+      expect(screen.queryByTestId('favorite-badge-BTC')).toBeNull();
+      expect(screen.queryByTestId('favorite-badge-ETH')).toBeNull();
+    });
+
+    it('shows only watchlist tiles when watchlist exceeds max carousel size', () => {
+      const markets = Array.from({ length: 7 }, (_, i) =>
+        makeTrendingMarket({
+          symbol: `MKT${i}`,
+          volumeNumber: 10000000 - i * 1000000,
+        }),
+      );
+      usePerpsMarkets.mockReturnValue({
+        markets,
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState(['MKT0', 'MKT1', 'MKT2', 'MKT3', 'MKT4', 'MKT5']),
+      });
+
+      const allTiles = screen.getAllByTestId(/^perps-market-tile-/);
+      expect(allTiles).toHaveLength(6);
+
+      expect(screen.queryByTestId('favorite-badge-MKT6')).toBeNull();
+      expect(screen.queryByText('MKT6')).toBeNull();
+    });
+
+    it('ignores watchlist symbols not present in market data', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(<PerpsSection />, {
+        state: watchlistState(['NONEXISTENT']),
+      });
+
+      expect(screen.getByText('BTC')).toBeOnTheScreen();
+      expect(screen.queryByTestId('favorite-badge-BTC')).toBeNull();
+      expect(screen.queryByTestId('favorite-badge-NONEXISTENT')).toBeNull();
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -845,7 +845,7 @@ describe('PerpsSection', () => {
       expect(screen.queryByTestId('favorite-badge-ETH')).toBeNull();
     });
 
-    it('shows only watchlist tiles when watchlist exceeds max carousel size', () => {
+    it('caps at 5 tiles even when watchlist exceeds max carousel size', () => {
       const markets = Array.from({ length: 7 }, (_, i) =>
         makeTrendingMarket({
           symbol: `MKT${i}`,
@@ -865,10 +865,12 @@ describe('PerpsSection', () => {
       });
 
       const allTiles = screen.getAllByTestId(/^perps-market-tile-/);
-      expect(allTiles).toHaveLength(6);
+      expect(allTiles).toHaveLength(5);
 
       expect(screen.queryByTestId('favorite-badge-MKT6')).toBeNull();
       expect(screen.queryByText('MKT6')).toBeNull();
+      // MKT5 is the 6th watchlist item, truncated by the cap
+      expect(screen.queryByText('MKT5')).toBeNull();
     });
 
     it('ignores watchlist symbols not present in market data', () => {

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -10,6 +10,7 @@ import { ScrollView } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
+import { useSelector } from 'react-redux';
 import {
   type PerpsMarketData,
   type Position,
@@ -24,6 +25,7 @@ import {
   usePerpsMarkets,
 } from '../../../../UI/Perps/hooks';
 import { filterAndSortMarkets } from '../../../../UI/Perps/utils/filterAndSortMarkets';
+import { selectPerpsWatchlistMarkets } from '../../../../UI/Perps/selectors/perpsController';
 import type { PerpsNavigationParamList } from '../../../../UI/Perps/types/navigation';
 import PerpsPositionCard from '../../../../UI/Perps/components/PerpsPositionCard/PerpsPositionCard';
 import PerpsCard from '../../../../UI/Perps/components/PerpsCard';
@@ -106,6 +108,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const tpSlReady = anyPositionHasTpSl || tpSlSettled;
 
   const { markets, isLoading: marketsLoading } = usePerpsMarkets();
+  const watchlistSymbols = useSelector(selectPerpsWatchlistMarkets);
 
   const displayPositions = useMemo(
     () => positions.slice(0, MAX_ITEMS),
@@ -123,25 +126,45 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   // When user has no positions/orders, keep skeleton visible until markets
   // load so the section doesn't flash empty while trending tiles are fetched.
   const pendingTrending = !showSkeleton && !hasItems && marketsLoading;
-  const showTrending = !showSkeleton && !hasItems && !marketsLoading;
 
-  const trendingMarkets = useMemo(
-    () =>
-      showTrending && markets.length > 0
-        ? filterAndSortMarkets({
-            marketData: markets,
-            showZeroVolume: false,
-          }).slice(0, MAX_TRENDING_MARKETS)
-        : [],
-    [showTrending, markets],
+  const safeWatchlistSymbols = useMemo(
+    () => watchlistSymbols ?? [],
+    [watchlistSymbols],
   );
 
-  const trendingSymbols = useMemo(
-    () => trendingMarkets.map((m) => m.symbol),
-    [trendingMarkets],
+  const watchlistMarkets = useMemo(() => {
+    if (markets.length === 0 || safeWatchlistSymbols.length === 0) return [];
+    const symbolSet = new Set(safeWatchlistSymbols);
+    return markets.filter((m) => symbolSet.has(m.symbol));
+  }, [markets, safeWatchlistSymbols]);
+
+  const trendingMarkets = useMemo(() => {
+    if (markets.length === 0) return [];
+    const wlSet = new Set(watchlistMarkets.map((m) => m.symbol));
+    return filterAndSortMarkets({
+      marketData: markets,
+      showZeroVolume: false,
+    })
+      .filter((m) => !wlSet.has(m.symbol))
+      .slice(0, Math.max(0, MAX_TRENDING_MARKETS - watchlistMarkets.length));
+  }, [markets, watchlistMarkets]);
+
+  const allCarouselMarkets = useMemo(
+    () => [...watchlistMarkets, ...trendingMarkets],
+    [watchlistMarkets, trendingMarkets],
+  );
+
+  const watchlistSymbolSet = useMemo(
+    () => new Set(watchlistMarkets.map((m) => m.symbol)),
+    [watchlistMarkets],
+  );
+
+  const carouselSymbols = useMemo(
+    () => allCarouselMarkets.map((m) => m.symbol),
+    [allCarouselMarkets],
   );
   const { sparklines, refresh: refreshSparklines } =
-    useHomepageSparklines(trendingSymbols);
+    useHomepageSparklines(carouselSymbols);
 
   useImperativeHandle(
     ref,
@@ -219,7 +242,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
             ))}
           </Box>
         </SectionRow>
-      ) : trendingMarkets.length > 0 ? (
+      ) : allCarouselMarkets.length > 0 ? (
         <FadingScrollContainer>
           {(scrollProps) => (
             <ScrollView
@@ -229,11 +252,12 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
               testID="homepage-trending-perps-carousel"
               {...scrollProps}
             >
-              {trendingMarkets.map((market) => (
+              {allCarouselMarkets.map((market) => (
                 <PerpsMarketTileCard
                   key={market.symbol}
                   market={market}
                   sparklineData={sparklines[market.symbol]}
+                  showFavoriteTag={watchlistSymbolSet.has(market.symbol)}
                   onPress={handleTilePress}
                 />
               ))}

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -15,6 +15,7 @@ import {
   type PerpsMarketData,
   type Position,
 } from '@metamask/perps-controller';
+import type { PerpsMarketDataWithVolumeNumber } from '../../../../UI/Perps/hooks/usePerpsMarkets';
 import SectionTitle from '../../components/SectionTitle';
 import SectionRow from '../../components/SectionRow';
 import FadingScrollContainer from '../../components/FadingScrollContainer';
@@ -126,6 +127,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   // When user has no positions/orders, keep skeleton visible until markets
   // load so the section doesn't flash empty while trending tiles are fetched.
   const pendingTrending = !showSkeleton && !hasItems && marketsLoading;
+  const showTrending = !showSkeleton && !hasItems && !marketsLoading;
 
   const safeWatchlistSymbols = useMemo(
     () => watchlistSymbols ?? [],
@@ -134,8 +136,10 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   const watchlistMarkets = useMemo(() => {
     if (markets.length === 0 || safeWatchlistSymbols.length === 0) return [];
-    const symbolSet = new Set(safeWatchlistSymbols);
-    return markets.filter((m) => symbolSet.has(m.symbol));
+    const marketBySymbol = new Map(markets.map((m) => [m.symbol, m]));
+    return safeWatchlistSymbols
+      .map((sym) => marketBySymbol.get(sym))
+      .filter((m): m is PerpsMarketDataWithVolumeNumber => m != null);
   }, [markets, safeWatchlistSymbols]);
 
   const trendingMarkets = useMemo(() => {
@@ -160,8 +164,8 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   );
 
   const carouselSymbols = useMemo(
-    () => allCarouselMarkets.map((m) => m.symbol),
-    [allCarouselMarkets],
+    () => (showTrending ? allCarouselMarkets.map((m) => m.symbol) : []),
+    [showTrending, allCarouselMarkets],
   );
   const { sparklines, refresh: refreshSparklines } =
     useHomepageSparklines(carouselSymbols);

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -154,7 +154,8 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   }, [markets, watchlistMarkets]);
 
   const allCarouselMarkets = useMemo(
-    () => [...watchlistMarkets, ...trendingMarkets],
+    () =>
+      [...watchlistMarkets, ...trendingMarkets].slice(0, MAX_TRENDING_MARKETS),
     [watchlistMarkets, trendingMarkets],
   );
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
@@ -36,6 +36,17 @@ const styleSheet = (params: {
       alignItems: 'center',
       gap: 6,
     },
+    tokenLogoWrapper: {
+      position: 'relative' as const,
+    },
+    favoriteBadge: {
+      position: 'absolute' as const,
+      top: -6,
+      right: -6,
+      backgroundColor: theme.colors.background.alternative,
+      borderRadius: 12,
+      padding: 3,
+    },
     sparklineContainer: {
       marginTop: 'auto' as const,
     },

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
@@ -5,6 +5,10 @@ import {
   TextColor,
   TextVariant,
   FontWeight,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import {
@@ -41,6 +45,7 @@ const TileCardInner: React.FC<
   cardWidth = DEFAULT_CARD_WIDTH,
   cardHeight = DEFAULT_CARD_HEIGHT,
   livePrices,
+  showFavoriteTag = false,
   testID = 'perps-market-tile-card',
 }) => {
   const { styles, theme } = useStyles(styleSheet, { cardWidth, cardHeight });
@@ -135,11 +140,22 @@ const TileCardInner: React.FC<
             </Text>
           </View>
 
-          <PerpsTokenLogo
-            symbol={market.symbol}
-            size={TOKEN_LOGO_SIZE}
-            recyclingKey={market.symbol}
-          />
+          <View style={styles.tokenLogoWrapper}>
+            <PerpsTokenLogo
+              symbol={market.symbol}
+              size={TOKEN_LOGO_SIZE}
+              recyclingKey={market.symbol}
+            />
+            {showFavoriteTag && (
+              <View style={styles.favoriteBadge}>
+                <Icon
+                  name={IconName.StarFilled}
+                  size={IconSize.Sm}
+                  color={IconColor.IconAlternative}
+                />
+              </View>
+            )}
+          </View>
         </View>
       </View>
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
@@ -147,7 +147,10 @@ const TileCardInner: React.FC<
               recyclingKey={market.symbol}
             />
             {showFavoriteTag && (
-              <View style={styles.favoriteBadge}>
+              <View
+                style={styles.favoriteBadge}
+                testID={`favorite-badge-${market.symbol}`}
+              >
                 <Icon
                   name={IconName.StarFilled}
                   size={IconSize.Sm}

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.types.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.types.ts
@@ -13,6 +13,8 @@ export interface PerpsMarketTileCardProps {
   cardHeight?: number;
   /** Skip live price WebSocket subscription (use static market data instead) */
   disableLivePrices?: boolean;
+  /** Show a "Favorite" tag */
+  showFavoriteTag?: boolean;
   /** Test ID for E2E testing */
   testID?: string;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When the user has no active perps positions or orders, the homepage Perpetuals carousel now prioritizes watchlist tokens - they appear first in the trending perps carousel with a star badge on the token logo. Remaining slots are filled with trending markets (excluding watchlist duplicates), respecting the existing 5-tile cap.

**Changes:**

- PerpsSection reads watchlist symbols from Redux (selectPerpsWatchlistMarkets) and computes watchlistMarkets + trendingMarkets separately, concatenating watchlist-first into allCarouselMarkets
- PerpsMarketTileCard accepts a new showFavoriteTag prop that renders a filled star icon badge in the top-right corner of the token logo
- New styles (tokenLogoWrapper, favoriteBadge) added to the tile card stylesheet
- 6 new unit tests covering watchlist ordering, deduplication, max tile count, empty watchlist, and non-existent symbols

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added watchlist tokens to the top of the Perpetuals trending carousel on the homepage with a star badge indicator

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-505

## **Manual testing steps**

```gherkin
Feature: Watchlist tokens in homepage Perps carousel

  Scenario: user sees watchlist tokens first in trending carousel
    Given user has no active perps positions or orders
    And user has added SOL to their perps watchlist

    When user views the homepage Perpetuals section
    Then SOL appears as the first tile in the carousel
    And SOL tile displays a star badge on the top-right of the token logo
    And remaining tiles show trending markets without duplicate SOL

  Scenario: user sees only trending when watchlist is empty
    Given user has no active perps positions or orders
    And user has no tokens in their perps watchlist

    When user views the homepage Perpetuals section
    Then the carousel shows trending markets sorted by volume
    And no tiles display a star badge

  Scenario: carousel respects max 5 tiles with watchlist
    Given user has no active perps positions or orders
    And user has 2 tokens in their perps watchlist

    When user views the homepage Perpetuals section
    Then the carousel shows exactly 5 tiles (2 watchlist + 3 trending)
    And both watchlist tiles display a star badge
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="380" height="244" alt="Screenshot 2026-03-02 at 11 42 12" src="https://github.com/user-attachments/assets/2a17768d-3df6-41dc-8749-c9873c865a60" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/selection logic change that reorders and filters carousel data based on Redux watchlist state; risks are mainly around ordering/deduplication and symbol mismatches, with good unit test coverage added.
> 
> **Overview**
> When the user has no open perps positions or orders, the homepage Perpetuals carousel now **prepends watchlist markets** (from `selectPerpsWatchlistMarkets`) ahead of volume-sorted trending markets, **deduplicates** overlapping symbols, and still enforces the existing **5-tile cap**.
> 
> `PerpsMarketTileCard` adds a new `showFavoriteTag` prop that renders a small filled-star badge on the token logo for watchlist entries, and `useHomepageSparklines` is updated to subscribe to the combined carousel symbol list.
> 
> Adds a new `PerpsSection` test suite covering watchlist-first ordering, multiple watchlist items, deduplication, max-tile behavior (including oversized watchlists), empty watchlist behavior, and ignoring unknown watchlist symbols.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a35f69374bf77cc5e7e3c8a0c9d112da74154ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->