### PR TITLE
test: reduce /create-bug root cause analysis cost with two-phase approach

### DIFF
--- a/.claude/commands/create-bug.md
+++ b/.claude/commands/create-bug.md
@@ -128,24 +128,37 @@ For `render: shell` fields, wrap the value in a code fence:
 
 ## Step 6: Root Cause Analysis
 
-When the user opts in, perform all three phases below and post a single comment on the issue with the combined findings.
+When the user opts in, run a two-phase analysis: a cheap gathering phase (Haiku subagent) followed by an expensive reasoning phase (main context).
 
-### 6a: Investigate the root cause
+### Phase 1 — Gather Evidence (Haiku subagent)
 
-- Trace the bug through the code to identify the exact files, lines, and logic causing the issue
-- Research only — no code changes
+Launch an Agent with `model: "haiku"` and `subagent_type: "general-purpose"`. Pass a prompt that includes the bug description, steps to reproduce, and any relevant context from the issue. The prompt must instruct the subagent to:
 
-### 6b: Identify regression PRs
+1. **6a gathering** — Search for files and functions related to the bug using grep, glob, and read. Trace the code path from entry point to failure point. Record file paths, line numbers, and relevant code snippets.
+2. **6b gathering** — Run `git log` on affected files comparing the current release branch against the previous release branch. Collect PR numbers, titles, authors, and relevant diffs that may have introduced or surfaced the bug.
+3. **6c gathering** — Search the codebase for the same pattern, function, or anti-pattern that causes the bug. List all files and locations that share the pattern.
 
-- Check `git log` history of affected files, comparing the release branch against the previous release branch
-- Identify which PRs introduced or surfaced the bug (new code, removed compensating mechanisms, refactors, etc.)
-- Note whether the issue is a new regression or pre-existing
+The subagent prompt must end with this instruction:
 
-### 6c: Scope analysis
+> Return a structured summary with exactly these sections. Do NOT return raw file contents or full git logs — only the distilled findings:
+>
+> **Relevant files** — path, line numbers, and what each file does in relation to the bug
+>
+> **Code flow trace** — entry point → intermediate steps → failure point, with file:line references
+>
+> **Git history findings** — PR numbers, titles, authors, what changed, and how the change relates to the bug
+>
+> **Pattern matches (scope analysis)** — other files and locations that use the same pattern/function/anti-pattern, with file:line references
 
-- Search the codebase for the same pattern, function, or anti-pattern causing the bug
-- Identify all affected areas beyond the originally reported bug
-- If other features are impacted, file separate bug issues for each and link them
+### Phase 2 — Analyze & Post (main context)
+
+Using the structured summary returned by the Haiku subagent, the main context performs the reasoning:
+
+1. **Determine root cause** — analyze the code flow trace and git history to identify exactly what causes the bug
+2. **Identify regression PRs** — determine which PRs introduced or surfaced the bug, and whether it is a new regression or pre-existing
+3. **Assess scope of impact** — review the pattern matches to understand the full blast radius beyond the reported bug
+4. **File separate bugs** — if other features are impacted by the same pattern/anti-pattern, file separate bug issues for each and link them
+5. **Post the comment** — write and post a single comment on the issue with all findings
 
 ### Comment format
 


### PR DESCRIPTION
## **Description**

The root cause analysis in `/create-bug` (Step 6) currently runs entirely on Opus — all file reads, grep searches, git log/blame calls, and reasoning happen in one expensive context. This refactors Step 6 into a two-phase approach:

- **Phase 1 (Gather Evidence):** A Haiku subagent (`model: "haiku"`) performs all the I/O-heavy work — grep/glob/read for code tracing, git log for regression PRs, and pattern searching for scope analysis. Returns a structured summary.
- **Phase 2 (Analyze & Post):** The main Opus context receives the distilled summary and does the reasoning — determines root cause, identifies regression PRs, assesses scope, files separate bugs, and posts the comment.

This reduces cost by ~5-8x per analysis while maintaining output quality since reasoning stays on Opus.


| | Opus (current) | Haiku gathering + Opus reasoning |
|---|---|---|
| Gathering phase tokens | ~100-150k on Opus | ~100-150k on Haiku |
| Reasoning phase tokens | (included above) | ~10-20k on Opus |
| **Estimated cost** | **$1-3** | **~$0.15-0.40** |
## **Related issues**

[MMQA-1530](https://consensyssoftware.atlassian.net/browse/MMQA-1530)

## **Manual testing steps**

```gherkin
Feature: Two-phase root cause analysis in /create-bug

  Scenario: user opts in to root cause analysis
    Given a bug report has been created via /create-bug

    When user opts in to root cause investigation at Step 5
    Then a Haiku subagent is launched to gather evidence
    And the subagent returns a structured summary with relevant files, code flow trace, git history findings, and pattern matches
    And the main context analyzes the summary and posts a comment with all required sections
```

## **Screenshots/Recordings**

### Before

Root cause analysis ran entirely on Opus — all file reads, greps, git logs, and reasoning in one context.

### After

Run `/create-bug` in Claude Code terminal, opt in to root cause analysis, and verify the Agent tool is called with `model: "haiku"` for evidence gathering while the final comment still contains all required sections.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [Labeling Guideline](https://github.com/user/repo/blob/main/.github/guidelines/LABELING.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and round trip)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket


[MMQA-1530]: https://consensyssoftware.atlassian.net/browse/MMQA-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the `/create-bug` Claude command; no production code paths or data handling are modified. Risk is limited to potential workflow/prompt regressions in how root-cause analysis is executed and formatted.
> 
> **Overview**
> Refactors `/create-bug` Step 6 root-cause investigation guidance to a **two-phase** flow: a **Haiku subagent** performs I/O-heavy evidence gathering (code search/trace, `git log` regression hunting, and scope/pattern matching) and returns a **structured summary**, then the main context performs the reasoning and posts a single consolidated issue comment.
> 
> Adds explicit instructions for the Haiku prompt (required sections and constraints on output) and updates the main-context checklist to consume that summary to determine root cause, identify regression PRs, assess blast radius, and file/link follow-up bugs as needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 932e9446aa93c5977bbf1704c1c066502dfea071. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->