### PR TITLE
feat(token-approvals): add Redux state slice and selectors

### DIFF
--- a/app/components/UI/TokenApprovals/selectors/index.ts
+++ b/app/components/UI/TokenApprovals/selectors/index.ts
@@ -1,0 +1,166 @@
+import { createSelector } from 'reselect';
+import { RootState } from '../../../../reducers';
+import { ApprovalItem, Verdict } from '../types';
+import { VERDICT_PRIORITY } from '../constants/approvals';
+import { CHAIN_DISPLAY_NAMES } from '../constants/chains';
+
+const selectTokenApprovalsState = (state: RootState) => state.tokenApprovals;
+
+export const selectApprovals = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.approvals,
+);
+
+export const selectIsLoading = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.isLoading,
+);
+
+export const selectError = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.error,
+);
+
+export const selectChainErrors = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.chainErrors,
+);
+
+export const selectSelectedChains = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.selectedChains,
+);
+
+export const selectVerdictFilter = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.verdictFilter,
+);
+
+export const selectSortBy = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.sortBy,
+);
+
+export const selectSearchQuery = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.searchQuery,
+);
+
+export const selectSelectedApprovalIds = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.selectedApprovalIds,
+);
+
+export const selectIsSelectionModeActive = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.isSelectionModeActive,
+);
+
+export const selectRevocations = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.revocations,
+);
+
+export const selectHasSeenEducation = createSelector(
+  selectTokenApprovalsState,
+  (tokenApprovals) => tokenApprovals.hasSeenEducation,
+);
+
+export const selectFilteredApprovals = createSelector(
+  [
+    selectApprovals,
+    selectSelectedChains,
+    selectVerdictFilter,
+    selectSortBy,
+    selectSearchQuery,
+  ],
+  (approvals, selectedChains, verdictFilter, sortBy, searchQuery) => {
+    let filtered = [...approvals];
+
+    // Chain filter
+    if (selectedChains.length > 0) {
+      filtered = filtered.filter((a) => selectedChains.includes(a.chainId));
+    }
+
+    // Verdict filter
+    if (verdictFilter !== 'All') {
+      filtered = filtered.filter((a) => a.verdict === verdictFilter);
+    }
+
+    // Search filter
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase().trim();
+      filtered = filtered.filter(
+        (a) =>
+          a.asset.symbol.toLowerCase().includes(query) ||
+          a.asset.name.toLowerCase().includes(query) ||
+          a.spender.address.toLowerCase().includes(query) ||
+          (a.spender.label?.toLowerCase().includes(query) ?? false),
+      );
+    }
+
+    // Sort
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case 'risk':
+          return (
+            VERDICT_PRIORITY[a.verdict] - VERDICT_PRIORITY[b.verdict] ||
+            b.exposure_usd - a.exposure_usd
+          );
+        case 'value':
+          return b.exposure_usd - a.exposure_usd;
+        case 'asset_name':
+          return a.asset.symbol.localeCompare(b.asset.symbol);
+        default:
+          return 0;
+      }
+    });
+
+    return filtered;
+  },
+);
+
+export const selectMaliciousApprovals = createSelector(
+  selectApprovals,
+  (approvals) => approvals.filter((a) => a.verdict === Verdict.Malicious),
+);
+
+export const selectMaliciousCount = createSelector(
+  selectMaliciousApprovals,
+  (malicious) => malicious.length,
+);
+
+export const selectMaliciousExposureUsd = createSelector(
+  selectMaliciousApprovals,
+  (malicious) => malicious.reduce((sum, a) => sum + a.exposure_usd, 0),
+);
+
+export const selectAvailableChains = createSelector(
+  selectApprovals,
+  (approvals) => {
+    const chainIds = [...new Set(approvals.map((a) => a.chainId))];
+    return chainIds.map((chainId) => ({
+      chainId,
+      displayName: CHAIN_DISPLAY_NAMES[chainId] ?? chainId,
+      count: approvals.filter((a) => a.chainId === chainId).length,
+    }));
+  },
+);
+
+export const selectGroupedByVerdict = createSelector(
+  selectFilteredApprovals,
+  (approvals) => {
+    const groups: Record<Verdict, ApprovalItem[]> = {
+      [Verdict.Malicious]: [],
+      [Verdict.Warning]: [],
+      [Verdict.Benign]: [],
+      [Verdict.Error]: [],
+    };
+
+    for (const approval of approvals) {
+      groups[approval.verdict].push(approval);
+    }
+
+    return groups;
+  },
+);

