### PR TITLE
refactor(predict): migrate usePredictPriceHistory to React Query

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictPriceHistory.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPriceHistory.test.tsx
@@ -1,29 +1,33 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import Engine from '../../../../core/Engine';
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   PredictPriceHistoryInterval,
   PredictPriceHistoryPoint,
 } from '../types';
 import { usePredictPriceHistory } from './usePredictPriceHistory';
 
-jest.mock('../../../../core/Engine', () => {
-  const mockContext = {
+const mockGetPriceHistory = jest.fn();
+jest.mock('../../../../core/Engine', () => ({
+  context: {
     PredictController: {
-      getPriceHistory: jest.fn(),
+      getPriceHistory: (...args: unknown[]) => mockGetPriceHistory(...args),
     },
-  };
-
-  return {
-    context: mockContext,
-  };
-});
-
-jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
-  DevLogger: {
-    log: jest.fn(),
   },
 }));
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: { log: jest.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
 
 describe('usePredictPriceHistory', () => {
   const mockPriceHistory: PredictPriceHistoryPoint[] = [
@@ -33,92 +37,88 @@ describe('usePredictPriceHistory', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset the mock implementation for getPriceHistory
-    (
-      Engine.context.PredictController.getPriceHistory as jest.Mock
-    ).mockResolvedValue(mockPriceHistory);
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
+    mockGetPriceHistory.mockResolvedValue(mockPriceHistory);
   });
 
   describe('initial state', () => {
-    it('returns empty price histories and not fetching when no markets provided', () => {
-      const { result } = renderHook(() =>
-        usePredictPriceHistory({ marketIds: [] }),
+    it('returns empty price histories when no markets provided', async () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => usePredictPriceHistory({ marketIds: [] }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.priceHistories).toEqual([]);
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.errors).toEqual([]);
       expect(typeof result.current.refetch).toBe('function');
     });
 
-    it('returns empty price histories when disabled', () => {
-      const { result } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-          enabled: false,
-        }),
+    it('returns empty price histories when disabled', async () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+            enabled: false,
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.priceHistories).toEqual([]);
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.errors).toEqual([]);
     });
   });
 
   describe('single market fetching', () => {
     it('fetches price history for a single market', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+          }),
+        { wrapper: Wrapper },
       );
 
-      expect(result.current.isFetching).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledWith({
+      expect(mockGetPriceHistory).toHaveBeenCalledWith({
         marketId: 'market-1',
         interval: PredictPriceHistoryInterval.ONE_DAY,
         fidelity: undefined,
+        startTs: undefined,
+        endTs: undefined,
       });
       expect(result.current.priceHistories).toEqual([mockPriceHistory]);
-      expect(result.current.isFetching).toBe(false);
       expect(result.current.errors).toEqual([null]);
     });
 
     it('handles error when fetching single market fails', async () => {
-      const mockError = new Error('Failed to fetch');
-      (
-        Engine.context.PredictController.getPriceHistory as jest.Mock
-      ).mockRejectedValueOnce(mockError);
+      const { Wrapper } = createWrapper();
+      mockGetPriceHistory.mockRejectedValue(new Error('Failed to fetch'));
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+          }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(result.current.priceHistories).toEqual([[]]);
       expect(result.current.errors).toEqual(['Failed to fetch']);
-      expect(result.current.isFetching).toBe(false);
-      expect(DevLogger.log).toHaveBeenCalledWith(
-        'usePredictPriceHistory: Error fetching price history for market market-1',
-        mockError,
-      );
     });
   });
 
   describe('multiple markets fetching', () => {
     it('fetches price history for multiple markets in parallel', async () => {
+      const { Wrapper } = createWrapper();
       const mockHistory1: PredictPriceHistoryPoint[] = [
         { timestamp: 1234567890, price: 0.5 },
       ];
@@ -129,69 +129,74 @@ describe('usePredictPriceHistory', () => {
         { timestamp: 1234567890, price: 0.2 },
       ];
 
-      (
-        Engine.context.PredictController.getPriceHistory as jest.Mock
-      ).mockImplementation(({ marketId }) => {
-        switch (marketId) {
-          case 'market-1':
-            return Promise.resolve(mockHistory1);
-          case 'market-2':
-            return Promise.resolve(mockHistory2);
-          case 'market-3':
-            return Promise.resolve(mockHistory3);
-          default:
-            return Promise.resolve([]);
-        }
-      });
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1', 'market-2', 'market-3'],
-        }),
+      mockGetPriceHistory.mockImplementation(
+        ({ marketId }: { marketId: string }) => {
+          switch (marketId) {
+            case 'market-1':
+              return Promise.resolve(mockHistory1);
+            case 'market-2':
+              return Promise.resolve(mockHistory2);
+            case 'market-3':
+              return Promise.resolve(mockHistory3);
+            default:
+              return Promise.resolve([]);
+          }
+        },
       );
 
-      await waitForNextUpdate();
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1', 'market-2', 'market-3'],
+          }),
+        { wrapper: Wrapper },
+      );
 
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledTimes(3);
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
+
+      expect(mockGetPriceHistory).toHaveBeenCalledTimes(3);
       expect(result.current.priceHistories).toEqual([
         mockHistory1,
         mockHistory2,
         mockHistory3,
       ]);
       expect(result.current.errors).toEqual([null, null, null]);
