### PR TITLE
feat(token-approvals): add approval card and risk display components

### DIFF
--- a/app/components/UI/TokenApprovals/components/ApprovalCard/index.tsx
+++ b/app/components/UI/TokenApprovals/components/ApprovalCard/index.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback } from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Checkbox from '../../../../../component-library/components/Checkbox';
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+} from '../../../../../component-library/components/Buttons/Button';
+import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
+import BadgeWrapper from '../../../../../component-library/components/Badges/BadgeWrapper';
+import { BadgePosition } from '../../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.types';
+import Badge from '../../../../../component-library/components/Badges/Badge';
+import { BadgeVariant } from '../../../../../component-library/components/Badges/Badge/Badge.types';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
+import { useTheme } from '../../../../../util/theme';
+import { renderShortAddress } from '../../../../../util/address';
+import { getNetworkImageSource } from '../../../../../util/networks';
+import { strings } from '../../../../../../locales/i18n';
+import { ApprovalItem, RevocationStatus } from '../../types';
+import { formatUsd } from '../../utils/formatUsd';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    gap: 16,
+    borderRadius: 12,
+  },
+  checkboxContainer: {
+    marginRight: -4,
+  },
+  avatarContainer: {
+    width: 40,
+    height: 40,
+  },
+  centerColumn: {
+    flex: 1,
+    gap: 2,
+  },
+  tokenRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  rightColumn: {
+    alignItems: 'flex-end',
+    gap: 6,
+  },
+});
+
+interface ApprovalCardProps {
+  approval: ApprovalItem;
+  isSelected: boolean;
+  revocationStatus?: RevocationStatus;
+  onPress: (approval: ApprovalItem) => void;
+  onSelect: (id: string) => void;
+  onRevoke: (approval: ApprovalItem) => void;
+  selectionMode: boolean;
+}
+
+const ApprovalCard: React.FC<ApprovalCardProps> = ({
+  approval,
+  isSelected,
+  revocationStatus,
+  onPress,
+  onSelect,
+  onRevoke,
+  selectionMode,
+}) => {
+  const { colors } = useTheme();
+
+  const handlePress = useCallback(() => onPress(approval), [approval, onPress]);
+
+  const handleSelect = useCallback(
+    () => onSelect(approval.id),
+    [approval.id, onSelect],
+  );
+
+  const handleRevoke = useCallback(
+    () => onRevoke(approval),
+    [approval, onRevoke],
+  );
+
+  const isRevoking =
+    revocationStatus?.status === 'pending' ||
+    revocationStatus?.status === 'submitted';
+
+  const revokeButtonLabel = (() => {
+    switch (revocationStatus?.status) {
+      case 'pending':
+      case 'submitted':
+        return strings('token_approvals.revoking');
+      case 'confirmed':
+        return strings('token_approvals.revoked');
+      case 'failed':
+        return strings('token_approvals.revoke_failed');
+      default:
+        return strings('token_approvals.revoke');
+    }
+  })();
+
+  const spenderLabel =
+    approval.spender.label || renderShortAddress(approval.spender.address);
+
+  const networkImageSource = getNetworkImageSource({
+    chainId: approval.chainId,
+  });
+
+  const selectedStyle = isSelected
+    ? { backgroundColor: colors.primary.muted }
+    : undefined;
+
+  const exposureUsd = Number(approval.exposure_usd) || 0;
+
+  return (
+    <TouchableOpacity
+      style={[styles.container, selectedStyle]}
+      onPress={selectionMode ? handleSelect : handlePress}
+      onLongPress={handleSelect}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${approval.asset.symbol} approval for ${spenderLabel}`}
+    >
+      {selectionMode && (
+        <View style={styles.checkboxContainer}>
+          <Checkbox isChecked={isSelected} onPress={handleSelect} />
+        </View>
+      )}
+
+      {/* Left: Token avatar with network badge */}
+      <View style={styles.avatarContainer}>
+        <BadgeWrapper
+          badgePosition={BadgePosition.BottomRight}
+          badgeElement={
+            networkImageSource ? (
+              <Badge
+                variant={BadgeVariant.Network}
+                imageSource={networkImageSource}
+                name={approval.chainName}
+                size={AvatarSize.Xs}
+                isScaled={false}
+              />
+            ) : undefined
+          }
+        >
+          <AvatarToken
+            size={AvatarSize.Lg}
+            name={approval.asset.symbol}
+            imageSource={
+              approval.asset.logo_url
+                ? { uri: approval.asset.logo_url }
+                : undefined
+            }
+          />
+        </BadgeWrapper>
+      </View>
+
+      {/* Center: Token name + value at risk, spender */}
+      <View style={styles.centerColumn}>
+        <View style={styles.tokenRow}>
+          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            {approval.asset.symbol}
+          </Text>
+          {exposureUsd > 0 && (
+            <Text variant={TextVariant.BodyXS} color={TextColor.Warning}>
+              {formatUsd(exposureUsd)} at risk
+            </Text>
+          )}
+        </View>
+        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          {spenderLabel}
+        </Text>
+      </View>
+
+      {/* Right: Revoke button */}
+      <View style={styles.rightColumn}>
+        <Button
+          variant={ButtonVariants.Secondary}
+          size={ButtonSize.Sm}
+          label={revokeButtonLabel}
+          onPress={handleRevoke}
+          isDisabled={isRevoking}
+        />
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default React.memo(ApprovalCard);

--- a/app/components/UI/TokenApprovals/components/ApprovalRiskBanner/index.tsx
+++ b/app/components/UI/TokenApprovals/components/ApprovalRiskBanner/index.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import { formatUsd } from '../../utils/formatUsd';
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 12,
+    borderRadius: 12,
+    padding: 16,
+    ...Platform.select({
+      ios: {
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.15,
+        shadowRadius: 8,
+      },
+      android: {
+        elevation: 4,
+      },
+    }),
+  },
+  contentRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    marginBottom: 16,
+  },
+  textColumn: {
+    flex: 1,
+  },
+  subtitle: {
+    marginTop: 2,
+    opacity: 0.8,
+  },
+});
+
+interface ApprovalRiskBannerProps {
+  maliciousCount: number;
+  exposureUsd: number;
+  onRevokeAll: () => void;
+}
+
+const ApprovalRiskBanner: React.FC<ApprovalRiskBannerProps> = ({
+  maliciousCount,
+  exposureUsd,
+  onRevokeAll,
+}) => {
+  const { colors } = useTheme();
+
+  if (maliciousCount === 0) {
+    return null;
+  }
+
+  const titleKey =
+    maliciousCount === 1
+      ? 'token_approvals.risk_banner_title'
+      : 'token_approvals.risk_banner_title_plural';
+
+  const formattedExposure = formatUsd(exposureUsd);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.error.muted,
+          shadowColor: colors.error.default,
+        },
+      ]}
+    >
+      <View style={styles.contentRow}>
+        <Icon
+          name={IconName.Danger}
+          size={IconSize.Lg}
+          color={IconColor.Error}
+        />
+        <View style={styles.textColumn}>
+          <Text variant={TextVariant.BodyMDBold} color={TextColor.Error}>
+            {strings(titleKey, { count: maliciousCount.toString() })}
+          </Text>
+          <Text
+            variant={TextVariant.BodySM}
+            color={TextColor.Error}
+            style={styles.subtitle}
+          >
+            {strings('token_approvals.risk_banner_subtitle', {
+              amount: formattedExposure,
+            })}
+          </Text>
+        </View>
+      </View>
+      <Button
+        variant={ButtonVariants.Primary}
+        size={ButtonSize.Md}
+        label={strings('token_approvals.risk_banner_cta')}
+        isDanger
+        onPress={onRevokeAll}
+        width={ButtonWidthTypes.Full}
+      />
+    </View>
+  );
+};
+
+export default ApprovalRiskBanner;

--- a/app/components/UI/TokenApprovals/components/ChainFilterBar/index.tsx
+++ b/app/components/UI/TokenApprovals/components/ChainFilterBar/index.tsx
@@ -1,0 +1,109 @@
+import React, { useCallback } from 'react';
+import { ScrollView, TouchableOpacity, View, StyleSheet } from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import AvatarNetwork from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
+import { useTheme } from '../../../../../util/theme';
+import { getNetworkImageSource } from '../../../../../util/networks';
+import { strings } from '../../../../../../locales/i18n';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 8,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    gap: 8,
+    flexDirection: 'row',
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    gap: 6,
+  },
+});
+
+interface ChainInfo {
+  chainId: string;
+  displayName: string;
+  count: number;
+}
+
+interface ChainFilterBarProps {
+  chains: ChainInfo[];
+  selectedChains: string[];
+  onChainToggle: (chainId: string) => void;
+}
+
+const ChainFilterBar: React.FC<ChainFilterBarProps> = ({
+  chains,
+  selectedChains,
+  onChainToggle,
+}) => {
+  const { colors } = useTheme();
+
+  const isSelected = useCallback(
+    (chainId: string) => selectedChains.includes(chainId),
+    [selectedChains],
+  );
+
+  if (chains.length <= 1) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {chains.map((chain) => {
+          const selected = isSelected(chain.chainId);
+          const networkImage = getNetworkImageSource({
+            chainId: chain.chainId,
+          });
+          return (
+            <TouchableOpacity
+              key={chain.chainId}
+              style={[
+                styles.chip,
+                {
+                  backgroundColor: selected
+                    ? colors.primary.default
+                    : colors.background.alternative,
+                },
+              ]}
+              onPress={() => onChainToggle(chain.chainId)}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              accessibilityLabel={`${chain.displayName} ${strings('token_approvals.filter_all')} ${chain.count}`}
+            >
+              {networkImage && (
+                <AvatarNetwork
+                  size={AvatarSize.Xs}
+                  imageSource={networkImage}
+                  name={chain.displayName}
+                />
+              )}
+              <Text
+                variant={TextVariant.BodySM}
+                color={selected ? TextColor.Inverse : TextColor.Default}
+              >
+                {chain.displayName} ({chain.count})
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default ChainFilterBar;

--- a/app/components/UI/TokenApprovals/components/RiskDashboardHeader/index.tsx
+++ b/app/components/UI/TokenApprovals/components/RiskDashboardHeader/index.tsx
@@ -1,0 +1,193 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../locales/i18n';
+import { ApprovalItem, Verdict } from '../../types';
+import { formatUsd } from '../../utils/formatUsd';
+
+interface RiskDashboardHeaderProps {
+  approvals: ApprovalItem[];
+  onRevokeAllRisky: () => void;
+  isProcessing?: boolean;
+}
+
+const RiskDashboardHeader: React.FC<RiskDashboardHeaderProps> = ({
+  approvals,
+  onRevokeAllRisky,
+  isProcessing = false,
+}) => {
+  const tw = useTailwind();
+
+  const stats = useMemo(() => {
+    let maliciousCount = 0;
+    let warningCount = 0;
+    let benignCount = 0;
+    let riskyExposure = 0;
+    let totalExposure = 0;
+
+    for (const a of approvals) {
+      const exposureUsd = Number(a.exposure_usd) || 0;
+      totalExposure += exposureUsd;
+      if (a.verdict === Verdict.Malicious) {
+        maliciousCount++;
+        riskyExposure += exposureUsd;
+      } else if (a.verdict === Verdict.Warning) {
+        warningCount++;
+        riskyExposure += exposureUsd;
+      } else {
+        benignCount++;
+      }
+    }
+
+    const total = approvals.length;
+    const riskyCount = maliciousCount + warningCount;
+
+    return {
+      maliciousCount,
+      warningCount,
+      benignCount,
+      riskyCount,
+      total,
+      riskyExposure,
+      totalExposure,
+    };
+  }, [approvals]);
+
+  if (stats.total === 0) return null;
+
+  if (stats.riskyCount === 0) {
+    return (
+      <Box twClassName="mx-4 mt-1 mb-3 rounded-2xl overflow-hidden bg-success-muted">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={3}
+          twClassName="px-4 py-4"
+        >
+          <Icon
+            name={IconName.SecurityTick}
+            size={IconSize.Md}
+            color={IconColor.SuccessDefault}
+          />
+          <Box twClassName="flex-1">
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.SuccessDefault}
+            >
+              {strings('token_approvals.dashboard_clean_title')}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {strings('token_approvals.dashboard_clean_subtitle', {
+                count: stats.total.toString(),
+              })}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box twClassName="mx-4 mt-1 mb-3 rounded-2xl overflow-hidden bg-background-alternative">
+      <Box twClassName="p-4" gap={4}>
+        {/* Risk indicator */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={3}
+        >
+          <Box
+            style={tw.style(
+              'w-10 h-10 rounded-full items-center justify-center bg-error-muted',
+            )}
+          >
+            <Icon
+              name={IconName.Danger}
+              size={IconSize.Md}
+              color={IconColor.ErrorDefault}
+            />
+          </Box>
+          <Text
+            variant={TextVariant.BodyLg}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+          >
+            {strings('token_approvals.dashboard_at_risk', {
+              count: stats.riskyCount.toString(),
+              total: stats.total.toString(),
+            })}
+          </Text>
+        </Box>
+
+        {/* Stats */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          alignItems={BoxAlignItems.Start}
+        >
+          <Box gap={1}>
+            <Text
+              variant={TextVariant.HeadingSm}
+              color={TextColor.ErrorDefault}
+            >
+              {formatUsd(stats.riskyExposure)}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {strings('token_approvals.dashboard_exposed')}
+            </Text>
+          </Box>
+          <Box gap={1} twClassName="items-end">
+            <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
+              {formatUsd(stats.totalExposure)}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {strings('token_approvals.dashboard_total_approved')}
+            </Text>
+          </Box>
+        </Box>
+
+        {/* CTA */}
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isDanger
+          onPress={onRevokeAllRisky}
+          isFullWidth
+          isDisabled={isProcessing}
+        >
+          {strings('token_approvals.dashboard_revoke_risky', {
+            count: stats.riskyCount.toString(),
+          })}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default RiskDashboardHeader;


### PR DESCRIPTION
## Stack Position
PR **8** of **11** — builds on PR 7.

> Split from POC branch: `feat/approval-dashboard`

## Changes
More complex display components — the core approval card and risk summary UI.

### Files
- `ApprovalCard` — the central list item: token avatar with network badge, spender address/label, allowance amount, verdict-colored risk badge, USD exposure, revoke button, and selection checkbox; shows revocation status overlay (pending/submitted/confirmed/failed)
- `ChainFilterBar` — horizontal scrollable row of network filter chips with network avatars
- `ApprovalRiskBanner` — warning banner showing total malicious/warning exposure USD with call-to-action
- `RiskDashboardHeader` — summary stats header showing malicious count and total exposure, with "Revoke All Risky" action; uses tailwind preset for layout

## Review Guidance
`ApprovalCard` is the most complex component here. Check the revocation status overlay logic — it should show as an overlay on top of the card while a revoke is in flight. `RiskDashboardHeader` uses `@metamask/design-system-twrnc-preset` for tailwind classes — verify the layout is correct.

## PR Stack
- PR 1–7: Foundation, state, API, hooks, basic components (see earlier PRs)
- **PR 8 (this):** Add approval card and risk display components ← you are here
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new UI components and computed display logic; risk is limited to potential UX/labeling issues around selection and revocation status states.
> 
> **Overview**
> Adds new Token Approvals UI building blocks: an `ApprovalCard` list item with network+token avatars, selection mode (tap/long-press + checkbox), optional “USD at risk” display, and a revoke button whose label/disabled state reflects `RevocationStatus`.
> 
> Introduces risk-focused summary components: `ApprovalRiskBanner` (only shown when malicious approvals exist, with total exposure and a “revoke all” CTA), `RiskDashboardHeader` (computes risky vs total counts and exposure totals and provides a “revoke risky” CTA), and `ChainFilterBar` (scrollable per-network filter chips with counts and selection styling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7143d0dbe2b015a4f948fa5e4093c3de3ddf2c34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->