### PR TITLE
Payment methods spacing issue

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.styles.ts
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.styles.ts
@@ -10,16 +10,17 @@ const styleSheet = (params: { vars: PaymentSelectionModalStyleSheetVars }) => {
 
   return StyleSheet.create({
     list: {
-      flex: 1,
       minHeight: 0,
+      flexShrink: 1,
+      flexGrow: 0,
     },
     containerOuter: {
-      height: screenHeight * 0.4,
+      maxHeight: screenHeight * 0.4,
       overflow: 'hidden',
     },
     paymentPanelContent: {
-      flex: 1,
       minHeight: 0,
+      flexShrink: 1,
     },
     alertContainer: {
       padding: 16,

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionModal.test.tsx.snap
@@ -315,7 +315,7 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                     <View
                       style={
                         {
-                          "height": 533.6,
+                          "maxHeight": 533.6,
                           "overflow": "hidden",
                         }
                       }
@@ -323,7 +323,7 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                       <View
                         style={
                           {
-                            "flex": 1,
+                            "flexShrink": 1,
                             "minHeight": 0,
                           }
                         }
@@ -408,7 +408,8 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                           stickyHeaderIndices={[]}
                           style={
                             {
-                              "flex": 1,
+                              "flexGrow": 0,
+                              "flexShrink": 1,
                               "minHeight": 0,
                             }
                           }
@@ -1081,7 +1082,7 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                     <View
                       style={
                         {
-                          "height": 533.6,
+                          "maxHeight": 533.6,
                           "overflow": "hidden",
                         }
                       }
@@ -1089,7 +1090,7 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                       <View
                         style={
                           {
-                            "flex": 1,
+                            "flexShrink": 1,
                             "minHeight": 0,
                           }
                         }
@@ -1134,7 +1135,8 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                           }
                           style={
                             {
-                              "flex": 1,
+                              "flexGrow": 0,
+                              "flexShrink": 1,
                               "minHeight": 0,
                             }
                           }
@@ -1577,7 +1579,7 @@ exports[`PaymentSelectionModal matches snapshot when payment methods are loading
                     <View
                       style={
                         {
-                          "height": 533.6,
+                          "maxHeight": 533.6,
                           "overflow": "hidden",
                         }
                       }
@@ -1585,7 +1587,7 @@ exports[`PaymentSelectionModal matches snapshot when payment methods are loading
                       <View
                         style={
                           {
-                            "flex": 1,
+                            "flexShrink": 1,
                             "minHeight": 0,
                           }
                         }
@@ -1624,7 +1626,8 @@ exports[`PaymentSelectionModal matches snapshot when payment methods are loading
                         <RCTScrollView
                           style={
                             {
-                              "flex": 1,
+                              "flexGrow": 0,
+                              "flexShrink": 1,
                               "minHeight": 0,
                             }
                           }
@@ -3865,7 +3868,7 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                     <View
                       style={
                         {
-                          "height": 533.6,
+                          "maxHeight": 533.6,
                           "overflow": "hidden",
                         }
                       }
@@ -3873,7 +3876,7 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                       <View
                         style={
                           {
-                            "flex": 1,
+                            "flexShrink": 1,
                             "minHeight": 0,
                           }
                         }
@@ -3918,7 +3921,8 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                           }
                           style={
                             {
-                              "flex": 1,
+                              "flexGrow": 0,
+                              "flexShrink": 1,
                               "minHeight": 0,
                             }
                           }


### PR DESCRIPTION
Fixes an extra gap under payment methods in the Ramp payment selection modal.

The blank area came from a fixed-height modal section plus a flexed list that expanded beyond content. Switching to content-driven sizing with a max-height cap removes the large empty gap under short payment-method lists while preserving bounded modal height behavior.

---
[Slack Thread](https://consensys.slack.com/archives/C09TEE4TL8M/p1772463609542399?thread_ts=1772463609.542399&cid=C09TEE4TL8M)

<p><a href="https://cursor.com/agents/bc-04a82706-e400-5ca2-b7d7-60f92935ec92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04a82706-e400-5ca2-b7d7-60f92935ec92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

