### PR TITLE
refactor: Balance refresh error logging

### DIFF
--- a/app/components/Views/Wallet/hooks/useBalanceRefresh.test.ts
+++ b/app/components/Views/Wallet/hooks/useBalanceRefresh.test.ts
@@ -33,6 +33,7 @@ jest.mock('../../../../core/Engine', () => ({
 }));
 
 jest.mock('../../../../util/Logger', () => ({
+  log: jest.fn(),
   error: jest.fn(),
 }));
 
@@ -85,7 +86,7 @@ describe('useBalanceRefresh', () => {
     ).toHaveBeenCalledWith(['ETH', 'POL']);
   });
 
-  it('handles individual promise rejections gracefully without logging', async () => {
+  it('does not log errors when individual refresh promises reject', async () => {
     const mockError = new Error('Refresh failed');
     (
       Engine.context.AccountTrackerController.refresh as jest.Mock
@@ -101,7 +102,7 @@ describe('useBalanceRefresh', () => {
     expect(Logger.error).not.toHaveBeenCalled();
   });
 
-  it('handles timeout gracefully', async () => {
+  it('logs timeout as non-error without emitting error events', async () => {
     jest.useFakeTimers();
 
     (
@@ -123,11 +124,29 @@ describe('useBalanceRefresh', () => {
 
     await refreshPromise;
 
-    expect(Logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Balance refresh timed out' }),
-      'Error refreshing balance',
-    );
+    expect(Logger.log).toHaveBeenCalledWith('Balance refresh timed out');
+    expect(Logger.error).not.toHaveBeenCalled();
 
     jest.useRealTimers();
+  });
+
+  it('logs unexpected refresh exceptions as errors', async () => {
+    const unexpectedError = new Error('Unexpected refresh failure');
+    (
+      Engine.context.AccountTrackerController.refresh as jest.Mock
+    ).mockImplementationOnce(() => {
+      throw unexpectedError;
+    });
+
+    const { result } = renderHook(() => useBalanceRefresh());
+
+    await act(async () => {
+      await result.current.refreshBalance();
+    });
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      unexpectedError,
+      'Error refreshing balance',
+    );
   });
 });

--- a/app/components/Views/Wallet/hooks/useBalanceRefresh.ts
+++ b/app/components/Views/Wallet/hooks/useBalanceRefresh.ts
@@ -8,6 +8,10 @@ import {
 } from '../../../../selectors/networkController';
 
 const REFRESH_TIMEOUT_MS = 5000;
+const REFRESH_TIMEOUT_ERROR_MESSAGE = 'Balance refresh timed out';
+
+const isRefreshTimeoutError = (error: unknown): error is Error =>
+  error instanceof Error && error.message === REFRESH_TIMEOUT_ERROR_MESSAGE;
 
 /**
  * Hook to manage balance refresh functionality for the Wallet screen.
@@ -42,12 +46,17 @@ export const useBalanceRefresh = () => {
         ]),
         new Promise((_, reject) =>
           setTimeout(
-            () => reject(new Error('Balance refresh timed out')),
+            () => reject(new Error(REFRESH_TIMEOUT_ERROR_MESSAGE)),
             REFRESH_TIMEOUT_MS,
           ),
         ),
       ]);
     } catch (error) {
+      if (isRefreshTimeoutError(error)) {
+        Logger.log(REFRESH_TIMEOUT_ERROR_MESSAGE);
+        return;
+      }
+
       Logger.error(error as Error, 'Error refreshing balance');
     }
   }, [evmNetworkConfigurations, nativeCurrencies]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Demote balance refresh timeout from error logging to regular logging.

A balance refresh timeout is a stale-data condition, not an application error, and should not trigger Sentry exceptions. This change ensures that only unexpected errors are logged as errors, while timeouts are logged as informational messages.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: Balance refresh error logging

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26881 https://consensyssoftware.atlassian.net/browse/ASSETS-2846

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<p><a href="https://cursor.com/agents/bc-ab44817b-7523-40c9-9a01-680fe5880fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab44817b-7523-40c9-9a01-680fe5880fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->