--- a/app/core/redux/slices/tokenApprovals/index.ts
+++ b/app/core/redux/slices/tokenApprovals/index.ts
@@ -1,0 +1,150 @@
+import { createSlice, PayloadAction, Action } from '@reduxjs/toolkit';
+import {
+  TokenApprovalsState,
+  ApprovalItem,
+  VerdictFilter,
+  SortOption,
+  RevocationStatus,
+} from '../../../../components/UI/TokenApprovals/types';
+
+export type { TokenApprovalsState };
+
+export const initialState: TokenApprovalsState = {
+  approvals: [],
+  isLoading: false,
+  error: null,
+  chainErrors: {},
+  selectedChains: [],
+  verdictFilter: 'All',
+  sortBy: 'risk',
+  searchQuery: '',
+  selectedApprovalIds: [],
+  isSelectionModeActive: false,
+  revocations: {},
+  hasSeenEducation: false,
+};
+
+interface RehydrateAction extends Action<'persist/REHYDRATE'> {
+  payload?: {
+    tokenApprovals?: TokenApprovalsState;
+  };
+}
+
+const tokenApprovalsSlice = createSlice({
+  name: 'tokenApprovals',
+  initialState,
+  reducers: {
+    setApprovals: (state, action: PayloadAction<ApprovalItem[]>) => {
+      state.approvals = action.payload;
+      state.isLoading = false;
+      state.error = null;
+    },
+    setLoading: (state, action: PayloadAction<boolean>) => {
+      state.isLoading = action.payload;
+    },
+    setError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+      state.isLoading = false;
+    },
+    setChainErrors: (state, action: PayloadAction<Record<string, string>>) => {
+      state.chainErrors = action.payload;
+    },
+    setSelectedChains: (state, action: PayloadAction<string[]>) => {
+      state.selectedChains = action.payload;
+    },
+    setVerdictFilter: (state, action: PayloadAction<VerdictFilter>) => {
+      state.verdictFilter = action.payload;
+    },
+    setSortBy: (state, action: PayloadAction<SortOption>) => {
+      state.sortBy = action.payload;
+    },
+    setSearchQuery: (state, action: PayloadAction<string>) => {
+      state.searchQuery = action.payload;
+    },
+    toggleApprovalSelection: (state, action: PayloadAction<string>) => {
+      const id = action.payload;
+      const index = state.selectedApprovalIds.indexOf(id);
+      if (index >= 0) {
+        state.selectedApprovalIds.splice(index, 1);
+      } else {
+        state.selectedApprovalIds.push(id);
+      }
+    },
+    selectAllApprovals: (state, action: PayloadAction<string[]>) => {
+      state.selectedApprovalIds = action.payload;
+    },
+    clearSelection: (state) => {
+      state.selectedApprovalIds = [];
+      state.isSelectionModeActive = false;
+    },
+    enterSelectionMode: (state) => {
+      state.isSelectionModeActive = true;
+    },
+    exitSelectionMode: (state) => {
+      state.isSelectionModeActive = false;
+      state.selectedApprovalIds = [];
+    },
+    setRevocationStatus: (
+      state,
+      action: PayloadAction<{ id: string; status: RevocationStatus }>,
+    ) => {
+      state.revocations[action.payload.id] = action.payload.status;
+    },
+    clearRevocationStatuses: (state, action: PayloadAction<string[]>) => {
+      for (const id of action.payload) {
+        delete state.revocations[id];
+      }
+    },
+    removeApproval: (state, action: PayloadAction<string>) => {
+      state.approvals = state.approvals.filter((a) => a.id !== action.payload);
+      state.selectedApprovalIds = state.selectedApprovalIds.filter(
+        (id) => id !== action.payload,
+      );
+      delete state.revocations[action.payload];
+    },
+    setHasSeenEducation: (state, action: PayloadAction<boolean>) => {
+      state.hasSeenEducation = action.payload;
+    },
+    resetTokenApprovals: (state) => {
+      Object.assign(state, {
+        ...initialState,
+        hasSeenEducation: state.hasSeenEducation,
+      });
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase('persist/REHYDRATE', (state, action: RehydrateAction) => {
+      if (action.payload?.tokenApprovals) {
+        return {
+          ...initialState,
+          hasSeenEducation:
+            action.payload.tokenApprovals.hasSeenEducation ?? false,
+        };
+      }
+      return state;
+    });
+  },
+});
+
+export const {
+  setApprovals,
+  setLoading,
+  setError,
+  setChainErrors,
+  setSelectedChains,
+  setVerdictFilter,
+  setSortBy,
+  setSearchQuery,
+  toggleApprovalSelection,
+  selectAllApprovals,
+  clearSelection,
+  enterSelectionMode,
+  exitSelectionMode,
+  setRevocationStatus,
+  clearRevocationStatuses,
+  removeApproval,
+  setHasSeenEducation,
+  resetTokenApprovals,
+} = tokenApprovalsSlice.actions;
+
+export default tokenApprovalsSlice.reducer;

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -43,6 +43,9 @@ import sampleCounterReducer from '../features/SampleFeature/reducers/sample-coun
 ///: END:ONLY_INCLUDE_IF
 import cardReducer from '../core/redux/slices/card';
 import rewardsReducer, { RewardsState } from './rewards';
