### PR TITLE
feat(token-approvals): add approval list and grouped list components

### DIFF
--- a/app/components/UI/TokenApprovals/components/ApprovalsList/index.tsx
+++ b/app/components/UI/TokenApprovals/components/ApprovalsList/index.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback } from 'react';
+import { FlatList, View, StyleSheet } from 'react-native';
+import { ApprovalItem, RevocationStatus } from '../../types';
+import ApprovalCard from '../ApprovalCard';
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flexGrow: 1,
+    paddingBottom: 100,
+  },
+  separator: {
+    height: 2,
+  },
+});
+
+interface ApprovalsListProps {
+  approvals: ApprovalItem[];
+  selectedIds: string[];
+  revocations: Record<string, RevocationStatus>;
+  selectionMode: boolean;
+  onApprovalPress: (approval: ApprovalItem) => void;
+  onApprovalSelect: (id: string) => void;
+  onApprovalRevoke: (approval: ApprovalItem) => void;
+  ListHeaderComponent?: React.ReactElement;
+}
+
+const ItemSeparator = () => <View style={styles.separator} />;
+
+const ApprovalsList: React.FC<ApprovalsListProps> = ({
+  approvals,
+  selectedIds,
+  revocations,
+  selectionMode,
+  onApprovalPress,
+  onApprovalSelect,
+  onApprovalRevoke,
+  ListHeaderComponent,
+}) => {
+  const renderItem = useCallback(
+    ({ item }: { item: ApprovalItem }) => (
+      <ApprovalCard
+        approval={item}
+        isSelected={selectedIds.includes(item.id)}
+        revocationStatus={revocations[item.id]}
+        onPress={onApprovalPress}
+        onSelect={onApprovalSelect}
+        onRevoke={onApprovalRevoke}
+        selectionMode={selectionMode}
+      />
+    ),
+    [
+      selectedIds,
+      revocations,
+      selectionMode,
+      onApprovalPress,
+      onApprovalSelect,
+      onApprovalRevoke,
+    ],
+  );
+
+  const keyExtractor = useCallback((item: ApprovalItem) => item.id, []);
+
+  return (
+    <FlatList
+      data={approvals}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      ListHeaderComponent={ListHeaderComponent}
+      ItemSeparatorComponent={ItemSeparator}
+      contentContainerStyle={styles.contentContainer}
+      removeClippedSubviews
+    />
+  );
+};
+
+export default ApprovalsList;

