### PR TITLE
fix(card): fix date of birth bug on Card onboarding

### DIFF
--- a/app/components/UI/Card/util/validateDateOfBirth.test.ts
+++ b/app/components/UI/Card/util/validateDateOfBirth.test.ts
@@ -216,18 +216,6 @@ describe('formatDateOfBirth', () => {
       expect(result).toBe('2006-01-15');
     });
 
-    it('formats timestamp with different time zones correctly', () => {
-      // Given: date created in local timezone (Jan 15, 2006)
-      const date = new Date(2006, 0, 15);
-      const timestampString = date.getTime().toString();
-
-      // When: formatting timestamp
-      const result = formatDateOfBirth(timestampString);
-
-      // Then: should return the local calendar date
-      expect(result).toBe('2006-01-15');
-    });
-
     it('handles leap year dates correctly', () => {
       // Given: leap year date created in local timezone (Feb 29, 2004)
       const leapYearDate = new Date(2004, 1, 29);

--- a/app/components/UI/Card/util/validateDateOfBirth.test.ts
+++ b/app/components/UI/Card/util/validateDateOfBirth.test.ts
@@ -217,13 +217,14 @@ describe('formatDateOfBirth', () => {
     });
 
     it('formats timestamp with different time zones correctly', () => {
-      // Given: timestamp for a specific UTC date
-      const timestampString = '1137312000000'; // 2006-01-15T00:00:00.000Z
+      // Given: date created in local timezone (Jan 15, 2006)
+      const date = new Date(2006, 0, 15);
+      const timestampString = date.getTime().toString();
 
       // When: formatting timestamp
       const result = formatDateOfBirth(timestampString);
 
-      // Then: should return correct date regardless of timezone
+      // Then: should return the local calendar date
       expect(result).toBe('2006-01-15');
     });
 

--- a/app/components/UI/Card/util/validateDateOfBirth.test.ts
+++ b/app/components/UI/Card/util/validateDateOfBirth.test.ts
@@ -300,8 +300,8 @@ describe('formatDateOfBirth', () => {
 
   describe('when handling edge cases', () => {
     it('formats very old dates correctly', () => {
-      // Given: very old date (year 1900)
-      const oldDate = new Date('1900-01-01T00:00:00.000Z');
+      // Given: very old date (year 1900) created in local timezone
+      const oldDate = new Date(1900, 0, 1);
       const timestampString = oldDate.getTime().toString();
 
       // When: formatting timestamp
@@ -336,8 +336,8 @@ describe('formatDateOfBirth', () => {
     });
 
     it('formats recent dates correctly', () => {
-      // Given: recent date
-      const recentDate = new Date('2023-12-31T23:59:59.999Z');
+      // Given: date created in local timezone (matching PersonalDetails.tsx parsing)
+      const recentDate = new Date(2023, 11, 31);
       const timestampString = recentDate.getTime().toString();
 
       // When: formatting timestamp
@@ -348,8 +348,9 @@ describe('formatDateOfBirth', () => {
     });
 
     it('handles zero timestamp correctly', () => {
-      // Given: zero timestamp (Unix epoch)
-      const timestampString = '0';
+      // Given: epoch date created in local timezone
+      const epochLocal = new Date(1970, 0, 1);
+      const timestampString = epochLocal.getTime().toString();
 
       // When: formatting timestamp
       const result = formatDateOfBirth(timestampString);

--- a/app/components/UI/Card/util/validateDateOfBirth.test.ts
+++ b/app/components/UI/Card/util/validateDateOfBirth.test.ts
@@ -1,8 +1,8 @@
 import { validateDateOfBirth, formatDateOfBirth } from './validateDateOfBirth';
 
 describe('validateDateOfBirth', () => {
-  // Mock Date.now() to ensure consistent test results
-  const mockCurrentDate = new Date('2024-01-15T10:00:00.000Z');
+  // Mock Date.now() to ensure consistent test results (local timezone)
+  const mockCurrentDate = new Date(2024, 0, 15);
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -15,8 +15,8 @@ describe('validateDateOfBirth', () => {
 
   describe('when validating age requirements', () => {
     it('returns true for person who is exactly 18 years old', () => {
-      // Given: date of birth exactly 18 years ago
-      const eighteenYearsAgo = new Date('2006-01-15T10:00:00.000Z');
+      // Given: date of birth exactly 18 years ago (local timezone)
+      const eighteenYearsAgo = new Date(2006, 0, 15);
       const timestamp = eighteenYearsAgo.getTime();
 
       // When: validating date of birth
@@ -27,8 +27,8 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns true for person who is older than 18', () => {
-      // Given: date of birth 25 years ago
-      const twentyFiveYearsAgo = new Date('1999-01-15T10:00:00.000Z');
+      // Given: date of birth 25 years ago (local timezone)
+      const twentyFiveYearsAgo = new Date(1999, 0, 15);
       const timestamp = twentyFiveYearsAgo.getTime();
 
       // When: validating date of birth
@@ -39,8 +39,8 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns false for person who is younger than 18', () => {
-      // Given: date of birth 17 years ago
-      const seventeenYearsAgo = new Date('2007-01-15T10:00:00.000Z');
+      // Given: date of birth 17 years ago (local timezone)
+      const seventeenYearsAgo = new Date(2007, 0, 15);
       const timestamp = seventeenYearsAgo.getTime();
 
       // When: validating date of birth
@@ -51,8 +51,8 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns false for person who turns 18 tomorrow', () => {
-      // Given: date of birth that makes person turn 18 tomorrow
-      const almostEighteen = new Date('2006-01-16T10:00:00.000Z');
+      // Given: date of birth that makes person turn 18 tomorrow (local timezone)
+      const almostEighteen = new Date(2006, 0, 16);
       const timestamp = almostEighteen.getTime();
 
       // When: validating date of birth
@@ -63,8 +63,8 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns true for person who turned 18 yesterday', () => {
-      // Given: date of birth that made person turn 18 yesterday
-      const justTurnedEighteen = new Date('2006-01-14T10:00:00.000Z');
+      // Given: date of birth that made person turn 18 yesterday (local timezone)
+      const justTurnedEighteen = new Date(2006, 0, 14);
       const timestamp = justTurnedEighteen.getTime();
 
       // When: validating date of birth
@@ -77,12 +77,12 @@ describe('validateDateOfBirth', () => {
 
   describe('when handling birthday edge cases', () => {
     it('correctly handles leap year birthdays', () => {
-      // Given: current date is March 1, 2024 (leap year)
-      const leapYearDate = new Date('2024-03-01T10:00:00.000Z');
+      // Given: current date is March 1, 2024 (leap year, local timezone)
+      const leapYearDate = new Date(2024, 2, 1);
       jest.setSystemTime(leapYearDate);
 
-      // And: person born on Feb 29, 2006 (18 years ago, leap year)
-      const leapYearBirthday = new Date('2006-02-29T10:00:00.000Z');
+      // And: person born on Feb 29, 2006 (18 years ago, leap year, local timezone)
+      const leapYearBirthday = new Date(2006, 1, 29);
       const timestamp = leapYearBirthday.getTime();
 
       // When: validating date of birth
@@ -93,12 +93,12 @@ describe('validateDateOfBirth', () => {
     });
 
     it('handles month boundary correctly when birthday has not occurred', () => {
-      // Given: current date is January 10, 2024
-      const currentDate = new Date('2024-01-10T10:00:00.000Z');
+      // Given: current date is January 10, 2024 (local timezone)
+      const currentDate = new Date(2024, 0, 10);
       jest.setSystemTime(currentDate);
 
-      // And: person born on January 15, 2006 (birthday later this month)
-      const birthdayLaterThisMonth = new Date('2006-01-15T10:00:00.000Z');
+      // And: person born on January 15, 2006 (birthday later this month, local timezone)
+      const birthdayLaterThisMonth = new Date(2006, 0, 15);
       const timestamp = birthdayLaterThisMonth.getTime();
 
       // When: validating date of birth
@@ -109,12 +109,12 @@ describe('validateDateOfBirth', () => {
     });
 
     it('handles year boundary correctly', () => {
-      // Given: current date is January 1, 2024
-      const newYearDate = new Date('2024-01-01T10:00:00.000Z');
+      // Given: current date is January 1, 2024 (local timezone)
+      const newYearDate = new Date(2024, 0, 1);
       jest.setSystemTime(newYearDate);
 
-      // And: person born on December 31, 2005 (18 years and 1 day old)
-      const lastYearBirthday = new Date('2005-12-31T10:00:00.000Z');
+      // And: person born on December 31, 2005 (18 years and 1 day old, local timezone)
+      const lastYearBirthday = new Date(2005, 11, 31);
       const timestamp = lastYearBirthday.getTime();
 
       // When: validating date of birth
@@ -127,9 +127,9 @@ describe('validateDateOfBirth', () => {
 
   describe('when handling dates before 1970 (negative timestamps)', () => {
     it('returns true for person born in 1959 (negative timestamp)', () => {
-      // Given: date of birth on September 16, 1959
-      const dateIn1959 = new Date('1959-09-16T00:00:00.000Z');
-      const timestamp = dateIn1959.getTime(); // This will be negative
+      // Given: date of birth on September 16, 1959 (local timezone)
+      const dateIn1959 = new Date(1959, 8, 16);
+      const timestamp = dateIn1959.getTime(); // This will be negative in some timezones
 
       // When: validating date of birth
       const result = validateDateOfBirth(timestamp);
@@ -139,9 +139,9 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns true for person born in 1950', () => {
-      // Given: date of birth in 1950
-      const dateIn1950 = new Date('1950-06-15T00:00:00.000Z');
-      const timestamp = dateIn1950.getTime(); // This will be negative
+      // Given: date of birth in 1950 (local timezone)
+      const dateIn1950 = new Date(1950, 5, 15);
+      const timestamp = dateIn1950.getTime(); // This will be negative in some timezones
 
       // When: validating date of birth
       const result = validateDateOfBirth(timestamp);
@@ -151,9 +151,9 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns true for person born on January 1, 1900', () => {
-      // Given: very old date of birth
-      const veryOldDate = new Date('1900-01-01T00:00:00.000Z');
-      const timestamp = veryOldDate.getTime(); // This will be very negative
+      // Given: very old date of birth (local timezone)
+      const veryOldDate = new Date(1900, 0, 1);
+      const timestamp = veryOldDate.getTime(); // This will be very negative in some timezones
 
       // When: validating date of birth
       const result = validateDateOfBirth(timestamp);
@@ -189,8 +189,8 @@ describe('validateDateOfBirth', () => {
     });
 
     it('returns false for future date', () => {
-      // Given: date in the future
-      const futureDate = new Date('2025-01-15T10:00:00.000Z');
+      // Given: date in the future (local timezone)
+      const futureDate = new Date(2025, 0, 15);
       const timestamp = futureDate.getTime();
 
       // When: validating future date
@@ -205,8 +205,8 @@ describe('validateDateOfBirth', () => {
 describe('formatDateOfBirth', () => {
   describe('when formatting valid timestamps', () => {
     it('formats valid timestamp string to YYYY-MM-DD', () => {
-      // Given: valid timestamp string
-      const date = new Date('2006-01-15T10:30:45.123Z');
+      // Given: date created in local timezone (Jan 15, 2006)
+      const date = new Date(2006, 0, 15);
       const timestampString = date.getTime().toString();
 
       // When: formatting timestamp
@@ -229,8 +229,8 @@ describe('formatDateOfBirth', () => {
     });
 
     it('handles leap year dates correctly', () => {
-      // Given: leap year date timestamp
-      const leapYearDate = new Date('2004-02-29T12:00:00.000Z');
+      // Given: leap year date created in local timezone (Feb 29, 2004)
+      const leapYearDate = new Date(2004, 1, 29);
       const timestampString = leapYearDate.getTime().toString();
 
       // When: formatting timestamp

--- a/app/components/UI/Card/util/validateDateOfBirth.ts
+++ b/app/components/UI/Card/util/validateDateOfBirth.ts
@@ -50,5 +50,9 @@ export const formatDateOfBirth = (timestamp: string): string => {
   if (isNaN(date.getTime())) {
     return '';
   }
-  return date.toISOString().split('T')[0]; // Returns YYYY-MM-DD format
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a date-of-birth (DOB) bug on Card onboarding where the formatted date could display the wrong calendar day for users in timezones behind UTC.

**Why**: `formatDateOfBirth` used `date.toISOString().split('T')[0]`, which formats the date in UTC. For users in negative UTC offsets (e.g. Americas), a local midnight date (e.g. Jan 1) becomes the previous day in UTC (Dec 31), so the displayed DOB could be off by one day and cause validation or display issues.

**What changed**:
- **`formatDateOfBirth`** (`validateDateOfBirth.ts`): Now builds the `YYYY-MM-DD` string from local date components (`getFullYear()`, `getMonth()`, `getDate()`) instead of the UTC-based ISO string, so the displayed date matches the user's selected calendar date regardless of timezone.
- **Tests** (`validateDateOfBirth.test.ts`): Updated `formatDateOfBirth` tests to construct dates in local timezone (e.g. `new Date(1900, 0, 1)`, `new Date(2023, 11, 31)`) instead of ISO strings, aligning with how the app (e.g. PersonalDetails) parses dates and making assertions timezone-independent.

## **Changelog**

CHANGELOG entry: Fixed date of birth formatting on Card onboarding so the displayed date matches the user's selected date in all timezones.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card onboarding date of birth

  Scenario: DOB displays correct calendar date in negative UTC offset
    Given the user is in a timezone behind UTC (e.g. US Pacific)
    When the user selects a date of birth (e.g. Jan 1, 1990) on Card onboarding
    Then the displayed/formatted DOB shows the same calendar date (Jan 1, 1990)
    And validation and submission use the correct date

  Scenario: DOB displays correct calendar date in positive UTC offset
    Given the user is in a timezone ahead of UTC
    When the user selects a date of birth on Card onboarding
    Then the displayed/formatted DOB shows the selected calendar date
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots or recordings -->

### **Before**

<!-- DOB could show previous day in timezones behind UTC -->

### **After**

<!-- DOB shows the selected calendar date in all timezones -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DOB formatting logic used during card onboarding, which impacts user-submitted personal data and could affect validation/submission if any downstream expects the prior UTC-derived day. Scope is small and covered by updated unit tests, but touches a sensitive onboarding path.
> 
> **Overview**
> Fixes an off-by-one-day DOB display/submission issue for users in timezones behind UTC by changing `formatDateOfBirth` to build `YYYY-MM-DD` from *local* date components (`getFullYear`/`getMonth`/`getDate`) instead of `toISOString()`.
> 
> Updates `validateDateOfBirth`/`formatDateOfBirth` tests to create dates in local time (and removes the explicit timezone-invariance test), making assertions consistent across environments and aligned with how the UI constructs DOB dates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b4335760fd2a6d1c47a2440596ad29c83c927ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->