### PR TITLE
feat(token-approvals): add main view, routes, and navigation integration

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -96,6 +96,10 @@ import { AccountPermissionsScreens } from '../../../components/Views/AccountPerm
 import { StakeModalStack, StakeScreenStack } from '../../UI/Stake/routes';
 import { AssetLoader } from '../../Views/AssetLoader';
 import { EarnScreenStack, EarnModalStack } from '../../UI/Earn/routes';
+import {
+  TokenApprovalsScreenStack,
+  TokenApprovalsModalStack,
+} from '../../UI/TokenApprovals/routes';
 import { BridgeTransactionDetails } from '../../UI/Bridge/components/TransactionDetails/TransactionDetails';
 import { BridgeModalStack, BridgeScreenStack } from '../../UI/Bridge/routes';
 import {
@@ -1073,6 +1077,16 @@ const MainNavigator = () => {
         name="StakeScreens"
         component={StakeScreenStack}
         options={{ headerShown: false, ...slideFromRightAnimation }}
+      />
+      <Stack.Screen
+        name={Routes.TOKEN_APPROVALS.ROOT}
+        component={TokenApprovalsScreenStack}
+        options={{ headerShown: false, ...slideFromRightAnimation }}
+      />
+      <Stack.Screen
+        name={Routes.TOKEN_APPROVALS.MODALS.ROOT}
+        component={TokenApprovalsModalStack}
+        options={clearStackNavigatorOptions}
       />
       <Stack.Screen
         name={Routes.EARN.ROOT}

--- a/app/components/UI/TokenApprovals/Views/TokenApprovalsView/index.tsx
+++ b/app/components/UI/TokenApprovals/Views/TokenApprovalsView/index.tsx
@@ -1,0 +1,387 @@
+import React, { useCallback } from 'react';
+import {
+  SafeAreaView,
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  Linking,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../../component-library/components/Icons/Icon';
+import { useTheme } from '../../../../../util/theme';
+import { strings } from '../../../../../../locales/i18n';
+import Routes from '../../../../../constants/navigation/Routes';
+import { ApprovalItem, Verdict } from '../../types';
+import { useTokenApprovals } from '../../hooks/useTokenApprovals';
+import { useApprovalFilters } from '../../hooks/useApprovalFilters';
+import { useRevokeApproval } from '../../hooks/useRevokeApproval';
+import RiskDashboardHeader from '../../components/RiskDashboardHeader';
+import RiskGroupedList from '../../components/RiskGroupedList';
+import ChainFilterBar from '../../components/ChainFilterBar';
+import BatchRevokeBar from '../../components/BatchRevokeBar';
+import EmptyState from '../../components/EmptyState';
+import SkeletonApprovalCard from '../../components/SkeletonApprovalCard';
+
+const LEARN_MORE_URL =
+  'https://support.metamask.io/privacy-and-security/how-to-revoke-smart-contract-allowances-token-approvals/';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  backButton: {
+    padding: 4,
+  },
+  headerTitleContainer: {
+    flex: 1,
+  },
+  searchContainer: {
+    paddingTop: 4,
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 44,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    gap: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+    paddingVertical: 10,
+  },
+  clearButton: {
+    padding: 4,
+  },
+  learnMoreRow: {
+    paddingHorizontal: 16,
+    paddingBottom: 4,
+  },
+  loadingContainer: {
+    paddingTop: 8,
+    gap: 2,
+  },
+  errorContainer: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  chainErrorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginHorizontal: 16,
+    marginBottom: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+});
+
+const SKELETON_COUNT = 5;
+
+const TokenApprovalsView: React.FC = () => {
+  const navigation = useNavigation();
+  const { colors } = useTheme();
+
+  const {
+    approvals,
+    filteredApprovals,
+    isLoading,
+    error,
+    chainErrors,
+    availableChains,
+  } = useTokenApprovals();
+
+  const failedChainCount = Object.keys(chainErrors).length;
+
+  const {
+    selectedChains,
+    searchQuery,
+    selectedApprovalIds,
+    revocations,
+    selectionMode,
+    onChainToggle,
+    onSearchChange,
+    onToggleSelection,
+    onSelectAll,
+    onClearSelection,
+    onEnterSelectionMode,
+    onExitSelectionMode,
+  } = useApprovalFilters();
+
+  const { revokeApproval } = useRevokeApproval();
+
+  const handleBack = useCallback(() => {
+    if (selectionMode) {
+      onExitSelectionMode();
+    }
+    navigation.goBack();
+  }, [navigation, selectionMode, onExitSelectionMode]);
+
+  const handleToggleSelectionMode = useCallback(() => {
+    if (selectionMode) {
+      onExitSelectionMode();
+    } else {
+      onEnterSelectionMode();
+    }
+  }, [selectionMode, onEnterSelectionMode, onExitSelectionMode]);
+
+  const showSelectButton = filteredApprovals.length > 0;
+
+  const handleApprovalPress = useCallback(
+    (approval: ApprovalItem) => {
+      navigation.navigate(Routes.TOKEN_APPROVALS.MODALS.ROOT, {
+        screen: Routes.TOKEN_APPROVALS.MODALS.APPROVAL_DETAIL,
+        params: { approvalId: approval.id },
+      });
+    },
+    [navigation],
+  );
+
+  const handleRevoke = useCallback(
+    (approval: ApprovalItem) => {
+      // Skip intermediate confirmation, go straight to standard MetaMask confirmation UI
+      revokeApproval(approval);
+    },
+    [revokeApproval],
+  );
+
+  const handleBatchRevoke = useCallback(() => {
+    navigation.navigate(
+      Routes.TOKEN_APPROVALS.MODALS.ROOT as never,
+      {
+        screen: Routes.TOKEN_APPROVALS.MODALS.BATCH_REVOKE_CONFIRM,
+        params: { approvalIds: selectedApprovalIds },
+      } as never,
+    );
+  }, [navigation, selectedApprovalIds]);
+
+  const handleRevokeAllRisky = useCallback(() => {
+    const riskyIds = approvals
+      .filter(
+        (a) => a.verdict === Verdict.Malicious || a.verdict === Verdict.Warning,
+      )
+      .map((a) => a.id);
+    if (riskyIds.length > 0) {
+      navigation.navigate(
+        Routes.TOKEN_APPROVALS.MODALS.ROOT as never,
+        {
+          screen: Routes.TOKEN_APPROVALS.MODALS.BATCH_REVOKE_CONFIRM,
+          params: { approvalIds: riskyIds },
+        } as never,
+      );
+    }
+  }, [approvals, navigation]);
+
+  const handleLearnMore = useCallback(() => {
+    Linking.openURL(LEARN_MORE_URL);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    onSearchChange('');
+  }, [onSearchChange]);
+
+  const renderSkeletonList = () => (
+    <View style={styles.loadingContainer}>
+      {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+        <SkeletonApprovalCard key={`skeleton-${i}`} />
+      ))}
+    </View>
+  );
+
+  const renderListHeader = () => (
+    <View>
+      {/* Risk Dashboard */}
+      <RiskDashboardHeader
+        approvals={approvals}
+        onRevokeAllRisky={handleRevokeAllRisky}
+        isProcessing={false}
+      />
+
+      {/* Partial data warning */}
+      {failedChainCount > 0 && (
+        <View
+          style={[
+            styles.chainErrorBanner,
+            { backgroundColor: colors.warning.muted },
+          ]}
+        >
+          <Icon
+            name={IconName.Warning}
+            size={IconSize.Sm}
+            color={IconColor.Warning}
+          />
+          <Text variant={TextVariant.BodySM} color={TextColor.Warning}>
+            {failedChainCount === 1
+              ? 'Could not load approvals for 1 network. Data may be incomplete.'
+              : `Could not load approvals for ${failedChainCount} networks. Data may be incomplete.`}
+          </Text>
+        </View>
+      )}
+
+      {/* Chain Filters */}
+      <ChainFilterBar
+        chains={availableChains}
+        selectedChains={selectedChains}
+        onChainToggle={onChainToggle}
+      />
+    </View>
+  );
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background.default }]}
+    >
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={handleBack}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Icon
+            name={IconName.ArrowLeft}
+            size={IconSize.Md}
+            color={IconColor.Default}
+          />
+        </TouchableOpacity>
+        <View style={styles.headerTitleContainer}>
+          <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+            {strings('token_approvals.title')}
+          </Text>
+        </View>
+        {showSelectButton && (
+          <TouchableOpacity
+            onPress={handleToggleSelectionMode}
+            accessibilityRole="button"
+            accessibilityLabel={
+              selectionMode
+                ? strings('token_approvals.cancel_button')
+                : strings('token_approvals.select_button')
+            }
+          >
+            <Text
+              variant={TextVariant.BodyMD}
+              color={selectionMode ? TextColor.Error : TextColor.Info}
+            >
+              {selectionMode
+                ? strings('token_approvals.cancel_button')
+                : strings('token_approvals.select_button')}
+            </Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {/* Learn more link */}
+      <View style={styles.learnMoreRow}>
+        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          {strings('token_approvals.subtitle')}{' '}
+          <Text
+            variant={TextVariant.BodySM}
+            color={TextColor.Info}
+            onPress={handleLearnMore}
+            suppressHighlighting
+          >
+            {strings('token_approvals.education_learn_more')}
+          </Text>
+        </Text>
+      </View>
+
+      {/* Search Bar */}
+      <View style={styles.searchContainer}>
+        <View
+          style={[
+            styles.searchBar,
+            { backgroundColor: colors.background.alternative },
+          ]}
+        >
+          <Icon
+            name={IconName.Search}
+            size={IconSize.Md}
+            color={IconColor.Muted}
+          />
+          <TextInput
+            style={[styles.searchInput, { color: colors.text.default }]}
+            placeholder={strings('token_approvals.search_placeholder')}
+            placeholderTextColor={colors.text.muted}
+            value={searchQuery}
+            onChangeText={onSearchChange}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+            accessibilityLabel={strings('token_approvals.search_placeholder')}
+          />
+          {searchQuery.length > 0 && (
+            <TouchableOpacity
+              onPress={handleClearSearch}
+              style={styles.clearButton}
+              accessibilityRole="button"
+              accessibilityLabel="Clear search"
+            >
+              <Icon
+                name={IconName.Close}
+                size={IconSize.Sm}
+                color={IconColor.Muted}
+              />
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      {/* Content */}
+      {isLoading && filteredApprovals.length === 0 ? (
+        renderSkeletonList()
+      ) : error && filteredApprovals.length === 0 ? (
+        <View style={styles.errorContainer}>
+          <Text variant={TextVariant.BodyMD} color={TextColor.Error}>
+            {error}
+          </Text>
+        </View>
+      ) : filteredApprovals.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <RiskGroupedList
+          approvals={filteredApprovals}
+          selectedIds={selectedApprovalIds}
+          revocations={revocations}
+          selectionMode={selectionMode}
+          onApprovalPress={handleApprovalPress}
+          onApprovalSelect={onToggleSelection}
+          onApprovalRevoke={handleRevoke}
+          onSelectAll={onSelectAll}
+          ListHeaderComponent={renderListHeader()}
+        />
+      )}
+
+      {/* Batch Revoke Bar */}
+      <BatchRevokeBar
+        selectedCount={selectedApprovalIds.length}
+        onRevoke={handleBatchRevoke}
+        onClear={onClearSelection}
+        isProcessing={false}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default TokenApprovalsView;

--- a/app/components/UI/TokenApprovals/routes/index.tsx
+++ b/app/components/UI/TokenApprovals/routes/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+import Routes from '../../../../constants/navigation/Routes';
+import TokenApprovalsView from '../Views/TokenApprovalsView';
+import ApprovalDetailSheet from '../components/ApprovalDetailSheet';
+import BatchRevokeConfirmSheet from '../components/BatchRevokeConfirmSheet';
+
+const Stack = createStackNavigator();
+const ModalStack = createStackNavigator();
+
+const clearStackNavigatorOptions = {
+  headerShown: false,
+  cardStyle: {
+    backgroundColor: 'transparent',
+  },
+  animationEnabled: false,
+};
+
+const TokenApprovalsScreenStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name={Routes.TOKEN_APPROVALS.VIEW}
+      component={TokenApprovalsView}
+      options={{ headerShown: false }}
+    />
+  </Stack.Navigator>
+);
+
+const TokenApprovalsModalStack = () => (
+  <ModalStack.Navigator mode="modal" screenOptions={clearStackNavigatorOptions}>
+    <ModalStack.Screen
+      name={Routes.TOKEN_APPROVALS.MODALS.APPROVAL_DETAIL}
+      component={ApprovalDetailSheet}
+      options={{ headerShown: false }}
+    />
+    <ModalStack.Screen
+      name={Routes.TOKEN_APPROVALS.MODALS.BATCH_REVOKE_CONFIRM}
+      component={BatchRevokeConfirmSheet}
+      options={{ headerShown: false }}
+    />
+  </ModalStack.Navigator>
+);
+
+export { TokenApprovalsScreenStack, TokenApprovalsModalStack };

--- a/app/components/Views/AccountsMenu/AccountsMenu.testIds.ts
+++ b/app/components/Views/AccountsMenu/AccountsMenu.testIds.ts
@@ -22,6 +22,7 @@ export const AccountsMenuSelectorsIDs = {
   CONTACTS: 'contacts-menu-item',
   PERMISSIONS: 'permissions-menu-item',
   NETWORKS: 'networks-menu-item',
+  TOKEN_APPROVALS: 'token-approvals-menu-item',
 
   // Resources Section
   ABOUT_METAMASK: 'about-metamask-menu-item',

--- a/app/components/Views/AccountsMenu/AccountsMenu.tsx
+++ b/app/components/Views/AccountsMenu/AccountsMenu.tsx
@@ -151,6 +151,10 @@ const AccountsMenu = () => {
     navigation.navigate(Routes.SETTINGS.SDK_SESSIONS_MANAGER);
   }, [navigation]);
 
+  const onPressTokenApprovals = useCallback(() => {
+    navigation.navigate(Routes.TOKEN_APPROVALS.ROOT);
+  }, [navigation]);
+
   const goToBrowserUrl = useCallback(
     (url: string, title: string) => {
       navigation.navigate('Webview', {
@@ -469,6 +473,17 @@ const AccountsMenu = () => {
             testID={AccountsMenuSelectorsIDs.NETWORKS}
           />
         )}
+
+        {/* Token Approvals Row */}
+        <ActionListItem
+          startAccessory={
+            <Icon name={IconName.SecuritySearch} size={IconSize.Lg} />
+          }
+          label={strings('accounts_menu.token_approvals')}
+          endAccessory={arrowRightIcon}
+          onPress={onPressTokenApprovals}
+          testID={AccountsMenuSelectorsIDs.TOKEN_APPROVALS}
+        />
 
         {separator}
 


### PR DESCRIPTION
## Stack Position
PR **11** of **11** — final PR. Ties the entire feature together.

> Split from POC branch: `feat/approval-dashboard`

## Changes
The main screen, navigation stack, and integration points that make the feature reachable.

### Files
- `TokenApprovalsView` — main screen orchestrating all components: header with back/select buttons, search bar, `ChainFilterBar`, `RiskDashboardHeader`, `RiskGroupedList` (or skeleton/empty state), and `BatchRevokeBar`; navigates to `ApprovalDetailSheet` on card press and to `BatchRevokeConfirmSheet` for batch revoke
- `routes/index.tsx` — defines `TokenApprovalsScreenStack` (main screen) and `TokenApprovalsModalStack` (detail sheet + batch confirm sheet as modal stack)
- `MainNavigator.js` — registers `TOKEN_APPROVALS.ROOT` (screen stack) and `TOKEN_APPROVALS.MODALS.ROOT` (modal stack) in the root navigator
- `AccountsMenu.tsx` — adds "Token Approvals" row with security icon, navigates to `TOKEN_APPROVALS.ROOT`
- `AccountsMenu.testIds.ts` — adds `TOKEN_APPROVALS` test ID constant

## Review Guidance
This is the integration PR — review the navigation setup: the main view is a `Stack.Screen` while the modals use a separate `ModalStack` with `mode="modal"` and transparent card style. Verify that navigating to `MODALS.ROOT` with a screen/params correctly presents the detail or batch confirm sheet.

## PR Stack
- PR 1: Fix confirmations title display for revoke transactions
- PR 2: Add token approvals types, constants, utilities, and config
- PR 3: Add token approvals Redux state and selectors
- PR 4: Add token approvals API and mock data layer
- PR 5: Add core token approvals hooks
- PR 6: Add batch revoke hooks
- PR 7: Add basic and filter UI components
- PR 8: Add card and risk display components
- PR 9: Add list and grouped list components
- PR 10: Add approval detail and batch revoke sheet modals
- **PR 11 (this):** Add main view, routes, and navigation integration ← review last

## Merge Order
Merge from the bottom up (PR 1 first). GitHub will auto-retarget subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new user-facing approvals/revocation screen and new modal navigation routes; moderate risk due to new navigation entry points and interactions that can trigger revoke flows.
> 
> **Overview**
> Adds the new **Token Approvals** entry point and navigation wiring so the feature is reachable from the app.
> 
> Introduces `TokenApprovalsView` as the main screen with search, chain filtering, selection/batch revoke actions, and links into the existing detail and batch-confirm bottom sheets via `Routes.TOKEN_APPROVALS.MODALS.*`. Registers a dedicated screen stack and modal stack in `MainNavigator`, and adds a new Accounts Menu row (with testID) that navigates to `Routes.TOKEN_APPROVALS.ROOT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24e0a069ce42eb4e52b8ea261508c897fbf80650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->