### PR TITLE
chore: Refine Send Review page to polish UI

### DIFF
--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/__snapshots__/EarnLendingDepositConfirmationView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/__snapshots__/EarnLendingDepositConfirmationView.test.tsx.snap
@@ -207,8 +207,8 @@ exports[`EarnLendingDepositConfirmationView matches snapshot 1`] = `
         style={
           {
             "backgroundColor": "#ffffff",
-            "borderRadius": 8,
-            "marginBottom": 8,
+            "borderRadius": 12,
+            "marginBottom": 12,
             "paddingBottom": 8,
             "paddingHorizontal": 8,
             "paddingTop": 12,
@@ -965,8 +965,8 @@ exports[`EarnLendingDepositConfirmationView matches snapshot 1`] = `
         style={
           {
             "backgroundColor": "#ffffff",
-            "borderRadius": 8,
-            "marginBottom": 8,
+            "borderRadius": 12,
+            "marginBottom": 12,
             "paddingBottom": 8,
             "paddingHorizontal": 8,
             "paddingTop": 12,

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositInfoSection/__snapshots__/DepositInfoSection.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositInfoSection/__snapshots__/DepositInfoSection.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`DepositInfoSection renders correctly 1`] = `
   style={
     {
       "backgroundColor": "#ffffff",
-      "borderRadius": 8,
-      "marginBottom": 8,
+      "borderRadius": 12,
+      "marginBottom": 12,
       "paddingBottom": 8,
       "paddingHorizontal": 8,
       "paddingTop": 12,

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositReceiveSection/__snapshots__/DepositReceiveSection.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositReceiveSection/__snapshots__/DepositReceiveSection.test.tsx.snap
@@ -5,8 +5,8 @@ exports[`DepositReceiveSection renders correctly 1`] = `
   style={
     {
       "backgroundColor": "#ffffff",
-      "borderRadius": 8,
-      "marginBottom": 8,
+      "borderRadius": 12,
+      "marginBottom": 12,
       "paddingBottom": 8,
       "paddingHorizontal": 8,
       "paddingTop": 12,

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/__snapshots__/EarnLendingWithdrawalConfirmationView.test.tsx.snap
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/__snapshots__/EarnLendingWithdrawalConfirmationView.test.tsx.snap
@@ -180,8 +180,8 @@ exports[`EarnLendingWithdrawalConfirmationView matches snapshot 1`] = `
         style={
           {
             "backgroundColor": "#ffffff",
-            "borderRadius": 8,
-            "marginBottom": 8,
+            "borderRadius": 12,
+            "marginBottom": 12,
             "paddingBottom": 8,
             "paddingHorizontal": 8,
             "paddingTop": 12,
@@ -341,8 +341,8 @@ exports[`EarnLendingWithdrawalConfirmationView matches snapshot 1`] = `
         style={
           {
             "backgroundColor": "#ffffff",
-            "borderRadius": 8,
-            "marginBottom": 8,
+            "borderRadius": 12,
+            "marginBottom": 12,
             "paddingBottom": 8,
             "paddingHorizontal": 8,
             "paddingTop": 12,

--- a/app/components/Views/confirmations/components/UI/info-row/info-section/info-section.styles.ts
+++ b/app/components/Views/confirmations/components/UI/info-row/info-section/info-section.styles.ts
@@ -8,11 +8,11 @@ const styleSheet = (params: { theme: Theme }) => {
   return StyleSheet.create({
     container: {
       backgroundColor: theme.colors.background.default,
-      borderRadius: 8,
+      borderRadius: 12,
       paddingTop: 12,
       paddingBottom: 8,
       paddingHorizontal: 8,
-      marginBottom: 8,
+      marginBottom: 12,
     },
   });
 };

--- a/app/components/Views/confirmations/components/gas/selected-gas-fee-token/selected-gas-fee-token.styles.ts
+++ b/app/components/Views/confirmations/components/gas/selected-gas-fee-token/selected-gas-fee-token.styles.ts
@@ -5,16 +5,16 @@ const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
   return StyleSheet.create({
     gasFeeTokenButton: {
-      backgroundColor: theme.colors.background.alternative,
+      backgroundColor: theme.colors.background.muted,
       alignItems: 'center',
       display: 'flex',
       flexDirection: 'row',
-      gap: 4,
-      borderRadius: 4,
+      gap: 6,
+      borderRadius: 8,
       paddingTop: 2,
       paddingBottom: 2,
-      paddingLeft: 6,
-      paddingRight: 6,
+      paddingLeft: 8,
+      paddingRight: 8,
     },
   });
 };

--- a/app/components/Views/confirmations/components/hero-token/hero-token.styles.ts
+++ b/app/components/Views/confirmations/components/hero-token/hero-token.styles.ts
@@ -14,6 +14,7 @@ const styleSheet = (params: {
     },
     assetAmountText: {
       textAlign: 'center',
+      paddingTop: 12,
     },
     assetTextUnknown: {
       color: theme.colors.text.alternative,

--- a/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.styles.ts
@@ -8,23 +8,24 @@ const styleSheet = (params: { theme: Theme }) => {
   return StyleSheet.create({
     container: {
       flexDirection: 'column',
-      paddingHorizontal: 4,
+      paddingHorizontal: 8,
     },
     row: {
-      paddingVertical: 8,
+      paddingBottom: 12,
     },
     rowSeparator: {
       borderTopWidth: StyleSheet.hairlineWidth,
       borderTopColor: theme.colors.border.muted,
+      paddingTop: 12,
+      paddingBottom: 8,
     },
     label: {
-      marginBottom: 2,
+      paddingBottom: 4,
     },
     labelRow: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: 4,
-      marginBottom: 2,
       marginLeft: -8,
     },
     addressRow: {

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.styles.ts
@@ -6,7 +6,8 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     wrapper: {
-      minHeight: 100,
+      paddingTop: 12,
+      paddingBottom: 16,
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -20,13 +21,13 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 32,
     },
     skeletonBorderRadiusMedium: {
-      borderRadius: 6,
+      borderRadius: 4,
       marginTop: 16,
     },
     skeletonBorderRadiusSmall: {
       borderRadius: 4,
       marginTop: 8,
-      marginBottom: 14,
+      marginBottom: 12,
     },
   });
 };

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
@@ -15,8 +15,8 @@ export function HeroRowSkeleton() {
   return (
     <View style={styles.wrapper}>
       <Skeleton
-        width={64}
-        height={64}
+        width={48}
+        height={48}
         style={styles.skeletonBorderRadiusLarge}
       />
       <Skeleton


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses design bugs in the `Send > Review` page to polish the UI. It improves the overall balance, vertical rhythm and elevations of the screen.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Transaction confirmation and login screen design polish

  Scenario: user sees updated spacing and styling on confirmation and unlock screens
    Given the user is in the transaction confirmation flow or the login (unlock) flow

    When the user views the Review (confirmation) or Login screen
    Then layout and typography match the updated design (spacing, radii, colors, and component usage)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

<img width="805" height="816" alt="Screenshot 2026-03-04 at 8 21 34 PM" src="https://github.com/user-attachments/assets/5b252fab-0aac-4f9d-a426-2df9a9d9976f" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes (spacing/radii/colors) plus snapshot updates; no transaction logic or data handling is modified.
> 
> **Overview**
> Polishes the confirmation/review screens’ visual rhythm by increasing section `borderRadius`/`marginBottom`, tweaking `from-to-row` paddings/separators, and adding top padding to the hero amount text.
> 
> Updates the gas fee token pill styling (muted background, larger radius/padding) and refines the hero row skeleton layout (wrapper padding and smaller avatar skeleton), with corresponding Jest snapshot updates for Earn deposit/withdrawal confirmations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98792d1662fa5cf60b315e064d084cadbce36f9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->