### PR TITLE
fix: Align Bridge native Max-button gasless gating with extension

### DIFF
--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
@@ -1,7 +1,7 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { RootState } from '../../../../../reducers';
-import { selectIsGaslessSwapEnabled } from '../../../../../core/redux/slices/bridge';
 import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
 import {
@@ -10,14 +10,23 @@ import {
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { BigNumber } from 'bignumber.js';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
 export const useShouldRenderMaxOption = (
   token?: BridgeToken,
   displayBalance?: string,
   isQuoteSponsored = false,
 ) => {
-  const isGaslessSwapEnabled = useSelector((state: RootState) =>
-    token?.chainId ? selectIsGaslessSwapEnabled(state, token.chainId) : false,
+  const evmChainId = useMemo(() => {
+    if (!token?.chainId || isNonEvmChainId(token.chainId)) {
+      return undefined;
+    }
+    return formatChainIdToHex(token.chainId);
+  }, [token?.chainId]);
+  const isSendBundleSupported = useIsSendBundleSupported(evmChainId);
+  const isGaslessSwapEnabled = useMemo(
+    () => Boolean(isSendBundleSupported),
+    [isSendBundleSupported],
   );
   const stxEnabled = useSelector((state: RootState) =>
     token?.chainId && !isNonEvmChainId(token.chainId)

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
@@ -1,12 +1,16 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  formatChainIdToHex,
+  isNativeAddress,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
+import { useSelector } from 'react-redux';
 import { useShouldRenderMaxOption } from '.';
 import { BridgeToken } from '../../types';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { useSelector } from 'react-redux';
 import { useTokenAddress } from '../useTokenAddress';
-import { isNativeAddress } from '@metamask/bridge-controller';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
-// Mock dependencies
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
@@ -15,580 +19,187 @@ jest.mock('../useTokenAddress', () => ({
   useTokenAddress: jest.fn(),
 }));
 
-jest.mock('@metamask/bridge-controller', () => ({
-  isNativeAddress: jest.fn(),
+jest.mock('../useIsSendBundleSupported', () => ({
+  useIsSendBundleSupported: jest.fn(),
 }));
 
-jest.mock('../../../../../core/redux/slices/bridge', () => ({
-  selectIsGaslessSwapEnabled: jest.fn(),
-}));
-
-jest.mock('../../../../../selectors/smartTransactionsController', () => ({
-  selectShouldUseSmartTransaction: jest.fn(),
-}));
+jest.mock('@metamask/bridge-controller', () => {
+  const actual = jest.requireActual('@metamask/bridge-controller');
+  return {
+    ...actual,
+    formatChainIdToHex: jest.fn(),
+    isNativeAddress: jest.fn(),
+    isNonEvmChainId: jest.fn(),
+  };
+});
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseTokenAddress = useTokenAddress as jest.MockedFunction<
   typeof useTokenAddress
 >;
+const mockUseIsSendBundleSupported =
+  useIsSendBundleSupported as jest.MockedFunction<typeof useIsSendBundleSupported>;
+const mockFormatChainIdToHex = formatChainIdToHex as jest.MockedFunction<
+  typeof formatChainIdToHex
+>;
 const mockIsNativeAddress = isNativeAddress as jest.MockedFunction<
   typeof isNativeAddress
 >;
+const mockIsNonEvmChainId = isNonEvmChainId as jest.MockedFunction<
+  typeof isNonEvmChainId
+>;
 
-/**
- * IMPORTANT: useSelector call order in the hook:
- * 1. First call: isGaslessSwapEnabled (line 12 in hook)
- * 2. Second call: stxEnabled (line 15 in hook)
- */
+const mockToken: BridgeToken = {
+  address: '0x1234567890123456789012345678901234567890',
+  symbol: 'TEST',
+  decimals: 18,
+  chainId: CHAIN_IDS.MAINNET,
+};
+
+const nativeToken: BridgeToken = {
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'ETH',
+  decimals: 18,
+  chainId: CHAIN_IDS.MAINNET,
+};
+
+const setSelectorValues = ({ stxEnabled = true }: { stxEnabled?: boolean }) => {
+  mockUseSelector.mockImplementation(() => stxEnabled);
+};
+
 describe('useShouldRenderMaxOption', () => {
-  const mockToken: BridgeToken = {
-    address: '0x1234567890123456789012345678901234567890',
-    symbol: 'TEST',
-    decimals: 18,
-    chainId: CHAIN_IDS.MAINNET,
-  };
-
-  const nativeToken: BridgeToken = {
-    address: '0x0000000000000000000000000000000000000000',
-    symbol: 'ETH',
-    decimals: 18,
-    chainId: CHAIN_IDS.MAINNET,
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
+
+    setSelectorValues({ stxEnabled: true });
     mockUseTokenAddress.mockReturnValue(mockToken.address);
+    mockUseIsSendBundleSupported.mockReturnValue(false);
+    mockFormatChainIdToHex.mockImplementation(
+      (chainId) => chainId as `0x${string}`,
+    );
     mockIsNativeAddress.mockReturnValue(false);
-    // Default: isGaslessSwapEnabled = false, stxEnabled = true
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      // First call: isGaslessSwapEnabled = false
-      // Second call: stxEnabled = true
-      return callCount === 2;
-    });
+    mockIsNonEvmChainId.mockReturnValue(false);
   });
 
-  describe('Zero balance scenarios', () => {
-    it('returns false when displayBalance is undefined', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, undefined, false),
-      );
+  it('returns false when token is undefined', () => {
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(undefined, '10'),
+    );
 
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false when displayBalance is "0"', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0', false),
-      );
-
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false when displayBalance is "0.0"', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0.0', false),
-      );
-
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false when displayBalance is empty string', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '', false),
-      );
-
-      expect(result.current).toBe(false);
-    });
+    expect(result.current).toBe(false);
   });
 
