### PR TITLE
feat(token-approvals): add basic and filter UI components

### DIFF
--- a/app/components/UI/TokenApprovals/components/ApprovalsEducation/index.tsx
+++ b/app/components/UI/TokenApprovals/components/ApprovalsEducation/index.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Button, {
+  ButtonVariants,
+} from '../../../../../component-library/components/Buttons/Button';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 16,
+    marginVertical: 8,
+    padding: 16,
+    borderRadius: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  iconCircle: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    padding: 4,
+  },
+  learnMore: {
+    marginTop: 12,
+  },
+});
+
+interface ApprovalsEducationProps {
+  onDismiss: () => void;
+}
+
+const ApprovalsEducation: React.FC<ApprovalsEducationProps> = ({
+  onDismiss,
+}) => {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.background.muted }]}
+    >
+      <View style={styles.header}>
+        <View style={styles.titleRow}>
+          <View
+            style={[styles.iconCircle, { backgroundColor: colors.info.muted }]}
+          >
+            <Icon
+              name={IconName.Info}
+              size={IconSize.Xs}
+              color={IconColor.Info}
+            />
+          </View>
+          <Text variant={TextVariant.BodyMDBold} color={TextColor.Default}>
+            {strings('token_approvals.education_title')}
+          </Text>
+        </View>
+        <TouchableOpacity
+          onPress={onDismiss}
+          style={styles.closeButton}
+          accessibilityRole="button"
+          accessibilityLabel={strings('token_approvals.education_dismiss')}
+        >
+          <Icon
+            name={IconName.Close}
+            size={IconSize.Sm}
+            color={IconColor.Muted}
+          />
+        </TouchableOpacity>
+      </View>
+      <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        {strings('token_approvals.education_description')}
+      </Text>
+      <Button
+        variant={ButtonVariants.Link}
+        label={strings('token_approvals.education_learn_more')}
+        style={styles.learnMore}
+      />
+    </View>
+  );
+};
+
+export default ApprovalsEducation;

--- a/app/components/UI/TokenApprovals/components/BatchRevokeBar/index.tsx
+++ b/app/components/UI/TokenApprovals/components/BatchRevokeBar/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+} from '../../../../../component-library/components/Buttons/Button';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 32,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    ...Platform.select({
+      ios: {
+        shadowOffset: { width: 0, height: -2 },
+        shadowOpacity: 0.1,
+        shadowRadius: 8,
+      },
+      android: {
+        elevation: 8,
+      },
+    }),
+  },
+  countText: {
+    flex: 1,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+});
+
+interface BatchRevokeBarProps {
+  selectedCount: number;
+  onRevoke: () => void;
+  onClear: () => void;
+  isProcessing: boolean;
+}
+
+const BatchRevokeBar: React.FC<BatchRevokeBarProps> = ({
+  selectedCount,
+  onRevoke,
+  onClear,
+  isProcessing,
+}) => {
+  const { colors } = useTheme();
+
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background.default,
+          shadowColor: colors.shadow?.default ?? colors.border.default,
+        },
+      ]}
+    >
+      <Text
+        variant={TextVariant.BodyLGMedium}
+        color={TextColor.Default}
+        style={styles.countText}
+      >
+        {strings('token_approvals.batch_revoke_bar', {
+          count: selectedCount.toString(),
+        })}
+      </Text>
+      <View style={styles.buttonRow}>
+        <Button
+          variant={ButtonVariants.Secondary}
+          size={ButtonSize.Sm}
+          label={strings('token_approvals.clear_selection')}
+          onPress={onClear}
+          isDisabled={isProcessing}
+        />
+        <Button
+          variant={ButtonVariants.Primary}
+          size={ButtonSize.Sm}
+          label={strings('token_approvals.batch_revoke_cta')}
+          onPress={onRevoke}
+          isDisabled={isProcessing}
+        />
+      </View>
+    </View>
+  );
+};
+
+export default BatchRevokeBar;

