### PR TITLE
fix: handle transient BLE errors during Ledger app switch and simplify HW retry logic

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
@@ -513,7 +513,7 @@ describe('HardwareWalletProvider', () => {
       });
     });
 
-    describe('retryLastOperation (internal, via bottom sheet props)', () => {
+    describe('retryEnsureDeviceReady (internal, via bottom sheet props)', () => {
       it('transitions to connecting state when retrying', async () => {
         const { result } = renderWithActions();
 
@@ -536,7 +536,7 @@ describe('HardwareWalletProvider', () => {
         );
 
         const internalRetry =
-          capturedBottomSheetProps.retryLastOperation as () => Promise<void>;
+          capturedBottomSheetProps.retryEnsureDeviceReady as () => Promise<void>;
         await act(async () => {
           await internalRetry();
         });

--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -33,7 +33,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
 
   const effectiveWalletType = targetWalletType ?? walletType;
 
-  const { handleDeviceEvent, handleError, clearError, updateConnectionState } =
+  const { handleDeviceEvent, handleError, updateConnectionState } =
     useDeviceEventHandlers({
       refs,
       setters,
@@ -72,15 +72,15 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
   const {
     ensureDeviceReady,
     connect,
-    retryLastOperation,
+    retryEnsureDeviceReady,
     closeFlow,
     handleConnectionSuccess,
   } = useDeviceConnectionFlow({
     refs,
     setters,
     walletType: effectiveWalletType,
+    deviceId,
     handleError,
-    clearError,
     updateConnectionState,
     createAdapterWithCallbacks,
     initializeAdapter,
@@ -158,7 +158,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
         connectionState={connectionState}
         deviceSelection={deviceSelection}
         walletType={effectiveWalletType}
-        retryLastOperation={retryLastOperation}
+        retryEnsureDeviceReady={retryEnsureDeviceReady}
         selectDevice={selectDevice}
         rescan={rescan}
         connect={connect}

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -162,16 +162,14 @@ describe('LedgerBluetoothAdapter', () => {
       expect(mockedTransportBLE.open).toHaveBeenCalledTimes(2);
     });
 
-    it('emits ConnectionFailed on error', async () => {
+    it('throws and clears state on connect error', async () => {
       const error = new Error('BLE connection failed');
       mockedTransportBLE.open.mockRejectedValueOnce(error);
 
       await expect(adapter.connect('device-123')).rejects.toThrow(error);
 
-      expect(onDeviceEvent).toHaveBeenCalledWith({
-        event: DeviceEvent.ConnectionFailed,
-        error,
-      });
+      expect(adapter.isConnected()).toBe(false);
+      expect(adapter.getConnectedDeviceId()).toBeNull();
     });
 
     it('throws if adapter is destroyed', async () => {
@@ -206,20 +204,14 @@ describe('LedgerBluetoothAdapter', () => {
       expect(adapter.isConnected()).toBe(false);
     });
 
-    it('emits ConnectionFailed with normalized error when connect rejects non-Error', async () => {
+    it('throws non-Error values as-is on connect failure', async () => {
       mockedTransportBLE.open.mockRejectedValueOnce('connection failed');
 
       await expect(adapter.connect('device-123')).rejects.toBe(
         'connection failed',
       );
 
-      expect(onDeviceEvent).toHaveBeenCalledWith({
-        event: DeviceEvent.ConnectionFailed,
-        error: expect.any(Error),
-      });
-      expect(
-        (onDeviceEvent.mock.calls[0][0] as { error: Error }).error.message,
-      ).toBe('connection failed');
+      expect(adapter.isConnected()).toBe(false);
     });
 
     it('ignores transport error event when flow is complete', async () => {
@@ -309,15 +301,13 @@ describe('LedgerBluetoothAdapter', () => {
       )?.[1];
       expect(disconnectHandler).toBeDefined();
 
-      // First 5 calls increment restartCount and return; 6th call hits limit and calls onDisconnect
+      // Fire 6 disconnect events (limit is 5)
       for (let i = 0; i < 6; i++) {
         disconnectHandler?.();
       }
 
       expect(onDisconnect).toHaveBeenCalledTimes(1);
-      expect(onDisconnect).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Device disconnected' }),
-      );
+      expect(adapter.isConnected()).toBe(false);
     });
 
     it('ignores disconnect event when flow is complete', async () => {
@@ -426,13 +416,11 @@ describe('LedgerBluetoothAdapter', () => {
     });
 
     it('returns false when no transport after connect', async () => {
-      // Mock connect to succeed but leave transport as null
       mockedTransportBLE.open.mockResolvedValueOnce(
         null as unknown as TransportBLE,
       );
 
       const result = await adapter.ensureDeviceReady('device-123');
-
       expect(result).toBe(false);
     });
 

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -1,5 +1,3 @@
-// TODO: when hw overhaul is complete, all DevLogger.log calls should be removed
-
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble';
 import { State as BleState } from 'react-native-ble-plx';
 import { Observable, Subscription } from 'rxjs';
@@ -27,7 +25,7 @@ const LEDGER_OPERATION_TIMEOUT_MS = 10000;
 const DEFAULT_SCAN_TIMEOUT_MS = 30000;
 const CONNECTION_RESTART_LIMIT = 5;
 const MAX_DISCONNECT_RETRIES = 3;
-const RETRY_DELAY_MS = 1000;
+const RETRY_DELAY_MS = 2000;
 
 /**
  * Adapter for Ledger hardware wallets using Bluetooth Low Energy (BLE).
@@ -322,7 +320,7 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
    * 3. If not open, emits AppClosed event and returns false
    * 4. If open, verifies device is unlocked
    *
-   * Handles transient disconnects (e.g., during app switch) by retrying.
+   * Handles transient BLE errors (e.g., during app switch) by retrying.
    *
    * @param deviceId - The device ID to connect to
    * @returns true if device is ready, false otherwise
@@ -337,24 +335,26 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
       deviceId,
     );
 
-    // Retry on transient disconnects (e.g., device switching apps)
+    this.#restartCount = 0;
+
+    // Retry on transient BLE errors (e.g., device switching apps)
     for (let attempt = 1; attempt <= MAX_DISCONNECT_RETRIES; attempt++) {
       try {
         return await this.#doEnsureDeviceReady(deviceId);
       } catch (error) {
         if (
-          this.#isDisconnectError(error) &&
+          this.#isTransientBleError(error) &&
           attempt < MAX_DISCONNECT_RETRIES
         ) {
           DevLogger.log(
-            `[LedgerBluetoothAdapter] Disconnect during check (attempt ${attempt}/${MAX_DISCONNECT_RETRIES}), retrying...`,
+            `[LedgerBluetoothAdapter] Transient BLE error during check (attempt ${attempt}/${MAX_DISCONNECT_RETRIES}), retrying...`,
           );
           await this.#closeTransport();
           await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
           continue;
         }
 
-        // Non-disconnect error or max retries reached
+        // Non-transient error or max retries reached
         throw error;
       }
     }
@@ -408,7 +408,7 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
 
   /**
    * Verify the Ethereum app is unlocked by requesting an address.
-   * Rethrows disconnect errors to allow retry in ensureDeviceReady.
+   * Rethrows transient BLE errors to allow retry in ensureDeviceReady.
    */
   async #verifyEthereumAppUnlocked(): Promise<boolean> {
     DevLogger.log(
@@ -438,7 +438,7 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         verifyError,
       );
 
-      if (this.#isDisconnectError(verifyError)) {
+      if (this.#isTransientBleError(verifyError)) {
         throw verifyError;
       }
 
@@ -646,14 +646,19 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
   }
 
   /**
-   * Check if error indicates a Ledger transport disconnect (so caller can retry).
+   * Check if error is a transient BLE error that can be retried
+   * (disconnects during app switch, pairing failures during reconnect, etc.)
    */
-  #isDisconnectError(error: unknown): boolean {
-    return (
-      error instanceof Error &&
-      (error.name === 'DisconnectedDevice' ||
-        error.name === 'DisconnectedDeviceDuringOperation')
-    );
+  #isTransientBleError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const transientBleErrorNames = [
+      'DisconnectedDevice',
+      'DisconnectedDeviceDuringOperation',
+      'PairingFailed',
+      'PeerRemovedPairing',
+      'BleError',
+    ];
+    return transientBleErrorNames.includes(error.name);
   }
 
   /**

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx
@@ -16,7 +16,7 @@ const mockDeviceSelection = {
   scanError: null,
 };
 const mockActions = {
-  retryLastOperation: jest.fn(),
+  retryEnsureDeviceReady: jest.fn(),
   selectDevice: jest.fn(),
   rescan: jest.fn(),
   connect: jest.fn(),
@@ -484,7 +484,7 @@ describe('HardwareWalletBottomSheet', () => {
       expect(mockActions.connect).toHaveBeenCalledWith('device-1');
     });
 
-    it('calls retryLastOperation when error continue is triggered', async () => {
+    it('calls retryEnsureDeviceReady when error continue is triggered', async () => {
       const error = new HardwareWalletError('Test error', {
         code: ErrorCode.Unknown,
         severity: Severity.Err,
@@ -495,7 +495,7 @@ describe('HardwareWalletBottomSheet', () => {
         status: ConnectionStatus.ErrorState,
         error,
       });
-      mockActions.retryLastOperation.mockResolvedValue(undefined);
+      mockActions.retryEnsureDeviceReady.mockResolvedValue(undefined);
       render(<HardwareWalletBottomSheet {...createDefaultProps()} />);
 
       const onContinue =
@@ -503,7 +503,7 @@ describe('HardwareWalletBottomSheet', () => {
       expect(onContinue).toBeDefined();
       await onContinue();
 
-      expect(mockActions.retryLastOperation).toHaveBeenCalled();
+      expect(mockActions.retryEnsureDeviceReady).toHaveBeenCalled();
     });
 
     it('calls onClose when error dismiss is triggered', () => {
@@ -567,20 +567,20 @@ describe('HardwareWalletBottomSheet', () => {
       expect(onAwaitingConfirmationCancel).toHaveBeenCalled();
     });
 
-    it('calls retryLastOperation when awaiting app continue is triggered', async () => {
+    it('calls retryEnsureDeviceReady when awaiting app continue is triggered', async () => {
       Object.assign(mockConnectionState, {
         status: ConnectionStatus.AwaitingApp,
         deviceId: 'device-123',
         requiredApp: 'Ethereum',
       });
-      mockActions.retryLastOperation.mockResolvedValue(undefined);
+      mockActions.retryEnsureDeviceReady.mockResolvedValue(undefined);
       render(<HardwareWalletBottomSheet {...createDefaultProps()} />);
 
       const onContinue = lastAwaitingAppProps.onContinue as () => Promise<void>;
       expect(onContinue).toBeDefined();
       await onContinue();
 
-      expect(mockActions.retryLastOperation).toHaveBeenCalled();
+      expect(mockActions.retryEnsureDeviceReady).toHaveBeenCalled();
     });
   });
 });

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
@@ -39,7 +39,7 @@ export interface HardwareWalletBottomSheetProps {
   deviceSelection: DeviceSelectionState;
   walletType: HardwareWalletType | null;
 
-  retryLastOperation: () => Promise<void>;
+  retryEnsureDeviceReady: () => Promise<void>;
   selectDevice: (device: DiscoveredDevice) => void;
   rescan: () => void;
   connect: (deviceId: string) => Promise<void>;
@@ -71,7 +71,7 @@ export const HardwareWalletBottomSheet: React.FC<
   connectionState,
   deviceSelection,
   walletType,
-  retryLastOperation,
+  retryEnsureDeviceReady,
   selectDevice,
   rescan,
   connect,
@@ -123,8 +123,8 @@ export const HardwareWalletBottomSheet: React.FC<
   }, [onAwaitingConfirmationCancel]);
 
   const handleErrorContinue = useCallback(async () => {
-    await retryLastOperation();
-  }, [retryLastOperation]);
+    await retryEnsureDeviceReady();
+  }, [retryEnsureDeviceReady]);
 
   const handleErrorDismiss = useCallback(() => {
     onClose();

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -16,8 +16,8 @@ interface UseDeviceConnectionFlowOptions {
   refs: HardwareWalletRefs;
   setters: HardwareWalletStateSetters;
   walletType: HardwareWalletType | null;
+  deviceId: string | null;
   handleError: (error: unknown) => void;
-  clearError: () => void;
   updateConnectionState: (state: HardwareWalletConnectionState) => void;
   createAdapterWithCallbacks: (
     targetType: HardwareWalletType,
@@ -31,7 +31,7 @@ interface UseDeviceConnectionFlowOptions {
 interface UseDeviceConnectionFlowResult {
   ensureDeviceReady: (targetDeviceId?: string) => Promise<boolean>;
   connect: (targetDeviceId: string) => Promise<void>;
-  retryLastOperation: () => Promise<void>;
+  retryEnsureDeviceReady: () => Promise<void>;
   closeFlow: () => void;
   handleConnectionSuccess: () => void;
 }
@@ -46,18 +46,13 @@ export const useDeviceConnectionFlow = ({
   refs,
   setters,
   walletType,
+  deviceId,
   handleError,
-  clearError,
   updateConnectionState,
   createAdapterWithCallbacks,
   initializeAdapter,
   checkTransportEnabledOrShowError,
 }: UseDeviceConnectionFlowOptions): UseDeviceConnectionFlowResult => {
-  const lastOperationRef = useRef<{
-    type: 'connect' | 'ensureReady';
-    deviceId?: string;
-  } | null>(null);
-
   const pendingReadyResolveRef = useRef<((ready: boolean) => void) | null>(
     null,
   );
@@ -148,11 +143,6 @@ export const useDeviceConnectionFlow = ({
       }
 
       refs.isConnectingRef.current = true;
-      lastOperationRef.current = {
-        type: 'connect',
-        deviceId: targetDeviceId,
-      };
-
       updateConnectionState({ status: ConnectionStatus.Connecting });
 
       try {
@@ -163,7 +153,7 @@ export const useDeviceConnectionFlow = ({
 
         await adapter.connect(targetDeviceId);
 
-        if (!lastOperationRef.current) {
+        if (!pendingReadyResolveRef.current) {
           DevLogger.log(
             '[HardwareWallet] Connect completed but flow was cancelled — ignoring',
           );
@@ -172,22 +162,15 @@ export const useDeviceConnectionFlow = ({
 
         setters.setDeviceId(targetDeviceId);
 
-        if (pendingReadyResolveRef.current) {
-          DevLogger.log(
-            '[HardwareWallet] Connect succeeded, continuing readiness check...',
-          );
+        DevLogger.log(
+          '[HardwareWallet] Connect succeeded, continuing readiness check...',
+        );
 
-          try {
-            await tryEnsureReady(adapter, targetDeviceId);
-          } catch (error) {
-            DevLogger.log('[HardwareWallet] Readiness check failed:', error);
-            handleError(error);
-          }
-        } else {
-          updateConnectionState({
-            status: ConnectionStatus.AwaitingApp,
-            deviceId: targetDeviceId,
-          });
+        try {
+          await tryEnsureReady(adapter, targetDeviceId);
+        } catch (error) {
+          DevLogger.log('[HardwareWallet] Readiness check failed:', error);
+          handleError(error);
         }
       } catch (error) {
         handleError(error);
@@ -221,11 +204,6 @@ export const useDeviceConnectionFlow = ({
       if (adapter.resetFlowState) {
         adapter.resetFlowState();
       }
-
-      lastOperationRef.current = {
-        type: 'ensureReady',
-        deviceId: deviceIdToUse,
-      };
 
       const transportUnavailable =
         await checkTransportEnabledOrShowError(adapter);
@@ -271,49 +249,28 @@ export const useDeviceConnectionFlow = ({
     ],
   );
 
-  const retryLastOperation = useCallback(async (): Promise<void> => {
+  const retryEnsureDeviceReady = useCallback(async (): Promise<void> => {
     const adapter = refs.adapterRef.current;
     if (adapter?.resetFlowState) {
       adapter.resetFlowState();
-    }
-
-    const lastOp = lastOperationRef.current;
-    if (!lastOp) {
-      clearError();
-      return;
     }
 
     if (adapter && (await checkTransportEnabledOrShowError(adapter))) {
       return;
     }
 
-    switch (lastOp.type) {
-      case 'ensureReady':
-        if (lastOp.deviceId && adapter) {
-          updateConnectionState({ status: ConnectionStatus.Connecting });
-          try {
-            await tryEnsureReady(adapter, lastOp.deviceId);
-          } catch (error) {
-            handleError(error);
-          }
-        } else {
-          DevLogger.log(
-            '[HardwareWallet] Retry: No deviceId - restarting device selection',
-          );
-          updateConnectionState({ status: ConnectionStatus.Scanning });
-        }
-        break;
-      case 'connect':
-        if (lastOp.deviceId) {
-          await connect(lastOp.deviceId);
-        }
-        break;
-      default:
-        break;
+    if (deviceId && adapter) {
+      updateConnectionState({ status: ConnectionStatus.Connecting });
+      try {
+        await tryEnsureReady(adapter, deviceId);
+      } catch (error) {
+        handleError(error);
+      }
+    } else {
+      updateConnectionState({ status: ConnectionStatus.Scanning });
     }
   }, [
-    connect,
-    clearError,
+    deviceId,
     handleError,
     updateConnectionState,
     refs,
@@ -326,7 +283,6 @@ export const useDeviceConnectionFlow = ({
       pendingReadyResolveRef.current(false);
       pendingReadyResolveRef.current = null;
     }
-    lastOperationRef.current = null;
     setters.setTargetWalletType(null);
     updateConnectionState({ status: ConnectionStatus.Disconnected });
   }, [setters, updateConnectionState]);
@@ -343,7 +299,7 @@ export const useDeviceConnectionFlow = ({
   return {
     ensureDeviceReady,
     connect,
-    retryLastOperation,
+    retryEnsureDeviceReady,
     closeFlow,
     handleConnectionSuccess,
   };

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
@@ -168,41 +168,6 @@ describe('useDeviceEventHandlers', () => {
     });
   });
 
-  describe('clearError', () => {
-    it('clears error state and returns to disconnected', () => {
-      const error = new HardwareWalletError('Test', {
-        code: ErrorCode.Unknown,
-        severity: Severity.Err,
-        category: Category.Unknown,
-        userMessage: 'Test',
-      });
-      lastConnectionState = { status: ConnectionStatus.ErrorState, error };
-
-      const { result } = createHook();
-
-      act(() => {
-        result.current.clearError();
-      });
-
-      expect(lastConnectionState.status).toBe(ConnectionStatus.Disconnected);
-    });
-
-    it('does not change non-error states', () => {
-      lastConnectionState = {
-        status: ConnectionStatus.Connected,
-        deviceId: 'device-123',
-      };
-
-      const { result } = createHook();
-
-      act(() => {
-        result.current.clearError();
-      });
-
-      expect(lastConnectionState.status).toBe(ConnectionStatus.Connected);
-    });
-  });
-
   describe('handleDeviceEvent', () => {
     describe('Connected event', () => {
       it('updates to connected state', () => {

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.ts
@@ -33,8 +33,6 @@ interface DeviceEventHandlersResult {
   handleDeviceEvent: (payload: DeviceEventPayload) => void;
   /** Parses an error into a HardwareWalletError and transitions to ErrorState. */
   handleError: (error: unknown) => void;
-  /** Clears the current error, returning to Disconnected if in ErrorState. */
-  clearError: () => void;
 }
 
 /**
@@ -79,15 +77,6 @@ export const useDeviceEventHandlers = ({
     },
     [updateConnectionState, walletType, refs],
   );
-
-  const clearError = useCallback(() => {
-    setters.setConnectionState((prev) => {
-      if (prev.status === ConnectionStatus.ErrorState) {
-        return { status: ConnectionStatus.Disconnected };
-      }
-      return prev;
-    });
-  }, [setters]);
 
   const handleDeviceEvent = useCallback(
     (payload: DeviceEventPayload) => {
@@ -207,6 +196,5 @@ export const useDeviceEventHandlers = ({
     updateConnectionState,
     handleDeviceEvent,
     handleError,
-    clearError,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Part "4.5.1" of the hardware wallet connection & error management overhaul. This is a small follow up PR and does not introduce user facing changes.

Will close:
- https://consensyssoftware.atlassian.net/browse/MUL-1506

Final implementation will look like this ([Figma designs](https://www.figma.com/design/1F3yNWYLOVPFpTPeJugH20/SWAP?node-id=11110-19571&t=tPMZNNiwCgbDfegd-0)):
<img width="1404" height="631" alt="image" src="https://github.com/user-attachments/assets/68850711-f53b-4060-8b47-6faceb67f82f" />

Reference feature branch: https://github.com/MetaMask/metamask-mobile/pull/25519

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

No manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core hardware-wallet connection/retry behavior (including BLE reconnection timing and which errors are retried), which could impact Ledger connection reliability and error recovery paths.
> 
> **Overview**
> Improves Ledger BLE readiness checks by retrying `ensureDeviceReady` on a broader set of *transient BLE errors* (e.g., disconnects during app switch, pairing-related failures) and increasing the retry backoff delay.
> 
> Simplifies the hardware-wallet retry path by removing generic "retry last operation" tracking and standardizing retries around `retryEnsureDeviceReady` (wired through `HardwareWalletProvider`/`HardwareWalletBottomSheet`), while dropping the now-unused `clearError` handler from `useDeviceEventHandlers`.
> 
> Tightens adapter connection failure behavior/tests to ensure connect errors clear adapter connection state and propagate thrown values consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e64c8a61d825515c4f39e84a1001f8c9bd69382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->