### PR TITLE
feat: remove ota modal for onboarding

### DIFF
--- a/app/components/hooks/useOTAUpdates.test.ts
+++ b/app/components/hooks/useOTAUpdates.test.ts
@@ -4,6 +4,7 @@ import { InteractionManager } from 'react-native';
 import {
   checkForUpdateAsync,
   fetchUpdateAsync,
+  reloadAsync,
   UpdateCheckResultNotAvailableReason,
 } from 'expo-updates';
 import { useOTAUpdates } from './useOTAUpdates';
@@ -12,6 +13,7 @@ import Logger from '../../util/Logger';
 jest.mock('expo-updates', () => ({
   checkForUpdateAsync: jest.fn(),
   fetchUpdateAsync: jest.fn(),
+  reloadAsync: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockNavigate = jest.fn();
@@ -25,6 +27,11 @@ jest.mock('@react-navigation/native', () => ({
 const mockSelectOtaUpdatesEnabledFlag = jest.fn();
 jest.mock('../../selectors/featureFlagController/otaUpdates', () => ({
   selectOtaUpdatesEnabledFlag: () => mockSelectOtaUpdatesEnabledFlag(),
+}));
+
+const mockSelectCompletedOnboarding = jest.fn();
+jest.mock('../../selectors/onboarding', () => ({
+  selectCompletedOnboarding: () => mockSelectCompletedOnboarding(),
 }));
 
 jest.mock('react-redux', () => ({
@@ -77,6 +84,7 @@ describe('useOTAUpdates', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSelectOtaUpdatesEnabledFlag.mockReturnValue(true);
+    mockSelectCompletedOnboarding.mockReturnValue(true);
     (global as unknown as { __DEV__: boolean }).__DEV__ = false;
   });
 
@@ -146,7 +154,8 @@ describe('useOTAUpdates', () => {
     });
   });
 
-  it('navigates to OTA update modal when a new update is available', async () => {
+  it('navigates to OTA update modal when a new update is available and user has completed onboarding', async () => {
+    mockSelectCompletedOnboarding.mockReturnValue(true);
     mockCheckForUpdateAsync.mockResolvedValue({
       isAvailable: true,
       manifest: mockManifest,
@@ -159,6 +168,10 @@ describe('useOTAUpdates', () => {
       manifest: mockManifest,
     });
 
+    const mockReloadAsync = reloadAsync as jest.MockedFunction<
+      typeof reloadAsync
+    >;
+
     renderHook(() => useOTAUpdates());
 
     await waitFor(() => {
@@ -170,6 +183,39 @@ describe('useOTAUpdates', () => {
         expect.objectContaining({
           screen: 'OTAUpdatesModal',
         }),
+      );
+      expect(mockReloadAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not reload or show modal when a new update is available and user has not completed onboarding (applies on next launch)', async () => {
+    mockSelectCompletedOnboarding.mockReturnValue(false);
+    mockCheckForUpdateAsync.mockResolvedValue({
+      isAvailable: true,
+      manifest: mockManifest,
+      isRollBackToEmbedded: false,
+      reason: undefined,
+    });
+    mockFetchUpdateAsync.mockResolvedValue({
+      isNew: true,
+      isRollBackToEmbedded: false,
+      manifest: mockManifest,
+    });
+
+    const mockReloadAsync = reloadAsync as jest.MockedFunction<
+      typeof reloadAsync
+    >;
+
+    renderHook(() => useOTAUpdates());
+
+    await waitFor(() => {
+      expect(mockCheckForUpdateAsync).toHaveBeenCalledTimes(1);
+      expect(mockFetchUpdateAsync).toHaveBeenCalledTimes(1);
+      expect(mockRunAfterInteractions).toHaveBeenCalledTimes(1);
+      expect(mockReloadAsync).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockLoggerLog).toHaveBeenCalledWith(
+        'OTA Updates: New update available on onboarding, will apply on next launch',
       );
     });
   });

--- a/app/components/hooks/useOTAUpdates.ts
+++ b/app/components/hooks/useOTAUpdates.ts
@@ -6,23 +6,26 @@ import { useNavigation } from '@react-navigation/native';
 import Logger from '../../util/Logger';
 import { createOTAUpdatesModalNavDetails } from '../UI/OTAUpdatesModal/OTAUpdatesModal';
 import { selectOtaUpdatesEnabledFlag } from '../../selectors/featureFlagController/otaUpdates';
+import { selectCompletedOnboarding } from '../../selectors/onboarding';
 /**
  * Hook to manage OTA updates based on a feature flag.
  *
  * Behavior:
  * - Runs once when the app initially opens.
  * - If the `otaUpdatesEnabled` flag is on and the app is not in development, checks for an OTA update via `checkForUpdateAsync`.
- * - When a new OTA update is downloaded (`fetchUpdateAsync().isNew === true`), navigates to the `OTAUpdatesModal` bottom sheet after interactions complete.
+ * - When a new OTA update is downloaded (`fetchUpdateAsync().isNew === true`):
+ * - If the user has not completed onboarding (e.g. fresh install, onboarding screen): the update is already fetched and will apply silently on next app launch (no reload, no modal).
+ * - If the user has completed onboarding (wallet screen): navigates to the `OTAUpdatesModal` bottom sheet after interactions complete; the modal calls `reloadAsync` when the user confirms.
  * - If no update is available or the fetched update is not new, logs and continues with the current version without blocking startup.
- *
- * This hook does not reload the app itself; the `OTAUpdatesModal` is responsible for
- * calling `reloadAsync` when the user confirms.
  */
 export const useOTAUpdates = () => {
   const otaUpdatesEnabled = useSelector(selectOtaUpdatesEnabledFlag);
+  const completedOnboarding = useSelector(selectCompletedOnboarding);
   const navigation = useNavigation();
 
   useEffect(() => {
+    const hadCompletedOnboarding = completedOnboarding;
+
     const checkForUpdates = async () => {
       if (!otaUpdatesEnabled || __DEV__) {
         return;
@@ -36,7 +39,13 @@ export const useOTAUpdates = () => {
 
           if (fetchResult.isNew) {
             InteractionManager.runAfterInteractions(() => {
-              navigation.navigate(...createOTAUpdatesModalNavDetails());
+              if (hadCompletedOnboarding) {
+                navigation.navigate(...createOTAUpdatesModalNavDetails());
+              } else {
+                Logger.log(
+                  'OTA Updates: New update available on onboarding, will apply on next launch',
+                );
+              }
             });
           } else {
             Logger.log('OTA Updates: Update fetched but not new');
@@ -53,5 +62,9 @@ export const useOTAUpdates = () => {
     };
 
     checkForUpdates();
+    // Intentionally omit completedOnboarding: we use its value at check start time
+    // so that finishing onboarding in the same session does not re-run the check
+    // and show the modal (update stays deferred to next launch).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigation, otaUpdatesEnabled]);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Don't show OTA modal when users are on the onboarding screen, the updates will apply in the next session automatically. 

Ticket: https://consensyssoftware.atlassian.net/browse/MCWP-374
Testing workflow: https://github.com/MetaMask/metamask-mobile/actions/runs/22643630725/job/65629911055

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed showing OTA modal when users are on onboarding screen

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
1. When users are on the onboarding screen and close the app, there is no modal and the updates apply in the next session
![onboarding](https://github.com/user-attachments/assets/525a471b-d441-4529-85b3-5a83fc351a4a)

2. When users are on the onboarding screen and continue the onboarding, there is no modal and the updates apply in the next session
![logging in](https://github.com/user-attachments/assets/2c46f9c3-a086-4c17-988e-cf0659119027)
second launch
<img width="463" height="930" alt="Screenshot 2026-03-03 at 2 26 06 PM" src="https://github.com/user-attachments/assets/47d3d1d1-e0aa-4306-8679-dea48fbc36ac" />



4. When users are already logged in (no changes from current behaviour)
![logged in](https://github.com/user-attachments/assets/52f0508f-0914-4896-b77a-121eaaa38068)



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small conditional change to OTA-update UX gating with targeted test updates; main risk is accidentally suppressing the update modal for some users if onboarding state is misreported.
> 
> **Overview**
> Prevents the OTA update modal from showing during onboarding by gating the `useOTAUpdates` post-download behavior on `selectCompletedOnboarding`.
> 
> When a new update is fetched while onboarding is incomplete, the hook now **logs and defers applying the update to the next app launch** instead of navigating to `OTAUpdatesModal`; existing behavior (showing the modal after interactions) remains for users who already completed onboarding. Tests are updated to cover both onboarding-complete and onboarding-incomplete cases and to assert no `reloadAsync` call from the hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0074e7cc58f17f61f833dc1829f31e4864f784f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->