### PR TITLE
feat: add Tempo Mainnet network logo

### DIFF
--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -388,6 +388,7 @@ export const NETWORK_CHAIN_ID: {
   readonly ROOTSTOCK: '0x1e';
   readonly ROOTSTOCK_TESTNET: '0x1f';
   readonly TEMPO_TESTNET: '0xa5bf';
+  readonly TEMPO_MAINNET: '0x1079';
   readonly CHILIZ: '0x15b38';
 } & typeof CHAIN_IDS = {
   FLARE_MAINNET: '0xe',
@@ -432,6 +433,7 @@ export const NETWORK_CHAIN_ID: {
   ROOTSTOCK: '0x1e',
   ROOTSTOCK_TESTNET: '0x1f',
   TEMPO_TESTNET: '0xa5bf',
+  TEMPO_MAINNET: '0x1079',
   CHILIZ: '0x15b38',
   ...CHAIN_IDS,
 };
@@ -481,5 +483,6 @@ export const CustomNetworkImgMapping: Record<Hex, string> = {
   [NETWORK_CHAIN_ID.ROOTSTOCK]: require('../../images/rootstock.png'),
   [NETWORK_CHAIN_ID.ROOTSTOCK_TESTNET]: require('../../images/rootstock.png'),
   [NETWORK_CHAIN_ID.TEMPO_TESTNET]: require('../../images/tempo.png'),
+  [NETWORK_CHAIN_ID.TEMPO_MAINNET]: require('../../images/tempo.png'),
   [NETWORK_CHAIN_ID.CHILIZ]: require('../../images/chiliz.png'),
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add network logo for Tempo mainnet

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-143?atlOrigin=eyJpIjoiZWU5NTZkOTkxNmZmNDg5YTgzNWVjZDVmYzkyMTNjNmUiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

- Add Tempo network manually with:
Name: `Tempo`
RPC: `https://tempo-mainnet.drpc.org`
Currency: `USD`
ChainId: `4217`

- Observe network logo is displayed correctly.
- Tempo has no native token, which the plan is to hide it in an upcoming support.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/2d76413c-ce68-4488-8997-1e3783c3bbd1" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/b694212e-4d7f-41f7-ba42-0666a674af37" />

(worth noting that the native token will disappear as part as upcoming Tempo support)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new constant and image mapping entry for Tempo Mainnet without changing any network logic or existing mappings.
> 
> **Overview**
> Adds support for displaying a logo for **Tempo Mainnet** by introducing a new `NETWORK_CHAIN_ID.TEMPO_MAINNET` (`0x1079`) and wiring it into `CustomNetworkImgMapping` to use the existing `tempo.png` asset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 674e343ff5506133847ea4db5e1e081df7487f7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->