### PR TITLE
refactor(predict): migrate usePredictOrderPreview to React Query

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
@@ -1,13 +1,33 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePredictOrderPreview } from './usePredictOrderPreview';
-import { usePredictTrading } from './usePredictTrading';
 import { OrderPreview, PreviewOrderParams, Side } from '../types';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
 
-jest.mock('./usePredictTrading');
+const mockPreviewOrder = jest.fn();
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      previewOrder: (...args: unknown[]) => mockPreviewOrder(...args),
+    },
+  },
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
 
 describe('usePredictOrderPreview', () => {
-  const mockPreviewOrder = jest.fn();
   const mockPreview: OrderPreview = {
     marketId: 'market-1',
     outcomeId: 'outcome-1',
@@ -33,9 +53,7 @@ describe('usePredictOrderPreview', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    (usePredictTrading as jest.Mock).mockReturnValue({
-      previewOrder: mockPreviewOrder,
-    });
+    mockPreviewOrder.mockResolvedValue(mockPreview);
   });
 
   afterEach(() => {
@@ -51,29 +69,33 @@ describe('usePredictOrderPreview', () => {
   };
 
   describe('basic functionality', () => {
-    it('initializes with null preview and not calculating', () => {
-      const { result } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+    it('initializes with null preview and loading state', () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.preview).toBeNull();
-      expect(result.current.isCalculating).toBe(false);
       expect(result.current.isLoading).toBe(true);
       expect(result.current.error).toBeNull();
     });
 
     it('calculates preview when size is valid', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      // Advance past debounce timer
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toEqual(mockPreview);
+      });
 
       expect(mockPreviewOrder).toHaveBeenCalledWith({
         marketId: 'market-1',
@@ -81,53 +103,59 @@ describe('usePredictOrderPreview', () => {
         outcomeTokenId: 'token-1',
         side: Side.BUY,
         size: 100,
+        positionId: undefined,
       });
 
-      expect(result.current.preview).toEqual(mockPreview);
-      expect(result.current.isCalculating).toBe(false);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
     });
 
-    it('does not calculate preview when size is 0', () => {
+    it('does not calculate preview when size is 0', async () => {
+      const { Wrapper } = createWrapper();
       const params = { ...defaultParams, size: 0 };
-      const { result } = renderHook(() => usePredictOrderPreview(params));
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
       expect(mockPreviewOrder).not.toHaveBeenCalled();
       expect(result.current.preview).toBeNull();
-      expect(result.current.isCalculating).toBe(false);
     });
 
-    it('does not calculate preview when size is negative', () => {
+    it('does not calculate preview when size is negative', async () => {
+      const { Wrapper } = createWrapper();
       const params = { ...defaultParams, size: -10 };
-      const { result } = renderHook(() => usePredictOrderPreview(params));
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
       expect(mockPreviewOrder).not.toHaveBeenCalled();
       expect(result.current.preview).toBeNull();
-      expect(result.current.isCalculating).toBe(false);
     });
 
     it('calculates preview for SELL side', async () => {
+      const { Wrapper } = createWrapper();
       mockPreviewOrder.mockResolvedValue({ ...mockPreview, side: Side.SELL });
 
       const params = { ...defaultParams, side: Side.SELL };
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(params),
-      );
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toBeTruthy();
+      });
 
       expect(mockPreviewOrder).toHaveBeenCalledWith(
         expect.objectContaining({ side: Side.SELL }),
@@ -137,346 +165,181 @@ describe('usePredictOrderPreview', () => {
   });
 
   describe('isLoading state', () => {
-    it('returns true when preview is null, no error, and is calculating', async () => {
-      let resolvePreview: ((value: OrderPreview) => void) | undefined;
-      const previewPromise = new Promise<OrderPreview>((resolve) => {
-        resolvePreview = resolve;
-      });
-      mockPreviewOrder.mockReturnValue(previewPromise);
-
-      const { result } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+    it('returns true when preview is null and no error', () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      // During calculation: preview is null, no error, isCalculating is true
       expect(result.current.preview).toBeNull();
       expect(result.current.error).toBeNull();
-      expect(result.current.isCalculating).toBe(true);
       expect(result.current.isLoading).toBe(true);
-
-      // Resolve the promise
-      await act(async () => {
-        if (resolvePreview) {
-          resolvePreview(mockPreview);
-        }
-        await previewPromise;
-      });
-
-      // After calculation: preview exists, isLoading should be false
-      expect(result.current.preview).toEqual(mockPreview);
-      expect(result.current.isLoading).toBe(false);
     });
 
     it('returns false when preview exists', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toEqual(mockPreview);
+      });
 
-      expect(result.current.preview).toEqual(mockPreview);
       expect(result.current.isLoading).toBe(false);
     });
 
     it('returns false when error exists', async () => {
+      const { Wrapper } = createWrapper();
       mockPreviewOrder.mockRejectedValue(new Error('API Error'));
 
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // Suppress console.error output during test
-        });
+        .mockImplementation(() => undefined);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
 
       expect(result.current.preview).toBeNull();
-      expect(result.current.error).toBe('Failed to preview order');
-      expect(result.current.isCalculating).toBe(false);
       expect(result.current.isLoading).toBe(false);
 
       consoleErrorSpy.mockRestore();
     });
 
-    it('returns true when preview is null and no error', () => {
-      const { result } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
-      );
-
-      expect(result.current.preview).toBeNull();
-      expect(result.current.error).toBeNull();
-      expect(result.current.isCalculating).toBe(false);
-      expect(result.current.isLoading).toBe(true);
-    });
-
-    it('returns true when size is invalid', () => {
+    it('returns true when size is invalid', async () => {
+      const { Wrapper } = createWrapper();
       const params = { ...defaultParams, size: 0 };
-      const { result } = renderHook(() => usePredictOrderPreview(params));
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
       expect(result.current.preview).toBeNull();
-      expect(result.current.isCalculating).toBe(false);
       expect(result.current.isLoading).toBe(true);
     });
   });
 
   describe('auto-refresh', () => {
     it('does not auto-refresh when autoRefreshTimeout is not provided', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toBeTruthy();
+      });
 
       expect(mockPreviewOrder).toHaveBeenCalledTimes(1);
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(5000);
       });
 
       expect(mockPreviewOrder).toHaveBeenCalledTimes(1);
     });
 
-    it('schedules next refresh after receiving response', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
+    it('auto-refreshes when autoRefreshTimeout is provided', async () => {
+      const { Wrapper } = createWrapper();
       const params = { ...defaultParams, autoRefreshTimeout: 2000 };
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(params),
-      );
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toBeTruthy();
+      });
 
       expect(mockPreviewOrder).toHaveBeenCalledTimes(1);
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(2000);
       });
 
-      await waitForNextUpdate();
-
-      expect(mockPreviewOrder).toHaveBeenCalledTimes(2);
-
-      act(() => {
-        jest.advanceTimersByTime(2000);
+      await waitFor(() => {
+        expect(mockPreviewOrder).toHaveBeenCalledTimes(2);
       });
-
-      await waitForNextUpdate();
-
-      expect(mockPreviewOrder).toHaveBeenCalledTimes(3);
-    });
-
-    it('waits for response before starting timeout countdown', async () => {
-      let callCount = 0;
-      mockPreviewOrder.mockImplementation(async () => {
-        callCount += 1;
-        return mockPreview;
-      });
-
-      const params = { ...defaultParams, autoRefreshTimeout: 1000 };
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(params),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitForNextUpdate();
-
-      expect(callCount).toBe(1);
-
-      act(() => {
-        jest.advanceTimersByTime(500);
-      });
-
-      expect(callCount).toBe(1);
-
-      act(() => {
-        jest.advanceTimersByTime(500);
-      });
-
-      await waitForNextUpdate();
-
-      expect(callCount).toBe(2);
-    });
-
-    it('schedules next refresh after error response', async () => {
-      mockPreviewOrder.mockRejectedValue(new Error('API Error'));
-
-      const consoleErrorSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // Suppress console.error output during test
-        });
-
-      const params = { ...defaultParams, autoRefreshTimeout: 2000 };
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(params),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitForNextUpdate();
-
-      expect(mockPreviewOrder).toHaveBeenCalledTimes(1);
-
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      act(() => {
-        jest.advanceTimersByTime(2000);
-      });
-
-      await waitForNextUpdate();
-
-      expect(mockPreviewOrder).toHaveBeenCalledTimes(2);
-
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('clears pending refresh timer when parameters change', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      const params = { ...defaultParams, autoRefreshTimeout: 2000 };
-      const { waitForNextUpdate, rerender } = renderHook(
-        (props: PreviewOrderParams & { autoRefreshTimeout?: number }) =>
-          usePredictOrderPreview(props),
-        { initialProps: params },
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitForNextUpdate();
-
-      expect(mockPreviewOrder).toHaveBeenCalledTimes(1);
-
-      act(() => {
-        jest.advanceTimersByTime(1000);
-      });
-
-      rerender({ ...params, size: 200 });
-
-      act(() => {
-        jest.advanceTimersByTime(100);
-      });
-
-      await waitForNextUpdate();
-
-      expect(mockPreviewOrder).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('error handling', () => {
     it('handles preview calculation errors', async () => {
-      const errorMessage = 'Failed to calculate preview';
-      mockPreviewOrder.mockRejectedValue(new Error(errorMessage));
+      const { Wrapper } = createWrapper();
+      mockPreviewOrder.mockRejectedValue(new Error('Failed to calculate'));
 
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // Suppress console.error output during test
-        });
+        .mockImplementation(() => undefined);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
 
-      expect(result.current.error).toBe('Failed to preview order');
       expect(result.current.preview).toBeNull();
-      expect(result.current.isCalculating).toBe(false);
       expect(result.current.isLoading).toBe(false);
 
       consoleErrorSpy.mockRestore();
     });
 
     it('handles non-Error exceptions', async () => {
+      const { Wrapper } = createWrapper();
       mockPreviewOrder.mockRejectedValue('String error');
 
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // Suppress console.error output during test
-        });
+        .mockImplementation(() => undefined);
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { result } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
-
-      expect(result.current.error).toBe('Failed to preview order');
-      expect(result.current.isCalculating).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('sets isCalculating to false after error', async () => {
-      mockPreviewOrder.mockRejectedValue(new Error('Error'));
-
-      const consoleErrorSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {
-          // Suppress console.error output during test
-        });
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
-      );
-
-      act(() => {
-        jest.advanceTimersByTime(100);
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
       });
 
-      await waitForNextUpdate();
-
-      expect(result.current.isCalculating).toBe(false);
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe('Failed to preview order');
 
       consoleErrorSpy.mockRestore();
     });
@@ -484,20 +347,23 @@ describe('usePredictOrderPreview', () => {
 
   describe('parameter changes', () => {
     it('reacts to outcomeTokenId changes', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview({
-          ...defaultParams,
-          outcomeTokenId: 'new-token',
-        }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () =>
+          usePredictOrderPreview({
+            ...defaultParams,
+            outcomeTokenId: 'new-token',
+          }),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toBeTruthy();
+      });
 
       expect(mockPreviewOrder).toHaveBeenCalledWith(
         expect.objectContaining({ outcomeTokenId: 'new-token' }),
@@ -505,20 +371,23 @@ describe('usePredictOrderPreview', () => {
     });
 
     it('reacts to marketId changes', async () => {
-      mockPreviewOrder.mockResolvedValue(mockPreview);
-
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictOrderPreview({
-          ...defaultParams,
-          marketId: 'market-2',
-        }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () =>
+          usePredictOrderPreview({
+            ...defaultParams,
+            marketId: 'market-2',
+          }),
+        { wrapper: Wrapper },
       );
 
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(100);
       });
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.preview).toBeTruthy();
+      });
 
       expect(mockPreviewOrder).toHaveBeenCalledWith(
         expect.objectContaining({ marketId: 'market-2' }),
@@ -528,25 +397,13 @@ describe('usePredictOrderPreview', () => {
 
   describe('cleanup', () => {
     it('cleans up on unmount', () => {
-      const { unmount } = renderHook(() =>
-        usePredictOrderPreview(defaultParams),
+      const { Wrapper } = createWrapper();
+      const { unmount } = renderHook(
+        () => usePredictOrderPreview(defaultParams),
+        { wrapper: Wrapper },
       );
 
       expect(() => unmount()).not.toThrow();
-    });
-
-    it('clears timers on unmount', () => {
-      const { unmount } = renderHook(() =>
-        usePredictOrderPreview({ ...defaultParams, autoRefreshTimeout: 1000 }),
-      );
-
-      unmount();
-
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-
-      expect(mockPreviewOrder).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
@@ -1,9 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Logger from '../../../../util/Logger';
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { OrderPreview, PreviewOrderParams } from '../types';
-import { usePredictTrading } from './usePredictTrading';
-import { ensureError, parseErrorMessage } from '../utils/predictErrorHandler';
-import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
+import { predictQueries } from '../queries';
 
 interface OrderPreviewResult {
   preview?: OrderPreview | null;
@@ -15,19 +13,6 @@ interface OrderPreviewResult {
 export function usePredictOrderPreview(
   params: PreviewOrderParams & { autoRefreshTimeout?: number },
 ): OrderPreviewResult {
-  const [preview, setPreview] = useState<OrderPreview | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isCalculating, setIsCalculating] = useState<boolean>(false);
-
-  const currentOperationRef = useRef<number>(0);
-  const isMountedRef = useRef<boolean>(true);
-  const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
-
-  const { previewOrder } = usePredictTrading();
-
-  const isLoading = useMemo(() => preview === null && !error, [preview, error]);
-
-  // Destructure params for stable dependencies
   const {
     marketId,
     outcomeId,
@@ -38,43 +23,19 @@ export function usePredictOrderPreview(
     positionId,
   } = params;
 
-  // Define ref before using it in scheduleNextRefresh
-  const calculatePreviewRef = useRef<(() => Promise<void>) | null>(null);
+  // Debounce param changes by 100ms to avoid rapid recalculations
+  const [debouncedParams, setDebouncedParams] = useState({
+    marketId,
+    outcomeId,
+    outcomeTokenId,
+    side,
+    size,
+    positionId,
+  });
 
-  const scheduleNextRefresh = useCallback(() => {
-    if (!autoRefreshTimeout || !isMountedRef.current) return;
-
-    // Clear any existing timer
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-    }
-
-    // Schedule next refresh after the timeout
-    refreshTimerRef.current = setTimeout(() => {
-      calculatePreviewRef.current?.();
-    }, autoRefreshTimeout);
-  }, [autoRefreshTimeout]);
-
-  const scheduleNextRefreshRef = useRef(scheduleNextRefresh);
-  scheduleNextRefreshRef.current = scheduleNextRefresh;
-
-  const calculatePreview = useCallback(async () => {
-    const operationId = ++currentOperationRef.current;
-
-    if (!isMountedRef.current) return;
-
-    if (!size || size <= 0) {
-      if (operationId === currentOperationRef.current) {
-        setPreview(null);
-        setIsCalculating(false);
-      }
-      return;
-    }
-
-    setIsCalculating(true);
-
-    try {
-      const p = await previewOrder({
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedParams({
         marketId,
         outcomeId,
         outcomeTokenId,
@@ -82,84 +43,23 @@ export function usePredictOrderPreview(
         size,
         positionId,
       });
-      if (operationId === currentOperationRef.current && isMountedRef.current) {
-        setPreview(p);
-        setError(null);
-        // Schedule next refresh after successful response
-        scheduleNextRefreshRef.current();
-      }
-    } catch (err) {
-      console.error('Failed to preview order:', err);
-
-      // Log error with order preview context (no sensitive amounts)
-      Logger.error(ensureError(err), {
-        tags: {
-          feature: PREDICT_CONSTANTS.FEATURE_NAME,
-          component: 'usePredictOrderPreview',
-        },
-        context: {
-          name: 'usePredictOrderPreview',
-          data: {
-            method: 'calculatePreview',
-            action: 'order_preview',
-            operation: 'order_management',
-            side,
-            marketId,
-            outcomeId,
-          },
-        },
-      });
-
-      if (operationId === currentOperationRef.current && isMountedRef.current) {
-        const parsedErrorMessage = parseErrorMessage({
-          error: err,
-          defaultCode: PREDICT_ERROR_CODES.PREVIEW_FAILED,
-        });
-        setError(parsedErrorMessage);
-        // Schedule next refresh after error response
-        scheduleNextRefreshRef.current();
-      }
-    } finally {
-      if (operationId === currentOperationRef.current && isMountedRef.current) {
-        setIsCalculating(false);
-      }
-    }
-  }, [
-    size,
-    previewOrder,
-    marketId,
-    outcomeId,
-    outcomeTokenId,
-    side,
-    positionId,
-  ]);
-
-  calculatePreviewRef.current = calculatePreview;
-
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
-      // Clear refresh timer on unmount
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    // Clear any pending refresh timer when parameters change
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-      refreshTimerRef.current = null;
-    }
-
-    const debounceTimer = setTimeout(() => {
-      calculatePreviewRef.current?.();
     }, 100);
+    return () => clearTimeout(timer);
+  }, [marketId, outcomeId, outcomeTokenId, side, size, positionId]);
 
-    return () => clearTimeout(debounceTimer);
-  }, [marketId, outcomeId, outcomeTokenId, side, size, autoRefreshTimeout]);
+  const hasValidSize = !!debouncedParams.size && debouncedParams.size > 0;
+
+  const query = useQuery({
+    ...predictQueries.orderPreview.options(debouncedParams),
+    enabled: hasValidSize,
+    refetchInterval:
+      hasValidSize && autoRefreshTimeout ? autoRefreshTimeout : false,
+  });
+
+  const preview = query.data ?? null;
+  const error = query.error?.message ?? null;
+  const isLoading = preview === null && !error;
+  const isCalculating = query.isFetching;
 
   return {
     preview,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -41,6 +41,7 @@ import {
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import type { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -181,6 +182,11 @@ jest.mock('./WebSocketManager', () => ({
   },
 }));
 
+jest.mock('../../utils/gameParser', () => ({
+  ...jest.requireActual('../../utils/gameParser'),
+  getEventLeague: jest.fn(),
+}));
+
 jest.mock('../../../../../util/transactions', () => ({
   generateTransferData: jest.fn(),
   isSmartContractAddress: jest.fn(),
@@ -215,6 +221,7 @@ const mockHasAllowances = hasAllowances as jest.Mock;
 const mockQuery = query as jest.Mock;
 const mockPreviewOrder = previewOrder as jest.Mock;
 const mockGetBalance = getBalance as jest.Mock;
+const mockGetEventLeague = getEventLeague as jest.Mock;
 
 describe('PolymarketProvider', () => {
   const defaultFeatureFlags: PredictFeatureFlags = {
@@ -2486,6 +2493,7 @@ describe('PolymarketProvider', () => {
 
     it('get market details successfully', async () => {
       const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+      mockGetEventLeague.mockReturnValue('nfl');
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
@@ -6713,8 +6721,9 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarketDetails', () => {
-      it('applies GameCache overlay to fetched market details when live sports are enabled', async () => {
+      it('applies GameCache overlay to fetched market details when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = {
           id: 'market-1',
@@ -6731,8 +6740,9 @@ describe('PolymarketProvider', () => {
         );
       });
 
-      it('returns market with cached game data overlay applied when live sports are enabled', async () => {
+      it('returns market with cached game data overlay applied when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = { id: 'market-1', title: 'Test Market' };
         const overlaidMarket = {
@@ -6749,6 +6759,25 @@ describe('PolymarketProvider', () => {
         });
 
         expect(result).toEqual(overlaidMarket);
+      });
+
+      it('skips GameCache overlay when event is not a sports event despite leagues being enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue(null);
+        const mockEvent = { id: 'market-1', question: 'Will BTC hit 100k?' };
+        const parsedMarket = { id: 'market-1', title: 'Will BTC hit 100k?' };
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
+        mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
+
+        const result = await provider.getMarketDetails({
+          marketId: 'market-1',
+        });
+
+        expect(mockGameCacheInstance.overlayOnMarket).not.toHaveBeenCalled();
+        expect(
+          mockTeamsCacheInstance.ensureLeaguesLoaded,
+        ).not.toHaveBeenCalled();
+        expect(result).toEqual(parsedMarket);
       });
 
       it('throws error when parsing fails without calling GameCache overlay', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -102,6 +102,7 @@ import {
   submitClobOrder,
 } from './utils';
 import { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { GameCache } from './GameCache';
 import { TeamsCache } from './TeamsCache';
 import { WebSocketManager } from './WebSocketManager';
@@ -193,20 +194,22 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     try {
-      const { liveSportsLeagues } = this.#getFeatureFlags();
       const event = await getMarketDetailsFromGammaApi({
         marketId,
       });
 
-      const liveSportsEnabled = liveSportsLeagues.length > 0;
+      const { liveSportsLeagues } = this.#getFeatureFlags();
+      const eventLeague = getEventLeague(event);
+      const isSportsEvent =
+        eventLeague !== null && liveSportsLeagues.length > 0;
 
-      if (liveSportsEnabled) {
+      if (isSportsEvent) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(
           liveSportsLeagues as typeof SUPPORTED_SPORTS_LEAGUES,
         );
       }
 
-      const teamLookup = liveSportsEnabled
+      const teamLookup = isSportsEvent
         ? (
             league: (typeof SUPPORTED_SPORTS_LEAGUES)[number],
             abbreviation: string,
@@ -222,7 +225,7 @@ export class PolymarketProvider implements PredictProvider {
         throw new Error('Failed to parse market details');
       }
 
-      return liveSportsEnabled
+      return isSportsEvent
         ? GameCache.getInstance().overlayOnMarket(parsedMarket)
         : parsedMarket;
     } catch (error) {

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,5 +1,9 @@
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
+import {
+  predictOrderPreviewKeys,
+  predictOrderPreviewOptions,
+} from './orderPreview';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
 
 export const predictQueries = {
@@ -10,6 +14,10 @@ export const predictQueries = {
   balance: {
     keys: predictBalanceKeys,
     options: predictBalanceOptions,
+  },
+  orderPreview: {
+    keys: predictOrderPreviewKeys,
+    options: predictOrderPreviewOptions,
   },
   positions: {
     keys: predictPositionsKeys,

--- a/app/components/UI/Predict/queries/orderPreview.ts
+++ b/app/components/UI/Predict/queries/orderPreview.ts
@@ -1,0 +1,78 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { ensureError, parseErrorMessage } from '../utils/predictErrorHandler';
+import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
+import type { OrderPreview, PreviewOrderParams } from '../types';
+
+export const predictOrderPreviewKeys = {
+  all: () => ['predict', 'orderPreview'] as const,
+  detail: (params: PreviewOrderParams) =>
+    [
+      ...predictOrderPreviewKeys.all(),
+      params.marketId,
+      params.outcomeId,
+      params.outcomeTokenId,
+      params.side,
+      params.size,
+      params.positionId,
+    ] as const,
+};
+
+export const predictOrderPreviewOptions = ({
+  marketId,
+  outcomeId,
+  outcomeTokenId,
+  side,
+  size,
+  positionId,
+}: PreviewOrderParams) =>
+  queryOptions({
+    queryKey: predictOrderPreviewKeys.detail({
+      marketId,
+      outcomeId,
+      outcomeTokenId,
+      side,
+      size,
+      positionId,
+    }),
+    queryFn: async (): Promise<OrderPreview> => {
+      try {
+        return await Engine.context.PredictController.previewOrder({
+          marketId,
+          outcomeId,
+          outcomeTokenId,
+          side,
+          size,
+          positionId,
+        });
+      } catch (err) {
+        console.error('Failed to preview order:', err);
+
+        Logger.error(ensureError(err), {
+          tags: {
+            feature: PREDICT_CONSTANTS.FEATURE_NAME,
+            component: 'usePredictOrderPreview',
+          },
+          context: {
+            name: 'usePredictOrderPreview',
+            data: {
+              method: 'calculatePreview',
+              action: 'order_preview',
+              operation: 'order_management',
+              side,
+              marketId,
+              outcomeId,
+            },
+          },
+        });
+
+        throw new Error(
+          parseErrorMessage({
+            error: err,
+            defaultCode: PREDICT_ERROR_CODES.PREVIEW_FAILED,
+          }),
+        );
+      }
+    },
+  });


### PR DESCRIPTION
## Summary
- Migrate `usePredictOrderPreview` hook from manual state management to React Query (`useQuery`)
- Extract query key factory and query options into `queries/orderPreview.ts`
- Simplify debounced order preview calculation by leveraging React Query for caching and automatic refetch

## Test plan
- [x] Unit tests updated and passing
- [ ] Verify order preview updates correctly when changing amount/side
- [ ] Verify debounce still works to avoid rapid recalculations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors order preview fetching/caching and refresh behavior to React Query and changes when Polymarket market details receive live-sports overlays, which could affect trading UX and market display if query keys/refresh timing or sports detection differs from before.
> 
> **Overview**
> **Order preview is now powered by React Query.** `usePredictOrderPreview` drops manual state/timer/operation tracking and instead debounces params for 100ms, queries via `useQuery`, and uses `refetchInterval` for `autoRefreshTimeout`.
> 
> **Adds a dedicated order-preview query definition.** Introduces `queries/orderPreview.ts` (keys + queryFn calling `Engine.context.PredictController.previewOrder` with centralized error logging/parsing) and wires it into `predictQueries`.
> 
> **Live-sports overlays in Polymarket are more selective.** `PolymarketProvider.getMarketDetails` now applies `TeamsCache` loading and `GameCache` overlay only when `getEventLeague(event)` indicates a sports event (even if leagues are enabled), with corresponding test updates and a new non-sports coverage case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f01e3b5430525c27c0d61c1e3e9c2e9a9f0bf5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->