### PR TITLE
test: remove bip44 ff from chain permissions tests

### DIFF
--- a/tests/smoke/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
+++ b/tests/smoke/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
@@ -12,8 +12,6 @@ import ConnectedAccountsModal from '../../../../page-objects/Browser/ConnectedAc
 import NetworkConnectMultiSelector from '../../../../page-objects/Browser/NetworkConnectMultiSelector';
 import NetworkNonPemittedBottomSheet from '../../../../page-objects/Network/NetworkNonPemittedBottomSheet';
 import { DappVariants } from '../../../../framework/Constants';
-import { setupRemoteFeatureFlagsMock } from '../../../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../api-mocking/mock-responses/feature-flags-mocks';
 
 describe(SmokeNetworkAbstractions('Chain Permission System'), () => {
   beforeAll(async () => {

--- a/tests/smoke/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
+++ b/tests/smoke/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
@@ -15,7 +15,7 @@ import { DappVariants } from '../../../../framework/Constants';
 import { setupRemoteFeatureFlagsMock } from '../../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../api-mocking/mock-responses/feature-flags-mocks';
 
-describe.skip(SmokeNetworkAbstractions('Chain Permission System'), () => {
+describe(SmokeNetworkAbstractions('Chain Permission System'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
   });
@@ -35,12 +35,6 @@ describe.skip(SmokeNetworkAbstractions('Chain Permission System'), () => {
             .withPermissionController()
             .build(),
           restartDevice: true,
-          testSpecificMock: async (mockServer) => {
-            await setupRemoteFeatureFlagsMock(
-              mockServer,
-              remoteFeatureMultichainAccountsAccountDetailsV2(false),
-            );
-          },
         },
         async () => {
           // Setup: Login and navigate to browser
@@ -69,11 +63,10 @@ describe.skip(SmokeNetworkAbstractions('Chain Permission System'), () => {
           await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
 
           // Navigate back to second Dapp and verify chain permissions
-          await ConnectedAccountsModal.tapManagePermissionsButton();
           await ConnectedAccountsModal.tapPermissionsSummaryTab();
 
           const networkPicker = ConnectedAccountsModal.networkPicker;
-          await Assertions.expectElementToHaveLabel(networkPicker, 'E');
+          await Assertions.expectElementToHaveLabel(networkPicker, 'l E');
         },
       );
     });

--- a/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js
+++ b/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js
@@ -88,7 +88,6 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
         await Assertions.expectElementToBeVisible(
           ConnectedAccountsModal.disconnectAllAccountsAndNetworksButton,
         );
-        // await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
         await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
 

--- a/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js
+++ b/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js
@@ -29,12 +29,6 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
         ],
         fixture: new FixtureBuilder().withPermissionController().build(),
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(false),
-          );
-        },
       },
       async () => {
         await loginToApp();
@@ -46,7 +40,9 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
         await ConnectBottomSheet.tapConnectButton();
 
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
-        await Assertions.expectElementToBeVisible(ConnectedAccountsModal.title);
+        await Assertions.expectElementToBeVisible(
+          ConnectedAccountsModal.disconnectAllAccountsAndNetworksButton,
+        );
       },
     );
   });
@@ -61,12 +57,6 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
         ],
         fixture: new FixtureBuilder().withPermissionController().build(),
         restartDevice: true,
-        testSpecificMock: async (mockServer) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetailsV2(false),
-          );
-        },
       },
       async () => {
         // Initial setup: Login and navigate to test dapp
@@ -97,16 +87,21 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
 
         // Open network permissions menu
         await Browser.tapNetworkAvatarOrAccountButtonOnBrowser();
-        await Assertions.expectElementToBeVisible(ConnectedAccountsModal.title);
-        await ConnectedAccountsModal.tapManagePermissionsButton();
+        await Assertions.expectElementToBeVisible(
+          ConnectedAccountsModal.disconnectAllAccountsAndNetworksButton,
+        );
+        // await ConnectedAccountsModal.tapManagePermissionsButton();
         await ConnectedAccountsModal.tapPermissionsSummaryTab();
         await ConnectedAccountsModal.tapNavigateToEditNetworksPermissionsButton();
 
         // Verify final permissions state
         // - Should have only Ethereum Mainnet and Sepolia selected
         // - Deselecting both should show the disconnect all button
-        await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
-        await NetworkNonPemittedBottomSheet.tapSepoliaNetworkName();
+        await ConnectedAccountsModal.tapSelectAllNetworksButton();
+        await ConnectedAccountsModal.tapDeselectAllNetworksButton();
+
+        // await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
+        // await NetworkNonPemittedBottomSheet.tapSepoliaNetworkName();
         await Assertions.expectElementToBeVisible(
           ConnectedAccountsModal.disconnectNetworksButton,
         );

--- a/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js
+++ b/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js
@@ -11,8 +11,6 @@ import ConnectBottomSheet from '../../../../page-objects/Browser/ConnectBottomSh
 import NetworkNonPemittedBottomSheet from '../../../../page-objects/Network/NetworkNonPemittedBottomSheet';
 import NetworkConnectMultiSelector from '../../../../page-objects/Browser/NetworkConnectMultiSelector';
 import { DappVariants } from '../../../../framework/Constants';
-import { setupRemoteFeatureFlagsMock } from '../../../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../../../api-mocking/mock-responses/feature-flags-mocks';
 
 describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
   beforeAll(async () => {
@@ -100,8 +98,6 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
         await ConnectedAccountsModal.tapSelectAllNetworksButton();
         await ConnectedAccountsModal.tapDeselectAllNetworksButton();
 
-        // await NetworkNonPemittedBottomSheet.tapEthereumMainNetNetworkName();
-        // await NetworkNonPemittedBottomSheet.tapSepoliaNetworkName();
         await Assertions.expectElementToBeVisible(
           ConnectedAccountsModal.disconnectNetworksButton,
         );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The E2E tests for the files,
e2e/specs/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.js
tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.js 
Fail once the BIP-44 flag is removed and currently it is being mocked to be OFF for this test. This mock is not correct since it does not represent the real state of the wallet in production.
The goal of this ticket is to update the test file to be compatible with BIP-44. If the tests are not relevant anymore, they can be deleted from the test suite. For this remove the testSpecificMock from the fixture and check for failures in the test.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to Detox smoke tests and primarily adjust setup/expectations to match updated UI flows. Main risk is increased test flakiness if the new selectors/labels vary across builds or locales.
> 
> **Overview**
> Removes the remote feature-flag mocking from the chain-permissions smoke tests and unskips the dApp chain-switch permission test so it runs by default.
> 
> Updates test flows/assertions to match the current Connected Accounts modal: checks for `disconnectAllAccountsAndNetworksButton` visibility instead of the modal title/manage-permissions step, uses select/deselect-all interactions for network permissions validation, and updates the expected network picker label (`'E'` -> `'l E'`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c25e60da1ce72dcff61cd4a453acc9086ffddac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->