### PR TITLE
Revert "feat: cp-7.68.0 MUSD-392 update mUSD conversion flow copy (#26840)"

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -57,9 +57,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       ),
     ).toBeOnTheScreen();
     expect(
-      getByText(
-        /Convert your stablecoins to mUSD.*receive up to a \d+% annual bonus that you can claim daily\./,
-      ),
+      getByText(/Convert your stablecoins to mUSD.*receive up to a \d+% bonus/),
     ).toBeOnTheScreen();
     expect(
       getByText(strings('earn.musd_conversion.education.primary_button')),
@@ -391,7 +389,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Assert
     const description = getByText(
-      /Convert your stablecoins to mUSD.*receive up to a \d+% annual bonus that you can claim daily\./,
+      /Convert your stablecoins to mUSD.*receive up to a \d+% bonus/,
     );
     expect(description).toBeOnTheScreen();
     expect(description.props.children[0]).toContain(`${MUSD_CONVERSION_APY}%`);

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.styles.ts
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.styles.ts
@@ -26,6 +26,9 @@ const styleSheet = () =>
       alignItems: 'center',
       gap: 8,
     },
+    termsApply: {
+      textDecorationLine: 'underline',
+    },
     balanceCardContainer: {
       paddingVertical: 12,
     },

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.test.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.test.tsx
@@ -15,6 +15,8 @@ import {
   selectMusdConversionStatuses,
 } from '../../selectors/musdConversionStatus';
 import { MUSD_CONVERSION_APY } from '../../constants/musd';
+import AppConstants from '../../../../../core/AppConstants';
+import { Linking } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../types/musd.types';
@@ -60,10 +62,18 @@ jest.mock('../../../../hooks/useStyles', () => ({
       listContainer: {},
       emptyContainer: {},
       listHeaderContainer: {},
+      termsApply: {},
       balanceCardHeader: {},
     },
     theme: { colors: {} },
   })),
+}));
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  openURL: jest.fn(),
+  canOpenURL: jest.fn(),
+  getInitialURL: jest.fn(),
 }));
 
 const mockSelectMusdQuickConvertEnabledFlag =
@@ -301,7 +311,7 @@ describe('MusdQuickConvertView', () => {
       expect(
         getByText(
           strings('earn.musd_conversion.quick_convert.title', {
-            percentage: MUSD_CONVERSION_APY,
+            apy: MUSD_CONVERSION_APY,
           }),
         ),
       ).toBeOnTheScreen();
@@ -479,6 +489,26 @@ describe('MusdQuickConvertView', () => {
         fireEvent.press(editButton);
       });
       expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('terms of use', () => {
+    it('opens terms URL when terms apply text is pressed', () => {
+      const { getByText } = renderWithProvider(<MusdQuickConvertView />, {
+        state: initialRootState,
+      });
+
+      const termsApplyText = getByText(
+        strings('earn.musd_conversion.education.terms_apply'),
+      );
+
+      act(() => {
+        fireEvent.press(termsApplyText);
+      });
+
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE,
+      );
     });
   });
 });

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/components/MusdBalanceCard/MusdBalanceCard.test.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/components/MusdBalanceCard/MusdBalanceCard.test.tsx
@@ -54,7 +54,7 @@ describe('MusdBalanceCard', () => {
       expect(getByText(MUSD_TOKEN.symbol)).toBeOnTheScreen();
     });
 
