### PR TITLE
refactor: Updated title and subtitle props for HeaderStandard to also take in node 

### DIFF
--- a/app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.test.tsx
+++ b/app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.test.tsx
@@ -107,6 +107,47 @@ describe('HeaderCompactStandard', () => {
       expect(getByText('Main Title')).toBeOnTheScreen();
       expect(getByText('Supporting Text')).toBeOnTheScreen();
     });
+
+    it('renders title when passed as React node', () => {
+      const TITLE_NODE_TEST_ID = 'custom-title-node';
+      const { getByTestId, getByText } = render(
+        <HeaderCompactStandard
+          title={<Text testID={TITLE_NODE_TEST_ID}>Custom Title Node</Text>}
+        />,
+      );
+
+      expect(getByTestId(TITLE_NODE_TEST_ID)).toBeOnTheScreen();
+      expect(getByText('Custom Title Node')).toBeOnTheScreen();
+    });
+
+    it('renders subtitle when passed as React node', () => {
+      const SUBTITLE_NODE_TEST_ID = 'custom-subtitle-node';
+      const { getByTestId, getByText } = render(
+        <HeaderCompactStandard
+          title="Page Title"
+          subtitle={
+            <Text testID={SUBTITLE_NODE_TEST_ID}>Custom Subtitle Node</Text>
+          }
+        />,
+      );
+
+      expect(getByTestId(SUBTITLE_NODE_TEST_ID)).toBeOnTheScreen();
+      expect(getByText('Custom Subtitle Node')).toBeOnTheScreen();
+    });
+
+    it('renders both title and subtitle as React nodes', () => {
+      const TITLE_NODE_TEST_ID = 'title-node';
+      const SUBTITLE_NODE_TEST_ID = 'subtitle-node';
+      const { getByTestId } = render(
+        <HeaderCompactStandard
+          title={<Text testID={TITLE_NODE_TEST_ID}>Node Title</Text>}
+          subtitle={<Text testID={SUBTITLE_NODE_TEST_ID}>Node Subtitle</Text>}
+        />,
+      );
+
+      expect(getByTestId(TITLE_NODE_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(SUBTITLE_NODE_TEST_ID)).toBeOnTheScreen();
+    });
   });
 
   describe('back button', () => {

--- a/app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.tsx
+++ b/app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.tsx
@@ -97,22 +97,31 @@ const HeaderCompactStandard: React.FC<HeaderCompactStandardProps> = ({
     if (title) {
       return (
         <Box alignItems={BoxAlignItems.Center}>
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Bold}
-            {...titleProps}
-          >
-            {title}
-          </Text>
-          {subtitle && (
+          {typeof title === 'string' ? (
             <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-              {...subtitleProps}
-              twClassName={`-mt-0.5 ${subtitleProps?.twClassName ?? ''}`.trim()}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Bold}
+              {...titleProps}
             >
-              {subtitle}
+              {title}
             </Text>
+          ) : (
+            title
+          )}
+          {subtitle && (
+            <Box twClassName="-mt-0.5">
+              {typeof subtitle === 'string' ? (
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                  {...subtitleProps}
+                >
+                  {subtitle}
+                </Text>
+              ) : (
+                subtitle
+              )}
+            </Box>
           )}
         </Box>
       );

--- a/app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.types.ts
+++ b/app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.types.ts
@@ -1,4 +1,5 @@
 // External dependencies.
+import React from 'react';
 import {
   ButtonIconProps,
   TextProps,
@@ -12,24 +13,28 @@ import { HeaderBaseProps } from '../../components/HeaderBase';
  */
 export interface HeaderCompactStandardProps extends HeaderBaseProps {
   /**
-   * Title text to display in the header.
+   * Title to display in the header. Can be a string or a React node.
    * Used as children if children prop is not provided.
-   * Rendered with TextVariant.BodyMd and FontWeight.Bold by default.
+   * When string: rendered with TextVariant.BodyMd and FontWeight.Bold by default; titleProps apply.
+   * When node: rendered as-is; titleProps are not applied.
    */
-  title?: string;
+  title?: string | React.ReactNode;
   /**
    * Additional props to pass to the title Text component.
    * Props are spread to the Text component and can override default values.
+   * Only applied when title is a string.
    */
   titleProps?: Partial<TextProps>;
   /**
-   * Subtitle text to display below the title.
-   * Rendered with TextVariant.BodySm and TextColor.TextAlternative by default.
+   * Subtitle to display below the title. Can be a string or a React node.
+   * When string: rendered with TextVariant.BodySm and TextColor.TextAlternative by default; subtitleProps apply.
+   * When node: rendered inside the same -mt-0.5 container; subtitleProps are not applied.
    */
-  subtitle?: string;
+  subtitle?: string | React.ReactNode;
   /**
    * Additional props to pass to the subtitle Text component.
    * Props are spread to the Text component and can override default values.
+   * Only applied when subtitle is a string.
    */
   subtitleProps?: Partial<TextProps>;
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR extends **HeaderCompactStandard** (component-library) so that **title** and **subtitle** can be either a **string** or a **React node**, while keeping existing string behavior and default typography unchanged.

**Reason for change:** Callers sometimes need custom title/subtitle content (e.g. styled text, icons, or composed components). Supporting `React.ReactNode` allows that without new props; string usage continues to use the default Text variants and `titleProps` / `subtitleProps`.

**What changed:**

1. **HeaderCompactStandard.types.ts** (`app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.types.ts`)
   - **title**: Type changed from `string` to `string | React.ReactNode`. JSDoc updated: when string, rendered with `TextVariant.BodyMd` and `FontWeight.Bold` and `titleProps` apply; when node, rendered as-is and `titleProps` are not applied.
   - **subtitle**: Type changed from `string` to `string | React.ReactNode`. JSDoc updated: when string, rendered with `TextVariant.BodySm` and `TextColor.TextAlternative` and `subtitleProps` apply; when node, rendered inside the same `-mt-0.5` container and `subtitleProps` are not applied.
   - **titleProps** / **subtitleProps**: JSDoc clarified that each applies only when the corresponding prop is a string.

2. **HeaderCompactStandard.tsx** (`app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.tsx`)
   - Title block: if `title` is a string, render the existing `Text` with `titleProps`; otherwise render `title` as-is.
   - Subtitle block: wrapped in a `Box` with `-mt-0.5`. If `subtitle` is a string, render the existing `Text` with `subtitleProps`; otherwise render `subtitle` as-is.

3. **HeaderCompactStandard.test.tsx** (`app/component-library/components-temp/HeaderCompactStandard/HeaderCompactStandard.test.tsx`)
   - Added: "renders title when passed as React node".
   - Added: "renders subtitle when passed as React node".
   - Added: "renders both title and subtitle as React nodes".

No other components or screens are modified; only HeaderCompactStandard and its types/tests are updated.

## **Changelog**

Extends HeaderCompactStandard to accept React nodes for title and subtitle in addition to strings.

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-501

## **Manual testing steps**

```gherkin
Feature: HeaderCompactStandard title/subtitle as string or node

  Scenario: Lint and type check pass
    Given the branch is checked out
    When the author runs yarn lint and yarn lint:tsc
    Then both complete without errors

  Scenario: HeaderCompactStandard unit tests pass
    Given the branch is checked out
    When the author runs yarn jest app/component-library/components-temp/HeaderCompactStandard/
    Then all tests pass

  Scenario: String title and subtitle unchanged
    Given a screen that uses HeaderCompactStandard with string title/subtitle
    When the header is rendered
    Then title uses BodyMd Bold and subtitle uses BodySm TextAlternative as before

  Scenario: Custom title or subtitle as node
    When HeaderCompactStandard is used with title or subtitle as a React node
    Then the node is rendered in place (no default Text wrapper); titleProps/subtitleProps are not applied
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


### **After**

<!-- [screenshots/recordings] -->
Everything still functional

https://github.com/user-attachments/assets/6cdec7a5-a48c-4f47-bc6f-30ffc9d5a47c


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to `HeaderCompactStandard` rendering and type definitions; primary risk is minor visual/layout differences when `subtitle` is present or when nodes are passed instead of strings.
> 
> **Overview**
> `HeaderCompactStandard` now accepts `title` and `subtitle` as either strings or React nodes. When a string is provided, the component preserves the existing default typography and applies `titleProps`/`subtitleProps`; when a node is provided, it renders the node as-is (without applying those props), wrapping `subtitle` in a small spacing container.
> 
> Unit tests were extended to cover rendering `title` and/or `subtitle` when passed as React nodes, and types/JSDoc were updated to document the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b104c2f88f6212a494be1aa699996a0c0cb2f4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->