### PR TITLE
refactor(predict): migrate useUnrealizedPnL to React Query

### DIFF
--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -285,7 +285,7 @@ describe('MarketsWonCard', () => {
 
       await ref.current?.refresh();
 
-      expect(mockLoadUnrealizedPnL).toHaveBeenCalledWith({ isRefresh: true });
+      expect(mockLoadUnrealizedPnL).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -119,7 +119,7 @@ const PredictPositionsHeader = forwardRef<
   useImperativeHandle(ref, () => ({
     refresh: async () => {
       await Promise.all([
-        loadUnrealizedPnL({ isRefresh: true }),
+        loadUnrealizedPnL(),
         queryClient.invalidateQueries({
           queryKey: predictQueries.balance.keys.all(),
         }),

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -1,12 +1,11 @@
+import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUnrealizedPnL } from './useUnrealizedPnL';
 import { UnrealizedPnL } from '../types';
 import { usePredictPositions } from './usePredictPositions';
 
 const mockSelectedAddress = '0x1234567890123456789012345678901234567890';
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => mockSelectedAddress),
-}));
 
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
@@ -44,6 +43,25 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+jest.mock('../utils/predictErrorHandler', () => ({
+  ensureError: (err: unknown) =>
+    err instanceof Error ? err : new Error(String(err)),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+
 describe('useUnrealizedPnL', () => {
   const basePnL: UnrealizedPnL = {
     user: '0x1111111111111111111111111111111111111111',
@@ -58,45 +76,47 @@ describe('useUnrealizedPnL', () => {
     });
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns initial state when disabled', () => {
-    const { result } = renderHook(() =>
-      useUnrealizedPnL({ loadOnMount: false }),
+  it('does not fetch when loadOnMount is false', () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useUnrealizedPnL({ loadOnMount: false }),
+      { wrapper: Wrapper },
     );
 
     expect(result.current.unrealizedPnL).toBeNull();
-    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(typeof result.current.loadUnrealizedPnL).toBe('function');
     expect(mockGetUnrealizedPnL).not.toHaveBeenCalled();
   });
 
   it('fetches unrealized P&L successfully with default options', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
-      expect(result.current.error).toBeNull();
     });
 
+    expect(result.current.unrealizedPnL).toEqual(basePnL);
+    expect(result.current.error).toBeNull();
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
       address: mockSelectedAddress,
     });
   });
 
-  it('passes provided options to getUnrealizedPnL', async () => {
+  it('uses provided address instead of selected account', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
+    const customAddress = '0x2222222222222222222222222222222222222222';
 
-    const { result } = renderHook(() =>
-      useUnrealizedPnL({
-        address: '0x2222222222222222222222222222222222222222',
-      }),
+    const { result } = renderHook(
+      () => useUnrealizedPnL({ address: customAddress }),
+      { wrapper: Wrapper },
     );
 
     await waitFor(() => {
@@ -104,45 +124,44 @@ describe('useUnrealizedPnL', () => {
     });
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
-      address: '0x2222222222222222222222222222222222222222',
+      address: customAddress,
     });
   });
 
-  it('handles null responses by clearing the data', async () => {
+  it('handles null responses', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(null);
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.error).toBeNull();
       expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.error).toBeNull();
   });
 
   it('surfaces errors thrown by getUnrealizedPnL', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockRejectedValue(new Error('Network error'));
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
       expect(result.current.error).toBe('Network error');
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.isLoading).toBe(false);
   });
 
-  it('maps non-Error rejections to a generic message', async () => {
-    mockGetUnrealizedPnL.mockRejectedValue('bad times');
-
-    const { result } = renderHook(() => useUnrealizedPnL());
-
-    await waitFor(() => {
-      expect(result.current.error).toBe('Failed to fetch unrealized P&L');
-    });
-  });
-
-  it('supports manual refetching', async () => {
+  it('supports manual refetching via loadUnrealizedPnL', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
     const updatedPnL: UnrealizedPnL = {
@@ -151,7 +170,9 @@ describe('useUnrealizedPnL', () => {
       percentUpnl: -2,
     };
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
       expect(result.current.unrealizedPnL).toEqual(basePnL);
@@ -165,70 +186,20 @@ describe('useUnrealizedPnL', () => {
 
     await waitFor(() => {
       expect(result.current.unrealizedPnL).toEqual(updatedPnL);
-      expect(result.current.error).toBeNull();
     });
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(2);
   });
 
-  it('loads data when loadOnMount changes from false to true', async () => {
-    mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-    const { result, rerender } = renderHook(
-      ({ loadOnMount }) => useUnrealizedPnL({ loadOnMount }),
-      {
-        initialProps: { loadOnMount: false },
-      },
-    );
-
-    expect(mockGetUnrealizedPnL).not.toHaveBeenCalled();
-
-    rerender({ loadOnMount: true });
-
-    await waitFor(() => {
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  it('refetches when dependencies change', async () => {
-    mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-    const { rerender } = renderHook(
-      ({ address }: { address?: string }) => useUnrealizedPnL({ address }),
-      {
-        initialProps: {
-          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        },
-      },
-    );
-
-    await waitFor(() => {
-      expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(1);
-    });
-
-    rerender({
-      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    });
-
-    await waitFor(() => {
-      expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(2);
-    });
-
-    expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(1, {
-      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    });
-    expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(2, {
-      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    });
-  });
-
   describe('positions-based visibility', () => {
     it('returns null when user has no positions', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({ data: [] });
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -239,12 +210,15 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns unrealized P&L when user has positions', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({
         data: [{ id: 'position-1' }, { id: 'position-2' }],
       });
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -255,9 +229,10 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('calls usePredictPositions with claimable: false', () => {
+      const { Wrapper } = createWrapper();
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      renderHook(() => useUnrealizedPnL());
+      renderHook(() => useUnrealizedPnL(), { wrapper: Wrapper });
 
       expect(mockUsePredictPositions).toHaveBeenCalledWith({
         claimable: false,
@@ -265,9 +240,12 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns null when getUnrealizedPnL returns null and user has positions', async () => {
+      const { Wrapper } = createWrapper();
       mockGetUnrealizedPnL.mockResolvedValue(null);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -278,10 +256,13 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns null when both getUnrealizedPnL returns null and no positions', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({ data: [] });
       mockGetUnrealizedPnL.mockResolvedValue(null);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -292,10 +273,13 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns null when positions data is undefined', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({ data: undefined });
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -1,12 +1,12 @@
+import { useCallback, useEffect, useMemo } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Logger from '../../../../util/Logger';
-import Engine from '../../../../core/Engine';
-import { UnrealizedPnL } from '../types';
-import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { ensureError } from '../utils/predictErrorHandler';
+import { UnrealizedPnL } from '../types';
+import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
+import { predictQueries } from '../queries';
 import { usePredictPositions } from './usePredictPositions';
 
 export interface UseUnrealizedPnLOptions {
@@ -31,7 +31,7 @@ export interface UseUnrealizedPnLResult {
   isLoading: boolean;
   isRefreshing: boolean;
   error: string | null;
-  loadUnrealizedPnL: (options?: { isRefresh?: boolean }) => Promise<void>;
+  loadUnrealizedPnL: () => Promise<void>;
 }
 
 /**
@@ -44,108 +44,71 @@ export const useUnrealizedPnL = (
 ): UseUnrealizedPnLResult => {
   const { address, loadOnMount = true, refreshOnFocus = true } = options;
 
-  const [pnlData, setPnlData] = useState<UnrealizedPnL | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const isInitialMount = useRef(true);
-
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const selectedInternalAccountAddress = evmAccount?.address ?? '0x0';
+  const resolvedAddress = address ?? selectedInternalAccountAddress;
+
+  const queryClient = useQueryClient();
 
   const { data: activePositions } = usePredictPositions({ claimable: false });
   const hasPositions = (activePositions?.length ?? 0) > 0;
 
-  const loadUnrealizedPnL = useCallback(
-    async (loadOptions?: { isRefresh?: boolean }) => {
-      const { isRefresh = false } = loadOptions || {};
+  const queryOpts = predictQueries.unrealizedPnL.options({
+    address: resolvedAddress,
+  });
 
-      try {
-        if (isRefresh) {
-          setIsRefreshing(true);
-        } else {
-          setIsLoading(true);
-        }
-        setError(null);
+  const query = useQuery({
+    ...queryOpts,
+    enabled: loadOnMount,
+  });
 
-        const unrealizedPnLResult =
-          await Engine.context.PredictController.getUnrealizedPnL({
-            address: address ?? selectedInternalAccountAddress,
-          });
-
-        setPnlData(unrealizedPnLResult ?? null);
-
-        DevLogger.log('useUnrealizedPnL: Loaded unrealized P&L', {
-          unrealizedPnL: unrealizedPnLResult,
-        });
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to fetch unrealized P&L';
-        setError(errorMessage);
-        setPnlData(null);
-        DevLogger.log('useUnrealizedPnL: Error loading unrealized P&L', err);
-
-        Logger.error(ensureError(err), {
-          tags: {
-            feature: PREDICT_CONSTANTS.FEATURE_NAME,
-            component: 'useUnrealizedPnL',
-          },
-          context: {
-            name: 'useUnrealizedPnL',
-            data: {
-              method: 'loadUnrealizedPnL',
-              action: 'unrealized_pnl_load',
-              operation: 'data_fetching',
-            },
-          },
-        });
-      } finally {
-        setIsLoading(false);
-        setIsRefreshing(false);
-      }
-    },
-    [address, selectedInternalAccountAddress],
-  );
-
-  // Load unrealized P&L on mount if enabled
   useEffect(() => {
-    if (loadOnMount) {
-      loadUnrealizedPnL();
-    }
-    // eslint-disable-next-line react-compiler/react-compiler
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadOnMount]);
+    if (!query.error) return;
 
-  // Refresh unrealized P&L when screen comes into focus if enabled
+    Logger.error(ensureError(query.error), {
+      tags: {
+        feature: PREDICT_CONSTANTS.FEATURE_NAME,
+        component: 'useUnrealizedPnL',
+      },
+      context: {
+        name: 'useUnrealizedPnL',
+        data: {
+          method: 'loadUnrealizedPnL',
+          action: 'unrealized_pnl_load',
+          operation: 'data_fetching',
+        },
+      },
+    });
+  }, [query.error]);
+
   useFocusEffect(
     useCallback(() => {
       if (refreshOnFocus) {
-        loadUnrealizedPnL({ isRefresh: true });
+        queryClient.invalidateQueries({ queryKey: queryOpts.queryKey });
       }
-    }, [refreshOnFocus, loadUnrealizedPnL]),
+    }, [refreshOnFocus, queryClient, queryOpts.queryKey]),
   );
 
-  // Reset and reload data when address changes (but not on initial mount)
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-
-    setPnlData(null);
-    setError(null);
-    loadUnrealizedPnL();
-  }, [address, loadUnrealizedPnL]);
+  const loadUnrealizedPnL = useCallback(async () => {
+    await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
+  }, [queryClient, queryOpts]);
 
   const unrealizedPnL = useMemo(
-    () => (hasPositions ? pnlData : null),
-    [hasPositions, pnlData],
+    () => (hasPositions ? (query.data ?? null) : null),
+    [hasPositions, query.data],
   );
+
+  const error = useMemo(() => {
+    if (!query.error) return null;
+    return query.error instanceof Error
+      ? query.error.message
+      : 'Failed to fetch unrealized P&L';
+  }, [query.error]);
 
   return {
     unrealizedPnL,
-    isLoading,
-    isRefreshing,
+    isLoading: query.isLoading,
+    isRefreshing: query.isFetching && !query.isLoading,
     error,
     loadUnrealizedPnL,
   };

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -53,9 +53,10 @@ export const useUnrealizedPnL = (
   const { data: activePositions } = usePredictPositions({ claimable: false });
   const hasPositions = (activePositions?.length ?? 0) > 0;
 
-  const queryOpts = predictQueries.unrealizedPnL.options({
-    address: resolvedAddress,
-  });
+  const queryOpts = useMemo(
+    () => predictQueries.unrealizedPnL.options({ address: resolvedAddress }),
+    [resolvedAddress],
+  );
 
   const query = useQuery({
     ...queryOpts,
@@ -90,7 +91,11 @@ export const useUnrealizedPnL = (
   );
 
   const loadUnrealizedPnL = useCallback(async () => {
-    await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
+    try {
+      await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
+    } catch {
+      // Error is tracked via query.error and logged by the useEffect above
+    }
   }, [queryClient, queryOpts]);
 
   const unrealizedPnL = useMemo(

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,6 +1,10 @@
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
+import {
+  predictUnrealizedPnLKeys,
+  predictUnrealizedPnLOptions,
+} from './unrealizedPnL';
 
 export const predictQueries = {
   activity: {
@@ -14,5 +18,9 @@ export const predictQueries = {
   positions: {
     keys: predictPositionsKeys,
     options: predictPositionsOptions,
+  },
+  unrealizedPnL: {
+    keys: predictUnrealizedPnLKeys,
+    options: predictUnrealizedPnLOptions,
   },
 };

--- a/app/components/UI/Predict/queries/unrealizedPnL.ts
+++ b/app/components/UI/Predict/queries/unrealizedPnL.ts
@@ -1,0 +1,25 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import type { UnrealizedPnL } from '../types';
+
+export const predictUnrealizedPnLKeys = {
+  all: (address: string) => ['predict', 'unrealizedPnL', address] as const,
+};
+
+export const predictUnrealizedPnLOptions = ({ address }: { address: string }) =>
+  queryOptions({
+    queryKey: predictUnrealizedPnLKeys.all(address),
+    queryFn: async (): Promise<UnrealizedPnL | null> => {
+      const result = await Engine.context.PredictController.getUnrealizedPnL({
+        address,
+      });
+
+      DevLogger.log('useUnrealizedPnL: Loaded unrealized P&L', {
+        unrealizedPnL: result,
+      });
+
+      return result ?? null;
+    },
+    staleTime: 10_000,
+  });


### PR DESCRIPTION
## Summary
- Migrate `useUnrealizedPnL` from manual `useState`/`useEffect` to React Query's `useQuery`, completing React Query adoption across the Predict module
- Extract query key factory and `queryOptions()` into `queries/unrealizedPnL.ts` following the established pattern (`balance.ts`, `positions.ts`)
- Register the new query in `predictQueries` index
- Update consumer (`PredictPositionsHeader`) to use the simplified `loadUnrealizedPnL()` signature (no more `{ isRefresh }` arg — React Query handles this)

## Test plan
- [ ] `npx jest useUnrealizedPnL` — all tests pass
- [ ] `npx jest PredictPositionsHeader` — consumer tests still pass
- [ ] Verify unrealized P&L displays correctly on the Positions screen
- [ ] Verify pull-to-refresh updates P&L data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors core data-fetch/refresh behavior for Predict unrealized P&L, which could change when/why the UI shows loading vs cached data or triggers network calls.
> 
> **Overview**
> Moves `useUnrealizedPnL` from manual `useState`/`useEffect` fetching to `@tanstack/react-query` (`useQuery` + `fetchQuery`/`invalidateQueries`), deriving loading/refreshing state from React Query and centralizing error logging off `query.error`.
> 
> Introduces a new React Query config (`queries/unrealizedPnL.ts`) and registers it under `predictQueries.unrealizedPnL`, including a 10s `staleTime` and address-scoped query keys.
> 
> Updates `PredictPositionsHeader` refresh flow to call `loadUnrealizedPnL()` with no `{ isRefresh }` argument, and adjusts/rewrites tests to run under a `QueryClientProvider` and assert the new call signatures/behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4596fe4bc2c57f72c99603d0e93a2bdbfc3d532. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->