### PR TITLE
fix: various ledger & hw connection improvements

### DIFF
--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -309,17 +309,25 @@ describe('LedgerBluetoothAdapter', () => {
 
     it('ignores stale events from a replaced transport', async () => {
       await adapter.connect('device-123');
-      onDisconnect.mockClear();
 
       const oldDisconnectHandler = mockTransportInstance.on.mock.calls.find(
         (call: [string, () => void]) => call[0] === 'disconnect',
       )?.[1];
 
-      for (let i = 0; i < 6; i++) {
-        oldDisconnectHandler?.();
-      }
+      const newTransport = {
+        on: jest.fn(),
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+      mockedTransportBLE.open.mockResolvedValueOnce(
+        newTransport as unknown as TransportBLE,
+      );
+      await adapter.connect('device-456');
 
-      expect(onDisconnect).not.toHaveBeenCalled();
+      expect(adapter.isConnected()).toBe(true);
+
+      oldDisconnectHandler?.();
+
+      expect(adapter.isConnected()).toBe(true);
     });
   });
 

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -292,7 +292,7 @@ describe('LedgerBluetoothAdapter', () => {
   });
 
   describe('handleDisconnect (via transport events)', () => {
-    it('calls onDisconnect when restart limit reached after repeated disconnect events', async () => {
+    it('clears transport without calling onDisconnect', async () => {
       await adapter.connect('device-123');
       onDisconnect.mockClear();
 
@@ -301,24 +301,23 @@ describe('LedgerBluetoothAdapter', () => {
       )?.[1];
       expect(disconnectHandler).toBeDefined();
 
-      // Fire 6 disconnect events (limit is 5)
-      for (let i = 0; i < 6; i++) {
-        disconnectHandler?.();
-      }
+      disconnectHandler?.();
 
-      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      expect(onDisconnect).not.toHaveBeenCalled();
       expect(adapter.isConnected()).toBe(false);
     });
 
-    it('ignores disconnect event when flow is complete', async () => {
+    it('ignores stale events from a replaced transport', async () => {
       await adapter.connect('device-123');
-      adapter.markFlowComplete();
       onDisconnect.mockClear();
 
-      const disconnectHandler = mockTransportInstance.on.mock.calls.find(
+      const oldDisconnectHandler = mockTransportInstance.on.mock.calls.find(
         (call: [string, () => void]) => call[0] === 'disconnect',
       )?.[1];
-      disconnectHandler?.();
+
+      for (let i = 0; i < 6; i++) {
+        oldDisconnectHandler?.();
+      }
 
       expect(onDisconnect).not.toHaveBeenCalled();
     });

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -23,7 +23,6 @@ import DevLogger from '../../SDKConnect/utils/DevLogger';
 const DEVICE_LOCKED_STATUS_CODE = 0x6b0c;
 const LEDGER_OPERATION_TIMEOUT_MS = 10000;
 const DEFAULT_SCAN_TIMEOUT_MS = 30000;
-const CONNECTION_RESTART_LIMIT = 5;
 const MAX_DISCONNECT_RETRIES = 3;
 const RETRY_DELAY_MS = 2000;
 
@@ -42,7 +41,6 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
   #transport: TransportBLE | null = null;
   #deviceId: string | null = null;
   #options: HardwareWalletAdapterOptions;
-  #restartCount = 0;
   #isDestroyed = false;
   #connectInFlight: Promise<void> | null = null;
   #flowComplete = false;
@@ -114,15 +112,14 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
 
       this.#transport = transport;
       this.#deviceId = deviceId;
-      this.#restartCount = 0;
 
       transport.on('disconnect', () => {
-        if (this.#transport != null && this.#transport !== transport) return;
+        if (this.#transport !== transport) return;
         this.#handleDisconnect();
       });
 
       transport.on('error', (error: Error) => {
-        if (this.#transport != null && this.#transport !== transport) return;
+        if (this.#transport !== transport) return;
         DevLogger.log(
           '[LedgerBluetoothAdapter] Transport error:',
           error.message,
@@ -335,8 +332,6 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
       deviceId,
     );
 
-    this.#restartCount = 0;
-
     // Retry on transient BLE errors (e.g., device switching apps)
     for (let attempt = 1; attempt <= MAX_DISCONNECT_RETRIES; attempt++) {
       try {
@@ -507,43 +502,19 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
   }
 
   /**
-   * Handle disconnect events from the transport
+   * Handle disconnect events from the transport.
    *
-   * Note: We only clear transport but preserve deviceId to allow reconnection
-   * during app switch scenarios (BOLOS → Ethereum). The deviceId is only cleared
-   * when explicitly disconnecting via disconnect() method.
-   *
-   * When checking for app readiness, we do not emit disconnect events or call
-   * onDisconnect callback since disconnects during app switch are expected.
+   * Clears the transport reference but preserves deviceId for reconnection.
+   * Does NOT call onDisconnect — disconnect handling is consolidated into
+   * ensureDeviceReady's retry loop, which catches transport errors and
+   * retries automatically. This avoids false-positive error UI from
+   * transient BLE disconnects (e.g. Ledger app switching).
    */
   #handleDisconnect(): void {
     this.#transport = null;
-    // If flow is complete, ignore disconnect events entirely
-    // This prevents errors from showing after a successful connection
-    if (this.#flowComplete) {
-      DevLogger.log(
-        '[LedgerBluetoothAdapter] handleDisconnect - flow complete, ignoring disconnect',
-      );
-      return;
-    }
-
-    // Check if we should try to reconnect (without emitting error)
-    if (this.#restartCount < CONNECTION_RESTART_LIMIT) {
-      this.#restartCount++;
-      DevLogger.log(
-        '[LedgerBluetoothAdapter] handleDisconnect - transport cleared, will attempt reconnect. restartCount:',
-        this.#restartCount,
-      );
-      return;
-    }
-
-    // Restart limit reached
     DevLogger.log(
-      '[LedgerBluetoothAdapter] handleDisconnect - restart limit reached, emitting error',
+      '[LedgerBluetoothAdapter] handleDisconnect - transport cleared',
     );
-    this.#clearTransportState();
-
-    this.#options.onDisconnect(new Error('Device disconnected'));
   }
 
   #emitEvent(payload: DeviceEventPayload): void {
@@ -565,7 +536,6 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
   #clearTransportState(): void {
     this.#transport = null;
     this.#deviceId = null;
-    this.#restartCount = 0;
   }
 
   /**

--- a/app/core/HardwareWallet/contexts/HardwareWalletContext.tsx
+++ b/app/core/HardwareWallet/contexts/HardwareWalletContext.tsx
@@ -20,7 +20,7 @@ export interface HardwareWalletContextValue {
    * @param deviceId - Optional. If not provided, shows device selection for hardware wallets.
    * @returns true if device is ready, false if user cancelled
    */
-  ensureDeviceReady: (deviceId?: string) => Promise<boolean>;
+  ensureDeviceReady: (deviceId?: string | null) => Promise<boolean>;
   /** Set the target wallet type for "Add Hardware Wallet" flows (no account yet). */
   setTargetWalletType: (walletType: HardwareWalletType) => void;
   /** Show a hardware wallet error in the bottom sheet. Use after ensureDeviceReady succeeds. */

--- a/app/core/HardwareWallet/errors/parser.test.ts
+++ b/app/core/HardwareWallet/errors/parser.test.ts
@@ -352,6 +352,16 @@ describe('parseErrorByType', () => {
       expect(result.code).toBe(ErrorCode.ConnectionTimeout);
     });
 
+    it('parses scan timeout message containing "unlocked" as ConnectionTimeout, not AuthenticationDeviceLocked', () => {
+      const error = new Error(
+        'Scan timeout: No Ledger devices found. Make sure your Ledger is unlocked and Bluetooth is enabled on the device.',
+      );
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.ConnectionTimeout);
+    });
+
     it('parses "bluetooth" with "off" message', () => {
       const error = new Error('Bluetooth is off');
 

--- a/app/core/HardwareWallet/errors/parser.ts
+++ b/app/core/HardwareWallet/errors/parser.ts
@@ -222,6 +222,7 @@ function parseErrorByMessage(
       patterns: ['disconnected', 'disconnect', 'connection lost'],
       code: ErrorCode.DeviceDisconnected,
     },
+    { patterns: ['timeout', 'timed out'], code: ErrorCode.ConnectionTimeout },
     {
       patterns: ['locked', 'unlock'],
       code: ErrorCode.AuthenticationDeviceLocked,
@@ -240,7 +241,6 @@ function parseErrorByMessage(
       patterns: ['rejected', 'cancelled', 'refused'],
       code: ErrorCode.UserRejected,
     },
-    { patterns: ['timeout', 'timed out'], code: ErrorCode.ConnectionTimeout },
     {
       patterns: ['not authorized', 'unauthorized'],
       code: ErrorCode.PermissionNearbyDevicesDenied,

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -182,7 +182,7 @@ export const useDeviceConnectionFlow = ({
   );
 
   const ensureDeviceReady = useCallback(
-    async (targetDeviceId?: string): Promise<boolean> => {
+    async (targetDeviceId?: string | null): Promise<boolean> => {
       DevLogger.log(
         '[HardwareWallet] ensureDeviceReady called with deviceId:',
         targetDeviceId,
@@ -196,8 +196,10 @@ export const useDeviceConnectionFlow = ({
       }
 
       const targetType = walletType ?? HardwareWalletType.Ledger;
-      const deviceIdToUse =
-        targetDeviceId === undefined ? undefined : targetDeviceId;
+
+      if (!targetDeviceId) {
+        setters.setDeviceId(null);
+      }
 
       const adapter = resolveOrCreateAdapter(targetType);
 
@@ -212,7 +214,7 @@ export const useDeviceConnectionFlow = ({
       }
 
       return createBlockingPromise(() => {
-        if (!deviceIdToUse) {
+        if (!targetDeviceId) {
           DevLogger.log(
             '[HardwareWallet] No device ID - starting device selection',
           );
@@ -227,7 +229,7 @@ export const useDeviceConnectionFlow = ({
         (async () => {
           try {
             refs.abortControllerRef.current = new AbortController();
-            await tryEnsureReady(adapter, deviceIdToUse);
+            await tryEnsureReady(adapter, targetDeviceId);
           } catch (error) {
             DevLogger.log('[HardwareWallet] ensureDeviceReady error:', error);
             handleError(error);
@@ -239,6 +241,7 @@ export const useDeviceConnectionFlow = ({
     },
     [
       refs,
+      setters,
       handleError,
       walletType,
       updateConnectionState,

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -29,7 +29,7 @@ interface UseDeviceConnectionFlowOptions {
 }
 
 interface UseDeviceConnectionFlowResult {
-  ensureDeviceReady: (targetDeviceId?: string) => Promise<boolean>;
+  ensureDeviceReady: (targetDeviceId?: string | null) => Promise<boolean>;
   connect: (targetDeviceId: string) => Promise<void>;
   retryEnsureDeviceReady: () => Promise<void>;
   closeFlow: () => void;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3386,7 +3386,7 @@
     ],
     "private_key_explanation": "Save it somewhere safe and secret.",
     "private_key_warning": "This is the private key for the current selected account: {{accountName}}. Never disclose this key. Anyone with your private key can fully control your account, including transferring away any of your funds.",
-    "seed_phrase_warning_explanation": 
+    "seed_phrase_warning_explanation":
       "Make sure nobody is looking at your screen. MetaMask Support will never ask for this.",
     "private_key_warning_explanation": "Never disclose this key. Anyone with your private key can fully control your account, including transferring away any of your funds.",
     "reveal_srp_description": "Your Secret Recovery Phrase gives full access to your wallet. Do not share it with anyone.",
@@ -7960,7 +7960,7 @@
       "scanning": "Scanning for devices...",
       "no_devices_found": "No devices found",
       "no_devices_hint": "Make sure your {{device}} is unlocked and Bluetooth is enabled",
-      "tips": "Unlock your {{device}}, open Bluetooth settings, and keep it close to your phone",
+      "tips": "Unlock your {{device}}, enable Bluetooth, and ensure Do Not Disturb is turned off",
       "connect": "Connect",
       "rescan": "Scan Again",
       "unknown_device": "Unknown Device",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Follow up PR containing various improvements regarding HW (and Ledger-specific) connection management. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

no manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ledger BLE disconnect handling and the `ensureDeviceReady` call contract, which can affect connection state transitions and user-facing error UI during hardware-wallet flows. Scope is contained to hardware-wallet connection/error parsing paths and is covered by updated tests.
> 
> **Overview**
> Reduces false-positive Ledger BLE disconnect errors by simplifying `LedgerBluetoothAdapter` transport event handling: disconnect/error events now **only clear the transport reference** (ignoring stale events from replaced transports) and no longer trigger `onDisconnect` or restart-limit logic.
> 
> Updates the hardware-wallet connection flow API so `ensureDeviceReady` accepts `null`/`undefined` and explicitly clears stored `deviceId` when no target is provided, ensuring device selection restarts cleanly.
> 
> Improves error classification by prioritizing *timeout* message parsing ahead of *locked/unlock* matching (so scan-timeout messages mentioning “unlocked” map to `ConnectionTimeout`), and tweaks the device-selection tip copy in `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f91c59395cea15f7481ff330579ef0d08f8454. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->