### PR TITLE
feat(networks): add network deletion logic and update tests

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -765,6 +765,34 @@ describe('NetworkDetailsView', () => {
 
       expect(ops.removeNetwork).toHaveBeenCalledWith('0x2a');
     });
+
+    it('does not show trash icon when editing non-deletable network (e.g. Ethereum mainnet)', () => {
+      const mainnetEditForm = createMockFormHook({
+        addMode: false,
+        nickname: 'Ethereum',
+        chainId: '0x1',
+        ticker: 'ETH',
+        rpcUrl: 'https://mainnet.infura.io/v3/key',
+        rpcName: 'Infura',
+        rpcUrls: [
+          {
+            url: 'https://mainnet.infura.io/v3/key',
+            name: 'Infura',
+            type: 'infura',
+          },
+        ],
+        blockExplorerUrl: 'https://etherscan.io',
+        blockExplorerUrls: ['https://etherscan.io'],
+        editable: true,
+      });
+      mockFormHook.mockReturnValue(mainnetEditForm);
+
+      const { getByTestId } = render(<NetworkDetailsView />);
+
+      const container = getByTestId(NetworkDetailsViewSelectorsIDs.CONTAINER);
+      const trashIcons = container.findAllByProps({ name: 'Trash' });
+      expect(trashIcons).toHaveLength(0);
+    });
   });
 
   describe('RPC modal interactions', () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -24,7 +24,10 @@ import { CaipChainId } from '@metamask/utils';
 import { strings } from '../../../../../locales/i18n';
 import { useTheme } from '../../../../util/theme';
 import { useStyles } from '../../../../component-library/hooks/useStyles';
-import { getNetworkImageSource } from '../../../../util/networks';
+import {
+  canDeleteNetwork,
+  getNetworkImageSource,
+} from '../../../../util/networks';
 import { useNetworkEnablement } from '../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { selectIsRpcFailoverEnabled } from '../../../../selectors/featureFlagController/walletFramework';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
@@ -186,7 +189,8 @@ const NetworkDetailsView = () => {
       <HeaderCompactStandard
         onBack={handleBack}
         endAccessory={
-          !formHook.form.addMode ? (
+          !formHook.form.addMode &&
+          canDeleteNetwork(formHook.form.chainId ?? '') ? (
             <Pressable
               onPress={handleDelete}
               style={({ pressed }) =>

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -343,6 +343,21 @@ export const isTestNetworkWithFaucet = (chainId) =>
  */
 export const isTestNet = (chainId) => TESTNET_CHAIN_IDS.includes(chainId);
 
+/**
+ * Returns whether the network can be deleted by the user.
+ * Aligns with NetworkSelector: mainnet, Linea mainnet, and testnets cannot be removed.
+ *
+ * @param {string} chainId - The chain ID to check (e.g. '0x1', '0x89').
+ * @returns {boolean} True if the network can be deleted, false otherwise.
+ */
+export const canDeleteNetwork = (chainId) =>
+  Boolean(
+    chainId &&
+      !isTestNet(chainId) &&
+      !isMainNet(chainId) &&
+      !isLineaMainnetChainId(chainId),
+  );
+
 export function getNetworkTypeById(id) {
   if (!id) {
     throw new Error(NetworkSwitchErrorType.missingNetworkId);

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -19,6 +19,7 @@ import NetworkList, {
   isWhitelistedSymbol,
   isWhitelistedRpcUrl,
   isWhitelistedNetworkName,
+  canDeleteNetwork,
 } from '.';
 import {
   convertNetworkId,
@@ -159,6 +160,33 @@ describe('network-utils', () => {
 
     it(`should return false if the given chain ID is not a known testnet`, () => {
       expect(isTestNet('42')).toEqual(false);
+    });
+  });
+
+  describe('canDeleteNetwork', () => {
+    it('returns false for Ethereum mainnet', () => {
+      expect(canDeleteNetwork('0x1')).toBe(false);
+    });
+    it('returns false for Linea mainnet', () => {
+      expect(canDeleteNetwork(NETWORKS_CHAIN_ID.LINEA_MAINNET)).toBe(false);
+    });
+    it('returns false for Goerli', () => {
+      expect(canDeleteNetwork(NETWORKS_CHAIN_ID.GOERLI)).toBe(false);
+    });
+    it.each(TESTNET_CHAIN_IDS)(
+      'returns false for testnet chain ID %s',
+      (chainId) => {
+        expect(canDeleteNetwork(chainId)).toBe(false);
+      },
+    );
+    it('returns false for empty/falsy chainId', () => {
+      expect(canDeleteNetwork('')).toBe(false);
+    });
+    it('returns true for custom mainnet (e.g. Polygon)', () => {
+      expect(canDeleteNetwork(NETWORKS_CHAIN_ID.POLYGON)).toBe(true);
+    });
+    it('returns true for custom chain ID 0x2a', () => {
+      expect(canDeleteNetwork('0x2a')).toBe(true);
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Reason:** The network details header always showed a trash/delete icon when editing a network, including for networks that cannot be removed (e.g. Ethereum mainnet, Linea, Goerli, testnets). That suggested deletion was possible when it wasn’t.
**Solution:** Introduced canDeleteNetwork(chainId) in app/util/networks (aligned with NetworkSelector: mainnet, Linea, Goerli, and testnets are non-deletable). The header delete control is only rendered when !formHook.form.addMode && canDeleteNetwork(formHook.form.chainId ?? ''), so the trash icon is hidden for non-deletable networks.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed network details screen showing a delete (trash) icon for networks that cannot be removed (e.g. Ethereum mainnet, Linea, Goerli, testnets).

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-519

## **Manual testing steps**

```gherkin
Feature: Network details – delete icon visibility

  Scenario: user opens network details for a non-deletable network
    Given the user has network management enabled and is on the networks list
    When the user taps "Ethereum Mainnet" (or Linea / Goerli / a testnet)
    Then the header does not show a trash/delete icon

  Scenario: user opens network details for a deletable custom network
    Given the user has added a custom network (e.g. Polygon or a custom RPC)
    When the user taps that network to edit it
    Then the header shows the trash/delete icon and delete remains available
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="396" height="844" alt="Screenshot 2026-03-04 at 12 53 36" src="https://github.com/user-attachments/assets/6c3efda6-d8c4-430a-98e4-e6730027383b" />
<img width="391" height="842" alt="Screenshot 2026-03-04 at 12 53 53" src="https://github.com/user-attachments/assets/c9876c13-a0b1-4d14-87b1-94b9d172a459" />
<img width="397" height="834" alt="Screenshot 2026-03-04 at 12 54 09" src="https://github.com/user-attachments/assets/12466e41-4991-40ad-9b50-9022e158914e" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="841" alt="Screenshot 2026-03-04 at 12 49 51" src="https://github.com/user-attachments/assets/852a4cd4-ba36-4b9c-b47b-ccea5e5185c9" />
<img width="395" height="839" alt="Screenshot 2026-03-04 at 12 50 26" src="https://github.com/user-attachments/assets/5534268b-8f90-4327-90a2-64147e53ae46" />
<img width="390" height="841" alt="Screenshot 2026-03-04 at 12 50 34" src="https://github.com/user-attachments/assets/fa93f229-3064-4630-9d1d-32ec8c540b73" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI gating change: it only conditionally hides the delete icon based on chain ID and adds unit coverage; core deletion flow is unchanged.
> 
> **Overview**
> Fixes the Network Details header to **only show the trash/delete icon for deletable networks** by introducing `canDeleteNetwork(chainId)` and using it to gate the header end accessory (e.g., hides delete for Ethereum mainnet, Linea mainnet, and testnets).
> 
> Adds unit tests for `canDeleteNetwork` and a UI test ensuring the trash icon is not rendered when editing a non-deletable network.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9852c502c780f7829b41049210393f01ccfa6b98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->