### PR TITLE
test: mock getQuoteStream with SSE format to fix SmokeTrade abort failures                                           

### DIFF
--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -368,12 +368,22 @@ export default class MockServerE2E implements Resource {
             }
           }
 
-          return handleDirectFetch(
-            updatedUrl,
-            method,
-            request.headers,
-            method === 'POST' ? requestBodyText : undefined,
-          );
+          try {
+            return await handleDirectFetch(
+              updatedUrl,
+              method,
+              request.headers,
+              method === 'POST' ? requestBodyText : undefined,
+            );
+          } catch (error) {
+            // Client dropped the connection before we could respond (e.g. bridge
+            // controller AbortController fired mid-request). Return a benign
+            // response so mockttp doesn't surface an unhandled rejection.
+            if (error instanceof Error && error.message === 'Aborted') {
+              return { statusCode: 499, body: '' };
+            }
+            throw error;
+          }
         } finally {
           this._activeRequests--;
         }
@@ -430,12 +440,22 @@ export default class MockServerE2E implements Resource {
           }
         }
 
-        return handleDirectFetch(
-          translatedUrl,
-          request.method,
-          request.headers,
-          await request.body.getText(),
-        );
+        try {
+          return await handleDirectFetch(
+            translatedUrl,
+            request.method,
+            request.headers,
+            await request.body.getText(),
+          );
+        } catch (error) {
+          // Client dropped the connection before we could respond (e.g. bridge
+          // controller AbortController fired mid-request). Return a benign
+          // response so mockttp doesn't surface an unhandled rejection.
+          if (error instanceof Error && error.message === 'Aborted') {
+            return { statusCode: 499, body: '' };
+          }
+          throw error;
+        }
       } finally {
         this._activeRequests--;
       }

