### PR TITLE
test: fix trending feed e2e flakiness (stability check + re-enable spec)

### DIFF
--- a/tests/api-mocking/mock-responses/trending-api-mocks.ts
+++ b/tests/api-mocking/mock-responses/trending-api-mocks.ts
@@ -44,8 +44,30 @@ const RWA_TOKENS_SEARCH_RESPONSE = {
   ],
 };
 
+/**
+ * Geolocation mock returning a non-restricted country (AR) so the RWA/Stocks
+ * section is visible in CI. useRwaTokens hides Stocks when isGeoRestricted
+ * (missing or ONDO_RESTRICTED_COUNTRIES). useDetectGeolocation can overwrite
+ * fixture state; mocking ensures the app always gets AR if it fetches geo.
+ */
+const TRENDING_GEOLOCATION_MOCKS_GET = [
+  {
+    urlEndpoint: 'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+    responseCode: 200,
+    response: 'AR',
+    priority: 1001,
+  },
+  {
+    urlEndpoint: 'https://on-ramp.api.cx.metamask.io/geolocation',
+    responseCode: 200,
+    response: 'AR',
+    priority: 1001,
+  },
+];
+
 export const TRENDING_API_MOCKS: MockEventsObject = {
   GET: [
+    ...TRENDING_GEOLOCATION_MOCKS_GET,
     {
       urlEndpoint:
         /https:\/\/price\.api\.cx\.metamask\.io\/v3\/historical-prices.*/,

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -497,6 +497,18 @@ class FixtureBuilder {
   }
 
   /**
+   * Sets detected geolocation (e.g. for RWA/Stocks section visibility in Trending).
+   * Use a non-restricted country code so RWA data is shown when not in __DEV__ (e.g. CI).
+   * @param {string} countryCode - ISO country code (e.g. 'AR' for Argentina).
+   * @returns {FixtureBuilder} - The FixtureBuilder instance for method chaining.
+   */
+  withDetectedGeolocation(countryCode: string) {
+    this.fixture.state.fiatOrders = this.fixture.state.fiatOrders ?? {};
+    merge(this.fixture.state.fiatOrders, { detectedGeolocation: countryCode });
+    return this;
+  }
+
+  /**
    * Adds chain switching permission for specific chains.
    * @param {string[]} chainIds - Array of chain IDs to permit (defaults to ['0x1']), other nexts like linea mainnet 0xe708
    * @returns {FixtureBuilder} - The FixtureBuilder instance for method chaining.

--- a/tests/page-objects/Trending/TrendingView.ts
+++ b/tests/page-objects/Trending/TrendingView.ts
@@ -195,6 +195,7 @@ class TrendingView {
 
     await Gestures.tap(quickActionButton, {
       elemDescription: `Tap QuickAction button for ${sectionTitle}`,
+      checkStability: true, // Wait for element to stop moving after horizontal scroll
     });
   }
 
@@ -217,6 +218,7 @@ class TrendingView {
 
     await Gestures.tap(viewAllButton, {
       elemDescription: `Tap View All for ${sectionTitle}`,
+      checkStability: true, // Wait for element to stop moving after scroll
     });
   }
 

--- a/tests/smoke/trending/trending-feed.spec.ts
+++ b/tests/smoke/trending/trending-feed.spec.ts
@@ -28,7 +28,7 @@ describe(SmokeWalletPlatform('Trending Feed View All Navigation'), () => {
     await setupMockEvents(mockServer, TRENDING_API_MOCKS);
   };
 
-  it.skip('Navigate to all sections full views via View All and return to feed', async () => {
+  it('Navigate to all sections full views via View All and return to feed', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().build(),

--- a/tests/smoke/trending/trending-feed.spec.ts
+++ b/tests/smoke/trending/trending-feed.spec.ts
@@ -31,7 +31,7 @@ describe(SmokeWalletPlatform('Trending Feed View All Navigation'), () => {
   it('Navigate to all sections full views via View All and return to feed', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder().withDetectedGeolocation('ES').build(),
+        fixture: new FixtureBuilder().withDetectedGeolocation('AR').build(),
         restartDevice: true,
         testSpecificMock,
       },

--- a/tests/smoke/trending/trending-feed.spec.ts
+++ b/tests/smoke/trending/trending-feed.spec.ts
@@ -31,7 +31,7 @@ describe(SmokeWalletPlatform('Trending Feed View All Navigation'), () => {
   it('Navigate to all sections full views via View All and return to feed', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder().build(),
+        fixture: new FixtureBuilder().withDetectedGeolocation('ES').build(),
         restartDevice: true,
         testSpecificMock,
       },


### PR DESCRIPTION
## **Description**

Reduces flakiness in the trending feed smoke e2e by waiting for elements to be stable before tapping, and re-enables the previously skipped spec.

1. **Reason**: Taps on "Quick Action" and "View All" sometimes ran while elements were still moving after horizontal scroll, causing intermittent failures.
2. **Change**: In `TrendingView` POM, set `checkStability: true` for those taps so the framework waits for the element to stop moving. Re-enable the `Navigate to all sections full views via View All and return to feed` test in `trending-feed.spec.ts`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Trending feed E2E

  Scenario: View All and Quick Action taps succeed after scroll
    Given the app is on the Trending tab with sections loaded
    When user scrolls a section and taps View All or a Quick Action
    Then navigation occurs without "element moving" failures
```

## **Screenshots/Recordings**

N/A (test-only changes).

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR. Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only changes: adds extra mocking/fixture state for geolocation and makes Detox taps wait for UI stability to reduce intermittent scroll-related failures.
> 
> **Overview**
> Reduces Trending feed E2E flakiness by making `TrendingView.tapQuickAction` and `tapViewAll` pass `checkStability: true` to `Gestures.tap`, waiting for elements to stop moving after scrolls.
> 
> Re-enables the previously skipped Trending smoke spec and makes it deterministic in CI by forcing a non-restricted geolocation (`AR`) via both fixture state (`FixtureBuilder.withDetectedGeolocation`) and new geolocation API mocks added to `TRENDING_API_MOCKS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3b1047633da1f329a53b30fefb44b042146748b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->