### PR TITLE
fix(perps): remove duplicate AppState listener causing reconnection race cp-7.67.2

### DIFF
--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -318,6 +318,7 @@ abstract class StreamChannel<T> {
         subscriber.timer = undefined;
       }
       subscriber.pendingUpdate = undefined;
+      subscriber.hasReceivedFirstUpdate = false;
     });
 
     // Disconnect the old WebSocket subscription to stop receiving old account data

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -94,6 +94,7 @@ jest.mock('react-native-background-timer', () => ({
 }));
 
 // Import non-singleton modules first
+import { addEventListener as mockNetInfoAddEventListener } from '@react-native-community/netinfo';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
@@ -130,11 +131,18 @@ const resetManager = (manager: unknown) => {
     hasPreloaded: boolean;
     isPreloading: boolean;
     prewarmCleanups: (() => void)[];
+    netInfoUnsubscribe: (() => void) | null;
+    wasOffline: boolean;
   };
   // Call unsubscribe if it exists before resetting
   if (m.unsubscribeFromStore) {
     m.unsubscribeFromStore();
   }
+  if (m.netInfoUnsubscribe) {
+    m.netInfoUnsubscribe();
+    m.netInfoUnsubscribe = null;
+  }
+  m.wasOffline = false;
   // Clean up any prewarm subscriptions
   m.prewarmCleanups.forEach((cleanup) => cleanup());
   m.prewarmCleanups = [];
