### PR TITLE
refactor: downgrade token refresh error levels

### DIFF
--- a/app/components/UI/Tokens/util/refreshEvmTokens.test.ts
+++ b/app/components/UI/Tokens/util/refreshEvmTokens.test.ts
@@ -52,6 +52,7 @@ jest.mock('../../../../core/Engine', () => ({
 
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 describe('refreshEvmTokens', () => {
@@ -140,7 +141,7 @@ describe('refreshEvmTokens', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('should log an error if a timeout occurs', async () => {
+  it('should log a non-error message if a timeout occurs', async () => {
     jest.useFakeTimers();
 
     try {
@@ -162,12 +163,10 @@ describe('refreshEvmTokens', () => {
 
       await refreshPromise;
 
-      expect(Logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('timed out'),
-        }),
-        'Error while refreshing tokens',
+      expect(Logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('performEvmTokenRefresh timed out'),
       );
+      expect(Logger.error).not.toHaveBeenCalled();
     } finally {
       jest.runOnlyPendingTimers();
       jest.useRealTimers();

--- a/app/components/UI/Tokens/util/refreshTokens.test.ts
+++ b/app/components/UI/Tokens/util/refreshTokens.test.ts
@@ -47,6 +47,7 @@ jest.mock('../../../../core/Engine', () => ({
 
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 describe('refreshTokens', () => {
@@ -152,12 +153,10 @@ describe('refreshTokens', () => {
 
       await refreshPromise;
 
-      expect(Logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('timed out'),
-        }),
-        'Error while refreshing tokens',
+      expect(Logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('performEvmTokenRefresh timed out'),
       );
+      expect(Logger.error).not.toHaveBeenCalled();
     } finally {
       jest.runOnlyPendingTimers();
       jest.useRealTimers();

--- a/app/components/UI/Tokens/util/tokenRefreshUtils.test.ts
+++ b/app/components/UI/Tokens/util/tokenRefreshUtils.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../../../core/Engine', () => ({
 
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 const fakeNetworkConfigurations = {
@@ -112,7 +113,7 @@ describe('performEvmTokenRefresh', () => {
     ).toHaveBeenCalledWith([]);
   });
 
-  it('logs error when refresh times out', async () => {
+  it('logs timeout as non-error when refresh times out', async () => {
     jest.useFakeTimers();
 
     (
@@ -134,12 +135,10 @@ describe('performEvmTokenRefresh', () => {
     jest.advanceTimersByTime(5000);
     await refreshPromise;
 
-    expect(Logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('timed out'),
-      }),
-      'Error while refreshing tokens',
+    expect(Logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('performEvmTokenRefresh timed out'),
     );
+    expect(Logger.error).not.toHaveBeenCalled();
 
     jest.useRealTimers();
   });

--- a/app/components/UI/Tokens/util/tokenRefreshUtils.ts
+++ b/app/components/UI/Tokens/util/tokenRefreshUtils.ts
@@ -71,8 +71,10 @@ export const performEvmTokenRefresh = async (
       REFRESH_TIMEOUT_MS,
       'performEvmTokenRefresh',
     );
-  } catch (error) {
-    Logger.error(error as Error, 'Error while refreshing tokens');
+  } catch {
+    Logger.log(
+      'performEvmTokenRefresh timed out; balances may be stale until the next refresh',
+    );
   }
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Downgrade token refresh timeout logging from error to log to reduce Sentry noise for non-fatal stale balance conditions.

The timeout during token refresh is not a critical error that crashes the UI; it merely means balances might be temporarily stale. Changing `Logger.error` to `Logger.log` prevents unnecessary error alerts in Sentry while still providing a useful breadcrumb for debugging.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: downgrade token refresh error levels

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26882 https://consensyssoftware.atlassian.net/browse/ASSETS-2847

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<p><a href="https://cursor.com/agents/bc-8170d121-6b92-4fc7-8a8d-6a5a2ad04fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8170d121-6b92-4fc7-8a8d-6a5a2ad04fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->