### PR TITLE
fix: market insights disclaimer text update

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -519,7 +519,7 @@ const MarketInsightsView: React.FC = () => {
               variant={TextVariant.BodySm}
               color={TextColor.TextAlternative}
             >
-              {strings('market_insights.fixed_footer_disclaimer')}
+              {strings('market_insights.footer_disclaimer')}
             </Text>
           </Box>
         </Box>

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -127,7 +127,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
               variant={TextVariant.BodySm}
               color={TextColor.TextAlternative}
             >
-              {strings('market_insights.fixed_footer_disclaimer')}
+              {strings('market_insights.footer_disclaimer')}
             </Text>
             <Text
               variant={TextVariant.BodySm}

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -127,7 +127,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
               variant={TextVariant.BodySm}
               color={TextColor.TextAlternative}
             >
-              {strings('market_insights.disclaimer')}
+              {strings('market_insights.fixed_footer_disclaimer')}
             </Text>
             <Text
               variant={TextVariant.BodySm}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2071,7 +2071,6 @@
   },
   "market_insights": {
     "title": "Market insights",
-    "disclaimer": "AI insights. Not financial advice.",
     "a_closer_look": "A closer look",
     "whats_being_said": "What's being said",
     "fixed_footer_disclaimer": "AI summary for information only",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2073,7 +2073,7 @@
     "title": "Market insights",
     "a_closer_look": "A closer look",
     "whats_being_said": "What's being said",
-    "fixed_footer_disclaimer": "AI summary for information only",
+    "footer_disclaimer": "AI summary for information only",
     "trade_button": "Trade",
     "sources_count": "+{{count}} sources",
     "sources_title": "News sources",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Small text update to the entry card disclaimer.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk text-only change: updates i18n keys used for the Market Insights disclaimers and removes unused English strings, with no logic or data-flow changes.
> 
> **Overview**
> Updates Market Insights UI to use a single `market_insights.footer_disclaimer` string for both the entry card and full view footer, replacing the previous `disclaimer`/`fixed_footer_disclaimer` keys.
> 
> Cleans up `en.json` by removing the old keys and keeping the updated disclaimer copy in one place.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f17ed96ee97093800f93e8d2054ec661ef6e4355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->