-  describe('Non-native token scenarios', () => {
-    beforeEach(() => {
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(mockToken.address);
-    });
+  it('returns false when display balance is zero', () => {
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(mockToken, '0'),
+    );
 
-    it('returns true for non-native token with balance regardless of gasless', () => {
-      mockUseSelector.mockImplementation(() => false); // Both selectors false
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '100.5', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('returns true for non-native token with balance regardless of stxEnabled', () => {
-      mockUseSelector.mockImplementation(() => false); // stxEnabled = false
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '50', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('returns true for non-native token with balance regardless of isQuoteSponsored', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '25.75', true),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('returns true for non-native token with very small balance', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0.000001', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('returns false for non-native token with zero balance', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0', false),
-      );
-
-      expect(result.current).toBe(false);
-    });
+    expect(result.current).toBe(false);
   });
 
-  describe('Native token scenarios', () => {
-    beforeEach(() => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-    });
+  it('returns true for non-native token with positive balance', () => {
+    mockIsNativeAddress.mockReturnValue(false);
 
-    it('returns false when native token has zero balance', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(nativeToken, '0', false),
-      );
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(mockToken, '10'),
+    );
 
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false when native token has zero balance even with all conditions favorable', () => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-      mockUseSelector.mockReturnValue(true); // stxEnabled=true, gasless=true
-
-      const { result } = renderHook(
-        () => useShouldRenderMaxOption(nativeToken, '0', true), // sponsored=true
-      );
-
-      // Zero balance always returns false
-      expect(result.current).toBe(false);
-    });
+    expect(result.current).toBe(true);
   });
 
-  describe('Edge cases', () => {
-    it('returns false when token is undefined', () => {
-      mockUseTokenAddress.mockReturnValue(undefined);
+  it('returns true for native token when stx and sendBundle are enabled', () => {
+    setSelectorValues({ stxEnabled: true });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+    mockUseIsSendBundleSupported.mockReturnValue(true);
 
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(undefined, '100', false),
-      );
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25'),
+    );
 
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false when token is undefined but has balance', () => {
-      mockUseTokenAddress.mockReturnValue(undefined);
-      mockIsNativeAddress.mockReturnValue(false);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(undefined, '500', false),
-      );
-
-      expect(result.current).toBe(false);
-    });
-
-    it('handles large balance values correctly for non-native tokens', () => {
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(mockToken.address);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '1000000.123456789', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('handles very small but non-zero balance for non-native tokens', () => {
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(mockToken.address);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0.000000001', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('correctly identifies native token without chainId in token object', () => {
-      const tokenWithoutChainId = {
-        address: '0x0000000000000000000000000000000000000000',
-        symbol: 'ETH',
-        decimals: 18,
-      } as BridgeToken;
-
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(tokenWithoutChainId.address);
-      mockUseSelector.mockReturnValue(false); // stxEnabled = false, isGaslessSwapEnabled = false
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(tokenWithoutChainId, '100', false),
-      );
-
-      // Should return false (native + no gasless + no sponsored + no stx)
-      expect(result.current).toBe(false);
-    });
+    expect(result.current).toBe(true);
   });
 