@@ -981,6 +989,161 @@ describe('PerpsConnectionManager', () => {
 
       // Cleanup
       m.pendingReconnectPromise = null;
+    });
+  });
+
+  describe('performActualDisconnection — grace period expiry', () => {
+    beforeEach(async () => {
+      mockPerpsController.init.mockResolvedValue();
+      mockPerpsController.disconnect.mockResolvedValue();
+      await PerpsConnectionManager.connect();
+      // Clear cache mock calls from connect/prewarm so we can assert specifically
+      Object.values(mockStreamManagerInstance).forEach(({ clearCache }) =>
+        clearCache.mockClear(),
+      );
+    });
+
+    it('clears all stream channel caches when grace period fires', async () => {
+      // Arrange
+      const m = PerpsConnectionManager as unknown as {
+        isConnected: boolean;
+        isInitialized: boolean;
+        connectionRefCount: number;
+        isPreloading: boolean;
+        performActualDisconnection: () => Promise<void>;
+      };
+      m.connectionRefCount = 0;
+
+      // Act
+      await m.performActualDisconnection();
+
+      // Assert
+      expect(mockStreamManagerInstance.positions.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.orders.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.account.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.prices.clearCache).toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.marketData.clearCache,
+      ).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.oiCaps.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.fills.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.topOfBook.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.candles.clearCache).toHaveBeenCalled();
+    });
+
+    it('resets isPreloading flag so next connect can prewarm', async () => {
+      // Arrange
+      const m = PerpsConnectionManager as unknown as {
+        connectionRefCount: number;
+        isPreloading: boolean;
+        performActualDisconnection: () => Promise<void>;
+      };
+      m.connectionRefCount = 0;
+      m.isPreloading = true;
+
+      // Act
+      await m.performActualDisconnection();
+
+      // Assert
+      expect(m.isPreloading).toBe(false);
+    });
+
+    it('resets connection state flags after disconnecting', async () => {
+      // Arrange
+      const m = PerpsConnectionManager as unknown as {
+        connectionRefCount: number;
+        performActualDisconnection: () => Promise<void>;
+      };
+      m.connectionRefCount = 0;
+
+      // Act
+      await m.performActualDisconnection();
+
+      // Assert
+      const state = PerpsConnectionManager.getConnectionState();
+      expect(state.isConnected).toBe(false);
+      expect(state.isInitialized).toBe(false);
+      expect(state.isConnecting).toBe(false);
+    });
+
+    it('skips disconnection when reference count is still positive', async () => {
+      // Arrange — refCount > 0 means another consumer reconnected during grace period
+      const m = PerpsConnectionManager as unknown as {
+        connectionRefCount: number;
+        performActualDisconnection: () => Promise<void>;
+      };
+      m.connectionRefCount = 1;
+
+      // Act
+      await m.performActualDisconnection();
+
+      // Assert — controller not called, caches not cleared
+      expect(mockPerpsController.disconnect).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.positions.clearCache,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('NetInfo isInternetReachable null handling', () => {
+    type NetInfoCallback = (state: {
+      isInternetReachable: boolean | null;
+      isConnected: boolean | null;
+    }) => void;
+
+    const mockAddEventListener = mockNetInfoAddEventListener as jest.Mock;
+
+    let capturedCallback: NetInfoCallback | null = null;
+
+    beforeEach(async () => {
+      // Set up to capture the listener, then connect so it registers
+      mockAddEventListener.mockImplementation((cb: NetInfoCallback) => {
+        capturedCallback = cb;
+        return jest.fn();
+      });
+      mockPerpsController.init.mockResolvedValue();
+      await PerpsConnectionManager.connect();
+    });
+
+    it('treats isInternetReachable null as online when isConnected is true', () => {
+      // Arrange — start disconnected so wasOffline is not set by online path
+      const m = PerpsConnectionManager as unknown as {
+        wasOffline: boolean;
+        isConnected: boolean;
+      };
+      m.isConnected = false; // not connected — online path won't clear wasOffline
+      m.wasOffline = false;
+
+      // Act — null isInternetReachable falls back to isConnected=true → isOnline=true
+      // Since isOnline=true and !wasOffline, the "set wasOffline=true" branch is skipped
+      capturedCallback?.({ isInternetReachable: null, isConnected: true });
+
+      // Assert — wasOffline stays false (not offline path, and not connected to clear it)
+      expect(m.wasOffline).toBe(false);
+    });
+
+    it('treats isInternetReachable null as offline when isConnected is false', () => {
+      // Arrange
+      const m = PerpsConnectionManager as unknown as { wasOffline: boolean };
+      m.wasOffline = false;
+
+      // Act — null isInternetReachable falls back to isConnected=false → offline
+      capturedCallback?.({ isInternetReachable: null, isConnected: false });
+
+      // Assert
+      expect(m.wasOffline).toBe(true);
+    });
+
+    it('treats isInternetReachable false as offline', () => {
+      // Arrange
+      const m = PerpsConnectionManager as unknown as { wasOffline: boolean };
+      m.wasOffline = false;
+
+      // Act
+      capturedCallback?.({ isInternetReachable: false, isConnected: true });
+
+      // Assert
+      expect(m.wasOffline).toBe(true);
     });
   });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -128,8 +128,8 @@ const resetManager = (manager: unknown) => {
     isInGracePeriod: boolean;
     gracePeriodTimer: number | null;
     hasPreloaded: boolean;
+    isPreloading: boolean;
     prewarmCleanups: (() => void)[];
-    lastBalanceUpdateTime: number;
   };
   // Call unsubscribe if it exists before resetting
   if (m.unsubscribeFromStore) {
@@ -155,7 +155,7 @@ const resetManager = (manager: unknown) => {
   m.isInGracePeriod = false;
   m.gracePeriodTimer = null;
   m.hasPreloaded = false;
-  m.lastBalanceUpdateTime = 0;
+  m.isPreloading = false;
 };
 
 describe('PerpsConnectionManager', () => {
@@ -837,6 +837,83 @@ describe('PerpsConnectionManager', () => {
           'PerpsConnectionManager: All signing cache cleared',
         );
       });
+    });
+  });
+
+  describe('preloadSubscriptions concurrency guard', () => {
+    it('should skip a second preload call while one is already in flight', async () => {
+      // Arrange: set isPreloading = true directly to simulate in-flight preload
+      const m = PerpsConnectionManager as unknown as {
+        isPreloading: boolean;
+        hasPreloaded: boolean;
+        preloadSubscriptions: () => Promise<void>;
+      };
+      m.isPreloading = true;
+
+      await m.preloadSubscriptions();
+
+      // prices.prewarm should NOT have been called — guard blocked concurrent call
+      expect(mockStreamManagerInstance.prices.prewarm).not.toHaveBeenCalled();
+    });
+
+    it('should allow a fresh preload after performReconnection resets isPreloading', async () => {
+      mockPerpsController.init.mockResolvedValue();
+      mockPerpsController.disconnect.mockResolvedValue();
+
+      // First full connection + preload
+      await PerpsConnectionManager.connect();
+      expect(mockStreamManagerInstance.prices.prewarm).toHaveBeenCalledTimes(1);
+
+      // Reconnect resets hasPreloaded and isPreloading, then preloads again
+      await (
+        PerpsConnectionManager as unknown as {
+          reconnectWithNewContext: () => Promise<void>;
+        }
+      ).reconnectWithNewContext();
+
+      expect(mockStreamManagerInstance.prices.prewarm).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('foreground reconnection — single reconnection flow', () => {
+    it('PerpsConnectionManager has no AppState listener — only the hook triggers foreground reconnect', () => {
+      // This test documents the fix for the race condition introduced by PR #26780.
+      // Previously, PerpsConnectionManager registered its own AppState listener in
+      // setupStateMonitoring(), which competed with usePerpsConnectionLifecycle hook.
+      //
+      // Both fired simultaneously on foreground:
+      //   hook  → connect()
+      //   manager → reconnectWithNewContext({ force: true })
+      //
+      // The force path cancelled the hook's in-flight connect() and cleaned up
+      // prewarm subscriptions mid-flight, leaving positions/prices without data.
+      //
+      // Fix: removed the manager-level AppState listener entirely.
+      // The hook is the sole owner of foreground recovery.
+
+      const m = PerpsConnectionManager as unknown as Record<string, unknown>;
+
+      // appStateSubscription field must not exist on the manager
+      expect(m.appStateSubscription).toBeUndefined();
+
+      // handleAppStateChange method must not exist on the manager
+      expect(typeof m.handleAppStateChange).not.toBe('function');
+    });
+
+    it('connect() on foreground completes without interference', async () => {
+      mockPerpsController.init.mockResolvedValue();
+
+      await PerpsConnectionManager.connect();
+
+      const state = PerpsConnectionManager.getConnectionState();
+      expect(state.isConnected).toBe(true);
+      expect(state.isConnecting).toBe(false);
+      expect(state.error).toBeNull();
+      // Prewarm subscriptions fired exactly once
+      expect(mockStreamManagerInstance.prices.prewarm).toHaveBeenCalledTimes(1);
+      expect(mockStreamManagerInstance.positions.prewarm).toHaveBeenCalledTimes(
+        1,
+      );
     });
   });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -209,7 +209,7 @@ describe('PerpsConnectionManager', () => {
   });
 
   describe('getInstance', () => {
-    it('should return the same instance when called multiple times', () => {
+    it('returns the same singleton instance on repeated calls', () => {
       const instance1 = PerpsConnectionManager;
       const instance2 = PerpsConnectionManager;
 
@@ -218,7 +218,7 @@ describe('PerpsConnectionManager', () => {
   });
 
   describe('connect', () => {
-    it('should initialize providers and connect successfully', async () => {
+    it('initializes providers and connects on first call', async () => {
       mockPerpsController.init.mockResolvedValueOnce();
 
       await PerpsConnectionManager.connect();
@@ -229,7 +229,7 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('should increment reference count on each connect call', async () => {
+    it('increments reference count on each connect call', async () => {
       mockPerpsController.init.mockResolvedValue();
 
       await PerpsConnectionManager.connect();
@@ -243,7 +243,7 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('should return existing promise if already connecting', async () => {
+    it('returns existing promise when connection is already in progress', async () => {
       // This test verifies that concurrent connect calls share the same promise
 
       // Track promises from both connect calls
@@ -274,7 +274,7 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('should handle connection failures', async () => {
+    it('sets error state and resets flags when connection fails', async () => {
       const error = new Error('Connection failed');
       mockPerpsController.init.mockRejectedValueOnce(error);
 
@@ -294,7 +294,7 @@ describe('PerpsConnectionManager', () => {
       expect(state.error).toBe('Connection failed');
     });
 
-    it('should skip reconnection if already connected', async () => {
+    it('skips reconnection when already connected', async () => {
       // First successful connection
       mockPerpsController.init.mockResolvedValueOnce();
       await PerpsConnectionManager.connect();
@@ -308,7 +308,7 @@ describe('PerpsConnectionManager', () => {
       expect(mockPerpsController.init).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle rapid disconnect-connect cycles with grace period', async () => {
+    it('cancels grace period timer when reconnecting during grace period', async () => {
       // Setup initial connection
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.getAccountState.mockResolvedValue({});
@@ -345,7 +345,7 @@ describe('PerpsConnectionManager', () => {
       mockPerpsController.disconnect.mockResolvedValue();
     });
 
-    it('should decrement reference count on disconnect', async () => {
+    it('decrements reference count on disconnect', async () => {
       await PerpsConnectionManager.connect();
       await PerpsConnectionManager.connect();
 
@@ -359,7 +359,7 @@ describe('PerpsConnectionManager', () => {
       expect(mockPerpsController.disconnect).not.toHaveBeenCalled();
     });
 
-    it('should only start grace period when reference count reaches zero', async () => {
+    it('starts grace period only when reference count reaches zero', async () => {
       await PerpsConnectionManager.connect();
       await PerpsConnectionManager.connect();
 
@@ -374,7 +374,7 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('should handle disconnect gracefully with grace period', async () => {
+    it('starts grace period timer on disconnect instead of disconnecting immediately', async () => {
       await PerpsConnectionManager.connect();
 
       // Disconnect should not throw even if controller would fail later
@@ -386,7 +386,7 @@ describe('PerpsConnectionManager', () => {
       expect(mockPerpsController.disconnect).not.toHaveBeenCalled();
     });
 
-    it('should prevent negative reference count', async () => {
+    it('prevents reference count from going below zero', async () => {
       await PerpsConnectionManager.disconnect();
       await PerpsConnectionManager.disconnect();
 
@@ -401,7 +401,7 @@ describe('PerpsConnectionManager', () => {
       expect(state.isConnected).toBe(false);
     });
 
-    it('should maintain connection state during grace period', async () => {
+    it('maintains connected state during grace period', async () => {
       await PerpsConnectionManager.connect();
 
       const connectedState = PerpsConnectionManager.getConnectionState();
@@ -418,7 +418,7 @@ describe('PerpsConnectionManager', () => {
       expect(gracePeriodState.isInGracePeriod).toBe(true);
     });
 
-    it('should maintain state monitoring during grace period', async () => {
+    it('maintains state monitoring during grace period', async () => {
       // Connect to set up monitoring
       await PerpsConnectionManager.connect();
 
@@ -444,7 +444,7 @@ describe('PerpsConnectionManager', () => {
   });
 
   describe('getConnectionState', () => {
-    it('should return initial state', () => {
+    it('returns initial disconnected state', () => {
       const state = PerpsConnectionManager.getConnectionState();
 
       expect(state).toEqual({
@@ -457,7 +457,7 @@ describe('PerpsConnectionManager', () => {
       });
     });
 
-    it('should return connecting state during connection', async () => {
+    it('returns connecting state while connection is in progress', async () => {
       mockPerpsController.init.mockImplementation(
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
@@ -556,7 +556,7 @@ describe('PerpsConnectionManager', () => {
   });
 
   describe('concurrent operations', () => {
-    it('should handle multiple concurrent connect/disconnect operations', async () => {
+    it('serializes concurrent connect and disconnect operations', async () => {
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.getAccountState.mockResolvedValue({});
       mockPerpsController.disconnect.mockResolvedValue();
@@ -595,7 +595,7 @@ describe('PerpsConnectionManager', () => {
       (store.getState as jest.Mock).mockReturnValue({});
     });
 
-    it('should set up Redux store subscription on first connect', async () => {
+    it('sets up Redux store subscription on first connect', async () => {
       // Connect to trigger monitoring setup
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.getAccountState.mockResolvedValue({});
@@ -610,7 +610,7 @@ describe('PerpsConnectionManager', () => {
       expect(typeof storeCallbacks[storeCallbacks.length - 1]).toBe('function');
     });
 
-    it('should detect account changes and trigger reconnection', async () => {
+    it('detects account changes and triggers reconnection', async () => {
       // Setup connected state
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.getAccountState.mockResolvedValue({});
@@ -645,7 +645,7 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('should detect network changes and trigger reconnection', async () => {
+    it('detects network changes and triggers reconnection', async () => {
       // Setup connected state
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.getAccountState.mockResolvedValue({});
@@ -680,7 +680,7 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('should continue monitoring during grace period', async () => {
+    it('continues monitoring state changes during grace period', async () => {
       // Setup but don't connect
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.getAccountState.mockResolvedValue({});
@@ -718,7 +718,7 @@ describe('PerpsConnectionManager', () => {
       mockPerpsController.reconnectWithNewContext.mockResolvedValue();
     });
 
-    it('should clear StreamManager caches', async () => {
+    it('clears all StreamManager caches on reconnection', async () => {
       // Setup connected state first
       mockPerpsController.init.mockResolvedValue();
       await PerpsConnectionManager.connect();
@@ -739,7 +739,7 @@ describe('PerpsConnectionManager', () => {
       expect(mockStreamManagerInstance.prices.clearCache).toHaveBeenCalled();
     });
 
-    it('should reinitialize controller with new context', async () => {
+    it('reinitializes controller with new account and network context', async () => {
       mockPerpsController.init.mockResolvedValue();
 
       await (
@@ -753,7 +753,7 @@ describe('PerpsConnectionManager', () => {
       expect(mockPerpsController.init).toHaveBeenCalled();
     });
 
-    it('should handle reconnection errors gracefully', async () => {
+    it('logs error and resets connecting flag when reconnection fails', async () => {
       const error = new Error('Reconnection failed');
       mockPerpsController.init.mockRejectedValueOnce(error);
 
@@ -841,8 +841,8 @@ describe('PerpsConnectionManager', () => {
   });
 
   describe('preloadSubscriptions concurrency guard', () => {
-    it('should skip a second preload call while one is already in flight', async () => {
-      // Arrange: set isPreloading = true directly to simulate in-flight preload
+    it('skips concurrent preload when one is already in flight', async () => {
+      // Arrange
       const m = PerpsConnectionManager as unknown as {
         isPreloading: boolean;
         hasPreloaded: boolean;
@@ -850,27 +850,28 @@ describe('PerpsConnectionManager', () => {
       };
       m.isPreloading = true;
 
+      // Act
       await m.preloadSubscriptions();
 
-      // prices.prewarm should NOT have been called — guard blocked concurrent call
+      // Assert
       expect(mockStreamManagerInstance.prices.prewarm).not.toHaveBeenCalled();
     });
 
-    it('should allow a fresh preload after performReconnection resets isPreloading', async () => {
+    it('allows fresh preload after performReconnection resets isPreloading', async () => {
+      // Arrange
       mockPerpsController.init.mockResolvedValue();
       mockPerpsController.disconnect.mockResolvedValue();
-
-      // First full connection + preload
       await PerpsConnectionManager.connect();
       expect(mockStreamManagerInstance.prices.prewarm).toHaveBeenCalledTimes(1);
 
-      // Reconnect resets hasPreloaded and isPreloading, then preloads again
+      // Act
       await (
         PerpsConnectionManager as unknown as {
           reconnectWithNewContext: () => Promise<void>;
         }
       ).reconnectWithNewContext();
 
+      // Assert
       expect(mockStreamManagerInstance.prices.prewarm).toHaveBeenCalledTimes(2);
     });
   });

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -468,6 +468,19 @@ class PerpsConnectionManagerClass {
             // Clean up preloaded subscriptions
             this.cleanupPreloadedSubscriptions();
 
+            // Clear all stream caches so subscribers reset to loading state
+            // and hasReceivedFirstUpdate is reset for clean reconnection
+            const streamManager = getStreamManagerInstance();
+            streamManager.positions.clearCache();
+            streamManager.orders.clearCache();
+            streamManager.account.clearCache();
+            streamManager.prices.clearCache();
+            streamManager.marketData.clearCache();
+            streamManager.oiCaps.clearCache();
+            streamManager.fills.clearCache();
+            streamManager.topOfBook.clearCache();
+            streamManager.candles.clearCache();
+
             // Reset state before disconnecting to prevent race conditions
             this.isConnected = false;
             this.isInitialized = false;

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -1,4 +1,3 @@
-import { AppState, type AppStateStatus } from 'react-native';
 import {
   addEventListener as netInfoAddEventListener,
   type NetInfoState,
@@ -52,6 +51,7 @@ class PerpsConnectionManagerClass {
   private initPromise: Promise<void> | null = null;
   private disconnectPromise: Promise<void> | null = null;
   private hasPreloaded = false;
+  private isPreloading = false;
   private prewarmCleanups: (() => void)[] = [];
   private unsubscribeFromStore: (() => void) | null = null;
   private previousAddress: string | undefined;
@@ -62,9 +62,6 @@ class PerpsConnectionManagerClass {
   private isInGracePeriod = false;
   private pendingReconnectPromise: Promise<void> | null = null;
   private connectionTimeoutRef: ReturnType<typeof setTimeout> | null = null;
-  private appStateSubscription: ReturnType<
-    typeof AppState.addEventListener
-  > | null = null;
   private netInfoUnsubscribe: (() => void) | null = null;
   private wasOffline = false;
   private networkRestoreRetryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -190,32 +187,12 @@ class PerpsConnectionManagerClass {
       this.previousHip3Version = currentHip3Version;
     });
 
-    // Listen for app state changes to reconnect after background
-    if (!this.appStateSubscription) {
-      this.appStateSubscription = AppState.addEventListener(
-        'change',
-        (nextAppState: AppStateStatus) => {
-          this.handleAppStateChange(nextAppState).catch((error) => {
-            Logger.error(
-              ensureError(error, 'PerpsConnectionManager.appStateListener'),
-              {
-                tags: { feature: PERPS_CONSTANTS.FeatureName },
-                context: {
-                  name: 'PerpsConnectionManager.appStateListener',
-                  data: { message: 'Error handling app state change' },
-                },
-              },
-            );
-          });
-        },
-      );
-    }
-
     // Listen for connectivity changes (WiFi off/on, airplane mode, etc.)
     if (!this.netInfoUnsubscribe) {
       this.netInfoUnsubscribe = netInfoAddEventListener(
         (netState: NetInfoState) => {
-          const isOnline = netState.isInternetReachable === true;
+          const isOnline =
+            netState.isInternetReachable ?? netState.isConnected ?? false;
 
           if (isOnline && this.wasOffline) {
             DevLogger.log(
@@ -238,8 +215,7 @@ class PerpsConnectionManagerClass {
 
   /**
    * Validate the WebSocket connection and force-reconnect if it is stale.
-   * Shared by both AppState (background→foreground) and NetInfo (offline→online)
-   * recovery paths.
+   * Used by the NetInfo (offline→online) recovery path.
    *
    * @param context - Caller identifier for error reporting
    * @param skipPing - Skip ping and force reconnect after known network loss
@@ -336,36 +312,9 @@ class PerpsConnectionManagerClass {
   }
 
   /**
-   * Handle app state transitions to recover from stale WebSocket connections.
-   * When the app returns from background, the OS may have silently killed the
-   * WebSocket. A health-check ping detects this and triggers reconnection.
-   */
-  private async handleAppStateChange(
-    nextAppState: AppStateStatus,
-  ): Promise<void> {
-    if (nextAppState !== 'active') {
-      return;
-    }
-
-    // Cancel any pending grace period — user is back
-    if (this.isInGracePeriod) {
-      DevLogger.log(
-        'PerpsConnectionManager: App resumed - cancelling grace period',
-      );
-      this.cancelGracePeriod();
-    }
-
-    await this.validateAndReconnect('appResume');
-  }
-
-  /**
    * Clean up state monitoring
    */
   private cleanupStateMonitoring(): void {
-    if (this.appStateSubscription) {
-      this.appStateSubscription.remove();
-      this.appStateSubscription = null;
-    }
     if (this.netInfoUnsubscribe) {
       this.netInfoUnsubscribe();
       this.netInfoUnsubscribe = null;
@@ -911,6 +860,7 @@ class PerpsConnectionManagerClass {
       this.isConnected = false;
       this.isInitialized = false;
       this.hasPreloaded = false;
+      this.isPreloading = false;
       // Clear previous errors when starting reconnection attempt
       this.clearError();
 
@@ -1078,12 +1028,15 @@ class PerpsConnectionManagerClass {
    * Also sets up balance update subscriptions for portfolio integration
    */
   private async preloadSubscriptions(): Promise<void> {
-    // Only pre-load once per session
-    if (this.hasPreloaded) {
-      DevLogger.log('PerpsConnectionManager: Already pre-loaded, skipping');
+    // Only pre-load once per session, and guard against concurrent calls
+    if (this.hasPreloaded || this.isPreloading) {
+      DevLogger.log(
+        'PerpsConnectionManager: Already pre-loaded or preloading, skipping',
+      );
       return;
     }
 
+    this.isPreloading = true;
     try {
       DevLogger.log(
         'PerpsConnectionManager: Pre-loading WebSocket subscriptions via StreamManager',
@@ -1137,6 +1090,8 @@ class PerpsConnectionManagerClass {
         },
       );
       // Non-critical error - components will still work with on-demand subscriptions
+    } finally {
+      this.isPreloading = false;
     }
   }
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -486,6 +486,7 @@ class PerpsConnectionManagerClass {
             this.isInitialized = false;
             this.isConnecting = false;
             this.hasPreloaded = false; // Reset pre-load flag on disconnect
+            this.isPreloading = false; // Reset in-flight preload guard on disconnect
             this.clearError(); // Clear any errors on disconnect
 
             await Engine.context.PerpsController.disconnect();


### PR DESCRIPTION
## **Description**

After long backgrounds (5+ min), Perps failed to reload positions, 24h price change was missing, and closing positions threw "BTC is not tradeable asset". After closing a position and backgrounding for >20s, the closed position would reappear on foreground.

**Root causes:**

1. **Duplicate AppState listener race** — `usePerpsConnectionLifecycle` hook and `PerpsConnectionManager.setupStateMonitoring()` both fired on foreground. The `force` reconnect path cancelled the hook's in-flight `connect()` and ran a competing `performReconnection()`, cleaning up prewarm subscriptions mid-flight and leaving positions/prices without data.

2. **Stale cache after grace-period disconnect** — `performActualDisconnection()` (fires after 20s grace period) did not clear stream channel caches or reset subscriber state (`hasReceivedFirstUpdate`). On next foreground, the old closed position was served from cache until the throttle window passed.

3. **`isPreloading` not reset on disconnect** — If a preload was in-flight when the grace period fired, `isPreloading` stayed `true`. The next `connect()` would silently skip all subscription prewarm, leaving positions and prices with no data.

**Fixes:**
- Remove the manager-level AppState listener (hook already handles foreground recovery)
- Fix `isInternetReachable` null handling in NetInfo listener (`null` treated as offline was blocking network-restore reconnects)
- Add `isPreloading` concurrency guard to `preloadSubscriptions()` to prevent concurrent calls racing on reconnect
- Call `clearCache()` on all stream channels in `performActualDisconnection()` — wipes stale positions, resets `hasReceivedFirstUpdate`, puts UI into loading state on next foreground
- Reset `isPreloading = false` in `performActualDisconnection()` alongside `hasPreloaded`

The NetInfo listener from #26780 is kept — it handles the distinct offline→online restore scenario.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TAT-2598

## **Manual testing steps**

```gherkin
Feature: Perps reconnection after long background

  Scenario: user returns to Perps after long background
    Given the user has open Perps positions
    And the app has been backgrounded for 5+ minutes

    When user foregrounds the app
    Then positions load correctly
    And 24h price change is displayed
    And closing a position succeeds without "not tradeable asset" error

  Scenario: closed position does not reappear after background
    Given the user closes a Perps position and sees the success toast
    And the app has been backgrounded for more than 20 seconds

    When user foregrounds the app
    Then the closed position is NOT shown in the positions list
    And no stale "already closed" error appears on interaction

  Scenario: user returns after network loss
    Given the user has open Perps positions
    And airplane mode was enabled then disabled while app was backgrounded

    When user foregrounds the app
    Then the connection is restored
    And positions load correctly
```

## **Screenshots/Recordings**

### **Before**

Positions blank, 24h change missing, close position fails with "BTC is not tradeable asset". Closed positions reappear after >20s background.

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps connection lifecycle (reconnect/disconnect, NetInfo handling, preload guards) and could impact data freshness and reconnection reliability if regressions occur, though changes are localized and well-covered by tests.
> 
> **Overview**
> Prevents a foreground reconnection race by **removing the manager-level `AppState` listener** so only the lifecycle hook initiates foreground recovery.
> 
> Hardens reconnect/disconnect behavior by **clearing all Perps stream channel caches on grace-period expiry**, resetting subscriber `hasReceivedFirstUpdate`, and resetting the in-flight preload state (`isPreloading`) so subsequent `connect()` calls reliably prewarm subscriptions.
> 
> Improves offline→online recovery by treating `NetInfo.isInternetReachable: null` as “unknown” and falling back to `isConnected`, and expands `PerpsConnectionManager` tests to cover these concurrency, cache-clearing, and network edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72739b2b36696d7b562e08e47cfd2e6d37a9966e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->