### PR TITLE
test: setup full ramps e2e flow using ramps provider

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.testIds.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.testIds.ts
@@ -1,0 +1,14 @@
+export type RampsOrderTypeSlug = 'buy' | 'sell' | 'deposit';
+
+export const getOrderRowTestId = (type: RampsOrderTypeSlug, index: number) =>
+  `orders-list-row-${type}-${index}`;
+
+export const getOrderRowCryptoAmountTestId = (
+  type: RampsOrderTypeSlug,
+  index: number,
+) => `orders-list-crypto-amount-${type}-${index}`;
+
+export const getOrderRowFiatAmountTestId = (
+  type: RampsOrderTypeSlug,
+  index: number,
+) => `orders-list-fiat-amount-${type}-${index}`;

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
@@ -41,6 +41,12 @@ import ListItemColumn, {
   WidthType,
 } from '../../../../../../component-library/components/List/ListItemColumn';
 import ListItemColumnEnd from '../../components/ListItemColumnEnd';
+import {
+  getOrderRowTestId,
+  getOrderRowCryptoAmountTestId,
+  getOrderRowFiatAmountTestId,
+  type RampsOrderTypeSlug,
+} from './OrdersList.testIds';
 
 type filterType = 'ALL' | 'PURCHASE' | 'SELL';
 
@@ -92,12 +98,25 @@ function getStatusColorAndText(
   return [statusColor, statusText];
 }
 
