### PR TITLE
test(snaps): Add name-lookup E2E

### DIFF
--- a/tests/page-objects/Send/RedesignedSendView.ts
+++ b/tests/page-objects/Send/RedesignedSendView.ts
@@ -127,6 +127,7 @@ class SendView {
     await Utilities.waitForElementToBeEnabled(this.reviewButton);
     await Gestures.waitAndTap(this.reviewButton, {
       elemDescription: 'Review button',
+      checkStability: true,
     });
   }
 

--- a/tests/page-objects/Send/TransactionConfirmView.ts
+++ b/tests/page-objects/Send/TransactionConfirmView.ts
@@ -164,6 +164,12 @@ class TransactionConfirmationView {
       elemDescription: 'Gas Fee Token Pill in Confirmation View',
     });
   }
+
+  async tapAdvancedDetails(): Promise<void> {
+    await Gestures.waitAndTap(RowComponents.AdvancedDetails, {
+      elemDescription: 'Advanced details in Confirmation View',
+    });
+  }
 }
 
 export default new TransactionConfirmationView();

--- a/tests/selectors/Browser/TestSnaps.selectors.ts
+++ b/tests/selectors/Browser/TestSnaps.selectors.ts
@@ -21,7 +21,7 @@ export const TestSnapViewSelectorWebIDS = {
   connectInteractiveButton: 'connectinteractive-ui',
   connectManageStateButton: 'connectmanage-state',
   connectMultichainProviderButton: 'connectmultichain-provider',
-  connectNameLookupButton: '#connectname-lookup',
+  connectNameLookupButton: 'connectname-lookup',
   connectNetworkAccessButton: 'connectnetwork-access',
   connectEthereumProviderButton: 'connectethereum-provider',
   connectStateButton: 'connectstate',

--- a/tests/selectors/Browser/TestSnaps.selectors.ts
+++ b/tests/selectors/Browser/TestSnaps.selectors.ts
@@ -21,6 +21,7 @@ export const TestSnapViewSelectorWebIDS = {
   connectInteractiveButton: 'connectinteractive-ui',
   connectManageStateButton: 'connectmanage-state',
   connectMultichainProviderButton: 'connectmultichain-provider',
+  connectNameLookupButton: '#connectname-lookup',
   connectNetworkAccessButton: 'connectnetwork-access',
   connectEthereumProviderButton: 'connectethereum-provider',
   connectStateButton: 'connectstate',

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -61,7 +61,7 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await RedesignedSendView.pressReviewButton();
         await TransactionConfirmView.tapAdvancedDetails();
 
-        await Gestures.waitAndTap(Matchers.getElementByText(domain));
+        await Gestures.waitAndTap(Matchers.getElementByText(domain, 1));
 
         await Assertions.expectTextDisplayed(
           '0xc0ffee254729296a45a3885639ac7e10f9d54979',

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -7,10 +7,11 @@ import TestSnaps from '../../page-objects/Browser/TestSnaps';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import WalletView from '../../page-objects/wallet/WalletView';
 import RedesignedSendView from '../../page-objects/Send/RedesignedSendView';
-import { Assertions, LocalNode } from '../../framework';
+import { Assertions, Gestures, LocalNode, Matchers } from '../../framework';
 import BrowserView from '../../page-objects/Browser/BrowserView';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
 import { AnvilManager } from '../../seeder/anvil-manager';
+import TransactionConfirmView from '../../page-objects/Send/TransactionConfirmView';
 
 jest.setTimeout(150_000);
 
@@ -31,14 +32,6 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
                 ticker: 'ETH',
               },
             })
-            .withTokensForAllPopularNetworks([
-              {
-                address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-                symbol: 'USDC',
-                decimals: 6,
-                name: 'USD Coin',
-              },
-            ])
             .build();
         },
         restartDevice: true,
@@ -55,13 +48,18 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await TabBarComponent.tapHome();
         await WalletView.tapWalletSendButton();
 
-        await RedesignedSendView.selectERC20Token();
+        await Gestures.tap(Matchers.getElementByText('Ethereum', 1));
         await RedesignedSendView.enterZeroAmount();
         await RedesignedSendView.pressContinueButton();
         await RedesignedSendView.inputRecipientAddress('metamask.domain');
         await RedesignedSendView.pressReviewButton();
+        await TransactionConfirmView.tapAdvancedDetails();
 
-        await Assertions.expectTextDisplayed('0xc0ffe...54979');
+        await Gestures.tap(Matchers.getElementByText('metamask.domain'));
+
+        await Assertions.expectTextDisplayed(
+          '0xc0ffee254729296a45a3885639ac7e10f9d54979',
+        );
       },
     );
   });

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -7,15 +7,40 @@ import TestSnaps from '../../page-objects/Browser/TestSnaps';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import WalletView from '../../page-objects/wallet/WalletView';
 import RedesignedSendView from '../../page-objects/Send/RedesignedSendView';
-import { Assertions } from '../../framework';
+import { Assertions, LocalNode } from '../../framework';
+import BrowserView from '../../page-objects/Browser/BrowserView';
+import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
+import { AnvilManager } from '../../seeder/anvil-manager';
 
 jest.setTimeout(150_000);
 
 describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
