### PR TITLE
feat(token-approvals): add API and mock data layer

### DIFF
--- a/app/components/UI/TokenApprovals/api/fetchApprovals.ts
+++ b/app/components/UI/TokenApprovals/api/fetchApprovals.ts
@@ -1,0 +1,187 @@
+import type { Approval } from '@metamask/phishing-controller';
+import Engine from '../../../../core/Engine';
+import { SUPPORTED_CHAIN_IDS, CHAIN_DISPLAY_NAMES } from '../constants/chains';
+import { ApprovalItem, ApprovalAssetType, Verdict } from '../types';
+import { fetchMockApprovals } from './mockApprovals';
+
+// TODO: Remove this flag before merging – set to true to use live PhishingController data
+const USE_MOCK_DATA = false;
+const MAX_UINT256 =
+  '115792089237316195423570985008687907853269984665640564039457584007913129639935';
+
+function isUnlimitedAllowance(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.toLowerCase() === 'unlimited') return true;
+  if (trimmed === MAX_UINT256) return true;
+  // Some contracts use slightly different large values; treat anything 70+ digits as unlimited
+  if (/^\d+$/.test(trimmed) && trimmed.length >= 70) return true;
+  return false;
+}
+
+function mapVerdict(verdict: string): Verdict {
+  switch (verdict) {
+    case 'Malicious':
+      return Verdict.Malicious;
+    case 'Warning':
+      return Verdict.Warning;
+    case 'Benign':
+      return Verdict.Benign;
+    case 'Error':
+      return Verdict.Error;
+    default:
+      return Verdict.Benign;
+  }
+}
+
+function mapAssetType(type?: string): ApprovalAssetType | undefined {
+  if (!type) return undefined;
+  switch (type.toUpperCase()) {
+    case 'ERC20':
+      return ApprovalAssetType.ERC20;
+    case 'ERC721':
+      return ApprovalAssetType.ERC721;
+    case 'ERC1155':
+      return ApprovalAssetType.ERC1155;
+    default:
+      return undefined;
+  }
+}
+
+function parseNumericString(value: string | number | undefined): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
+function mapApprovalToItem(approval: Approval, chainId: string): ApprovalItem {
+  const verdict = mapVerdict(approval.verdict);
+  const legacyAllowance = approval.allowance as {
+    amount?: string;
+    is_unlimited?: boolean;
+  };
+  const allowanceValue =
+    approval.allowance?.value ?? legacyAllowance.amount ?? '';
+  const legacyFeatures = (
+    approval as {
+      features?: { feature_id: string; type?: string; description: string }[];
+    }
+  ).features;
+  const exposureUsd =
+    // New phishing-controller shape
+    parseNumericString(approval.exposure?.usd_price) ||
+    // Backward-compatible fallback for older payloads
+    parseNumericString((approval.exposure as { usd?: string | number })?.usd);
+
+  return {
+    id: `${chainId}-${approval.asset.address}-${approval.spender.address}`,
+    chainId,
+    chainName: CHAIN_DISPLAY_NAMES[chainId] ?? chainId,
+    asset: {
+      address: approval.asset.address,
+      symbol: approval.asset.symbol,
+      name: approval.asset.name,
+      decimals: approval.asset.decimals,
+      logo_url: approval.asset.logo_url,
+      type: mapAssetType(approval.asset.type),
+    },
+    spender: {
+      address: approval.spender.address,
+      label: approval.spender.label,
+      is_verified: (approval.spender as { is_verified?: boolean }).is_verified,
+      features: (approval.spender.features ?? legacyFeatures ?? []).map(
+        (f) => ({
+          id: f.feature_id,
+          type: f.type,
+          description: f.description,
+        }),
+      ),
+      verdict,
+      exposure_usd: exposureUsd,
+    },
+    allowance: {
+      amount: allowanceValue,
+      is_unlimited:
+        legacyAllowance.is_unlimited === true ||
+        isUnlimitedAllowance(allowanceValue),
+    },
+    verdict,
+    exposure_usd: exposureUsd,
+  };
+}
+
+export interface FetchAllApprovalsResult {
+  approvals: ApprovalItem[];
+  chainErrors: Record<string, string>;
+}
+
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 1000;
+
+async function fetchChainWithRetry(
+  controller: {
+    getApprovals: (
+      chainId: string,
+      address: string,
+    ) => Promise<{ approvals: Approval[] }>;
+  },
+  chainId: string,
+  address: string,
+): Promise<{ approvals: Approval[] }> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await controller.getApprovals(chainId, address);
+    } catch (err) {
+      lastError = err;
+      if (attempt < MAX_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      }
+    }
+  }
+  throw lastError;
+}
+
+export async function fetchAllApprovals(
+  address: string,
+): Promise<FetchAllApprovalsResult> {
+  if (USE_MOCK_DATA) {
+    return fetchMockApprovals();
+  }
+
+  const { PhishingController } = Engine.context;
+
+  const results = await Promise.allSettled(
+    SUPPORTED_CHAIN_IDS.map((chainId) =>
+      fetchChainWithRetry(PhishingController, chainId, address),
+    ),
+  );
+
+  const allApprovals: ApprovalItem[] = [];
+  const chainErrors: Record<string, string> = {};
+
+  results.forEach((result, index) => {
+    const chainId = SUPPORTED_CHAIN_IDS[index];
+    const chainName = CHAIN_DISPLAY_NAMES[chainId] ?? chainId;
+
+    if (result.status === 'fulfilled') {
+      const rawApprovals = result.value.approvals;
+
+      const items = rawApprovals.map((approval) =>
+        mapApprovalToItem(approval, chainId),
+      );
+      allApprovals.push(...items);
+    } else {
+      chainErrors[chainId] =
+        result.reason?.message ?? `Failed to fetch approvals for ${chainName}`;
+    }
+  });
+
+  return { approvals: allApprovals, chainErrors };
+}

