### PR TITLE
feat(token-approvals): add core hooks for data loading, filters, and revocation

### DIFF
--- a/app/components/UI/TokenApprovals/hooks/useApprovalFilters.ts
+++ b/app/components/UI/TokenApprovals/hooks/useApprovalFilters.ts
@@ -1,0 +1,109 @@
+import { useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  setSelectedChains,
+  setVerdictFilter,
+  setSortBy,
+  setSearchQuery,
+  toggleApprovalSelection,
+  selectAllApprovals,
+  enterSelectionMode,
+  exitSelectionMode,
+} from '../../../../core/redux/slices/tokenApprovals';
+import {
+  selectSelectedChains,
+  selectVerdictFilter,
+  selectSortBy,
+  selectSearchQuery,
+  selectSelectedApprovalIds,
+  selectIsSelectionModeActive,
+  selectRevocations,
+} from '../selectors';
+import { VerdictFilter, SortOption } from '../types';
+
+export function useApprovalFilters() {
+  const dispatch = useDispatch();
+  const selectedChains = useSelector(selectSelectedChains);
+  const verdictFilter = useSelector(selectVerdictFilter);
+  const sortBy = useSelector(selectSortBy);
+  const searchQuery = useSelector(selectSearchQuery);
+  const selectedApprovalIds = useSelector(selectSelectedApprovalIds);
+  const isSelectionModeActive = useSelector(selectIsSelectionModeActive);
+  const revocations = useSelector(selectRevocations);
+
+  const handleChainToggle = useCallback(
+    (chainId: string) => {
+      const updated = selectedChains.includes(chainId)
+        ? selectedChains.filter((id) => id !== chainId)
+        : [...selectedChains, chainId];
+      dispatch(setSelectedChains(updated));
+    },
+    [selectedChains, dispatch],
+  );
+
+  const handleVerdictFilterChange = useCallback(
+    (filter: VerdictFilter) => {
+      dispatch(setVerdictFilter(filter));
+    },
+    [dispatch],
+  );
+
+  const handleSortChange = useCallback(
+    (sort: SortOption) => {
+      dispatch(setSortBy(sort));
+    },
+    [dispatch],
+  );
+
+  const handleSearchChange = useCallback(
+    (query: string) => {
+      dispatch(setSearchQuery(query));
+    },
+    [dispatch],
+  );
+
+  const handleToggleSelection = useCallback(
+    (id: string) => {
+      dispatch(toggleApprovalSelection(id));
+    },
+    [dispatch],
+  );
+
+  const handleSelectAll = useCallback(
+    (ids: string[]) => {
+      dispatch(selectAllApprovals(ids));
+    },
+    [dispatch],
+  );
+
+  const handleClearSelection = useCallback(() => {
+    dispatch(exitSelectionMode());
+  }, [dispatch]);
+
+  const handleEnterSelectionMode = useCallback(() => {
+    dispatch(enterSelectionMode());
+  }, [dispatch]);
+
+  const handleExitSelectionMode = useCallback(() => {
+    dispatch(exitSelectionMode());
+  }, [dispatch]);
+
+  return {
+    selectedChains,
+    verdictFilter,
+    sortBy,
+    searchQuery,
+    selectedApprovalIds,
+    revocations,
+    selectionMode: isSelectionModeActive || selectedApprovalIds.length > 0,
+    onChainToggle: handleChainToggle,
+    onVerdictFilterChange: handleVerdictFilterChange,
+    onSortChange: handleSortChange,
+    onSearchChange: handleSearchChange,
+    onToggleSelection: handleToggleSelection,
+    onSelectAll: handleSelectAll,
+    onClearSelection: handleClearSelection,
+    onEnterSelectionMode: handleEnterSelectionMode,
+    onExitSelectionMode: handleExitSelectionMode,
+  };
+}

