### PR TITLE
feat(token-approvals): add batch revoke hooks

### DIFF
--- a/app/components/UI/TokenApprovals/hooks/useBatchRevoke.ts
+++ b/app/components/UI/TokenApprovals/hooks/useBatchRevoke.ts
@@ -1,0 +1,229 @@
+import { useCallback, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import { TransactionType } from '@metamask/transaction-controller';
+import { selectApprovals } from '../selectors';
+import {
+  clearSelection,
+  setRevocationStatus,
+  clearRevocationStatuses,
+  removeApproval,
+} from '../../../../core/redux/slices/tokenApprovals';
+import { ApprovalItem, ApprovalAssetType } from '../types';
+import {
+  addTransaction,
+  addTransactionBatch,
+} from '../../../../util/transaction-controller';
+import {
+  buildRevokeTransactionData,
+  getNetworkClientIdForChain,
+} from '../utils/revokeTransaction';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { isUserRejection } from '../utils/isUserRejection';
+import type { ChainBatchInfo } from './useBatchRevokeSupport';
+
+function getTransactionType(approval: ApprovalItem) {
+  if (
+    approval.asset.type === ApprovalAssetType.ERC721 ||
+    approval.asset.type === ApprovalAssetType.ERC1155
+  ) {
+    return TransactionType.tokenMethodSetApprovalForAll;
+  }
+  return TransactionType.tokenMethodApprove;
+}
+
+export function useBatchRevoke() {
+  const dispatch = useDispatch();
+  const approvals = useSelector(selectApprovals);
+  const address = useSelector(selectSelectedInternalAccountAddress);
+  const isProcessingRef = useRef(false);
+
+  const revokeSequential = useCallback(
+    async (chainApprovals: ApprovalItem[]) => {
+      for (const approval of chainApprovals) {
+        dispatch(
+          setRevocationStatus({
+            id: approval.id,
+            status: { status: 'pending' },
+          }),
+        );
+
+        try {
+          const data = buildRevokeTransactionData(approval);
+          const networkClientId = getNetworkClientIdForChain(approval.chainId);
+
+          const txParams = {
+            to: approval.asset.address as `0x${string}`,
+            from: address as `0x${string}`,
+            data: data as `0x${string}`,
+            value: '0x0' as `0x${string}`,
+          };
+
+          const result = await addTransaction(txParams, {
+            networkClientId,
+            origin: 'MetaMask',
+            type: getTransactionType(approval),
+          });
+
+          dispatch(
+            setRevocationStatus({
+              id: approval.id,
+              status: {
+                status: 'submitted',
+                transactionHash: result.transactionMeta.hash,
+              },
+            }),
+          );
+
+          await result.result;
+
+          dispatch(
+            setRevocationStatus({
+              id: approval.id,
+              status: { status: 'confirmed' },
+            }),
+          );
+
+          setTimeout(() => {
+            dispatch(removeApproval(approval.id));
+          }, 2000);
+        } catch (err) {
+          if (isUserRejection(err)) {
+            dispatch(clearRevocationStatuses(chainApprovals.map((a) => a.id)));
+            return;
+          }
+          dispatch(
+            setRevocationStatus({
+              id: approval.id,
+              status: {
+                status: 'failed',
+                error:
+                  err instanceof Error ? err.message : 'Transaction failed',
+              },
+            }),
+          );
+        }
+      }
+    },
+    [dispatch, address],
+  );
+
+  const revokeBatch = useCallback(
+    async (chainInfo: ChainBatchInfo) => {
+      const networkClientId = getNetworkClientIdForChain(chainInfo.chainId);
+      if (!networkClientId || !address) return;
+
+      const approvalIds = chainInfo.approvals.map((a) => a.id);
+
+      for (const approval of chainInfo.approvals) {
+        dispatch(
+          setRevocationStatus({
+            id: approval.id,
+            status: { status: 'pending' },
+          }),
+        );
+      }
+
+      try {
+        const transactions = chainInfo.approvals.map((approval) => ({
+          params: {
+            to: approval.asset.address as Hex,
+            from: address as Hex,
+            data: buildRevokeTransactionData(approval) as Hex,
+            value: '0x0' as Hex,
+          },
+          type: getTransactionType(approval),
+        }));
+
+        await addTransactionBatch({
+          from: address as Hex,
+          networkClientId,
+          origin: ORIGIN_METAMASK,
+          transactions,
+          requireApproval: true,
+        });
+
+        for (const approval of chainInfo.approvals) {
+          dispatch(
+            setRevocationStatus({
+              id: approval.id,
+              status: { status: 'confirmed' },
+            }),
+          );
+
+          setTimeout(() => {
+            dispatch(removeApproval(approval.id));
+          }, 2000);
+        }
+      } catch (err) {
+        if (isUserRejection(err)) {
+          dispatch(clearRevocationStatuses(approvalIds));
+          return;
+        }
+        for (const approval of chainInfo.approvals) {
+          dispatch(
+            setRevocationStatus({
+              id: approval.id,
+              status: {
+                status: 'failed',
+                error:
+                  err instanceof Error
+                    ? err.message
+                    : 'Batch transaction failed',
+              },
+            }),
+          );
+        }
+      }
+    },
+    [address, dispatch],
+  );
+
+  const batchRevoke = useCallback(
+    async (approvalIds: string[], chainBreakdown?: ChainBatchInfo[]) => {
+      if (isProcessingRef.current) return;
+      isProcessingRef.current = true;
+
+      try {
+        const approvalsToRevoke = approvals.filter((a) =>
+          approvalIds.includes(a.id),
+        );
+
+        // If we have chain breakdown with batch support info, use smart routing
+        if (chainBreakdown) {
+          const promises = chainBreakdown.map(async (chainInfo) => {
+            if (chainInfo.supportsBatch) {
+              await revokeBatch(chainInfo);
+            } else {
+              await revokeSequential(chainInfo.approvals);
+            }
+          });
+
+          await Promise.allSettled(promises);
+        } else {
+          // Fallback: group by chain and process sequentially (no batch info available)
+          const byChain = new Map<string, ApprovalItem[]>();
+          for (const approval of approvalsToRevoke) {
+            const existing = byChain.get(approval.chainId) ?? [];
+            existing.push(approval);
+            byChain.set(approval.chainId, existing);
+          }
+
+          const chainPromises = Array.from(byChain.values()).map(
+            (chainApprovals) => revokeSequential(chainApprovals),
+          );
+
+          await Promise.allSettled(chainPromises);
+        }
+
+        dispatch(clearSelection());
+      } finally {
+        isProcessingRef.current = false;
+      }
+    },
+    [approvals, revokeBatch, revokeSequential, dispatch],
+  );
+
+  return { batchRevoke };
+}

--- a/app/components/UI/TokenApprovals/hooks/useBatchRevokeSupport.ts
+++ b/app/components/UI/TokenApprovals/hooks/useBatchRevokeSupport.ts
@@ -1,0 +1,138 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import { isAtomicBatchSupported } from '../../../../util/transaction-controller';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectApprovals } from '../selectors';
+import { ApprovalItem } from '../types';
+import { CHAIN_DISPLAY_NAMES } from '../constants/chains';
+
+export interface ChainBatchInfo {
+  chainId: string;
+  chainName: string;
+  approvals: ApprovalItem[];
+  supportsBatch: boolean;
+  isUpgraded: boolean;
+  canUpgrade: boolean;
+  upgradeContractAddress?: string;
+}
+
+export interface BatchRevokeSupport {
+  chainBreakdown: ChainBatchInfo[];
+  hasBatchableChains: boolean;
+  hasUpgradeRequired: boolean;
+  isLoading: boolean;
+}
+
+export function useBatchRevokeSupport(
+  approvalIds: string[],
+): BatchRevokeSupport {
+  const allApprovals = useSelector(selectApprovals);
+  const address = useSelector(selectSelectedInternalAccountAddress);
+  const [batchSupportMap, setBatchSupportMap] = useState<
+    Map<
+      string,
+      {
+        isSupported: boolean;
+        delegationAddress?: string;
+        upgradeContractAddress?: string;
+      }
+    >
+  >(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+
+  const selectedApprovals = useMemo(
+    () => allApprovals.filter((a) => approvalIds.includes(a.id)),
+    [allApprovals, approvalIds],
+  );
+
+  const chainIds = useMemo(
+    () => [...new Set(selectedApprovals.map((a) => a.chainId))],
+    [selectedApprovals],
+  );
+
+  useEffect(() => {
+    if (!address || chainIds.length === 0) {
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      setIsLoading(true);
+      try {
+        const result = await isAtomicBatchSupported({
+          address: address as Hex,
+          chainIds: chainIds as Hex[],
+        });
+
+        if (cancelled) return;
+
+        const map = new Map<
+          string,
+          {
+            isSupported: boolean;
+            delegationAddress?: string;
+            upgradeContractAddress?: string;
+          }
+        >();
+        for (const entry of result) {
+          map.set(entry.chainId.toLowerCase(), {
+            isSupported: entry.isSupported,
+            delegationAddress: entry.delegationAddress,
+            upgradeContractAddress: entry.upgradeContractAddress,
+          });
+        }
+        setBatchSupportMap(map);
+      } catch {
+        // If the check fails, assume no batch support
+        setBatchSupportMap(new Map());
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, chainIds]);
+
+  const chainBreakdown = useMemo((): ChainBatchInfo[] => {
+    const byChain = new Map<string, ApprovalItem[]>();
+    for (const approval of selectedApprovals) {
+      const existing = byChain.get(approval.chainId) ?? [];
+      existing.push(approval);
+      byChain.set(approval.chainId, existing);
+    }
+
+    return Array.from(byChain.entries()).map(([chainId, approvals]) => {
+      const support = batchSupportMap.get(chainId.toLowerCase());
+      const isSupported = support?.isSupported ?? false;
+      const isUpgraded = isSupported && !!support?.delegationAddress;
+      const canUpgrade = isSupported && !support?.delegationAddress;
+
+      return {
+        chainId,
+        chainName: CHAIN_DISPLAY_NAMES[chainId] ?? chainId,
+        approvals,
+        supportsBatch: isSupported && approvals.length >= 2,
+        isUpgraded,
+        canUpgrade,
+        upgradeContractAddress: support?.upgradeContractAddress,
+      };
+    });
+  }, [selectedApprovals, batchSupportMap]);
+
+  const hasBatchableChains = chainBreakdown.some((c) => c.supportsBatch);
+  const hasUpgradeRequired = chainBreakdown.some(
+    (c) => c.supportsBatch && c.canUpgrade,
+  );
+
+  return {
+    chainBreakdown,
+    hasBatchableChains,
+    hasUpgradeRequired,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## Stack Position
PR **6** of **11** — builds on PR 5.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Hooks for EIP-7702 smart account batch revocation support detection and execution.

### Files
- `useBatchRevokeSupport.ts` — given a list of approval IDs, groups them by chain and calls `isAtomicBatchSupported` to determine whether each chain supports batch transactions for this wallet; returns `ChainBatchInfo[]` with `supportsBatch`, `isUpgraded`, `canUpgrade` flags per chain
- `useBatchRevoke.ts` — executes multi-approval revocation with smart routing: uses `addTransactionBatch` for chains with batch support (EIP-7702), falls back to sequential `addTransaction` calls for chains without; uses a mutex ref to prevent double-execution

## Review Guidance
The smart routing logic in `useBatchRevoke.batchRevoke` is the key complexity here. Chains with `supportsBatch: true` and `approvals.length >= 2` get the batch path; others get sequential. Verify that `Promise.allSettled` is the right choice for parallel chain processing (it is — we want all chains to attempt revocation even if one fails).

## PR Stack
- PR 1: Fix confirmations title display for revoke transactions
- PR 2: Add token approvals types, constants, utilities, and config
- PR 3: Add token approvals Redux state and selectors
- PR 4: Add token approvals API and mock data layer
- PR 5: Add core token approvals hooks
- **PR 6 (this):** Add batch revoke hooks ← you are here
- PR 7: Add basic and filter UI components
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new transaction-submission paths (including `addTransactionBatch`) and parallel per-chain execution for approval revocations, which can affect onchain transaction behavior and UI state updates if edge cases occur (network client lookup, rejection/partial failures). Scope is contained to the token approvals feature and uses existing transaction-controller APIs.
> 
> **Overview**
> Adds `useBatchRevokeSupport` to detect per-chain EIP-7702 atomic batch capability for a given set of approval IDs, grouping approvals by chain and returning a `ChainBatchInfo` breakdown plus `hasBatchableChains`/`hasUpgradeRequired` flags.
> 
> Adds `useBatchRevoke` to execute multi-approval revocations with **smart routing**: for batch-capable chains it submits a single `addTransactionBatch` (with `requireApproval`), otherwise it falls back to sequential `addTransaction` calls. The hook updates token-approvals Redux revocation statuses (`pending`/`submitted`/`confirmed`/`failed`), clears statuses on user rejection, removes approvals after confirmation with a short delay, and uses a ref mutex to prevent double execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737d43dfba6ecce797cd640419ae71d05aeeddf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->