### PR TITLE
refactor(predict): gate sports data pipeline by category in getMarkets

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -309,7 +309,7 @@ describe('PolymarketProvider', () => {
 
     const markets = await createProvider({
       liveSportsLeagues: ['nfl'],
-    }).getMarkets();
+    }).getMarkets({ category: 'sports' });
     expect(Array.isArray(markets)).toBe(true);
     expect(markets.length).toBeGreaterThan(0);
     expect(markets.length).toBe(2);
@@ -324,7 +324,7 @@ describe('PolymarketProvider', () => {
 
     const result = await createProvider({
       liveSportsLeagues: ['nfl'],
-    }).getMarkets();
+    }).getMarkets({ category: 'sports' });
 
     expect(result).toEqual([]);
     expect(mockGetMarketsFromPolymarketApi).toHaveBeenCalledWith(
@@ -7188,7 +7188,7 @@ describe('PolymarketProvider', () => {
         ];
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
 
-        await provider.getMarkets();
+        await provider.getMarkets({ category: 'sports' });
 
         expect(mockGameCacheInstance.overlayOnMarkets).toHaveBeenCalledWith(
           mockMarkets,
@@ -7208,7 +7208,7 @@ describe('PolymarketProvider', () => {
         mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
         mockGameCacheInstance.overlayOnMarkets.mockReturnValue(overlaidMarkets);
 
-        const result = await provider.getMarkets();
+        const result = await provider.getMarkets({ category: 'sports' });
 
         expect(result).toEqual(overlaidMarkets);
       });
@@ -7219,7 +7219,7 @@ describe('PolymarketProvider', () => {
           new Error('API error'),
         );
 
-        const result = await provider.getMarkets();
+        const result = await provider.getMarkets({ category: 'sports' });
 
         expect(result).toEqual([]);
         expect(mockGameCacheInstance.overlayOnMarkets).not.toHaveBeenCalled();
@@ -7446,6 +7446,23 @@ describe('PolymarketProvider', () => {
         expect(
           mockTeamsCacheInstance.ensureLeaguesLoaded,
         ).not.toHaveBeenCalled();
+      });
+
+      it('skips sports pipeline when category is not sports even if leagues are configured', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+        const mockMarkets = [{ id: 'market-1', title: 'Test Market' }];
+        mockGetMarketsFromPolymarketApi.mockResolvedValue(mockMarkets);
+
+        const result = await provider.getMarkets({ category: 'trending' });
+
+        expect(
+          mockTeamsCacheInstance.ensureLeaguesLoaded,
+        ).not.toHaveBeenCalled();
+        expect(mockGameCacheInstance.overlayOnMarkets).not.toHaveBeenCalled();
+        expect(mockGetMarketsFromPolymarketApi).toHaveBeenCalledWith(
+          expect.objectContaining({ teamLookup: undefined }),
+        );
+        expect(result).toEqual(mockMarkets);
       });
     });
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -351,8 +351,10 @@ export class PolymarketProvider implements PredictProvider {
 
   public async getMarkets(params?: GetMarketsParams): Promise<PredictMarket[]> {
     try {
+      const isSportsCategory = params?.category === 'sports';
       const { liveSportsLeagues } = this.#getFeatureFlags();
-      const liveSportsEnabled = liveSportsLeagues.length > 0;
+      const liveSportsEnabled =
+        isSportsCategory && liveSportsLeagues.length > 0;
 
       if (liveSportsEnabled) {
         await TeamsCache.getInstance().ensureLeaguesLoaded(

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -777,7 +777,6 @@ export const parsePolymarketEvents = (
   const parsedMarkets: PredictMarket[] = events.map(
     (event: PolymarketApiEvent) => {
       const tags = Array.isArray(event.tags) ? event.tags : [];
-      const eventLeague = getEventLeague(event);
 
       const markets = sortMarkets(event, sortBy).filter(
         (market: PolymarketApiMarket) => market?.active !== false,
@@ -789,6 +788,8 @@ export const parsePolymarketEvents = (
             return apiTeam ? mapApiTeamToPredictTeam(apiTeam) : undefined;
           }
         : undefined;
+
+      const eventLeague = predictTeamLookup ? getEventLeague(event) : null;
 
       const game =
         eventLeague && predictTeamLookup


### PR DESCRIPTION
## Summary
- Gates `TeamsCache.ensureLeaguesLoaded()`, `teamLookup`, and `GameCache.overlayOnMarkets()` in `PolymarketProvider.getMarkets()` to only activate when `category === 'sports'`
- Skips `getEventLeague()` tag/slug checking in `parsePolymarketEvents` when `teamLookup` is absent
- Non-sports tabs (trending, crypto, politics, etc.) no longer trigger sports API calls or game data processing

## Test plan
- [x] Updated existing tests that use `liveSportsLeagues: ['nfl']` to pass `{ category: 'sports' }` to `.getMarkets()`
- [x] Added new test verifying non-sports categories skip the sports pipeline even when leagues are configured
- [x] All 399 PolymarketProvider tests pass
- [x] All 328 utils tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes when the sports enrichment pipeline (TeamsCache/team lookup/GameCache overlay) runs, gated behind `category === 'sports'`. Main risk is missing game overlays/extra API calls if callers don’t pass the expected category.
> 
> **Overview**
> `PolymarketProvider.getMarkets()` now only runs the live-sports pipeline (loading `TeamsCache`, providing `teamLookup`, and applying `GameCache.overlayOnMarkets()`) when `params.category === 'sports'`; other categories return parsed markets without sports enrichment.
> 
> `parsePolymarketEvents()` skips league detection (`getEventLeague`) and game-data building when no `teamLookup` is provided, reducing unnecessary work for non-sports categories.
> 
> Tests were updated to pass `{ category: 'sports' }` where sports behavior is expected, and a new test asserts non-sports categories skip Teams/Game cache even if sports leagues are configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb1ce30a461803b4e395e17df2103189408a0863. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->