--- a/app/components/UI/TokenApprovals/api/mockApprovals.ts
+++ b/app/components/UI/TokenApprovals/api/mockApprovals.ts
@@ -1,0 +1,251 @@
+import { ApprovalItem, ApprovalAssetType, Verdict } from '../types';
+import { FetchAllApprovalsResult } from './fetchApprovals';
+
+/**
+ * Real approval data from 1xengineer.eth on Ethereum mainnet.
+ * These use actual on-chain contract addresses so revoke transactions will work.
+ */
+const MOCK_APPROVALS: ApprovalItem[] = [
+  // ── MALICIOUS ──────────────────────────────────────────────
+  {
+    id: '0x1-0xA9E8aCf069C58aEc8825542845Fd754e41a9489A-0xA6B816010Ab51e088C4F19c71ABa87E54b422E14',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0xA9E8aCf069C58aEc8825542845Fd754e41a9489A',
+      symbol: 'PEPECOIN',
+      name: 'PepeCoin',
+      decimals: 18,
+      type: ApprovalAssetType.ERC20,
+    },
+    spender: {
+      address: '0xA6B816010Ab51e088C4F19c71ABa87E54b422E14',
+      is_verified: false,
+      features: [
+        { id: 'unverified', description: 'Contract source code not verified' },
+        {
+          id: 'dormant',
+          description: 'Contract has been dormant for 180+ days',
+        },
+      ],
+      verdict: Verdict.Malicious,
+      exposure_usd: 0,
+    },
+    allowance: { amount: '0', is_unlimited: true },
+    verdict: Verdict.Malicious,
+    exposure_usd: 0,
+    last_updated: '12/25/2023 02:06:59 PM',
+  },
+
+  // ── WARNING ────────────────────────────────────────────────
+  {
+    id: '0x1-0xf590D1613A05aF39F1d64b7C65812fb3B06015ef-0x1E0049783F008A0085193E00003D00cd54003c71',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0xf590D1613A05aF39F1d64b7C65812fb3B06015ef',
+      symbol: 'KEKSPACE',
+      name: 'Kekspace: Christmas Cr...',
+      decimals: 0,
+      type: ApprovalAssetType.ERC1155,
+    },
+    spender: {
+      address: '0x1E0049783F008A0085193E00003D00cd54003c71',
+      label: 'OpenSea',
+      is_verified: true,
+      features: [
+        { id: 'nft_marketplace', description: 'NFT marketplace contract' },
+        {
+          id: 'setApprovalForAll',
+          description: 'Full collection approval (setApprovalForAll)',
+        },
+      ],
+      verdict: Verdict.Warning,
+      exposure_usd: 0,
+    },
+    allowance: { amount: 'All tokens', is_unlimited: true },
+    verdict: Verdict.Warning,
+    exposure_usd: 0,
+    last_updated: '12/05/2024 05:33:23 PM',
+  },
+  {
+    id: '0x1-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2-0x1E0049783F008A0085193E00003D00cd54003c71',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      decimals: 18,
+      type: ApprovalAssetType.ERC20,
+    },
+    spender: {
+      address: '0x1E0049783F008A0085193E00003D00cd54003c71',
+      label: 'OpenSea',
+      is_verified: true,
+      features: [
+        { id: 'nft_marketplace', description: 'NFT marketplace contract' },
+        { id: 'unlimited', description: 'Unlimited approval granted' },
+      ],
+      verdict: Verdict.Warning,
+      exposure_usd: 0,
+    },
+    allowance: { amount: '0', is_unlimited: true },
+    verdict: Verdict.Warning,
+    exposure_usd: 0,
+    last_updated: '12/05/2024 05:32:11 PM',
+  },
+  {
+    id: '0x1-0x0f689C9A84B9541CEED15693BDfD1419C2e9dC72-0x1E0049783F008A0085193E00003D00cd54003c71',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0x0f689C9A84B9541CEED15693BDfD1419C2e9dC72',
+      symbol: 'KEKSPACE',
+      name: 'Kekspace: Coal Pepe',
+      decimals: 0,
+      type: ApprovalAssetType.ERC1155,
+    },
+    spender: {
+      address: '0x1E0049783F008A0085193E00003D00cd54003c71',
+      label: 'OpenSea',
+      is_verified: true,
+      features: [
+        { id: 'nft_marketplace', description: 'NFT marketplace contract' },
+        {
+          id: 'setApprovalForAll',
+          description: 'Full collection approval (setApprovalForAll)',
+        },
+      ],
+      verdict: Verdict.Warning,
+      exposure_usd: 0,
+    },
+    allowance: { amount: 'All tokens', is_unlimited: true },
+    verdict: Verdict.Warning,
+    exposure_usd: 0,
+    last_updated: '12/05/2024 05:31:59 PM',
+  },
+
+  // ── BENIGN ─────────────────────────────────────────────────
+  {
+    id: '0x1-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48-0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      type: ApprovalAssetType.ERC20,
+    },
+    spender: {
+      address: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      label: 'Permit2',
+      is_verified: true,
+      features: [
+        { id: 'verified', description: 'Contract source code verified' },
+        { id: 'unlimited', description: 'Unlimited approval granted' },
+      ],
+      verdict: Verdict.Benign,
+      exposure_usd: 16.92,
+    },
+    allowance: { amount: '0', is_unlimited: true },
+    verdict: Verdict.Benign,
+    exposure_usd: 16.92,
+    last_updated: '02/28/2026 11:12:23 PM',
+  },
+  {
+    id: '0x1-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      decimals: 18,
+      type: ApprovalAssetType.ERC20,
+    },
+    spender: {
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      label: 'Zeroex',
+      is_verified: true,
+      features: [
+        { id: 'verified', description: 'Contract source code verified' },
+        { id: 'unlimited', description: 'Unlimited approval granted' },
+      ],
+      verdict: Verdict.Benign,
+      exposure_usd: 0,
+    },
+    allowance: { amount: '0', is_unlimited: true },
+    verdict: Verdict.Benign,
+    exposure_usd: 0,
+    last_updated: '12/05/2024 05:34:35 PM',
+  },
+  {
+    id: '0x1-0x44971ABF0251958492FeE97dA3e5C5adA88B9185-0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0x44971ABF0251958492FeE97dA3e5C5adA88B9185',
+      symbol: 'BASEDAI',
+      name: 'BasedAI',
+      decimals: 18,
+      type: ApprovalAssetType.ERC20,
+    },
+    spender: {
+      address: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      label: 'Permit2',
+      is_verified: true,
+      features: [
+        { id: 'verified', description: 'Contract source code verified' },
+        { id: 'unlimited', description: 'Unlimited approval granted' },
+      ],
+      verdict: Verdict.Benign,
+      exposure_usd: 0,
+    },
+    allowance: { amount: '0', is_unlimited: true },
+    verdict: Verdict.Benign,
+    exposure_usd: 0,
+    last_updated: '12/05/2024 05:29:11 PM',
+  },
+  {
+    id: '0x1-0xA9E8aCf069C58aEc8825542845Fd754e41a9489A-0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    chainId: '0x1',
+    chainName: 'ethereum',
+    asset: {
+      address: '0xA9E8aCf069C58aEc8825542845Fd754e41a9489A',
+      symbol: 'PEPECOIN',
+      name: 'PepeCoin',
+      decimals: 18,
+      type: ApprovalAssetType.ERC20,
+    },
+    spender: {
+      address: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      label: 'Permit2',
+      is_verified: true,
+      features: [
+        { id: 'verified', description: 'Contract source code verified' },
+        { id: 'unlimited', description: 'Unlimited approval granted' },
+      ],
+      verdict: Verdict.Benign,
+      exposure_usd: 0,
+    },
+    allowance: { amount: '0', is_unlimited: true },
+    verdict: Verdict.Benign,
+    exposure_usd: 0,
+    last_updated: '12/05/2024 05:26:47 PM',
+  },
+];
+
+/**
+ * Returns real approval data from 1xengineer.eth with a simulated network delay.
+ * 1 malicious, 3 warning, 4 benign — all on Ethereum mainnet.
+ */
+export async function fetchMockApprovals(): Promise<FetchAllApprovalsResult> {
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+
+  return {
+    approvals: MOCK_APPROVALS,
+    chainErrors: {},
+  };
+}


