### PR TITLE
fix(analytics): fire NFT_DETAILS_OPENED event from NftGridItem instead of NftDetails screen mount

### DIFF
--- a/app/components/UI/NftGrid/NftGridItem.test.tsx
+++ b/app/components/UI/NftGrid/NftGridItem.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { Nft } from '@metamask/assets-controllers';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../util/test/initial-root-state';
+import NftGridItem from './NftGridItem';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+
+const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn();
+const mockBuild = jest.fn();
+const mockCreateEventBuilder = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  debounce: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+jest.mock('../CollectibleMedia', () => () => null);
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => {
+    const styleFunc = (className: string) => ({ [className]: true });
+    styleFunc.style = styleFunc;
+    return styleFunc;
+  },
+}));
+
+const mockNft: Nft = {
+  address: '0xABC',
+  tokenId: '1',
+  name: 'Test NFT',
+  image: 'https://example.com/nft.png',
+  collection: { name: 'Test Collection' },
+  chainId: 1,
+  isCurrentlyOwned: true,
+  standard: 'ERC721',
+} as Nft;
+
+const initialState = {
+  engine: { backgroundState },
+};
+
+describe('NftGridItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuild.mockReturnValue({ builtEvent: true });
+    mockAddProperties.mockReturnValue({ build: mockBuild });
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+    });
+  });
+
+  it('renders NFT name and collection', () => {
+    const { getByText } = renderWithProvider(
+      <NftGridItem item={mockNft} onLongPress={jest.fn()} />,
+      { state: initialState },
+    );
+
+    expect(getByText('Test NFT')).toBeTruthy();
+    expect(getByText('Test Collection')).toBeTruthy();
+  });
+
+  it('tracks NFT_DETAILS_OPENED event with source when NFT is pressed', () => {
+    const { getByTestId } = renderWithProvider(
+      <NftGridItem
+        item={mockNft}
+        onLongPress={jest.fn()}
+        source="mobile-nft-list"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('collectible-Test NFT-1'));
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.NFT_DETAILS_OPENED,
+    );
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'mobile-nft-list' }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith({ builtEvent: true });
+  });
+
+  it('tracks NFT_DETAILS_OPENED event with mobile-nft-list-page source from full view', () => {
+    const { getByTestId } = renderWithProvider(
+      <NftGridItem
+        item={mockNft}
+        onLongPress={jest.fn()}
+        source="mobile-nft-list-page"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('collectible-Test NFT-1'));
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'mobile-nft-list-page' }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks NFT_DETAILS_OPENED event without source when source is not provided', () => {
+    const { getByTestId } = renderWithProvider(
+      <NftGridItem item={mockNft} onLongPress={jest.fn()} />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('collectible-Test NFT-1'));
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.NFT_DETAILS_OPENED,
+    );
+    const propertiesArg = mockAddProperties.mock.calls[0][0];
+    expect(propertiesArg).not.toHaveProperty('source');
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to NftDetails with correct params when pressed', () => {
+    const { getByTestId } = renderWithProvider(
+      <NftGridItem
+        item={mockNft}
+        onLongPress={jest.fn()}
+        source="mobile-nft-list"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('collectible-Test NFT-1'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('NftDetails', {
+      collectible: mockNft,
+      source: 'mobile-nft-list',
+    });
+  });
+
+  it('calls onLongPress with the NFT item when long pressed', () => {
+    const mockOnLongPress = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <NftGridItem
+        item={mockNft}
+        onLongPress={mockOnLongPress}
+        source="mobile-nft-list"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent(getByTestId('collectible-Test NFT-1'), 'onLongPress');
+
+    expect(mockOnLongPress).toHaveBeenCalledWith(mockNft);
+  });
+
+  it('tracks chain_id from the current EVM chain', () => {
+    const { getByTestId } = renderWithProvider(
+      <NftGridItem
+        item={mockNft}
+        onLongPress={jest.fn()}
+        source="mobile-nft-list"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('collectible-Test NFT-1'));
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ chain_id: expect.any(String) }),
+    );
+  });
+});

