### PR TITLE
fix(predict): prediction market positions not updating when switching accounts cp-7.68.0

### DIFF
--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../../../../component-library/components/Texts/Text/Text.types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
+import { selectSelectedAccountGroupId } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
 import { usePredictClaim } from '../../hooks/usePredictClaim';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
@@ -79,6 +80,8 @@ const PredictPositionsHeader = forwardRef<
     isLoading: isBalanceLoading,
     error: balanceError,
   } = usePredictBalance();
+  // Subscribe to account group changes so the component re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const selectedAddress = evmAccount?.address ?? '0x0';
   const { isDepositPending } = usePredictDeposit();

--- a/app/components/UI/Predict/hooks/usePredictActivity.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.test.ts
@@ -27,6 +27,18 @@ jest.mock('./usePredictNetworkManagement', () => ({
   }),
 }));
 
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupId: jest.fn(() => 'mock-account-group-id'),
+  }),
+);
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: Infinity } },

--- a/app/components/UI/Predict/hooks/usePredictActivity.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.ts
@@ -1,16 +1,19 @@
 import { useEffect } from 'react';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import Logger from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import type { PredictActivity } from '../types';
 import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { predictQueries } from '../queries';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { ensureError } from '../utils/predictErrorHandler';
 
 export function usePredictActivity(): UseQueryResult<PredictActivity[], Error> {
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
-
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const address = evmAccount?.address ?? '0x0';
 

--- a/app/components/UI/Predict/hooks/usePredictBalance.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.test.ts
@@ -37,6 +37,18 @@ jest.mock('./usePredictNetworkManagement', () => ({
   }),
 }));
 
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupId: jest.fn(() => 'mock-account-group-id'),
+  }),
+);
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/app/components/UI/Predict/hooks/usePredictBalance.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.ts
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { predictQueries } from '../queries';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 
 export function usePredictBalance(): UseQueryResult<number, Error> {
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
-
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const address = evmAccount?.address ?? '0x0';
 

--- a/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
@@ -79,6 +79,13 @@ jest.mock('../utils/accounts', () => ({
   }),
 }));
 
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupId: jest.fn(() => 'mock-account-group-id'),
+  }),
+);
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: (selector: () => unknown) => selector(),

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -15,6 +15,7 @@ import { selectPredictPendingDepositByAddress } from '../selectors/predictContro
 import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 import {
   PredictEventValues,
   PredictTradeStatus,
@@ -32,6 +33,8 @@ export const usePredictDeposit = () => {
   const { toastRef } = useContext(ToastContext);
   const navigation = useNavigation();
 
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const selectedInternalAccountAddress = evmAccount?.address ?? '0x0';
 

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -22,6 +22,18 @@ jest.mock('../utils/accounts', () => ({
     mockGetEvmAccountFromSelectedAccountGroup(),
 }));
 
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupId: jest.fn(() => 'mock-account-group-id'),
+  }),
+);
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
 const mockGetPositions = jest.fn<
   Promise<PredictPosition[]>,
   [{ address: string }]

--- a/app/components/UI/Predict/hooks/usePredictPositions.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.ts
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import type { PredictPosition } from '../types';
 import { usePredictNetworkManagement } from './usePredictNetworkManagement';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { predictQueries } from '../queries';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 
 const OPTIMISTIC_POLL_INTERVAL = 2_000;
 
@@ -36,6 +38,8 @@ export function usePredictPositions(options: UsePredictPositionsOptions = {}) {
   const { enabled = true, refetchInterval, claimable, marketId } = options;
 
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const address = evmAccount?.address ?? '0x0';
   const queryClient = useQueryClient();

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
@@ -69,6 +69,18 @@ jest.mock('../utils/accounts', () => ({
   })),
 }));
 
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupId: jest.fn(() => 'mock-account-group-id'),
+  }),
+);
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
 jest.mock('../../../../store', () => ({
   store: {
     getState: jest.fn(() => ({})),

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@metamask/design-system-react-native/dist/components/te
 import { useNavigation } from '@react-navigation/native';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
@@ -19,6 +20,7 @@ import type { PredictTransactionStatusChangedPayload } from '../controllers/Pred
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { formatPrice } from '../utils/format';
 import { predictQueries } from '../queries';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 import type { Hex } from '@metamask/utils';
 import { usePredictClaim } from './usePredictClaim';
 import { usePredictDeposit } from './usePredictDeposit';
@@ -139,6 +141,8 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
   const navigation = useNavigation();
   const theme = useAppThemeFromContext();
 
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const selectedAddress =
     getEvmAccountFromSelectedAccountGroup()?.address ?? '0x0';
   const normalizedSelectedAddress = selectedAddress.toLowerCase();

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -1,4 +1,5 @@
 import { useFocusEffect } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Logger from '../../../../util/Logger';
@@ -7,6 +8,7 @@ import { UnrealizedPnL } from '../types';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { ensureError } from '../utils/predictErrorHandler';
+import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { usePredictPositions } from './usePredictPositions';
 
 export interface UseUnrealizedPnLOptions {
@@ -50,6 +52,8 @@ export const useUnrealizedPnL = (
   const [error, setError] = useState<string | null>(null);
   const isInitialMount = useRef(true);
 
+  // Subscribe to account group changes so the hook re-renders when the user switches accounts
+  useSelector(selectSelectedAccountGroupId);
   const evmAccount = getEvmAccountFromSelectedAccountGroup();
   const selectedInternalAccountAddress = evmAccount?.address ?? '0x0';
 


### PR DESCRIPTION
## **Description**

When switching accounts, prediction market positions (and balance, activity, P&L) did not update — the UI kept showing data from the previous account until a manual pull-to-refresh.

**Root cause:** Predict hooks use `getEvmAccountFromSelectedAccountGroup()` — a plain imperative function that reads from `Engine.context.AccountTreeController` but never triggers React re-renders. Combined with `useMemo`-ed tab elements in `WalletTokensTabView` (whose deps don't include account state), the Predict components never re-render when the account changes, so the React Query cache key stays pinned to the old address.

**Fix:** Added `useSelector(selectSelectedAccountGroupId)` to all 7 affected hooks/components. This subscribes each to Redux account-group changes, triggering re-renders that cause `getEvmAccountFromSelectedAccountGroup()` to re-evaluate with the new account and produce a fresh React Query cache key.

## **Changelog**

CHANGELOG entry: Fixed prediction market positions not updating when switching accounts

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26719

## **Manual testing steps**

```gherkin
Feature: Prediction market positions update on account switch

  Scenario: user switches from an account with positions to another account
    Given user is on the home screen with an account that has prediction market positions
    And the prediction market positions are displayed

    When user switches to a different account
    Then the prediction market positions update to reflect the new account's data
    And if the new account has no positions, trending markets are shown instead

  Scenario: user switches accounts and pulls to refresh
    Given user is on the home screen after switching accounts

    When user swipes down to refresh
    Then the data shown matches the currently selected account
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://www.loom.com/share/130885ec91ae41ecbfc6a2bbfa9e272d

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding Redux subscriptions to trigger re-renders on account-group changes, plus test-mock updates; no business logic or transaction flows are altered.
> 
> **Overview**
> Fixes stale Predict data after switching accounts by making affected Predict hooks/components re-render on account-group changes via `useSelector(selectSelectedAccountGroupId)`, ensuring React Query keys update to the new address.
> 
> Updates unit tests for these hooks to mock `selectSelectedAccountGroupId` (and `useSelector`) so the new subscription doesn’t break existing test setups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6211c088abf80ddeadab7423cf1fe9f6bbd6df5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->