### PR TITLE
fix(SDKConnectV2): harden INTERNAL_ORIGINS check and restrict dapp.url to http(s)

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -662,36 +662,6 @@ describe('ConnectionRegistry', () => {
       expect(mockStore.save).not.toHaveBeenCalled();
     });
 
-    it('blocks connection requests whose dapp url hostname matches an internal origin', async () => {
-      registry = new ConnectionRegistry(
-        RELAY_URL,
-        mockKeyManager,
-        mockHostApp,
-        mockStore,
-      );
-
-      const blockedRequest = {
-        ...mockConnectionRequest,
-        metadata: {
-          ...mockConnectionRequest.metadata,
-          dapp: {
-            ...mockConnectionRequest.metadata.dapp,
-            url: 'https://metamask/',
-          },
-        },
-      };
-
-      const blockedDeeplink = `metamask://connect/mwp?p=${encodeURIComponent(
-        JSON.stringify(blockedRequest),
-      )}`;
-
-      await registry.handleConnectDeeplink(blockedDeeplink);
-
-      expect(mockHostApp.showConnectionError).toHaveBeenCalledTimes(1);
-      expect(Connection.create).not.toHaveBeenCalled();
-      expect(mockStore.save).not.toHaveBeenCalled();
-    });
-
     it('blocks connection requests with an internal origin as dapp name', async () => {
       registry = new ConnectionRegistry(
         RELAY_URL,

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -662,6 +662,48 @@ describe('ConnectionRegistry', () => {
       expect(mockStore.save).not.toHaveBeenCalled();
     });
 
+    it('blocks connection requests with an internal origin as dapp url (defense-in-depth)', async () => {
+      // isConnectionRequest() normally rejects non-URL dapp.url values,
+      // making this code path unreachable. We bypass that validation here
+      // to verify the defense-in-depth check still works if the upstream
+      // guard is ever relaxed.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      const connReqModule = require('../types/connection-request');
+      const spy = jest
+        .spyOn(connReqModule, 'isConnectionRequest')
+        .mockReturnValueOnce(true);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      const blockedRequest = {
+        ...mockConnectionRequest,
+        metadata: {
+          ...mockConnectionRequest.metadata,
+          dapp: {
+            ...mockConnectionRequest.metadata.dapp,
+            url: 'metamask',
+          },
+        },
+      };
+
+      const blockedDeeplink = `metamask://connect/mwp?p=${encodeURIComponent(
+        JSON.stringify(blockedRequest),
+      )}`;
+
+      await registry.handleConnectDeeplink(blockedDeeplink);
+
+      expect(mockHostApp.showConnectionError).toHaveBeenCalledTimes(1);
+      expect(Connection.create).not.toHaveBeenCalled();
+      expect(mockStore.save).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+
     it('blocks connection requests with an internal origin as dapp name', async () => {
       registry = new ConnectionRegistry(
         RELAY_URL,

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -15,9 +15,6 @@ jest.mock('./connection');
 jest.mock('react-native');
 jest.mock('@sentry/react-native');
 jest.mock('../../Permissions');
-jest.mock('../../../constants/transaction', () => ({
-  INTERNAL_ORIGINS: ['metamask', 'MetaMask Mobile', 'https://internal.metamask.io'],
-}));
 jest.mock('../../../store', () => ({
   store: {
     dispatch: jest.fn(),
@@ -577,7 +574,7 @@ describe('ConnectionRegistry', () => {
       // Re-import to pick up the mock
       const {
         ConnectionRegistry: FreshRegistry,
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
       } = require('./connection-registry');
 
       const freshRegistry = new FreshRegistry(
@@ -665,7 +662,7 @@ describe('ConnectionRegistry', () => {
       expect(mockStore.save).not.toHaveBeenCalled();
     });
 
-    it('blocks connection requests with an internal origin as dapp url', async () => {
+    it('blocks connection requests whose dapp url hostname matches an internal origin', async () => {
       registry = new ConnectionRegistry(
         RELAY_URL,
         mockKeyManager,
@@ -679,7 +676,7 @@ describe('ConnectionRegistry', () => {
           ...mockConnectionRequest.metadata,
           dapp: {
             ...mockConnectionRequest.metadata.dapp,
-            url: 'https://internal.metamask.io',
+            url: 'https://metamask/',
           },
         },
       };

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -171,12 +171,8 @@ export class ConnectionRegistry {
 
     try {
       const connReq = this.parseConnectionRequest(url);
-      // Prevent external connections from using internal origins
-      // This is an external connection (SDK V2), so block any internal origin
-      if (
-        INTERNAL_ORIGINS.includes(connReq.metadata.dapp.url) ||
-        INTERNAL_ORIGINS.includes(connReq.metadata.dapp.name)
-      ) {
+
+      if (this.matchesInternalOrigin(connReq)) {
         throw rpcErrors.invalidParams({
           message: 'External transactions cannot use internal origins',
         });
@@ -252,6 +248,23 @@ export class ConnectionRegistry {
     }
 
     return connReq;
+  }
+
+  /**
+   * Checks whether the dApp metadata matches any known internal origin.
+   * Compares both the URL hostname and the dApp name (case-insensitive)
+   * against INTERNAL_ORIGINS to prevent external SDK connections from
+   * spoofing internal MetaMask origins.
+   */
+  private matchesInternalOrigin(connReq: ConnectionRequest): boolean {
+    const { url, name } = connReq.metadata.dapp;
+    const hostname = new URL(url).hostname.toLowerCase();
+
+    return INTERNAL_ORIGINS.some((origin) => {
+      if (!origin) return false;
+      const lower = origin.toLowerCase();
+      return hostname === lower || name.toLowerCase() === lower;
+    });
   }
 
   private toConnectionInfo(connReq: ConnectionRequest): ConnectionInfo {

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -172,7 +172,17 @@ export class ConnectionRegistry {
     try {
       const connReq = this.parseConnectionRequest(url);
 
-      if (this.matchesInternalOrigin(connReq)) {
+      // Defense-in-depth: block connections whose self-reported dapp metadata
+      // matches a known internal origin. This check is currently redundant
+      // because isConnectionRequest() validates dapp.url as a valid https://
+      // URL, which can never equal plain-string INTERNAL_ORIGINS values like
+      // 'metamask'. It remains as a safety net in case that upstream
+      // validation is ever relaxed. See isConnectionRequest() for the
+      // primary security boundary.
+      if (
+        INTERNAL_ORIGINS.includes(connReq.metadata.dapp.url) ||
+        INTERNAL_ORIGINS.includes(connReq.metadata.dapp.name)
+      ) {
         throw rpcErrors.invalidParams({
           message: 'External transactions cannot use internal origins',
         });
@@ -248,23 +258,6 @@ export class ConnectionRegistry {
     }
 
     return connReq;
-  }
-
-  /**
-   * Checks whether the dApp metadata matches any known internal origin.
-   * Compares both the URL hostname and the dApp name (case-insensitive)
-   * against INTERNAL_ORIGINS to prevent external SDK connections from
-   * spoofing internal MetaMask origins.
-   */
-  private matchesInternalOrigin(connReq: ConnectionRequest): boolean {
-    const { url, name } = connReq.metadata.dapp;
-    const hostname = new URL(url).hostname.toLowerCase();
-
-    return INTERNAL_ORIGINS.some((origin) => {
-      if (!origin) return false;
-      const lower = origin.toLowerCase();
-      return hostname === lower || name.toLowerCase() === lower;
-    });
   }
 
   private toConnectionInfo(connReq: ConnectionRequest): ConnectionInfo {

--- a/app/core/SDKConnectV2/types/connection-request.test.ts
+++ b/app/core/SDKConnectV2/types/connection-request.test.ts
@@ -249,6 +249,24 @@ describe('isConnectionRequest', () => {
     expect(isConnectionRequest(req)).toBe(false);
   });
 
+  it.each(['metamask://evil.com', 'ftp://example.com', 'file:///etc/passwd'])(
+    'returns false when dapp.url uses a non-http(s) scheme: %p',
+    (url) => {
+      const req = validRequest();
+      (req.metadata.dapp as Record<string, unknown>).url = url;
+      expect(isConnectionRequest(req)).toBe(false);
+    },
+  );
+
+  it.each(['https://example.com', 'http://localhost:3000'])(
+    'accepts dapp.url with http(s) scheme: %p',
+    (url) => {
+      const req = validRequest();
+      (req.metadata.dapp as Record<string, unknown>).url = url;
+      expect(isConnectionRequest(req)).toBe(true);
+    },
+  );
+
   // ──────────────────────────────────────────
   // metadata.dapp.icon (optional)
   // ──────────────────────────────────────────

--- a/app/core/SDKConnectV2/types/connection-request.ts
+++ b/app/core/SDKConnectV2/types/connection-request.ts
@@ -106,7 +106,10 @@ export function isConnectionRequest(data: unknown): data is ConnectionRequest {
   }
 
   try {
-    new URL(metadata.dapp.url);
+    const parsed = new URL(metadata.dapp.url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
   } catch {
     return false;
   }

--- a/app/core/SDKConnectV2/types/connection-request.ts
+++ b/app/core/SDKConnectV2/types/connection-request.ts
@@ -105,6 +105,11 @@ export function isConnectionRequest(data: unknown): data is ConnectionRequest {
     return false;
   }
 
+  // SECURITY: Restricting dapp.url to http(s) ensures it can never equal
+  // plain-string internal origins like 'metamask' or 'MetaMask Mobile',
+  // which downstream code uses for privilege checks (INTERNAL_ORIGINS).
+  // Do not relax this without also updating the defense-in-depth check
+  // in ConnectionRegistry.handleConnectDeeplink().
   try {
     const parsed = new URL(metadata.dapp.url);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {

--- a/app/core/SDKConnectV2/types/connection-request.ts
+++ b/app/core/SDKConnectV2/types/connection-request.ts
@@ -105,9 +105,11 @@ export function isConnectionRequest(data: unknown): data is ConnectionRequest {
     return false;
   }
 
-  // SECURITY: Restricting dapp.url to http(s) ensures it can never equal
-  // plain-string internal origins like 'metamask' or 'MetaMask Mobile',
-  // which downstream code uses for privilege checks (INTERNAL_ORIGINS).
+  // SECURITY: The try/catch rejects plain strings (e.g. 'metamask') that
+  // aren't parseable URLs. The protocol check additionally blocks custom
+  // schemes like metamask:// that are valid URLs but could collide with
+  // internal origin identifiers. Together these ensure dapp.url can never
+  // match INTERNAL_ORIGINS values used in downstream privilege checks.
   // Do not relax this without also updating the defense-in-depth check
   // in ConnectionRegistry.handleConnectDeeplink().
   try {


### PR DESCRIPTION
## **Description**

The `new URL(metadata.dapp.url)` validation added in the parent branch ensures `dapp.url` is always a parseable URL. However, the production `INTERNAL_ORIGINS` array contains plain strings (`'metamask'`, `'MetaMask Mobile'`, `process.env.MM_FOX_CODE`), so the existing `INTERNAL_ORIGINS.includes(dapp.url)` check became dead code — no validated URL can equal those strings. The test masked this by mocking `INTERNAL_ORIGINS` with `'https://internal.metamask.io'`, a value absent from the production array.

This PR:

1. **Restricts `dapp.url` to `http:`/`https:` schemes** in `isConnectionRequest()` — this is the primary security boundary. It prevents a malicious dApp from sending `metamask://...` or other non-web schemes as its URL, which could match internal origin strings.
2. **Retains the original `INTERNAL_ORIGINS.includes()` check as documented defense-in-depth** — currently redundant but will activate if the upstream URL validation is ever relaxed.
3. **Adds cross-referencing security comments** in both locations so future developers understand the invariant linking them.
4. **Removes the `INTERNAL_ORIGINS` mock** from the test file so tests exercise the real production values instead of a synthetic URL that hid the dead code.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: parent branch `jl/make-mmc-parsing-more-robust`

## **Manual testing steps**

```gherkin
Feature: SDKConnectV2 internal origin blocking

  Scenario: dApp with non-http scheme is rejected at validation
    Given a dApp connection request with url "metamask://evil.com"
    When isConnectionRequest validates the request
    Then it returns false

  Scenario: dApp with internal origin name is blocked
    Given a dApp connection request with dapp.name "metamask"
    When ConnectionRegistry handles the deeplink
    Then it throws "External transactions cannot use internal origins"
```

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens SDKConnectV2 connection-request validation and could reject previously accepted dApps that supplied non-HTTP(S) `dapp.url` values; it also touches internal-origin security checks on the deeplink connection path.
> 
> **Overview**
> **Hardens SDKConnectV2 connection request validation** by requiring `metadata.dapp.url` to be a parseable URL *and* to use only `http:`/`https:` schemes, rejecting custom/non-web schemes (e.g. `metamask://`, `ftp://`, `file://`).
> 
> **Clarifies and reinforces internal-origin blocking** in `ConnectionRegistry.handleConnectDeeplink()` as a documented defense-in-depth check, and updates tests to stop mocking `INTERNAL_ORIGINS` and instead explicitly bypass `isConnectionRequest()` to exercise the internal-origin rejection path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84a9794201058223fbbffc5328e00368eab1b1fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->