### PR TITLE
feat(token-approvals): add approval detail and batch revoke sheet modals

### DIFF
--- a/app/components/UI/TokenApprovals/components/ApprovalDetailSheet/index.tsx
+++ b/app/components/UI/TokenApprovals/components/ApprovalDetailSheet/index.tsx
@@ -1,0 +1,365 @@
+import React, { useMemo, useRef, useCallback } from 'react';
+import { View, StyleSheet, Linking, ScrollView } from 'react-native';
+import { useSelector } from 'react-redux';
+import { useRoute } from '@react-navigation/native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import { useTheme } from '../../../../../util/theme';
+import { renderShortAddress } from '../../../../../util/address';
+import { strings } from '../../../../../../locales/i18n';
+import { selectApprovals } from '../../selectors';
+import { CHAIN_DISPLAY_NAMES } from '../../constants/chains';
+import { Verdict } from '../../types';
+import { formatUsd } from '../../utils/formatUsd';
+import { useRevokeApproval } from '../../hooks/useRevokeApproval';
+
+const BLOCK_EXPLORER_URLS: Record<string, string> = {
+  '0x1': 'https://etherscan.io/address/',
+  '0x89': 'https://polygonscan.com/address/',
+  '0x38': 'https://bscscan.com/address/',
+  '0xa86a': 'https://snowtrace.io/address/',
+  '0xa4b1': 'https://arbiscan.io/address/',
+  '0x2105': 'https://basescan.org/address/',
+  '0xe708': 'https://lineascan.build/address/',
+  '0xa': 'https://optimistic.etherscan.io/address/',
+};
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+  },
+  heroSection: {
+    alignItems: 'center',
+    paddingTop: 8,
+    paddingBottom: 20,
+    gap: 8,
+  },
+  tokenName: {
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  detailCard: {
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  detailRowBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  exposureRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: 12,
+    marginTop: 8,
+  },
+  sectionHeader: {
+    marginTop: 20,
+    marginBottom: 10,
+  },
+  featuresList: {
+    gap: 8,
+  },
+  featurePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    gap: 8,
+  },
+  warningIcon: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  featureText: {
+    flex: 1,
+  },
+  explorerButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginTop: 20,
+    gap: 6,
+  },
+  revokeButton: {
+    marginTop: 12,
+    borderRadius: 999,
+  },
+});
+
+const ApprovalDetailSheet: React.FC = () => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const route = useRoute();
+  const { colors } = useTheme();
+  const approvals = useSelector(selectApprovals);
+  const { revokeApproval } = useRevokeApproval();
+
+  const { approvalId } = (route.params as { approvalId: string }) ?? {};
+
+  const approval = useMemo(
+    () => approvals.find((a) => a.id === approvalId),
+    [approvals, approvalId],
+  );
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleRevoke = useCallback(() => {
+    if (!approval) return;
+    // Close the detail sheet, then submit the revoke transaction
+    // addTransaction() inside revokeApproval triggers the standard confirmation UI
+    sheetRef.current?.onCloseBottomSheet(() => {
+      revokeApproval(approval);
+    });
+  }, [approval, revokeApproval]);
+
+  if (!approval) {
+    return null;
+  }
+
+  const chainName = CHAIN_DISPLAY_NAMES[approval.chainId] ?? approval.chainId;
+  const explorerUrl = BLOCK_EXPLORER_URLS[approval.chainId];
+  const isMalicious = approval.verdict === Verdict.Malicious;
+  const isWarning = approval.verdict === Verdict.Warning;
+  const exposureUsd = Number(approval.exposure_usd) || 0;
+
+  const handleViewExplorer = () => {
+    if (explorerUrl) {
+      Linking.openURL(`${explorerUrl}${approval.spender.address}`);
+    }
+  };
+
+  const getFeatureIconBg = () => {
+    if (isMalicious) return colors.error.muted;
+    if (isWarning) return colors.warning.muted;
+    return colors.background.alternative;
+  };
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      shouldNavigateBack
+      keyboardAvoidingViewEnabled={false}
+    >
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingSM}>
+          {strings('token_approvals.detail_title')}
+        </Text>
+      </BottomSheetHeader>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {/* Hero Section */}
+        <View style={styles.heroSection}>
+          <AvatarToken
+            size={AvatarSize.Xl}
+            name={approval.asset.symbol}
+            imageSource={
+              approval.asset.logo_url
+                ? { uri: approval.asset.logo_url }
+                : undefined
+            }
+          />
+          <Text
+            variant={TextVariant.HeadingSM}
+            color={TextColor.Default}
+            style={styles.tokenName}
+          >
+            {approval.asset.name} ({approval.asset.symbol})
+          </Text>
+        </View>
+
+        {/* Detail Card */}
+        <View
+          style={[
+            styles.detailCard,
+            { backgroundColor: colors.background.muted },
+          ]}
+        >
+          {/* Network */}
+          <View
+            style={[
+              styles.detailRow,
+              styles.detailRowBorder,
+              { borderBottomColor: colors.border.muted },
+            ]}
+          >
+            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              {strings('token_approvals.detail_chain')}
+            </Text>
+            <Text variant={TextVariant.BodyMDBold} color={TextColor.Default}>
+              {chainName}
+            </Text>
+          </View>
+
+          {/* Spender */}
+          <View
+            style={[
+              styles.detailRow,
+              styles.detailRowBorder,
+              { borderBottomColor: colors.border.muted },
+            ]}
+          >
+            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              {strings('token_approvals.detail_spender')}
+            </Text>
+            <Text variant={TextVariant.BodyMDBold} color={TextColor.Default}>
+              {approval.spender.label ||
+                renderShortAddress(approval.spender.address)}
+            </Text>
+          </View>
+
+          {/* Allowance */}
+          <View style={styles.detailRow}>
+            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              {strings('token_approvals.detail_allowance')}
+            </Text>
+            <Text
+              variant={TextVariant.BodyMDBold}
+              color={
+                approval.allowance.is_unlimited
+                  ? TextColor.Warning
+                  : TextColor.Default
+              }
+            >
+              {approval.allowance.is_unlimited
+                ? strings('token_approvals.unlimited')
+                : approval.allowance.amount}
+            </Text>
+          </View>
+        </View>
+
+        {/* Exposure / Value at Risk - Highlighted separately */}
+        {exposureUsd > 0 && (
+          <View
+            style={[
+              styles.exposureRow,
+              { backgroundColor: colors.error.muted },
+            ]}
+          >
+            <Text variant={TextVariant.BodyMDBold} color={TextColor.Error}>
+              {strings('token_approvals.detail_exposure')}
+            </Text>
+            <Text variant={TextVariant.HeadingSM} color={TextColor.Error}>
+              {formatUsd(exposureUsd)}
+            </Text>
+          </View>
+        )}
+
+        {/* Spender Features / Analysis */}
+        {approval.spender.features.length > 0 && (
+          <>
+            <Text
+              variant={TextVariant.BodyMDBold}
+              color={TextColor.Alternative}
+              style={styles.sectionHeader}
+            >
+              {strings('token_approvals.detail_spender_features')}
+            </Text>
+            <View style={styles.featuresList}>
+              {approval.spender.features.map((feature) => (
+                <View
+                  key={feature.id}
+                  style={[
+                    styles.featurePill,
+                    { backgroundColor: colors.background.muted },
+                  ]}
+                >
+                  <View
+                    style={[
+                      styles.warningIcon,
+                      { backgroundColor: getFeatureIconBg() },
+                    ]}
+                  >
+                    <Icon
+                      name={
+                        isMalicious || isWarning
+                          ? IconName.Warning
+                          : IconName.Info
+                      }
+                      size={IconSize.Xs}
+                      color={
+                        isMalicious
+                          ? IconColor.Error
+                          : isWarning
+                            ? IconColor.Warning
+                            : IconColor.Muted
+                      }
+                    />
+                  </View>
+                  <Text
+                    variant={TextVariant.BodySM}
+                    color={TextColor.Default}
+                    style={styles.featureText}
+                  >
+                    {feature.description}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+
+        {/* Block Explorer */}
+        {explorerUrl && (
+          <Button
+            variant={ButtonVariants.Secondary}
+            size={ButtonSize.Lg}
+            label={strings('token_approvals.detail_view_explorer')}
+            onPress={handleViewExplorer}
+            style={styles.explorerButton}
+            width={ButtonWidthTypes.Full}
+            startIconName={IconName.Export}
+          />
+        )}
+
+        {/* Revoke */}
+        <Button
+          variant={ButtonVariants.Primary}
+          size={ButtonSize.Lg}
+          label={strings('token_approvals.revoke')}
+          onPress={handleRevoke}
+          style={styles.revokeButton}
+          width={ButtonWidthTypes.Full}
+        />
+      </ScrollView>
+    </BottomSheet>
+  );
+};
+
+export default ApprovalDetailSheet;

--- a/app/components/UI/TokenApprovals/components/BatchRevokeConfirmSheet/index.tsx
+++ b/app/components/UI/TokenApprovals/components/BatchRevokeConfirmSheet/index.tsx
@@ -1,0 +1,236 @@
+import React, { useRef, useCallback, useState } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { useRoute } from '@react-navigation/native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import { useBatchRevokeSupport } from '../../hooks/useBatchRevokeSupport';
+import { useBatchRevoke } from '../../hooks/useBatchRevoke';
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+  },
+  chainCard: {
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 8,
+  },
+  chainRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  chainName: {
+    flex: 1,
+  },
+  badge: {
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  upgradeNote: {
+    marginTop: 6,
+  },
+  upgradeBanner: {
+    flexDirection: 'row',
+    borderRadius: 12,
+    padding: 12,
+    marginTop: 8,
+    marginBottom: 8,
+    gap: 10,
+    alignItems: 'flex-start',
+  },
+  upgradeBannerText: {
+    flex: 1,
+  },
+  footer: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 16,
+  },
+  footerButton: {
+    flex: 1,
+  },
+});
+
+const BatchRevokeConfirmSheet: React.FC = () => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const route = useRoute();
+  const { colors } = useTheme();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { approvalIds } = (route.params as { approvalIds: string[] }) ?? {
+    approvalIds: [],
+  };
+
+  const { chainBreakdown, hasUpgradeRequired, isLoading } =
+    useBatchRevokeSupport(approvalIds);
+  const { batchRevoke } = useBatchRevoke();
+
+  const totalCount = approvalIds.length;
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      sheetRef.current?.onCloseBottomSheet(async () => {
+        await batchRevoke(approvalIds, chainBreakdown);
+      });
+    } catch {
+      setIsSubmitting(false);
+    }
+  }, [isSubmitting, approvalIds, chainBreakdown, batchRevoke]);
+
+  const upgradeChainNames = chainBreakdown
+    .filter((c) => c.supportsBatch && c.canUpgrade)
+    .map((c) => c.chainName)
+    .join(', ');
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      shouldNavigateBack
+      keyboardAvoidingViewEnabled={false}
+    >
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingSM}>
+          {strings('token_approvals.batch_confirm_title', {
+            count: totalCount.toString(),
+          })}
+        </Text>
+      </BottomSheetHeader>
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {/* Per-chain breakdown */}
+        {chainBreakdown.map((chain) => {
+          const txCount = chain.supportsBatch ? 1 : chain.approvals.length;
+          const isBatched = chain.supportsBatch;
+
+          return (
+            <View
+              key={chain.chainId}
+              style={[
+                styles.chainCard,
+                { backgroundColor: colors.background.muted },
+              ]}
+            >
+              <View style={styles.chainRow}>
+                <Text
+                  variant={TextVariant.BodyMDBold}
+                  color={TextColor.Default}
+                  style={styles.chainName}
+                >
+                  {chain.chainName} ({chain.approvals.length})
+                </Text>
+                <View
+                  style={[
+                    styles.badge,
+                    {
+                      backgroundColor: isBatched
+                        ? colors.success.muted
+                        : colors.background.alternative,
+                    },
+                  ]}
+                >
+                  <Text
+                    variant={TextVariant.BodySM}
+                    color={
+                      isBatched ? TextColor.Success : TextColor.Alternative
+                    }
+                  >
+                    {isBatched
+                      ? strings('token_approvals.batch_confirm_batched')
+                      : strings('token_approvals.batch_confirm_sequential', {
+                          count: txCount.toString(),
+                        })}
+                  </Text>
+                </View>
+              </View>
+              {chain.supportsBatch && chain.canUpgrade && (
+                <Text
+                  variant={TextVariant.BodySM}
+                  color={TextColor.Alternative}
+                  style={styles.upgradeNote}
+                >
+                  {strings('token_approvals.batch_confirm_upgrade_title')}
+                </Text>
+              )}
+            </View>
+          );
+        })}
+
+        {/* Upgrade info banner */}
+        {hasUpgradeRequired && (
+          <View
+            style={[
+              styles.upgradeBanner,
+              { backgroundColor: colors.info.muted },
+            ]}
+          >
+            <Icon
+              name={IconName.Info}
+              size={IconSize.Md}
+              color={IconColor.Info}
+            />
+            <Text
+              variant={TextVariant.BodySM}
+              color={TextColor.Default}
+              style={styles.upgradeBannerText}
+            >
+              {strings('token_approvals.batch_confirm_upgrade_description', {
+                chains: upgradeChainNames,
+              })}
+            </Text>
+          </View>
+        )}
+
+        {/* Footer buttons */}
+        <View style={styles.footer}>
+          <Button
+            variant={ButtonVariants.Secondary}
+            size={ButtonSize.Lg}
+            label={strings('token_approvals.cancel_button')}
+            onPress={handleClose}
+            style={styles.footerButton}
+            width={ButtonWidthTypes.Full}
+            isDisabled={isSubmitting}
+          />
+          <Button
+            variant={ButtonVariants.Primary}
+            size={ButtonSize.Lg}
+            label={strings('token_approvals.batch_confirm_cta')}
+            onPress={handleConfirm}
+            style={styles.footerButton}
+            width={ButtonWidthTypes.Full}
+            isDisabled={isSubmitting || isLoading}
+          />
+        </View>
+      </ScrollView>
+    </BottomSheet>
+  );
+};
+
+export default BatchRevokeConfirmSheet;


