### PR TITLE
Token search bar text alignment

### DIFF
--- a/app/component-library/components/Form/TextField/TextField.test.tsx
+++ b/app/component-library/components/Form/TextField/TextField.test.tsx
@@ -55,4 +55,15 @@ describe('TextField', () => {
 
     expect(inputComponent.prop('numberOfLines')).toBe(1);
   });
+
+  it('applies inputStyle to the default input element', () => {
+    const inputStyle = { paddingVertical: 2 };
+    const wrapper = shallow(<TextField inputStyle={inputStyle} />);
+
+    const inputComponent = wrapper.find('ForwardRef');
+    const inputComponentStyle = inputComponent.prop('style');
+
+    expect(Array.isArray(inputComponentStyle)).toBe(true);
+    expect(inputComponentStyle).toContainEqual(inputStyle);
+  });
 });

--- a/app/component-library/components/Form/TextField/TextField.tsx
+++ b/app/component-library/components/Form/TextField/TextField.tsx
@@ -36,6 +36,7 @@ const TextField = React.forwardRef<TextInput | null, TextFieldProps>(
       endAccessory,
       isError = false,
       inputElement,
+      inputStyle,
       isDisabled = false,
       autoFocus = false,
       onBlur,
@@ -115,7 +116,7 @@ const TextField = React.forwardRef<TextInput | null, TextFieldProps>(
               onBlur={onBlurHandler}
               onFocus={onFocusHandler}
               testID={testID}
-              style={styles.input}
+              style={inputStyle ? [styles.input, inputStyle] : styles.input}
               numberOfLines={1}
               multiline={false}
               {...props}

--- a/app/component-library/components/Form/TextField/TextField.types.ts
+++ b/app/component-library/components/Form/TextField/TextField.types.ts
@@ -24,6 +24,10 @@ export interface TextFieldProps
    */
   inputElement?: React.ReactNode;
   /**
+   * Optional style override for the default Input element.
+   */
+  inputStyle?: InputProps['style'];
+  /**
    * Optional test ID for the input element.
    */
   testID?: string;

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/TokenSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/TokenSelectorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { View, useWindowDimensions } from 'react-native';
+import { Platform, View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { CaipChainId } from '@metamask/utils';
 import { useSelector } from 'react-redux';
@@ -44,6 +44,13 @@ export const createTokenSelectorModalNavigationDetails =
     Routes.DEPOSIT.MODALS.ID,
     Routes.DEPOSIT.MODALS.TOKEN_SELECTOR,
   );
+
+const TOKEN_SELECTOR_SEARCH_INPUT_STYLE = Platform.select({
+  ios: {
+    paddingVertical: 2,
+    textAlignVertical: 'center' as const,
+  },
+});
 
 function TokenSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
@@ -202,6 +209,7 @@ function TokenSelectorModal() {
               onPressClearButton={clearSearchText}
               onFocus={scrollToTop}
               onChangeText={handleSearchTextChange}
+              inputStyle={TOKEN_SELECTOR_SEARCH_INPUT_STYLE}
               placeholder={strings(
                 'deposit.token_modal.search_by_name_or_address',
               )}

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -851,14 +851,21 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                   placeholderTextColor="#686e7d"
                                   style={
                                     {
-                                      "backgroundColor": "inherit",
+                                      "0": {
+                                        "backgroundColor": "inherit",
+                                        "height": 46,
+                                      },
+                                      "1": {
+                                        "paddingVertical": 2,
+                                        "textAlignVertical": "center",
+                                      },
+                                      "backgroundColor": "#ffffff",
                                       "borderColor": "transparent",
                                       "borderWidth": 1,
                                       "color": "#121314",
                                       "fontFamily": "Geist-Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 46,
                                       "letterSpacing": 0,
                                       "opacity": 1,
                                     }
@@ -3063,14 +3070,21 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                   placeholderTextColor="#686e7d"
                                   style={
                                     {
-                                      "backgroundColor": "inherit",
+                                      "0": {
+                                        "backgroundColor": "inherit",
+                                        "height": 46,
+                                      },
+                                      "1": {
+                                        "paddingVertical": 2,
+                                        "textAlignVertical": "center",
+                                      },
+                                      "backgroundColor": "#ffffff",
                                       "borderColor": "transparent",
                                       "borderWidth": 1,
                                       "color": "#121314",
                                       "fontFamily": "Geist-Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 46,
                                       "letterSpacing": 0,
                                       "opacity": 1,
                                     }

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ActivityIndicator } from 'react-native';
+import { ActivityIndicator, Platform } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { CaipChainId } from '@metamask/utils';
 import { useNavigation } from '@react-navigation/native';
@@ -49,6 +49,13 @@ import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 export const createTokenSelectionNavDetails = createNavigationDetails(
   Routes.RAMP.TOKEN_SELECTION,
 );
+
+const TOKEN_SELECTOR_SEARCH_INPUT_STYLE = Platform.select({
+  ios: {
+    paddingVertical: 2,
+    textAlignVertical: 'center' as const,
+  },
+});
 
 function TokenSelection() {
   const listRef = useRef<FlatList>(null);
@@ -389,6 +396,7 @@ function TokenSelection() {
             onPressClearButton={clearSearchText}
             onFocus={scrollToTop}
             onChangeText={handleSearchTextChange}
+            inputStyle={TOKEN_SELECTOR_SEARCH_INPUT_STYLE}
             placeholder={strings(
               'deposit.token_modal.search_by_name_or_address',
             )}

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -711,14 +711,21 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                   placeholderTextColor="#686e7d"
                                   style={
                                     {
-                                      "backgroundColor": "inherit",
+                                      "0": {
+                                        "backgroundColor": "inherit",
+                                        "height": 46,
+                                      },
+                                      "1": {
+                                        "paddingVertical": 2,
+                                        "textAlignVertical": "center",
+                                      },
+                                      "backgroundColor": "#ffffff",
                                       "borderColor": "transparent",
                                       "borderWidth": 1,
                                       "color": "#121314",
                                       "fontFamily": "Geist-Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 46,
                                       "letterSpacing": 0,
                                       "opacity": 1,
                                     }
@@ -1571,14 +1578,21 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                   placeholderTextColor="#686e7d"
                                   style={
                                     {
-                                      "backgroundColor": "inherit",
+                                      "0": {
+                                        "backgroundColor": "inherit",
+                                        "height": 46,
+                                      },
+                                      "1": {
+                                        "paddingVertical": 2,
+                                        "textAlignVertical": "center",
+                                      },
+                                      "backgroundColor": "#ffffff",
                                       "borderColor": "transparent",
                                       "borderWidth": 1,
                                       "color": "#121314",
                                       "fontFamily": "Geist-Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 46,
                                       "letterSpacing": 0,
                                       "opacity": 1,
                                     }
@@ -3890,14 +3904,21 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                   placeholderTextColor="#686e7d"
                                   style={
                                     {
-                                      "backgroundColor": "inherit",
+                                      "0": {
+                                        "backgroundColor": "inherit",
+                                        "height": 46,
+                                      },
+                                      "1": {
+                                        "paddingVertical": 2,
+                                        "textAlignVertical": "center",
+                                      },
+                                      "backgroundColor": "#ffffff",
                                       "borderColor": "transparent",
                                       "borderWidth": 1,
                                       "color": "#121314",
                                       "fontFamily": "Geist-Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 46,
                                       "letterSpacing": 0,
                                       "opacity": 1,
                                     }


### PR DESCRIPTION
Fixes intermittent vertical misalignment of token search text on iOS by re-applying a targeted style override.

A recent shared input cleanup removed an iOS-specific vertical alignment compensation for custom Geist font baseline behavior in fixed-height inputs. This caused the placeholder/text in the fixed-height `TextFieldSearch` component used in Ramp token selectors to render lower than expected intermittently on iOS.

---
[Slack Thread](https://consensys.slack.com/archives/C09TEE4TL8M/p1772463611595129?thread_ts=1772463611.595129&cid=C09TEE4TL8M)

<p><a href="https://cursor.com/agents/bc-c102fe8f-0b13-5f50-a7a3-b66bf0119f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c102fe8f-0b13-5f50-a7a3-b66bf0119f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