-      expect(result.current.isFetching).toBe(false);
     });
 
     it('handles partial failures in multiple markets', async () => {
+      const { Wrapper } = createWrapper();
       const mockHistory1: PredictPriceHistoryPoint[] = [
         { timestamp: 1234567890, price: 0.5 },
       ];
-      const mockError = new Error('Failed to fetch market-2');
 
-      (
-        Engine.context.PredictController.getPriceHistory as jest.Mock
-      ).mockImplementation(({ marketId }) => {
-        switch (marketId) {
-          case 'market-1':
-            return Promise.resolve(mockHistory1);
-          case 'market-2':
-            return Promise.reject(mockError);
-          case 'market-3':
-            return Promise.resolve(mockPriceHistory);
-          default:
-            return Promise.resolve([]);
-        }
-      });
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1', 'market-2', 'market-3'],
-        }),
+      mockGetPriceHistory.mockImplementation(
+        ({ marketId }: { marketId: string }) => {
+          switch (marketId) {
+            case 'market-1':
+              return Promise.resolve(mockHistory1);
+            case 'market-2':
+              return Promise.reject(new Error('Failed to fetch market-2'));
+            case 'market-3':
+              return Promise.resolve(mockPriceHistory);
+            default:
+              return Promise.resolve([]);
+          }
+        },
       );
 
-      await waitForNextUpdate();
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1', 'market-2', 'market-3'],
+          }),
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(result.current.priceHistories).toEqual([
         mockHistory1,
@@ -203,106 +208,114 @@ describe('usePredictPriceHistory', () => {
         'Failed to fetch market-2',
         null,
       ]);
-      expect(result.current.isFetching).toBe(false);
     });
   });
 
   describe('refetch functionality', () => {
     it('refetches data when refetch is called', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+          }),
+        { wrapper: Wrapper },
       );
 
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledTimes(1);
-
-      await act(async () => {
-        await result.current.refetch();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
       });
 
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledTimes(2);
+      expect(mockGetPriceHistory).toHaveBeenCalledTimes(1);
+
+      await result.current.refetch();
+
+      expect(mockGetPriceHistory).toHaveBeenCalledTimes(2);
       expect(result.current.priceHistories).toEqual([mockPriceHistory]);
     });
   });
 
   describe('configuration options', () => {
     it('uses custom interval when provided', async () => {
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
+      const { Wrapper } = createWrapper();
+      renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+            interval: PredictPriceHistoryInterval.ONE_WEEK,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(mockGetPriceHistory).toHaveBeenCalled();
+      });
+
+      expect(mockGetPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketId: 'market-1',
           interval: PredictPriceHistoryInterval.ONE_WEEK,
         }),
       );
