### PR TITLE
chore: Polish list item styling for consistency

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsListItem.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsListItem.tsx
@@ -135,7 +135,7 @@ const DeFiPositionsListItem: React.FC<DeFiPositionsListItemProps> = ({
       />
 
       <View style={styles.contentWrapper}>
-        <Text variant={TextVariant.BodyLGMedium}>
+        <Text variant={TextVariant.BodyMDMedium}>
           {protocolAggregate.protocolDetails.name}
         </Text>
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>
@@ -145,7 +145,7 @@ const DeFiPositionsListItem: React.FC<DeFiPositionsListItemProps> = ({
 
       <View style={styles.balance}>
         <SensitiveText
-          variant={TextVariant.BodyLGMedium}
+          variant={TextVariant.BodyMDMedium}
           isHidden={privacyMode}
           length={SensitiveTextLength.Medium}
         >

--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
@@ -562,7 +562,7 @@ export const TokenListItemV2 = React.memo(
               <View style={styles.assetNameContainer}>
                 <View style={styles.assetName}>
                   <Text
-                    variant={TextVariant.BodyMDBold}
+                    variant={TextVariant.BodyMDMedium}
                     numberOfLines={1}
                     style={styles.assetNameText}
                   >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Inconsistencies addressed
- DeFi list item title was `20px`
- Token List Item title weight was `bold`

Improvements
- DeFi list item title updated to `16px`, same as all other list items
- Token List Item title weight reduced to `medium`

Changes approved by @mmragkandala 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null - minor UI fix

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: List item typography consistency (DeFi and Token list)

  Scenario: user views DeFi and token list items with updated text styling
    Given the user has DeFi positions and/or tokens in their wallet
    When the user opens the Wallet tab and views the token list or DeFi section
    Then DeFi protocol names and values use BodyMDMedium (16px)
    And token list item titles (asset names) use medium weight instead of bold
    And list content remains readable with consistent hierarchy
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1126" height="791" alt="Screenshot 2026-03-03 at 9 11 01 PM" src="https://github.com/user-attachments/assets/9d649d65-f78e-4fbb-bf88-1ea0322b612e" />


### **After**

<img width="1137" height="811" alt="Screenshot 2026-03-03 at 9 11 13 PM" src="https://github.com/user-attachments/assets/ffe2958d-9273-4980-a8f0-c1fa0e7de693" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes that adjust text variants/weights; no logic, data, or navigation behavior is modified.
> 
> **Overview**
> Aligns wallet list item typography for consistency.
> 
> In `DeFiPositionsListItem`, changes the protocol name and USD value text from `BodyLGMedium` to `BodyMDMedium` (smaller size). In `TokenListItemV2`, changes the token title text from `BodyMDBold` to `BodyMDMedium` (reduced weight).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2c2ffaaf84655b29a9fff8948d4acb73e3b626a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->