### PR TITLE
feat: update BannerBase default text variants

### DIFF
--- a/app/component-library/components/Banners/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/app/component-library/components/Banners/Banner/__snapshots__/Banner.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Banner should render correctly 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -64,9 +64,9 @@ exports[`Banner should render correctly 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >
@@ -126,7 +126,7 @@ exports[`Banner should render correctly with a close button 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -140,9 +140,9 @@ exports[`Banner should render correctly with a close button 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >
@@ -282,7 +282,7 @@ exports[`Banner should render correctly with a start accessory 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -296,9 +296,9 @@ exports[`Banner should render correctly with a start accessory 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >
@@ -358,7 +358,7 @@ exports[`Banner should render correctly with an action button 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -372,9 +372,9 @@ exports[`Banner should render correctly with an action button 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >

--- a/app/component-library/components/Banners/Banner/foundation/BannerBase/BannerBase.constants.tsx
+++ b/app/component-library/components/Banners/Banner/foundation/BannerBase/BannerBase.constants.tsx
@@ -18,8 +18,8 @@ import { BannerBaseProps } from './BannerBase.types';
 export const TESTID_BANNER_CLOSE_BUTTON_ICON = 'banner-close-button-icon';
 
 // Defaults
-export const DEFAULT_BANNERBASE_TITLE_TEXTVARIANT = TextVariant.BodyLGMedium;
-export const DEFAULT_BANNERBASE_DESCRIPTION_TEXTVARIANT = TextVariant.BodyMD;
+export const DEFAULT_BANNERBASE_TITLE_TEXTVARIANT = TextVariant.BodyMDMedium;
+export const DEFAULT_BANNERBASE_DESCRIPTION_TEXTVARIANT = TextVariant.BodySM;
 export const DEFAULT_BANNERBASE_ACTIONBUTTON_VARIANT = ButtonVariants.Link;
 export const DEFAULT_BANNERBASE_ACTIONBUTTON_SIZE = ButtonSize.Auto;
 export const DEFAULT_BANNERBASE_CLOSEBUTTON_BUTTONICON_ICONCOLOR =

--- a/app/component-library/components/Banners/Banner/variants/BannerAlert/__snapshots__/BannerAlert.test.tsx.snap
+++ b/app/component-library/components/Banners/Banner/variants/BannerAlert/__snapshots__/BannerAlert.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`BannerAlert should render BannerAlert 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -63,9 +63,9 @@ exports[`BannerAlert should render BannerAlert 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >

--- a/app/component-library/components/Banners/Banner/variants/BannerTip/__snapshots__/BannerTip.test.tsx.snap
+++ b/app/component-library/components/Banners/Banner/variants/BannerTip/__snapshots__/BannerTip.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`BannerTip should render default settings correctly 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -68,9 +68,9 @@ exports[`BannerTip should render default settings correctly 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >

--- a/app/components/UI/Earn/components/EarnMaintenanceBanner/__snapshots__/EarnMaintenanceBanner.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnMaintenanceBanner/__snapshots__/EarnMaintenanceBanner.test.tsx.snap
@@ -50,9 +50,9 @@ exports[`EarnMaintenanceBanner renders banner and maintenance message 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >

--- a/app/components/UI/Earn/components/Earnings/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Earn/components/Earnings/__snapshots__/index.test.tsx.snap
@@ -74,9 +74,9 @@ exports[`Earnings displays lending maintenance banner when feature flag is enabl
               {
                 "color": "#131416",
                 "fontFamily": "Geist-Regular",
-                "fontSize": 16,
+                "fontSize": 14,
                 "letterSpacing": 0,
-                "lineHeight": 24,
+                "lineHeight": 22,
               }
             }
           >
@@ -432,9 +432,9 @@ exports[`Earnings displays pooled-staking maintenance banner when feature flag i
               {
                 "color": "#131416",
                 "fontFamily": "Geist-Regular",
-                "fontSize": 16,
+                "fontSize": 14,
                 "letterSpacing": 0,
-                "lineHeight": 24,
+                "lineHeight": 22,
               }
             }
           >

--- a/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
+++ b/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
@@ -181,9 +181,9 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
               {
                 "color": "#131416",
                 "fontFamily": "Geist-Regular",
-                "fontSize": 16,
+                "fontSize": 14,
                 "letterSpacing": 0,
-                "lineHeight": 24,
+                "lineHeight": 22,
               }
             }
           >

--- a/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -212,9 +212,9 @@ exports[`BuildQuote Continue button displays error banner when quote fetch fails
                 {
                   "color": "#131416",
                   "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
+                  "fontSize": 14,
                   "letterSpacing": 0,
-                  "lineHeight": 24,
+                  "lineHeight": 22,
                 }
               }
             >

--- a/app/components/UI/Stake/components/StakingEarnings/__snapshots__/StakingEarnings.test.tsx.snap
+++ b/app/components/UI/Stake/components/StakingEarnings/__snapshots__/StakingEarnings.test.tsx.snap
@@ -73,9 +73,9 @@ exports[`Staking Earnings displays pooled-staking maintenance banner when featur
             {
               "color": "#131416",
               "fontFamily": "Geist-Regular",
-              "fontSize": 16,
+              "fontSize": 14,
               "letterSpacing": 0,
-              "lineHeight": 24,
+              "lineHeight": 22,
             }
           }
         >

--- a/app/components/Views/BrowserTab/components/IpfsBanner/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/BrowserTab/components/IpfsBanner/__snapshots__/index.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`IpfsBanner should render banner correctly 1`] = `
           {
             "color": "#131416",
             "fontFamily": "Geist-Medium",
-            "fontSize": 20,
+            "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
           }

--- a/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
+++ b/app/components/Views/Settings/SecuritySettings/__snapshots__/SecuritySettings.test.tsx.snap
@@ -315,7 +315,7 @@ exports[`SecuritySettings renders correctly 1`] = `
                   {
                     "color": "#131416",
                     "fontFamily": "Geist-Medium",
-                    "fontSize": 20,
+                    "fontSize": 16,
                     "letterSpacing": 0,
                     "lineHeight": 24,
                   }

--- a/app/components/Views/confirmations/components/blockaid-banner/__snapshots__/BlockaidBanner.test.tsx.snap
+++ b/app/components/Views/confirmations/components/blockaid-banner/__snapshots__/BlockaidBanner.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`BlockaidBanner should render correctly 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -87,9 +87,9 @@ exports[`BlockaidBanner should render correctly 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >
@@ -225,7 +225,7 @@ exports[`BlockaidBanner should render correctly with list attack details 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -239,9 +239,9 @@ exports[`BlockaidBanner should render correctly with list attack details 1`] = `
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >
@@ -377,7 +377,7 @@ exports[`BlockaidBanner should render correctly with reason "raw_signature_farmi
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -391,9 +391,9 @@ exports[`BlockaidBanner should render correctly with reason "raw_signature_farmi
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >
@@ -538,7 +538,7 @@ exports[`BlockaidBanner should render normal banner alert if resultType is faile
           {
             "color": "#131416",
             "fontFamily": "Geist-Medium",
-            "fontSize": 20,
+            "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
           }
@@ -552,9 +552,9 @@ exports[`BlockaidBanner should render normal banner alert if resultType is faile
           {
             "color": "#131416",
             "fontFamily": "Geist-Regular",
-            "fontSize": 16,
+            "fontSize": 14,
             "letterSpacing": 0,
-            "lineHeight": 24,
+            "lineHeight": 22,
           }
         }
       >
@@ -630,7 +630,7 @@ exports[`BlockaidBanner should render something does not look right with contact
         {
           "color": "#131416",
           "fontFamily": "Geist-Medium",
-          "fontSize": 20,
+          "fontSize": 16,
           "letterSpacing": 0,
           "lineHeight": 24,
         }
@@ -644,9 +644,9 @@ exports[`BlockaidBanner should render something does not look right with contact
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 16,
+          "fontSize": 14,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 22,
         }
       }
     >


### PR DESCRIPTION
## **Description**

Updated `BannerBase` default text variants to align with the typography scale update from #26842.

- `DEFAULT_BANNERBASE_TITLE_TEXTVARIANT`: `BodyLGMedium` -> `BodyMDMedium`
- `DEFAULT_BANNERBASE_DESCRIPTION_TEXTVARIANT`: `BodyMD` -> `BodySM`

Also updated affected snapshots across banner consumers that inherit these defaults.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: BannerBase typography defaults

  Scenario: Banner components render with updated default text variants
    Given the app/component-library/components/Banners tests are available
    When I run `yarn jest app/component-library/components/Banners`
    Then all Banner unit tests pass with updated snapshots
```

## **Screenshots/Recordings**

### **Before**

N/A (snapshot-only visual baseline updates)

<img width="464" height="225" alt="Screenshot 2026-03-03 at 3 37 40 PM" src="https://github.com/user-attachments/assets/9ca02b88-f80f-498e-a9af-5ba7c001298b" />


### **After**

N/A (snapshot-only visual baseline updates)

<img width="439" height="167" alt="Screenshot 2026-03-03 at 3 34 51 PM" src="https://github.com/user-attachments/assets/ef0956f8-a995-45ef-b8a1-0e0bad4b99b2" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change: updates `BannerBase` default typography variants and refreshes Jest snapshots for affected banner renders; no functional logic or data flow changes.
> 
> **Overview**
> Updates `BannerBase` default `Text` variants so banner titles/descriptions render with smaller typography (`BodyMDMedium`/`BodySM` instead of `BodyLGMedium`/`BodyMD`).
> 
> Refreshes Jest snapshots across banner variants and multiple banner consumers that inherit these defaults to reflect the new font sizes/line heights.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaec7613f97542f0ea4d05c6961e06eafad057dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->