--- a/app/components/UI/TokenApprovals/components/EmptyState/index.tsx
+++ b/app/components/UI/TokenApprovals/components/EmptyState/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    paddingVertical: 64,
+  },
+  card: {
+    alignItems: 'center',
+    borderRadius: 16,
+    padding: 32,
+    width: '100%',
+  },
+  iconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  description: {
+    textAlign: 'center',
+  },
+});
+
+const EmptyState: React.FC = () => {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.card, { backgroundColor: colors.background.muted }]}>
+        <View
+          style={[styles.iconCircle, { backgroundColor: colors.success.muted }]}
+        >
+          <Icon
+            name={IconName.SecurityTick}
+            size={IconSize.Xl}
+            color={IconColor.Success}
+          />
+        </View>
+        <Text
+          variant={TextVariant.HeadingSM}
+          color={TextColor.Default}
+          style={styles.title}
+        >
+          {strings('token_approvals.empty_title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMD}
+          color={TextColor.Alternative}
+          style={styles.description}
+        >
+          {strings('token_approvals.empty_description')}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export default EmptyState;

--- a/app/components/UI/TokenApprovals/components/FilterSortRow/index.tsx
+++ b/app/components/UI/TokenApprovals/components/FilterSortRow/index.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import { VerdictFilter, SortOption } from '../../types';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  filterChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    gap: 6,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  sortButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 12,
+    gap: 4,
+  },
+});
+
+const VERDICT_FILTERS: VerdictFilter[] = [
+  'All',
+  'Malicious',
+  'Warning',
+  'Benign',
+];
+
+const SORT_LABELS: Record<SortOption, string> = {
+  risk: 'token_approvals.sort_risk',
+  value: 'token_approvals.sort_value',
+  asset_name: 'token_approvals.sort_name',
+};
+
+const SORT_OPTIONS: SortOption[] = ['risk', 'value', 'asset_name'];
+
+interface FilterSortRowProps {
+  verdictFilter: VerdictFilter;
+  sortBy: SortOption;
+  onVerdictFilterChange: (filter: VerdictFilter) => void;
+  onSortChange: (sort: SortOption) => void;
+}
+
+const FilterSortRow: React.FC<FilterSortRowProps> = ({
+  verdictFilter,
+  sortBy,
+  onVerdictFilterChange,
+  onSortChange,
+}) => {
+  const { colors } = useTheme();
+
+  const handleSortPress = () => {
+    const currentIndex = SORT_OPTIONS.indexOf(sortBy);
+    const nextIndex = (currentIndex + 1) % SORT_OPTIONS.length;
+    onSortChange(SORT_OPTIONS[nextIndex]);
+  };
+
+  const getFilterLabel = (filter: VerdictFilter) => {
+    switch (filter) {
+      case 'All':
+        return strings('token_approvals.filter_all');
+      case 'Malicious':
+        return strings('token_approvals.filter_malicious');
+      case 'Warning':
+        return strings('token_approvals.filter_warning');
+      case 'Benign':
+        return strings('token_approvals.filter_benign');
+    }
+  };
+
+  const getDotColor = (filter: VerdictFilter): string | null => {
+    switch (filter) {
+      case 'Malicious':
+        return colors.error.default;
+      case 'Warning':
+        return colors.warning.default;
+      case 'Benign':
+        return colors.success.default;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.filterRow}>
+        {VERDICT_FILTERS.map((filter) => {
+          const isActive = verdictFilter === filter;
+          const dotColor = getDotColor(filter);
+          return (
+            <TouchableOpacity
+              key={filter}
+              style={[
+                styles.filterChip,
+                {
+                  backgroundColor: isActive
+                    ? colors.primary.default
+                    : colors.background.alternative,
+                },
+              ]}
+              onPress={() => onVerdictFilterChange(filter)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+            >
+              {dotColor && !isActive && (
+                <View style={[styles.dot, { backgroundColor: dotColor }]} />
+              )}
+              <Text
+                variant={TextVariant.BodySM}
+                color={isActive ? TextColor.Inverse : TextColor.Default}
+              >
+                {getFilterLabel(filter)}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+      <TouchableOpacity
+        style={[
+          styles.sortButton,
+          { backgroundColor: colors.background.alternative },
+        ]}
+        onPress={handleSortPress}
+        accessibilityRole="button"
+        accessibilityLabel={`Sort by ${strings(SORT_LABELS[sortBy])}`}
+      >
+        <Icon
+          name={IconName.SwapVertical}
+          size={IconSize.Sm}
+          color={IconColor.Default}
+        />
+        <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+          {strings(SORT_LABELS[sortBy])}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default FilterSortRow;

--- a/app/components/UI/TokenApprovals/components/RiskBadge/index.tsx
+++ b/app/components/UI/TokenApprovals/components/RiskBadge/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import { useTheme } from '../../../../../util/theme';
+import { Verdict } from '../../types';
+
+const styles = StyleSheet.create({
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 24,
+    alignSelf: 'flex-start',
+    gap: 4,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+});
+
+interface RiskBadgeProps {
+  verdict: Verdict;
+}
+
+const RiskBadge: React.FC<RiskBadgeProps> = ({ verdict }) => {
+  const { colors } = useTheme();
+
+  const badgeColors = {
+    [Verdict.Malicious]: {
+      bg: colors.error.muted,
+      dot: colors.error.default,
+      text: TextColor.Error,
+    },
+    [Verdict.Warning]: {
+      bg: colors.warning.muted,
+      dot: colors.warning.default,
+      text: TextColor.Warning,
+    },
+    [Verdict.Benign]: {
+      bg: colors.success.muted,
+      dot: colors.success.default,
+      text: TextColor.Success,
+    },
+    [Verdict.Error]: {
+      bg: colors.background.alternative,
+      dot: colors.icon.muted,
+      text: TextColor.Alternative,
+    },
+  };
+
+  const { bg, dot, text } = badgeColors[verdict];
+
+  return (
+    <View style={[styles.badge, { backgroundColor: bg }]}>
+      <View style={[styles.dot, { backgroundColor: dot }]} />
+      <Text variant={TextVariant.BodyXS} color={text}>
+        {verdict}
+      </Text>
+    </View>
+  );
+};
+
+export default RiskBadge;

--- a/app/components/UI/TokenApprovals/components/SkeletonApprovalCard/index.tsx
+++ b/app/components/UI/TokenApprovals/components/SkeletonApprovalCard/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Skeleton } from '../../../../../component-library/components/Skeleton';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    gap: 16,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+  centerColumn: {
+    flex: 1,
+    gap: 6,
+  },
+  nameSkeleton: {
+    height: 16,
+    borderRadius: 8,
+    width: '60%',
+  },
+  spenderSkeleton: {
+    height: 12,
+    borderRadius: 8,
+    width: '40%',
+  },
+  rightColumn: {
+    alignItems: 'flex-end',
+    gap: 6,
+  },
+  valueSkeleton: {
+    height: 16,
+    width: 60,
+    borderRadius: 8,
+  },
+  buttonSkeleton: {
+    height: 28,
+    width: 64,
+    borderRadius: 14,
+  },
+});
+
+const SkeletonApprovalCard: React.FC = () => (
+  <View style={styles.container}>
+    <Skeleton style={styles.avatar} />
+    <View style={styles.centerColumn}>
+      <Skeleton style={styles.nameSkeleton} />
+      <Skeleton style={styles.spenderSkeleton} />
+    </View>
+    <View style={styles.rightColumn}>
+      <Skeleton style={styles.valueSkeleton} />
+      <Skeleton style={styles.buttonSkeleton} />
+    </View>
+  </View>
+);
+
+export default SkeletonApprovalCard;


### PR DESCRIPTION
## Stack Position
PR **7** of **11** — builds on PR 6.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Self-contained presentational components with no dependencies on other changed components.

### Files
- `SkeletonApprovalCard` — shimmer placeholder shown during loading (uses design system Skeleton)
- `EmptyState` — shown when there are no approvals to display
- `RiskBadge` — colored badge displaying a `Verdict` value (Malicious/Warning/Benign/Error)
- `ApprovalsEducation` — informational card explaining what token approvals are
- `BatchRevokeBar` — sticky bottom bar showing selected count with "Revoke Selected" and "Clear" actions
- `FilterSortRow` — row of filter/sort chips for verdict filter and sort order selection

## Review Guidance
These are all purely presentational — no Redux or hook usage. Focus on theming (all use `useTheme()`) and accessibility labels.

## PR Stack
- PR 1–6: Foundation, state, API, hooks (see earlier PRs)
- **PR 7 (this):** Add basic and filter UI components ← you are here
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new presentational React Native components only, with theming/i18n and no changes to approval fetching, state, or transaction logic.
> 
> **Overview**
> Adds several new presentational components under `TokenApprovals/components` to support the upcoming approvals dashboard UI.
> 
> Includes an education callout (`ApprovalsEducation`) with dismiss CTA, an empty state card (`EmptyState`), a loading shimmer row (`SkeletonApprovalCard`), and a verdict-driven `RiskBadge`.
> 
> Also introduces interaction UI for list controls: `FilterSortRow` for verdict filtering and cycling sort options, and a sticky `BatchRevokeBar` that appears when items are selected and disables actions while processing (with accessibility labels/states and theme-driven colors throughout).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894903b995fc6c297b9654568f7801554142be17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->