### PR TITLE
test: disables BROWSERSTACK_LOCAL on demand

### DIFF
--- a/.yarn/patches/appwright-patch-9fcd858d19.patch
+++ b/.yarn/patches/appwright-patch-9fcd858d19.patch
@@ -7,7 +7,7 @@ index c84d31cb938f284c04051bcca7245ccbe42fa684..58a8bc4f521fd46a34d6caba7b0a8817
                  "bstack:options": {
                      debug: true,
 -                    local: true,
-+                    local: process.env.BROWSERSTACK_LOCAL,
++                    local: process.env.BROWSERSTACK_LOCAL?.toLowerCase() !== 'false',
                      ...(process.env.BROWSERSTACK_LOCAL_IDENTIFIER ? { localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER } : {}),
                      networkProfile : '4g-lte-advanced-good',
                      interactiveDebugging: true,

--- a/.yarn/patches/appwright-patch-9fcd858d19.patch
+++ b/.yarn/patches/appwright-patch-9fcd858d19.patch
@@ -7,7 +7,7 @@ index c84d31cb938f284c04051bcca7245ccbe42fa684..58a8bc4f521fd46a34d6caba7b0a8817
                  "bstack:options": {
                      debug: true,
 -                    local: true,
-+                    local: process.env.BROWSERSTACK_LOCAL !== undefined ? process.env.BROWSERSTACK_LOCAL === 'true' : true,
++                    local: process.env.BROWSERSTACK_LOCAL,
                      ...(process.env.BROWSERSTACK_LOCAL_IDENTIFIER ? { localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER } : {}),
                      networkProfile : '4g-lte-advanced-good',
                      interactiveDebugging: true,

--- a/.yarn/patches/appwright-patch-9fcd858d19.patch
+++ b/.yarn/patches/appwright-patch-9fcd858d19.patch
@@ -7,7 +7,7 @@ index c84d31cb938f284c04051bcca7245ccbe42fa684..58a8bc4f521fd46a34d6caba7b0a8817
                  "bstack:options": {
                      debug: true,
 -                    local: true,
-+                    local: process.env.BROWSER_STACK_LOCAL !== undefined ? process.env.BROWSER_STACK_LOCAL === 'true' : true,
++                    local: process.env.BROWSERSTACK_LOCAL !== undefined ? process.env.BROWSERSTACK_LOCAL === 'true' : true,
                      ...(process.env.BROWSERSTACK_LOCAL_IDENTIFIER ? { localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER } : {}),
                      networkProfile : '4g-lte-advanced-good',
                      interactiveDebugging: true,

--- a/.yarn/patches/appwright-patch-9fcd858d19.patch
+++ b/.yarn/patches/appwright-patch-9fcd858d19.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/providers/browserstack/index.js b/dist/providers/browserstack/index.js
+index c84d31cb938f284c04051bcca7245ccbe42fa684..58a8bc4f521fd46a34d6caba7b0a88170e7ac6a1 100644
+--- a/dist/providers/browserstack/index.js
++++ b/dist/providers/browserstack/index.js
+@@ -248,7 +248,7 @@ class BrowserStackDeviceProvider {
+             capabilities: {
+                 "bstack:options": {
+                     debug: true,
+-                    local: true,
++                    local: process.env.BROWSER_STACK_LOCAL !== undefined ? process.env.BROWSER_STACK_LOCAL === 'true' : true,
+                     ...(process.env.BROWSERSTACK_LOCAL_IDENTIFIER ? { localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER } : {}),
+                     networkProfile : '4g-lte-advanced-good',
+                     interactiveDebugging: true,

--- a/package.json
+++ b/package.json
@@ -570,7 +570,7 @@
     "appium-chromium-driver": "^2.0.2",
     "appium-uiautomator2-driver": "4.2.7",
     "appium-xcuitest-driver": "5.16.1",
-    "appwright": "patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch",
+    "appwright": "patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch",
     "assert": "^1.5.0",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21770,7 +21770,7 @@ __metadata:
 
 "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch":
   version: 0.1.45
-  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=b7552c"
+  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=0ae41e"
   dependencies:
     "@empiricalrun/llm": "npm:^0.9.25"
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
@@ -21786,7 +21786,7 @@ __metadata:
     webdriver: "npm:^8.36.1"
   bin:
     appwright: dist/bin/index.js
-  checksum: 10/e025abc967a47fb7eb1f9eaa7af0c583c0736937c949ca83bef2f146deac1f58e4ae3510c614cf16633b313bdc3acf92debde38606460a47d784e2ba4addc52e
+  checksum: 10/6f6e0a22262d1206992b29acefdc03804fd56410f67b4ce1739d6614d872f1634ee75153f4567766187f95ec67928ab61504c307ce13e6521f5b77e8b822451e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21746,7 +21746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch":
+"appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=9b6269":
   version: 0.1.45
   resolution: "appwright@patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch::version=0.1.45&hash=9b6269"
   dependencies:
@@ -21765,6 +21765,28 @@ __metadata:
   bin:
     appwright: dist/bin/index.js
   checksum: 10/da34a39901c340ca3adc39fc7299457dd30decce2b17586e4a3de71d8c8afa257183c66d09ab673e5c0d66b1ef9866630f0c6759c2e945179b33a2b35f1a35a8
+  languageName: node
+  linkType: hard
+
+"appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch":
+  version: 0.1.45
+  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=4e4752"
+  dependencies:
+    "@empiricalrun/llm": "npm:^0.9.25"
+    "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
+    "@playwright/test": "npm:^1.47.1"
+    appium: "npm:^2.6.0"
+    appium-uiautomator2-driver: "npm:^3.8.0"
+    appium-xcuitest-driver: "npm:^7.27.0"
+    async-retry: "npm:^1.3.3"
+    fluent-ffmpeg: "npm:^2.1.3"
+    form-data: "npm:4.0.0"
+    node-fetch: "npm:^3.3.2"
+    picocolors: "npm:^1.1.0"
+    webdriver: "npm:^8.36.1"
+  bin:
+    appwright: dist/bin/index.js
+  checksum: 10/d658891f3f127e6573d1a1fff8014d778b7c5d173da95e70898c5ad43d76b692ea86d7ef7aa626fe744c2523cd82c762052cc447d89051c103b0808b27299682
   languageName: node
   linkType: hard
 
@@ -35562,7 +35584,7 @@ __metadata:
     appium-chromium-driver: "npm:^2.0.2"
     appium-uiautomator2-driver: "npm:4.2.7"
     appium-xcuitest-driver: "npm:5.16.1"
-    appwright: "patch:appwright@npm%3A0.1.45#~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch"
+    appwright: "patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch"
     assert: "npm:^1.5.0"
     asyncstorage-down: "npm:4.2.0"
     axios: "npm:^1.13.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21770,7 +21770,7 @@ __metadata:
 
 "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch":
   version: 0.1.45
-  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=4e4752"
+  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=d3f4e7"
   dependencies:
     "@empiricalrun/llm": "npm:^0.9.25"
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
@@ -21786,7 +21786,7 @@ __metadata:
     webdriver: "npm:^8.36.1"
   bin:
     appwright: dist/bin/index.js
-  checksum: 10/d658891f3f127e6573d1a1fff8014d778b7c5d173da95e70898c5ad43d76b692ea86d7ef7aa626fe744c2523cd82c762052cc447d89051c103b0808b27299682
+  checksum: 10/a67a2d944f46a65df75acb85209448fcc0b359bea63fa280e9b33f61006df9c7ccd9fa55f14605753be66c8809545c6030d6ea979128a6a8bc033b0ecb401454
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21770,7 +21770,7 @@ __metadata:
 
 "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch":
   version: 0.1.45
-  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=d3f4e7"
+  resolution: "appwright@patch:appwright@patch%3Aappwright@npm%253A0.1.45%23~/.yarn/patches/appwright-npm-0.1.45-f282bc1c1b.patch%3A%3Aversion=0.1.45&hash=9b6269#~/.yarn/patches/appwright-patch-9fcd858d19.patch::version=0.1.45&hash=b7552c"
   dependencies:
     "@empiricalrun/llm": "npm:^0.9.25"
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
@@ -21786,7 +21786,7 @@ __metadata:
     webdriver: "npm:^8.36.1"
   bin:
     appwright: dist/bin/index.js
-  checksum: 10/a67a2d944f46a65df75acb85209448fcc0b359bea63fa280e9b33f61006df9c7ccd9fa55f14605753be66c8809545c6030d6ea979128a6a8bc033b0ecb401454
+  checksum: 10/e025abc967a47fb7eb1f9eaa7af0c583c0736937c949ca83bef2f146deac1f58e4ae3510c614cf16633b313bdc3acf92debde38606460a47d784e2ba4addc52e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds the ability to disable the BrowserStack tunnel on demand. 
General behavior:
- `BROWSERSTACK_LOCAL=true` -> Enables the browserstack local tunnel
- `BROWSERSTACK_LOCAL=false` -> Disables the browserstack local tunnel

As we move frameworks, enabling the local tunnel will be absolutely transparent to whoever runs the performance tests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to test infrastructure toggles BrowserStack Local based on an environment variable, plus associated Yarn patch/lockfile updates.
> 
> **Overview**
> Makes BrowserStack sessions started by `appwright` optionally run *without* the local tunnel by changing `bstack:options.local` to be controlled by `BROWSERSTACK_LOCAL` (treated as enabled unless explicitly set to `false`).
> 
> Updates the `appwright` dependency to point at a new Yarn patch file and refreshes `yarn.lock` entries/checksums accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e750676a432110dd77c04c0a681b976b171ffaf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->