--- a/app/components/UI/NftGrid/NftGridItem.tsx
+++ b/app/components/UI/NftGrid/NftGridItem.tsx
@@ -11,6 +11,11 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import CollectibleMedia from '../CollectibleMedia';
+import { useSelector } from 'react-redux';
+import { selectEvmChainId } from '../../../selectors/networkController';
+import { getDecimalChainId } from '../../../util/networks';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 
 const debouncedNavigation = debounce((navigation, collectible, source) => {
   navigation.navigate('NftDetails', { collectible, source });
@@ -27,10 +32,20 @@ const NftGridItem = ({
 }) => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const chainId = useSelector(selectEvmChainId);
 
   const onPress = useCallback(() => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.NFT_DETAILS_OPENED)
+        .addProperties({
+          chain_id: getDecimalChainId(chainId),
+          ...(source && { source }),
+        })
+        .build(),
+    );
     debouncedNavigation(navigation, item, source);
-  }, [navigation, item, source]);
+  }, [navigation, item, source, trackEvent, createEventBuilder, chainId]);
 
   return (
     <Pressable

--- a/app/components/Views/NftDetails/NftDetails.test.ts
+++ b/app/components/Views/NftDetails/NftDetails.test.ts
@@ -10,7 +10,6 @@ const initialState = {
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
-const mockTrackEvent = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -21,50 +20,6 @@ jest.mock('@react-navigation/native', () => {
       setOptions: mockSetOptions,
     }),
     useFocusEffect: jest.fn(),
-  };
-});
-
-jest.mock('../../hooks/useAnalytics/useAnalytics', () => {
-  let capturedTrackEvent: jest.Mock;
-
-  return {
-    useAnalytics: () => {
-      capturedTrackEvent = jest.fn((event) => {
-        if (mockTrackEvent) {
-          mockTrackEvent(event);
-        }
-      });
-
-      return {
-        trackEvent: capturedTrackEvent,
-        createEventBuilder: jest.fn((eventName) => {
-          const builder = {
-            eventName,
-            properties: {},
-            addProperties: jest.fn(function (props) {
-              this.properties = { ...this.properties, ...props };
-              return this;
-            }),
-            build: jest.fn(function () {
-              return {
-                eventName: this.eventName,
-                properties: this.properties,
-              };
-            }),
-          };
-          return builder;
-        }),
-        enable: jest.fn(),
-        addTraitsToUser: jest.fn(),
-        createDataDeletionTask: jest.fn(),
-        checkDataDeleteStatus: jest.fn(),
-        getDeleteRegulationCreationDate: jest.fn(),
-        getDeleteRegulationId: jest.fn(),
-        isDataRecorded: jest.fn(),
-        isEnabled: jest.fn(),
-        getAnalyticsId: jest.fn(),
-      };
-    },
   };
 });
 
@@ -179,7 +134,6 @@ const TEST_COLLECTIBLE = {
 
 let mockUseParamsValues: {
   collectible: typeof TEST_COLLECTIBLE;
-  source?: 'mobile-nft-list' | 'mobile-nft-list-page';
 } = {
   collectible: TEST_COLLECTIBLE,
 };
@@ -205,60 +159,5 @@ describe('NftDetails', () => {
     );
 
     expect(toJSON()).toMatchSnapshot();
-  });
-
-  it('tracks NFT Details Opened event with mobile-nft-list source', () => {
-    mockUseParamsValues = {
-      collectible: TEST_COLLECTIBLE,
-      source: 'mobile-nft-list',
-    };
-
-    renderScreen(QrScanner, { name: 'NftDetails' }, { state: initialState });
-
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        properties: expect.objectContaining({
-          chain_id: '1',
-          source: 'mobile-nft-list',
-        }),
-      }),
-    );
-  });
-
-  it('tracks NFT Details Opened event with mobile-nft-list-page source', () => {
-    mockUseParamsValues = {
-      collectible: TEST_COLLECTIBLE,
-      source: 'mobile-nft-list-page',
-    };
-
-    renderScreen(QrScanner, { name: 'NftDetails' }, { state: initialState });
-
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        properties: expect.objectContaining({
-          chain_id: '1',
-          source: 'mobile-nft-list-page',
-        }),
-      }),
-    );
-  });
-
-  it('tracks NFT Details Opened event without source when not provided', () => {
-    mockUseParamsValues = {
-      collectible: TEST_COLLECTIBLE,
-    };
-
-    renderScreen(QrScanner, { name: 'NftDetails' }, { state: initialState });
-
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        properties: expect.objectContaining({
-          chain_id: '1',
-        }),
-      }),
-    );
-    // Verify source is not included when not provided
-    const callArgs = mockTrackEvent.mock.calls[0][0];
-    expect(callArgs.properties).not.toHaveProperty('source');
   });
 });

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -40,9 +40,7 @@ import { formatCurrency } from '../../../util/confirm-tx';
 import CollectibleMedia from '../../../components/UI/CollectibleMedia';
 import ContentDisplay from '../../../components/UI/AssetOverview/AboutAsset/ContentDisplay';
 import BigNumber from 'bignumber.js';
