### PR TITLE
test: fix browser network selection behaviour

### DIFF
--- a/app/components/Approvals/SwitchChainApproval/SwitchChainApproval.test.tsx
+++ b/app/components/Approvals/SwitchChainApproval/SwitchChainApproval.test.tsx
@@ -38,15 +38,6 @@ jest.mock('../../hooks/useNetworksByNamespace/useNetworksByNamespace', () => ({
   },
 }));
 
-const mockSelectNetwork = jest.fn();
-jest.mock('../../hooks/useNetworkSelection/useNetworkSelection', () => ({
-  useNetworkSelection: () => ({
-    selectCustomNetwork: jest.fn(),
-    selectPopularNetwork: jest.fn(),
-    selectNetwork: mockSelectNetwork,
-  }),
-}));
-
 jest.mock('../../Views/confirmations/hooks/useApprovalRequest');
 jest.mock('../../../actions/onboardNetwork');
 
@@ -154,24 +145,6 @@ describe('SwitchChainApproval', () => {
     const wrapper = shallow(<SwitchChainApproval />);
     wrapper.find('SwitchCustomNetwork').simulate('confirm');
 
-    expect(networkSwitched).toHaveBeenCalledTimes(1);
-    expect(networkSwitched).toHaveBeenCalledWith({
-      networkUrl: URL_MOCK,
-      networkStatus: true,
-    });
-  });
-
-  it('calls selectNetwork when confirm is pressed', () => {
-    mockApprovalRequest({
-      type: ApprovalTypes.SWITCH_ETHEREUM_CHAIN,
-      requestData: mockApprovalRequestData,
-    });
-
-    const wrapper = shallow(<SwitchChainApproval />);
-    wrapper.find('SwitchCustomNetwork').simulate('confirm');
-
-    expect(mockSelectNetwork).toHaveBeenCalledTimes(1);
-    expect(mockSelectNetwork).toHaveBeenCalledWith('0x1');
     expect(networkSwitched).toHaveBeenCalledTimes(1);
     expect(networkSwitched).toHaveBeenCalledWith({
       networkUrl: URL_MOCK,

--- a/app/components/Approvals/SwitchChainApproval/SwitchChainApproval.test.tsx
+++ b/app/components/Approvals/SwitchChainApproval/SwitchChainApproval.test.tsx
@@ -18,26 +18,6 @@ jest.mock('../../../selectors/networkController', () => ({
   }),
 }));
 
-jest.mock('../../hooks/useNetworksByNamespace/useNetworksByNamespace', () => ({
-  useNetworksByNamespace: () => ({
-    networks: [
-      {
-        id: 'eip155:1',
-        name: 'Ethereum',
-        caipChainId: 'eip155:1',
-        isSelected: false,
-        imageSource:
-          'https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880',
-        networkTypeOrRpcUrl: 'https://mock-url.com',
-      },
-    ],
-  }),
-  NetworkType: {
-    Popular: 'popular',
-    Custom: 'custom',
-  },
-}));
-
 jest.mock('../../Views/confirmations/hooks/useApprovalRequest');
 jest.mock('../../../actions/onboardNetwork');
 
@@ -121,22 +101,6 @@ describe('SwitchChainApproval', () => {
   });
 
   it('calls networkSwitched action when confirm is pressed', () => {
-    mockApprovalRequest({
-      type: ApprovalTypes.SWITCH_ETHEREUM_CHAIN,
-      requestData: mockApprovalRequestData,
-    });
-
-    const wrapper = shallow(<SwitchChainApproval />);
-    wrapper.find('SwitchCustomNetwork').simulate('confirm');
-
-    expect(networkSwitched).toHaveBeenCalledTimes(1);
-    expect(networkSwitched).toHaveBeenCalledWith({
-      networkUrl: URL_MOCK,
-      networkStatus: true,
-    });
-  });
-
-  it('sets token network filter', () => {
     mockApprovalRequest({
       type: ApprovalTypes.SWITCH_ETHEREUM_CHAIN,
       requestData: mockApprovalRequestData,

--- a/app/components/Approvals/SwitchChainApproval/SwitchChainApproval.tsx
+++ b/app/components/Approvals/SwitchChainApproval/SwitchChainApproval.tsx
@@ -6,11 +6,6 @@ import SwitchCustomNetwork from '../../UI/SwitchCustomNetwork';
 import { networkSwitched } from '../../../actions/onboardNetwork';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  NetworkType,
-  useNetworksByNamespace,
-} from '../../hooks/useNetworksByNamespace/useNetworksByNamespace';
-import { useNetworkSelection } from '../../hooks/useNetworkSelection/useNetworkSelection';
-import {
   Caip25CaveatType,
   Caip25EndowmentPermissionName,
   getPermittedEthChainIds,
@@ -26,12 +21,6 @@ const SwitchChainApproval = () => {
   } = useApprovalRequest();
 
   const dispatch = useDispatch();
-  const { networks } = useNetworksByNamespace({
-    networkType: NetworkType.Popular,
-  });
-  const { selectNetwork } = useNetworkSelection({
-    networks,
-  });
 
   const evmNetworkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
@@ -52,16 +41,13 @@ const SwitchChainApproval = () => {
   const onConfirm = useCallback(() => {
     defaultOnConfirm();
 
-    // If remove global network selector is enabled should set network filter
-    selectNetwork(chainId);
-
     dispatch(
       networkSwitched({
         networkUrl: approvalRequest?.requestData?.metadata?.rpcUrl,
         networkStatus: true,
       }),
     );
-  }, [approvalRequest, defaultOnConfirm, dispatch, selectNetwork, chainId]);
+  }, [approvalRequest, defaultOnConfirm, dispatch]);
 
   if (
     approvalRequest?.requestData?.diff?.permissionDiffMap?.[

--- a/tests/smoke/networks/network-manager2.spec.ts
+++ b/tests/smoke/networks/network-manager2.spec.ts
@@ -286,7 +286,6 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
         await TabBarComponent.tapWallet();
 
         // Verify Ethereum is still the active network (preservation)
-        // Okay this fails because the network manager invokes and updates network, fek
         await NetworkManager.checkBaseControlBarText(
           NetworkToCaipChainId.ETHEREUM,
         );

--- a/tests/smoke/networks/network-manager2.spec.ts
+++ b/tests/smoke/networks/network-manager2.spec.ts
@@ -221,7 +221,7 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
     );
   });
 
-  it.skip('should preserve existing enabled networks when adding a network via dapp', async () => {
+  it('should preserve existing enabled networks when adding a network via dapp', async () => {
     await withFixtures(
       {
         dapps: [
@@ -286,6 +286,7 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
         await TabBarComponent.tapWallet();
 
         // Verify Ethereum is still the active network (preservation)
+        // Okay this fails because the network manager invokes and updates network, fek
         await NetworkManager.checkBaseControlBarText(
           NetworkToCaipChainId.ETHEREUM,
         );


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

E2E tests were failing since we removed the old GNS flag and started testing the logic.
From the test understanding, we DO NOT want to change networks when you select a network in a dapp. In that case we should not update the networkEnabledMap that controls networks across the app.

If this behaviour is incorrect, we can revert this change, but also update the test to reflect the new behaviour

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: fix browser network selection behaviour

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2553

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `SwitchChainApproval` side effects on confirm by no longer selecting/switching the app’s active network, which can affect network state across the wallet. Also re-enables an E2E test that may surface additional network-manager behavior regressions.
> 
> **Overview**
> `SwitchChainApproval` no longer triggers a global network selection on confirm; it now only calls the default approval confirm and dispatches `networkSwitched`.
> 
> Unit tests were simplified to drop mocks/assertions around `useNetworkSelection`/token network filtering, and the previously skipped smoke test for preserving enabled networks when adding a network via a dapp is now enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 213b446970341d16e186c1ed1873e68355cd9395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->