--- a/tests/helpers/swap/constants.ts
+++ b/tests/helpers/swap/constants.ts
@@ -1,3 +1,12 @@
+/**
+ * Wraps quote fixture objects as an SSE-formatted response string.
+ * Required because bridge-controller uses fetchServerEvents (SSE parser)
+ * which expects lines prefixed with "data: ". Raw JSON returns zero quotes.
+ */
+export function toSSEResponse(quotes: object[]): string {
+  return quotes.map((q) => `data: ${JSON.stringify(q)}\n\n`).join('');
+}
+
 export const localNodeOptions = {
   hardfork: 'london',
   mnemonic:

--- a/tests/helpers/swap/swap-mocks.ts
+++ b/tests/helpers/swap/swap-mocks.ts
@@ -74,6 +74,7 @@ export const testSpecificMock: TestSpecificMock = async (
 ) => {
   await setupSpotPricesMock(mockServer);
 
+  // ── SSE path (bridge-controller SSE feature flag ON) ──────────────────────
   // Catch-all for getQuoteStream with no slippage param (initial render before
   // useInitialSlippage fires). Registered first so specific mocks below at
   // priority 999 take precedence. Prevents real network calls that cause
@@ -89,7 +90,7 @@ export const testSpecificMock: TestSpecificMock = async (
     1, // lower priority than the specific mocks below (999)
   );
 
-  // Mock ETH->USDC with default 2% slippage
+  // Mock ETH->USDC with default 2% slippage (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=2/i,
@@ -97,7 +98,7 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock ETH->USDC with 3.5% custom slippage
+  // Mock ETH->USDC with 3.5% custom slippage (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=3\.5/i,
@@ -105,7 +106,7 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock ETH->DAI
+  // Mock ETH->DAI (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0x6B175474E89094C44Da98b954EedeAC495271d0F/i,
@@ -113,7 +114,7 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock USDC->USDT
+  // Mock USDC->USDT (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0xdAC17F958D2ee523a2206206994597C13D831ec7/i,
@@ -121,7 +122,7 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // No quote when destination is mUSD
+  // No quote when destination is mUSD (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0xacA92E438df0B2401fF60dA7E4337B687a2435DA/i,
@@ -129,7 +130,7 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock USDC->ETH (ETH native token address is 0x0000...0000)
+  // Mock USDC->ETH (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*srcTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
@@ -137,7 +138,7 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock ETH->WETH (wrapped native)
+  // Mock ETH->WETH (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/i,
@@ -145,11 +146,93 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock WETH->ETH (same-chain unwrap for E2E)
+  // Mock WETH->ETH (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*srcTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
     response: toSSEResponse(GET_QUOTE_WETH_ETH_SAME_CHAIN_RESPONSE),
+    responseCode: 200,
+  });
+
+  // ── JSON path (bridge-controller SSE feature flag OFF) ─────────────────────
+  // The bridge controller falls back to fetchBridgeQuotes → /getQuote? (no
+  // "Stream" suffix) returning plain JSON when sse.enabled is false (e.g. local
+  // dev with BRIDGE_USE_DEV_APIS=true). Use /\/getQuote\?/i so the regex matches
+  // "getQuote?" but NOT "getQuoteStream?".
+
+  // Catch-all for getQuote (no slippage / initial render)
+  await setupMockRequest(
+    mockServer,
+    {
+      requestMethod: 'GET',
+      url: /\/getQuote\?/i,
+      response: GET_QUOTE_ETH_USDC_RESPONSE,
+      responseCode: 200,
+    },
+    1, // lower priority than specific mocks below (999)
+  );
+
+  // Mock ETH->USDC with default 2% slippage (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=2/i,
+    response: GET_QUOTE_ETH_USDC_RESPONSE,
+    responseCode: 200,
+  });
+
+  // Mock ETH->USDC with 3.5% custom slippage (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=3\.5/i,
+    response: GET_QUOTE_ETH_USDC_RESPONSE_CUSTOM_SLIPPAGE,
+    responseCode: 200,
+  });
+
+  // Mock ETH->DAI (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0x6B175474E89094C44Da98b954EedeAC495271d0F/i,
+    response: GET_QUOTE_ETH_DAI_RESPONSE,
+    responseCode: 200,
+  });
+
+  // Mock USDC->USDT (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0xdAC17F958D2ee523a2206206994597C13D831ec7/i,
+    response: GET_QUOTE_USDC_USDT_RESPONSE,
+    responseCode: 200,
+  });
+
+  // No quote when destination is mUSD (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0xacA92E438df0B2401fF60dA7E4337B687a2435DA/i,
+    response: [],
+    responseCode: 200,
+  });
+
+  // Mock USDC->ETH (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*srcTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
+    response: GET_QUOTE_USDC_ETH_RESPONSE,
+    responseCode: 200,
+  });
+
+  // Mock ETH->WETH (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/i,
+    response: GET_QUOTE_ETH_WETH_RESPONSE,
+    responseCode: 200,
+  });
+
+  // Mock WETH->ETH (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*srcTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
+    response: GET_QUOTE_WETH_ETH_SAME_CHAIN_RESPONSE,
     responseCode: 200,
   });
 
@@ -185,11 +268,19 @@ export const testSpecificMock: TestSpecificMock = async (
     responseCode: 200,
   });
 
-  // Mock USDC->GOOGLON
+  // Mock USDC->GOOGLON (SSE)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
     url: /getQuoteStream.*destTokenAddress=0xba47214edd2bb43099611b208f75e4b42fdcfedc/i,
     response: toSSEResponse(GET_QUOTE_USDC_GOOGLON_RESPONSE),
+    responseCode: 200,
+  });
+
+  // Mock USDC->GOOGLON (JSON)
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: /\/getQuote\?.*destTokenAddress=0xba47214edd2bb43099611b208f75e4b42fdcfedc/i,
+    response: GET_QUOTE_USDC_GOOGLON_RESPONSE,
     responseCode: 200,
   });
 

