### PR TITLE
Missing task description

### DIFF
--- a/tests/framework/fixtures/DeviceProxyConfig.ts
+++ b/tests/framework/fixtures/DeviceProxyConfig.ts
@@ -44,6 +44,28 @@ export async function configureAndroidProxy(
   await execAsync(
     `adb ${deviceFlag} shell settings put global http_proxy 10.0.2.2:${proxyPort}`,
   );
+
+  // IMPORTANT (Android emulator + adb reverse):
+  // Our in-app test servers (mock server, fixture server, local nodes) are reached
+  // via fixed "fallback" ports on the device (e.g. localhost:8000/12345), then
+  // mapped to random host ports using `adb reverse`.
+  //
+  // If we proxy those localhost requests, the proxy runs on the HOST and will try
+  // to connect to its own localhost:8000/12345 (which is NOT where the servers are
+  // actually listening) → requests abort → app rehydration/stabilization fails.
+  //
+  // Exclude local endpoints from the system proxy so adb-reverse continues to work.
+  const exclusionList = [
+    'localhost',
+    '127.0.0.1',
+    '127.*',
+    // Some parts of the app/tests fall back to the emulator-host alias.
+    // If proxied, the host-side proxy cannot reach 10.0.2.2 reliably.
+    '10.0.2.2',
+  ].join(',');
+  await execAsync(
+    `adb ${deviceFlag} shell settings put global global_http_proxy_exclusion_list "${exclusionList}"`,
+  );
 }
 
 /**
@@ -52,6 +74,9 @@ export async function configureAndroidProxy(
 export async function removeAndroidProxy(deviceId: string): Promise<void> {
   const deviceFlag = deviceId ? `-s ${deviceId}` : getAdbDeviceFlag();
   await execAsync(`adb ${deviceFlag} shell settings delete global http_proxy`);
+  await execAsync(
+    `adb ${deviceFlag} shell settings delete global global_http_proxy_exclusion_list`,
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
e2e(android): Exclude localhost from device proxy to fix Solana swap tests.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The transparent proxy on Android was intercepting `localhost` and `10.0.2.2` traffic, which is used by Detox for internal communication (mock and fixture servers via `adb reverse`). This caused the app to fail stabilization during e2e tests, specifically for Solana swap. By adding these addresses to `global_http_proxy_exclusion_list`, internal traffic bypasses the proxy, allowing external HTTP/HTTPS and WebSocket calls (e.g., to Infura) to still be intercepted and mocked as intended.

---
<p><a href="https://cursor.com/agents/bc-479339f0-d5f9-453d-8a0c-926d9e7dae44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-479339f0-d5f9-453d-8a0c-926d9e7dae44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->