### PR TITLE
fix(analytics): add PERPS_UI_INTERACTION event tracking when clicking a position in the homepage sections UI

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -3,8 +3,20 @@ import { screen, fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PerpsSection from './PerpsSection';
 import Routes from '../../../../../constants/navigation/Routes';
+import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller';
 
 const mockNavigate = jest.fn();
+const mockTrack = jest.fn();
+
+jest.mock('../../../../UI/Perps/hooks/usePerpsEventTracking', () => ({
+  usePerpsEventTracking: jest.fn(() => ({
+    track: mockTrack,
+  })),
+}));
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -382,6 +394,29 @@ describe('PerpsSection', () => {
         initialTab: 'position',
       },
     });
+  });
+
+  it('fires PERPS_UI_INTERACTION event when a position is pressed', () => {
+    usePerpsLivePositions.mockReturnValue({
+      positions: [makePosition()],
+      isInitialLoading: false,
+    });
+
+    renderWithProvider(<PerpsSection />);
+
+    fireEvent.press(screen.getByTestId('perps-position-row-BTC'));
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEvents.PERPS_UI_INTERACTION,
+      {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.OPEN_POSITION,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.WALLET_HOME,
+      },
+    );
   });
 
   it('limits items to max 5 (positions first, then orders)', () => {

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -14,6 +14,8 @@ import { useSelector } from 'react-redux';
 import {
   type PerpsMarketData,
   type Position,
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
 } from '@metamask/perps-controller';
 import type { PerpsMarketDataWithVolumeNumber } from '../../../../UI/Perps/hooks/usePerpsMarkets';
 import SectionTitle from '../../components/SectionTitle';
@@ -36,6 +38,8 @@ import ViewMoreCard from '../../components/ViewMoreCard';
 import { useHomepageSparklines } from './hooks/useHomepageSparklines';
 import { strings } from '../../../../../../locales/i18n';
 import type { SectionRefreshHandle } from '../../types';
+import { usePerpsEventTracking } from '../../../../UI/Perps/hooks/usePerpsEventTracking';
+import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
 
 const MAX_ITEMS = 5;
 const MAX_TRENDING_MARKETS = 5;
@@ -53,6 +57,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const tw = useTailwind();
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const title = strings('homepage.sections.perpetuals');
+  const { track } = usePerpsEventTracking();
 
   const { positions, isInitialLoading: positionsLoading } =
     usePerpsLivePositions({
@@ -190,6 +195,14 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   const handlePositionPress = useCallback(
     (position: Position) => {
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.OPEN_POSITION,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.WALLET_HOME,
+      });
       const market = markets.find((m) => m.symbol === position.symbol);
       navigation.navigate(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.MARKET_DETAILS,
@@ -202,7 +215,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
         },
       });
     },
-    [navigation, markets],
+    [navigation, markets, track],
   );
 
   const handleTilePress = useCallback(


### PR DESCRIPTION
## **Description**

The homepage redesign (behind a feature flag) uses a Sections-based UI instead of the old tab-based layout. When a user clicks an open position in the Sections UI `PerpsSection`, the Perp UI Interaction segment event was never fired — unlike the tab UI which correctly tracks this via `PerpsCard`. This PR restores the missing event in the Sections UI.

Note: ignore the branch name, it is wrong

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-500

## **Manual testing steps**

```gherkin
Feature: Perps position click tracking in homepage sections UI

  Scenario: user clicks an open position in the homepage sections UI
    Given the homepage redesign feature flag is enabled
    And the user has an open perps position visible on the wallet home screen

    When user taps the position row
    Then the "Perp UI Interaction" segment event fires with:
      | interaction_type | button_clicked  |
      | button_clicked   | open_position   |
      | button_location  | wallet_home     |
    And the user is navigated to the market details screen
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/9d15eb47-2afb-4202-bedb-0a0157b9dfda

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