-  describe('Hook parameter validation', () => {
-    it('uses useTokenAddress hook to get token address', () => {
-      const customToken = {
-        ...mockToken,
-        address: '0xabcdef1234567890abcdef1234567890abcdef12',
-      };
-      mockUseTokenAddress.mockReturnValue(customToken.address);
+  it('returns false for native token when sendBundle is disabled', () => {
+    setSelectorValues({ stxEnabled: true });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+    mockUseIsSendBundleSupported.mockReturnValue(false);
 
-      renderHook(() => useShouldRenderMaxOption(customToken, '100', false));
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25'),
+    );
 
-      expect(mockUseTokenAddress).toHaveBeenCalledWith(customToken);
-    });
-
-    it('checks if token address is native using isNativeAddress', () => {
-      const tokenAddress = '0x1234567890123456789012345678901234567890';
-      mockUseTokenAddress.mockReturnValue(tokenAddress);
-      mockIsNativeAddress.mockReturnValue(false);
-
-      renderHook(() => useShouldRenderMaxOption(mockToken, '100', false));
-
-      expect(mockIsNativeAddress).toHaveBeenCalledWith(tokenAddress);
-    });
-
-    it('calls selectIsGaslessSwapEnabled with correct chainId', () => {
-      const tokenWithChainId = {
-        ...mockToken,
-        chainId: '0xa' as `0x${string}`, // Optimism
-      };
-      mockUseSelector.mockReturnValue(true);
-
-      renderHook(() =>
-        useShouldRenderMaxOption(tokenWithChainId, '100', false),
-      );
-
-      // Verify useSelector was called (it uses selectIsGaslessSwapEnabled)
-      expect(mockUseSelector).toHaveBeenCalled();
-    });
+    expect(result.current).toBe(false);
   });
 
-  describe('Default parameter values', () => {
-    it('uses false as default for isQuoteSponsored when not provided', () => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-      let callCount = 0;
-      mockUseSelector.mockImplementation(() => {
-        callCount++;
-        // First call: isGaslessSwapEnabled = false
-        // Second call: stxEnabled = true
-        return callCount === 2;
-      });
+  it('returns false for native token when stx is disabled even if sendBundle is enabled', () => {
+    setSelectorValues({ stxEnabled: false });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+    mockUseIsSendBundleSupported.mockReturnValue(true);
 
-      // Call without isQuoteSponsored parameter
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(nativeToken, '100'),
-      );
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25'),
+    );
 
-      // Should return false (native + stx=true + gasless=false + sponsored=false)
-      expect(result.current).toBe(false);
-    });
+    expect(result.current).toBe(false);
   });
 