-function DisplayOrderListItem({ item }: { item: DisplayOrder }) {
+function getOrderTypeSlug(orderType: string): RampsOrderTypeSlug {
+  if (orderType === 'DEPOSIT') return 'deposit';
+  if (orderType === 'SELL') return 'sell';
+  return 'buy';
+}
+
+function DisplayOrderListItem({
+  item,
+  index,
+}: {
+  item: DisplayOrder;
+  index: number;
+}) {
   const isBuy = item.orderType === 'BUY' || item.orderType === 'DEPOSIT';
   const [statusColor, statusText] = getStatusColorAndText(
     item.status,
     item.orderType,
   );
+  const typeSlug = getOrderTypeSlug(item.orderType);
 
   const title = item.providerName
     ? `${item.providerName}: ${strings(
@@ -128,10 +147,17 @@ function DisplayOrderListItem({ item }: { item: DisplayOrder }) {
       </ListItemColumn>
 
       <ListItemColumnEnd>
-        <Text variant={TextVariant.BodyMD}>
+        <Text
+          testID={getOrderRowCryptoAmountTestId(typeSlug, index)}
+          variant={TextVariant.BodyMD}
+        >
           {item.cryptoAmount} {item.cryptoCurrencySymbol}
         </Text>
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <Text
+          testID={getOrderRowFiatAmountTestId(typeSlug, index)}
+          variant={TextVariant.BodySM}
+          color={TextColor.Alternative}
+        >
           {item.fiatAmount == null
             ? '...'
             : addCurrencySymbol(
@@ -256,8 +282,15 @@ function OrdersList() {
     ],
   );
 
-  const renderItem = ({ item }: { item: DisplayOrder }) => (
+  const renderItem = ({
+    item,
+    index,
+  }: {
+    item: DisplayOrder;
+    index: number;
+  }) => (
     <TouchableHighlight
+      testID={getOrderRowTestId(getOrderTypeSlug(item.orderType), index + 1)}
       accessibilityRole="button"
       accessible
       style={styles.row}
@@ -265,7 +298,7 @@ function OrdersList() {
       underlayColor={colors.background.alternative}
       activeOpacity={1}
     >
-      <DisplayOrderListItem item={item} />
+      <DisplayOrderListItem item={item} index={index + 1} />
     </TouchableHighlight>
   );
 

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/__snapshots__/OrdersList.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/__snapshots__/OrdersList.test.tsx.snap
@@ -476,6 +476,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-1"
         underlayColor="#f3f3f4"
       >
         <View
@@ -583,6 +584,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-1"
               >
                 0.01231324
                  
@@ -599,6 +601,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-1"
               >
                 $34.23 
               </Text>
@@ -623,6 +626,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-2"
         underlayColor="#f3f3f4"
       >
         <View
@@ -730,6 +734,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-2"
               >
                 0.01231324
                  
@@ -746,6 +751,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-2"
               >
                 $34.23 
               </Text>
@@ -770,6 +776,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-3"
         underlayColor="#f3f3f4"
       >
         <View
@@ -877,6 +884,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-3"
               >
                 0.5
                  
@@ -893,6 +901,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-3"
               >
                 $1000 
               </Text>
@@ -917,6 +926,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-deposit-4"
         underlayColor="#f3f3f4"
       >
         <View
@@ -1024,6 +1034,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-deposit-4"
               >
                 100
                  
@@ -1040,6 +1051,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-deposit-4"
               >
                 $100 
               </Text>
@@ -1064,6 +1076,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-deposit-5"
         underlayColor="#f3f3f4"
       >
         <View
@@ -1171,6 +1184,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-deposit-5"
               >
                 20
                  
@@ -1187,6 +1201,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-deposit-5"
               >
                 $20 
               </Text>
@@ -1211,6 +1226,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-6"
         underlayColor="#f3f3f4"
       >
         <View
@@ -1318,6 +1334,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-6"
               >
                 0
                  
@@ -1334,6 +1351,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-6"
               >
                 ...
               </Text>
@@ -1836,6 +1854,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-1"
         underlayColor="#f3f3f4"
       >
         <View
@@ -1943,6 +1962,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-1"
               >
                 0.01231324
                  
@@ -1959,6 +1979,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-1"
               >
                 $34.23 
               </Text>
@@ -1983,6 +2004,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-sell-2"
         underlayColor="#f3f3f4"
       >
         <View
@@ -2090,6 +2112,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-sell-2"
               >
                 0.01231324
                  
@@ -2106,6 +2129,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-sell-2"
               >
                 $34.23 
               </Text>
@@ -2130,6 +2154,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-3"
         underlayColor="#f3f3f4"
       >
         <View
@@ -2237,6 +2262,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-3"
               >
                 0.01231324
                  
@@ -2253,6 +2279,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-3"
               >
                 $34.23 
               </Text>
@@ -2277,6 +2304,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-4"
         underlayColor="#f3f3f4"
       >
         <View
@@ -2384,6 +2412,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-4"
               >
                 0.5
                  
@@ -2400,6 +2429,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-4"
               >
                 $1000 
               </Text>
@@ -2424,6 +2454,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-deposit-5"
         underlayColor="#f3f3f4"
       >
         <View
@@ -2531,6 +2562,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-deposit-5"
               >
                 100
                  
@@ -2547,6 +2579,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-deposit-5"
               >
                 $100 
               </Text>
@@ -2571,6 +2604,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-deposit-6"
         underlayColor="#f3f3f4"
       >
         <View
@@ -2678,6 +2712,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-deposit-6"
               >
                 20
                  
@@ -2694,6 +2729,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-deposit-6"
               >
                 $20 
               </Text>
@@ -2718,6 +2754,7 @@ exports[`OrdersList renders correctly 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-7"
         underlayColor="#f3f3f4"
       >
         <View
@@ -2825,6 +2862,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-7"
               >
                 0
                  
@@ -2841,6 +2879,7 @@ exports[`OrdersList renders correctly 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-7"
               >
                 ...
               </Text>
@@ -4117,6 +4156,7 @@ exports[`OrdersList renders sell only correctly when pressing sell filter 1`] = 
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-sell-1"
         underlayColor="#f3f3f4"
       >
         <View
@@ -4224,6 +4264,7 @@ exports[`OrdersList renders sell only correctly when pressing sell filter 1`] = 
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-sell-1"
               >
                 0.01231324
                  
@@ -4240,6 +4281,7 @@ exports[`OrdersList renders sell only correctly when pressing sell filter 1`] = 
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-sell-1"
               >
                 $34.23 
               </Text>
@@ -4658,6 +4700,7 @@ exports[`OrdersList resets filter to all after other filter was set 1`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-sell-1"
         underlayColor="#f3f3f4"
       >
         <View
@@ -4765,6 +4808,7 @@ exports[`OrdersList resets filter to all after other filter was set 1`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-sell-1"
               >
                 0.01231324
                  
@@ -4781,6 +4825,7 @@ exports[`OrdersList resets filter to all after other filter was set 1`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-sell-1"
               >
                 $34.23 
               </Text>
@@ -5283,6 +5328,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-1"
         underlayColor="#f3f3f4"
       >
         <View
@@ -5390,6 +5436,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-1"
               >
                 0.01231324
                  
@@ -5406,6 +5453,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-1"
               >
                 $34.23 
               </Text>
@@ -5430,6 +5478,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-sell-2"
         underlayColor="#f3f3f4"
       >
         <View
@@ -5537,6 +5586,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-sell-2"
               >
                 0.01231324
                  
@@ -5553,6 +5603,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-sell-2"
               >
                 $34.23 
               </Text>
@@ -5577,6 +5628,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-3"
         underlayColor="#f3f3f4"
       >
         <View
@@ -5684,6 +5736,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-3"
               >
                 0.01231324
                  
@@ -5700,6 +5753,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-3"
               >
                 $34.23 
               </Text>
@@ -5724,6 +5778,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-4"
         underlayColor="#f3f3f4"
       >
         <View
@@ -5831,6 +5886,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-4"
               >
                 0.5
                  
@@ -5847,6 +5903,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-4"
               >
                 $1000 
               </Text>
@@ -5871,6 +5928,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-deposit-5"
         underlayColor="#f3f3f4"
       >
         <View
@@ -5978,6 +6036,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-deposit-5"
               >
                 100
                  
@@ -5994,6 +6053,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-deposit-5"
               >
                 $100 
               </Text>
@@ -6018,6 +6078,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-deposit-6"
         underlayColor="#f3f3f4"
       >
         <View
@@ -6125,6 +6186,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-deposit-6"
               >
                 20
                  
@@ -6141,6 +6203,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-deposit-6"
               >
                 $20 
               </Text>
@@ -6165,6 +6228,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
             "borderColor": "#b4b4b566",
           }
         }
+        testID="orders-list-row-buy-7"
         underlayColor="#f3f3f4"
       >
         <View
@@ -6272,6 +6336,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 24,
                   }
                 }
+                testID="orders-list-crypto-amount-buy-7"
               >
                 0
                  
@@ -6288,6 +6353,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                     "lineHeight": 22,
                   }
                 }
+                testID="orders-list-fiat-amount-buy-7"
               >
                 ...
               </Text>

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.testIds.ts
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.testIds.ts
@@ -1,0 +1,4 @@
+export const EnterEmailSelectorsIDs = {
+  EMAIL_INPUT: 'ramps-enter-email-input',
+  SEND_EMAIL_BUTTON: 'ramps-enter-email-send-button',
+};

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx
@@ -29,6 +29,7 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useTransakController } from '../../hooks/useTransakController';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { EnterEmailSelectorsIDs } from './EnterEmail.testIds';
 
 export interface V2EnterEmailParams {
   amount?: string;
@@ -149,6 +150,7 @@ const V2EnterEmail = () => {
             </Text>
 
             <TextField
+              testID={EnterEmailSelectorsIDs.EMAIL_INPUT}
               autoComplete="email"
               keyboardType="email-address"
               placeholder={strings('deposit.enter_email.input_placeholder')}
@@ -176,6 +178,7 @@ const V2EnterEmail = () => {
       <ScreenLayout.Footer>
         <ScreenLayout.Content style={styles.footerContent}>
           <Button
+            testID={EnterEmailSelectorsIDs.SEND_EMAIL_BUTTON}
             size={ButtonSize.Lg}
             onPress={handleSubmit}
             label={strings('deposit.enter_email.submit_button')}

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.testIds.ts
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.testIds.ts
@@ -1,0 +1,6 @@
+export const OtpCodeSelectorsIDs = {
+  OTP_CODE_SCREEN: 'otp-code-screen',
+  OTP_CODE_INPUT: 'otp-code-input',
+  PASTE_BUTTON: 'otp-code-paste-button',
+  SUBMIT_BUTTON: 'otp-code-submit-button',
+};

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
@@ -40,6 +40,7 @@ import { useTransakController } from '../../hooks/useTransakController';
 import { useTransakRouting } from '../../hooks/useTransakRouting';
 import { useRampsController } from '../../hooks/useRampsController';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { OtpCodeSelectorsIDs } from './OtpCode.testIds';
 
 export interface V2OtpCodeParams {
   email: string;
@@ -324,7 +325,7 @@ const V2OtpCode = () => {
   });
 
   return (
-    <ScreenLayout>
+    <ScreenLayout testID={OtpCodeSelectorsIDs.OTP_CODE_SCREEN}>
       <ScreenLayout.Body>
         <ScreenLayout.Content grow>
           <DepositProgressBar steps={4} currentStep={1} />
@@ -340,14 +341,14 @@ const V2OtpCode = () => {
               variant={TextVariant.BodyMD}
               color={TextColor.Primary}
               onPress={handlePaste}
-              testID="otp-code-paste-button"
+              testID={OtpCodeSelectorsIDs.PASTE_BUTTON}
             >
               {strings('deposit.otp_code.paste')}
             </Text>
           </Box>
 
           <CodeField
-            testID="otp-code-input"
+            testID={OtpCodeSelectorsIDs.OTP_CODE_INPUT}
             ref={inputRef as React.RefObject<TextInput>}
             {...props}
             value={value}
@@ -416,7 +417,7 @@ const V2OtpCode = () => {
             width={ButtonWidthTypes.Full}
             loading={isLoading}
             isDisabled={isLoading || value.length !== CELL_COUNT}
-            testID="otp-code-submit-button"
+            testID={OtpCodeSelectorsIDs.SUBMIT_BUTTON}
           />
           <PoweredByTransak name="powered-by-transak-logo" />
         </ScreenLayout.Content>

--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.testIds.ts
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.testIds.ts
@@ -1,0 +1,5 @@
+export const VerifyIdentitySelectorsIDs = {
+  CONTINUE_BUTTON: 'ramps-verify-identity-continue-button',
+  PRIVACY_POLICY_LINK_1: 'privacy-policy-link-1',
+  PRIVACY_POLICY_LINK_2: 'privacy-policy-link-2',
+};

--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
@@ -32,6 +32,7 @@ import {
   useParams,
 } from '../../../../../util/navigation/navUtils';
 import { createV2EnterEmailNavDetails } from './EnterEmail';
+import { VerifyIdentitySelectorsIDs } from './VerifyIdentity.testIds';
 
 export interface V2VerifyIdentityParams {
   amount?: string;
@@ -195,7 +196,7 @@ const V2VerifyIdentity = () => {
               <Text
                 style={styles.linkText}
                 onPress={handlePrivacyPolicyLink}
-                testID="privacy-policy-link-1"
+                testID={VerifyIdentitySelectorsIDs.PRIVACY_POLICY_LINK_1}
               >
                 {strings(
                   'deposit.verify_identity.description_3_privacy_policy',
@@ -228,13 +229,14 @@ const V2VerifyIdentity = () => {
               color={TextColor.Muted}
               style={styles.linkText}
               onPress={handlePrivacyPolicyLink}
-              testID="privacy-policy-link-2"
+              testID={VerifyIdentitySelectorsIDs.PRIVACY_POLICY_LINK_2}
             >
               {strings('deposit.verify_identity.agreement_text_privacy_policy')}
             </Text>
             {strings('deposit.verify_identity.agreement_text_part2')}
           </Text>
           <Button
+            testID={VerifyIdentitySelectorsIDs.CONTINUE_BUTTON}
             size={ButtonSize.Lg}
             onPress={handleSubmit}
             label={strings('deposit.verify_identity.button')}

--- a/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/EnterEmail.test.tsx.snap
@@ -173,6 +173,7 @@ exports[`V2EnterEmail matches snapshot 1`] = `
                     "opacity": 1,
                   }
                 }
+                testID="ramps-enter-email-input"
                 value=""
               />
             </View>
@@ -217,6 +218,7 @@ exports[`V2EnterEmail matches snapshot 1`] = `
               "paddingHorizontal": 16,
             }
           }
+          testID="ramps-enter-email-send-button"
         >
           <Text
             accessibilityRole="text"

--- a/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/OtpCode.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/OtpCode.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`V2OtpCode matches snapshot 1`] = `
         undefined,
       ]
     }