--- a/app/components/UI/TokenApprovals/hooks/useRevokeApproval.ts
+++ b/app/components/UI/TokenApprovals/hooks/useRevokeApproval.ts
@@ -1,0 +1,102 @@
+import { useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { TransactionType } from '@metamask/transaction-controller';
+import { addTransaction } from '../../../../util/transaction-controller';
+import {
+  setRevocationStatus,
+  clearRevocationStatuses,
+  removeApproval,
+} from '../../../../core/redux/slices/tokenApprovals';
+import { ApprovalItem, ApprovalAssetType } from '../types';
+import {
+  buildRevokeTransactionData,
+  getNetworkClientIdForChain,
+} from '../utils/revokeTransaction';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { isUserRejection } from '../utils/isUserRejection';
+
+function getTransactionType(approval: ApprovalItem) {
+  if (
+    approval.asset.type === ApprovalAssetType.ERC721 ||
+    approval.asset.type === ApprovalAssetType.ERC1155
+  ) {
+    return TransactionType.tokenMethodSetApprovalForAll;
+  }
+  return TransactionType.tokenMethodApprove;
+}
+
+export function useRevokeApproval() {
+  const dispatch = useDispatch();
+  const address = useSelector(selectSelectedInternalAccountAddress);
+
+  const revokeApproval = useCallback(
+    async (approval: ApprovalItem) => {
+      dispatch(
+        setRevocationStatus({
+          id: approval.id,
+          status: { status: 'pending' },
+        }),
+      );
+
+      try {
+        const data = buildRevokeTransactionData(approval);
+        const networkClientId = getNetworkClientIdForChain(approval.chainId);
+
+        const txParams = {
+          to: approval.asset.address as `0x${string}`,
+          from: address as `0x${string}`,
+          data: data as `0x${string}`,
+          value: '0x0' as `0x${string}`,
+        };
+
+        const result = await addTransaction(txParams, {
+          networkClientId,
+          origin: 'MetaMask',
+          type: getTransactionType(approval),
+        });
+
+        dispatch(
+          setRevocationStatus({
+            id: approval.id,
+            status: {
+              status: 'submitted',
+              transactionHash: result.transactionMeta.hash,
+            },
+          }),
+        );
+
+        // Wait for the transaction to be confirmed
+        await result.result;
+
+        dispatch(
+          setRevocationStatus({
+            id: approval.id,
+            status: { status: 'confirmed' },
+          }),
+        );
+
+        // Remove from list after a short delay to show confirmed state
+        setTimeout(() => {
+          dispatch(removeApproval(approval.id));
+        }, 2000);
+      } catch (err) {
+        if (isUserRejection(err)) {
+          dispatch(clearRevocationStatuses([approval.id]));
+          return;
+        }
+        dispatch(
+          setRevocationStatus({
+            id: approval.id,
+            status: {
+              status: 'failed',
+              error: err instanceof Error ? err.message : 'Transaction failed',
+            },
+          }),
+        );
+      }
+    },
+    [dispatch, address],
+  );
+
+  return { revokeApproval };
+}

--- a/app/components/UI/TokenApprovals/hooks/useTokenApprovals.ts
+++ b/app/components/UI/TokenApprovals/hooks/useTokenApprovals.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  setApprovals,
+  setLoading,
+  setError,
+  setChainErrors,
+  resetTokenApprovals,
+} from '../../../../core/redux/slices/tokenApprovals';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { fetchAllApprovals } from '../api/fetchApprovals';
+import {
+  selectApprovals,
+  selectIsLoading,
+  selectError,
+  selectChainErrors,
+  selectFilteredApprovals,
+  selectMaliciousCount,
+  selectMaliciousExposureUsd,
+  selectAvailableChains,
+} from '../selectors';
+
+export function useTokenApprovals() {
+  const dispatch = useDispatch();
+  const address = useSelector(selectSelectedInternalAccountAddress);
+  const approvals = useSelector(selectApprovals);
+  const filteredApprovals = useSelector(selectFilteredApprovals);
+  const isLoading = useSelector(selectIsLoading);
+  const error = useSelector(selectError);
+  const chainErrors = useSelector(selectChainErrors);
+  const maliciousCount = useSelector(selectMaliciousCount);
+  const maliciousExposureUsd = useSelector(selectMaliciousExposureUsd);
+  const availableChains = useSelector(selectAvailableChains);
+
+  const loadApprovals = useCallback(async () => {
+    if (!address) {
+      dispatch(setError('No account address available'));
+      return;
+    }
+
+    dispatch(resetTokenApprovals());
+    dispatch(setLoading(true));
+
+    try {
+      const result = await fetchAllApprovals(address);
+      dispatch(setApprovals(result.approvals));
+      dispatch(setChainErrors(result.chainErrors));
+    } catch (err) {
+      dispatch(
+        setError(
+          err instanceof Error ? err.message : 'Failed to load approvals',
+        ),
+      );
+    }
+  }, [dispatch, address]);
+
+  useEffect(() => {
+    loadApprovals();
+  }, [loadApprovals]);
+
+  return {
+    approvals,
+    filteredApprovals,
+    isLoading,
+    error,
+    chainErrors,
+    maliciousCount,
+    maliciousExposureUsd,
+    availableChains,
+    refresh: loadApprovals,
+  };
+}


### PR DESCRIPTION
## Stack Position
PR **5** of **11** — builds on PR 4.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Core React hooks that components will consume for all data and interaction logic.

### Files
- `useTokenApprovals.ts` — loads approvals via `fetchAllApprovals`, dispatches to Redux, exposes `approvals`, `filteredApprovals`, risk stats, and a `refresh` callback; auto-fetches on mount and when account address changes
- `useApprovalFilters.ts` — manages chain filter, verdict filter, sort, search query, and selection mode via Redux; exposes all handlers as stable callbacks
- `useRevokeApproval.ts` — submits a revoke transaction via `addTransaction`, tracks status (`pending` → `submitted` → `confirmed`) in Redux, handles user rejection silently, removes approval from state after confirmation

## Review Guidance
In `useRevokeApproval`, verify the `isUserRejection` check — user rejections should clear revocation status silently rather than showing an error. Also confirm the 2-second delay before `removeApproval` gives enough time for the UI to show the confirmed state.

## PR Stack
- PR 1: Fix confirmations title display for revoke transactions
- PR 2: Add token approvals types, constants, utilities, and config
- PR 3: Add token approvals Redux state and selectors
- PR 4: Add token approvals API and mock data layer
- **PR 5 (this):** Add core token approvals hooks ← you are here
- PR 6: Add batch revoke hooks
- PR 7: Add basic and filter UI components
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new async hooks that reset/load Redux state and submit revoke transactions; risk is mainly around state resets, selection-mode behavior, and transaction status/error handling impacting UX rather than core security.
> 
> **Overview**
> Adds three new `TokenApprovals` hooks to centralize UI logic in Redux-backed callbacks.
> 
> `useTokenApprovals` now loads approvals on mount/account change via `fetchAllApprovals`, resets token-approvals state before fetching, and exposes approvals, filtered approvals, chain errors, and malicious-risk aggregates plus a `refresh` function.
> 
> `useApprovalFilters` wires chain/verdict/sort/search and selection-mode actions into stable handlers, and treats selection mode as active when either the mode flag is set or any approvals are selected.
> 
> `useRevokeApproval` adds a revoke flow that builds and submits an approval-revocation transaction (choosing `approve` vs `setApprovalForAll` by asset type), tracks revocation status through pending/submitted/confirmed/failed in Redux, silently clears status on user rejection, and removes the approval from state shortly after confirmation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c8a03952560b1d4d2811ada1168f65448ed28a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->