### PR TITLE
test: color-no-hex snaps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -123,6 +123,12 @@ module.exports = {
       },
     },
     {
+      files: ['app/components/Snaps/**/*.{js,jsx,ts,tsx}'],
+      rules: {
+        '@metamask/design-tokens/color-no-hex': 'error',
+      },
+    },
+    {
       files: [
         'app/components/UI/Name/**/*.{js,ts,tsx}',
         'app/components/UI/SimulationDetails/**/*.{js,ts,tsx}',

--- a/app/components/Snaps/SnapUIRenderer/components/copyable.test.tsx
+++ b/app/components/Snaps/SnapUIRenderer/components/copyable.test.tsx
@@ -3,6 +3,7 @@
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import ClipboardManager from '../../../../core/ClipboardManager';
 import { Copyable } from '@metamask/snaps-sdk/jsx';
+import { mockTheme } from '../../../../util/theme';
 import { renderInterface } from '../testUtils';
 import { copyable } from './copyable';
 
@@ -42,14 +43,6 @@ jest.mock('../../../../core/Engine/Engine', () => ({
 describe('SnapUICopyable', () => {
   // Tests for the factory function
   describe('copyable factory function', () => {
-    // Create a mock theme object
-    const mockTheme = {
-      colors: {
-        text: { default: '#000000' },
-        background: { default: '#FFFFFF' },
-      },
-    };
-
     // Create base params that match UIComponentParams interface
     const baseParams = {
       map: {},

--- a/app/components/Snaps/SnapUIRenderer/components/link.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/link.test.ts
@@ -30,7 +30,7 @@ describe('link component', () => {
           children: 'link',
           key: expect.any(String),
           props: {
-            color: '#4459ff',
+            color: mockTheme.colors.info.default,
             style: {
               fontWeight: undefined,
               textAlign: undefined,
@@ -75,7 +75,7 @@ describe('link component', () => {
           children: 'Visit ',
           key: expect.any(String),
           props: {
-            color: '#4459ff',
+            color: mockTheme.colors.info.default,
             style: {
               fontWeight: undefined,
               textAlign: undefined,
@@ -120,7 +120,7 @@ describe('link component', () => {
           children: 'Visit ',
           key: expect.any(String),
           props: {
-            color: '#4459ff',
+            color: mockTheme.colors.info.default,
             style: {
               fontWeight: undefined,
               textAlign: undefined,
@@ -133,7 +133,7 @@ describe('link component', () => {
           children: 'MetaMask',
           key: expect.any(String),
           props: {
-            color: '#4459ff',
+            color: mockTheme.colors.info.default,
             style: {
               fontWeight: undefined,
               textAlign: undefined,

--- a/app/components/Snaps/SnapUISpinner/SnapUISpinner.test.tsx
+++ b/app/components/Snaps/SnapUISpinner/SnapUISpinner.test.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { SnapUISpinner } from './SnapUISpinner';
-import { lightTheme } from '@metamask/design-tokens';
 
 const mockUseTheme = jest.fn();
 jest.mock('../../../util/theme', () => ({
   useTheme: () => mockUseTheme(),
 }));
 
-const mockColor = lightTheme.colors.primary.default;
+const { mockTheme } = jest.requireActual('../../../util/theme');
+const mockColor = mockTheme.colors.primary.default;
 
 describe('SnapUISpinner', () => {
   beforeEach(() => {


### PR DESCRIPTION
## **Description**

Continues the color-no-hex cleanup in small codeowner batches by updating the Snaps (`@MetaMask/core-platform`) tests to remove hardcoded hex color expectations and local hex theme mocks.

This follows the same pattern as the original PR:
- Original reference PR: https://github.com/MetaMask/metamask-mobile/pull/26651
- use shared `mockTheme` from `util/theme`
- assert token-backed theme values (for example `mockTheme.colors.info.default`) instead of literal hex strings

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
Related: https://github.com/MetaMask/metamask-mobile/pull/26651

## **Manual testing steps**

```gherkin
Feature: static hex prevention in tests

  Scenario: snaps tests rely on shared theme values
    Given the Snap UI Renderer test suite

    When user runs the updated copyable and link tests
    Then both tests pass without hardcoded hex color values in assertions or local theme mocks
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low runtime risk since changes are limited to tests and ESLint config, but enabling `color-no-hex` as an error for all `app/components/Snaps` files could surface new lint failures across that folder.
> 
> **Overview**
> **Enables stricter linting for Snaps theming.** ESLint now enforces `@metamask/design-tokens/color-no-hex` as an *error* for `app/components/Snaps/**/*`.
> 
> **Updates Snaps tests to use token-backed theme values.** Snap UI tests (`copyable`, `link`, and `SnapUISpinner`) stop using hardcoded hex colors/local theme mocks and instead import the shared `mockTheme` and assert against values like `mockTheme.colors.info.default` / `mockTheme.colors.primary.default`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 468e216d2b6105945f8c410b24c7681a28a90ab0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->