### PR TITLE
fix: MUSD-365 update mUSD conversion tertiary CTA cta_text property to reflect current component CTA text 

### DIFF
--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
@@ -435,7 +435,9 @@ describe('MusdConversionAssetOverviewCta', () => {
       });
 
       // Assert
-      const expectedCtaText = `${strings('earn.musd_conversion.earn_rewards_when')} ${strings('earn.musd_conversion.you_convert_to')} mUSD`;
+      const expectedCtaText = strings('earn.musd_conversion.boost_title', {
+        percentage: MUSD_CONVERSION_APY,
+      });
 
       expect(mockCreateEventBuilder).toHaveBeenCalledTimes(1);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
@@ -482,7 +484,9 @@ describe('MusdConversionAssetOverviewCta', () => {
       });
 
       // Assert
-      const expectedCtaText = `${strings('earn.musd_conversion.earn_rewards_when')} ${strings('earn.musd_conversion.you_convert_to')} mUSD`;
+      const expectedCtaText = strings('earn.musd_conversion.boost_title', {
+        percentage: MUSD_CONVERSION_APY,
+      });
 
       expect(mockCreateEventBuilder).toHaveBeenCalledTimes(1);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
@@ -530,7 +534,9 @@ describe('MusdConversionAssetOverviewCta', () => {
       });
 
       // Assert
-      const expectedCtaText = `${strings('earn.musd_conversion.earn_rewards_when')} ${strings('earn.musd_conversion.you_convert_to')} mUSD`;
+      const expectedCtaText = strings('earn.musd_conversion.boost_title', {
+        percentage: MUSD_CONVERSION_APY,
+      });
 
       expect(mockCreateEventBuilder).toHaveBeenCalledTimes(1);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
@@ -53,7 +53,9 @@ const MusdConversionAssetOverviewCta = ({
   const submitCtaPressedEvent = () => {
     const { EVENT_LOCATIONS, MUSD_CTA_TYPES } = MUSD_EVENTS_CONSTANTS;
 
-    const ctaText = `${strings('earn.musd_conversion.earn_rewards_when')} ${strings('earn.musd_conversion.you_convert_to')} mUSD`;
+    const ctaText = strings('earn.musd_conversion.boost_title', {
+      percentage: MUSD_CONVERSION_APY,
+    });
 
     const getRedirectLocation = () => {
       if (!hasSeenConversionEducationScreen) {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6031,8 +6031,6 @@
       "boost_title": "Get {{percentage}}% on your stablecoins",
       "boost_description": "Convert your stablecoins to mUSD and receive up to a {{percentage}}% bonus.",
       "powered_by_relay": "Powered by Relay",
-      "earn_rewards_when": "Earn rewards when",
-      "you_convert_to": "you convert to",
       "max": "Max",
       "quick_convert_button": "Convert",
       "cta_body_earn_apy": "Earn {{apy}} yield automatically for holding mUSD.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates the `cta_text` event property for the mUSD conversion tertiary CTA. Previously, this attached an invalid value.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update mUSD conversion tertiary CTA cta_text property

## **Related issues**

Fixes: [MUSD-365: Tertiary CTA event tracking using old cta_text string](https://consensyssoftware.atlassian.net/browse/MUSD-365)

## **Manual testing steps**

```gherkin
Feature: mUSD conversion CTA event tracking

  Scenario: user taps the tertiary mUSD conversion CTA
    Given user is on the asset details page for an eligible token (e.g. mainnet USDC)

    When user taps the CTA to start conversion
    Then the tracking event records the CTA text using the current boost title format with bonus percentage
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a single analytics event property and its unit tests, plus removes unused English strings; no conversion flow or business logic changes.
> 
> **Overview**
> Updates the mUSD asset overview conversion CTA MetaMetrics payload so `cta_text` matches the on-screen boost title string (including the APY percentage) instead of the older concatenated copy.
> 
> Adjusts the associated tests to assert the new `cta_text` value, and removes the now-unused English locale keys (`earn_rewards_when`, `you_convert_to`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c95bec4ed631754c2fd49f626158bf5aad5aa87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->