### PR TITLE
fix(input): simplify iOS placeholder lineHeight fix

### DIFF
--- a/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
@@ -25,13 +25,14 @@ const styleSheet = (params: { theme: Theme; vars: InputStyleSheetVars }) => {
     isDisabled,
     isStateStylesDisabled,
     isFocused,
-    value = '',
+    value,
     placeholder,
   } = vars;
 
-  const hasPlaceholder = placeholder != null && placeholder !== '';
-  const isPlaceholderVisible =
-    hasPlaceholder && (value === '' || value == null);
+  // Only apply placeholder-mode styling for controlled empty inputs.
+  // For uncontrolled inputs (value is undefined), we avoid forcing lineHeight
+  // since style vars cannot track typing state transitions.
+  const isPlaceholderVisible = !!placeholder && value === '';
 
   const stateObj = isStateStylesDisabled
     ? {
@@ -56,6 +57,11 @@ const styleSheet = (params: { theme: Theme; vars: InputStyleSheetVars }) => {
         fontWeight: theme.typography[textVariant].fontWeight,
         fontSize: theme.typography[textVariant].fontSize,
         letterSpacing: theme.typography[textVariant].letterSpacing,
+        // iOS-only workaround: when a placeholder is visible, the native
+        // TextInput renders it misaligned (vertically offset) due to how iOS
+        // applies lineHeight to placeholder text. Setting lineHeight: 0 resets
+        // this. We guard with Platform.OS === 'ios' because lineHeight: 0 on
+        // Android collapses the text area, making typed content invisible.
         ...(Platform.OS === 'ios' && isPlaceholderVisible && { lineHeight: 0 }),
       },
       style,

--- a/app/component-library/components/Form/TextField/foundation/Input/Input.test.tsx
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.test.tsx
@@ -104,4 +104,13 @@ describe('Input', () => {
 
     expect(onChangeText).toHaveBeenCalledWith('a');
   });
+
+  it('does not force controlled mode when value is omitted', () => {
+    const { getByTestId } = renderWithTheme(<Input placeholder="Enter text" />);
+
+    const input = getByTestId(INPUT_TEST_ID);
+
+    expect(input.props.value).toBeUndefined();
+    expect(getStyleProp(input.props.style, 'lineHeight')).toBeUndefined();
+  });
 });

--- a/app/component-library/components/Form/TextField/foundation/Input/Input.tsx
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.tsx
@@ -36,7 +36,6 @@ const Input = React.forwardRef<TextInput, InputProps>(
       autoFocus = true,
       value,
       placeholder,
-      onChangeText,
       ...props
     },
     ref,
@@ -49,7 +48,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
       isStateStylesDisabled,
       isDisabled,
       isFocused,
-      value: value ?? '',
+      value,
       placeholder,
     });
 
@@ -79,8 +78,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
         placeholderTextColor={theme.colors.text.alternative}
         {...props}
         placeholder={placeholder}
-        value={value}
-        onChangeText={onChangeText}
+        {...(value !== undefined ? { value } : {})}
         style={styles.base}
         editable={!isDisabled && !isReadonly}
         autoFocus={autoFocus}

--- a/app/component-library/components/Form/TextField/foundation/Input/Input.types.ts
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.types.ts
@@ -28,6 +28,12 @@ export interface InputProps extends Omit<TextInputProps, 'editable'> {
    * @default false
    */
   isStateStylesDisabled?: boolean;
+  /**
+   * The value of the text input. Defaults to empty string when not provided,
+   * ensuring the iOS placeholder alignment workaround (lineHeight: 0) can
+   * safely determine whether the placeholder is visible without internal state.
+   */
+  value?: string;
 }
 
 /**


### PR DESCRIPTION
## **Description**

The original PR (#26835) introduced controlled/uncontrolled state tracking (`isControlledRef`, `internalValue`, `useEffect`) and an `onChangeText` interception solely to compute `isPlaceholderVisible` — all to gate a single `lineHeight: 0` style on iOS.

This PR simplifies that approach:

1. **Remove state machinery** — `internalValue`, `isControlledRef`, the `useEffect` for `defaultValue` sync, and `onChangeTextHandler` are all removed. The component returns to its original uncontrolled-friendly shape.
2. **Pass `value` and `placeholder` as style vars** — already available as props, so no extra state is needed.
3. **Compute `isPlaceholderVisible` in the stylesheet** — `!!placeholder && !value`, keeping the logic co-located with where it's used.
4. **Guard with `Platform.OS === 'ios'`** — `lineHeight: 0` is applied only on iOS, preventing the Android text-disappearing regression reported in the Slack thread (text content became invisible while typing because `lineHeight: 0` collapsed the text area on Android).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #26835 (addresses Android regression introduced by that approach)

## **Manual testing steps**

```gherkin
Feature: TextField Input placeholder alignment

  Scenario: user views a text field with placeholder on iOS
    Given the app is running on an iOS device
    When a TextField is rendered with a placeholder and no value
    Then the placeholder text is vertically aligned correctly

  Scenario: user types into a text field on iOS
    Given a TextField with a placeholder is visible
    When the user types text into the field
    Then the typed text is visible and not hidden

  Scenario: user types into a text field on Android
    Given a TextField with a placeholder is visible on Android
    When the user types text into the field
    Then the typed text remains visible and does not disappear
```

## **Screenshots/Recordings**

### **After**

https://github.com/user-attachments/assets/39b301a3-0c5b-475d-83f3-bbdd78ec2c7a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `Input` controlled/uncontrolled behavior by no longer defaulting `value` to `''` and conditionally omitting the `value` prop, which could affect consumers relying on the previous always-controlled semantics. Styling logic also changes for placeholder visibility, so cross-platform rendering should be spot-checked (especially iOS placeholder and Android typing).
> 
> **Overview**
> Simplifies the iOS placeholder alignment workaround by deriving `isPlaceholderVisible` in `Input.styles.ts` from `placeholder` + `value === ''`, and applying `lineHeight: 0` *only* on iOS.
> 
> Updates `Input.tsx` to stop coercing `value` to `''` and to only pass the `value` prop when it’s defined (preserving uncontrolled inputs), with tests added to ensure omitting `value` doesn’t force controlled mode or apply the placeholder `lineHeight` style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53f40d458a60565ee12a20350842fa76b1aae133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->