+    testID="otp-code-screen"
   >
     <View
       style={

--- a/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/VerifyIdentity.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/NativeFlow/__snapshots__/VerifyIdentity.test.tsx.snap
@@ -255,6 +255,7 @@ exports[`V2VerifyIdentity matches snapshot 1`] = `
               "paddingHorizontal": 16,
             }
           }
+          testID="ramps-verify-identity-continue-button"
         >
           <Text
             accessibilityRole="text"

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
@@ -37,6 +37,7 @@ import Button, {
 import { hasDepositOrderField } from '../../Deposit/utils';
 import BankDetailRow from '../../Deposit/components/BankDetailRow/BankDetailRow';
 import Routes from '../../../../../constants/navigation/Routes';
+import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
 
 const localStyles = StyleSheet.create({
   badgeWrapperCenter: {
@@ -309,6 +310,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
         </BadgeWrapper>
 
         <Text
+          testID={RampsOrderDetailsSelectorsIDs.TOKEN_AMOUNT}
           variant={TextVariant.DisplayLg}
           fontWeight={FontWeight.Bold}
           twClassName="mt-6 text-center"
@@ -571,6 +573,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
 
         {showCloseButton && (
           <Button
+            testID={RampsOrderDetailsSelectorsIDs.CLOSE_BUTTON}
             variant={ButtonVariants.Primary}
             size={ButtonSize.Lg}
             width={ButtonWidthTypes.Full}

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.testIds.ts
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.testIds.ts
@@ -1,0 +1,6 @@
+export const RampsOrderDetailsSelectorsIDs = {
+  CONTAINER: 'ramps-order-details-container',
+  CLOSE_BUTTON: 'ramps-order-details-close-button',
+  TOKEN_AMOUNT: 'ramps-order-details-token-amount',
+  BACK_BUTTON: 'ramps-order-details-back-navbar-button',
+};

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -31,6 +31,7 @@ import OrderContent from './OrderContent';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
 
 interface RampsOrderDetailsParams {
   orderId: string;
@@ -196,7 +197,7 @@ const OrderDetails = () => {
   }
 
   return (
-    <ScreenLayout>
+    <ScreenLayout testID={RampsOrderDetailsSelectorsIDs.CONTAINER}>
       <ScrollView
         refreshControl={
           <RefreshControl

--- a/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderContent.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderContent.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
           undefined,
         ]
       }
+      testID="ramps-order-details-token-amount"
     >
       0.05
        
@@ -759,6 +760,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
           undefined,
         ]
       }
+      testID="ramps-order-details-token-amount"
     >
       0.05
        

--- a/app/components/Views/ActivityView/ActivitiesView.testIds.ts
+++ b/app/components/Views/ActivityView/ActivitiesView.testIds.ts
@@ -7,6 +7,7 @@ function getSentUnitMessage(unit: string) {
 export const ActivitiesViewSelectorsIDs = {
   CONTAINER: 'transactions-container',
   TABS_CONTAINER: 'activity-view-tabs',
+  TRANSFER_TAB: 'activity-view-tabs-bar-tab-1',
 };
 
 export const ActivitiesViewSelectorsText = {

--- a/tests/api-mocking/mock-responses/ramps/onramp-persona-data.ts
+++ b/tests/api-mocking/mock-responses/ramps/onramp-persona-data.ts
@@ -1,0 +1,14 @@
+export const ONRAMP_PERSONA = {
+  email: 'curtis@example.com',
+  firstName: 'Curt',
+  lastName: 'Angle',
+  mobileNumber: '+15555555555',
+  address: {
+    addressLine1: '123 Test St',
+    city: 'Test City',
+    state: 'CA',
+    postCode: '90210',
+    country: 'United States',
+    countryCode: 'US',
+  },
+};

--- a/tests/api-mocking/mock-responses/ramps/ramps-mocks.ts
+++ b/tests/api-mocking/mock-responses/ramps/ramps-mocks.ts
@@ -12,7 +12,29 @@ import { RAMPS_TOP_TOKENS_RESPONSE } from './responses/ramps-tokens-response.ts'
 import { RAMPS_PROVIDERS_RESPONSE } from './responses/ramps-providers-response.ts';
 import { RAMPS_PAYMENTS_V2_RESPONSE } from './responses/ramps-payments-response.ts';
 import { createGeolocationResponse } from './responses/ramps-geolocation.ts';
-import { RAMPS_QUOTE_RESPONSE } from './responses/ramps-quotes-response.ts';
+import {
+  createRampsQuoteResponse,
+  ProviderType,
+} from './responses/ramps-quotes-response.ts';
+import {
+  TRANSAK_AUTH_LOGIN_RESPONSE,
+  TRANSAK_AUTH_VERIFY_RESPONSE,
+} from './transak/transak-auth-response.ts';
+import { TRANSAK_QUOTE_RESPONSE } from './transak/transak-quotes-response.ts';
+import {
+  TRANSAK_USER_DETAILS_RESPONSE,
+  TRANSAK_KYC_REQUIREMENT_RESPONSE,
+  TRANSAK_USER_LIMITS_RESPONSE,
+} from './transak/transak-user-response.ts';
+import { TRANSAK_CREATE_ORDER_RESPONSE } from './transak/transak-order-response.ts';
+import { TRANSAK_RAMPS_TRANSLATE_RESPONSE } from './transak/transak-ramps-translate-response.ts';
+import { TRANSAK_PAYMENTS_OVERRIDE_RESPONSE } from './transak/transak-payments-override-response.ts';
+import {
+  BUY_ORDER_WIDGET_URL_RESPONSE,
+  BUY_ORDER_CALLBACK_RESPONSE,
+} from './responses/ramps-buy-order-checkout-response.ts';
+import { createBuyOrderResponse } from './responses/ramps-buy-order-status-response.ts';
+import { createDepositOrderResponse } from './responses/ramps-deposit-order-status-response.ts';
 
 /** Registers an array of static GET mocks in parallel. */
 const registerGetMocks = (mockServer: Mockttp, mocks: MockApiEndpoint[]) =>
@@ -122,20 +144,26 @@ export const RAMPS_CATALOG_MOCKS = async (mockServer: Mockttp) => {
 /**
  * Quote mocks for V1 and V2 endpoints.
  * Returns a single transak-staging quote so the controller auto-selects it.
+ *
+ * @param providerType - 'native' for the Transak KYC flow, 'aggregator' for the widget/WebView flow.
  */
-export const RAMPS_QUOTE_MOCKS = async (mockServer: Mockttp) => {
+export const RAMPS_QUOTE_MOCKS = async (
+  mockServer: Mockttp,
+  providerType: ProviderType = 'aggregator',
+) => {
+  const quoteResponse = createRampsQuoteResponse(providerType);
   await registerGetMocks(mockServer, [
     {
       urlEndpoint:
         /^https:\/\/on-ramp\.uat-api\.cx\.metamask\.io\/providers\/all\/quote\?.*$/,
       responseCode: 200,
-      response: RAMPS_QUOTE_RESPONSE,
+      response: quoteResponse,
     },
     {
       urlEndpoint:
         /^https:\/\/on-ramp\.uat-api\.cx\.metamask\.io\/v2\/quotes\?.*$/,
       responseCode: 200,
-      response: RAMPS_QUOTE_RESPONSE,
+      response: quoteResponse,
     },
   ]);
 };
@@ -147,24 +175,17 @@ export const RAMPS_QUOTE_MOCKS = async (mockServer: Mockttp) => {
  */
 export const RAMPS_CHECKOUT_MOCKS = async (mockServer: Mockttp) => {
   await registerGetMocks(mockServer, [
-    // Buy widget URL — returns a staging callback URL so the WebView
-    // immediately triggers the "order complete" flow.
     {
       urlEndpoint:
         /^https:\/\/on-ramp\.uat-api\.cx\.metamask\.io\/v2\/providers\/[^/]+\/buy(\?.*)?$/,
       responseCode: 200,
-      response: {
-        url: 'https://on-ramp-content.uat-api.cx.metamask.io/regions/fake-callback?orderId=mock-order-123',
-        browser: 'APP_BROWSER',
-        orderId: null,
-      },
+      response: BUY_ORDER_WIDGET_URL_RESPONSE,
     },
-    // Callback — extracts order ID from provider callback URL
     {
       urlEndpoint:
         /^https:\/\/on-ramp\.uat-api\.cx\.metamask\.io\/v2\/providers\/[^/]+\/callback(\?.*)?$/,
       responseCode: 200,
-      response: { id: 'mock-order-123' },
+      response: BUY_ORDER_CALLBACK_RESPONSE,
     },
   ]);
 };
@@ -192,57 +213,16 @@ export const RAMPS_TOKEN_ICON_MOCKS = async (mockServer: Mockttp) => {
   ]);
 };
 
-/** Builds a full order response object for the given status. */
-const buildOrderResponse = (status: string) => ({
-  id: 'mock-order-123',
-  isOnlyLink: false,
-  success: status === 'COMPLETED',
-  cryptoAmount: '0.00355373',
-  fiatAmount: 15,
-  cryptoCurrency: {
-    symbol: 'ETH',
-    name: 'Ethereum',
-    decimals: 18,
-  },
-  fiatCurrency: {
-    symbol: 'USD',
-    name: 'US Dollar',
-    decimals: 2,
-    denomSymbol: '$',
-  },
-  provider: {
-    id: '/providers/transak-staging',
-    name: 'Transak (Staging)',
-  },
-  providerOrderId: 'mock-order-123',
-  providerOrderLink: '',
-  createdAt: Date.now(),
-  totalFeesFiat: 3.5,
-  txHash: status === 'COMPLETED' ? '0xmocktxhash123' : null,
-  walletAddress: '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3',
-  status,
-  network: {
-    name: 'Ethereum Mainnet',
-    chainId: '1',
-  },
-  canBeUpdated: false,
-  idHasExpired: false,
-  excludeFromPurchases: false,
-  timeDescriptionPending: 'Usually completes in a few minutes',
-  orderType: 'BUY',
-  exchangeRate: 4072.34,
-});
-
 /**
- * Stateful order-status mock.
- * Returns PENDING on the first call, then COMPLETED on every subsequent call.
- * This lets tests observe the pending -> completed transition during order polling.
+ * Buy order-status mock.
+ * Always returns COMPLETED so the order is stored as completed by
+ * getOrderFromCallback, matching how the native deposit flow works
+ * (refreshOrder is called before addOrder there, so the stored order
+ * is already completed when OrderDetails mounts).
  */
-export const RAMPS_ORDER_STATUS_MOCKS = async (mockServer: Mockttp) => {
+export const BUY_ORDER_STATUS_MOCKS = async (mockServer: Mockttp) => {
   const orderUrlPattern =
     /^https:\/\/on-ramp\.uat-api\.cx\.metamask\.io\/v2\/providers\/[^/]+\/orders\/[^/]+(\?.*)?$/;
-
-  let orderCallCount = 0;
 
   await mockServer
     .forGet('/proxy')
@@ -251,22 +231,203 @@ export const RAMPS_ORDER_STATUS_MOCKS = async (mockServer: Mockttp) => {
       return orderUrlPattern.test(url);
     })
     .asPriority(999)
-    .thenCallback((_) => {
-      orderCallCount++;
-      const status = orderCallCount <= 1 ? 'PENDING' : 'COMPLETED';
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: createBuyOrderResponse('COMPLETED'),
+    }));
+};
+
+/**
+ * Stateful deposit order-status mock for the native Transak flow.
+ * Returns PENDING on the first call, then COMPLETED on every subsequent call.
+ */
+export const DEPOSIT_ORDER_STATUS_MOCKS = async (mockServer: Mockttp) => {
+  let depositOrderCallCount = 0;
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      // Matches both the legacy TransakService endpoint (/providers/...) and the
+      // v2 RampsService endpoint (/v2/providers/...) used by refreshOrder.
+      return url.includes('providers/transak-native-staging/orders/');
+    })
+    .asPriority(1000)
+    .thenCallback(() => {
+      depositOrderCallCount++;
+      const status = depositOrderCallCount <= 1 ? 'PENDING' : 'COMPLETED';
       return {
         statusCode: 200,
-        json: buildOrderResponse(status),
+        json: createDepositOrderResponse(status),
       };
     });
 };
 
 /**
- * Sets up all on-ramp API mocks for a given region.
- * This is the main entry point used by test files.
+ * Mocks all Transak API endpoints for the native KYC + bank-transfer flow.
+ * Covers: auth/login, auth/verify, lookup/quotes, user details, KYC requirement,
+ * user limits, create order, ramps translation, and ramps orders (with stateful polling).
  *
- * @param mockServer - The mock server instance
- * @param selectedRegion - The region selected in the test fixture
+ * Also overrides the payments mock to add isManualBankTransfer: true to debit-credit-card
+ * so the flow takes the bank transfer path (avoiding the unmockable WebView).
+ */
+export const TRANSAK_NATIVE_FLOW_MOCKS = async (mockServer: Mockttp) => {
+  // --- Transak API mocks (api-gateway-stg.transak.com) ---
+  // All responses wrapped in { data: ... } because TransakService unwraps .data
+
+  // POST auth/login — sendUserOtp(email)
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes('api-gateway-stg.transak.com/api/v2/auth/login');
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_AUTH_LOGIN_RESPONSE,
+    }));
+
+  // POST auth/verify — verifyUserOtp()
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes('api-gateway-stg.transak.com/api/v2/auth/verify');
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_AUTH_VERIFY_RESPONSE,
+    }));
+
+  // GET lookup/quotes — transakGetBuyQuote() internal Transak quote
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes('api-gateway-stg.transak.com/api/v2/lookup/quotes');
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_QUOTE_RESPONSE,
+    }));
+
+  // GET user/ — getUserDetails()
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes('api-gateway-stg.transak.com/api/v2/user/');
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_USER_DETAILS_RESPONSE,
+    }));
+
+  // GET kyc/requirement — getKycRequirement()
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes('api-gateway-stg.transak.com/api/v2/kyc/requirement');
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_KYC_REQUIREMENT_RESPONSE,
+    }));
+
+  // GET orders/user-limit — getUserLimits()
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes(
+        'api-gateway-stg.transak.com/api/v2/orders/user-limit',
+      );
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_USER_LIMITS_RESPONSE,
+    }));
+
+  // POST orders — createOrder()
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return (
+        url.includes('api-gateway-stg.transak.com/api/v2/orders') &&
+        !url.includes('user-limit') &&
+        !url.includes('payment-confirmation') &&
+        !url.includes('active-orders')
+      );
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_CREATE_ORDER_RESPONSE,
+    }));
+
+  // GET orders/{id} — TransakService.getOrder() payment-details enrichment
+  // Called after createOrder when an access token is present.
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return (
+        url.includes('api-gateway-stg.transak.com/api/v2/orders/') &&
+        !url.includes('user-limit') &&
+        !url.includes('active-orders')
+      );
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: { data: { orderId: 'mock-transak-order-123' } },
+    }));
+
+  // GET translate — getTranslation() (on-ramp.uat-api.cx.metamask.io)
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes(
+        'on-ramp.uat-api.cx.metamask.io/providers/transak-native-staging/native/translate',
+      );
+    })
+    .asPriority(999)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: TRANSAK_RAMPS_TRANSLATE_RESPONSE,
+    }));
+
+  await DEPOSIT_ORDER_STATUS_MOCKS(mockServer);
+
+  // Payments override — isManualBankTransfer: true for bank transfer path
+  await setupMockRequest(
+    mockServer,
+    {
+      requestMethod: 'GET',
+      url: /^https:\/\/on-ramp-cache\.uat-api\.cx\.metamask\.io\/v2\/regions\/[^/]+\/payments\?.*$/,
+      response: TRANSAK_PAYMENTS_OVERRIDE_RESPONSE,
+      responseCode: 200,
+    },
+    1000,
+  );
+};
+
+/**
+ * Sets up region eligibility and catalog mocks.
+ * Covers geolocation, deposit/aggregator eligibility, and all catalog data
+ * (networks, tokens, providers, payment methods, token icons).
+ *
+ * Use directly for tests that navigate the token-selection or off-ramp UI
+ * without proceeding to a quote or checkout step.
+ * Use setupDepositOnRampMocks or setupBuyOnRampMocks for full-flow tests.
  */
 export const setupRegionAwareOnRampMocks = async (
   mockServer: Mockttp,
@@ -274,8 +435,35 @@ export const setupRegionAwareOnRampMocks = async (
 ) => {
   await RAMPS_REGION_MOCKS(mockServer, selectedRegion);
   await RAMPS_CATALOG_MOCKS(mockServer);
+  await RAMPS_TOKEN_ICON_MOCKS(mockServer);
+};
+
+/**
+ * Sets up all mocks for the native Transak deposit flow (KYC/OTP + bank transfer).
+ * Builds on region/catalog mocks and adds native quotes, checkout, and all
+ * Transak-specific API endpoints.
+ */
+export const setupDepositOnRampMocks = async (
+  mockServer: Mockttp,
+  selectedRegion: RampsRegion,
+) => {
+  await setupRegionAwareOnRampMocks(mockServer, selectedRegion);
+  await RAMPS_QUOTE_MOCKS(mockServer, 'native');
+  await RAMPS_CHECKOUT_MOCKS(mockServer);
+  await TRANSAK_NATIVE_FLOW_MOCKS(mockServer);
+};
+
+/**
+ * Sets up all mocks for the aggregator WebView buy flow.
+ * Builds on region/catalog mocks and adds aggregator quotes, checkout,
+ * and buy order status polling.
+ */
+export const setupBuyOnRampMocks = async (
+  mockServer: Mockttp,
+  selectedRegion: RampsRegion,
+) => {
+  await setupRegionAwareOnRampMocks(mockServer, selectedRegion);
   await RAMPS_QUOTE_MOCKS(mockServer);
   await RAMPS_CHECKOUT_MOCKS(mockServer);
-  await RAMPS_TOKEN_ICON_MOCKS(mockServer);
-  await RAMPS_ORDER_STATUS_MOCKS(mockServer);
+  await BUY_ORDER_STATUS_MOCKS(mockServer);
 };

--- a/tests/api-mocking/mock-responses/ramps/responses/ramps-buy-order-checkout-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/responses/ramps-buy-order-checkout-response.ts
@@ -1,0 +1,16 @@
+/**
+ * Mock response data for buy (aggregator) checkout flow.
+ * Endpoints: GET buy widget URL, GET callback.
+ * After a quote is selected, RampsController.syncWidgetUrl() fetches the widget URL,
+ * then getOrderFromCallback() extracts the order ID from the provider callback.
+ */
+
+export const BUY_ORDER_WIDGET_URL_RESPONSE = {
+  url: 'https://on-ramp-content.uat-api.cx.metamask.io/regions/fake-callback?orderId=mock-order-123',
+  browser: 'APP_BROWSER',
+  orderId: null,
+};
+
+export const BUY_ORDER_CALLBACK_RESPONSE = {
+  id: 'mock-order-123',
+};

--- a/tests/api-mocking/mock-responses/ramps/responses/ramps-buy-order-status-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/responses/ramps-buy-order-status-response.ts
@@ -1,0 +1,45 @@
+/**
+ * Mock response data for buy (aggregator) order status polling.
+ * Endpoint: GET on-ramp.uat-api.../v2/providers/.../orders/...
+ * Returns a full order object; status is typically PENDING then COMPLETED.
+ */
+
+export const createBuyOrderResponse = (status: string) => ({
+  id: 'mock-order-123',
+  isOnlyLink: false,
+  success: status === 'COMPLETED',
+  cryptoAmount: '0.00355',
+  fiatAmount: 15,
+  cryptoCurrency: {
+    symbol: 'ETH',
+    name: 'Ethereum',
+    decimals: 18,
+  },
+  fiatCurrency: {
+    symbol: 'USD',
+    name: 'US Dollar',
+    decimals: 2,
+    denomSymbol: '$',
+  },
+  provider: {
+    id: '/providers/transak-staging',
+    name: 'Transak (Staging)',
+  },
+  providerOrderId: 'mock-order-123',
+  providerOrderLink: '',
+  createdAt: Date.now(),
+  totalFeesFiat: 3.5,
+  txHash: status === 'COMPLETED' ? '0xmocktxhash123' : null,
+  walletAddress: '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3',
+  status,
+  network: {
+    name: 'Ethereum Mainnet',
+    chainId: '1',
+  },
+  canBeUpdated: false,
+  idHasExpired: false,
+  excludeFromPurchases: false,
+  timeDescriptionPending: 'Usually completes in a few minutes',
+  orderType: 'BUY',
+  exchangeRate: 4072.34,
+});

--- a/tests/api-mocking/mock-responses/ramps/responses/ramps-deposit-order-status-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/responses/ramps-deposit-order-status-response.ts
@@ -1,0 +1,42 @@
+/**
+ * Mock response data for deposit (Transak native) order status polling.
+ * Endpoint: GET on-ramp.uat-api.../providers/transak-native-staging/orders/...
+ * Used by ramps orders API mock (getOrder after createOrder) and processDepositOrder.
+ * Returns deposit-format order; status is typically PENDING then COMPLETED.
+ */
+
+export const createDepositOrderResponse = (status: string) => ({
+  provider: '/providers/transak-native-staging',
+  providerOrderId: 'mock-transak-order-123',
+  providerOrderLink: '',
+  createdAt: Date.now(),
+  fiatAmount: 100,
+  totalFeesFiat: 23.33,
+  cryptoAmount: '0.02455',
+  fiatCurrency: {
+    symbol: 'USD',
+    name: 'US Dollar',
+    decimals: 2,
+    denomSymbol: '$',
+  },
+  fiatAmountInUsd: 100,
+  cryptoCurrency: {
+    symbol: 'ETH',
+    name: 'Ethereum',
+  },
+  network: {
+    chainId: '1',
+    name: 'Ethereum Mainnet',
+  },
+  walletAddress: '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3',
+  status,
+  txHash: status === 'COMPLETED' ? '0xmocktxhash123' : null,
+  orderType: 'DEPOSIT',
+  isOnlyLink: false,
+  success: status === 'COMPLETED',
+  canBeUpdated: false,
+  idHasExpired: false,
+  excludeFromPurchases: false,
+  timeDescriptionPending: 'Usually completes in a few minutes',
+  exchangeRate: 4072.34,
+});

--- a/tests/api-mocking/mock-responses/ramps/responses/ramps-providers-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/responses/ramps-providers-response.ts
@@ -1,4 +1,7 @@
-// Providers V2 response — staging providers: Transak (default) + Moonpay.
+// Providers V2 response — staging providers: Transak (native) + MoonPay (aggregator).
+// Transak uses the native SDK flow; MoonPay uses the WebView/widget aggregator flow.
+// Note: provider.type here is informational catalog metadata. Flow routing is NOT
+// driven by this field — it is determined at the quote level (quote.providerInfo.type).
 // determinePreferredProvider() auto-selects Transak (matches "transak" in id/name).
 export const RAMPS_PROVIDERS_RESPONSE = {
   providers: [
@@ -56,7 +59,7 @@ export const RAMPS_PROVIDERS_RESPONSE = {
         },
         recurringBuy: {},
       },
-      type: 'aggregator',
+      type: 'native',
       supportedCryptoCurrencies: {
         'eip155:1/slip44:60': true,
       },

--- a/tests/api-mocking/mock-responses/ramps/responses/ramps-quotes-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/responses/ramps-quotes-response.ts
@@ -6,7 +6,12 @@
 // controller auto-selects it (RampsController.mjs:952).
 // Returning multiple quotes breaks auto-selection and leaves the Continue
 // button disabled.
-export const RAMPS_QUOTE_RESPONSE = {
+
+export type ProviderType = 'native' | 'aggregator';
+
+export const createRampsQuoteResponse = (
+  providerType: ProviderType = 'native',
+) => ({
   success: [
     {
       provider: '/providers/transak-staging',
@@ -40,11 +45,11 @@ export const RAMPS_QUOTE_RESPONSE = {
           denomSymbol: '$',
         },
         fiatId: '/currencies/fiat/usd',
-        amountIn: 15,
-        amountOut: 0.00355373,
+        amountIn: providerType === 'native' ? 100 : 15,
+        amountOut: providerType === 'native' ? 0.02455598 : 0.00355373,
         exchangeRate: 4072.34318439678,
         networkFee: 0.02,
-        providerFee: 3.5,
+        providerFee: providerType === 'native' ? 23.33 : 3.5,
         extraFee: 0,
         receiver: '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3',
         paymentMethod: '/payments/debit-credit-card',
@@ -56,7 +61,7 @@ export const RAMPS_QUOTE_RESPONSE = {
       providerInfo: {
         id: '/providers/transak-staging',
         name: 'Transak (Staging)',
-        type: 'aggregator',
+        type: providerType,
         environmentType: 'STAGING',
         description:
           'Per Transak: "The fastest and securest way to buy 100+ cryptocurrencies on 75+ blockchains. Pay via Apple Pay, UPI, bank transfer or use your debit or credit card. Trusted by 2+ million global users. Transak empowers wallets, gaming, DeFi, NFTs, Exchanges, and DAOs across 125+ countries."',
@@ -132,4 +137,4 @@ export const RAMPS_QUOTE_RESPONSE = {
   ],
   error: [],
   customActions: [],
-};
+});

--- a/tests/api-mocking/mock-responses/ramps/transak/transak-auth-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/transak/transak-auth-response.ts
@@ -1,0 +1,24 @@
+/**
+ * Mock response data for Transak auth API endpoints.
+ * Endpoints: POST auth/login (sendUserOtp), POST auth/verify (verifyUserOtp).
+ * Transak API returns responses wrapped in { data: ... }.
+ */
+
+import { ONRAMP_PERSONA } from '../onramp-persona-data';
+
+export const TRANSAK_AUTH_LOGIN_RESPONSE = {
+  data: {
+    stateToken: 'mock-state-token',
+    isTncAccepted: true,
+    email: ONRAMP_PERSONA.email,
+    expiresIn: 20,
+  },
+};
+
+export const TRANSAK_AUTH_VERIFY_RESPONSE = {
+  data: {
+    accessToken: 'mock-access-token',
+    ttl: 3600,
+    created: new Date().toISOString(),
+  },
+};

--- a/tests/api-mocking/mock-responses/ramps/transak/transak-order-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/transak/transak-order-response.ts
@@ -1,0 +1,11 @@
+/**
+ * Mock response data for Transak create order API.
+ * Endpoint: POST api-gateway-stg.transak.com/api/v2/orders
+ */
+
+export const TRANSAK_CREATE_ORDER_RESPONSE = {
+  data: {
+    orderId: 'mock-transak-order-123',
+    walletAddress: '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3',
+  },
+};

--- a/tests/api-mocking/mock-responses/ramps/transak/transak-payments-override-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/transak/transak-payments-override-response.ts
@@ -1,0 +1,42 @@
+/**
+ * Payments override for Transak native flow (bank transfer path).
+ * Adds isManualBankTransfer: true to debit-credit-card so the flow
+ * avoids the unmockable WebView and uses the bank transfer path.
+ * Overrides: GET on-ramp-cache.../v2/regions/.../payments
+ */
+
+export const TRANSAK_PAYMENTS_OVERRIDE_RESPONSE = {
+  payments: [
+    {
+      id: '/payments/debit-credit-card',
+      paymentType: 'debit-credit-card',
+      name: 'Debit or Credit',
+      score: 100,
+      icons: [{ type: 'materialIcons', name: 'card' }],
+      logo: {
+        light: [
+          'assets/Visa-regular@3x.png',
+          'assets/Mastercard-regular@3x.png',
+        ],
+        dark: ['assets/Visa@3x.png', 'assets/Mastercard@3x.png'],
+      },
+      disclaimer:
+        "Credit card purchases may incur your bank's cash advance fees, subject to your bank's policies.",
+      delay: [5, 10],
+      pendingOrderDescription:
+        'Card purchases may take a few minutes to complete.',
+      amountTier: [1, 3],
+      isManualBankTransfer: true,
+      sellEnabled: true,
+      sell: { enabled: true },
+      recurringBuy: { enabled: true },
+      buy: { enabled: true },
+    },
+  ],
+  sorted: [
+    {
+      sortBy: '1',
+      ids: ['/payments/debit-credit-card'],
+    },
+  ],
+};

--- a/tests/api-mocking/mock-responses/ramps/transak/transak-quotes-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/transak/transak-quotes-response.ts
@@ -1,0 +1,23 @@
+/**
+ * Mock response data for Transak lookup/quotes API.
+ * Endpoint: GET api-gateway-stg.transak.com/api/v2/lookup/quotes
+ * Used by transakGetBuyQuote() internal Transak quote.
+ */
+
+export const TRANSAK_QUOTE_RESPONSE = {
+  data: {
+    quoteId: 'mock-quote-id',
+    conversionPrice: 4072.34,
+    fiatCurrency: 'USD',
+    cryptoCurrency: 'ETH',
+    paymentMethod: 'credit_debit_card',
+    fiatAmount: 100,
+    cryptoAmount: 0.02455598,
+    isBuyOrSell: 'BUY',
+    network: 'ethereum',
+    totalFee: 23.33,
+    feeDecimal: 0.23,
+    feeBreakdown: [],
+    nonce: 1,
+  },
+};

--- a/tests/api-mocking/mock-responses/ramps/transak/transak-ramps-translate-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/transak/transak-ramps-translate-response.ts
@@ -1,0 +1,12 @@
+/**
+ * Mock response data for Ramps translate endpoint (Transak native flow).
+ * Endpoint: GET on-ramp.uat-api.cx.metamask.io/providers/transak-native-staging/native/translate
+ * Used by getBuyQuote, createOrder, getUserLimits. Response is NOT wrapped in { data: ... }.
+ */
+
+export const TRANSAK_RAMPS_TRANSLATE_RESPONSE = {
+  cryptoCurrency: 'ETH',
+  network: 'ethereum',
+  fiatCurrency: 'USD',
+  paymentMethod: 'credit_debit_card',
+};

--- a/tests/api-mocking/mock-responses/ramps/transak/transak-user-response.ts
+++ b/tests/api-mocking/mock-responses/ramps/transak/transak-user-response.ts
@@ -1,0 +1,41 @@
+/**
+ * Mock response data for Transak user/KYC/limits API endpoints.
+ * Endpoints: GET user/, GET kyc/requirement, GET orders/user-limit.
+ */
+
+import { ONRAMP_PERSONA } from '../onramp-persona-data';
+
+export const TRANSAK_USER_DETAILS_RESPONSE = {
+  data: {
+    id: 'mock-user-id',
+    firstName: ONRAMP_PERSONA.firstName,
+    lastName: ONRAMP_PERSONA.lastName,
+    email: ONRAMP_PERSONA.email,
+    mobileNumber: ONRAMP_PERSONA.mobileNumber,
+    status: 'active',
+    kyc: {
+      status: 'APPROVED',
+      type: 'SIMPLE',
+      highestApprovedKYCType: 'SIMPLE',
+    },
+    address: ONRAMP_PERSONA.address,
+    createdAt: new Date().toISOString(),
+  },
+};
+
+export const TRANSAK_KYC_REQUIREMENT_RESPONSE = {
+  data: {
+    status: 'APPROVED',
+    kycType: 'SIMPLE',
+    isAllowedToPlaceOrder: true,
+  },
+};
+
+export const TRANSAK_USER_LIMITS_RESPONSE = {
+  data: {
+    limits: { '1': 5000, '30': 25000, '365': 100000 },
+    spent: { '1': 0, '30': 0, '365': 0 },
+    remaining: { '1': 5000, '30': 25000, '365': 100000 },
+    exceeded: { '1': false, '30': false, '365': false },
+  },
+};

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -481,6 +481,9 @@ class FixtureBuilder {
     // with the sell/offramp flow which still uses the aggregator SDK
     this.fixture.state.fiatOrders.selectedRegionAgg = aggregatorCountry;
 
+    this.fixture.state.fiatOrders.detectedGeolocation =
+      selectedRegion.countryIsoCode;
+
     return this;
   }
 

--- a/tests/page-objects/Ramps/BuildQuoteView.ts
+++ b/tests/page-objects/Ramps/BuildQuoteView.ts
@@ -1,5 +1,7 @@
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
+import Utilities from '../../framework/Utilities';
+
 import { BuildQuoteSelectors } from '../../../app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
 import { AddressSelectorSelectors } from '../../../app/components/Views/AddressSelector/AddressSelector.testIds';
 
@@ -101,6 +103,15 @@ class BuildQuoteView {
   async tapAccountPicker(): Promise<void> {
     await Gestures.waitAndTap(this.accountPicker, {
       elemDescription: 'Account Picker in Build Quote View',
+    });
+  }
+
+  async tapContinueButton(): Promise<void> {
+    await Utilities.waitForElementToBeEnabled(this.continueButton);
+
+    await Gestures.waitAndTap(this.continueButton, {
+      timeout: 2500,
+      elemDescription: 'Continue Button in Build Quote View',
     });
   }
 

--- a/tests/page-objects/Ramps/KYCScreen.ts
+++ b/tests/page-objects/Ramps/KYCScreen.ts
@@ -1,0 +1,60 @@
+import { EnterEmailSelectorsIDs } from '../../../app/components/UI/Ramp/Views/NativeFlow/EnterEmail.testIds';
+import { OtpCodeSelectorsIDs } from '../../../app/components/UI/Ramp/Views/NativeFlow/OtpCode.testIds';
+import { VerifyIdentitySelectorsIDs } from '../../../app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.testIds';
+import Matchers from '../../framework/Matchers';
+import Gestures from '../../framework/Gestures';
+import { Utilities } from '../../framework';
+class KYCScreen {
+  get verifyIdentityContinueButton(): DetoxElement {
+    return Matchers.getElementByID(VerifyIdentitySelectorsIDs.CONTINUE_BUTTON);
+  }
+
+  get emailInput(): DetoxElement {
+    return Matchers.getElementByID(EnterEmailSelectorsIDs.EMAIL_INPUT);
+  }
+
+  get sendEmailButton(): DetoxElement {
+    return Matchers.getElementByID(EnterEmailSelectorsIDs.SEND_EMAIL_BUTTON);
+  }
+
+  get otpScreen(): DetoxElement {
+    return Matchers.getElementByID(OtpCodeSelectorsIDs.OTP_CODE_SCREEN);
+  }
+
+  get otpCodeInput(): DetoxElement {
+    return Matchers.getElementByID(OtpCodeSelectorsIDs.OTP_CODE_INPUT);
+  }
+
+  async enterOtpCode(code: string): Promise<void> {
+    await Gestures.typeText(this.otpCodeInput, code, {
+      checkVisibility: false,
+      elemDescription: 'OTP code input in Verify your identity View',
+    });
+  }
+  async tapVerifyIdentityContinueButton(): Promise<void> {
+    await Utilities.waitForElementToBeEnabled(
+      this.verifyIdentityContinueButton,
+    );
+
+    await Gestures.waitAndTap(this.verifyIdentityContinueButton, {
+      elemDescription: 'Verify Identity continue button',
+    });
+  }
+
+  async enterEmail(email: string): Promise<void> {
+    await Utilities.waitForElementToBeEnabled(this.emailInput);
+
+    await Gestures.typeText(this.emailInput, email, {
+      hideKeyboard: true,
+      elemDescription: 'Email input',
+    });
+  }
+
+  async tapSendEmail(): Promise<void> {
+    await Gestures.waitAndTap(this.sendEmailButton, {
+      elemDescription: 'Send email button',
+    });
+  }
+}
+
+export default new KYCScreen();

--- a/tests/page-objects/Ramps/OrderDetailsView.ts
+++ b/tests/page-objects/Ramps/OrderDetailsView.ts
@@ -1,0 +1,37 @@
+import { RampsOrderDetailsSelectorsIDs } from '../../../app/components/UI/Ramp/Views/OrderDetails/OrderDetails.testIds';
+import Matchers from '../../framework/Matchers';
+import Gestures from '../../framework/Gestures';
+import Utilities from '../../framework/Utilities';
+
+class OrderDetailsView {
+  get container(): DetoxElement {
+    return Matchers.getElementByID(RampsOrderDetailsSelectorsIDs.CONTAINER);
+  }
+
+  get closeButton(): DetoxElement {
+    return Matchers.getElementByID(RampsOrderDetailsSelectorsIDs.CLOSE_BUTTON);
+  }
+
+  get tokenAmount(): DetoxElement {
+    return Matchers.getElementByID(RampsOrderDetailsSelectorsIDs.TOKEN_AMOUNT);
+  }
+  get backButton(): DetoxElement {
+    return Matchers.getElementByID(RampsOrderDetailsSelectorsIDs.BACK_BUTTON);
+  }
+
+  async tapCloseButton(): Promise<void> {
+    await Utilities.waitForElementToBeEnabled(this.closeButton);
+    await Gestures.waitAndTap(this.closeButton, {
+      timeout: 2500,
+      elemDescription: 'Ramps Order Details Close Button',
+    });
+  }
+
+  async tapBackButton(): Promise<void> {
+    await Gestures.waitAndTap(this.backButton, {
+      elemDescription: 'Ramps Order Details Back Button',
+    });
+  }
+}
+
+export default new OrderDetailsView();

--- a/tests/page-objects/Transactions/ActivitiesView.ts
+++ b/tests/page-objects/Transactions/ActivitiesView.ts
@@ -2,6 +2,12 @@ import {
   ActivitiesViewSelectorsIDs,
   ActivitiesViewSelectorsText,
 } from '../../../app/components/Views/ActivityView/ActivitiesView.testIds';
+import {
+  getOrderRowFiatAmountTestId,
+  getOrderRowCryptoAmountTestId,
+  getOrderRowTestId,
+  type RampsOrderTypeSlug,
+} from '../../../app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.testIds';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
 import Assertions from '../../framework/Assertions';
@@ -14,6 +20,9 @@ class ActivitiesView {
     return Matchers.getElementByLabel(
       ActivitiesViewSelectorsText.PREDICTIONS_TAB,
     );
+  }
+  get transferTab(): DetoxElement {
+    return Matchers.getElementByID(ActivitiesViewSelectorsIDs.TRANSFER_TAB);
   }
 
   get tabsBar(): DetoxElement {
@@ -137,10 +146,46 @@ class ActivitiesView {
     });
   }
 
+  async tapOnTransfersTab(): Promise<void> {
+    await Gestures.waitAndTap(this.transferTab, {
+      elemDescription: 'Transfer Tab in Activity View',
+    });
+  }
+
   async tapPredictPosition(positionName: string): Promise<void> {
     const el = Matchers.getElementByText(positionName);
     await Gestures.waitAndTap(el, {
       elemDescription: `Tapping Predict Position: ${positionName}`,
+    });
+  }
+
+  rampsOrderCryptoAmount(
+    orderType: RampsOrderTypeSlug,
+    rowIndex: number,
+  ): DetoxElement {
+    return Matchers.getElementByID(
+      getOrderRowCryptoAmountTestId(orderType, rowIndex),
+    );
+  }
+
+  rampsOrderFiatAmount(
+    orderType: RampsOrderTypeSlug,
+    rowIndex: number,
+  ): DetoxElement {
+    return Matchers.getElementByID(
+      getOrderRowFiatAmountTestId(orderType, rowIndex),
+    );
+  }
+
+  async tapRampsOrder(
+    orderType: RampsOrderTypeSlug,
+    rowIndex: number,
+  ): Promise<void> {
+    const order = Matchers.getElementByID(
+      getOrderRowTestId(orderType, rowIndex),
+    );
+    await Gestures.waitAndTap(order, {
+      elemDescription: `Tapping Ramps Order: ${orderType} ${rowIndex}`,
     });
   }
 

--- a/tests/smoke/ramps/onramp-unified-buy.spec.ts
+++ b/tests/smoke/ramps/onramp-unified-buy.spec.ts
@@ -7,13 +7,18 @@ import { CustomNetworks } from '../../resources/networks.e2e';
 import { SmokeRamps } from '../../tags';
 import Assertions from '../../framework/Assertions';
 import BuildQuoteView from '../../page-objects/Ramps/BuildQuoteView';
+import OrderDetailsView from '../../page-objects/Ramps/OrderDetailsView';
 import TokenSelectScreen from '../../page-objects/Ramps/TokenSelectScreen';
 
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
-import { setupRegionAwareOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-mocks';
+import {
+  setupDepositOnRampMocks,
+  setupBuyOnRampMocks,
+} from '../../api-mocking/mock-responses/ramps/ramps-mocks';
 import { remoteFeatureFlagRampsUnifiedEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { ONRAMP_PERSONA } from '../../api-mocking/mock-responses/ramps/onramp-persona-data';
 import {
   getEventsPayloads,
   EventPayload,
@@ -21,18 +26,50 @@ import {
 import SoftAssert from '../../framework/SoftAssert';
 
 import { UnifiedRampRoutingType } from '../../../app/reducers/fiatOrders/types';
-
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
+import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
+import KYCScreen from '../../page-objects/Ramps/KYCScreen';
 const selectedRegion = RampsRegions[RampsRegionsEnum.UNITED_STATES];
 
-const unifiedBuyV2Mocks = async (mockServer: Mockttp) => {
+const newUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagRampsUnifiedEnabled(true),
+    depositConfig: {
+      active: true,
+      providerApiKey: 'DUMMY_VALUE_FOR_TESTING',
+      entrypoints: { walletActions: true },
+      minimumVersion: '1.0.0',
+    },
+  });
+  await setupDepositOnRampMocks(mockServer, selectedRegion);
+};
+
+const returningUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(
     mockServer,
     remoteFeatureFlagRampsUnifiedEnabled(true),
   );
-  await setupRegionAwareOnRampMocks(mockServer, selectedRegion);
+  await setupBuyOnRampMocks(mockServer, selectedRegion);
 };
 
-const tokenToBuy = 'ETH';
+// Deposit order mock (ramps-deposit-order-status-response) returns USD; UI shows $ + formatFiatValue
+const nativeDepositOrder = {
+  token: 'ETH',
+  tokenAmount: '0.02455',
+  totalFiat: '$100 USD',
+  feesFiat: '$23.33 USD',
+  quoteDisplayAmount: '100 USD',
+  provider: 'Transak (Staging)',
+};
+
+const aggregatorBuyOrder = {
+  token: 'ETH',
+  tokenAmount: '0.00355',
+  totalFiat: '$15 USD',
+  feesFiat: '$3.5 USD',
+  quoteDisplayAmount: '$15.00',
+  provider: 'Transak (Staging)',
+};
 
 const eventsToCheck: EventPayload[] = [];
 
@@ -45,9 +82,12 @@ const expectedEventNames = [
   expectedEvents.RampsButtonClicked,
   expectedEvents.RampsTokenSelected,
 ];
-
 describe(SmokeRamps('Onramp Unified Buy'), () => {
-  it('build quote', async () => {
+  beforeEach(async () => {
+    await device.clearKeychain();
+  });
+
+  it('New user native flow: Places ETH DEPOSIT order through Transak', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -56,7 +96,7 @@ describe(SmokeRamps('Onramp Unified Buy'), () => {
           .withMetaMetricsOptIn()
           .build(),
         restartDevice: true,
-        testSpecificMock: unifiedBuyV2Mocks,
+        testSpecificMock: newUserUnifiedBuyV2Mocks,
         endTestfn: async ({ mockServer }) => {
           const events = await getEventsPayloads(
             mockServer,
@@ -69,19 +109,118 @@ describe(SmokeRamps('Onramp Unified Buy'), () => {
         await loginToApp();
         await WalletView.tapWalletBuyButton();
         await FundActionMenu.tapUnifiedBuyButton();
-        /*
-        at the time of this code, the dev team is still working on hooking up the quotes logic
-        as of now, you cannot (both manually and via e2e) go past the continue button
-        there is an animated infinite spinner. And as a result detox is hanging here
-        the disable sync allows detox to proceed without hang
-        Once the code is completed, this should be removed and the test shall go past the continue button
-        */
-        await device.disableSynchronization();
-        await TokenSelectScreen.tapTokenByName(tokenToBuy);
+        await TokenSelectScreen.tapTokenByName(nativeDepositOrder.token);
+
+        await BuildQuoteView.tapContinueButton();
+
+        await KYCScreen.tapVerifyIdentityContinueButton();
+
+        await KYCScreen.enterEmail(ONRAMP_PERSONA.email);
+
+        await Assertions.expectElementToBeVisible(KYCScreen.otpScreen, {
+          description: 'OTP code screen is visible before entering code',
+        });
+
+        await KYCScreen.enterOtpCode('000000');
+
+        // Verify order details screen
+        await Assertions.expectElementToBeVisible(OrderDetailsView.container, {
+          elemDescription: 'ramps order confirmation screen',
+        });
+        await Assertions.expectElementToHaveText(
+          OrderDetailsView.tokenAmount,
+          `${nativeDepositOrder.tokenAmount} ${nativeDepositOrder.token}`,
+        );
+
+        for (const text of [
+          nativeDepositOrder.totalFiat,
+          nativeDepositOrder.feesFiat,
+        ]) {
+          await Assertions.expectTextDisplayed(text);
+        }
+
+        await OrderDetailsView.tapCloseButton();
+
+        // Verify order in transfers list
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.tapOnTransfersTab();
+
+        await Assertions.expectTextDisplayed(
+          `${nativeDepositOrder.tokenAmount} ${nativeDepositOrder.token}`,
+        );
+        await ActivitiesView.tapRampsOrder('deposit', 1);
+
+        for (const text of [
+          `${nativeDepositOrder.tokenAmount} ${nativeDepositOrder.token}`,
+          nativeDepositOrder.totalFiat,
+        ]) {
+          await Assertions.expectTextDisplayed(text);
+        }
+      },
+    );
+  });
+
+  it('Returning User Aggregator Flow: Places ETH BUY order', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder()
+          .withNetworkController(CustomNetworks.Tenderly.Mainnet)
+          .withRampsSelectedRegion(selectedRegion)
+          .withMetaMetricsOptIn()
+          .build(),
+        restartDevice: true,
+        testSpecificMock: returningUserUnifiedBuyV2Mocks,
+        endTestfn: async ({ mockServer }) => {
+          const events = await getEventsPayloads(
+            mockServer,
+            expectedEventNames,
+          );
+          eventsToCheck.push(...events);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await WalletView.tapWalletBuyButton();
+        await FundActionMenu.tapUnifiedBuyButton();
+        await TokenSelectScreen.tapTokenByName(aggregatorBuyOrder.token);
         await BuildQuoteView.tapKeypadDeleteButton(1);
         await BuildQuoteView.enterAmount('15', 'unifiedBuy');
 
-        await Assertions.expectTextDisplayed('$15.00');
+        await BuildQuoteView.tapContinueButton();
+
+        // Verify order details screen
+        await Assertions.expectElementToBeVisible(OrderDetailsView.container, {
+          elemDescription: 'ramps order confirmation screen',
+        });
+        await Assertions.expectElementToHaveText(
+          OrderDetailsView.tokenAmount,
+          `${aggregatorBuyOrder.tokenAmount} ${aggregatorBuyOrder.token}`,
+        );
+
+        for (const text of [
+          aggregatorBuyOrder.totalFiat,
+          aggregatorBuyOrder.feesFiat,
+        ]) {
+          await Assertions.expectTextDisplayed(text);
+        }
+
+        await OrderDetailsView.tapCloseButton();
+
+        // Verify order in transfers list
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.tapOnTransfersTab();
+
+        await Assertions.expectTextDisplayed(
+          `${aggregatorBuyOrder.tokenAmount} ${aggregatorBuyOrder.token}`,
+        );
+        await ActivitiesView.tapRampsOrder('buy', 1);
+
+        for (const text of [
+          `${aggregatorBuyOrder.tokenAmount} ${aggregatorBuyOrder.token}`,
+          aggregatorBuyOrder.totalFiat,
+        ]) {
+          await Assertions.expectTextDisplayed(text);
+        }
       },
     );
   });
@@ -206,16 +345,16 @@ describe(SmokeRamps('Onramp Unified Buy'), () => {
         await Assertions.checkIfObjectContains(
           rampsTokenSelected?.properties ?? {},
           {
-            token_symbol: tokenToBuy,
+            token_symbol: aggregatorBuyOrder.token,
             token_caip19: 'eip155:1/slip44:60',
             currency_destination: 'eip155:1/slip44:60',
-            currency_destination_symbol: tokenToBuy,
+            currency_destination_symbol: aggregatorBuyOrder.token,
             currency_destination_network:
               CustomNetworks.Tenderly.Mainnet.providerConfig.nickname,
             ramp_routing: UnifiedRampRoutingType.DEPOSIT,
           },
         ),
-      `Ramps Token Selected: token_symbol should be ${tokenToBuy}`,
+      `Ramps Token Selected: token_symbol should be ${aggregatorBuyOrder.token}`,
     );
 
     softAssert.throwIfErrors();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

 The purpose of this PR is to add E2E smoke test coverage for the Unified Buy V2 flow, validating both routing paths a user can take when purchasing crypto through the ramps experience.                                                                       
                                                                                                                                  
                                                                                                                                  
  - Two smoke test scenarios: new user (no prior completed orders) routes through the native Transak deposit flow (KYC/OTP + bank  transfer); returning user (prior non-Transak aggregator order) routes through the aggregator WebView buy flow

  - New page objects: KYCScreen, OrderDetailsView, ActivitiesView, ToastModal, extended BuildQuoteView
  - Full Transak native flow mocking: auth/login, auth/verify, quotes, user details, KYC requirements, user limits, create order
  - Ramps mock infrastructure refactor: introduced setupDepositOnRampMocks and setupBuyOnRampMocks as single-purpose helpers;
  - 
  setupRegionAwareOnRampMocks retained as the base for build-quote-only tests; default providerType corrected from native to aggregator

  - TestID additions: crypto/fiat amount testIDs moved to DisplayOrderListItem (the actually-rendered component), testIDs added to
   EnterEmail, OtpCode, VerifyIdentity, and ActivitiesView; removed dead OrdersListTestIds aggregate export


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly E2E test, selector, and mock refactors, but it substantially changes the on-ramp mocking setup and fixtures used across ramps smoke tests, which could cause test flakiness or broken flows if assumptions drift.
> 
> **Overview**
> Adds end-to-end smoke coverage for Unified Buy V2 across both routing paths: **new users** go through the native Transak KYC/OTP deposit flow, while **returning users** go through the aggregator (widget/WebView) buy flow, including verification of the resulting order in the Activity transfers list and basic analytics assertions.
> 
> Refactors ramps API mocking to provide dedicated helpers (`setupDepositOnRampMocks`, `setupBuyOnRampMocks`) and expands mocked endpoints for the native Transak flow (auth, quotes, user/KYC/limits, order creation, translation, and stateful order polling), while splitting buy vs deposit order-status mocking.
> 
> Improves Detox automation by adding/centralizing `testID` selectors for ramps screens (`EnterEmail`, `OtpCode`, `VerifyIdentity`, `OrderDetails`) and for `OrdersList` rows/amounts, plus new page objects (`KYCScreen`, `OrderDetailsView`) and enhanced page object actions (e.g., wait-for-enabled Continue).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b768fea6143189ca0743193de74ca97a1008e01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->