### PR TITLE
refactor: update icon sizes in PerpsSection and PredictMarketCard components

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -203,7 +203,6 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
                 position={position}
                 compact
                 compactVariant="position"
-                iconSize={36}
                 tpSlLoading={!tpSlReady}
                 onPress={() => handlePositionPress(position)}
                 testID={`perps-position-row-${position.symbol}`}
@@ -213,7 +212,6 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
               <PerpsCard
                 key={order.orderId}
                 order={order}
-                iconSize={36}
                 testID={`perps-order-row-${order.orderId}`}
               />
             ))}

--- a/app/components/Views/Homepage/Sections/Predictions/components/PredictMarketCard.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/PredictMarketCard.tsx
@@ -68,11 +68,11 @@ const OutcomeRow: React.FC<{
       gap={3}
     >
       {/* Outcome image */}
-      <Box twClassName="w-8 h-8 rounded-lg overflow-hidden bg-background-alternative">
+      <Box twClassName="w-6 h-6 rounded-lg overflow-hidden bg-background-alternative">
         {outcome.image ? (
           <Image
             source={{ uri: outcome.image }}
-            style={tw.style('w-8 h-8')}
+            style={tw.style('w-6 h-6')}
             resizeMode="cover"
           />
         ) : null}

--- a/app/components/Views/Homepage/Sections/Predictions/components/PredictMarketCardSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/PredictMarketCardSkeleton.tsx
@@ -29,7 +29,7 @@ const PredictMarketCardSkeleton: React.FC = () => {
           <View style={tw.style('gap-2')}>
             {/* Outcome 1 */}
             <View style={tw.style('flex-row items-center gap-3')}>
-              <View style={tw.style('w-8 h-8 rounded-lg')} />
+              <View style={tw.style('w-6 h-6 rounded-lg')} />
               <View style={tw.style('flex-1')}>
                 <View style={tw.style('w-[60%] h-4 rounded')} />
               </View>
@@ -38,7 +38,7 @@ const PredictMarketCardSkeleton: React.FC = () => {
 
             {/* Outcome 2 */}
             <View style={tw.style('flex-row items-center gap-3')}>
-              <View style={tw.style('w-8 h-8 rounded-lg')} />
+              <View style={tw.style('w-6 h-6 rounded-lg')} />
               <View style={tw.style('flex-1')}>
                 <View style={tw.style('w-[50%] h-4 rounded')} />
               </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed asset image sizes on the homepage to match design specifications. The Perps section was displaying position/order icons at 36px instead of the intended 40px, and the Predictions section was displaying outcome images at 32px instead of the intended 24px.

## **Changelog**

CHANGELOG entry: Fixed homepage asset image sizes to match design specifications

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-504

## **Manual testing steps**

```gherkin
Feature: Homepage asset image sizes

  Scenario: Perps position/order icons display at correct size
    Given user has open perpetual positions or orders
    When user views the Perpetuals section on the homepage
    Then position and order icons are displayed at 40px

  Scenario: Prediction outcome images display at correct size
    Given there are trending prediction markets
    When user views the Predictions section on the homepage
    Then outcome images in market cards are displayed at 24px
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="385" height="526" alt="Screenshot 2026-03-02 at 15 05 45" src="https://github.com/user-attachments/assets/4dda784d-c138-412b-ba97-cad5e00a20be" />
<img width="382" height="232" alt="Screenshot 2026-03-02 at 15 11 13" src="https://github.com/user-attachments/assets/ff87321a-d620-4b46-a694-699c710efa15" />

<!-- [screenshots/recordings] -->

### **After**
<img width="383" height="533" alt="Screenshot 2026-03-02 at 15 06 48" src="https://github.com/user-attachments/assets/1f345bdf-bbfa-40fa-926a-2f7aecbcff79" />
<img width="379" height="239" alt="Screenshot 2026-03-02 at 15 12 22" src="https://github.com/user-attachments/assets/0c7c62ed-e08b-4766-b7d1-32cb0dc87031" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that adjusts homepage asset image sizing by relying on component defaults and smaller Predict outcome thumbnails.
> 
> **Overview**
> Fixes homepage asset icon sizing to match design specs.
> 
> In `PerpsSection`, removes the explicit `iconSize={36}` overrides for position/order rows so `PerpsPositionCard`/`PerpsCard` use their default icon sizes.
> 
> In Predictions, reduces `PredictMarketCard` outcome thumbnail (and its skeleton) from `w-8 h-8` to `w-6 h-6` for a smaller 24px image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b4686cae0f4e693658e0e831200bd47a6541eb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->