### PR TITLE
fix: charting library url

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -315,6 +315,7 @@ jobs:
       QUICKNODE_POLYGON_URL: ${{ secrets.QUICKNODE_POLYGON_URL }}
       QUICKNODE_BSC_URL: ${{ secrets.QUICKNODE_BSC_URL }}
       QUICKNODE_SEI_URL: ${{ secrets.QUICKNODE_SEI_URL }}
+      MM_CHARTING_LIBRARY_URL: ${{ secrets.MM_CHARTING_LIBRARY_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/builds.yml
+++ b/builds.yml
@@ -41,7 +41,7 @@ _public_envs: &public_envs # Servers (production)
   MM_PERPS_HIP3_ENABLED: 'true'
   # Temporary flag to enable builds with GitHub Actions, remove it when deprecating bitrise
   BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY: 'true'
-  MM_CHARTING_LIBRARY_URL: 'MM_CHARTING_LIBRARY_URL'
+  MM_CHARTING_LIBRARY_URL: 'https://va-mmcx-terminal.s3.us-east-2.amazonaws.com/charting_library/'
 
 # Common secrets (shared across ALL builds - same names, GitHub Environment determines values)
 _secrets: &secrets # Infrastructure

--- a/builds.yml
+++ b/builds.yml
@@ -41,6 +41,7 @@ _public_envs: &public_envs # Servers (production)
   MM_PERPS_HIP3_ENABLED: 'true'
   # Temporary flag to enable builds with GitHub Actions, remove it when deprecating bitrise
   BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY: 'true'
+  MM_CHARTING_LIBRARY_URL: 'MM_CHARTING_LIBRARY_URL'
 
 # Common secrets (shared across ALL builds - same names, GitHub Environment determines values)
 _secrets: &secrets # Infrastructure

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -712,6 +712,7 @@ createEnvFile() {
 		"QUICKNODE_OPTIMISM_URL"
 		"QUICKNODE_POLYGON_URL"
 		"QUICKNODE_HYPEREVM_URL"
+		"MM_CHARTING_LIBRARY_URL"
 	)
 
 	# Create .env file and export to GITHUB_ENV


### PR DESCRIPTION

## **Description**

Fix charting library url config

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk configuration-only change, but a missing/incorrect `MM_CHARTING_LIBRARY_URL` secret/value could cause builds or OTA updates to use the wrong charting assets.
> 
> **Overview**
> Fixes charting library URL configuration by introducing `MM_CHARTING_LIBRARY_URL` as a first-class env var across the build system.
> 
> The OTA push workflow (`push-eas-update.yml`) now injects `MM_CHARTING_LIBRARY_URL` from GitHub secrets, `builds.yml` defines the default URL, and `scripts/build.sh` exports it into the generated `.env` for Expo update/build steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18c053a8eff6ba3eadcc684bbc019fef5444b186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->