### PR TITLE
refactor(predict): scope GameCache updates to subscribed games only

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -211,12 +211,13 @@ describe('WebSocketManager', () => {
       });
     });
 
-    it('does not call callback for unrelated gameId', () => {
+    it('does not call callback or update cache for unrelated gameId', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();
 
       manager.subscribeToGame('123', callback);
       mockWebSocketInstances[0].simulateOpen();
+      mockGameCacheInstance.updateGame.mockClear();
       mockWebSocketInstances[0].simulateMessage({
         gameId: 456,
         score: '7-0',
@@ -227,6 +228,7 @@ describe('WebSocketManager', () => {
       });
 
       expect(callback).not.toHaveBeenCalled();
+      expect(mockGameCacheInstance.updateGame).not.toHaveBeenCalled();
     });
 
     it('calls multiple callbacks for same gameId', () => {

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -211,7 +211,7 @@ describe('WebSocketManager', () => {
       });
     });
 
-    it('does not call callback or update cache for unrelated gameId', () => {
+    it('does not call callback for unrelated gameId', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();
 
@@ -228,6 +228,24 @@ describe('WebSocketManager', () => {
       });
 
       expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not update cache for unrelated gameId', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToGame('123', callback);
+      mockWebSocketInstances[0].simulateOpen();
+      mockGameCacheInstance.updateGame.mockClear();
+      mockWebSocketInstances[0].simulateMessage({
+        gameId: 456,
+        score: '7-0',
+        elapsed: '05:00',
+        period: 'Q1',
+        live: true,
+        ended: false,
+      });
+
       expect(mockGameCacheInstance.updateGame).not.toHaveBeenCalled();
     });
 

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -161,6 +161,11 @@ export class WebSocketManager {
       const data: SportsWebSocketEvent = JSON.parse(event.data);
       const gameId = String(data.gameId);
 
+      const callbacks = this.gameSubscriptions.get(gameId);
+      if (!callbacks || callbacks.size === 0) {
+        return;
+      }
+
       const update: GameUpdate = {
         gameId,
         score: data.score,
@@ -171,11 +176,7 @@ export class WebSocketManager {
       };
 
       GameCache.getInstance().updateGame(gameId, update);
-
-      const callbacks = this.gameSubscriptions.get(gameId);
-      if (callbacks && callbacks.size > 0) {
-        callbacks.forEach((callback) => callback(update));
-      }
+      callbacks.forEach((callback) => callback(update));
     } catch (error) {
       DevLogger.log('WebSocketManager: Failed to parse sports message', {
         error,


### PR DESCRIPTION
## Summary
- Sports WebSocket broadcast handler now early-returns for games with no active subscribers
- Only subscribed games get cached in `GameCache` and dispatched to callbacks
- Prevents unbounded `GameCache` growth from broadcast messages for games the user isn't viewing

## Test plan
- [x] Updated existing test to also assert `GameCache.updateGame` is not called for unsubscribed games
- [x] All 82 WebSocketManager tests pass across 4 test suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of the sports WebSocket handler to drop updates when there are no active subscribers, which could affect any flows that implicitly relied on `GameCache` being populated for non-viewed games.
> 
> **Overview**
> Sports WebSocket message handling now **early-returns for games with no active subscribers**, so only subscribed games get `GameCache.updateGame` calls and callback dispatch.
> 
> Tests were updated to assert that **unrelated `gameId` broadcasts neither trigger callbacks nor write to `GameCache`**, preventing cache growth from irrelevant messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80311c564a254f5323c3a2e2f563ee384c66ddc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->