### PR TITLE
fix(TMCU-508): trigger NFT detection on homepage focus

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -13,8 +13,23 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: jest.fn(),
     }),
+    useFocusEffect: (callback: () => void) => {
+      const React = jest.requireActual('react');
+      React.useEffect(callback, [callback]);
+    },
   };
 });
+
+const mockDetectNfts = jest.fn().mockResolvedValue(undefined);
+const mockAbortDetection = jest.fn();
+
+jest.mock('../../hooks/useNftDetection', () => ({
+  useNftDetection: () => ({
+    detectNfts: mockDetectNfts,
+    abortDetection: mockAbortDetection,
+    chainIdsToDetectNftsFor: [],
+  }),
+}));
 
 // Mock feature flags - enable all sections
 jest.mock('../../UI/Perps', () => ({

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
@@ -159,6 +159,24 @@ describe('NFTsSection', () => {
     expect(mockDetectNfts).toHaveBeenCalledTimes(1);
   });
 
+  it('calls abortDetection on unmount', () => {
+    const { unmount } = renderWithProvider(<NFTsSection />);
+
+    unmount();
+
+    expect(mockAbortDetection).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles rejected detectNfts gracefully', async () => {
+    mockDetectNfts.mockRejectedValueOnce(new Error('Aborted'));
+
+    renderWithProvider(<NFTsSection />);
+
+    await act(async () => undefined);
+
+    expect(screen.getByText('NFTs')).toBeOnTheScreen();
+  });
+
   it('exposes refresh function via ref that calls useNftRefresh.onRefresh', async () => {
     const ref = createRef<SectionRefreshHandle>();
 

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
@@ -167,7 +167,7 @@ describe('NFTsSection', () => {
     expect(mockAbortDetection).toHaveBeenCalledTimes(1);
   });
 
-  it('handles rejected detectNfts gracefully', async () => {
+  it('renders without error when detectNfts rejects', async () => {
     mockDetectNfts.mockRejectedValueOnce(new Error('Aborted'));
 
     renderWithProvider(<NFTsSection />);

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
@@ -8,6 +8,8 @@ import { SectionRefreshHandle } from '../../types';
 
 const mockNavigate = jest.fn();
 const mockOnRefresh = jest.fn().mockResolvedValue(undefined);
+const mockDetectNfts = jest.fn().mockResolvedValue(undefined);
+const mockAbortDetection = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -16,11 +18,23 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: mockNavigate,
     }),
+    useFocusEffect: (callback: () => void) => {
+      const React = jest.requireActual('react');
+      React.useEffect(callback, [callback]);
+    },
   };
 });
 
 jest.mock('../../../../../reducers/collectibles', () => ({
   isNftFetchingProgressSelector: jest.fn(() => false),
+}));
+
+jest.mock('../../../../hooks/useNftDetection', () => ({
+  useNftDetection: () => ({
+    detectNfts: mockDetectNfts,
+    abortDetection: mockAbortDetection,
+    chainIdsToDetectNftsFor: [],
+  }),
 }));
 
 jest.mock('../../../../UI/NftGrid/useNftRefresh', () => ({
@@ -137,6 +151,12 @@ describe('NFTsSection', () => {
     // NFTs beyond the limit (indices 6-7) should NOT be displayed
     expect(screen.queryByText('NFT 6')).not.toBeOnTheScreen();
     expect(screen.queryByText('NFT 7')).not.toBeOnTheScreen();
+  });
+
+  it('triggers NFT detection on focus', () => {
+    renderWithProvider(<NFTsSection />);
+
+    expect(mockDetectNfts).toHaveBeenCalledTimes(1);
   });
 
   it('exposes refresh function via ref that calls useNftRefresh.onRefresh', async () => {

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -64,7 +64,9 @@ const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   useFocusEffect(
     useCallback(() => {
-      detectNfts();
+      detectNfts().catch(() => {
+        // AbortError is expected when detection is cancelled on blur
+      });
 
       return () => {
         abortDetection();

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
@@ -19,6 +19,7 @@ import { useOwnedNfts } from './hooks';
 import NftGridItem from '../../../../UI/NftGrid/NftGridItem';
 import { useNftRefresh } from '../../../../UI/NftGrid/useNftRefresh';
 import { CollectiblesEmptyState } from '../../../../UI/CollectiblesEmptyState/CollectiblesEmptyState';
+import { useNftDetection } from '../../../../hooks/useNftDetection';
 import { SectionRefreshHandle } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
 import { isNftFetchingProgressSelector } from '../../../../../reducers/collectibles';
@@ -59,6 +60,17 @@ const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const hasNfts = ownedNfts.length > 0;
   const isNftFetchingProgress = useSelector(isNftFetchingProgressSelector);
   const { onRefresh } = useNftRefresh();
+  const { detectNfts, abortDetection } = useNftDetection();
+
+  useFocusEffect(
+    useCallback(() => {
+      detectNfts();
+
+      return () => {
+        abortDetection();
+      };
+    }, [detectNfts, abortDetection]),
+  );
 
   const title = strings('homepage.sections.nfts');
 

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { View } from 'react-native';
@@ -61,18 +62,30 @@ const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
   const isNftFetchingProgress = useSelector(isNftFetchingProgressSelector);
   const { onRefresh } = useNftRefresh();
   const { detectNfts, abortDetection } = useNftDetection();
+  const hasLoadedOnceRef = useRef(false);
+  const isSilentDetectionRef = useRef(false);
 
   useFocusEffect(
     useCallback(() => {
-      detectNfts().catch(() => {
-        // AbortError is expected when detection is cancelled on blur
-      });
+      isSilentDetectionRef.current = hasLoadedOnceRef.current;
+
+      detectNfts()
+        .catch(() => {
+          // AbortError is expected when detection is cancelled on blur
+        })
+        .finally(() => {
+          hasLoadedOnceRef.current = true;
+          isSilentDetectionRef.current = false;
+        });
 
       return () => {
         abortDetection();
+        isSilentDetectionRef.current = false;
       };
     }, [detectNfts, abortDetection]),
   );
+
+  const showSkeleton = isNftFetchingProgress && !isSilentDetectionRef.current;
 
   const title = strings('homepage.sections.nfts');
 
@@ -142,7 +155,7 @@ const NFTsSection = forwardRef<SectionRefreshHandle>((_, ref) => {
             ))}
           </Box>
         </SectionRow>
-      ) : isNftFetchingProgress ? (
+      ) : showSkeleton ? (
         <SectionRow>
           <NftSkeletonRow />
         </SectionRow>


### PR DESCRIPTION
## **Description**

When the homepage was redesigned from tabs to sections, the `detectNfts` call that ran when the NFTs tab was visited was lost. This PR ports over the missing behavior by using `useFocusEffect` in `NFTsSection` to trigger `detectNfts` (via the existing `useNftDetection` hook) whenever the Homepage screen gains focus. Detection is aborted on blur/unmount via the effect's cleanup function.

## **Changelog**

CHANGELOG entry: Fixed missing NFT detection on homepage focus, restoring auto-detection when the user navigates to the homepage

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-508

## **Manual testing steps**

```gherkin
Feature: NFT detection on homepage focus

  Scenario: user navigates to homepage and NFTs are detected
    Given user has NFT-owning accounts configured
    And the homepage is not currently focused

    When user navigates to the homepage
    Then NFT detection is triggered automatically for configured chains

  Scenario: user navigates away from homepage and detection is aborted
    Given user is on the homepage and NFT detection is in progress

    When user navigates away from the homepage
    Then the in-flight NFT detection is aborted
```

## **Screenshots/Recordings**

N/A — no UI changes, behavioral fix only.

### **Before**

NFT detection was not triggered when navigating to the homepage.

### **After**

NFT detection runs on homepage focus and is aborted on blur.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds focus-driven side effects that start/cancel NFT detection, which can impact network activity and loading UI timing when navigating between screens.
> 
> **Overview**
> Restores missing NFT auto-detection on the redesigned Homepage by running `useNftDetection().detectNfts()` from `NFTsSection` via `useFocusEffect`, and cancelling via `abortDetection()` on blur/unmount.
> 
> Adjusts loading UI to avoid showing the skeleton during *silent* re-detection after the first successful load, and adds/updates tests to mock `useFocusEffect` and assert detection/abort behavior (including rejected detection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 500bdab4415f213d88b2e999596fcfcf80e54f8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->