--- a/app/components/UI/TokenApprovals/components/RiskGroupedList/index.tsx
+++ b/app/components/UI/TokenApprovals/components/RiskGroupedList/index.tsx
@@ -1,0 +1,371 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  SectionList,
+  TouchableOpacity,
+  LayoutAnimation,
+  Platform,
+  UIManager,
+} from 'react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Checkbox from '../../../../../component-library/components/Checkbox';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import { ApprovalItem, RevocationStatus, Verdict } from '../../types';
+import ApprovalCard from '../ApprovalCard';
+
+if (
+  Platform.OS === 'android' &&
+  UIManager.setLayoutAnimationEnabledExperimental
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    flexGrow: 1,
+    paddingBottom: 100,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 10,
+  },
+  sectionHeaderLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    gap: 10,
+  },
+  riskIndicator: {
+    width: 4,
+    height: 28,
+    borderRadius: 2,
+  },
+  sectionTitleColumn: {
+    flex: 1,
+  },
+  sectionTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  countBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 10,
+    minWidth: 20,
+    alignItems: 'center',
+  },
+  selectAllContainer: {
+    marginRight: 4,
+  },
+  separator: {
+    height: 2,
+  },
+  collapsedHint: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    alignItems: 'center',
+  },
+});
+
+interface RiskSection {
+  verdict: Verdict;
+  title: string;
+  data: ApprovalItem[];
+}
+
+interface RiskGroupedListProps {
+  approvals: ApprovalItem[];
+  selectedIds: string[];
+  revocations: Record<string, RevocationStatus>;
+  selectionMode: boolean;
+  onApprovalPress: (approval: ApprovalItem) => void;
+  onApprovalSelect: (id: string) => void;
+  onApprovalRevoke: (approval: ApprovalItem) => void;
+  onSelectAll: (ids: string[]) => void;
+  ListHeaderComponent?: React.ReactElement;
+}
+
+const SECTION_CONFIG: Record<
+  Verdict,
+  {
+    titleKey: string;
+    colorKey: 'error' | 'warning' | 'success' | 'background';
+    iconName: IconName;
+    iconColor: IconColor;
+    textColor: TextColor;
+    defaultExpanded: boolean;
+  }
+> = {
+  [Verdict.Malicious]: {
+    titleKey: 'token_approvals.section_malicious',
+    colorKey: 'error',
+    iconName: IconName.Danger,
+    iconColor: IconColor.Error,
+    textColor: TextColor.Error,
+    defaultExpanded: true,
+  },
+  [Verdict.Warning]: {
+    titleKey: 'token_approvals.section_warning',
+    colorKey: 'warning',
+    iconName: IconName.Warning,
+    iconColor: IconColor.Warning,
+    textColor: TextColor.Warning,
+    defaultExpanded: true,
+  },
+  [Verdict.Benign]: {
+    titleKey: 'token_approvals.section_benign',
+    colorKey: 'success',
+    iconName: IconName.SecurityTick,
+    iconColor: IconColor.Success,
+    textColor: TextColor.Success,
+    defaultExpanded: true,
+  },
+  [Verdict.Error]: {
+    titleKey: 'token_approvals.section_benign',
+    colorKey: 'background',
+    iconName: IconName.Info,
+    iconColor: IconColor.Muted,
+    textColor: TextColor.Alternative,
+    defaultExpanded: true,
+  },
+};
+
+const RiskGroupedList: React.FC<RiskGroupedListProps> = ({
+  approvals,
+  selectedIds,
+  revocations,
+  selectionMode,
+  onApprovalPress,
+  onApprovalSelect,
+  onApprovalRevoke,
+  onSelectAll,
+  ListHeaderComponent,
+}) => {
+  const { colors } = useTheme();
+
+  const sections = useMemo(() => {
+    const groups: Record<Verdict, ApprovalItem[]> = {
+      [Verdict.Malicious]: [],
+      [Verdict.Warning]: [],
+      [Verdict.Benign]: [],
+      [Verdict.Error]: [],
+    };
+
+    for (const a of approvals) {
+      groups[a.verdict].push(a);
+    }
+
+    const result: RiskSection[] = [];
+    const order = [
+      Verdict.Malicious,
+      Verdict.Warning,
+      Verdict.Benign,
+      Verdict.Error,
+    ];
+
+    for (const verdict of order) {
+      if (groups[verdict].length > 0) {
+        result.push({
+          verdict,
+          title: strings(SECTION_CONFIG[verdict].titleKey),
+          data: groups[verdict],
+        });
+      }
+    }
+
+    return result;
+  }, [approvals]);
+
+  const [collapsedSections, setCollapsedSections] = useState<
+    Record<string, boolean>
+  >({});
+
+  const toggleSection = useCallback((verdict: string) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setCollapsedSections((prev) => ({
+      ...prev,
+      [verdict]: !prev[verdict],
+    }));
+  }, []);
+
+  const handleSelectAllInSection = useCallback(
+    (sectionData: ApprovalItem[]) => {
+      const sectionIds = sectionData.map((a) => a.id);
+      const allAlreadySelected = sectionIds.every((id) =>
+        selectedIds.includes(id),
+      );
+
+      if (allAlreadySelected) {
+        // Deselect this section's items, keep others
+        const remaining = selectedIds.filter((id) => !sectionIds.includes(id));
+        onSelectAll(remaining);
+      } else {
+        // Add all section items to current selection
+        const merged = [...new Set([...selectedIds, ...sectionIds])];
+        onSelectAll(merged);
+      }
+    },
+    [onSelectAll, selectedIds],
+  );
+
+  const renderItem = useCallback(
+    ({ item, section }: { item: ApprovalItem; section: RiskSection }) => {
+      if (collapsedSections[section.verdict]) {
+        return null;
+      }
+      return (
+        <ApprovalCard
+          approval={item}
+          isSelected={selectedIds.includes(item.id)}
+          revocationStatus={revocations[item.id]}
+          onPress={onApprovalPress}
+          onSelect={onApprovalSelect}
+          onRevoke={onApprovalRevoke}
+          selectionMode={selectionMode}
+        />
+      );
+    },
+    [
+      collapsedSections,
+      selectedIds,
+      revocations,
+      selectionMode,
+      onApprovalPress,
+      onApprovalSelect,
+      onApprovalRevoke,
+    ],
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: RiskSection }) => {
+      const config = SECTION_CONFIG[section.verdict];
+      const isCollapsed = collapsedSections[section.verdict] ?? false;
+      const indicatorColor =
+        config.colorKey === 'background'
+          ? colors.border.muted
+          : colors[config.colorKey].default;
+      const badgeBg =
+        config.colorKey === 'background'
+          ? colors.background.alternative
+          : colors[config.colorKey].muted;
+
+      const sectionIds = section.data.map((a) => a.id);
+      const allSelected =
+        sectionIds.length > 0 &&
+        sectionIds.every((id) => selectedIds.includes(id));
+
+      return (
+        <View>
+          <TouchableOpacity
+            style={styles.sectionHeader}
+            onPress={() => toggleSection(section.verdict)}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={`${section.title}, ${section.data.length} items, ${isCollapsed ? 'collapsed' : 'expanded'}`}
+          >
+            {selectionMode && (
+              <View style={styles.selectAllContainer}>
+                <Checkbox
+                  isChecked={allSelected}
+                  onPress={() => handleSelectAllInSection(section.data)}
+                />
+              </View>
+            )}
+            <View
+              style={[
+                styles.riskIndicator,
+                { backgroundColor: indicatorColor },
+              ]}
+            />
+            <View style={styles.sectionTitleColumn}>
+              <View style={styles.sectionTitleRow}>
+                <Text
+                  variant={TextVariant.BodyMDMedium}
+                  color={TextColor.Default}
+                >
+                  {section.title}
+                </Text>
+                <View style={[styles.countBadge, { backgroundColor: badgeBg }]}>
+                  <Text variant={TextVariant.BodyXS} color={config.textColor}>
+                    {section.data.length}
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <Icon
+              name={isCollapsed ? IconName.ArrowRight : IconName.ArrowDown}
+              size={IconSize.Sm}
+              color={IconColor.Muted}
+            />
+          </TouchableOpacity>
+        </View>
+      );
+    },
+    [
+      collapsedSections,
+      colors,
+      selectionMode,
+      selectedIds,
+      toggleSection,
+      handleSelectAllInSection,
+    ],
+  );
+
+  const renderSectionFooter = useCallback(
+    ({ section }: { section: RiskSection }) => {
+      if (!collapsedSections[section.verdict]) return null;
+      return (
+        <TouchableOpacity
+          style={styles.collapsedHint}
+          onPress={() => toggleSection(section.verdict)}
+          activeOpacity={0.7}
+        >
+          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            {strings('token_approvals.section_tap_to_expand', {
+              count: section.data.length.toString(),
+            })}
+          </Text>
+        </TouchableOpacity>
+      );
+    },
+    [collapsedSections, toggleSection],
+  );
+
+  const ItemSeparator = useCallback(
+    () => <View style={styles.separator} />,
+    [],
+  );
+
+  const keyExtractor = useCallback((item: ApprovalItem) => item.id, []);
+
+  return (
+    <SectionList
+      sections={sections}
+      renderItem={renderItem}
+      renderSectionHeader={renderSectionHeader}
+      renderSectionFooter={renderSectionFooter}
+      keyExtractor={keyExtractor}
+      ListHeaderComponent={ListHeaderComponent}
+      ItemSeparatorComponent={ItemSeparator}
+      contentContainerStyle={styles.contentContainer}
+      stickySectionHeadersEnabled={false}
+      removeClippedSubviews
+    />
+  );
+};
+
+export default RiskGroupedList;


