### PR TITLE
fix: Ensure `redux-persist-filesystem-storage` returns a promise and throws correctly cp-7.67.2 cp-7.67.3

### DIFF
--- a/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch
+++ b/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch
@@ -11,7 +11,7 @@ index b0caa94ceaa9afaa6c112947a328887e580f76a2..76b0442a7367f39d8ae9300825815edd
      ) => Promise<void>
  
 diff --git a/index.js b/index.js
-index d69afb678b3d06760ad59831457cfd5c51fdb89b..72a5e6a011ed73144b2c582f570c4090042f3757 100644
+index d69afb678b3d06760ad59831457cfd5c51fdb89b..8d5ecb060a91f137c865ed21f891b640d3cc65fe 100644
 --- a/index.js
 +++ b/index.js
 @@ -41,11 +41,19 @@ const FilesystemStorage = {
@@ -32,7 +32,7 @@ index d69afb678b3d06760ad59831457cfd5c51fdb89b..72a5e6a011ed73144b2c582f570c4090
 +        if (!callback) {
 +          throw error;
 +        }
-+        callback && callback(error);
++        callback(error);
 +      });
 +  },
  

--- a/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch
+++ b/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch
@@ -1,7 +1,7 @@
-diff --git a/node_modules/redux-persist-filesystem-storage/index.d.ts b/node_modules/redux-persist-filesystem-storage/index.d.ts
-index b0caa94..76b0442 100644
---- a/node_modules/redux-persist-filesystem-storage/index.d.ts
-+++ b/node_modules/redux-persist-filesystem-storage/index.d.ts
+diff --git a/index.d.ts b/index.d.ts
+index b0caa94ceaa9afaa6c112947a328887e580f76a2..76b0442a7367f39d8ae9300825815edda5b02c44 100644
+--- a/index.d.ts
++++ b/index.d.ts
 @@ -12,6 +12,7 @@ declare module 'redux-persist-filesystem-storage' {
      setItem: (
        key: string,
@@ -10,24 +10,30 @@ index b0caa94..76b0442 100644
        callback?: (error?: Error) => void,
      ) => Promise<void>
  
-diff --git a/node_modules/redux-persist-filesystem-storage/index.js b/node_modules/redux-persist-filesystem-storage/index.js
-index d69afb6..0ca3a25 100644
---- a/node_modules/redux-persist-filesystem-storage/index.js
-+++ b/node_modules/redux-persist-filesystem-storage/index.js
-@@ -41,11 +41,14 @@ const FilesystemStorage = {
+diff --git a/index.js b/index.js
+index d69afb678b3d06760ad59831457cfd5c51fdb89b..72a5e6a011ed73144b2c582f570c4090042f3757 100644
+--- a/index.js
++++ b/index.js
+@@ -41,11 +41,19 @@ const FilesystemStorage = {
      onStorageReady = onStorageReadyFactory(options.storagePath);
    },
  
 -  setItem: (key: string, value: string, callback?: (error: ?Error) => void) =>
+-    ReactNativeBlobUtil.fs
 +  setItem: (key: string, value: string, isIOS: boolean = false, callback?: (error: ?Error) => void) => {
-     ReactNativeBlobUtil.fs
++    return ReactNativeBlobUtil.fs
        .writeFile(pathForKey(key), value, options.encoding)
 -      .then(() => callback && callback())
 -      .catch(error => callback && callback(error)),
 +      .then(() => {
 +        if (isIOS) ReactNativeBlobUtil.ios.excludeFromBackupKey(pathForKey(key));
 +        callback && callback();
-+      }).catch(error => callback && callback(error));
++      }).catch((error) => {
++        if (!callback) {
++          throw error;
++        }
++        callback && callback(error);
++      });
 +  },
  
    getItem: onStorageReady(

--- a/package.json
+++ b/package.json
@@ -479,7 +479,7 @@
     "redux": "^4.2.1",
     "redux-mock-store": "1.5.4",
     "redux-persist": "6.0.0",
-    "redux-persist-filesystem-storage": "^4.2.0",
+    "redux-persist-filesystem-storage": "patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch",
     "redux-saga": "^1.3.0",
     "redux-thunk": "^2.4.2",
     "reselect": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41528,10 +41528,10 @@ __metadata:
 
 "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch":
   version: 4.2.0
-  resolution: "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch::version=4.2.0&hash=7a56d0"
+  resolution: "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch::version=4.2.0&hash=314496"
   dependencies:
     react-native-blob-util: "npm:^0.18.0"
-  checksum: 10/49bc8247e77a4ea7badb551dd86e8c31dd6625a14aa29a278b6b27482959dbbc48519e98a53443ecb76b84ada17eebae3b626e762deb80055e4c4a692f7ad5bb
+  checksum: 10/421ba38bcf61fea1fb8491f9ea894c37bf6657ec8ccd9b2556c87683f2f71139c773bd44367810af7f0d7797906818646e2bb75440152e9eef0af57d43e446e5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -35775,7 +35775,7 @@ __metadata:
     redux-devtools-expo-dev-plugin: "npm:^1.0.0"
     redux-mock-store: "npm:1.5.4"
     redux-persist: "npm:6.0.0"
-    redux-persist-filesystem-storage: "npm:^4.2.0"
+    redux-persist-filesystem-storage: "patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch"
     redux-saga: "npm:^1.3.0"
     redux-saga-test-plan: "npm:^4.0.6"
     redux-thunk: "npm:^2.4.2"
@@ -41517,12 +41517,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-persist-filesystem-storage@npm:^4.2.0":
+"redux-persist-filesystem-storage@npm:4.2.0":
   version: 4.2.0
   resolution: "redux-persist-filesystem-storage@npm:4.2.0"
   dependencies:
     react-native-blob-util: "npm:^0.18.0"
   checksum: 10/c2edeb92b72874ab08c7a34e9dae8a06ac13c4a5b238d92e798ec0355027a99eb0c27c6b4c95b8c0efda8123a50f9c232e7a215a97726f07dc4af73a991ac343
+  languageName: node
+  linkType: hard
+
+"redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch":
+  version: 4.2.0
+  resolution: "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch::version=4.2.0&hash=7a56d0"
+  dependencies:
+    react-native-blob-util: "npm:^0.18.0"
+  checksum: 10/49bc8247e77a4ea7badb551dd86e8c31dd6625a14aa29a278b6b27482959dbbc48519e98a53443ecb76b84ada17eebae3b626e762deb80055e4c4a692f7ad5bb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -41528,10 +41528,10 @@ __metadata:
 
 "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch":
   version: 4.2.0
-  resolution: "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch::version=4.2.0&hash=314496"
+  resolution: "redux-persist-filesystem-storage@patch:redux-persist-filesystem-storage@npm%3A4.2.0#~/.yarn/patches/redux-persist-filesystem-storage-npm-4.2.0-3a6fff24ab.patch::version=4.2.0&hash=4dfd27"
   dependencies:
     react-native-blob-util: "npm:^0.18.0"
-  checksum: 10/421ba38bcf61fea1fb8491f9ea894c37bf6657ec8ccd9b2556c87683f2f71139c773bd44367810af7f0d7797906818646e2bb75440152e9eef0af57d43e446e5
+  checksum: 10/fa556e2d1784a5e664e2e7024fa2255b08334e0dacf8993acca676cb912ad82c0f8ef3ba9ec2597d455f9dded83acf3343cc0a66d4e2fc14486e31dd9efe6def
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adjusts our existing patch for `redux-persist-filesystem-storage` to always return a promise for `setItem` so it can be awaited correctly, fixing potential race conditions. This was broken when the patch originally was created by adding brackets to an arrow function and not returning. The PR also fixes a bug where not passing in a callback would cause errors to be swallowed. Additionally, this PR moves our existing patch to use the built-in Yarn patch feature (because creating new patches with `patch-package` seems broken).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improve reliability of persistence

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence write behavior by changing the patched `redux-persist-filesystem-storage` `setItem` control flow and error propagation, which could affect app startup/migrations if any callers depend on the old callback-only semantics. Also introduces an iOS-only side effect (exclude-from-backup) after writes.
> 
> **Overview**
> This PR updates the Yarn patch for `redux-persist-filesystem-storage` so `setItem` **always returns a Promise** that can be awaited, rather than potentially relying on callback chaining.
> 
> It also fixes error handling so write failures are **thrown when no callback is provided** (instead of being swallowed), and adds an optional `isIOS` flag to run `ReactNativeBlobUtil.ios.excludeFromBackupKey(...)` after successful writes on iOS.
> 
> Dependency wiring is switched from a normal semver dependency to Yarn’s built-in `patch:` reference for `redux-persist-filesystem-storage@4.2.0`, with corresponding `yarn.lock` updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 192a5c846d0e01487929a506d71542523b2a96cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->