### PR TITLE
fix(token-details): Use scoped account for EVM receive address after non-EVM network switch

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.ts
@@ -176,10 +176,11 @@ export const useTokenActions = ({
       location: ActionLocation.ASSET_DETAILS,
     });
 
-    const accountForChain =
-      isNonEvmToken && token.chainId
-        ? getAccountByScope(token.chainId as CaipChainId)
-        : selectedInternalAccount;
+    const accountForChain = token.chainId
+      ? (getAccountByScope(
+          formatChainIdToCaip(token.chainId as Hex) as CaipChainId,
+        ) ?? selectedInternalAccount)
+      : selectedInternalAccount;
 
     const addressForChain = accountForChain?.address;
 


### PR DESCRIPTION
## **Description**

When switching from a Non-EVM network (e.g. Solana, Bitcoin) to All Popular Networks,
the Receive QR modal in EVM token details was displaying the Non-EVM account address
instead of the correct EVM (0x) address.

The root cause was in `useTokenActions.ts`: the `onReceive` handler only called
`getAccountByScope` for non-EVM tokens, falling back to `selectedInternalAccount`
for EVM tokens. Since `selectedInternalAccount` is the globally selected account and
remains stale from the previous non-EVM network selection, the wrong address was passed
to the QR modal.

The fix aligns `onReceive` with the pattern already used correctly in
`useTokenTransactions.ts` — always resolving the account via `getAccountByScope` with
the CAIP-formatted chain ID, falling back to `selectedInternalAccount` only if no
scoped account is found.

## **Changelog**

CHANGELOG entry: Fixed a bug where the Receive address in EVM token details showed a
Non-EVM address after switching from a Non-EVM network.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26793

## **Manual testing steps**

```gherkin
Feature: Receive address in token details

  Scenario: user switches from a Non-EVM network to an EVM network and opens Receive
    Given the user has both a Solana account and an Ethereum account in the same group
    And the user is viewing a Solana token and opens the Receive modal
    And the user navigates back and switches to All Popular Networks

    When the user opens an Ethereum token details and taps Receive
    Then the QR modal should display the correct 0x Ethereum address
    And the address should NOT be a base58 Solana address
```

## **Screenshots/Recordings**

`~`

### **Before**

https://github.com/user-attachments/assets/0a26d5be-fbc6-4275-b27a-ff2c094e395f

### **After**

https://github.com/user-attachments/assets/efee1b40-26cc-438c-9fd6-7621443486d4

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the address-selection logic used when displaying the Receive QR modal; a wrong scope/CAIP conversion could show an incorrect address for some networks. The change is small and localized, with a fallback to the previously selected internal account.
> 
> **Overview**
> **Fixes a Receive-address scoping bug in Token Details.** The `onReceive` handler now always resolves the account via `selectSelectedInternalAccountByScope` using a CAIP-formatted `token.chainId`, falling back to `selectedInternalAccount` only if no scoped account exists.
> 
> This prevents the Receive QR sheet from showing a stale non-EVM address when opening an EVM token after switching networks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4202b646b31a18eca615d2fad9b088ebed69ad08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->