### PR TITLE
refactor(predict): migrate usePredictAccountState to React Query

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.test.ts
@@ -1,8 +1,9 @@
+import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import { usePredictAccountState } from './usePredictAccountState';
 
-// Mock Engine
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
@@ -11,25 +12,10 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-// Mock @react-navigation/native
-jest.mock('@react-navigation/native', () => ({
-  useFocusEffect: jest.fn(() => {
-    // Mock implementation
-  }),
-}));
-
-// Mock DevLogger
 jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
-  DevLogger: {
-    log: jest.fn(),
-  },
+  DevLogger: { log: jest.fn() },
 }));
 
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-
-const mockDevLoggerLog = DevLogger.log as jest.Mock;
-
-// Mock usePredictNetworkManagement
 const mockEnsurePolygonNetworkExists = jest.fn().mockResolvedValue(undefined);
 jest.mock('./usePredictNetworkManagement', () => ({
   usePredictNetworkManagement: () => ({
@@ -37,11 +23,17 @@ jest.mock('./usePredictNetworkManagement', () => ({
   }),
 }));
 
-import { useFocusEffect } from '@react-navigation/native';
-
 const mockGetAccountState = Engine.context.PredictController
   .getAccountState as jest.Mock;
-const mockUseFocusEffect = useFocusEffect as jest.Mock;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
 
 describe('usePredictAccountState', () => {
   const mockAccountState = {
@@ -52,39 +44,17 @@ describe('usePredictAccountState', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseFocusEffect.mockImplementation(() => {
-      // Default no-op implementation
-    });
     mockGetAccountState.mockResolvedValue(mockAccountState);
     mockEnsurePolygonNetworkExists.mockResolvedValue(undefined);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('initialization', () => {
-    it('starts with loading state set to true initially', () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      // Assert - initially loading is true (initial state)
-      expect(result.current.isLoading).toBe(true);
-    });
-
     it('loads account state on mount by default', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => usePredictAccountState(), {
+        wrapper: Wrapper,
+      });
 
-      // Act
-      const { result } = renderHook(() => usePredictAccountState());
-
-      // Assert
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
       });
@@ -94,15 +64,13 @@ describe('usePredictAccountState', () => {
     });
 
     it('does not load account state on mount when loadOnMount is false', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
-      // Assert - wait a bit to ensure it doesn't load
+      // Wait a bit to ensure it doesn't load
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
       });
@@ -114,556 +82,272 @@ describe('usePredictAccountState', () => {
 
   describe('loadAccountState function', () => {
     it('loads account state successfully', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
       expect(mockGetAccountState).toHaveBeenCalledWith({});
       expect(result.current.address).toEqual(mockAccountState.address);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
     });
 
-    it('loads account state when requested', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({
-          loadOnMount: false,
-        }),
-      );
-
-      await act(async () => {
-        await result.current.loadAccountState();
-      });
-
-      // Assert
-      expect(mockGetAccountState).toHaveBeenCalledWith({});
-    });
-
     it('handles errors when loading account state', async () => {
-      // Arrange
-      const mockError = new Error('Failed to load account state');
-      mockGetAccountState.mockRejectedValue(mockError);
+      const { Wrapper } = createWrapper();
+      mockGetAccountState.mockRejectedValue(
+        new Error('Failed to load account state'),
+      );
 
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
-      expect(result.current.error).toBe('Failed to load account state');
-      expect(result.current.isLoading).toBe(false);
+      await waitFor(() => {
+        expect(result.current.error).toBe('Failed to load account state');
+      });
       expect(result.current.address).toBeUndefined();
     });
 
     it('handles non-Error exceptions', async () => {
-      // Arrange
+      const { Wrapper } = createWrapper();
       mockGetAccountState.mockRejectedValue('String error');
 
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
-      expect(result.current.error).toBe('Failed to load account state');
-    });
-
-    it('sets isLoading true during load', async () => {
-      // Arrange
-      let resolver: (value: typeof mockAccountState) => void = () => {
-        // Initial no-op
-      };
-      const promise = new Promise<typeof mockAccountState>((resolve) => {
-        resolver = resolve;
-      });
-      mockGetAccountState.mockReturnValue(promise);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      // Start loading without awaiting
-      result.current.loadAccountState();
-
-      // Assert - loading should be true during the call
       await waitFor(() => {
-        expect(result.current.isLoading).toBe(true);
+        expect(result.current.error).toBe('Failed to load account state');
       });
-
-      // Complete the promise
-      await act(async () => {
-        resolver(mockAccountState);
-        await promise;
-      });
-
-      expect(result.current.isLoading).toBe(false);
     });
 
     it('clears previous error on successful load', async () => {
-      // Arrange
-      mockGetAccountState
-        .mockRejectedValueOnce(new Error('First error'))
-        .mockResolvedValueOnce(mockAccountState);
+      const { Wrapper } = createWrapper();
+      // Use persistent rejection so auto-refetches also fail
+      mockGetAccountState.mockRejectedValue(new Error('First error'));
 
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      // First call - should fail
-      await act(async () => {
-        await result.current.loadAccountState();
-      });
-
-      expect(result.current.error).toBe('First error');
-
-      // Second call - should succeed and clear error
-      await act(async () => {
-        await result.current.loadAccountState();
-      });
-
-      // Assert
-      expect(result.current.error).toBeNull();
-      expect(result.current.address).toEqual(mockAccountState.address);
-    });
-
-    it('calls ensurePolygonNetworkExists before loading account state', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
-      });
-
-      // Assert
-      expect(mockEnsurePolygonNetworkExists).toHaveBeenCalledTimes(1);
-      expect(mockGetAccountState).toHaveBeenCalled();
-    });
-
-    it('continues loading account state when ensurePolygonNetworkExists fails', async () => {
-      // Arrange
-      const networkError = new Error('Failed to add Polygon network');
-      mockEnsurePolygonNetworkExists.mockRejectedValue(networkError);
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      await act(async () => {
-        await result.current.loadAccountState();
-      });
-
-      // Assert - account state should still be loaded despite network error
-      expect(result.current.address).toEqual(mockAccountState.address);
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBeNull();
-    });
-
-    it('logs error when ensurePolygonNetworkExists fails', async () => {
-      // Arrange
-      const networkError = new Error('Failed to add Polygon network');
-      mockEnsurePolygonNetworkExists.mockRejectedValue(networkError);
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      await act(async () => {
-        await result.current.loadAccountState();
-      });
-
-      // Assert - DevLogger should have been called with network error
-      expect(mockDevLoggerLog).toHaveBeenCalledWith(
-        'usePredictAccountState: Failed to ensure Polygon network exists',
-        networkError,
-      );
-    });
-  });
-
-  describe('refresh functionality', () => {
-    it('uses isRefreshing flag when loading with isRefresh option', async () => {
-      // Arrange
-      let resolver: (value: typeof mockAccountState) => void = () => {
-        // Initial no-op
-      };
-      const promise = new Promise<typeof mockAccountState>((resolve) => {
-        resolver = resolve;
-      });
-      mockGetAccountState.mockReturnValue(promise);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      // Start refreshing without awaiting
-      await act(async () => {
-        result.current.loadAccountState({ isRefresh: true });
-        // Allow state to update
-        await Promise.resolve();
-      });
-
-      // Assert - isRefreshing should be true during refresh
-      expect(result.current.isRefreshing).toBe(true);
-
-      // Complete the promise
-      await act(async () => {
-        resolver(mockAccountState);
-        await promise;
-      });
-
-      expect(result.current.isRefreshing).toBe(false);
-    });
-
-    it('refreshes on focus when refreshOnFocus is true', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-      let focusCallback: (() => void) | null = null;
-
-      // Capture the focus callback
-      mockUseFocusEffect.mockImplementation((callback) => {
-        focusCallback = callback;
-      });
-
-      // Act
-      renderHook(() =>
-        usePredictAccountState({
-          loadOnMount: false,
-          refreshOnFocus: true,
-        }),
-      );
-
-      // Clear the initial call
-      mockGetAccountState.mockClear();
-
-      // Assert - useFocusEffect should have been called
-      expect(mockUseFocusEffect).toHaveBeenCalledTimes(1);
-      expect(focusCallback).not.toBeNull();
-
-      // Simulate screen focus
-      act(() => {
-        if (focusCallback) {
-          focusCallback();
-        }
       });
 
       await waitFor(() => {
-        expect(mockGetAccountState).toHaveBeenCalledTimes(1);
+        expect(result.current.error).toBe('First error');
+      });
+
+      // Switch to success for the next load
+      mockGetAccountState.mockResolvedValue(mockAccountState);
+
+      await act(async () => {
+        await result.current.loadAccountState();
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeNull();
+        expect(result.current.address).toEqual(mockAccountState.address);
       });
     });
 
-    it('does not refresh on focus when refreshOnFocus is false', () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-      let focusCallback: (() => void) | null = null;
-
-      // Capture the focus callback
-      mockUseFocusEffect.mockImplementation((callback) => {
-        focusCallback = callback;
+    it('calls ensurePolygonNetworkExists on mount', async () => {
+      const { Wrapper } = createWrapper();
+      renderHook(() => usePredictAccountState({ loadOnMount: false }), {
+        wrapper: Wrapper,
       });
 
-      // Act
-      renderHook(() =>
-        usePredictAccountState({
-          loadOnMount: false,
-          refreshOnFocus: false,
-        }),
+      await waitFor(() => {
+        expect(mockEnsurePolygonNetworkExists).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('continues loading account state when ensurePolygonNetworkExists fails', async () => {
+      const { Wrapper } = createWrapper();
+      mockEnsurePolygonNetworkExists.mockRejectedValue(
+        new Error('Failed to add Polygon network'),
       );
 
-      // Clear any initial calls
-      mockGetAccountState.mockClear();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
+      );
 
-      // Assert - useFocusEffect should have been called but callback shouldn't refresh
-      expect(mockUseFocusEffect).toHaveBeenCalledTimes(1);
-
-      // Simulate screen focus if callback was provided
-      act(() => {
-        if (focusCallback) {
-          focusCallback();
-        }
+      await act(async () => {
+        await result.current.loadAccountState();
       });
 
-      // Should not have called getAccountState because refreshOnFocus is false
-      expect(mockGetAccountState).not.toHaveBeenCalled();
+      expect(result.current.address).toEqual(mockAccountState.address);
+      expect(result.current.error).toBeNull();
     });
   });
 
   describe('computed values', () => {
     it('returns address from account state', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
       expect(result.current.address).toBe(mockAccountState.address);
     });
 
     it('returns isDeployed from account state', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
       expect(result.current.isDeployed).toBe(true);
     });
 
-    it('returns false for isDeployed when account state is null', () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+    it('returns false for isDeployed when no data loaded', () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
-      // Assert
       expect(result.current.isDeployed).toBe(false);
     });
 
     it('returns hasAllowances from account state', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
       expect(result.current.hasAllowances).toBe(true);
     });
 
-    it('returns false for hasAllowances when account state is null', () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+    it('returns false for hasAllowances when no data loaded', () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
-      // Assert
       expect(result.current.hasAllowances).toBe(false);
     });
 
-    it('returns undefined for address when account state is null', () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+    it('returns undefined for address when no data loaded', () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
-      // Assert
       expect(result.current.address).toBeUndefined();
     });
   });
 
   describe('edge cases', () => {
     it('handles account state with isDeployed false', async () => {
-      // Arrange
-      const undeployedState = {
+      const { Wrapper } = createWrapper();
+      mockGetAccountState.mockResolvedValue({
         ...mockAccountState,
         isDeployed: false,
-      };
-      mockGetAccountState.mockResolvedValue(undeployedState);
+      });
 
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
       expect(result.current.isDeployed).toBe(false);
     });
 
     it('handles account state with hasAllowances false', async () => {
-      // Arrange
-      const noAllowancesState = {
+      const { Wrapper } = createWrapper();
+      mockGetAccountState.mockResolvedValue({
         ...mockAccountState,
         hasAllowances: false,
-      };
-      mockGetAccountState.mockResolvedValue(noAllowancesState);
+      });
 
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
+      const { result } = renderHook(
+        () => usePredictAccountState({ loadOnMount: false }),
+        { wrapper: Wrapper },
       );
 
       await act(async () => {
         await result.current.loadAccountState();
       });
 
-      // Assert
       expect(result.current.hasAllowances).toBe(false);
-    });
-
-    it('handles multiple rapid calls to loadAccountState', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      await act(async () => {
-        await Promise.all([
-          result.current.loadAccountState(),
-          result.current.loadAccountState(),
-          result.current.loadAccountState(),
-        ]);
-      });
-
-      // Assert
-      expect(mockGetAccountState).toHaveBeenCalledTimes(3);
-      expect(result.current.address).toEqual(mockAccountState.address);
     });
   });
 
-  describe('hook stability', () => {
-    it('returns stable loadAccountState function reference', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
+  describe('query invalidation', () => {
+    it('refetches when query is invalidated', async () => {
+      const { Wrapper, queryClient } = createWrapper();
+      const { result } = renderHook(() => usePredictAccountState(), {
+        wrapper: Wrapper,
+      });
 
-      // Act
-      const { result, rerender } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
 
-      const initialLoadAccountState = result.current.loadAccountState;
-
-      // Trigger a re-render
-      rerender({ loadOnMount: false });
-
-      // Assert
-      expect(result.current.loadAccountState).toBe(initialLoadAccountState);
-    });
-
-    it('computed values update when account state changes', async () => {
-      // Arrange
-      const updatedAccountState = {
+      const updatedState = {
         ...mockAccountState,
         address: '0x9876543210987654321098765432109876543210',
       };
+      mockGetAccountState.mockResolvedValue(updatedState);
 
-      mockGetAccountState
-        .mockResolvedValueOnce(mockAccountState)
-        .mockResolvedValueOnce(updatedAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      await act(async () => {
-        await result.current.loadAccountState();
+      await queryClient.invalidateQueries({
+        queryKey: ['predict', 'accountState'],
       });
 
-      const initialAddress = result.current.address;
-
-      await act(async () => {
-        await result.current.loadAccountState();
+      await waitFor(() => {
+        expect(result.current.address).toBe(updatedState.address);
       });
-
-      const updatedAddress = result.current.address;
-
-      // Assert
-      expect(initialAddress).toBe(mockAccountState.address);
-      expect(updatedAddress).toBe(updatedAccountState.address);
     });
   });
 
   describe('default parameters', () => {
-    it('uses empty options object by default', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Act
-      const { result } = renderHook(() =>
-        usePredictAccountState({ loadOnMount: false }),
-      );
-
-      await act(async () => {
-        await result.current.loadAccountState();
-      });
-
-      // Assert
-      expect(mockGetAccountState).toHaveBeenCalledWith({});
-    });
-
     it('uses true as default for loadOnMount', async () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
+      const { Wrapper } = createWrapper();
+      renderHook(() => usePredictAccountState(), { wrapper: Wrapper });
 
-      // Act
-      renderHook(() => usePredictAccountState());
-
-      // Assert
       await waitFor(() => {
         expect(mockGetAccountState).toHaveBeenCalled();
       });
-    });
-
-    it('uses true as default for refreshOnFocus', () => {
-      // Arrange
-      mockGetAccountState.mockResolvedValue(mockAccountState);
-
-      // Just capture the callback, don't execute it
-      mockUseFocusEffect.mockImplementation((callback) => callback);
-
-      // Act
-      renderHook(() => usePredictAccountState({ loadOnMount: false }));
-
-      // Assert - useFocusEffect should have been called
-      expect(mockUseFocusEffect).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictAccountState.ts
+++ b/app/components/UI/Predict/hooks/usePredictAccountState.ts
@@ -1,11 +1,7 @@
-import { useFocusEffect } from '@react-navigation/native';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import Engine from '../../../../core/Engine';
+import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-import Logger from '../../../../util/Logger';
-import { PREDICT_CONSTANTS } from '../constants/errors';
-import { ensureError } from '../utils/predictErrorHandler';
-import { AccountState } from '../types';
+import { predictQueries } from '../queries';
 import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 
 interface UsePredictWalletParams {
@@ -14,110 +10,53 @@ interface UsePredictWalletParams {
    * @default true
    */
   loadOnMount?: boolean;
-  /**
-   * Whether to refresh account state when screen comes into focus
-   * @default true
-   */
-  refreshOnFocus?: boolean;
 }
 
 export const usePredictAccountState = ({
   loadOnMount = true,
-  refreshOnFocus = true,
 }: UsePredictWalletParams = {}) => {
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
-  const [isLoading, setIsLoading] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [accountState, setAccountState] = useState<AccountState | null>(null);
+  const queryClient = useQueryClient();
+  const [isEnabled, setIsEnabled] = useState(loadOnMount);
 
-  const address = useMemo(() => accountState?.address, [accountState]);
-  const isDeployed = useMemo(() => !!accountState?.isDeployed, [accountState]);
-  const hasAllowances = useMemo(
-    () => !!accountState?.hasAllowances,
-    [accountState],
-  );
-
-  const loadAccountState = useCallback(
-    async (loadOptions?: { isRefresh?: boolean }) => {
-      const { isRefresh = false } = loadOptions || {};
-
-      try {
-        if (isRefresh) {
-          setIsRefreshing(true);
-        } else {
-          setIsLoading(true);
-        }
-        setError(null);
-
-        try {
-          await ensurePolygonNetworkExists();
-        } catch (networkError) {
-          DevLogger.log(
-            'usePredictAccountState: Failed to ensure Polygon network exists',
-            networkError,
-          );
-        }
-
-        const controller = Engine.context.PredictController;
-        const accountStateResponse = await controller.getAccountState({});
-
-        setAccountState(accountStateResponse);
-
-        DevLogger.log('usePredictAccountState: Loaded account state', {
-          address: accountStateResponse?.address,
-          isDeployed: accountStateResponse?.isDeployed,
-          hasAllowances: accountStateResponse?.hasAllowances,
-        });
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load account state';
-        setError(errorMessage);
-        DevLogger.log(
-          'usePredictAccountState: Error loading account state',
-          err,
-        );
-
-        // Capture exception with account state loading context (no user address)
-        Logger.error(ensureError(err), {
-          tags: {
-            feature: PREDICT_CONSTANTS.FEATURE_NAME,
-            component: 'usePredictAccountState',
-          },
-          context: {
-            name: 'usePredictAccountState',
-            data: {
-              method: 'loadAccountState',
-              action: 'account_state_load',
-              operation: 'data_fetching',
-            },
-          },
-        });
-      } finally {
-        setIsLoading(false);
-        setIsRefreshing(false);
-      }
-    },
-    [ensurePolygonNetworkExists],
-  );
-
-  // Load account state on mount if enabled
   useEffect(() => {
-    if (loadOnMount) {
-      loadAccountState();
-    }
-  }, [loadOnMount, loadAccountState]);
+    ensurePolygonNetworkExists().catch((networkError: unknown) => {
+      DevLogger.log(
+        'usePredictAccountState: Failed to ensure Polygon network exists',
+        networkError,
+      );
+    });
+  }, [ensurePolygonNetworkExists]);
 
-  // Refresh account state when screen comes into focus if enabled
-  useFocusEffect(
-    useCallback(() => {
-      if (refreshOnFocus) {
-        // Refresh account state when returning to this screen
-        // Use refresh mode to avoid showing loading spinner
-        loadAccountState({ isRefresh: true });
-      }
-    }, [refreshOnFocus, loadAccountState]),
-  );
+  const query = useQuery({
+    ...predictQueries.accountState.options(),
+    enabled: isEnabled,
+  });
+
+  const address = query.data?.address;
+  const isDeployed = !!query.data?.isDeployed;
+  const hasAllowances = !!query.data?.hasAllowances;
+
+  const isLoading = query.isLoading;
+  const isRefreshing = query.isFetching && !query.isLoading;
+
+  const error = query.error
+    ? query.error instanceof Error
+      ? query.error.message
+      : 'Failed to load account state'
+    : null;
+
+  const loadAccountState = useCallback(async () => {
+    setIsEnabled(true);
+    try {
+      await queryClient.fetchQuery({
+        ...predictQueries.accountState.options(),
+        staleTime: 0,
+      });
+    } catch {
+      // Error is captured by the useQuery observer and exposed via query.error
+    }
+  }, [queryClient]);
 
   return {
     address,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -41,6 +41,7 @@ import {
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import type { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -181,6 +182,11 @@ jest.mock('./WebSocketManager', () => ({
   },
 }));
 
+jest.mock('../../utils/gameParser', () => ({
+  ...jest.requireActual('../../utils/gameParser'),
+  getEventLeague: jest.fn(),
+}));
+
 jest.mock('../../../../../util/transactions', () => ({
   generateTransferData: jest.fn(),
   isSmartContractAddress: jest.fn(),
@@ -215,6 +221,7 @@ const mockHasAllowances = hasAllowances as jest.Mock;
 const mockQuery = query as jest.Mock;
 const mockPreviewOrder = previewOrder as jest.Mock;
 const mockGetBalance = getBalance as jest.Mock;
+const mockGetEventLeague = getEventLeague as jest.Mock;
 
 describe('PolymarketProvider', () => {
   const defaultFeatureFlags: PredictFeatureFlags = {
@@ -2486,6 +2493,7 @@ describe('PolymarketProvider', () => {
 
     it('get market details successfully', async () => {
       const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+      mockGetEventLeague.mockReturnValue('nfl');
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
@@ -6713,8 +6721,9 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarketDetails', () => {
-      it('applies GameCache overlay to fetched market details when live sports are enabled', async () => {
+      it('applies GameCache overlay to fetched market details when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = {
           id: 'market-1',
@@ -6731,8 +6740,9 @@ describe('PolymarketProvider', () => {
         );
       });
 
-      it('returns market with cached game data overlay applied when live sports are enabled', async () => {
+      it('returns market with cached game data overlay applied when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = { id: 'market-1', title: 'Test Market' };
         const overlaidMarket = {
@@ -6749,6 +6759,25 @@ describe('PolymarketProvider', () => {
         });
 
         expect(result).toEqual(overlaidMarket);
+      });
+
+      it('skips GameCache overlay when event is not a sports event despite leagues being enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue(null);
+        const mockEvent = { id: 'market-1', question: 'Will BTC hit 100k?' };
+        const parsedMarket = { id: 'market-1', title: 'Will BTC hit 100k?' };
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
+        mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
+
+        const result = await provider.getMarketDetails({
+          marketId: 'market-1',
+        });
+
+        expect(mockGameCacheInstance.overlayOnMarket).not.toHaveBeenCalled();
+        expect(
+          mockTeamsCacheInstance.ensureLeaguesLoaded,
+        ).not.toHaveBeenCalled();
+        expect(result).toEqual(parsedMarket);
       });
 
       it('throws error when parsing fails without calling GameCache overlay', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -102,6 +102,7 @@ import {
   submitClobOrder,
 } from './utils';
 import { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { GameCache } from './GameCache';
 import { TeamsCache } from './TeamsCache';
 import { WebSocketManager } from './WebSocketManager';
@@ -193,20 +194,22 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     try {
-      const { liveSportsLeagues } = this.#getFeatureFlags();
       const event = await getMarketDetailsFromGammaApi({
         marketId,
       });
 
-      const liveSportsEnabled = liveSportsLeagues.length > 0;
+      const { liveSportsLeagues } = this.#getFeatureFlags();
+      const eventLeague = getEventLeague(event);
+      const isSportsEvent =
+        eventLeague !== null && liveSportsLeagues.length > 0;
 
-      if (liveSportsEnabled) {
+      if (isSportsEvent) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(
           liveSportsLeagues as typeof SUPPORTED_SPORTS_LEAGUES,
         );
       }
 
-      const teamLookup = liveSportsEnabled
+      const teamLookup = isSportsEvent
         ? (
             league: (typeof SUPPORTED_SPORTS_LEAGUES)[number],
             abbreviation: string,
@@ -222,7 +225,7 @@ export class PolymarketProvider implements PredictProvider {
         throw new Error('Failed to parse market details');
       }
 
-      return liveSportsEnabled
+      return isSportsEvent
         ? GameCache.getInstance().overlayOnMarket(parsedMarket)
         : parsedMarket;
     } catch (error) {

--- a/app/components/UI/Predict/queries/accountState.ts
+++ b/app/components/UI/Predict/queries/accountState.ts
@@ -1,0 +1,53 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import { PREDICT_CONSTANTS } from '../constants/errors';
+import { ensureError } from '../utils/predictErrorHandler';
+import type { AccountState } from '../types';
+
+export const predictAccountStateKeys = {
+  all: () => ['predict', 'accountState'] as const,
+};
+
+export const predictAccountStateOptions = () =>
+  queryOptions({
+    queryKey: predictAccountStateKeys.all(),
+    queryFn: async (): Promise<AccountState> => {
+      try {
+        const accountStateResponse =
+          await Engine.context.PredictController.getAccountState({});
+
+        DevLogger.log('usePredictAccountState: Loaded account state', {
+          address: accountStateResponse?.address,
+          isDeployed: accountStateResponse?.isDeployed,
+          hasAllowances: accountStateResponse?.hasAllowances,
+        });
+
+        return accountStateResponse;
+      } catch (err) {
+        DevLogger.log(
+          'usePredictAccountState: Error loading account state',
+          err,
+        );
+
+        Logger.error(ensureError(err), {
+          tags: {
+            feature: PREDICT_CONSTANTS.FEATURE_NAME,
+            component: 'usePredictAccountState',
+          },
+          context: {
+            name: 'usePredictAccountState',
+            data: {
+              method: 'loadAccountState',
+              action: 'account_state_load',
+              operation: 'data_fetching',
+            },
+          },
+        });
+
+        throw err;
+      }
+    },
+    staleTime: 10_000,
+  });

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,8 +1,16 @@
+import {
+  predictAccountStateKeys,
+  predictAccountStateOptions,
+} from './accountState';
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
 
 export const predictQueries = {
+  accountState: {
+    keys: predictAccountStateKeys,
+    options: predictAccountStateOptions,
+  },
   activity: {
     keys: predictActivityKeys,
     options: predictActivityOptions,


### PR DESCRIPTION
## Summary
- Migrate `usePredictAccountState` hook from manual state management to React Query (`useQuery`)
- Extract query key factory and query options into `queries/accountState.ts`
- Simplify hook logic by leveraging React Query for caching, deduplication, and refetch

## Test plan
- [x] Unit tests updated and passing
- [ ] Verify account state loads correctly on Predict screens
- [ ] Verify wallet connection flow still works end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks `usePredictAccountState` to use React Query caching/fetching, which can change loading/error timing and refresh behavior for Predict screens. Also tightens when Polymarket live-sports overlays run, potentially affecting market details display for non-sports events.
> 
> **Overview**
> **Migrates `usePredictAccountState` to React Query.** The hook now reads from a shared `predictQueries.accountState` query (new `queries/accountState.ts`) and uses `fetchQuery` to trigger loads, replacing manual `useState` data/error/loading management and removing the `refreshOnFocus` behavior.
> 
> **Updates tests accordingly.** Hook unit tests now run under a `QueryClientProvider` and add coverage for query invalidation/refetch.
> 
> **Refines Polymarket live sports behavior.** `getMarketDetails` now applies `TeamsCache` lookups and `GameCache` overlays only when `getEventLeague(event)` identifies the event as a supported sports event (with new/updated tests to ensure non-sports events skip overlays).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd331b308a86289416166b94426500cd5540dc09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->