### PR TITLE
Pull request review

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -63,7 +63,7 @@ export const usePerpsHomeData = ({
   searchQuery = '',
 }: UsePerpsHomeDataParams = {}): UsePerpsHomeDataReturn => {
   // Get connection state to guard REST calls that require an initialized controller
-  const { isConnected, isInitialized } = usePerpsConnection();
+  const { isConnected, isInitialized, isConnecting } = usePerpsConnection();
 
   // Fetch positions via WebSocket with throttling for performance
   const { positions, isInitialLoading: isPositionsLoading } =
@@ -366,12 +366,14 @@ export const usePerpsHomeData = ({
     recentActivity: limitedActivity,
     sortBy,
     isLoading: {
-      positions: isPositionsLoading,
-      orders: isOrdersLoading,
+      // During reconnection, treat WebSocket-backed data as loading so the UI
+      // shows skeletons instead of briefly flashing "no positions" → positions.
+      positions: isPositionsLoading || isConnecting,
+      orders: isOrdersLoading || isConnecting,
       markets: isMarketsLoading,
       // Only wait for WebSocket fills (fast ~100ms), not REST fills (slow 3s+)
       // REST fills merge in background via mergedFills without blocking initial render
-      activity: isFillsLoading,
+      activity: isFillsLoading || isConnecting,
     },
     refresh,
   };

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -1,3 +1,8 @@
+import { AppState, type AppStateStatus } from 'react-native';
+import {
+  addEventListener as netInfoAddEventListener,
+  type NetInfoState,
+} from '@react-native-community/netinfo';
 import { setMeasurement } from '@sentry/react-native';
 import BackgroundTimer from 'react-native-background-timer';
 import performance from 'react-native-performance';
@@ -57,6 +62,11 @@ class PerpsConnectionManagerClass {
   private isInGracePeriod = false;
   private pendingReconnectPromise: Promise<void> | null = null;
   private connectionTimeoutRef: ReturnType<typeof setTimeout> | null = null;
+  private appStateSubscription: ReturnType<
+    typeof AppState.addEventListener
+  > | null = null;
+  private netInfoUnsubscribe: (() => void) | null = null;
+  private wasOffline = false;
 
   private constructor() {
     // Private constructor to enforce singleton pattern
@@ -178,13 +188,135 @@ class PerpsConnectionManagerClass {
       this.previousHip3Version = currentHip3Version;
     });
 
+    // Listen for app state changes to reconnect after background
+    if (!this.appStateSubscription) {
+      this.appStateSubscription = AppState.addEventListener(
+        'change',
+        (nextAppState: AppStateStatus) => {
+          this.handleAppStateChange(nextAppState).catch((error) => {
+            Logger.error(
+              ensureError(error, 'PerpsConnectionManager.appStateListener'),
+              {
+                tags: { feature: PERPS_CONSTANTS.FeatureName },
+                context: {
+                  name: 'PerpsConnectionManager.appStateListener',
+                  data: { message: 'Error handling app state change' },
+                },
+              },
+            );
+          });
+        },
+      );
+    }
+
+    // Listen for connectivity changes (WiFi off/on, airplane mode, etc.)
+    if (!this.netInfoUnsubscribe) {
+      this.netInfoUnsubscribe = netInfoAddEventListener(
+        (netState: NetInfoState) => {
+          const isOnline =
+            netState.isInternetReachable ?? netState.isConnected ?? false;
+
+          if (isOnline && this.wasOffline) {
+            DevLogger.log(
+              'PerpsConnectionManager: Network restored - validating connection',
+            );
+            this.validateAndReconnect(
+              'PerpsConnectionManager.netInfoListener',
+            ).catch((error) => {
+              Logger.error(
+                ensureError(error, 'PerpsConnectionManager.netInfoListener'),
+                {
+                  tags: { feature: PERPS_CONSTANTS.FeatureName },
+                  context: {
+                    name: 'PerpsConnectionManager.netInfoListener',
+                    data: {
+                      message: 'Error reconnecting after network restored',
+                    },
+                  },
+                },
+              );
+            });
+          }
+
+          this.wasOffline = !isOnline;
+        },
+      );
+    }
+
     DevLogger.log('PerpsConnectionManager: State monitoring set up');
+  }
+
+  /**
+   * Validate the WebSocket connection and force-reconnect if it is stale.
+   * Shared by both AppState (background→foreground) and NetInfo (offline→online)
+   * recovery paths.
+   *
+   * @param context - Caller identifier for error reporting
+   */
+  private async validateAndReconnect(context: string): Promise<void> {
+    if (this.connectionRefCount <= 0 || this.isConnecting) {
+      return;
+    }
+
+    if (this.isConnected) {
+      try {
+        const provider = Engine.context.PerpsController.getActiveProvider();
+        await provider.ping();
+        DevLogger.log(
+          `PerpsConnectionManager: ${context} - connection healthy`,
+        );
+        return;
+      } catch {
+        DevLogger.log(
+          `PerpsConnectionManager: ${context} - connection stale, triggering reconnection`,
+        );
+        this.isConnected = false;
+        this.isInitialized = false;
+      }
+    }
+
+    await this.reconnectWithNewContext({ force: true });
+    DevLogger.log(
+      `PerpsConnectionManager: ${context} - reconnection successful`,
+    );
+  }
+
+  /**
+   * Handle app state transitions to recover from stale WebSocket connections.
+   * When the app returns from background, the OS may have silently killed the
+   * WebSocket. A health-check ping detects this and triggers reconnection.
+   */
+  private async handleAppStateChange(
+    nextAppState: AppStateStatus,
+  ): Promise<void> {
+    if (nextAppState !== 'active') {
+      return;
+    }
+
+    // Cancel any pending grace period — user is back
+    if (this.isInGracePeriod) {
+      DevLogger.log(
+        'PerpsConnectionManager: App resumed - cancelling grace period',
+      );
+      this.cancelGracePeriod();
+    }
+
+    await this.validateAndReconnect('appResume');
   }
 
   /**
    * Clean up state monitoring
    */
   private cleanupStateMonitoring(): void {
+    if (this.appStateSubscription) {
+      this.appStateSubscription.remove();
+      this.appStateSubscription = null;
+    }
+    if (this.netInfoUnsubscribe) {
+      this.netInfoUnsubscribe();
+      this.netInfoUnsubscribe = null;
+      this.wasOffline = false;
+    }
     if (this.unsubscribeFromStore) {
       this.unsubscribeFromStore();
       this.unsubscribeFromStore = null;

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -355,6 +355,12 @@ class PerpsConnectionManagerClass {
       this.cancelGracePeriod();
     }
 
+    // Cancel any pending network-restore retry timer so it doesn't fire after
+    // this app-resume path already recovers the connection. Without this, a
+    // stale timer calls validateAndReconnect with skipPing=true, forcing an
+    // unnecessary disconnect-and-reconnect on a healthy connection.
+    this.cancelNetworkRestoreRetry();
+
     await this.validateAndReconnect('appResume');
   }
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -915,7 +915,17 @@ class PerpsConnectionManagerClass {
       this.clearError();
 
       // Stage 2: Force the controller to reinitialize with new context
+      // Disconnect first so the controller resets its isInitialized flag —
+      // without this, init() silently skips when the controller thinks it's
+      // already initialized (even though the underlying WebSocket is dead).
       const reinitStart = performance.now();
+      try {
+        await Engine.context.PerpsController.disconnect();
+      } catch {
+        DevLogger.log(
+          'PerpsConnectionManager: disconnect before reinit failed (continuing)',
+        );
+      }
       await Engine.context.PerpsController.init();
       setMeasurement(
         PerpsMeasurementName.PerpsControllerReinit,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -67,6 +67,8 @@ class PerpsConnectionManagerClass {
   > | null = null;
   private netInfoUnsubscribe: (() => void) | null = null;
   private wasOffline = false;
+  private networkRestoreRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private networkRestoreRetryCount = 0;
 
   private constructor() {
     // Private constructor to enforce singleton pattern
@@ -213,32 +215,20 @@ class PerpsConnectionManagerClass {
     if (!this.netInfoUnsubscribe) {
       this.netInfoUnsubscribe = netInfoAddEventListener(
         (netState: NetInfoState) => {
-          const isOnline =
-            netState.isInternetReachable ?? netState.isConnected ?? false;
+          const isOnline = netState.isInternetReachable === true;
 
           if (isOnline && this.wasOffline) {
             DevLogger.log(
               'PerpsConnectionManager: Network restored - validating connection',
             );
-            this.validateAndReconnect(
-              'PerpsConnectionManager.netInfoListener',
-            ).catch((error) => {
-              Logger.error(
-                ensureError(error, 'PerpsConnectionManager.netInfoListener'),
-                {
-                  tags: { feature: PERPS_CONSTANTS.FeatureName },
-                  context: {
-                    name: 'PerpsConnectionManager.netInfoListener',
-                    data: {
-                      message: 'Error reconnecting after network restored',
-                    },
-                  },
-                },
-              );
-            });
+            this.reconnectAfterNetworkRestore();
           }
 
-          this.wasOffline = !isOnline;
+          if (!isOnline) {
+            this.wasOffline = true;
+          } else if (isOnline && this.isConnected) {
+            this.wasOffline = false;
+          }
         },
       );
     }
@@ -252,13 +242,17 @@ class PerpsConnectionManagerClass {
    * recovery paths.
    *
    * @param context - Caller identifier for error reporting
+   * @param skipPing - Skip ping and force reconnect after known network loss
    */
-  private async validateAndReconnect(context: string): Promise<void> {
+  private async validateAndReconnect(
+    context: string,
+    skipPing = false,
+  ): Promise<void> {
     if (this.connectionRefCount <= 0 || this.isConnecting) {
       return;
     }
 
-    if (this.isConnected) {
+    if (this.isConnected && !skipPing) {
       try {
         const provider = Engine.context.PerpsController.getActiveProvider();
         await provider.ping();
@@ -270,15 +264,75 @@ class PerpsConnectionManagerClass {
         DevLogger.log(
           `PerpsConnectionManager: ${context} - connection stale, triggering reconnection`,
         );
-        this.isConnected = false;
-        this.isInitialized = false;
       }
     }
+
+    this.isConnected = false;
+    this.isInitialized = false;
 
     await this.reconnectWithNewContext({ force: true });
     DevLogger.log(
       `PerpsConnectionManager: ${context} - reconnection successful`,
     );
+  }
+
+  /**
+   * Attempt reconnection after network restore with exponential backoff.
+   * WebSocket endpoints may not be reachable immediately even though
+   * NetInfo reports isInternetReachable: true.
+   */
+  private reconnectAfterNetworkRestore(): void {
+    this.cancelNetworkRestoreRetry();
+    this.networkRestoreRetryCount = 0;
+    this.attemptNetworkRestoreReconnect();
+  }
+
+  private attemptNetworkRestoreReconnect(): void {
+    this.validateAndReconnect('PerpsConnectionManager.netInfoListener', true)
+      .then(() => {
+        this.wasOffline = false;
+        this.networkRestoreRetryCount = 0;
+      })
+      .catch((error) => {
+        this.networkRestoreRetryCount++;
+        if (
+          this.networkRestoreRetryCount <
+          PERPS_CONSTANTS.NetworkRestoreMaxRetries
+        ) {
+          const delay =
+            PERPS_CONSTANTS.NetworkRestoreRetryBaseMs *
+            this.networkRestoreRetryCount;
+          DevLogger.log(
+            `PerpsConnectionManager: Network restore retry ${this.networkRestoreRetryCount} in ${delay}ms`,
+          );
+          this.networkRestoreRetryTimer = setTimeout(() => {
+            this.networkRestoreRetryTimer = null;
+            this.attemptNetworkRestoreReconnect();
+          }, delay);
+        } else {
+          Logger.error(
+            ensureError(error, 'PerpsConnectionManager.netInfoListener'),
+            {
+              tags: { feature: PERPS_CONSTANTS.FeatureName },
+              context: {
+                name: 'PerpsConnectionManager.netInfoListener',
+                data: {
+                  message:
+                    'Network restore reconnection failed after max retries',
+                },
+              },
+            },
+          );
+        }
+      });
+  }
+
+  private cancelNetworkRestoreRetry(): void {
+    if (this.networkRestoreRetryTimer) {
+      clearTimeout(this.networkRestoreRetryTimer);
+      this.networkRestoreRetryTimer = null;
+    }
+    this.networkRestoreRetryCount = 0;
   }
 
   /**
@@ -317,6 +371,7 @@ class PerpsConnectionManagerClass {
       this.netInfoUnsubscribe = null;
       this.wasOffline = false;
     }
+    this.cancelNetworkRestoreRetry();
     if (this.unsubscribeFromStore) {
       this.unsubscribeFromStore();
       this.unsubscribeFromStore = null;

--- a/app/controllers/perps/constants/perpsConfig.ts
+++ b/app/controllers/perps/constants/perpsConfig.ts
@@ -30,6 +30,8 @@ export const PERPS_CONSTANTS = {
   ReconnectionDelayAndroidMs: 300, // Android-specific reconnection delay for better reliability on slower devices
   ReconnectionDelayIosMs: 100, // iOS-specific reconnection delay for optimal performance
   ReconnectionRetryDelayMs: 5_000, // 5 seconds delay between reconnection attempts
+  NetworkRestoreMaxRetries: 8, // Max retry attempts when reconnecting after WiFi/network restore
+  NetworkRestoreRetryBaseMs: 1_500, // Base delay (ms) between network restore retries (multiplied by attempt number)
 
   // Connection manager timing constants
   BalanceUpdateThrottleMs: 15000, // Update at most every 15 seconds to reduce state updates in PerpsConnectionManager


### PR DESCRIPTION
Cancel pending network restore retries when the app resumes to prevent unnecessary reconnections.

The `handleAppStateChange` method now calls `cancelNetworkRestoreRetry()` to prevent a race condition where a stale network-restore retry timer could fire after the app-resume path has already successfully re-established the connection, forcing an unwanted disconnect and reconnect.

---
<p><a href="https://cursor.com/agents/bc-0fd13a72-6fad-4352-bd09-15f159837eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd13a72-6fad-4352-bd09-15f159837eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