-  describe('Integration scenarios', () => {
-    it('returns correct value for typical non-native ERC20 token', () => {
-      const usdcToken: BridgeToken = {
-        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        symbol: 'USDC',
-        decimals: 6,
-        chainId: CHAIN_IDS.MAINNET,
-      };
+  it('returns true for sponsored native quote when stx is enabled', () => {
+    setSelectorValues({ stxEnabled: true });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+    mockUseIsSendBundleSupported.mockReturnValue(false);
 
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(usdcToken.address);
-      mockUseSelector.mockReturnValue(false); // Everything disabled
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25', true),
+    );
 
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(usdcToken, '1000', false),
-      );
-
-      // Non-native tokens always show max (even with everything disabled)
-      expect(result.current).toBe(true);
-    });
-
-    it('returns correct value for native ETH with gasless swap enabled', () => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-      mockUseSelector.mockReturnValue(true); // stxEnabled=true, gasless=true
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(nativeToken, '5.5', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('returns correct value for native ETH with sponsored quote', () => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-      let callCount = 0;
-      mockUseSelector.mockImplementation(() => {
-        callCount++;
-        // First call: isGaslessSwapEnabled = false
-        // Second call: stxEnabled = true
-        return callCount === 2;
-      });
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(nativeToken, '2.25', true),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('returns correct value for native ETH without gasless or sponsored but stx enabled', () => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-      let callCount = 0;
-      mockUseSelector.mockImplementation(() => {
-        callCount++;
-        // First call: isGaslessSwapEnabled = false
-        // Second call: stxEnabled = true
-        return callCount === 2;
-      });
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(nativeToken, '10', false),
-      );
-
-      // Should be false (native + stx=true + gasless=false + sponsored=false)
-      expect(result.current).toBe(false);
-    });
+    expect(result.current).toBe(true);
   });
 
-  describe('Boundary conditions', () => {
-    it('handles balance exactly equal to zero', () => {
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0.00000', false),
-      );
+  it('returns false for sponsored native quote when stx is disabled', () => {
+    setSelectorValues({ stxEnabled: false });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
 
-      expect(result.current).toBe(false);
-    });
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25', true),
+    );
 
-    it('handles extremely small but non-zero balance', () => {
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(mockToken.address);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(mockToken, '0.00000001', false),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('handles extremely large balance', () => {
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(mockToken.address);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(
-          mockToken,
-          '999999999999999999999999999.999999',
-          false,
-        ),
-      );
-
-      expect(result.current).toBe(true);
-    });
-
-    it('handles balance with many decimal places', () => {
-      mockIsNativeAddress.mockReturnValue(false);
-      mockUseTokenAddress.mockReturnValue(mockToken.address);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(
-          mockToken,
-          '123.456789012345678901234567',
-          false,
-        ),
-      );
-
-      expect(result.current).toBe(true);
-    });
+    expect(result.current).toBe(false);
   });
 
-  describe('Truth table - Native token with all combinations', () => {
-    beforeEach(() => {
-      mockIsNativeAddress.mockReturnValue(true);
-      mockUseTokenAddress.mockReturnValue(nativeToken.address);
-    });
+  it('passes formatted EVM chain id to sendBundle hook', () => {
+    const chainId = '0xa' as `0x${string}`;
+    const formattedChainId = '0xa' as `0x${string}`;
+    const token = { ...nativeToken, chainId };
+    mockUseTokenAddress.mockReturnValue(token.address);
+    mockIsNativeAddress.mockReturnValue(true);
+    mockFormatChainIdToHex.mockReturnValue(formattedChainId);
 
-    const truthTable = [
-      { stxEnabled: true, gasless: true, sponsored: false, expected: true },
-      { stxEnabled: true, gasless: false, sponsored: true, expected: true },
-      { stxEnabled: true, gasless: true, sponsored: true, expected: true },
-      { stxEnabled: true, gasless: false, sponsored: false, expected: false },
-      { stxEnabled: false, gasless: true, sponsored: false, expected: false },
-      { stxEnabled: false, gasless: false, sponsored: true, expected: false },
-      { stxEnabled: false, gasless: true, sponsored: true, expected: false },
-      { stxEnabled: false, gasless: false, sponsored: false, expected: false },
-    ];
+    renderHook(() => useShouldRenderMaxOption(token, '1.25'));
 
-    truthTable.forEach(({ stxEnabled, gasless, sponsored, expected }) => {
-      it(`stxEnabled=${stxEnabled}, gasless=${gasless}, sponsored=${sponsored} → returns ${expected}`, () => {
-        let callCount = 0;
-        mockUseSelector.mockImplementation(() => {
-          callCount++;
-          // First call: isGaslessSwapEnabled (line 12 in hook)
-          // Second call: stxEnabled (line 15 in hook)
-          if (callCount === 1) {
-            return gasless;
-          }
-          return stxEnabled;
-        });
-
-        const { result } = renderHook(() =>
-          useShouldRenderMaxOption(nativeToken, '100', sponsored),
-        );
-
-        expect(result.current).toBe(expected);
-      });
-    });
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(formattedChainId);
   });
 
-  describe('Non-EVM native token scenarios', () => {
+  it('passes undefined chain id to sendBundle hook for non-EVM token', () => {
     const solanaToken: BridgeToken = {
-      address: '0x0000000000000000000000000000000000000000',
-      symbol: 'SOL',
-      decimals: 9,
-      chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', // Solana mainnet CAIP-2
+      ...nativeToken,
+      chainId:
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as `${string}:${string}`,
     };
+    mockUseTokenAddress.mockReturnValue(solanaToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+    mockIsNonEvmChainId.mockReturnValue(true);
+    setSelectorValues({ stxEnabled: false });
 
-    const bitcoinToken: BridgeToken = {
-      address: '0x0000000000000000000000000000000000000000',
-      symbol: 'BTC',
-      decimals: 8,
-      chainId: 'bip122:000000000019d6689c085ae165831e93', // Bitcoin mainnet CAIP-2
-    };
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(solanaToken, '3'),
+    );
 
-    beforeEach(() => {
-      mockIsNativeAddress.mockReturnValue(true);
-    });
-
-    it('returns false for Solana native token even with gasless enabled', () => {
-      mockUseTokenAddress.mockReturnValue(solanaToken.address);
-      let callCount = 0;
-      mockUseSelector.mockImplementation(() => {
-        callCount++;
-        // First call: isGaslessSwapEnabled = true
-        // Second call: stxEnabled = false (non-EVM chain)
-        if (callCount === 1) {
-          return true; // gasless enabled
-        }
-        return false; // stxEnabled is false for non-EVM
-      });
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(solanaToken, '100', false),
-      );
-
-      // Should return false because stxEnabled is false for non-EVM chains
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false for Solana native token even with sponsored quote', () => {
-      mockUseTokenAddress.mockReturnValue(solanaToken.address);
-      mockUseSelector.mockImplementation(
-        () =>
-          // First call: isGaslessSwapEnabled = false
-          // Second call: stxEnabled = false (non-EVM chain)
-          false,
-      );
-
-      const { result } = renderHook(
-        () => useShouldRenderMaxOption(solanaToken, '50', true), // sponsored = true
-      );
-
-      // Should return false because stxEnabled is false for non-EVM chains
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false for Solana native token with both gasless and sponsored enabled', () => {
-      mockUseTokenAddress.mockReturnValue(solanaToken.address);
-      let callCount = 0;
-      mockUseSelector.mockImplementation(() => {
-        callCount++;
-        // First call: isGaslessSwapEnabled = true
-        // Second call: stxEnabled = false (non-EVM chain)
-        if (callCount === 1) {
-          return true; // gasless enabled
-        }
-        return false; // stxEnabled is false for non-EVM
-      });
-
-      const { result } = renderHook(
-        () => useShouldRenderMaxOption(solanaToken, '25.5', true), // sponsored = true
-      );
-
-      // Should return false because stxEnabled is false for non-EVM chains
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false for Bitcoin native token with gasless enabled', () => {
-      mockUseTokenAddress.mockReturnValue(bitcoinToken.address);
-      let callCount = 0;
-      mockUseSelector.mockImplementation(() => {
-        callCount++;
-        // First call: isGaslessSwapEnabled = true
-        // Second call: stxEnabled = false (non-EVM chain)
-        if (callCount === 1) {
-          return true; // gasless enabled
-        }
-        return false; // stxEnabled is false for non-EVM
-      });
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(bitcoinToken, '1.5', false),
-      );
-
-      // Should return false because stxEnabled is false for non-EVM chains
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false for Bitcoin native token without any flags enabled', () => {
-      mockUseTokenAddress.mockReturnValue(bitcoinToken.address);
-      mockUseSelector.mockReturnValue(false); // All flags disabled
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(bitcoinToken, '0.5', false),
-      );
-
-      // Should return false because stxEnabled is false for non-EVM chains
-      expect(result.current).toBe(false);
-    });
-
-    it('returns false for non-EVM native token with zero balance', () => {
-      mockUseTokenAddress.mockReturnValue(solanaToken.address);
-      mockUseSelector.mockReturnValue(false);
-
-      const { result } = renderHook(() =>
-        useShouldRenderMaxOption(solanaToken, '0', false),
-      );
-
-      // Should return false due to zero balance (checked before non-EVM logic)
-      expect(result.current).toBe(false);
-    });
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(undefined);
+    expect(result.current).toBe(false);
   });
 });

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
@@ -38,7 +38,9 @@ const mockUseTokenAddress = useTokenAddress as jest.MockedFunction<
   typeof useTokenAddress
 >;
 const mockUseIsSendBundleSupported =
-  useIsSendBundleSupported as jest.MockedFunction<typeof useIsSendBundleSupported>;
+  useIsSendBundleSupported as jest.MockedFunction<
+    typeof useIsSendBundleSupported
+  >;
 const mockFormatChainIdToHex = formatChainIdToHex as jest.MockedFunction<
   typeof formatChainIdToHex
 >;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Align Bridge native Max-button gasless gating with extension by using Sentinel sendBundle support instead of LD isGaslessSwapEnabled.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Bridge native-token Max-button eligibility logic to depend on Sentinel `sendBundle` support (plus Smart Transactions/sponsored quotes), which can alter when users are allowed to max native balances on different chains.
> 
> **Overview**
> Aligns Bridge native-token Max-button rendering with extension by replacing the `selectIsGaslessSwapEnabled` feature-flag check with a Sentinel-based `useIsSendBundleSupported` check, using a memoized EVM-only `chainId` (non-EVM passes `undefined`).
> 
> Updates and heavily simplifies `useShouldRenderMaxOption` tests to mock `useIsSendBundleSupported`/`isNonEvmChainId`/`formatChainIdToHex`, and to validate the new native-token truth table and chain-id wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be560bf31f9047fbe0c9d3288a43201d4947d83b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->