### PR TITLE
test: update evm-provider-events e2e tests for BIP-44 compatibility

### DIFF
--- a/tests/smoke/wallet/connections/evm-provider-events.spec.ts
+++ b/tests/smoke/wallet/connections/evm-provider-events.spec.ts
@@ -8,6 +8,7 @@ import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import TestDApp from '../../../page-objects/Browser/TestDApp';
 import Browser from '../../../page-objects/Browser/BrowserView';
 import ConnectedAccountsModal from '../../../page-objects/Browser/ConnectedAccountsModal';
+import NetworkConnectMultiSelector from '../../../page-objects/Browser/NetworkConnectMultiSelector';
 import { loginToApp } from '../../../flows/wallet.flow';
 import { navigateToBrowserView } from '../../../flows/browser.flow';
 import {
@@ -17,7 +18,8 @@ import {
 import { DappVariants } from '../../../framework/Constants';
 import ToastModal from '../../../page-objects/wallet/ToastModal';
 import AccountListBottomSheet from '../../../page-objects/wallet/AccountListBottomSheet';
-import NetworkListModal from '../../../page-objects/Network/NetworkListModal';
+import TabBarComponent from '../../../page-objects/wallet/TabBarComponent';
+import WalletView from '../../../page-objects/wallet/WalletView';
 
 describe(SmokeWalletPlatform('EVM Provider Events'), () => {
   beforeAll(async () => {
@@ -108,13 +110,14 @@ describe(SmokeWalletPlatform('EVM Provider Events'), () => {
           );
         }
 
-        await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
-        await Assertions.expectElementToBeVisible(ConnectedAccountsModal.title);
-        await Assertions.expectElementToNotBeVisible(
-          ToastModal.notificationTitle,
+        await Browser.tapCloseBrowserButton();
+        await Assertions.expectElementToBeVisible(
+          TabBarComponent.tabBarWalletButton,
         );
-
+        await TabBarComponent.tapWallet();
+        await WalletView.tapIdenticon();
         await AccountListBottomSheet.tapAccountByNameV2('Account 2');
+        await navigateToBrowserView();
 
         const connectedAccountsAfter = await TestDApp.getConnectedAccounts();
         if (
@@ -182,17 +185,17 @@ describe(SmokeWalletPlatform('EVM Provider Events'), () => {
         }
 
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
-        await Assertions.expectElementToBeVisible(ConnectedAccountsModal.title);
+        await Assertions.expectTextDisplayed('Account 1');
         await Assertions.expectElementToNotBeVisible(
           ToastModal.notificationTitle,
         );
 
-        await ConnectedAccountsModal.tapManagePermissionsButton();
-        await ConnectedAccountsModal.tapNetworksPicker();
-        await Assertions.expectElementToBeVisible(
-          NetworkListModal.networkScroll,
+        await ConnectedAccountsModal.tapPermissionsSummaryTab();
+        await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
+        await NetworkConnectMultiSelector.selectNetworkChainPermission(
+          'Ethereum Main Network',
         );
-        await NetworkListModal.changeNetworkTo('Localhost');
+        await NetworkConnectMultiSelector.tapUpdateButton();
 
         const connectedChainIdAfter = await TestDApp.getConnectedChainId();
         if (connectedChainIdAfter !== '0x539') {

--- a/tests/smoke/wallet/connections/evm-provider-events.spec.ts
+++ b/tests/smoke/wallet/connections/evm-provider-events.spec.ts
@@ -18,8 +18,6 @@ import { DappVariants } from '../../../framework/Constants';
 import ToastModal from '../../../page-objects/wallet/ToastModal';
 import AccountListBottomSheet from '../../../page-objects/wallet/AccountListBottomSheet';
 import NetworkListModal from '../../../page-objects/Network/NetworkListModal';
-import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../api-mocking/mock-responses/feature-flags-mocks';
 
 describe(SmokeWalletPlatform('EVM Provider Events'), () => {
   beforeAll(async () => {
@@ -92,12 +90,6 @@ describe(SmokeWalletPlatform('EVM Provider Events'), () => {
           })
           .build(),
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(false),
-          );
-        },
       },
       async () => {
         await loginToApp();
@@ -122,7 +114,7 @@ describe(SmokeWalletPlatform('EVM Provider Events'), () => {
           ToastModal.notificationTitle,
         );
 
-        await AccountListBottomSheet.tapAccountByName('Account 2');
+        await AccountListBottomSheet.tapAccountByNameV2('Account 2');
 
         const connectedAccountsAfter = await TestDApp.getConnectedAccounts();
         if (
@@ -176,12 +168,6 @@ describe(SmokeWalletPlatform('EVM Provider Events'), () => {
           })
           .build(),
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(false),
-          );
-        },
       },
       async () => {
         await loginToApp();


### PR DESCRIPTION
## **Description**

The `evm-provider-events.spec.ts` E2E tests had `testSpecificMock` blocks in tests 2 and 3 that explicitly disabled the BIP-44 feature flag (`enableMultichainAccountsState2`). This does not represent the production state where BIP-44 is enabled by default.

This PR removes those mocks and updates the test flows to work with the V2 UI (`MultichainAccountPermissions` / `MultichainPermissionsSummary`):

- **Test 1** — No changes needed. Already works with BIP-44 defaults.
- **Test 2 (account switching)** — V2 does not support switching the active account from the connected accounts modal. Updated to switch accounts via the wallet home screen account selector (close browser → tap wallet → tap identicon → select Account 2 → navigate back to browser).
- **Test 3 (network switching)** — V2 uses a permissions-based flow for network changes. Updated to open the Permissions tab, edit network permissions, and deselect Ethereum Main Network — which triggers an auto-switch to Localhost (the remaining permitted network).
- Removed unused imports (`setupRemoteFeatureFlagsMock`, `remoteFeatureMultichainAccountsAccountDetailsV2`, `NetworkListModal`)
- Added new imports (`NetworkConnectMultiSelector`, `TabBarComponent`, `WalletView`)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #24143
[MMQA-1510](https://consensyssoftware.atlassian.net/browse/MMQA-1510)

## **Manual testing steps**

```gherkin
Feature: EVM Provider Events E2E Tests

  Scenario: Tests run with BIP-44 enabled by default
    Given the app is built and E2E test environment is configured

    When the evm-provider-events smoke tests are executed
    Then test 1 (notify connected account on load) passes
    And test 2 (notify dapp on account switch) passes using wallet home account selector
    And test 3 (notify dapp on network change) passes using V2 permissions flow
    And no tests mock the BIP-44 feature flag to false
```

## **Screenshots/Recordings**

### **Before**

- Tests 2 and 3 mocked `enableMultichainAccountsState2` to `false`, bypassing BIP-44
- Test 2 switched accounts by tapping an account in the "Connected accounts" modal (V1 `tapAccountByName`)
- Test 3 switched networks via `tapManagePermissionsButton` → `tapNetworksPicker` → `NetworkListModal.changeNetworkTo` (V1 flow)

### **After**

- Tests 2 and 3 run with BIP-44 enabled (production default) — no feature flag mocks
- Test 2 switches accounts via the wallet home screen account selector (close browser → identicon → select account → return to browser)
- Test 3 switches networks via V2 permissions flow (Permissions tab → edit networks → deselect Mainnet → update triggers auto-switch to Localhost)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to smoke test automation flows and imports; production code paths aren’t modified. Main risk is test brittleness due to updated UI navigation for account/network permission changes.
> 
> **Overview**
> Updates `tests/smoke/wallet/connections/evm-provider-events.spec.ts` to stop mocking the multichain/BIP-44 feature flag off, so the suite runs against the default production-like state.
> 
> Refactors the account-switch test to switch accounts via the wallet home account selector (close browser → wallet tab → identicon → `tapAccountByNameV2`) instead of the connected-accounts modal.
> 
> Refactors the network-change test to use the V2 permissions flow (Permissions tab → edit network permissions → toggle via `NetworkConnectMultiSelector` → update) rather than the legacy network picker/modal, and cleans up/adds page-object imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d53fa58f900eba979fe234d26c483592e1c971b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->