-
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledWith({
-        marketId: 'market-1',
-        interval: PredictPriceHistoryInterval.ONE_WEEK,
-        fidelity: undefined,
-      });
     });
 
     it('uses custom fidelity when provided', async () => {
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
+      const { Wrapper } = createWrapper();
+      renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+            fidelity: 30,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      await waitFor(() => {
+        expect(mockGetPriceHistory).toHaveBeenCalled();
+      });
+
+      expect(mockGetPriceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketId: 'market-1',
+          interval: PredictPriceHistoryInterval.ONE_DAY,
           fidelity: 30,
         }),
       );
-
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalledWith({
-        marketId: 'market-1',
-        interval: PredictPriceHistoryInterval.ONE_DAY,
-        fidelity: 30,
-      });
     });
   });
 
   describe('reactivity', () => {
     it('refetches when marketIds change', async () => {
-      const { result, rerender, waitForNextUpdate } = renderHook(
+      const { Wrapper } = createWrapper();
+      const { result, rerender } = renderHook(
         ({ marketIds }) =>
           usePredictPriceHistory({
             marketIds,
           }),
         {
           initialProps: { marketIds: ['market-1'] },
+          wrapper: Wrapper,
         },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(result.current.priceHistories).toEqual([mockPriceHistory]);
 
       rerender({ marketIds: ['market-2'] });
 
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenLastCalledWith({
-        marketId: 'market-2',
-        interval: PredictPriceHistoryInterval.ONE_DAY,
-        fidelity: undefined,
+      await waitFor(() => {
+        expect(mockGetPriceHistory).toHaveBeenLastCalledWith(
+          expect.objectContaining({ marketId: 'market-2' }),
+        );
       });
     });
 
     it('refetches when interval changes', async () => {
-      const { rerender, waitForNextUpdate } = renderHook(
+      const { Wrapper } = createWrapper();
+      const { result, rerender } = renderHook(
         ({ interval }) =>
           usePredictPriceHistory({
             marketIds: ['market-1'],
@@ -310,25 +323,42 @@ describe('usePredictPriceHistory', () => {
           }),
         {
           initialProps: { interval: PredictPriceHistoryInterval.ONE_DAY },
+          wrapper: Wrapper,
         },
       );
 
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       rerender({ interval: PredictPriceHistoryInterval.ONE_WEEK });
 
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenLastCalledWith({
-        marketId: 'market-1',
-        interval: PredictPriceHistoryInterval.ONE_WEEK,
-        fidelity: undefined,
+      await waitFor(() => {
+        expect(mockGetPriceHistory).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            marketId: 'market-1',
+            interval: PredictPriceHistoryInterval.ONE_WEEK,
+          }),
+        );
       });
     });
 
-    it('does not refetch when enabled changes from false to false', () => {
+    it('does not fetch when disabled', () => {
+      const { Wrapper } = createWrapper();
+      renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+            enabled: false,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      expect(mockGetPriceHistory).not.toHaveBeenCalled();
+    });
+
+    it('fetches when enabled changes from false to true', async () => {
+      const { Wrapper } = createWrapper();
       const { rerender } = renderHook(
         ({ enabled }) =>
           usePredictPriceHistory({
@@ -337,127 +367,39 @@ describe('usePredictPriceHistory', () => {
           }),
         {
           initialProps: { enabled: false },
+          wrapper: Wrapper,
         },
       );
 
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).not.toHaveBeenCalled();
-
-      rerender({ enabled: false });
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('fetches when enabled changes from false to true', async () => {
-      const { rerender, waitForNextUpdate } = renderHook(
-        ({ enabled }) =>
-          usePredictPriceHistory({
-            marketIds: ['market-1'],
-            enabled,
-          }),
-        {
-          initialProps: { enabled: false },
-        },
-      );
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).not.toHaveBeenCalled();
+      expect(mockGetPriceHistory).not.toHaveBeenCalled();
 
       rerender({ enabled: true });
 
-      await waitForNextUpdate();
-
-      expect(
-        Engine.context.PredictController.getPriceHistory,
-      ).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockGetPriceHistory).toHaveBeenCalled();
+      });
     });
   });
 
   describe('error handling', () => {
-    it('handles Engine not initialized error', async () => {
-      // Save the original Engine.context
-      const originalContext = Engine.context;
+    it('handles non-Error exceptions', async () => {
+      const { Wrapper } = createWrapper();
+      mockGetPriceHistory.mockRejectedValue('String error');
 
-      // Set Engine.context to null
-      (Engine as unknown as { context: null }).context = null;
-
-      const { result, waitFor } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
+      const { result } = renderHook(
+        () =>
+          usePredictPriceHistory({
+            marketIds: ['market-1'],
+          }),
+        { wrapper: Wrapper },
       );
 
-      // Wait for the error to be handled
-      await waitFor(() => result.current.isFetching === false);
-
-      // Should have handled the error gracefully
-      expect(result.current.priceHistories).toEqual([[]]);
-      expect(result.current.errors).toEqual(['Engine not initialized']);
-      expect(result.current.isFetching).toBe(false);
-      expect(DevLogger.log).toHaveBeenCalled();
-
-      // Restore the original Engine.context
-      (Engine as unknown as { context: typeof originalContext }).context =
-        originalContext;
-    });
-
-    it('handles non-Error exceptions in individual market fetches', async () => {
-      // The Engine context is already mocked at the module level
-      (
-        Engine.context.PredictController.getPriceHistory as jest.Mock
-      ).mockRejectedValueOnce('String error');
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
-      );
-
-      await waitForNextUpdate();
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+      });
 
       expect(result.current.priceHistories).toEqual([[]]);
       expect(result.current.errors).toEqual(['Failed to fetch price history']);
-      expect(DevLogger.log).toHaveBeenCalled();
-    });
-  });
-
-  describe('cleanup', () => {
-    it('does not update state after unmount', async () => {
-      jest.useFakeTimers();
-
-      // Mock a delayed response
-      (
-        Engine.context.PredictController.getPriceHistory as jest.Mock
-      ).mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            setTimeout(() => resolve(mockPriceHistory), 100);
-          }),
-      );
-
-      const { unmount, result } = renderHook(() =>
-        usePredictPriceHistory({
-          marketIds: ['market-1'],
-        }),
-      );
-
-      // Initial state should be fetching
-      expect(result.current.isFetching).toBe(true);
-
-      // Unmount immediately
-      unmount();
-
-      // Fast-forward timers
-      jest.runAllTimers();
-
-      // No errors should be thrown
-      expect(true).toBe(true);
-
-      jest.useRealTimers();
     });
   });
 
@@ -473,22 +415,26 @@ describe('usePredictPriceHistory', () => {
 
     intervals.forEach((interval) => {
       it(`handles ${interval} interval correctly`, async () => {
-        const { result, waitForNextUpdate } = renderHook(() =>
-          usePredictPriceHistory({
-            marketIds: ['market-1'],
+        const { Wrapper } = createWrapper();
+        const { result } = renderHook(
+          () =>
+            usePredictPriceHistory({
+              marketIds: ['market-1'],
+              interval,
+            }),
+          { wrapper: Wrapper },
+        );
+
+        await waitFor(() => {
+          expect(result.current.isFetching).toBe(false);
+        });
+
+        expect(mockGetPriceHistory).toHaveBeenCalledWith(
+          expect.objectContaining({
+            marketId: 'market-1',
             interval,
           }),
         );
-
-        await waitForNextUpdate();
-
-        expect(
-          Engine.context.PredictController.getPriceHistory,
-        ).toHaveBeenCalledWith({
-          marketId: 'market-1',
-          interval,
-          fidelity: undefined,
-        });
         expect(result.current.priceHistories).toEqual([mockPriceHistory]);
       });
     });

--- a/app/components/UI/Predict/hooks/usePredictPriceHistory.tsx
+++ b/app/components/UI/Predict/hooks/usePredictPriceHistory.tsx
@@ -1,9 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import Engine from '../../../../core/Engine';
-import Logger from '../../../../util/Logger';
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-import { PREDICT_CONSTANTS } from '../constants/errors';
-import { ensureError } from '../utils/predictErrorHandler';
+import { useQueries } from '@tanstack/react-query';
+import { predictQueries } from '../queries';
 import {
   PredictPriceHistoryInterval,
   PredictPriceHistoryPoint,
@@ -26,7 +22,10 @@ export interface UsePredictPriceHistoryResult {
 }
 
 /**
- * Hook to fetch and manage price history data for multiple markets
+ * Hook to fetch and manage price history data for multiple markets.
+ *
+ * Internally creates one React Query per marketId so each market is
+ * cached and refetched independently.
  */
 export const usePredictPriceHistory = (
   options: UsePredictPriceHistoryOptions,
@@ -40,169 +39,37 @@ export const usePredictPriceHistory = (
     enabled = true,
   } = options;
 
-  const [priceHistories, setPriceHistories] = useState<
-    PredictPriceHistoryPoint[][]
-  >([]);
-  const [isFetching, setIsFetching] = useState(false);
-  const [errors, setErrors] = useState<(string | null)[]>([]);
+  const queries = useQueries({
+    queries: marketIds.map((marketId) => ({
+      ...predictQueries.priceHistory.options({
+        marketId,
+        interval,
+        fidelity,
+        startTs,
+        endTs,
+      }),
+      enabled: enabled && marketIds.length > 0,
+    })),
+  });
 
-  const isMountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
-    },
-    [],
-  );
+  const priceHistories = queries.map((q) => q.data ?? []);
+  const isFetching = queries.some((q) => q.isFetching);
+  const errors = queries.map((q) => {
+    if (!q.error) return null;
+    return q.error instanceof Error
+      ? q.error.message
+      : 'Failed to fetch price history';
+  });
 
-  useEffect(() => {
-    if (!enabled && isMountedRef.current) {
-      setPriceHistories([]);
-      setErrors([]);
-      setIsFetching(false);
-    }
-  }, [enabled]);
-
-  // Create a stable string representation for the dependency array
-  const marketIdsKey = marketIds?.join(',') ?? '';
-
-  const fetchPriceHistories = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
-
-    if (!marketIds?.length) {
-      if (isMountedRef.current) {
-        setPriceHistories([]);
-        setErrors([]);
-        setIsFetching(false);
-      }
-      return;
-    }
-
-    if (isMountedRef.current) {
-      setIsFetching(true);
-      setErrors(new Array(marketIds.length).fill(null));
-    }
-
-    try {
-      if (!Engine || !Engine.context) {
-        throw new Error('Engine not initialized');
-      }
-
-      const controller = Engine.context.PredictController;
-      if (!controller) {
-        throw new Error('Predict controller not available');
-      }
-
-      // Fetch all price histories in parallel
-      const promises = marketIds.map(async (marketId, index) => {
-        try {
-          const history = await controller.getPriceHistory({
-            marketId,
-            fidelity,
-            interval,
-            startTs,
-            endTs,
-          });
-          return { index, data: history ?? [], error: null };
-        } catch (err) {
-          const errorMessage =
-            err instanceof Error
-              ? err.message
-              : 'Failed to fetch price history';
-          DevLogger.log(
-            `usePredictPriceHistory: Error fetching price history for market ${marketId}`,
-            err,
-          );
-
-          // Capture exception with price history loading context (single market)
-          Logger.error(ensureError(err), {
-            tags: {
-              feature: PREDICT_CONSTANTS.FEATURE_NAME,
-              component: 'usePredictPriceHistory',
-            },
-            context: {
-              name: 'usePredictPriceHistory',
-              data: {
-                method: 'loadPriceHistory',
-                action: 'price_history_load_single',
-                operation: 'data_fetching',
-                marketId,
-                interval,
-                startTs,
-                endTs,
-                fidelity,
-              },
-            },
-          });
-
-          return { index, data: [], error: errorMessage };
-        }
-      });
-
-      const results = await Promise.all(promises);
-
-      if (isMountedRef.current) {
-        const histories = new Array(marketIds.length).fill([]);
-        const errorList = new Array(marketIds.length).fill(null);
-
-        results.forEach(({ index, data, error }) => {
-          histories[index] = data;
-          errorList[index] = error;
-        });
-
-        setPriceHistories(histories);
-        setErrors(errorList);
-      }
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Failed to fetch price histories';
-
-      DevLogger.log('usePredictPriceHistory: Error in batch fetching', err);
-
-      // Capture exception with price history batch loading context
-      Logger.error(ensureError(err), {
-        tags: {
-          feature: PREDICT_CONSTANTS.FEATURE_NAME,
-          component: 'usePredictPriceHistory',
-        },
-        context: {
-          name: 'usePredictPriceHistory',
-          data: {
-            method: 'loadPriceHistory',
-            action: 'price_history_load_batch',
-            operation: 'data_fetching',
-            marketCount: marketIds.length,
-            interval,
-            startTs,
-            endTs,
-            fidelity,
-          },
-        },
-      });
-
-      if (isMountedRef.current) {
-        setErrors(new Array(marketIds.length).fill(errorMessage));
-        setPriceHistories(new Array(marketIds.length).fill([]));
-      }
-    } finally {
-      if (isMountedRef.current) {
-        setIsFetching(false);
-      }
-    }
-    // eslint-disable-next-line react-compiler/react-compiler
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, marketIdsKey, fidelity, interval, startTs, endTs]);
-
-  useEffect(() => {
-    fetchPriceHistories();
-  }, [fetchPriceHistories]);
+  const refetch = async () => {
+    await Promise.all(queries.map((q) => q.refetch()));
+  };
 
   return {
-    priceHistories,
+    priceHistories: enabled ? priceHistories : [],
     isFetching,
-    errors,
-    refetch: fetchPriceHistories,
+    errors: enabled ? errors : [],
+    refetch,
   };
 };
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -41,6 +41,7 @@ import {
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import type { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { OrderPreview, PlaceOrderParams } from '../types';
 import { PolymarketProvider } from './PolymarketProvider';
 import {
@@ -181,6 +182,11 @@ jest.mock('./WebSocketManager', () => ({
   },
 }));
 
+jest.mock('../../utils/gameParser', () => ({
+  ...jest.requireActual('../../utils/gameParser'),
+  getEventLeague: jest.fn(),
+}));
+
 jest.mock('../../../../../util/transactions', () => ({
   generateTransferData: jest.fn(),
   isSmartContractAddress: jest.fn(),
@@ -215,6 +221,7 @@ const mockHasAllowances = hasAllowances as jest.Mock;
 const mockQuery = query as jest.Mock;
 const mockPreviewOrder = previewOrder as jest.Mock;
 const mockGetBalance = getBalance as jest.Mock;
+const mockGetEventLeague = getEventLeague as jest.Mock;
 
 describe('PolymarketProvider', () => {
   const defaultFeatureFlags: PredictFeatureFlags = {
@@ -2486,6 +2493,7 @@ describe('PolymarketProvider', () => {
 
     it('get market details successfully', async () => {
       const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+      mockGetEventLeague.mockReturnValue('nfl');
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
@@ -6713,8 +6721,9 @@ describe('PolymarketProvider', () => {
     });
 
     describe('getMarketDetails', () => {
-      it('applies GameCache overlay to fetched market details when live sports are enabled', async () => {
+      it('applies GameCache overlay to fetched market details when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = {
           id: 'market-1',
@@ -6731,8 +6740,9 @@ describe('PolymarketProvider', () => {
         );
       });
 
-      it('returns market with cached game data overlay applied when live sports are enabled', async () => {
+      it('returns market with cached game data overlay applied when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = { id: 'market-1', question: 'Test Market?' };
         const parsedMarket = { id: 'market-1', title: 'Test Market' };
         const overlaidMarket = {
@@ -6749,6 +6759,25 @@ describe('PolymarketProvider', () => {
         });
 
         expect(result).toEqual(overlaidMarket);
+      });
+
+      it('skips GameCache overlay when event is not a sports event despite leagues being enabled', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        mockGetEventLeague.mockReturnValue(null);
+        const mockEvent = { id: 'market-1', question: 'Will BTC hit 100k?' };
+        const parsedMarket = { id: 'market-1', title: 'Will BTC hit 100k?' };
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
+        mockParsePolymarketEvents.mockReturnValue([parsedMarket]);
+
+        const result = await provider.getMarketDetails({
+          marketId: 'market-1',
+        });
+
+        expect(mockGameCacheInstance.overlayOnMarket).not.toHaveBeenCalled();
+        expect(
+          mockTeamsCacheInstance.ensureLeaguesLoaded,
+        ).not.toHaveBeenCalled();
+        expect(result).toEqual(parsedMarket);
       });
 
       it('throws error when parsing fails without calling GameCache overlay', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -102,6 +102,7 @@ import {
   submitClobOrder,
 } from './utils';
 import { PredictFeatureFlags } from '../../types/flags';
+import { getEventLeague } from '../../utils/gameParser';
 import { GameCache } from './GameCache';
 import { TeamsCache } from './TeamsCache';
 import { WebSocketManager } from './WebSocketManager';
@@ -193,20 +194,22 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     try {
-      const { liveSportsLeagues } = this.#getFeatureFlags();
       const event = await getMarketDetailsFromGammaApi({
         marketId,
       });
 
-      const liveSportsEnabled = liveSportsLeagues.length > 0;
+      const { liveSportsLeagues } = this.#getFeatureFlags();
+      const eventLeague = getEventLeague(event);
+      const isSportsEvent =
+        eventLeague !== null && liveSportsLeagues.length > 0;
 
-      if (liveSportsEnabled) {
+      if (isSportsEvent) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(
           liveSportsLeagues as typeof SUPPORTED_SPORTS_LEAGUES,
         );
       }
 
-      const teamLookup = liveSportsEnabled
+      const teamLookup = isSportsEvent
         ? (
             league: (typeof SUPPORTED_SPORTS_LEAGUES)[number],
             abbreviation: string,
@@ -222,7 +225,7 @@ export class PolymarketProvider implements PredictProvider {
         throw new Error('Failed to parse market details');
       }
 
-      return liveSportsEnabled
+      return isSportsEvent
         ? GameCache.getInstance().overlayOnMarket(parsedMarket)
         : parsedMarket;
     } catch (error) {

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,6 +1,10 @@
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
+import {
+  predictPriceHistoryKeys,
+  predictPriceHistoryOptions,
+} from './priceHistory';
 
 export const predictQueries = {
   activity: {
@@ -14,5 +18,9 @@ export const predictQueries = {
   positions: {
     keys: predictPositionsKeys,
     options: predictPositionsOptions,
+  },
+  priceHistory: {
+    keys: predictPriceHistoryKeys,
+    options: predictPriceHistoryOptions,
   },
 };

--- a/app/components/UI/Predict/queries/priceHistory.ts
+++ b/app/components/UI/Predict/queries/priceHistory.ts
@@ -1,0 +1,92 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import { PREDICT_CONSTANTS } from '../constants/errors';
+import { ensureError } from '../utils/predictErrorHandler';
+import {
+  PredictPriceHistoryInterval,
+  PredictPriceHistoryPoint,
+} from '../types';
+
+export const predictPriceHistoryKeys = {
+  all: () => ['predict', 'priceHistory'] as const,
+  detail: (
+    marketId: string,
+    interval: PredictPriceHistoryInterval,
+    fidelity?: number,
+    startTs?: number,
+    endTs?: number,
+  ) =>
+    [
+      ...predictPriceHistoryKeys.all(),
+      marketId,
+      interval,
+      fidelity,
+      startTs,
+      endTs,
+    ] as const,
+};
+
+export const predictPriceHistoryOptions = ({
+  marketId,
+  interval = PredictPriceHistoryInterval.ONE_DAY,
+  fidelity,
+  startTs,
+  endTs,
+}: {
+  marketId: string;
+  interval?: PredictPriceHistoryInterval;
+  fidelity?: number;
+  startTs?: number;
+  endTs?: number;
+}) =>
+  queryOptions({
+    queryKey: predictPriceHistoryKeys.detail(
+      marketId,
+      interval,
+      fidelity,
+      startTs,
+      endTs,
+    ),
+    queryFn: async (): Promise<PredictPriceHistoryPoint[]> => {
+      try {
+        const history = await Engine.context.PredictController.getPriceHistory({
+          marketId,
+          fidelity,
+          interval,
+          startTs,
+          endTs,
+        });
+        return history ?? [];
+      } catch (err) {
+        DevLogger.log(
+          `usePredictPriceHistory: Error fetching price history for market ${marketId}`,
+          err,
+        );
+
+        Logger.error(ensureError(err), {
+          tags: {
+            feature: PREDICT_CONSTANTS.FEATURE_NAME,
+            component: 'usePredictPriceHistory',
+          },
+          context: {
+            name: 'usePredictPriceHistory',
+            data: {
+              method: 'loadPriceHistory',
+              action: 'price_history_load_single',
+              operation: 'data_fetching',
+              marketId,
+              interval,
+              startTs,
+              endTs,
+              fidelity,
+            },
+          },
+        });
+
+        throw err;
+      }
+    },
+    staleTime: 5_000,
+  });


### PR DESCRIPTION
## Summary
- Migrate `usePredictPriceHistory` hook from manual state management to React Query (`useQueries`)
- Extract query key factory and query options into `queries/priceHistory.ts`
- Create one query per market ID for independent caching and refetch of each market's price history

## Test plan
- [x] Unit tests updated and passing
- [ ] Verify price history charts render correctly on market detail screens
- [ ] Verify interval switching (1D, 1W, 1M, etc.) refetches data properly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors price-history fetching to React Query and changes when Polymarket market details receive sports overlays, which can affect chart/market-detail data freshness and conditional rendering. No auth/security changes, but behavior around caching/refetch and sports detection may shift subtly.
> 
> **Overview**
> **Predict price history fetching is refactored to React Query.** `usePredictPriceHistory` now uses `useQueries` (one query per `marketId`) and a new `predictQueries.priceHistory` query definition (`queries/priceHistory.ts`) with stable query keys, shared error logging, and a short `staleTime`; `refetch` now triggers all underlying query refetches.
> 
> **Polymarket market details overlays are now gated by event type.** `PolymarketProvider.getMarketDetails` only loads team caches and applies `GameCache` overlays when `getEventLeague(event)` indicates a sports event (even if sports leagues are enabled), and tests are updated to cover both sports and non-sports events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2bf6785b006728a56179096e6e824137508624f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->