### PR TITLE
fix: source prop now has origin data for empty token state

### DIFF
--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import PopularTokenRow from './PopularTokenRow';
 import type { PopularToken } from '../hooks/usePopularTokens';
+import { TokenDetailsSource } from '../../../../../UI/TokenDetails/constants/constants';
 
 const mockNavigate = jest.fn();
 const mockGoToBuy = jest.fn();
@@ -160,6 +161,7 @@ describe('PopularTokenRow', () => {
         address: '0xabcdef1234567890abcdef1234567890abcdef12',
         symbol: 'USDC',
         isNative: false,
+        source: TokenDetailsSource.MobileTokenList,
       });
     });
 
@@ -178,6 +180,7 @@ describe('PopularTokenRow', () => {
         address: '0x0000000000000000000000000000000000000000',
         symbol: 'ETH',
         isNative: true,
+        source: TokenDetailsSource.MobileTokenList,
       });
     });
 
@@ -196,7 +199,26 @@ describe('PopularTokenRow', () => {
         address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
         symbol: 'SOL',
         isNative: true,
+        source: TokenDetailsSource.MobileTokenList,
       });
+    });
+
+    it('passes source as MobileTokenList for analytics tracking', () => {
+      const token = createMockToken({
+        assetId: 'eip155:1/erc20:0xabcdef1234567890abcdef1234567890abcdef12',
+        symbol: 'USDC',
+      });
+
+      renderWithProvider(<PopularTokenRow token={token} />);
+
+      fireEvent.press(screen.getByText('Test Token'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'Asset',
+        expect.objectContaining({
+          source: TokenDetailsSource.MobileTokenList,
+        }),
+      );
     });
 
     it('does not navigate for invalid CAIP-19 format', () => {
@@ -245,6 +267,7 @@ describe('PopularTokenRow', () => {
         address: '0x0000000000000000000000000000000000000000',
         symbol: 'BNB',
         isNative: true,
+        source: TokenDetailsSource.MobileTokenList,
       });
     });
 

--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.tsx
@@ -27,6 +27,7 @@ import { useRampNavigation } from '../../../../../UI/Ramp/hooks/useRampNavigatio
 import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
 import { strings } from '../../../../../../../locales/i18n';
 import type { PopularToken } from '../hooks/usePopularTokens';
+import { TokenDetailsSource } from '../../../../../UI/TokenDetails/constants/constants';
 
 // Zero address used for native EVM tokens (ETH, BNB, etc.)
 const NATIVE_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -159,6 +160,7 @@ const PopularTokenRow: React.FC<PopularTokenRowProps> = ({ token }) => {
       address,
       symbol: token.symbol,
       isNative,
+      source: TokenDetailsSource.MobileTokenList,
     });
   }, [navigation, token.assetId, token.symbol]);
 


### PR DESCRIPTION
## **Description**

The homepage token empty state (`PopularTokenRow`) was navigating to the Asset screen without a `source` prop, causing the analytics event in `TokenDetails` to fall back to `TokenDetailsSource.Unknown`. The filled state (`TokenListItem`) correctly passed `source: TokenDetailsSource.MobileTokenList`.

Fix adds the missing `source` prop to the `navigation.navigate('Asset', ...)` call in `PopularTokenRow`, matching the filled state behaviour.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-497

## **Manual testing steps**

```gherkin
Feature: Homepage token empty state analytics source

  Scenario: user taps a token row in the zero balance (empty) state
    Given the user has a zero balance account
    And the homepage displays the popular tokens list

    When user taps on a token row
    Then the Asset screen opens
    And the analytics event "Token Details Opened" includes source = "mobile-token-list"
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single `source` navigation param used for analytics attribution, with no changes to parsing, balances, or transaction logic.
> 
> **Overview**
> Fixes missing analytics attribution when opening `Asset` from the homepage popular tokens (zero-balance) row by adding `source: TokenDetailsSource.MobileTokenList` to the `navigation.navigate('Asset', ...)` params.
> 
> Updates `PopularTokenRow` tests to assert the new `source` param across EVM, native, and non-EVM navigation cases, and adds a dedicated test to ensure `source` is passed for tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a5de4abd59921aa3d18d2e80417a440cdf8132e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->