--- a/tests/helpers/swap/swap-mocks.ts
+++ b/tests/helpers/swap/swap-mocks.ts
@@ -18,6 +18,7 @@ import {
   GET_TOKENS_API_USDC_RESPONSE,
   GET_TOKENS_API_USDT_RESPONSE,
   GET_QUOTE_USDC_GOOGLON_RESPONSE,
+  toSSEResponse,
 } from './constants';
 
 const USDC_MAINNET = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
@@ -73,67 +74,82 @@ export const testSpecificMock: TestSpecificMock = async (
 ) => {
   await setupSpotPricesMock(mockServer);
 
+  // Catch-all for getQuoteStream with no slippage param (initial render before
+  // useInitialSlippage fires). Registered first so specific mocks below at
+  // priority 999 take precedence. Prevents real network calls that cause
+  // Error: Aborted when the bridge controller aborts the in-flight request.
+  await setupMockRequest(
+    mockServer,
+    {
+      requestMethod: 'GET',
+      url: /getQuoteStream/i,
+      response: toSSEResponse(GET_QUOTE_ETH_USDC_RESPONSE),
+      responseCode: 200,
+    },
+    1, // lower priority than the specific mocks below (999)
+  );
+
   // Mock ETH->USDC with default 2% slippage
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=2/i,
-    response: GET_QUOTE_ETH_USDC_RESPONSE,
+    url: /getQuoteStream.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=2/i,
+    response: toSSEResponse(GET_QUOTE_ETH_USDC_RESPONSE),
     responseCode: 200,
   });
 
   // Mock ETH->USDC with 3.5% custom slippage
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=3.5/i,
-    response: GET_QUOTE_ETH_USDC_RESPONSE_CUSTOM_SLIPPAGE,
+    url: /getQuoteStream.*destTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*slippage=3\.5/i,
+    response: toSSEResponse(GET_QUOTE_ETH_USDC_RESPONSE_CUSTOM_SLIPPAGE),
     responseCode: 200,
   });
 
   // Mock ETH->DAI
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0x6B175474E89094C44Da98b954EedeAC495271d0F/i,
-    response: GET_QUOTE_ETH_DAI_RESPONSE,
+    url: /getQuoteStream.*destTokenAddress=0x6B175474E89094C44Da98b954EedeAC495271d0F/i,
+    response: toSSEResponse(GET_QUOTE_ETH_DAI_RESPONSE),
     responseCode: 200,
   });
 
   // Mock USDC->USDT
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0xdAC17F958D2ee523a2206206994597C13D831ec7/i,
-    response: GET_QUOTE_USDC_USDT_RESPONSE,
+    url: /getQuoteStream.*destTokenAddress=0xdAC17F958D2ee523a2206206994597C13D831ec7/i,
+    response: toSSEResponse(GET_QUOTE_USDC_USDT_RESPONSE),
     responseCode: 200,
   });
 
-  // No need quote when destination is mUSD
+  // No quote when destination is mUSD
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0xacA92E438df0B2401fF60dA7E4337B687a2435DA/i,
-    response: [],
+    url: /getQuoteStream.*destTokenAddress=0xacA92E438df0B2401fF60dA7E4337B687a2435DA/i,
+    response: '',
     responseCode: 200,
   });
 
   // Mock USDC->ETH (ETH native token address is 0x0000...0000)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*srcTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
-    response: GET_QUOTE_USDC_ETH_RESPONSE,
+    url: /getQuoteStream.*srcTokenAddress=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
+    response: toSSEResponse(GET_QUOTE_USDC_ETH_RESPONSE),
     responseCode: 200,
   });
 
   // Mock ETH->WETH (wrapped native)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/i,
-    response: GET_QUOTE_ETH_WETH_RESPONSE,
+    url: /getQuoteStream.*destTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/i,
+    response: toSSEResponse(GET_QUOTE_ETH_WETH_RESPONSE),
     responseCode: 200,
   });
 
   // Mock WETH->ETH (same-chain unwrap for E2E)
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*srcTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
-    response: GET_QUOTE_WETH_ETH_SAME_CHAIN_RESPONSE,
+    url: /getQuoteStream.*srcTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2.*destTokenAddress=0x0000000000000000000000000000000000000000/i,
+    response: toSSEResponse(GET_QUOTE_WETH_ETH_SAME_CHAIN_RESPONSE),
     responseCode: 200,
   });
 