-import { getDecimalChainId } from '../../../util/networks';
-import { MetaMetricsEvents } from '../../../core/Analytics';
-import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
+
 import { renderShortText } from '../../../util/general';
 import { prefixUrlWithProtocol } from '../../../util/browser';
 import { formatTimestampToYYYYMMDD } from '../../../util/date';
@@ -55,12 +53,11 @@ import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
 
 const NftDetails = () => {
   const navigation = useNavigation();
-  const { collectible, source } = useParams<NftDetailsParams>();
+  const { collectible } = useParams<NftDetailsParams>();
   const chainId = useSelector(selectChainId);
   const dispatch = useDispatch();
   const currentCurrency = useSelector(selectCurrentCurrency);
   const ticker = useSelector(selectEvmTicker);
-  const { trackEvent, createEventBuilder } = useAnalytics();
   const selectedNativeConversionRate = useSelector(selectConversionRate);
   const { navigateToSendPage } = useSendNavigation();
   const hasLastSalePrice = Boolean(
@@ -99,20 +96,6 @@ const NftDetails = () => {
   useEffect(() => {
     updateNavBar();
   }, [updateNavBar]);
-
-  useEffect(() => {
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.NFT_DETAILS_OPENED)
-        .addProperties({
-          chain_id: getDecimalChainId(chainId),
-          ...(source && { source }),
-        })
-        .build(),
-    );
-    // The linter wants `trackEvent` to be added as a dependency,
-    // But the event fires twice if I do that.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, source]);
 
   const viewHighestFloorPriceSource = () => {
     const url =


### PR DESCRIPTION
## **Description**

The `NFT Details Opened` Segment event was not firing when tapping an NFT from the homepage section (NFTsSection). The event was previously tracked inside `NftDetails.tsx` via a `useEffect` on mount, which is unreliable — screen caching in React Navigation can prevent a remount, silently dropping the event.

Fix: Moved the `NFT_DETAILS_OPENED` tracking to `NftGridItem.onPress` — the single click handler that is the only entry point for navigating to `NftDetails`. This guarantees the event fires at interaction time, regardless of navigation stack state.

- Removed useEffect analytics tracking from `NftDetails.tsx`
- Added NFT_DETAILS_OPENED tracking to `NftGridItem.onPress` with chain_id and source properties
- Replaced deprecated `useMetrics` → `useAnalytics` and `selectChainId` → `selectEvmChainId`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-498

## **Manual testing steps**

```gherkin
Feature: NFT Details Opened analytics event

  Scenario: user taps an NFT from the homepage section
    Given the homepage redesign feature flag is enabled
    And the user has NFTs in their wallet

    When user taps an NFT in the homepage NFTs section
    Then the NFT Details Opened Segment event fires with the correct chain_id and source

  Scenario: user taps an NFT from the full NFT list view
    Given the user navigates to the full NFT list

    When user taps an NFT
    Then the NFT Details Opened Segment event fires with source "mobile-nft-list-page"

```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: shifts an analytics event from a screen-mount `useEffect` to the NFT grid press handler and updates associated tests, with minimal impact beyond event timing/properties.
> 
> **Overview**
> Moves `MetaMetricsEvents.NFT_DETAILS_OPENED` tracking from `NftDetails` screen mount to `NftGridItem`’s `onPress`, ensuring the event fires on user interaction (and still includes `chain_id` plus optional `source`).
> 
> Removes the now-redundant analytics `useEffect` and `source` param usage in `NftDetails`, deletes the corresponding `NftDetails` analytics tests, and adds a new `NftGridItem` test suite covering event properties, navigation params, and long-press behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 381b0f5c3dca5fddf41d2fa4b132f5a7329825b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->