-  it('connects to the Name Lookup Snap', async () => {
+  it('displays the resolved recipient address in the send flow', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder().build(),
+        fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {
+          const node = localNodes?.[0] as unknown as AnvilManager;
+
+          return new FixtureBuilder()
+            .withNetworkController({
+              providerConfig: {
+                chainId: '0x1',
+                rpcUrl: `http://localhost:${node.getPort() ?? AnvilPort()}`,
+                type: 'custom',
+                nickname: 'Local RPC',
+                ticker: 'ETH',
+              },
+            })
+            .withTokensForAllPopularNetworks([
+              {
+                address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                symbol: 'USDC',
+                decimals: 6,
+                name: 'USD Coin',
+              },
+            ])
+            .build();
+        },
         restartDevice: true,
         skipReactNativeReload: true,
       },
@@ -25,22 +50,16 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await TestSnaps.navigateToTestSnap();
 
         await TestSnaps.installSnap('connectNameLookupButton');
-      },
-    );
-  });
 
-  it('displays the recipient address in the send flow', async () => {
-    await withFixtures(
-      {
-        fixture: new FixtureBuilder().build(),
-        skipReactNativeReload: true,
-      },
-      async () => {
+        await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapHome();
         await WalletView.tapWalletSendButton();
 
-        await RedesignedSendView.selectEthereumToken();
+        await RedesignedSendView.selectERC20Token();
+        await RedesignedSendView.enterZeroAmount();
+        await RedesignedSendView.pressContinueButton();
         await RedesignedSendView.inputRecipientAddress('metamask.domain');
+        await RedesignedSendView.pressReviewButton();
 
         await Assertions.expectTextDisplayed('0xc0ffe...54979');
       },

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -1,0 +1,49 @@
+import { FlaskBuildTests } from '../../tags';
+import { loginToApp } from '../../flows/wallet.flow';
+import { navigateToBrowserView } from '../../flows/browser.flow';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TestSnaps from '../../page-objects/Browser/TestSnaps';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
+import WalletView from '../../page-objects/wallet/WalletView';
+import RedesignedSendView from '../../page-objects/Send/RedesignedSendView';
+import { Assertions } from '../../framework';
+
+jest.setTimeout(150_000);
+
+describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
+  it('connects to the Name Lookup Snap', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        skipReactNativeReload: true,
+      },
+      async () => {
+        await loginToApp();
+        await navigateToBrowserView();
+        await TestSnaps.navigateToTestSnap();
+
+        await TestSnaps.installSnap('connectNameLookupButton');
+      },
+    );
+  });
+
+  it('displays the recipient address in the send flow', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        skipReactNativeReload: true,
+      },
+      async () => {
+        await TabBarComponent.tapHome();
+        await WalletView.tapWalletSendButton();
+
+        await RedesignedSendView.selectEthereumToken();
+        await RedesignedSendView.inputRecipientAddress('metamask.domain');
+
+        await Assertions.expectTextDisplayed('0xc0ffe...54979');
+      },
+    );
+  });
+});

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -61,7 +61,12 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await RedesignedSendView.pressReviewButton();
         await TransactionConfirmView.tapAdvancedDetails();
 
-        await Gestures.waitAndTap(Matchers.getElementByText(domain, 1));
+        await Gestures.waitAndTap(
+          Matchers.getElementByText(
+            domain,
+            device.getPlatform() === 'ios' ? 1 : 0,
+          ),
+        );
 
         await Assertions.expectTextDisplayed(
           '0xc0ffee254729296a45a3885639ac7e10f9d54979',

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -12,8 +12,11 @@ import BrowserView from '../../page-objects/Browser/BrowserView';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
 import { AnvilManager } from '../../seeder/anvil-manager';
 import TransactionConfirmView from '../../page-objects/Send/TransactionConfirmView';
+import TokenOverview from '../../page-objects/wallet/TokenOverview';
 
 jest.setTimeout(150_000);
+
+const TOKEN = 'Ethereum';
 
 describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
   it('displays the resolved recipient address in the send flow', async () => {
@@ -46,16 +49,19 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
 
         await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapHome();
-        await WalletView.tapWalletSendButton();
+        await device.disableSynchronization();
+        await WalletView.waitForTokenToBeReady(TOKEN);
+        await WalletView.tapOnToken(TOKEN);
+        await TokenOverview.tapSendButton();
 
-        await Gestures.tap(Matchers.getElementByText('Ethereum', 1));
+        const domain = 'metamask.domain';
         await RedesignedSendView.enterZeroAmount();
         await RedesignedSendView.pressContinueButton();
-        await RedesignedSendView.inputRecipientAddress('metamask.domain');
+        await RedesignedSendView.inputRecipientAddress(domain);
         await RedesignedSendView.pressReviewButton();
         await TransactionConfirmView.tapAdvancedDetails();
 
-        await Gestures.tap(Matchers.getElementByText('metamask.domain'));
+        await Gestures.waitAndTap(Matchers.getElementByText(domain));
 
         await Assertions.expectTextDisplayed(
           '0xc0ffee254729296a45a3885639ac7e10f9d54979',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Port extension name-lookup test to mobile for increased coverage. The PR adjusts a few shared utilities to make the tests more stable and enable the flow tested in this test.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/3572

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Detox E2E test code and test selectors, with a small tap-stability tweak that could affect test flakiness but not app behavior.
> 
> **Overview**
> Adds a new smoke E2E test (`test-snap-name-lookup.spec.ts`) that installs the **Name Lookup** test snap and verifies a domain recipient resolves to the expected address during the send/confirmation flow.
> 
> Extends test infrastructure to support the scenario by adding the `connectNameLookupButton` selector, adding a `tapAdvancedDetails()` helper on `TransactionConfirmView`, and making `RedesignedSendView.pressReviewButton()` use `checkStability` when tapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d21a06fd542541db9af1a01b71fd10d44ddadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->