### PR TITLE
fix: fix currency issue on ramps deposit order details

### DIFF
--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
@@ -176,4 +176,23 @@ describe('OrderContent', () => {
       screen.queryByText('Card purchases typically take a few minutes'),
     ).toBeNull();
   });
+
+  it('displays currency symbol for supported currencies', () => {
+    // USD is in currency-symbols.json (lowercase key); symbol must be lowercased
+    // before lookup or renderFiat returns "100 USD" instead of "$100"
+    renderOrder(mockOrder);
+    expect(screen.getByText('$100')).toBeOnTheScreen();
+    expect(screen.getByText('$2.5')).toBeOnTheScreen();
+  });
+
+  it('falls back to code suffix for unsupported currencies', () => {
+    // GBP is not in currency-symbols.json; renderFiat returns "100 GBP"
+    const gbpOrder: RampsOrder = {
+      ...mockOrder,
+      fiatCurrency: { symbol: 'GBP', decimals: 2, denomSymbol: '£' },
+    };
+    renderOrder(gbpOrder);
+    expect(screen.getByText('100 GBP')).toBeOnTheScreen();
+    expect(screen.getByText('2.5 GBP')).toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
@@ -201,8 +201,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
     trackEvent,
   ]);
 
-  const fiatDenomSymbol = order.fiatCurrency?.denomSymbol ?? '';
-  const fiatCurrencyCode = order.fiatCurrency?.symbol ?? '';
+  const fiatCurrencyCode = order.fiatCurrency?.symbol?.toLowerCase() ?? '';
   const cryptoSymbol = order.cryptoCurrency?.symbol ?? '';
 
   const normalizeChainIdForBadge = (chainId: string): string => {
@@ -442,7 +441,6 @@ const OrderContent: React.FC<OrderContentProps> = ({
           <Box twClassName="bg-muted rounded h-[18px] w-20" />
         ) : (
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-            {fiatDenomSymbol}
             {renderFiat(
               Number(order.totalFeesFiat ?? 0),
               fiatCurrencyCode,
@@ -468,7 +466,6 @@ const OrderContent: React.FC<OrderContentProps> = ({
           <Box twClassName="bg-muted rounded h-[18px] w-24" />
         ) : (
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-            {fiatDenomSymbol}
             {renderFiat(
               Number(order.fiatAmount ?? 0),
               fiatCurrencyCode,

--- a/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderContent.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderContent.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Bold",
             "fontSize": 40,
             "fontWeight": 700,
@@ -191,7 +191,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -305,7 +305,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -338,7 +338,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
           style={
             [
               {
-                "color": "#131416",
+                "color": "#121314",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
@@ -358,7 +358,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
           style={
             [
               {
-                "color": "#131416",
+                "color": "#121314",
                 "height": 20,
                 "width": 20,
               },
@@ -388,7 +388,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -406,7 +406,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -439,7 +439,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -457,7 +457,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -468,8 +468,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
         ]
       }
     >
-      $
-      2.5 USD
+      $2.5
     </Text>
   </View>
   <View
@@ -491,7 +490,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -509,7 +508,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -520,8 +519,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
         ]
       }
     >
-      $
-      100 USD
+      $100
     </Text>
   </View>
   <View
@@ -559,7 +557,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
           style={
             [
               {
-                "color": "#66676a",
+                "color": "#686e7d",
                 "fontFamily": "Geist-Regular",
                 "fontSize": 14,
                 "fontWeight": 400,
@@ -578,7 +576,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
           style={
             [
               {
-                "color": "#66676a",
+                "color": "#686e7d",
                 "height": 16,
                 "marginLeft": 4,
                 "width": 16,
@@ -747,7 +745,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Bold",
             "fontSize": 40,
             "fontWeight": 700,
@@ -784,7 +782,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -812,7 +810,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
         style={
           [
             {
-              "backgroundColor": "#b4b4b528",
+              "backgroundColor": "#3c4d9d0f",
               "borderRadius": 4,
               "display": "flex",
               "height": 18,
@@ -843,7 +841,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -860,7 +858,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "backgroundColor": "#b4b4b528",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 4,
             "display": "flex",
             "height": 18,
@@ -890,7 +888,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -907,7 +905,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "backgroundColor": "#b4b4b528",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 4,
             "display": "flex",
             "height": 18,
@@ -937,7 +935,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -954,7 +952,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "backgroundColor": "#b4b4b528",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 4,
             "display": "flex",
             "height": 18,
@@ -984,7 +982,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "color": "#131416",
+            "color": "#121314",
             "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "fontWeight": 400,
@@ -1001,7 +999,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       style={
         [
           {
-            "backgroundColor": "#b4b4b528",
+            "backgroundColor": "#3c4d9d0f",
             "borderRadius": 4,
             "display": "flex",
             "height": 18,
@@ -1047,7 +1045,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
           style={
             [
               {
-                "color": "#66676a",
+                "color": "#686e7d",
                 "fontFamily": "Geist-Regular",
                 "fontSize": 14,
                 "fontWeight": 400,
@@ -1066,7 +1064,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
           style={
             [
               {
-                "color": "#66676a",
+                "color": "#686e7d",
                 "height": 16,
                 "marginLeft": 4,
                 "width": 16,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a currency formatting issue on the order details page for a deposit order that affects iOS but not Android. The deposit flow uses Intl.NumberFormat.formatToParts() to extract the currency symbol, while the aggregator flow likely sets it directly.

  On Android, React Native ships with full ICU support, so Intl.NumberFormat works correctly, and formatToParts() returns a currency part with "$". On iOS, React Native uses JavaScriptCore, which has incomplete or inconsistent Intl support `formatToParts()` may not return the currency type part, or the method may behave unexpectedly. When it fails or returns no match, the function falls back to ''(empty string)".


The fix is to not rely on `Intl.NumberFormat.formatToParts()` and instead use the existing currency-symbols.json map that
renderFiat already uses. 





## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Android:
<img width="780" height="946" alt="image" src="https://github.com/user-attachments/assets/284fb69e-769e-4f15-b576-f2ac8a9be06d" />


iOS


<img width="386" height="577" alt="image" src="https://github.com/user-attachments/assets/42b51487-0b0d-430b-a65a-0d40a7b10fbc" />

<img width="376" height="535" alt="image" src="https://github.com/user-attachments/assets/69a2e24b-e9ac-4bf4-b490-5dd8de190584" />


<!-- [screenshots/recordings] -->

### **After**
Android:
<img width="738" height="972" alt="image" src="https://github.com/user-attachments/assets/143d7435-8c82-4f86-be6e-0aaf52ae0189" />


iOS:


<img width="740" height="836" alt="image" src="https://github.com/user-attachments/assets/5583ff4d-48d5-49c3-ad82-6f502f12aa93" />

<img width="780" height="1058" alt="image" src="https://github.com/user-attachments/assets/bf3f10e0-8cfe-4d5e-b1fc-acac84c6fbd0" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts fiat formatting for Ramp order fees/total by normalizing currency codes; covered by added unit tests and snapshot updates.
> 
> **Overview**
> Fixes Ramp Order Details fiat formatting by **lowercasing `fiatCurrency.symbol` before passing it to `renderFiat`** and removing the manual `denomSymbol` prefix, so supported currencies render as symbols (e.g. `$100`) instead of code-suffixed strings.
> 
> Adds tests to verify symbol rendering for supported currencies and `"<amount> <CODE>"` fallback for unsupported currencies, and updates snapshots accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7626baf38aff49e64678427d302a67d4c2d24d13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->