### PR TITLE
refactor(predict): migrate useUnrealizedPnL to React Query

### DIFF
--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -76,6 +76,15 @@ jest.mock('@tanstack/react-query', () => ({
   }),
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+  useFocusEffect: jest.fn(),
+}));
+
 const mockExecuteGuardedAction = jest.fn(async (action) => await action());
 jest.mock('../../hooks/usePredictActionGuard', () => ({
   usePredictActionGuard: () => ({
@@ -87,7 +96,7 @@ jest.mock('../../hooks/usePredictActionGuard', () => ({
 const mockRefetchClaimablePositions = jest.fn();
 jest.mock('../../hooks/usePredictPositions', () => ({
   usePredictPositions: () => ({
-    data: [],
+    data: [{ id: 'position-1' }],
     isLoading: false,
     error: null,
     refetch: mockRefetchClaimablePositions,
@@ -101,14 +110,6 @@ jest.mock('../../hooks/usePredictClaim', () => ({
     loading: false,
     completed: false,
     error: false,
-  }),
-}));
-
-const mockNavigate = jest.fn();
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({
-    navigate: mockNavigate,
   }),
 }));
 
@@ -191,16 +192,15 @@ describe('MarketsWonCard', () => {
     mockBalanceResult.isLoading = false;
 
     mockUseUnrealizedPnL.mockReturnValue({
-      unrealizedPnL: {
+      data: {
         user: '0x1234567890123456789012345678901234567890',
         cashUpnl: 8.63,
         percentUpnl: 3.9,
       },
       isLoading: false,
-      isRefreshing: false,
+      isFetching: false,
       error: null,
-      loadUnrealizedPnL: jest.fn(),
-    });
+    } as unknown as ReturnType<typeof useUnrealizedPnL>);
   });
 
   afterEach(() => {
@@ -265,19 +265,7 @@ describe('MarketsWonCard', () => {
   });
 
   describe('refresh', () => {
-    it('reloads balance and unrealized P&L when refresh is called', async () => {
-      const mockLoadUnrealizedPnL = jest.fn();
-      mockUseUnrealizedPnL.mockReturnValue({
-        unrealizedPnL: {
-          user: '0x1234567890123456789012345678901234567890',
-          cashUpnl: 8.63,
-          percentUpnl: 3.9,
-        },
-        isLoading: false,
-        isRefreshing: false,
-        error: null,
-        loadUnrealizedPnL: mockLoadUnrealizedPnL,
-      });
+    it('invalidates balance and unrealized P&L queries when refresh is called', async () => {
       const ref = React.createRef<{ refresh: () => Promise<void> }>();
       const state = createTestState(100.5);
 
@@ -285,7 +273,7 @@ describe('MarketsWonCard', () => {
 
       await ref.current?.refresh();
 
-      expect(mockLoadUnrealizedPnL).toHaveBeenCalled();
+      expect(mockInvalidateQueries).toHaveBeenCalled();
     });
   });
 
@@ -303,16 +291,15 @@ describe('MarketsWonCard', () => {
 
     it('displays skeleton loader when unrealized P&L is loading', () => {
       mockUseUnrealizedPnL.mockReturnValue({
-        unrealizedPnL: {
+        data: {
           user: '0x1234567890123456789012345678901234567890',
           cashUpnl: 0,
           percentUpnl: 0,
         },
         isLoading: true,
-        isRefreshing: false,
+        isFetching: true,
         error: null,
-        loadUnrealizedPnL: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof useUnrealizedPnL>);
       const state = createTestState(100.5);
 
       renderWithProvider(<MarketsWonCard />, { state });
@@ -326,12 +313,11 @@ describe('MarketsWonCard', () => {
       mockBalanceResult.data = undefined;
       mockBalanceResult.isLoading = false;
       mockUseUnrealizedPnL.mockReturnValue({
-        unrealizedPnL: null,
+        data: undefined,
         isLoading: false,
-        isRefreshing: false,
+        isFetching: false,
         error: null,
-        loadUnrealizedPnL: jest.fn(),
-      });
+      } as unknown as ReturnType<typeof useUnrealizedPnL>);
       const state = createTestState();
 
       const { toJSON } = renderWithProvider(<MarketsWonCard />, { state });
@@ -357,16 +343,15 @@ describe('MarketsWonCard', () => {
       mockBalanceResult.error = null;
       mockBalanceResult.data = 100.5;
       mockUseUnrealizedPnL.mockReturnValue({
-        unrealizedPnL: {
+        data: {
           user: '0x1234567890123456789012345678901234567890',
           cashUpnl: 8.63,
           percentUpnl: 3.9,
         },
         isLoading: false,
-        isRefreshing: false,
-        error: 'P&L fetch failed',
-        loadUnrealizedPnL: jest.fn(),
-      });
+        isFetching: false,
+        error: new Error('P&L fetch failed'),
+      } as unknown as ReturnType<typeof useUnrealizedPnL>);
       const state = createTestState(100.5);
 
       renderWithProvider(<MarketsWonCard onError={mockOnError} />, { state });
@@ -379,16 +364,15 @@ describe('MarketsWonCard', () => {
       mockBalanceResult.error = { message: 'Balance error' };
       mockBalanceResult.data = 100.5;
       mockUseUnrealizedPnL.mockReturnValue({
-        unrealizedPnL: {
+        data: {
           user: '0x1234567890123456789012345678901234567890',
           cashUpnl: 8.63,
           percentUpnl: 3.9,
         },
         isLoading: false,
-        isRefreshing: false,
-        error: 'P&L error',
-        loadUnrealizedPnL: jest.fn(),
-      });
+        isFetching: false,
+        error: new Error('P&L error'),
+      } as unknown as ReturnType<typeof useUnrealizedPnL>);
       const state = createTestState(100.5);
 
       renderWithProvider(<MarketsWonCard onError={mockOnError} />, { state });

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -285,7 +285,7 @@ describe('MarketsWonCard', () => {
 
       await ref.current?.refresh();
 
-      expect(mockLoadUnrealizedPnL).toHaveBeenCalledWith({ isRefresh: true });
+      expect(mockLoadUnrealizedPnL).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -8,7 +8,11 @@ import {
   ButtonSize as ButtonSizeHero,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { NavigationProp, useNavigation , useFocusEffect } from '@react-navigation/native';
+import {
+  NavigationProp,
+  useNavigation,
+  useFocusEffect,
+} from '@react-navigation/native';
 import React, {
   forwardRef,
   useCallback,
@@ -104,8 +108,10 @@ const PredictPositionsHeader = forwardRef<
   const unrealizedPnL = hasPositions ? (pnlData ?? null) : null;
 
   // Invalidate unrealized P&L query when screen comes into focus
-  const pnlQueryKey =
-    predictQueries.unrealizedPnL.keys.byAddress(selectedAddress);
+  const pnlQueryKey = useMemo(
+    () => predictQueries.unrealizedPnL.keys.byAddress(selectedAddress),
+    [selectedAddress],
+  );
   useFocusEffect(
     useCallback(() => {
       queryClient.invalidateQueries({ queryKey: pnlQueryKey });

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -122,7 +122,7 @@ const PredictPositionsHeader = forwardRef<
   useImperativeHandle(ref, () => ({
     refresh: async () => {
       await Promise.all([
-        loadUnrealizedPnL({ isRefresh: true }),
+        loadUnrealizedPnL(),
         queryClient.invalidateQueries({
           queryKey: predictQueries.balance.keys.all(),
         }),

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -8,9 +8,10 @@ import {
   ButtonSize as ButtonSizeHero,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { NavigationProp, useNavigation , useFocusEffect } from '@react-navigation/native';
 import React, {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -41,6 +42,7 @@ import { usePredictClaim } from '../../hooks/usePredictClaim';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import { useUnrealizedPnL } from '../../hooks/useUnrealizedPnL';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
+import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { selectPredictWonPositions } from '../../selectors/predictController';
 import { PredictPosition } from '../../types';
 import { PredictNavigationParamList } from '../../types/navigation';
@@ -89,16 +91,30 @@ const PredictPositionsHeader = forwardRef<
     selectPredictWonPositions({ address: selectedAddress }),
   );
 
+  const { data: activePositions } = usePredictPositions({ claimable: false });
+  const hasPositions = (activePositions?.length ?? 0) > 0;
+
   const {
-    unrealizedPnL,
+    data: pnlData,
     isLoading: isUnrealizedPnLLoading,
-    loadUnrealizedPnL,
     error: pnlError,
   } = useUnrealizedPnL();
 
+  // Only show P&L when the user has active (non-claimable) positions
+  const unrealizedPnL = hasPositions ? (pnlData ?? null) : null;
+
+  // Invalidate unrealized P&L query when screen comes into focus
+  const pnlQueryKey =
+    predictQueries.unrealizedPnL.keys.byAddress(selectedAddress);
+  useFocusEffect(
+    useCallback(() => {
+      queryClient.invalidateQueries({ queryKey: pnlQueryKey });
+    }, [queryClient, pnlQueryKey]),
+  );
+
   // Notify parent of errors while keeping state isolated
   useEffect(() => {
-    const combinedError = balanceError?.message ?? pnlError ?? null;
+    const combinedError = balanceError?.message ?? pnlError?.message ?? null;
     onError?.(combinedError);
   }, [balanceError, pnlError, onError]);
 
@@ -122,7 +138,7 @@ const PredictPositionsHeader = forwardRef<
   useImperativeHandle(ref, () => ({
     refresh: async () => {
       await Promise.all([
-        loadUnrealizedPnL(),
+        queryClient.invalidateQueries({ queryKey: pnlQueryKey }),
         queryClient.invalidateQueries({
           queryKey: predictQueries.balance.keys.all(),
         }),

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -194,6 +194,10 @@ export function usePredictPlaceOrder(
           queryKey: predictQueries.activity.keys.all(),
         });
 
+        queryClient.invalidateQueries({
+          queryKey: predictQueries.unrealizedPnL.keys.all(),
+        });
+
         if (side === Side.BUY) {
           showOrderPlacedToast();
         } else {

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
@@ -189,6 +189,11 @@ describe('usePredictToastRegistrations', () => {
           queryKey: ['predict', 'balance'],
         }),
       );
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ['predict', 'unrealizedPnL'],
+        }),
+      );
     });
 
     it('uses account ready fallback when deposit confirmed amount is missing', () => {
@@ -335,6 +340,11 @@ describe('usePredictToastRegistrations', () => {
           queryKey: ['predict', 'balance'],
         }),
       );
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ['predict', 'unrealizedPnL'],
+        }),
+      );
     });
 
     it('shows error toast with retry on failed status', async () => {
@@ -427,6 +437,11 @@ describe('usePredictToastRegistrations', () => {
       expect(mockInvalidateQueries).toHaveBeenCalledWith(
         expect.objectContaining({
           queryKey: ['predict', 'balance'],
+        }),
+      );
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ['predict', 'unrealizedPnL'],
         }),
       );
     });

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -161,6 +161,10 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
         queryClient.invalidateQueries({
           queryKey: predictQueries.activity.keys.all(),
         });
+
+        queryClient.invalidateQueries({
+          queryKey: predictQueries.unrealizedPnL.keys.all(),
+        });
       }
 
       if (type === 'deposit') {

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -1,12 +1,11 @@
+import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUnrealizedPnL } from './useUnrealizedPnL';
 import { UnrealizedPnL } from '../types';
 import { usePredictPositions } from './usePredictPositions';
 
 const mockSelectedAddress = '0x1234567890123456789012345678901234567890';
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => mockSelectedAddress),
-}));
 
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
@@ -44,6 +43,25 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+jest.mock('../utils/predictErrorHandler', () => ({
+  ensureError: (err: unknown) =>
+    err instanceof Error ? err : new Error(String(err)),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+
 describe('useUnrealizedPnL', () => {
   const basePnL: UnrealizedPnL = {
     user: '0x1111111111111111111111111111111111111111',
@@ -58,45 +76,47 @@ describe('useUnrealizedPnL', () => {
     });
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns initial state when disabled', () => {
-    const { result } = renderHook(() =>
-      useUnrealizedPnL({ loadOnMount: false }),
+  it('does not fetch when loadOnMount is false', () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useUnrealizedPnL({ loadOnMount: false }),
+      { wrapper: Wrapper },
     );
 
     expect(result.current.unrealizedPnL).toBeNull();
-    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(typeof result.current.loadUnrealizedPnL).toBe('function');
     expect(mockGetUnrealizedPnL).not.toHaveBeenCalled();
   });
 
   it('fetches unrealized P&L successfully with default options', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
-      expect(result.current.error).toBeNull();
     });
 
+    expect(result.current.unrealizedPnL).toEqual(basePnL);
+    expect(result.current.error).toBeNull();
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
       address: mockSelectedAddress,
     });
   });
 
-  it('passes provided options to getUnrealizedPnL', async () => {
+  it('uses provided address instead of selected account', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
+    const customAddress = '0x2222222222222222222222222222222222222222';
 
-    const { result } = renderHook(() =>
-      useUnrealizedPnL({
-        address: '0x2222222222222222222222222222222222222222',
-      }),
+    const { result } = renderHook(
+      () => useUnrealizedPnL({ address: customAddress }),
+      { wrapper: Wrapper },
     );
 
     await waitFor(() => {
@@ -104,45 +124,44 @@ describe('useUnrealizedPnL', () => {
     });
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
-      address: '0x2222222222222222222222222222222222222222',
+      address: customAddress,
     });
   });
 
-  it('handles null responses by clearing the data', async () => {
+  it('handles null responses', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(null);
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.error).toBeNull();
       expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.error).toBeNull();
   });
 
   it('surfaces errors thrown by getUnrealizedPnL', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockRejectedValue(new Error('Network error'));
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
       expect(result.current.error).toBe('Network error');
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.isLoading).toBe(false);
     });
+
+    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.isLoading).toBe(false);
   });
 
-  it('maps non-Error rejections to a generic message', async () => {
-    mockGetUnrealizedPnL.mockRejectedValue('bad times');
-
-    const { result } = renderHook(() => useUnrealizedPnL());
-
-    await waitFor(() => {
-      expect(result.current.error).toBe('Failed to fetch unrealized P&L');
-    });
-  });
-
-  it('supports manual refetching', async () => {
+  it('supports manual refetching via loadUnrealizedPnL', async () => {
+    const { Wrapper } = createWrapper();
     mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
     const updatedPnL: UnrealizedPnL = {
@@ -151,7 +170,9 @@ describe('useUnrealizedPnL', () => {
       percentUpnl: -2,
     };
 
-    const { result } = renderHook(() => useUnrealizedPnL());
+    const { result } = renderHook(() => useUnrealizedPnL(), {
+      wrapper: Wrapper,
+    });
 
     await waitFor(() => {
       expect(result.current.unrealizedPnL).toEqual(basePnL);
@@ -165,70 +186,20 @@ describe('useUnrealizedPnL', () => {
 
     await waitFor(() => {
       expect(result.current.unrealizedPnL).toEqual(updatedPnL);
-      expect(result.current.error).toBeNull();
     });
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(2);
   });
 
-  it('loads data when loadOnMount changes from false to true', async () => {
-    mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-    const { result, rerender } = renderHook(
-      ({ loadOnMount }) => useUnrealizedPnL({ loadOnMount }),
-      {
-        initialProps: { loadOnMount: false },
-      },
-    );
-
-    expect(mockGetUnrealizedPnL).not.toHaveBeenCalled();
-
-    rerender({ loadOnMount: true });
-
-    await waitFor(() => {
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  it('refetches when dependencies change', async () => {
-    mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-    const { rerender } = renderHook(
-      ({ address }: { address?: string }) => useUnrealizedPnL({ address }),
-      {
-        initialProps: {
-          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        },
-      },
-    );
-
-    await waitFor(() => {
-      expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(1);
-    });
-
-    rerender({
-      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    });
-
-    await waitFor(() => {
-      expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(2);
-    });
-
-    expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(1, {
-      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    });
-    expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(2, {
-      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    });
-  });
-
   describe('positions-based visibility', () => {
     it('returns null when user has no positions', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({ data: [] });
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -239,12 +210,15 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns unrealized P&L when user has positions', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({
         data: [{ id: 'position-1' }, { id: 'position-2' }],
       });
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -255,9 +229,10 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('calls usePredictPositions with claimable: false', () => {
+      const { Wrapper } = createWrapper();
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      renderHook(() => useUnrealizedPnL());
+      renderHook(() => useUnrealizedPnL(), { wrapper: Wrapper });
 
       expect(mockUsePredictPositions).toHaveBeenCalledWith({
         claimable: false,
@@ -265,9 +240,12 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns null when getUnrealizedPnL returns null and user has positions', async () => {
+      const { Wrapper } = createWrapper();
       mockGetUnrealizedPnL.mockResolvedValue(null);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -278,10 +256,13 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns null when both getUnrealizedPnL returns null and no positions', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({ data: [] });
       mockGetUnrealizedPnL.mockResolvedValue(null);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -292,10 +273,13 @@ describe('useUnrealizedPnL', () => {
     });
 
     it('returns null when positions data is undefined', async () => {
+      const { Wrapper } = createWrapper();
       mockUsePredictPositions.mockReturnValue({ data: undefined });
       mockGetUnrealizedPnL.mockResolvedValue(basePnL);
 
-      const { result } = renderHook(() => useUnrealizedPnL());
+      const { result } = renderHook(() => useUnrealizedPnL(), {
+        wrapper: Wrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -134,10 +134,8 @@ describe('useUnrealizedPnL', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.error).toBeTruthy();
+      expect(result.current.error?.message).toBe('Network error');
     });
-
-    expect(result.current.error?.message).toBe('Network error');
     expect(result.current.data).toBeUndefined();
     expect(result.current.isLoading).toBe(false);
   });

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUnrealizedPnL } from './useUnrealizedPnL';
 import { UnrealizedPnL } from '../types';
-import { usePredictPositions } from './usePredictPositions';
 
 const mockSelectedAddress = '0x1234567890123456789012345678901234567890';
 
-jest.mock('@react-navigation/native', () => ({
-  useFocusEffect: jest.fn(),
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => 'mock-account-group-id'),
 }));
-
-jest.mock('./usePredictPositions');
-const mockUsePredictPositions = usePredictPositions as jest.Mock;
 
 const mockGetUnrealizedPnL = jest.fn();
 
@@ -43,16 +39,6 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-jest.mock('../../../../util/Logger', () => ({
-  __esModule: true,
-  default: { error: jest.fn() },
-}));
-
-jest.mock('../utils/predictErrorHandler', () => ({
-  ensureError: (err: unknown) =>
-    err instanceof Error ? err : new Error(String(err)),
-}));
-
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -71,22 +57,17 @@ describe('useUnrealizedPnL', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUsePredictPositions.mockReturnValue({
-      data: [{ id: 'position-1' }],
-    });
   });
 
-  it('does not fetch when loadOnMount is false', () => {
+  it('does not fetch when enabled is false', () => {
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(
-      () => useUnrealizedPnL({ loadOnMount: false }),
-      { wrapper: Wrapper },
-    );
+    const { result } = renderHook(() => useUnrealizedPnL({ enabled: false }), {
+      wrapper: Wrapper,
+    });
 
-    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.data).toBeUndefined();
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(typeof result.current.loadUnrealizedPnL).toBe('function');
     expect(mockGetUnrealizedPnL).not.toHaveBeenCalled();
   });
 
@@ -102,7 +83,7 @@ describe('useUnrealizedPnL', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.unrealizedPnL).toEqual(basePnL);
+    expect(result.current.data).toEqual(basePnL);
     expect(result.current.error).toBeNull();
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
       address: mockSelectedAddress,
@@ -120,7 +101,7 @@ describe('useUnrealizedPnL', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
+      expect(result.current.data).toEqual(basePnL);
     });
 
     expect(mockGetUnrealizedPnL).toHaveBeenCalledWith({
@@ -140,7 +121,7 @@ describe('useUnrealizedPnL', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.data).toBeNull();
     expect(result.current.error).toBeNull();
   });
 
@@ -153,139 +134,11 @@ describe('useUnrealizedPnL', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.error).toBe('Network error');
+      expect(result.current.error).toBeTruthy();
     });
 
-    expect(result.current.unrealizedPnL).toBeNull();
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.data).toBeUndefined();
     expect(result.current.isLoading).toBe(false);
-  });
-
-  it('supports manual refetching via loadUnrealizedPnL', async () => {
-    const { Wrapper } = createWrapper();
-    mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-    const updatedPnL: UnrealizedPnL = {
-      user: '0x9999999999999999999999999999999999999999',
-      cashUpnl: -5,
-      percentUpnl: -2,
-    };
-
-    const { result } = renderHook(() => useUnrealizedPnL(), {
-      wrapper: Wrapper,
-    });
-
-    await waitFor(() => {
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
-    });
-
-    mockGetUnrealizedPnL.mockResolvedValue(updatedPnL);
-
-    await act(async () => {
-      await result.current.loadUnrealizedPnL();
-    });
-
-    await waitFor(() => {
-      expect(result.current.unrealizedPnL).toEqual(updatedPnL);
-    });
-
-    expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(2);
-  });
-
-  describe('positions-based visibility', () => {
-    it('returns null when user has no positions', async () => {
-      const { Wrapper } = createWrapper();
-      mockUsePredictPositions.mockReturnValue({ data: [] });
-      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-      const { result } = renderHook(() => useUnrealizedPnL(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.error).toBeNull();
-    });
-
-    it('returns unrealized P&L when user has positions', async () => {
-      const { Wrapper } = createWrapper();
-      mockUsePredictPositions.mockReturnValue({
-        data: [{ id: 'position-1' }, { id: 'position-2' }],
-      });
-      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-      const { result } = renderHook(() => useUnrealizedPnL(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.unrealizedPnL).toEqual(basePnL);
-      expect(result.current.error).toBeNull();
-    });
-
-    it('calls usePredictPositions with claimable: false', () => {
-      const { Wrapper } = createWrapper();
-      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-      renderHook(() => useUnrealizedPnL(), { wrapper: Wrapper });
-
-      expect(mockUsePredictPositions).toHaveBeenCalledWith({
-        claimable: false,
-      });
-    });
-
-    it('returns null when getUnrealizedPnL returns null and user has positions', async () => {
-      const { Wrapper } = createWrapper();
-      mockGetUnrealizedPnL.mockResolvedValue(null);
-
-      const { result } = renderHook(() => useUnrealizedPnL(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.error).toBeNull();
-    });
-
-    it('returns null when both getUnrealizedPnL returns null and no positions', async () => {
-      const { Wrapper } = createWrapper();
-      mockUsePredictPositions.mockReturnValue({ data: [] });
-      mockGetUnrealizedPnL.mockResolvedValue(null);
-
-      const { result } = renderHook(() => useUnrealizedPnL(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.unrealizedPnL).toBeNull();
-      expect(result.current.error).toBeNull();
-    });
-
-    it('returns null when positions data is undefined', async () => {
-      const { Wrapper } = createWrapper();
-      mockUsePredictPositions.mockReturnValue({ data: undefined });
-      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
-
-      const { result } = renderHook(() => useUnrealizedPnL(), {
-        wrapper: Wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.unrealizedPnL).toBeNull();
-    });
   });
 });

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -1,14 +1,12 @@
+import { useCallback, useEffect, useMemo } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Logger from '../../../../util/Logger';
-import Engine from '../../../../core/Engine';
-import { UnrealizedPnL } from '../types';
-import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { ensureError } from '../utils/predictErrorHandler';
-import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
+import { UnrealizedPnL } from '../types';
+import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
+import { predictQueries } from '../queries';
 import { usePredictPositions } from './usePredictPositions';
 
 export interface UseUnrealizedPnLOptions {
@@ -33,7 +31,7 @@ export interface UseUnrealizedPnLResult {
   isLoading: boolean;
   isRefreshing: boolean;
   error: string | null;
-  loadUnrealizedPnL: (options?: { isRefresh?: boolean }) => Promise<void>;
+  loadUnrealizedPnL: () => Promise<void>;
 }
 
 /**
@@ -46,110 +44,71 @@ export const useUnrealizedPnL = (
 ): UseUnrealizedPnLResult => {
   const { address, loadOnMount = true, refreshOnFocus = true } = options;
 
-  const [pnlData, setPnlData] = useState<UnrealizedPnL | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const isInitialMount = useRef(true);
-
-  // Subscribe to account group changes so the hook re-renders when the user switches accounts
-  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const selectedInternalAccountAddress = evmAccount?.address ?? '0x0';
+  const resolvedAddress = address ?? selectedInternalAccountAddress;
+
+  const queryClient = useQueryClient();
 
   const { data: activePositions } = usePredictPositions({ claimable: false });
   const hasPositions = (activePositions?.length ?? 0) > 0;
 
-  const loadUnrealizedPnL = useCallback(
-    async (loadOptions?: { isRefresh?: boolean }) => {
-      const { isRefresh = false } = loadOptions || {};
+  const queryOpts = predictQueries.unrealizedPnL.options({
+    address: resolvedAddress,
+  });
 
-      try {
-        if (isRefresh) {
-          setIsRefreshing(true);
-        } else {
-          setIsLoading(true);
-        }
-        setError(null);
+  const query = useQuery({
+    ...queryOpts,
+    enabled: loadOnMount,
+  });
 
-        const unrealizedPnLResult =
-          await Engine.context.PredictController.getUnrealizedPnL({
-            address: address ?? selectedInternalAccountAddress,
-          });
-
-        setPnlData(unrealizedPnLResult ?? null);
-
-        DevLogger.log('useUnrealizedPnL: Loaded unrealized P&L', {
-          unrealizedPnL: unrealizedPnLResult,
-        });
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to fetch unrealized P&L';
-        setError(errorMessage);
-        setPnlData(null);
-        DevLogger.log('useUnrealizedPnL: Error loading unrealized P&L', err);
-
-        Logger.error(ensureError(err), {
-          tags: {
-            feature: PREDICT_CONSTANTS.FEATURE_NAME,
-            component: 'useUnrealizedPnL',
-          },
-          context: {
-            name: 'useUnrealizedPnL',
-            data: {
-              method: 'loadUnrealizedPnL',
-              action: 'unrealized_pnl_load',
-              operation: 'data_fetching',
-            },
-          },
-        });
-      } finally {
-        setIsLoading(false);
-        setIsRefreshing(false);
-      }
-    },
-    [address, selectedInternalAccountAddress],
-  );
-
-  // Load unrealized P&L on mount if enabled
   useEffect(() => {
-    if (loadOnMount) {
-      loadUnrealizedPnL();
-    }
-    // eslint-disable-next-line react-compiler/react-compiler
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadOnMount]);
+    if (!query.error) return;
 
-  // Refresh unrealized P&L when screen comes into focus if enabled
+    Logger.error(ensureError(query.error), {
+      tags: {
+        feature: PREDICT_CONSTANTS.FEATURE_NAME,
+        component: 'useUnrealizedPnL',
+      },
+      context: {
+        name: 'useUnrealizedPnL',
+        data: {
+          method: 'loadUnrealizedPnL',
+          action: 'unrealized_pnl_load',
+          operation: 'data_fetching',
+        },
+      },
+    });
+  }, [query.error]);
+
   useFocusEffect(
     useCallback(() => {
       if (refreshOnFocus) {
-        loadUnrealizedPnL({ isRefresh: true });
+        queryClient.invalidateQueries({ queryKey: queryOpts.queryKey });
       }
-    }, [refreshOnFocus, loadUnrealizedPnL]),
+    }, [refreshOnFocus, queryClient, queryOpts.queryKey]),
   );
 
-  // Reset and reload data when address changes (but not on initial mount)
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-
-    setPnlData(null);
-    setError(null);
-    loadUnrealizedPnL();
-  }, [address, loadUnrealizedPnL]);
+  const loadUnrealizedPnL = useCallback(async () => {
+    await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
+  }, [queryClient, queryOpts]);
 
   const unrealizedPnL = useMemo(
-    () => (hasPositions ? pnlData : null),
-    [hasPositions, pnlData],
+    () => (hasPositions ? (query.data ?? null) : null),
+    [hasPositions, query.data],
   );
+
+  const error = useMemo(() => {
+    if (!query.error) return null;
+    return query.error instanceof Error
+      ? query.error.message
+      : 'Failed to fetch unrealized P&L';
+  }, [query.error]);
 
   return {
     unrealizedPnL,
-    isLoading,
-    isRefreshing,
+    isLoading: query.isLoading,
+    isRefreshing: query.isFetching && !query.isLoading,
     error,
     loadUnrealizedPnL,
   };

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -1,9 +1,13 @@
+import { useEffect } from 'react';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
+import Logger from '../../../../util/Logger';
+import { PREDICT_CONSTANTS } from '../constants/errors';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { predictQueries } from '../queries';
 import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 import type { UnrealizedPnL } from '../types';
+import { ensureError } from '../utils/predictErrorHandler';
 
 interface UseUnrealizedPnLOptions {
   /**
@@ -31,8 +35,29 @@ export function useUnrealizedPnL(
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const resolvedAddress = address ?? evmAccount?.address ?? '0x0';
 
-  return useQuery({
+  const queryResult = useQuery({
     ...predictQueries.unrealizedPnL.options({ address: resolvedAddress }),
     enabled,
   });
+
+  useEffect(() => {
+    if (!queryResult.error) return;
+
+    Logger.error(ensureError(queryResult.error), {
+      tags: {
+        feature: PREDICT_CONSTANTS.FEATURE_NAME,
+        component: 'useUnrealizedPnL',
+      },
+      context: {
+        name: 'useUnrealizedPnL',
+        data: {
+          method: 'queryFn',
+          action: 'unrealized_pnl_load',
+          operation: 'data_fetching',
+        },
+      },
+    });
+  }, [queryResult.error]);
+
+  return queryResult;
 }

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -19,9 +19,7 @@ interface UseUnrealizedPnLOptions {
 }
 
 /**
- * Thin wrapper around the unrealizedPnL query that resolves the current
- * EVM account address automatically, matching the pattern used by
- * usePredictBalance and usePredictPositions.
+ * Hook to fetch unrealized P&L data for the current account
  */
 export function useUnrealizedPnL(
   options: UseUnrealizedPnLOptions = {},

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -53,9 +53,10 @@ export const useUnrealizedPnL = (
   const { data: activePositions } = usePredictPositions({ claimable: false });
   const hasPositions = (activePositions?.length ?? 0) > 0;
 
-  const queryOpts = predictQueries.unrealizedPnL.options({
-    address: resolvedAddress,
-  });
+  const queryOpts = useMemo(
+    () => predictQueries.unrealizedPnL.options({ address: resolvedAddress }),
+    [resolvedAddress],
+  );
 
   const query = useQuery({
     ...queryOpts,
@@ -90,7 +91,11 @@ export const useUnrealizedPnL = (
   );
 
   const loadUnrealizedPnL = useCallback(async () => {
-    await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
+    try {
+      await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
+    } catch {
+      // Error is tracked via query.error and logged by the useEffect above
+    }
   }, [queryClient, queryOpts]);
 
   const unrealizedPnL = useMemo(

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -1,120 +1,40 @@
-import { useCallback, useEffect, useMemo } from 'react';
-import { useFocusEffect } from '@react-navigation/native';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import Logger from '../../../../util/Logger';
-import { PREDICT_CONSTANTS } from '../constants/errors';
-import { ensureError } from '../utils/predictErrorHandler';
-import { UnrealizedPnL } from '../types';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { predictQueries } from '../queries';
-import { usePredictPositions } from './usePredictPositions';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
+import type { UnrealizedPnL } from '../types';
 
-export interface UseUnrealizedPnLOptions {
+interface UseUnrealizedPnLOptions {
   /**
-   * The address to fetch unrealized P&L for
+   * The address to fetch unrealized P&L for.
+   * Defaults to the EVM address from the currently selected account group.
    */
   address?: string;
   /**
-   * Whether to load unrealized P&L on mount
+   * Whether to enable the query.
    * @default true
    */
-  loadOnMount?: boolean;
-  /**
-   * Whether to refresh unrealized P&L when screen comes into focus
-   * @default true
-   */
-  refreshOnFocus?: boolean;
-}
-
-export interface UseUnrealizedPnLResult {
-  unrealizedPnL: UnrealizedPnL | null;
-  isLoading: boolean;
-  isRefreshing: boolean;
-  error: string | null;
-  loadUnrealizedPnL: () => Promise<void>;
+  enabled?: boolean;
 }
 
 /**
- * Hook for managing unrealized P&L data with loading states
- * @param options Configuration options for the hook
- * @returns Unrealized P&L data and loading utilities
+ * Thin wrapper around the unrealizedPnL query that resolves the current
+ * EVM account address automatically, matching the pattern used by
+ * usePredictBalance and usePredictPositions.
  */
-export const useUnrealizedPnL = (
+export function useUnrealizedPnL(
   options: UseUnrealizedPnLOptions = {},
-): UseUnrealizedPnLResult => {
-  const { address, loadOnMount = true, refreshOnFocus = true } = options;
+): UseQueryResult<UnrealizedPnL | null, Error> {
+  const { address, enabled = true } = options;
 
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
-  const selectedInternalAccountAddress = evmAccount?.address ?? '0x0';
-  const resolvedAddress = address ?? selectedInternalAccountAddress;
+  const resolvedAddress = address ?? evmAccount?.address ?? '0x0';
 
-  const queryClient = useQueryClient();
-
-  const { data: activePositions } = usePredictPositions({ claimable: false });
-  const hasPositions = (activePositions?.length ?? 0) > 0;
-
-  const queryOpts = useMemo(
-    () => predictQueries.unrealizedPnL.options({ address: resolvedAddress }),
-    [resolvedAddress],
-  );
-
-  const query = useQuery({
-    ...queryOpts,
-    enabled: loadOnMount,
+  return useQuery({
+    ...predictQueries.unrealizedPnL.options({ address: resolvedAddress }),
+    enabled,
   });
-
-  useEffect(() => {
-    if (!query.error) return;
-
-    Logger.error(ensureError(query.error), {
-      tags: {
-        feature: PREDICT_CONSTANTS.FEATURE_NAME,
-        component: 'useUnrealizedPnL',
-      },
-      context: {
-        name: 'useUnrealizedPnL',
-        data: {
-          method: 'loadUnrealizedPnL',
-          action: 'unrealized_pnl_load',
-          operation: 'data_fetching',
-        },
-      },
-    });
-  }, [query.error]);
-
-  useFocusEffect(
-    useCallback(() => {
-      if (refreshOnFocus) {
-        queryClient.invalidateQueries({ queryKey: queryOpts.queryKey });
-      }
-    }, [refreshOnFocus, queryClient, queryOpts.queryKey]),
-  );
-
-  const loadUnrealizedPnL = useCallback(async () => {
-    try {
-      await queryClient.fetchQuery({ ...queryOpts, staleTime: 0 });
-    } catch {
-      // Error is tracked via query.error and logged by the useEffect above
-    }
-  }, [queryClient, queryOpts]);
-
-  const unrealizedPnL = useMemo(
-    () => (hasPositions ? (query.data ?? null) : null),
-    [hasPositions, query.data],
-  );
-
-  const error = useMemo(() => {
-    if (!query.error) return null;
-    return query.error instanceof Error
-      ? query.error.message
-      : 'Failed to fetch unrealized P&L';
-  }, [query.error]);
-
-  return {
-    unrealizedPnL,
-    isLoading: query.isLoading,
-    isRefreshing: query.isFetching && !query.isLoading,
-    error,
-    loadUnrealizedPnL,
-  };
-};
+}

--- a/app/components/UI/Predict/queries/index.ts
+++ b/app/components/UI/Predict/queries/index.ts
@@ -1,6 +1,10 @@
 import { predictActivityKeys, predictActivityOptions } from './activity';
 import { predictBalanceKeys, predictBalanceOptions } from './balance';
 import { predictPositionsKeys, predictPositionsOptions } from './positions';
+import {
+  predictUnrealizedPnLKeys,
+  predictUnrealizedPnLOptions,
+} from './unrealizedPnL';
 
 export const predictQueries = {
   activity: {
@@ -14,5 +18,9 @@ export const predictQueries = {
   positions: {
     keys: predictPositionsKeys,
     options: predictPositionsOptions,
+  },
+  unrealizedPnL: {
+    keys: predictUnrealizedPnLKeys,
+    options: predictUnrealizedPnLOptions,
   },
 };

--- a/app/components/UI/Predict/queries/unrealizedPnL.ts
+++ b/app/components/UI/Predict/queries/unrealizedPnL.ts
@@ -1,0 +1,25 @@
+import { queryOptions } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import type { UnrealizedPnL } from '../types';
+
+export const predictUnrealizedPnLKeys = {
+  all: (address: string) => ['predict', 'unrealizedPnL', address] as const,
+};
+
+export const predictUnrealizedPnLOptions = ({ address }: { address: string }) =>
+  queryOptions({
+    queryKey: predictUnrealizedPnLKeys.all(address),
+    queryFn: async (): Promise<UnrealizedPnL | null> => {
+      const result = await Engine.context.PredictController.getUnrealizedPnL({
+        address,
+      });
+
+      DevLogger.log('useUnrealizedPnL: Loaded unrealized P&L', {
+        unrealizedPnL: result,
+      });
+
+      return result ?? null;
+    },
+    staleTime: 10_000,
+  });

--- a/app/components/UI/Predict/queries/unrealizedPnL.ts
+++ b/app/components/UI/Predict/queries/unrealizedPnL.ts
@@ -4,12 +4,14 @@ import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import type { UnrealizedPnL } from '../types';
 
 export const predictUnrealizedPnLKeys = {
-  all: (address: string) => ['predict', 'unrealizedPnL', address] as const,
+  all: () => ['predict', 'unrealizedPnL'] as const,
+  byAddress: (address: string) =>
+    [...predictUnrealizedPnLKeys.all(), address] as const,
 };
 
 export const predictUnrealizedPnLOptions = ({ address }: { address: string }) =>
   queryOptions({
-    queryKey: predictUnrealizedPnLKeys.all(address),
+    queryKey: predictUnrealizedPnLKeys.byAddress(address),
     queryFn: async (): Promise<UnrealizedPnL | null> => {
       const result = await Engine.context.PredictController.getUnrealizedPnL({
         address,


### PR DESCRIPTION
## Summary
- Migrate `useUnrealizedPnL` from manual `useState`/`useEffect` to React Query's `useQuery`, completing React Query adoption across the Predict module
- Extract query key factory and `queryOptions()` into `queries/unrealizedPnL.ts` following the established pattern (`balance.ts`, `positions.ts`)
- Register the new query in `predictQueries` index
- Update consumer (`PredictPositionsHeader`) to use the simplified `loadUnrealizedPnL()` signature (no more `{ isRefresh }` arg — React Query handles this)

## Test plan
- [ ] `npx jest useUnrealizedPnL` — all tests pass
- [ ] `npx jest PredictPositionsHeader` — consumer tests still pass
- [ ] Verify unrealized P&L displays correctly on the Positions screen
- [ ] Verify pull-to-refresh updates P&L data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how unrealized P&L is fetched/cached (React Query) and when the UI shows/refreshes it (focus + position-gated), which could affect staleness and error/display states.
> 
> **Overview**
> Migrates `useUnrealizedPnL` from manual `useState`/`useEffect` fetching to a React Query `useQuery` implementation backed by a new `predictQueries.unrealizedPnL` entry and `queries/unrealizedPnL.ts` (keys + `queryOptions`).
> 
> Updates `PredictPositionsHeader` to consume the new hook shape (`data`/`error` as `Error`), **only render P&L when there are active (non-claimable) positions**, and refresh by invalidating the unrealized P&L query on screen focus and via the imperative `refresh()` handler.
> 
> Ensures unrealized P&L cache is refreshed after relevant actions by invalidating `predictQueries.unrealizedPnL` on order placement and on confirmed deposit/claim/withdraw toast events; tests are adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31008662b999d9bd5dea9d1228ba0cc912161a5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->