### PR TITLE
fix(perps): add timeout to perps controller disconnect

### DIFF
--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -727,7 +727,11 @@ class PerpsConnectionManagerClass {
       // Clear previous errors when starting reconnection attempt
       this.clearError();
 
-      // Stage 2: Force the controller to reinitialize with new context
+      // Stage 2: Disconnect controller so init() will run #performInitialization()
+      // (otherwise init() no-ops when controller.isInitialized is still true after connection loss)
+      await Engine.context.PerpsController.disconnect();
+
+      // Stage 3: Force the controller to reinitialize with new context
       const reinitStart = performance.now();
       await Engine.context.PerpsController.init();
       setMeasurement(

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -3663,7 +3663,11 @@ export class PerpsController extends BaseController<
 
   /**
    * Disconnect provider and cleanup subscriptions
-   * Call this when navigating away from Perps screens to prevent battery drain
+   * Call this when navigating away from Perps screens to prevent battery drain.
+   * Also used by PerpsConnectionManager before init() on "Try again" so that
+   * init() actually runs #performInitialization() (full teardown + new providers).
+   * State reset (isInitialized, #initializationPromise) is always done in finally
+   * so reconnection can proceed even if provider.disconnect() hangs or throws.
    */
   async disconnect(): Promise<void> {
     this.#debugLog(
@@ -3673,50 +3677,61 @@ export class PerpsController extends BaseController<
       },
     );
 
-    // Stop preload interval and messenger subscriptions first,
-    // so no background work fires while we tear down providers.
-    if (this.#preloadTimer) {
-      clearInterval(this.#preloadTimer);
-      this.#preloadTimer = null;
-    }
-    if (this.#preloadStateUnsubscribe) {
-      this.#preloadStateUnsubscribe();
-      this.#preloadStateUnsubscribe = null;
-    }
-    if (this.#accountChangeUnsubscribe) {
-      this.#accountChangeUnsubscribe();
-      this.#accountChangeUnsubscribe = null;
-    }
-    this.#previousIsTestnet = null;
-    this.#previousHip3ConfigVersion = null;
-
-    // Only disconnect the provider if we're initialized
-    if (this.isInitialized && !this.isCurrentlyReinitializing()) {
-      try {
-        const provider = this.getActiveProvider();
-        await provider.disconnect();
-      } catch (error) {
-        this.#logError(
-          ensureError(error, 'PerpsController.disconnect'),
-          this.#getErrorContext('disconnect'),
-        );
+    try {
+      // Stop preload interval and messenger subscriptions first,
+      // so no background work fires while we tear down providers.
+      if (this.#preloadTimer) {
+        clearInterval(this.#preloadTimer);
+        this.#preloadTimer = null;
       }
+      if (this.#preloadStateUnsubscribe) {
+        this.#preloadStateUnsubscribe();
+        this.#preloadStateUnsubscribe = null;
+      }
+      if (this.#accountChangeUnsubscribe) {
+        this.#accountChangeUnsubscribe();
+        this.#accountChangeUnsubscribe = null;
+      }
+      this.#previousIsTestnet = null;
+      this.#previousHip3ConfigVersion = null;
+
+      // Only disconnect the provider if we're initialized (best-effort; may hang if WebSocket is dead)
+      if (this.isInitialized && !this.isCurrentlyReinitializing()) {
+        try {
+          const provider = this.getActiveProvider();
+          const disconnectPromise = provider.disconnect();
+          const timeoutPromise = wait(PERPS_CONSTANTS.DisconnectTimeoutMs).then(
+            () => {
+              throw new Error(
+                `Provider disconnect timed out after ${PERPS_CONSTANTS.DisconnectTimeoutMs}ms`,
+              );
+            },
+          );
+          await Promise.race([disconnectPromise, timeoutPromise]);
+        } catch (error) {
+          this.#logError(
+            ensureError(error, 'PerpsController.disconnect'),
+            this.#getErrorContext('disconnect'),
+          );
+        }
+      }
+
+      // Clear stale reference so standalone reads don't route through old provider
+      this.activeProviderInstance = null;
+
+      // Cleanup cached standalone provider (if any) — awaited to prevent races
+      await this.#cleanupStandaloneProvider();
+    } finally {
+      // Note: Feature-flag subscription is NOT cleaned up here.
+      // It is a controller-lifetime concern (set once in the constructor),
+      // not a session-lifetime concern. Unsubscribing here would break
+      // geo-blocking / HIP-3 flag propagation after disconnect → reconnect.
+
+      // Always reset initialization state so init() will run #performInitialization() on next call
+      // (e.g. when user clicks "Try again" after connection loss)
+      this.isInitialized = false;
+      this.#initializationPromise = null;
     }
-
-    // Clear stale reference so standalone reads don't route through old provider
-    this.activeProviderInstance = null;
-
-    // Cleanup cached standalone provider (if any) — awaited to prevent races
-    await this.#cleanupStandaloneProvider();
-
-    // Note: Feature-flag subscription is NOT cleaned up here.
-    // It is a controller-lifetime concern (set once in the constructor),
-    // not a session-lifetime concern. Unsubscribing here would break
-    // geo-blocking / HIP-3 flag propagation after disconnect → reconnect.
-
-    // Reset initialization state to ensure proper reconnection
-    this.isInitialized = false;
-    this.#initializationPromise = null;
   }
 
   /**

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -3697,22 +3697,30 @@ export class PerpsController extends BaseController<
 
       // Only disconnect the provider if we're initialized (best-effort; may hang if WebSocket is dead)
       if (this.isInitialized && !this.isCurrentlyReinitializing()) {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Provider disconnect timed out after ${PERPS_CONSTANTS.DisconnectTimeoutMs}ms`,
+                ),
+              ),
+            PERPS_CONSTANTS.DisconnectTimeoutMs,
+          );
+        });
         try {
           const provider = this.getActiveProvider();
-          const disconnectPromise = provider.disconnect();
-          const timeoutPromise = wait(PERPS_CONSTANTS.DisconnectTimeoutMs).then(
-            () => {
-              throw new Error(
-                `Provider disconnect timed out after ${PERPS_CONSTANTS.DisconnectTimeoutMs}ms`,
-              );
-            },
-          );
-          await Promise.race([disconnectPromise, timeoutPromise]);
+          await Promise.race([provider.disconnect(), timeoutPromise]);
         } catch (error) {
           this.#logError(
             ensureError(error, 'PerpsController.disconnect'),
             this.#getErrorContext('disconnect'),
           );
+        } finally {
+          if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+          }
         }
       }
 

--- a/app/controllers/perps/constants/perpsConfig.ts
+++ b/app/controllers/perps/constants/perpsConfig.ts
@@ -30,6 +30,8 @@ export const PERPS_CONSTANTS = {
   ReconnectionDelayAndroidMs: 300, // Android-specific reconnection delay for better reliability on slower devices
   ReconnectionDelayIosMs: 100, // iOS-specific reconnection delay for optimal performance
   ReconnectionRetryDelayMs: 5_000, // 5 seconds delay between reconnection attempts
+  /** Max time to wait for provider.disconnect() during teardown; prevents hang when WebSocket is dead */
+  DisconnectTimeoutMs: 5_000,
 
   // Connection manager timing constants
   BalanceUpdateThrottleMs: 15000, // Update at most every 15 seconds to reduce state updates in PerpsConnectionManager


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When the user lost internet and saw "Couldn't connect to perps", tapping "Try again" did not reconnect or rebuild the perps controller correctly. The root cause was that `performReconnection()` called `PerpsController.init()` to force a full reinit, but `init()` returns immediately when `this.isInitialized` is true. After a connection drop, nothing cleared the controller’s `isInitialized`, so no provider teardown or recreation happened and the health check ran against the same dead provider.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps not reconnecting when tapping "Try again" after losing internet connection.

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Perps reconnection after connection loss

  Scenario: user taps "Try again" after seeing "Couldn't connect to perps"
    Given the user had Perps loaded and then lost internet (or connection failed)
    And the user sees the error screen "Couldn't connect to perps" with "Try again"

    When the user restores connectivity (or the failure is transient)
    And the user taps "Try again"

    Then the app disconnects the previous provider and reinitializes
    And a new connection is established and the health check passes
    And the user sees the Perps UI (no longer stuck on the error screen)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c84c8f21-c441-4ce1-b29f-69ff59e1876f



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/acf7b8d0-9ac5-400b-b31a-485db8bc761f



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconnection/teardown flow for Perps WebSocket providers and adds a forced `disconnect()` plus a timeout around `provider.disconnect()`, which could affect connection stability and edge-case cleanup behavior.
> 
> **Overview**
> Fixes Perps not reconnecting after connection loss by making `PerpsConnectionManager.performReconnection()` explicitly call `PerpsController.disconnect()` before `init()`, ensuring initialization isn’t skipped due to stale `isInitialized`.
> 
> Hardens `PerpsController.disconnect()` by adding a `PERPS_CONSTANTS.DisconnectTimeoutMs` timeout around `provider.disconnect()` and moving `isInitialized`/`#initializationPromise` resets into a `finally` block so reconnection can proceed even if disconnect hangs or throws.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 115f7467dd408b0ed288ee0dcab3f2a84899d842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->