-    it('displays percentage bonus text from localization', () => {
+    it('displays percentage boost text from localization', () => {
       const { getByText } = renderWithProvider(
         <MusdBalanceCard chainId={CHAIN_IDS.MAINNET} balance="$100.00" />,
         {
@@ -62,7 +62,7 @@ describe('MusdBalanceCard', () => {
         },
       );
 
-      expect(getByText('3% bonus')).toBeOnTheScreen();
+      expect(getByText('3% boost')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/components/MusdBalanceCard/MusdBalanceCard.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/components/MusdBalanceCard/MusdBalanceCard.tsx
@@ -71,7 +71,7 @@ const MusdBalanceCard = ({ chainId, balance }: MusdBalanceCardProps) => {
 
       <View style={styles.right}>
         <Text variant={TextVariant.BodyMDMedium} color={TextColor.Success}>
-          {strings('earn.musd_conversion.percentage_bonus', {
+          {strings('earn.musd_conversion.percentage_boost', {
             percentage: MUSD_CONVERSION_APY,
           })}
         </Text>

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/index.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { View, SectionList } from 'react-native';
+import { View, SectionList, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -25,6 +25,7 @@ import styleSheet from './MusdQuickConvertView.styles';
 import Tag from '../../../../../component-library/components/Tags/Tag';
 import { TagProps } from '../../../../../component-library/components/Tags/Tag/Tag.types';
 import { MUSD_CONVERSION_APY } from '../../constants/musd';
+import AppConstants from '../../../../../core/AppConstants';
 import MusdBalanceCard from './components/MusdBalanceCard';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../types/musd.types';
 import Logger from '../../../../../util/Logger';
@@ -237,6 +238,10 @@ const MusdQuickConvertView = () => {
     </View>
   );
 
+  const handleTermsOfUsePressed = useCallback(() => {
+    Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);
+  }, []);
+
   // If feature flags are not enabled, don't render
   if (!isQuickConvertEnabled) {
     return null;
@@ -253,13 +258,21 @@ const MusdQuickConvertView = () => {
         <View style={styles.headerTextContainer}>
           <Text variant={TextVariant.HeadingLG}>
             {strings('earn.musd_conversion.quick_convert.title', {
-              percentage: MUSD_CONVERSION_APY,
+              apy: MUSD_CONVERSION_APY,
             })}
           </Text>
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
             {strings('earn.musd_conversion.quick_convert.subtitle', {
-              percentage: MUSD_CONVERSION_APY,
-            })}
+              apy: MUSD_CONVERSION_APY,
+            })}{' '}
+            <Text
+              variant={TextVariant.BodySM}
+              color={TextColor.Alternative}
+              style={styles.termsApply}
+              onPress={handleTermsOfUsePressed}
+            >
+              {strings('earn.musd_conversion.education.terms_apply')}
+            </Text>
           </Text>
         </View>
         {hasMusdBalanceOnAnyChain && (

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
@@ -131,7 +131,7 @@ describe('MusdConversionAssetOverviewCta', () => {
       ).toBeOnTheScreen();
       expect(
         getByText(
-          `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% annual bonus that you can claim daily.`,
+          `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
         ),
       ).toBeOnTheScreen();
     });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -103,7 +103,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     ).toBeOnTheScreen();
     expect(
       getByText(
-        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% annual bonus that you can claim daily.`,
+        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
       ),
     ).toBeOnTheScreen();
   });
@@ -474,7 +474,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders CTA with correct bonus title text', () => {
+  it('renders CTA with correct boost title text', () => {
     // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
@@ -507,7 +507,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders CTA with correct bonus description text', () => {
+  it('renders CTA with correct boost description text', () => {
     // Arrange
     const state = initialStateWallet()
       .withMinimalMultichainAssets()
@@ -537,7 +537,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     // Assert
     expect(
       getByText(
-        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% annual bonus that you can claim daily.`,
+        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
       ),
     ).toBeOnTheScreen();
   });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
@@ -114,12 +114,12 @@ const MusdConversionAssetOverviewCta = ({
       {/* Text content in the center */}
       <View style={styles.textContainer}>
         <Text variant={TextVariant.BodySMMedium} style={styles.title}>
-          {strings('earn.musd_conversion.bonus_title', {
+          {strings('earn.musd_conversion.boost_title', {
             percentage: MUSD_CONVERSION_APY,
           })}
         </Text>
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>
-          {strings('earn.musd_conversion.bonus_description', {
+          {strings('earn.musd_conversion.boost_description', {
             percentage: MUSD_CONVERSION_APY,
           })}
         </Text>

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "mUSD kaufen",
       "get_musd": "mUSD erhalten",
-      "bonus_title": "Erhalten Sie {{percentage}} % auf Ihre Stablecoins",
-      "bonus_description": "Konvertieren Sie Ihre Stablecoins in mUSD und sichern Sie sich einen Bonus von bis zu {{percentage}} %.",
+      "boost_title": "Erhalten Sie {{percentage}} % auf Ihre Stablecoins",
+      "boost_description": "Konvertieren Sie Ihre Stablecoins in mUSD und sichern Sie sich einen Bonus von bis zu {{percentage}} %.",
       "powered_by_relay": "Unterstützt von Relay"
     },
     "bonus_claim": {

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Αγοράστε mUSD",
       "get_musd": "Αποκτήστε mUSD",
-      "bonus_title": "Λάβετε {{percentage}}% σε stablecoins",
-      "bonus_description": "Μετατρέψτε τα stablecoins σε mUSD και λάβετε μπόνους έως και {{percentage}}%.",
+      "boost_title": "Λάβετε {{percentage}}% σε stablecoins",
+      "boost_description": "Μετατρέψτε τα stablecoins σε mUSD και λάβετε μπόνους έως και {{percentage}}%.",
       "powered_by_relay": "Υποστηρίζεται από το Relay"
     },
     "bonus_claim": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6003,6 +6003,7 @@
       "ok": "OK",
       "continue": "Continue",
       "convert_and_get_percentage_bonus": "Convert and get {{percentage}}%",
+      "no_boost": "No boost",
       "your_musd": "Your mUSD",
       "balance_breakdown_title": "Your mUSD balances by network",
       "balance_amount": "{{amount}} mUSD",
@@ -6025,15 +6026,15 @@
       },
       "education": {
         "heading": "GET {{percentage}}% ON\nSTABLECOINS",
-        "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% annual bonus that you can claim daily.",
+        "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% bonus.",
         "terms_apply": "Terms apply.",
         "primary_button": "Get Started",
         "secondary_button": "Not now"
       },
       "buy_musd": "Buy mUSD",
       "get_musd": "Get mUSD",
-      "bonus_title": "Get {{percentage}}% on your stablecoins",
-      "bonus_description": "Convert your stablecoins to mUSD and receive up to a {{percentage}}% annual bonus that you can claim daily.",
+      "boost_title": "Get {{percentage}}% on your stablecoins",
+      "boost_description": "Convert your stablecoins to mUSD and receive up to a {{percentage}}% bonus.",
       "powered_by_relay": "Powered by Relay",
       "earn_rewards_when": "Earn rewards when",
       "you_convert_to": "you convert to",
@@ -6044,14 +6045,14 @@
       "tooltip_title": "Earn yield with mUSD",
       "tooltip_content": "Convert your USDC, USDT, or DAI for mUSD, MetaMask's dollar-backed stablecoin. Earn {{apy}} yield on every dollar you hold.",
       "quick_convert": {
-        "title": "Convert and get {{percentage}}% bonus",
-        "subtitle": "Convert your stablecoins to mUSD and earn up to a {{percentage}}% annualized bonus that you can claim daily.",
+        "title": "Convert and get {{apy}}%",
+        "subtitle": "Convert your stablecoins to mUSD and receive up to a {{apy}}% bonus.",
         "inline_failed_message": "Conversion failed. Try again.",
         "confirmation": {
           "title": "Convert max"
         }
       },
-      "percentage_bonus": "{{percentage}}% bonus",
+      "percentage_boost": "{{percentage}}% boost",
       "rate": "Rate"
     },
     "bonus_claim": {

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Comprar mUSD",
       "get_musd": "Obtener USDC",
-      "bonus_title": "Obtén un {{percentage}} % en tus monedas estables",
-      "bonus_description": "Convierte tus monedas estables a mUSD y recibe un bono de hasta el {{percentage}} %.",
+      "boost_title": "Obtén un {{percentage}} % en tus monedas estables",
+      "boost_description": "Convierte tus monedas estables a mUSD y recibe un bono de hasta el {{percentage}} %.",
       "powered_by_relay": "Desarrollado por Relay"
     },
     "bonus_claim": {

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Acheter des mUSD",
       "get_musd": "Obtenir des mUSD",
-      "bonus_title": "Obtenez {{percentage}} % sur vos stablecoins",
-      "bonus_description": "Convertissez vos stablecoins en mUSD et recevez jusqu’à {{percentage}} % de bonus.",
+      "boost_title": "Obtenez {{percentage}} % sur vos stablecoins",
+      "boost_description": "Convertissez vos stablecoins en mUSD et recevez jusqu’à {{percentage}} % de bonus.",
       "powered_by_relay": "Propulsé par Relay"
     },
     "bonus_claim": {

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "mUSD खरीदें",
       "get_musd": "mUSD प्राप्त करें",
-      "bonus_title": "अपने स्टेबलकॉइंस पर {{percentage}}% पाएं",
-      "bonus_description": "अपने स्टेबलकॉइंस को mUSD में कन्वर्ट करें और {{percentage}}% तक का बोनस प्राप्त करें।",
+      "boost_title": "अपने स्टेबलकॉइंस पर {{percentage}}% पाएं",
+      "boost_description": "अपने स्टेबलकॉइंस को mUSD में कन्वर्ट करें और {{percentage}}% तक का बोनस प्राप्त करें।",
       "powered_by_relay": "Relay द्वारा संचालित"
     },
     "bonus_claim": {

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Beli mUSD",
       "get_musd": "Dapatkan mUSD",
-      "bonus_title": "Dapatkan {{percentage}}% pada stablecoin",
-      "bonus_description": "Konversikan stablecoin ke mUSD dan dapatkan bonus hingga {{percentage}}%.",
+      "boost_title": "Dapatkan {{percentage}}% pada stablecoin",
+      "boost_description": "Konversikan stablecoin ke mUSD dan dapatkan bonus hingga {{percentage}}%.",
       "powered_by_relay": "Didukung oleh Relay"
     },
     "bonus_claim": {

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "mUSDを購入",
       "get_musd": "mUSDを入手",
-      "bonus_title": "ステーブルコインで{{percentage}}%をゲット",
-      "bonus_description": "お持ちのステーブルコインをmUSDに換えて、最大{{percentage}}%のボーナスを受け取りましょう。",
+      "boost_title": "ステーブルコインで{{percentage}}%をゲット",
+      "boost_description": "お持ちのステーブルコインをmUSDに換えて、最大{{percentage}}%のボーナスを受け取りましょう。",
       "powered_by_relay": "Powered by Relay"
     },
     "bonus_claim": {

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "mUSD 구매",
       "get_musd": "mUSD 받기",
-      "bonus_title": "스테이블코인으로 {{percentage}}% 받기",
-      "bonus_description": "스테이블코인을 mUSD로 전환하고 최대 {{percentage}}%의 보너스를 받으세요.",
+      "boost_title": "스테이블코인으로 {{percentage}}% 받기",
+      "boost_description": "스테이블코인을 mUSD로 전환하고 최대 {{percentage}}%의 보너스를 받으세요.",
       "powered_by_relay": "제공자: Relay"
     },
     "bonus_claim": {

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Comprar mUSD",
       "get_musd": "Obter mUSD",
-      "bonus_title": "Obtenha {{percentage}}% sobre suas stablecoins",
-      "bonus_description": "Converta suas stablecoins em mUSD e receba um bônus de até {{percentage}}%.",
+      "boost_title": "Obtenha {{percentage}}% sobre suas stablecoins",
+      "boost_description": "Converta suas stablecoins em mUSD e receba um bônus de até {{percentage}}%.",
       "powered_by_relay": "Desenvolvido por Relay"
     },
     "bonus_claim": {

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Купить mUSD",
       "get_musd": "Получить mUSD",
-      "bonus_title": "Получите {{percentage}}% на ваши стейблкоины",
-      "bonus_description": "Конвертируйте свои стейблкоины в mUSD и получите бонус до {{percentage}}%.",
+      "boost_title": "Получите {{percentage}}% на ваши стейблкоины",
+      "boost_description": "Конвертируйте свои стейблкоины в mUSD и получите бонус до {{percentage}}%.",
       "powered_by_relay": "При поддержке Relay"
     },
     "bonus_claim": {

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Bumili ng mUSD",
       "get_musd": "Kumuha ng mUSD",
-      "bonus_title": "Makakakuha ng {{percentage}}% sa mga stablecoin mo",
-      "bonus_description": "I-convert ang mga stablecoin mo sa mUSD at makakatanggap ng hanggang {{percentage}}% na bonus.",
+      "boost_title": "Makakakuha ng {{percentage}}% sa mga stablecoin mo",
+      "boost_description": "I-convert ang mga stablecoin mo sa mUSD at makakatanggap ng hanggang {{percentage}}% na bonus.",
       "powered_by_relay": "Pinapagana ng Relay"
     },
     "bonus_claim": {

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "mUSD al",
       "get_musd": "mUSD kazan",
-      "bonus_title": "Stabil kripto paranızda %{{percentage}} bonus kazanın",
-      "bonus_description": "Stabil kripto paranızı mUSD'ye dönüştürün ve %{{percentage}} oranına varan bonus kazanın.",
+      "boost_title": "Stabil kripto paranızda %{{percentage}} bonus kazanın",
+      "boost_description": "Stabil kripto paranızı mUSD'ye dönüştürün ve %{{percentage}} oranına varan bonus kazanın.",
       "powered_by_relay": "Destekleyen Relay"
     },
     "bonus_claim": {

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "Mua mUSD",
       "get_musd": "Nhận mUSD",
-      "bonus_title": "Nhận {{percentage}}% cho đồng ổn định của bạn",
-      "bonus_description": "Chuyển đổi đồng ổn định sang mUSD và nhận thưởng lên đến {{percentage}}%.",
+      "boost_title": "Nhận {{percentage}}% cho đồng ổn định của bạn",
+      "boost_description": "Chuyển đổi đồng ổn định sang mUSD và nhận thưởng lên đến {{percentage}}%.",
       "powered_by_relay": "Cung cấp bởi Relay"
     },
     "bonus_claim": {

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -5931,8 +5931,8 @@
       },
       "buy_musd": "购买 mUSD",
       "get_musd": "获取 mUSD",
-      "bonus_title": "获得稳定币的 {{percentage}}% 奖励",
-      "bonus_description": "将您的稳定币兑换为 mUSD，即可获得高达 {{percentage}}% 的奖励。",
+      "boost_title": "获得稳定币的 {{percentage}}% 奖励",
+      "boost_description": "将您的稳定币兑换为 mUSD，即可获得高达 {{percentage}}% 的奖励。",
       "powered_by_relay": "由 Relay 提供技术支持"
     },
     "bonus_claim": {


### PR DESCRIPTION
This reverts commit 8ada535ba51a6177866a0737901f945e679e952c.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Reverts changes from https://github.com/MetaMask/metamask-mobile/pull/26840
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: reverting commit 8ada535ba51a6177866a0737901f945e679e952c

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly localization/copy changes plus a simple `Linking.openURL` handler for Terms in the quick convert header; main risk is broken i18n keys or an incorrect URL constant.
> 
> **Overview**
> Reverts recent mUSD conversion copy updates by switching CTA and balance-card strings from *bonus* to `boost` keys, and simplifying education/CTA descriptions to remove the “annual bonus claim daily” wording.
> 
> Updates the quick convert header localization to use `apy` placeholders (instead of `percentage`) and adds an underlined, tappable “Terms apply” link that opens `AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE` via `Linking`.
> 
> Adjusts/extends unit tests and i18n JSON across languages to match the reverted keys/text (including new `en` key `no_boost`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9ab6c72e66f8e14e2357d2fb0a2caf4b16258d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->