@@ -172,8 +188,8 @@ export const testSpecificMock: TestSpecificMock = async (
   // Mock USDC->GOOGLON
   await setupMockRequest(mockServer, {
     requestMethod: 'GET',
-    url: /getQuote.*destTokenAddress=0xba47214edd2bb43099611b208f75e4b42fdcfedc/i,
-    response: GET_QUOTE_USDC_GOOGLON_RESPONSE,
+    url: /getQuoteStream.*destTokenAddress=0xba47214edd2bb43099611b208f75e4b42fdcfedc/i,
+    response: toSSEResponse(GET_QUOTE_USDC_GOOGLON_RESPONSE),
     responseCode: 200,
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
## Problem

  `SmokeTrade: Swap from Actions` was failing in CI with:

  Error: Aborted at IncomingMessage.failWithAbortError (node_modules/mockttp/src/u...)

  Two compounding issues:

  1. **Wrong endpoint mocked.** The bridge controller uses `getQuoteStream` (SSE) for all quote requests, not `getQuote`.
  The existing mock patterns (`/getQuote.*slippage=.*/`) happened to substring-match `getQuoteStream` for requests *with* a
   slippage param, but the **initial render request** (fired before `useInitialSlippage` dispatches the first slippage
  value) has no `slippage=` param and matched no rule. It fell through to `handleDirectFetch` → real network call to
  `bridge.api.cx.metamask.io` in CI.

  2. **Wrong response format.** Even when a mock matched, it returned raw JSON (`[{...}]`). The bridge controller's
  `fetchServerEvents` SSE parser only calls `onMessage` for lines prefixed with `data:` — raw JSON yields zero quotes, so
  `activeQuote` was never set and the confirm button never appeared.

  The combination caused: real API call in flight → bridge controller fires `AbortController.abort()` on the next param
  change → TCP connection dropped → mockttp throws `Error: Aborted` from its callback chain — bypassing the existing
  `_installAbortFilter` (which only catches `unhandledRejection`, not errors propagating through the callback chain).

  ## Changes

  **`tests/helpers/swap/constants.ts`**
  - Added `toSSEResponse()` helper that wraps quote fixture arrays into SSE format (`data: {...}\n\n` per quote)

  **`tests/helpers/swap/swap-mocks.ts`**
  - Changed all mock URL patterns from `getQuote` → `getQuoteStream`
  - Wrapped all quote fixture responses in `toSSEResponse()` so the SSE parser receives and dispatches quotes correctly
  - Added a priority-1 blanket catch-all for any `getQuoteStream` URL as a safety net for no-slippage initial requests

  **`tests/api-mocking/MockServerE2E.ts`**
  - Wrapped both `handleDirectFetch` call sites (the `/proxy` catch-all and `forUnmatchedRequest`) with a try-catch that
  converts `Error: Aborted` to a 499 response, preventing it from propagating out of the mockttp callback chain
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to E2E test mocking and mock server error handling, with no production logic impacted. Main risk is overly-broad catch-all mocks or `499` masking unexpected abort-related failures in tests.
> 
> **Overview**
> Fixes flaky swap E2E runs by updating swap quote mocks to match the bridge-controller’s SSE `getQuoteStream` endpoint and returning SSE-formatted quote data via a new `toSSEResponse` helper.
> 
> Adds low-priority catch-all mocks for both `getQuoteStream` (SSE) and `/getQuote?` (JSON fallback) to prevent accidental live-network fallthrough, and hardens `MockServerE2E` forwarding so `Error: Aborted` from dropped client connections is converted into a benign `499` response instead of failing the test harness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed9c27d0b02d0f79634df885ad72fdf8fd6eb8aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->