### PR DESCRIPTION
## Stack Position
PR **9** of **11** — builds on PR 8.

> Split from POC branch: `feat/approval-dashboard`

## Changes
List rendering components that consume `ApprovalCard` from PR 8.

### Files
- `ApprovalsList` — simple `FlatList` wrapper that renders a flat list of `ApprovalCard` items; used for filtered/sorted views without risk grouping
- `RiskGroupedList` — `FlatList` with a custom section-like header per verdict group (Malicious → Warning → Benign → Error); each section has a collapsible header with count, select-all checkbox, and renders `ApprovalCard` items; supports selection mode with per-group select-all

## Review Guidance
`RiskGroupedList` is the primary list used in production. Check the select-all per group behavior — selecting all in a group should add those IDs to the global selection without clearing others. Also verify the collapsible section state is local (not in Redux) — this is intentional.

## PR Stack
- PR 1–8: Foundation, state, API, hooks, components (see earlier PRs)
- **PR 9 (this):** Add approval list and grouped list components ← you are here
- PR 10: Add approval detail and batch revoke sheet modals
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new list/selection UI that drives which approvals users may act on; mistakes in grouping/collapse or per-section select-all could lead to confusing or incorrect selections.
> 
> **Overview**
> Adds two new Token Approvals list-rendering components that consume `ApprovalCard`: `ApprovalsList` (simple `FlatList`) and `RiskGroupedList` (`SectionList` grouped by `Verdict` in Malicious→Warning→Benign→Error order).
> 
> `RiskGroupedList` introduces collapsible section headers with counts and (in `selectionMode`) per-section select-all that merges/deselects IDs without clearing other selections, plus a footer hint to expand collapsed sections and Android `LayoutAnimation` enabling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45eba9ad1c8de8b993c5d452da7568c362acbf94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->