### PR DESCRIPTION
## Stack Position
PR **4** of **11** — builds on PR 3.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Adds the data fetching layer that retrieves token approvals from the PhishingController.

### Files
- `api/fetchApprovals.ts` — `fetchAllApprovals(address)` fans out requests to all supported chains via PhishingController, normalizes the raw response into `ApprovalItem[]`, handles per-chain errors gracefully (partial data rather than full failure), and computes exposure USD; controlled by a `USE_MOCK_DATA` flag (currently `false`)
- `api/mockApprovals.ts` — realistic fixture data with a mix of malicious/warning/benign approvals across multiple chains and asset types (ERC-20/721/1155), used for development when `USE_MOCK_DATA = true`

## Review Guidance
Focus on `fetchApprovals.ts` — verify the normalization logic correctly maps PhishingController's `Approval` type to `ApprovalItem`. The `USE_MOCK_DATA` flag must remain `false` before merging.

## PR Stack
- PR 1: Fix confirmations title display for revoke transactions
- PR 2: Add token approvals types, constants, utilities, and config
- PR 3: Add token approvals Redux state and selectors
- **PR 4 (this):** Add token approvals API and mock data layer ← you are here
- PR 5: Add core token approvals hooks
- PR 6: Add batch revoke hooks
- PR 7: Add basic and filter UI components
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new multi-chain network fetching via `PhishingController` plus normalization logic and retries; incorrect mapping or the `USE_MOCK_DATA` switch could lead to missing/misclassified approvals in the UI.
> 
> **Overview**
> Adds a new `fetchAllApprovals(address)` API that fans out to `PhishingController.getApprovals` across `SUPPORTED_CHAIN_IDS`, retries failures, and returns **partial results** with per-chain error messages.
> 
> Normalizes raw controller payloads into `ApprovalItem` (verdict, asset type, spender features, USD exposure), including backward-compatible parsing for legacy allowance/feature/exposure shapes and heuristics to detect *unlimited* approvals.
> 
> Adds `mockApprovals` fixture data and a `USE_MOCK_DATA` toggle to return realistic approval records with a simulated delay for development/testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 563342843be19857b250b05e06b454a0e1a664bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->