+import tokenApprovalsReducer, {
+  TokenApprovalsState,
+} from '../core/redux/slices/tokenApprovals';
 import { isTest } from '../util/test/utils';
 
 /**
@@ -131,6 +134,7 @@ export interface RootState {
   ///: END:ONLY_INCLUDE_IF
   cronjobController: StateFromReducer<typeof cronjobControllerReducer>;
   rewards: RewardsState;
+  tokenApprovals: TokenApprovalsState;
   networkConnectionBanner: NetworkConnectionBannerState;
 }
 
@@ -173,6 +177,7 @@ const baseReducers = {
   qrKeyringScanner: qrKeyringScannerReducer,
   cronjobController: cronjobControllerReducer,
   rewards: rewardsReducer,
+  tokenApprovals: tokenApprovalsReducer,
   networkConnectionBanner: networkConnectionBannerReducer,
 };
 


### PR DESCRIPTION
## Stack Position
PR **3** of **11** — builds on PR 2.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Implements the Redux state management backbone of the token approvals feature.

### Files
- `app/core/redux/slices/tokenApprovals/index.ts` — Redux Toolkit slice with actions for: approval CRUD (`setApprovals`, `removeApproval`), loading/error state, filter/sort/search/chain selection, selection mode, per-approval revocation status, `hasSeenEducation` flag, and `persist/REHYDRATE` handler
- `app/reducers/index.ts` — registers `tokenApprovalsReducer` in the root reducer and adds `TokenApprovalsState` to `RootState`
- `app/components/UI/TokenApprovals/selectors/index.ts` — memoized reselect selectors for filtered/sorted approvals, risk groupings, chain availability, malicious count and exposure USD

## Review Guidance
Check the `persist/REHYDRATE` handler — it intentionally discards all state except `hasSeenEducation` on rehydration to avoid stale data on app launch.

## PR Stack
- PR 1: Fix confirmations title display for revoke transactions
- PR 2: Add token approvals types, constants, utilities, and config
- **PR 3 (this):** Add token approvals Redux state and selectors ← you are here
- PR 4: Add token approvals API and mock data layer
- PR 5: Add core token approvals hooks
- PR 6: Add batch revoke hooks
- PR 7: Add basic and filter UI components
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted Redux slice wired into the root reducer; incorrect rehydration/reset behavior or selector filtering/sorting could lead to stale or wrong approval UI state across launches.
> 
> **Overview**
> Introduces a new `tokenApprovals` Redux Toolkit slice to store token approval data plus UI state (loading/error, chain/verdict filters, sort/search, selection mode, per-approval revocation status, and an education dismissal flag), including actions to mutate and reset this state.
> 
> Wires the slice into `RootState`/`combineReducers`, and adds memoized selectors to derive filtered/sorted approval lists, malicious counts/exposure, available chains, and verdict-grouped results. Rehydration via `persist/REHYDRATE` intentionally discards all persisted data except `hasSeenEducation` to avoid stale approvals on startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c23f4bfa306ad12df5fd32de45fc0028fc5e95a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->