### PR TITLE
fix: normalize EVM ERC-20 icon URL casing for swap deeplinks

### DIFF
--- a/app/components/UI/Bridge/hooks/useAssetMetadata/utils.test.ts
+++ b/app/components/UI/Bridge/hooks/useAssetMetadata/utils.test.ts
@@ -76,7 +76,7 @@ describe('asset-utils', () => {
       expect(getAssetImageUrl(assetId, 'eip155:1')).toBe(expectedUrl);
     });
 
-    it('should lowercase EVM erc20 asset references in the image URL', () => {
+    it('lowercases EVM erc20 asset references in the image URL', () => {
       const assetId =
         'eip155:1/erc20:0xFeDC5f4a6c38211c1338aa411018DFAf26612c08' as CaipAssetType;
       const expectedUrl = `${STATIC_METAMASK_BASE_URL}/api/v2/tokenIcons/assets/eip155/1/erc20/0xfedc5f4a6c38211c1338aa411018dfaf26612c08.png`;

--- a/app/components/UI/Bridge/hooks/useAssetMetadata/utils.test.ts
+++ b/app/components/UI/Bridge/hooks/useAssetMetadata/utils.test.ts
@@ -76,6 +76,14 @@ describe('asset-utils', () => {
       expect(getAssetImageUrl(assetId, 'eip155:1')).toBe(expectedUrl);
     });
 
+    it('should lowercase EVM erc20 asset references in the image URL', () => {
+      const assetId =
+        'eip155:1/erc20:0xFeDC5f4a6c38211c1338aa411018DFAf26612c08' as CaipAssetType;
+      const expectedUrl = `${STATIC_METAMASK_BASE_URL}/api/v2/tokenIcons/assets/eip155/1/erc20/0xfedc5f4a6c38211c1338aa411018dfaf26612c08.png`;
+
+      expect(getAssetImageUrl(assetId, 'eip155:1')).toBe(expectedUrl);
+    });
+
     it('should return correct image URL for non-hex CAIP asset ID', () => {
       const assetId = `${SolScope.Mainnet}/token:aBCD` as CaipAssetType;
       const expectedUrl = `${STATIC_METAMASK_BASE_URL}/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token/aBCD.png`;
@@ -123,7 +131,7 @@ describe('asset-utils', () => {
         symbol: 'TEST',
         decimals: 18,
         image:
-          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3Afb0bB76683eCb4225F9DBc91f998713C3b01.png',
+          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3afb0bb76683ecb4225f9dbc91f998713c3b01.png',
         assetId: mockAssetId,
         address: mockAddress,
         chainId: mockHexChainId,
@@ -184,7 +192,7 @@ describe('asset-utils', () => {
         decimals: 18,
         name: 'Test Token',
         image:
-          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3Afb0bB76683eCb4225F9DBc91f998713C3b01.png',
+          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3afb0bb76683ecb4225f9dbc91f998713c3b01.png',
         assetId: mockAssetId,
         address: mockAddress,
         chainId: mockHexChainId,
@@ -215,7 +223,7 @@ describe('asset-utils', () => {
         decimals: 18,
         name: 'Test Token',
         image:
-          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3Afb0bB76683eCb4225F9DBc91f998713C3b01.png',
+          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3afb0bb76683ecb4225f9dbc91f998713c3b01.png',
         assetId: mockAssetId,
         address: mockAddress,
         chainId: mockHexChainId,
@@ -260,7 +268,7 @@ describe('asset-utils', () => {
         decimals: 18,
         name: 'Test Token',
         image:
-          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3Afb0bB76683eCb4225F9DBc91f998713C3b01.png',
+          'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xbd3afb0bb76683ecb4225f9dbc91f998713c3b01.png',
         assetId: mockAssetId,
         address: mockAddress,
         chainId: mockHexChainId,

--- a/app/components/UI/Bridge/hooks/useAssetMetadata/utils.ts
+++ b/app/components/UI/Bridge/hooks/useAssetMetadata/utils.ts
@@ -23,6 +23,29 @@ import { TokenRwaData } from '@metamask/assets-controllers';
 const TOKEN_API_V3_BASE_URL = 'https://tokens.api.cx.metamask.io/v3';
 const STATIC_METAMASK_BASE_URL = 'https://static.cx.metamask.io';
 
+const normalizeAssetIdForImageUrl = (
+  assetId: CaipAssetType,
+  chainId: CaipChainId,
+): CaipAssetType => {
+  if (isNonEvmChainId(chainId)) {
+    return assetId;
+  }
+
+  const {
+    chainId: parsedChainId,
+    assetNamespace,
+    assetReference,
+  } = parseCaipAssetType(assetId);
+
+  if (assetNamespace !== 'erc20') {
+    return assetId;
+  }
+
+  return CaipAssetTypeStruct.create(
+    `${parsedChainId}/${assetNamespace}:${assetReference.toLowerCase()}`,
+  );
+};
+
 export const toAssetId = (
   address: Hex | CaipAssetType | string,
   chainId: CaipChainId,
@@ -59,7 +82,12 @@ export const getAssetImageUrl = (
     return undefined;
   }
 
-  return `${STATIC_METAMASK_BASE_URL}/api/v2/tokenIcons/assets/${assetIdInCaip
+  const normalizedAssetId = normalizeAssetIdForImageUrl(
+    assetIdInCaip,
+    chainIdInCaip,
+  );
+
+  return `${STATIC_METAMASK_BASE_URL}/api/v2/tokenIcons/assets/${normalizedAssetId
     .split(':')
     .join('/')}.png`;
 };


### PR DESCRIPTION
## **Description**

This PR fixes SWAPS-3854 by normalizing EVM `erc20` token icon URLs to lowercase in the shared Bridge asset metadata URL builder.

Reason for change:
- Swap deeplink token icons can fail to load when a checksummed token address is used in the icon URL path.

Solution:
- Normalize only EVM `erc20` `assetReference` to lowercase inside `getAssetImageUrl`.
- Keep `toAssetId` behavior and Token API `assetIds` request format unchanged.
- Preserve non-EVM and non-`erc20` behavior.

## **Changelog**

CHANGELOG entry: Fixed a bug where some swap deeplink token icons did not load because ERC-20 icon URLs used checksummed addresses.

## **Related issues**

Fixes: SWAPS-3854

## **Manual testing steps**

```gherkin
Feature: Swap deeplink token icon rendering

  Scenario: user opens a swap deeplink with checksummed ERC-20 addresses
    Given the app receives a /swap deeplink with CAIP-19 from/to ERC-20 assets
    And at least one token address in the deeplink is checksummed (mixed case)

    When the deeplink opens the unified swap/bridge view
    Then the token icon URL is generated with a lowercase ERC-20 address
    And the token icon loads successfully from static.cx.metamask.io
```

## **Screenshots/Recordings**

### **Before**

N/A (logic and unit-test change)

### **After**

N/A (logic and unit-test change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how ERC-20 icon URLs are constructed (lowercasing the address in the static icon path) and updates unit tests; token API requests and non-EVM behavior are unchanged.
> 
> **Overview**
> Fixes swap/bridge token icons failing to load when CAIP-19 ERC-20 asset references are checksummed (mixed case) by **lowercasing the ERC-20 `assetReference`** when building the static icon URL in `getAssetImageUrl`.
> 
> Adds a small normalization helper that applies only to *EVM `erc20`* assets (leaving non-EVM chains and non-`erc20` namespaces untouched) and updates/extends tests to assert the new lowercase URL behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84c0cac260850aebae5d649cddd34cf39e756ffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->