### PR TITLE
Fix confirmations title display for revoke transactions

### DIFF
--- a/app/components/Views/confirmations/components/title/title.test.tsx
+++ b/app/components/Views/confirmations/components/title/title.test.tsx
@@ -246,6 +246,27 @@ describe('Confirm Title', () => {
       ).toBeTruthy();
     });
 
+    it('renders revoke title for ERC20 while token details are still loading', () => {
+      mockUseGetTokenStandardAndDetails.mockReturnValue({
+        details: {
+          standard: TokenStandard.ERC20,
+          decimalsNumber: 0,
+        },
+        isPending: true,
+      } as unknown as ReturnType<typeof useGetTokenStandardAndDetails>);
+
+      const { getByText } = renderWithProvider(<Title />, {
+        state: revokeERC20TransactionStateMock,
+      });
+
+      expect(getByText('Remove permission')).toBeTruthy();
+      expect(
+        getByText(
+          "You're removing someone's permission to spend tokens from your account.",
+        ),
+      ).toBeTruthy();
+    });
+
     it('renders correct title and subtitle for approve NFTs', () => {
       mockUseGetTokenStandardAndDetails.mockReturnValue({
         details: {

--- a/app/components/Views/confirmations/components/title/title.tsx
+++ b/app/components/Views/confirmations/components/title/title.tsx
@@ -46,22 +46,26 @@ const getApproveTitle = (approveTransactionData?: ApproveTransactionData) => {
   let title = strings('confirm.title.permit');
   let subTitle = strings('confirm.sub_title.permit');
 
+  // Revoke intent should take precedence immediately, even when token metadata
+  // is still loading on first render.
+  if (isRevoke) {
+    title = strings('confirm.title.permit_revoke');
+    subTitle = strings('confirm.sub_title.permit_revoke');
+  }
+
   if (tokenStandard === TokenStandard.ERC20) {
-    if (isRevoke) {
-      title = strings('confirm.title.permit_revoke');
-      subTitle = strings('confirm.sub_title.permit_revoke');
-    }
+    // Uses default approve/revoke copy for ERC20.
   }
   if (
     tokenStandard === TokenStandard.ERC721 ||
     tokenStandard === TokenStandard.ERC1155
   ) {
-    title = strings('confirm.title.permit_NFTs');
-    subTitle = strings('confirm.sub_title.permit_NFTs');
-
     if (isRevoke) {
       title = strings('confirm.title.permit_revoke');
       subTitle = strings('confirm.sub_title.permit_revoke_NFTs');
+    } else {
+      title = strings('confirm.title.permit_NFTs');
+      subTitle = strings('confirm.sub_title.permit_NFTs');
     }
   }
 

--- a/app/components/Views/confirmations/hooks/useApproveTransactionData.ts
+++ b/app/components/Views/confirmations/hooks/useApproveTransactionData.ts
@@ -58,6 +58,36 @@ export interface ApproveTransactionData {
   tokenSymbol?: string;
 }
 
+function getProvisionalRevokeState({
+  fourByteCode,
+  parsedData,
+}: {
+  fourByteCode?: string;
+  parsedData?: ReturnType<typeof parseStandardTokenTransactionData>;
+}): boolean {
+  const args = parsedData?.args ?? [];
+
+  switch (fourByteCode) {
+    case APPROVAL_4BYTE_SELECTORS.APPROVE: {
+      const [spender, amountOrTokenId] = args;
+      return (
+        amountOrTokenId?.toString() === ZERO_AMOUNT ||
+        spender?.toLowerCase?.() === ZERO_ADDRESS.toLowerCase()
+      );
+    }
+    case APPROVAL_4BYTE_SELECTORS.SET_APPROVAL_FOR_ALL: {
+      const approved = args[1];
+      return !approved;
+    }
+    case APPROVAL_4BYTE_SELECTORS.PERMIT2_APPROVE: {
+      const amount = args[2];
+      return amount?.toString() === ZERO_AMOUNT;
+    }
+    default:
+      return false;
+  }
+}
+
 /**
  * Hook to parse and extract approval transaction data from current transaction.
  *
@@ -106,15 +136,24 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
 
   // Memoize the entire parsed approval data
   const parsedApproveData = useMemo((): ApproveTransactionData => {
-    if (!transactionMetadata || isTokenStandardPending || !parsedData) {
+    if (!transactionMetadata || !parsedData) {
       return {
         isLoading: true,
       };
     }
 
+    if (isTokenStandardPending) {
+      return {
+        isLoading: true,
+        isRevoke: getProvisionalRevokeState({ fourByteCode, parsedData }),
+      };
+    }
+
+    const tokenDecimals = details?.decimalsNumber ?? 0;
+
     const result: ApproveTransactionData = {
       approveMethod: undefined,
-      decimals: details?.decimalsNumber,
+      decimals: tokenDecimals,
       isLoading: false,
       isRevoke: false,
       tokenStandard: tokenStandard as TokenStandard,
@@ -136,14 +175,14 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
           const { amount: amountInDecimals, rawAmount } =
             calculateApprovalTokenAmount(
               amount?.toString() as string,
-              details.decimalsNumber,
+              tokenDecimals,
             );
           result.amount = amountInDecimals;
           result.rawAmount = rawAmount;
           result.isRevoke = amount?.toString() === ZERO_AMOUNT;
           result.tokenBalance = calculateTokenBalance(
             tokenBalance ?? '0',
-            details.decimalsNumber,
+            tokenDecimals,
           );
         }
 
@@ -156,7 +195,7 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
         const { amount: amountInDecimals, rawAmount } =
           calculateApprovalTokenAmount(
             amount?.toString() as string,
-            details.decimalsNumber,
+            tokenDecimals,
           );
         result.amount = amountInDecimals;
         result.rawAmount = rawAmount;
@@ -168,7 +207,7 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
             : ApproveMethod.INCREASE_ALLOWANCE;
         result.tokenBalance = calculateTokenBalance(
           tokenBalance ?? '0',
-          details.decimalsNumber,
+          tokenDecimals,
         );
         break;
       }
@@ -186,7 +225,7 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
         const { amount: amountInDecimals, rawAmount } =
           calculateApprovalTokenAmount(
             amount?.toString() as string,
-            details.decimalsNumber,
+            tokenDecimals,
           );
         result.amount = amountInDecimals;
         result.rawAmount = rawAmount;
@@ -195,7 +234,7 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
         result.approveMethod = ApproveMethod.PERMIT2_APPROVE;
         result.tokenBalance = calculateTokenBalance(
           tokenBalance ?? '0',
-          details.decimalsNumber,
+          tokenDecimals,
         );
         break;
       }
@@ -207,8 +246,8 @@ export const useApproveTransactionData = (): ApproveTransactionData => {
 
     return result;
   }, [
-    details.decimalsNumber,
-    details.symbol,
+    details?.decimalsNumber,
+    details?.symbol,
     isTokenStandardPending,
     tokenStandard,
     fourByteCode,


### PR DESCRIPTION
## Stack Position
PR **1** of **11** — this is the base of the stack.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Improves revoke detection in the confirmation flow so the correct title is shown immediately, even before token metadata finishes loading. Fixes title display priority for ERC-721/1155 revocations.

### Files
- `title.tsx` — reorders revoke check to take precedence over token standard checks; extracted early-return for ERC-721/1155 revoke case
- `title.test.tsx` — updated tests covering new title priority logic
- `useApproveTransactionData.ts` — adds `getProvisionalRevokeState` helper for detecting revoke intent from 4-byte selector before token standard resolves; returns `isRevoke` immediately when `isTokenStandardPending`

## Review Guidance
This is an independent bugfix with no dependency on the token approvals feature. Focus on whether the provisional revoke detection logic (`getProvisionalRevokeState`) correctly handles all four selector cases (`approve`, `setApprovalForAll`, `permit2Approve`, default).

## PR Stack
- **PR 1 (this):** Fix confirmations title display for revoke transactions ← review first
- PR 2: Add token approvals types, constants, utilities, and config
- PR 3: Add token approvals Redux state and selectors
- PR 4: Add token approvals API and mock data layer
- PR 5: Add core token approvals hooks
- PR 6: Add batch revoke hooks
- PR 7: Add basic and filter UI components
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirmation messaging for approval/revoke flows; incorrect provisional revoke detection could show the wrong title/subtitle during loading, potentially confusing users about what they are signing.
> 
> **Overview**
> Fixes approval confirmation titles so **revoke** transactions show the revoke copy immediately, even while token standard/metadata is still loading.
> 
> Updates `getApproveTitle` to prioritize `isRevoke` and correct ERC721/1155 title/subtitle selection, and enhances `useApproveTransactionData` to return a provisional `isRevoke` based on the 4-byte selector/args when token details are pending. Adds a regression test covering the ERC20 revoke title during loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ba1a55b574840f5a7f7630243637a7d5b22513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->