### PR TITLE
test: enhance DeFiSection tests with error handling and retry logic

### DIFF
--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
@@ -6,12 +6,21 @@ import { SectionRefreshHandle } from '../../types';
 import Routes from '../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
+const mockExecutePoll = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
   }),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    DeFiPositionsController: {
+      _executePoll: (...args: unknown[]) => mockExecutePoll(...args),
+    },
+  },
 }));
 
 jest.mock(
@@ -120,7 +129,7 @@ describe('DeFiSection', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('returns null when there is an error and not loading', () => {
+  it('renders error state with retry when there is an error and not loading', () => {
     mockUseDeFiPositionsForHomepage.mockReturnValue({
       positions: [],
       isLoading: false,
@@ -128,9 +137,28 @@ describe('DeFiSection', () => {
       isEmpty: false,
     });
 
-    const { toJSON } = renderWithProvider(<DeFiSection />);
+    renderWithProvider(<DeFiSection />);
 
-    expect(toJSON()).toBeNull();
+    expect(screen.getByText('DeFi')).toBeOnTheScreen();
+    expect(screen.getByText(/unable to load/i)).toBeOnTheScreen();
+    expect(screen.getByText(/retry/i)).toBeOnTheScreen();
+  });
+
+  it('calls _executePoll on retry button press', async () => {
+    mockUseDeFiPositionsForHomepage.mockReturnValue({
+      positions: [],
+      isLoading: false,
+      hasError: true,
+      isEmpty: false,
+    });
+
+    renderWithProvider(<DeFiSection />);
+
+    await act(async () => {
+      fireEvent.press(screen.getByText(/retry/i));
+    });
+
+    expect(mockExecutePoll).toHaveBeenCalled();
   });
 
   it('renders skeleton when loading', () => {
@@ -195,6 +223,6 @@ describe('DeFiSection', () => {
       await ref.current?.refresh();
     });
 
-    // Refresh is a no-op for DeFi (data comes from controller)
+    expect(mockExecutePoll).toHaveBeenCalled();
   });
 });

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -8,6 +8,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
 import SectionTitle from '../../components/SectionTitle';
 import SectionRow from '../../components/SectionRow';
+import ErrorState from '../../components/ErrorState';
 import { SectionRefreshHandle } from '../../types';
 import { useDeFiPositionsForHomepage, DeFiPositionEntry } from './hooks';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
@@ -15,6 +16,7 @@ import DeFiPositionsListItem from '../../../../UI/DeFiPositions/DeFiPositionsLis
 import { selectAssetsDefiPositionsEnabled } from '../../../../../selectors/featureFlagController/assetsDefiPositions';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
+import Engine from '../../../../../core/Engine';
 
 const MAX_POSITIONS_DISPLAYED = 5;
 
@@ -71,9 +73,9 @@ const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     navigation.navigate(Routes.WALLET.DEFI_FULL_VIEW as never);
   }, [navigation]);
 
-  // DeFi positions come from Redux selectors - no async refresh needed
   const refresh = useCallback(async () => {
-    // Data refreshes automatically via DeFiPositionsController
+    const controller = Engine.context.DeFiPositionsController;
+    await controller._executePoll();
   }, []);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
@@ -83,9 +85,24 @@ const DeFiSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     return null;
   }
 
-  // Don't render if error or empty (and not loading)
-  if (!isLoading && (hasError || isEmpty)) {
+  // Don't render if empty and not loading (200 with no data)
+  if (!isLoading && isEmpty) {
     return null;
+  }
+
+  // Show retry UI on error
+  if (!isLoading && hasError) {
+    return (
+      <Box gap={3}>
+        <SectionTitle title={title} onPress={handleViewAllDeFi} />
+        <ErrorState
+          title={strings('homepage.error.unable_to_load', {
+            section: title.toLowerCase(),
+          })}
+          onRetry={refresh}
+        />
+      </Box>
+    );
   }
 
   return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The DeFi homepage section was returning null (hiding entirely) when the API responded with an error (e.g. 501). This matched the behavior for the empty-data case, but the acceptance criteria requires showing a retry UI on API failure — consistent with how the Predictions and Tokens sections handle errors.

**This PR:**

- Separates error and empty handling in DeFiSection: errors now render the shared ErrorState component with a retry button, while empty data (200 with 0 positions) still hides the section.

- Replaces the no-op refresh function with a real one that calls DeFiPositionsController._executePoll(), so both the retry button and pull-to-refresh actually re-fetch.

- Updates tests to assert the new error UI behavior and verify retry triggers _executePoll.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed DeFi homepage section to show retry UI when API request fails instead of hiding the section

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-496

## **Manual testing steps**

```gherkin
Feature: DeFi section error handling on homepage

  Scenario: user sees retry UI when DeFi API fails
    Given the DeFi positions API returns a 501 error
    And the user navigates to the homepage

    When the homepage loads
    Then the DeFi section displays with a "Unable to load" message and a "Retry" button

  Scenario: user retries after API failure
    Given the DeFi section is showing the error/retry UI

    When user taps the "Retry" button
    Then the DeFi positions are re-fetched from the API

  Scenario: DeFi section hidden when no positions exist
    Given the DeFi positions API returns 200 with no positions

    When the homepage loads
    Then the DeFi section is not displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="377" height="613" alt="Screenshot 2026-03-02 at 13 21 18" src="https://github.com/user-attachments/assets/55d6b7e4-2187-4824-87c9-fa1161439e70" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes homepage DeFi rendering and refresh behavior to call `DeFiPositionsController._executePoll()`, which could affect polling frequency and error-handling paths. Uses a controller internal method, so regressions are possible if controller APIs change.
> 
> **Overview**
> DeFi homepage section no longer disappears on API errors: when `hasError` (and not loading) it now renders the shared `ErrorState` with a Retry button while still hiding the section for the *empty data* case.
> 
> The section’s `refresh` handler (used by pull-to-refresh and Retry) is wired to `Engine.context.DeFiPositionsController._executePoll()` to actively re-fetch positions.
> 
> Tests were updated to validate the new error UI and to assert that both Retry and the exposed `ref.refresh()` call `_executePoll()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296c33002a642cd269f9a41638174ee758d7fc1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->