### PR TITLE
Account list balance display

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
@@ -110,6 +110,15 @@ describe('AccountCell', () => {
     expect(getByText('Test Account Group')).toBeTruthy();
   });
 
+  it('renders zero fiat balance values', () => {
+    mockBalance.value = 0;
+    mockBalance.currency = 'usd';
+
+    const { getByText } = renderAccountCell();
+
+    expect(getByText('$0.00')).toBeOnTheScreen();
+  });
+
   it.each([
     { currency: 'usd', value: 1234.56, expected: '$1,234.56' },
     { currency: 'eur', value: 987.65, expected: '€987.65' },

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -88,7 +88,7 @@ const BalanceEndContainer = ({
             color={TextColor.Default}
             testID={AccountCellIds.BALANCE}
           >
-            {totalBalance ? displayBalance : null}
+            {totalBalance != null ? displayBalance : null}
           </Text>
           {networkImageSource && (
             <Avatar


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes zero-fiat balance rendering in the account selector by correctly displaying `0` values.

The previous conditional `{totalBalance ? displayBalance : null}` treated `0` as a falsy value, causing valid zero balances (e.g., `$0.00`) to be hidden. This change ensures `0` is rendered when `totalBalance` is explicitly `0`, resolving the UI bug.

---
<p><a href="https://cursor.com/agents/bc-688e076a-a405-4bfd-be3e-365ddfb557ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-688e076a-a405-4bfd-be3e-365ddfb557ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->