### PR DESCRIPTION
## Stack Position
PR **10** of **11** — builds on PR 9.

> Split from POC branch: `feat/approval-dashboard`

## Changes
Bottom sheet modals for viewing approval details and confirming batch revocations.

### Files
- `ApprovalDetailSheet` — full-screen bottom sheet showing: token avatar, spender address with short display, allowance amount (unlimited or formatted), verdict badge, USD exposure, spender features list (e.g. "DEX", "Bridge"), block explorer link, chain name, and a "Revoke" action button
- `BatchRevokeConfirmSheet` — bottom sheet for confirming batch revocation: shows per-chain breakdown from `useBatchRevokeSupport` (batch vs sequential, upgrade prompts for EIP-7702), total count, and confirms execution via `useBatchRevoke`

## Review Guidance
`BatchRevokeConfirmSheet` is the most complex piece here — verify the chain breakdown rendering correctly distinguishes between: (1) chains with native batch support, (2) chains that can upgrade to batch (EIP-7702), and (3) chains falling back to sequential. The sheet should show a loading state while `useBatchRevokeSupport` resolves.

## PR Stack
- PR 1–9: Foundation, state, API, hooks, components (see earlier PRs)
- **PR 10 (this):** Add approval detail and batch revoke sheet modals ← you are here
- PR 11: Add main view, routes, and navigation integration

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new UI flows that trigger single and batched on-chain revocation transactions; main risk is incorrect parameter passing/state handling leading to unintended transaction submission paths or confusing UX.
> 
> **Overview**
> Adds a new `ApprovalDetailSheet` bottom sheet modal to view a selected approval’s key details (chain, spender, allowance, exposure/features) and launch a revoke action, including an optional block-explorer deep link.
> 
> Adds a `BatchRevokeConfirmSheet` modal to confirm multi-approval revocations by showing a per-chain breakdown (batched vs sequential, optional upgrade messaging) and then invoking the existing batch revoke flow while disabling actions during submission/loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f769e216848975d288b66b814d6e2d272e93d90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->