### PR TITLE
feat(perps): add source parameter to navigation in PerpsSection

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -341,6 +341,7 @@ describe('PerpsSection', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
       screen: Routes.PERPS.PERPS_HOME,
+      params: { source: 'home_section' },
     });
   });
 
@@ -373,6 +374,7 @@ describe('PerpsSection', () => {
       params: {
         market: fullMarket,
         initialTab: 'position',
+        source: 'section_position',
       },
     });
   });
@@ -392,6 +394,7 @@ describe('PerpsSection', () => {
       params: {
         market: { symbol: 'BTC', maxLeverage: 50 },
         initialTab: 'position',
+        source: 'section_position',
       },
     });
   });
@@ -646,7 +649,7 @@ describe('PerpsSection', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.MARKET_DETAILS,
-        params: { market },
+        params: { market, source: 'home_section' },
       });
     });
 
@@ -710,6 +713,7 @@ describe('PerpsSection', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.PERPS_HOME,
+        params: { source: 'home_section' },
       });
     });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -190,6 +190,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const handleViewAllPerps = useCallback(() => {
     navigation.navigate(Routes.PERPS.ROOT, {
       screen: Routes.PERPS.PERPS_HOME,
+      params: { source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION },
     });
   }, [navigation]);
 
@@ -212,6 +213,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
             maxLeverage: position.maxLeverage,
           },
           initialTab: 'position',
+          source: 'section_position',
         },
       });
     },
@@ -222,7 +224,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
     (market: PerpsMarketData) => {
       navigation.navigate(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.MARKET_DETAILS,
-        params: { market },
+        params: { market, source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION },
       });
     },
     [navigation],

--- a/app/controllers/perps/constants/eventNames.ts
+++ b/app/controllers/perps/constants/eventNames.ts
@@ -190,6 +190,7 @@ export const PERPS_EVENT_VALUE = {
     PERPS_ASSET_SCREEN_NO_FUNDS: 'perps_asset_screen_no_funds',
     TRADE_MENU_ACTION: 'trade_menu_action',
     WALLET_HOME: 'wallet_home',
+    HOME_SECTION: 'home_section',
     TOOLTIP: 'tooltip',
     MAGNIFYING_GLASS: 'magnifying_glass',
     CRYPTO_BUTTON: 'crypto_button',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes incorrect source prop being sent in Segment analytics events when navigating from the Perps homepage section. The "View More", market card, and position card navigation calls were missing the source parameter, causing incorrect tracking data in analytics.

**Changes:**

- Added HOME_SECTION constant to PERPS_EVENT_VALUE.SOURCE

- Pass source: 'home_section' when navigating to Perps Home and Market Details from the homepage section

- Pass source: 'section_position' when navigating from a position card in the homepage section

- Updated tests to assert the correct source params

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-506
https://consensyssoftware.atlassian.net/browse/TMCU-503

## **Manual testing steps**

```gherkin
Feature: Perps Section source tracking

  Scenario: user taps View More in Perps section
    Given the user is on the homepage with the Perps section visible

    When user taps the "View More" button or section title in the Perps section
    Then the navigation to Perps Home includes source parameter "home_section"

  Scenario: user taps a market card in Perps section
    Given the user is on the homepage with the Perps section visible

    When user taps on a market card (e.g. BTC)
    Then the navigation to Market Details includes source parameter "home_section"

  Scenario: user taps a position card in Perps section
    Given the user is on the homepage with an open perps position visible

    When user taps on the position card
    Then the navigation includes source parameter "section_position"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds/standardizes `source` navigation params for analytics tracking and updates unit tests; functional behavior should be unchanged aside from route params.
> 
> **Overview**
> Fixes analytics attribution from the homepage Perps section by **including a `source` param in navigation** to `PERPS_HOME` and `MARKET_DETAILS`.
> 
> Adds `PERPS_EVENT_VALUE.SOURCE.HOME_SECTION` and passes it for title/"View more" and market tile taps, while position taps now navigate with `source: 'section_position'`. Tests are updated to assert the new navigation params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8089055819c495378acc42bb74a852f7765813de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->