### PR TITLE
fix(card): cashback UI fixes

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -5709,7 +5709,7 @@ describe('CardHome Component', () => {
       ).toBeOnTheScreen();
     });
 
-    it('navigates to cashback screen and tracks analytics on press', () => {
+    it('navigates to cashback screen on press', () => {
       // Given: authenticated international user with verified KYC
       setupMockSelectors({
         isAuthenticated: true,
@@ -5723,12 +5723,33 @@ describe('CardHome Component', () => {
         kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
       });
 
-      // When: component renders and user taps cashback item
+      // When: user taps cashback item
       render();
       fireEvent.press(screen.getByTestId(CardHomeSelectors.CASHBACK_ITEM));
 
-      // Then: navigates to cashback route and tracks event
+      // Then: navigates to cashback route
       expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    it('tracks analytics event on press', () => {
+      // Given: authenticated international user with verified KYC
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
+      });
+
+      // When: user taps cashback item
+      render();
+      fireEvent.press(screen.getByTestId(CardHomeSelectors.CASHBACK_ITEM));
+
+      // Then: tracks cashback button event
       expect(mockTrackEvent).toHaveBeenCalled();
     });
   });

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -531,6 +531,11 @@ jest.mock('../../../../../../locales/i18n', () => ({
         'Failed to load PIN. Please try again.',
       'card.password_bottomsheet.description_view_pin':
         'Enter your wallet password to view your card PIN.',
+      'card.card_home.manage_card_options.cashback': 'Cashback',
+      'card.card_home.manage_card_options.cashback_description':
+        'Earn 1% back on all spending',
+      'card.card_home.manage_card_options.cashback_description_metal':
+        'Earn 3% back on all spending',
     };
     return strings[key] || key;
   },
@@ -5563,6 +5568,168 @@ describe('CardHome Component', () => {
       const cardDetails = options.cardDetails as { holderName: string };
 
       expect(cardDetails.holderName).toBe('Jane Smith');
+    });
+  });
+
+  describe('Cashback List Item', () => {
+    it('displays cashback item for authenticated international user with VERIFIED KYC', () => {
+      // Given: authenticated international user with verified KYC
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
+      });
+
+      // When: component renders
+      render();
+
+      // Then: cashback item is visible
+      expect(
+        screen.getByTestId(CardHomeSelectors.CASHBACK_ITEM),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides cashback item for US users', () => {
+      // Given: authenticated US user with verified KYC
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'us',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
+      });
+
+      // When: component renders
+      render();
+
+      // Then: cashback item is not rendered
+      expect(
+        screen.queryByTestId(CardHomeSelectors.CASHBACK_ITEM),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('hides cashback item when user is not authenticated', () => {
+      // Given: unauthenticated user
+      setupMockSelectors({
+        isAuthenticated: false,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: false,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+      });
+
+      // When: component renders
+      render();
+
+      // Then: cashback item is not rendered
+      expect(
+        screen.queryByTestId(CardHomeSelectors.CASHBACK_ITEM),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('hides cashback item when KYC is not verified', () => {
+      // Given: authenticated international user with pending KYC
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'PENDING', userId: 'user-123' },
+      });
+
+      // When: component renders
+      render();
+
+      // Then: cashback item is not rendered
+      expect(
+        screen.queryByTestId(CardHomeSelectors.CASHBACK_ITEM),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('shows standard cashback description for virtual card', () => {
+      // Given: authenticated international user with virtual card
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
+      });
+
+      // When: component renders
+      render();
+
+      // Then: standard description is shown
+      expect(
+        screen.getByText('Earn 1% back on all spending'),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows metal cashback description for metal card', () => {
+      // Given: authenticated international user with metal card
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.METAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
+      });
+
+      // When: component renders
+      render();
+
+      // Then: metal description is shown
+      expect(
+        screen.getByText('Earn 3% back on all spending'),
+      ).toBeOnTheScreen();
+    });
+
+    it('navigates to cashback screen and tracks analytics on press', () => {
+      // Given: authenticated international user with verified KYC
+      setupMockSelectors({
+        isAuthenticated: true,
+        userLocation: 'international',
+      });
+      setupLoadCardDataMock({
+        isAuthenticated: true,
+        isBaanxLoginEnabled: true,
+        cardDetails: { type: CardType.VIRTUAL },
+        isLoading: false,
+        kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
+      });
+
+      // When: component renders and user taps cashback item
+      render();
+      fireEvent.press(screen.getByTestId(CardHomeSelectors.CASHBACK_ITEM));
+
+      // Then: navigates to cashback route and tracks event
+      expect(mockNavigate).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -708,24 +708,6 @@ const CardHome = () => {
     });
   }, [navigation, trackEvent, createEventBuilder, userShippingAddress]);
 
-  const isUserEligibleForMetalCard = useMemo(
-    () =>
-      isMetalCardCheckoutEnabled &&
-      isBaanxLoginEnabled &&
-      isAuthenticated &&
-      userLocation === 'us' &&
-      userShippingAddress &&
-      cardDetails?.type === CardType.VIRTUAL,
-    [
-      isMetalCardCheckoutEnabled,
-      isBaanxLoginEnabled,
-      isAuthenticated,
-      userLocation,
-      userShippingAddress,
-      cardDetails,
-    ],
-  );
-
   const showCardDetailsErrorToast = useCallback(() => {
     toastRef?.current?.showToast({
       variant: ToastVariants.Icon,
@@ -1043,6 +1025,31 @@ const CardHome = () => {
     openOnboardingDelegationAction,
     isCardProvisioning,
   ]);
+
+  const isUserEligibleForMetalCard = useMemo(
+    () =>
+      !isLoading &&
+      !cardSetupState.isKYCPending &&
+      !cardSetupState.needsSetup &&
+      !isCardProvisioning &&
+      isMetalCardCheckoutEnabled &&
+      isBaanxLoginEnabled &&
+      isAuthenticated &&
+      userLocation === 'us' &&
+      userShippingAddress &&
+      cardDetails?.type === CardType.VIRTUAL,
+    [
+      isMetalCardCheckoutEnabled,
+      isBaanxLoginEnabled,
+      isAuthenticated,
+      userLocation,
+      userShippingAddress,
+      cardDetails,
+      isLoading,
+      cardSetupState,
+      isCardProvisioning,
+    ],
+  );
 
   useEffect(
     () => () => {
@@ -1428,6 +1435,19 @@ const CardHome = () => {
       )}
 
       <Box style={tw.style(cardSetupState.needsSetup && 'hidden')}>
+        {isUserEligibleForMetalCard && (
+          <ManageCardListItem
+            title={strings(
+              'card.card_home.manage_card_options.order_metal_card',
+            )}
+            description={strings(
+              'card.card_home.manage_card_options.order_metal_card_description',
+            )}
+            rightIcon={IconName.ArrowRight}
+            onPress={orderMetalCardAction}
+            testID={CardHomeSelectors.ORDER_METAL_CARD_ITEM}
+          />
+        )}
         {isAuthenticated && !isLoading && cardDetails && (
           <ManageCardListItem
             title={strings(
@@ -1519,19 +1539,6 @@ const CardHome = () => {
               onPress={navigateToCardPage}
               testID={CardHomeSelectors.ADVANCED_CARD_MANAGEMENT_ITEM}
             />
-            {isUserEligibleForMetalCard && (
-              <ManageCardListItem
-                title={strings(
-                  'card.card_home.manage_card_options.order_metal_card',
-                )}
-                description={strings(
-                  'card.card_home.manage_card_options.order_metal_card_description',
-                )}
-                rightIcon={IconName.ArrowRight}
-                onPress={orderMetalCardAction}
-                testID={CardHomeSelectors.ORDER_METAL_CARD_ITEM}
-              />
-            )}
             {isAuthenticated &&
               kycStatus?.verificationState === 'VERIFIED' &&
               userLocation !== 'us' && (

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -1532,26 +1532,30 @@ const CardHome = () => {
                 testID={CardHomeSelectors.ORDER_METAL_CARD_ITEM}
               />
             )}
-            {isAuthenticated && kycStatus?.verificationState === 'VERIFIED' && (
-              <ManageCardListItem
-                title={strings('card.card_home.manage_card_options.cashback')}
-                description={strings(
-                  'card.card_home.manage_card_options.cashback_description',
-                )}
-                rightIcon={IconName.ArrowRight}
-                onPress={() => {
-                  trackEvent(
-                    createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-                      .addProperties({
-                        action: CardActions.CASHBACK_BUTTON,
-                      })
-                      .build(),
-                  );
-                  navigation.navigate(Routes.CARD.CASHBACK);
-                }}
-                testID={CardHomeSelectors.CASHBACK_ITEM}
-              />
-            )}
+            {isAuthenticated &&
+              kycStatus?.verificationState === 'VERIFIED' &&
+              userLocation !== 'us' && (
+                <ManageCardListItem
+                  title={strings('card.card_home.manage_card_options.cashback')}
+                  description={strings(
+                    cardDetails?.type === CardType.METAL
+                      ? 'card.card_home.manage_card_options.cashback_description_metal'
+                      : 'card.card_home.manage_card_options.cashback_description',
+                  )}
+                  rightIcon={IconName.ArrowRight}
+                  onPress={() => {
+                    trackEvent(
+                      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+                        .addProperties({
+                          action: CardActions.CASHBACK_BUTTON,
+                        })
+                        .build(),
+                    );
+                    navigation.navigate(Routes.CARD.CASHBACK);
+                  }}
+                  testID={CardHomeSelectors.CASHBACK_ITEM}
+                />
+              )}
             <ManageCardListItem
               title={strings('card.card_home.manage_card_options.travel_title')}
               description={strings(

--- a/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
@@ -1,3 +1,4 @@
+const mockGoBack = jest.fn();
 const mockShowToast = jest.fn();
 const mockCloseToast = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -35,6 +36,16 @@ jest.mock('../../util/metrics', () => ({
     CASHBACK_BUTTON: 'CASHBACK_BUTTON',
   },
 }));
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+    }),
+  };
+});
 
 jest.mock('../../../../../util/theme', () => {
   const actual = jest.requireActual('../../../../../util/theme');
@@ -411,6 +422,51 @@ describe('Cashback Component', () => {
           labelOptions: [{ label: 'Withdrawal completed successfully' }],
         }),
       );
+    });
+
+    it('navigates back after successful withdrawal', () => {
+      mockHookReturn.cashbackWallet = {
+        id: 'w1',
+        balance: '10.00',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.monitoringStatus = 'success';
+
+      render();
+
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+
+    it('does not navigate back when monitoring fails', () => {
+      mockHookReturn.cashbackWallet = {
+        id: 'w1',
+        balance: '10.00',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.monitoringStatus = 'failed';
+
+      render();
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate back when status is idle', () => {
+      mockHookReturn.cashbackWallet = {
+        id: 'w1',
+        balance: '10.00',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.monitoringStatus = 'idle';
+
+      render();
+
+      expect(mockGoBack).not.toHaveBeenCalled();
     });
 
     it('shows failure toast when monitoring fails', () => {

--- a/app/components/UI/Card/Views/Cashback/Cashback.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.tsx
@@ -5,11 +5,11 @@ import {
   Text,
   TextVariant,
   TextColor,
+  Skeleton,
 } from '@metamask/design-system-react-native';
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
-import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import { strings } from '../../../../../../locales/i18n';
 import Button, {
   ButtonSize,
@@ -26,6 +26,7 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { CardActions } from '../../util/metrics';
 import { CashbackSelectors } from './Cashback.testIds';
+import { useNavigation } from '@react-navigation/native';
 
 const CURRENCY_DISPLAY_MAP: Record<string, string> = {
   musd: 'mUSD',
@@ -45,6 +46,7 @@ const formatAmount = (value: string | number): string => {
 };
 
 const Cashback: React.FC = () => {
+  const { goBack } = useNavigation();
   const tw = useTailwind();
   const theme = useTheme();
   const { toastRef } = useContext(ToastContext);
@@ -94,8 +96,9 @@ const Cashback: React.FC = () => {
         iconColor: theme.colors.success.default,
         hasNoTimeout: false,
       });
+      goBack();
     }
-  }, [monitoringStatus, toastRef, theme]);
+  }, [monitoringStatus, toastRef, theme, goBack]);
 
   useEffect(() => {
     if (monitoringStatus === 'failed' || monitoringError) {
@@ -189,7 +192,7 @@ const Cashback: React.FC = () => {
         </Box>
 
         {error ? (
-          <Box twClassName="rounded-xl bg-background-alternative p-4 items-center">
+          <Box twClassName="rounded-xl bg-background-muted p-4 items-center">
             <Text
               variant={TextVariant.BodyMd}
               color={TextColor.TextAlternative}
@@ -199,7 +202,7 @@ const Cashback: React.FC = () => {
           </Box>
         ) : (
           <Box
-            twClassName="rounded-xl bg-background-alternative p-4"
+            twClassName="rounded-xl bg-background-muted p-4"
             testID={CashbackSelectors.DETAILS_CARD}
           >
             <Box twClassName="gap-3">

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7233,6 +7233,7 @@
         "order_metal_card_description": "Order your physical Metal Card now",
         "cashback": "Cashback",
         "cashback_description": "Earn 1% back on all spending",
+        "cashback_description_metal": "Earn 3% back on all spending",
         "freeze_card": "Freeze card",
         "unfreeze_card": "Unfreeze card",
         "freeze_card_description": "Pause all spending on your card",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes several cashback-related issues in the Card feature: hides the cashback option for US users, shows a differentiated cashback rate for Metal Card holders, navigates back after a successful withdrawal, and applies minor UI polish.

**Why**: US users should not see the cashback option. Metal Card holders earn a higher cashback rate (3%) that was not reflected in the UI. After a successful cashback withdrawal, users remained on the Cashback screen with no clear dismissal path.

**What changed**:
- **`CardHome.tsx`**: Added `userLocation !== 'us'` guard so the cashback list item is hidden for US users. Updated the cashback description to show "Earn 3% back on all spending" when `cardDetails.type` is `METAL`, falling back to the existing 1% description otherwise.
- **`Cashback.tsx`**: Added `useNavigation().goBack()` call after a successful withdrawal (when `monitoringStatus === 'success'`), so the user is automatically returned to the Card home screen. Migrated `Skeleton` import to `@metamask/design-system-react-native`. Changed background color tokens from `bg-background-alternative` to `bg-background-muted` for the error and details cards.
- **`en.json`**: Added `cashback_description_metal` translation key ("Earn 3% back on all spending").
- **`CardHome.test.tsx`**: Added 7 tests covering cashback item visibility (international vs US, authenticated vs not, verified KYC vs pending), description text for virtual vs metal card, and navigation/analytics on press.
- **`Cashback.test.tsx`**: Added `useNavigation` mock and 3 tests verifying `goBack` is called on success and not called on failure or idle status.

## **Changelog**

CHANGELOG entry: Hide cashback option for US users on Card home screen.
CHANGELOG entry: Show "Earn 3% back" cashback description for Metal Card holders.
CHANGELOG entry: Automatically navigate back after successful cashback withdrawal.
CHANGELOG entry: Update Cashback screen background tokens to `bg-background-muted`.
CHANGELOG entry: Add comprehensive test coverage for cashback visibility, description, and navigation behavior.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Cashback visibility by region

  Scenario: Cashback item hidden for US users
    Given the user is authenticated with verified KYC
    And the user location is "us"
    When the Card home screen renders
    Then the Cashback list item is not visible

  Scenario: Cashback item visible for non-US users
    Given the user is authenticated with verified KYC
    And the user location is not "us"
    When the Card home screen renders
    Then the Cashback list item is visible

Feature: Cashback description by card type

  Scenario: Standard cashback description for virtual card
    Given the user has a virtual card
    And the user is a non-US authenticated user with verified KYC
    When the Card home screen renders
    Then the cashback description reads "Earn 1% back on all spending"

  Scenario: Metal cashback description for metal card
    Given the user has a metal card
    And the user is a non-US authenticated user with verified KYC
    When the Card home screen renders
    Then the cashback description reads "Earn 3% back on all spending"

Feature: Navigate back after successful withdrawal

  Scenario: User is returned to Card home after successful withdrawal
    Given the user is on the Cashback screen with a withdrawable balance
    When the user taps Withdraw and the withdrawal succeeds
    Then a success toast is shown
    And the user is navigated back to the Card home screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots or recordings -->

### **Before**

<!-- Cashback item was visible for US users; description always showed 1%; user stayed on Cashback screen after successful withdrawal -->

### **After**

<!-- Cashback item hidden for US users; Metal Card users see "Earn 3% back"; user auto-navigates back after successful withdrawal -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Card home eligibility/visibility rules and adds an automatic navigation side effect after cashback withdrawal success, which could change what actions users can access and when they’re redirected. Scope is limited to card UI/UX and copy, with added test coverage to reduce regression risk.
> 
> **Overview**
> **Cashback visibility and copy is updated on Card home.** The cashback list item is now hidden for `userLocation === 'us'`, and its description switches to a new Metal-specific string when `cardDetails.type === CardType.METAL`.
> 
> **Cashback withdrawal UX is tightened.** On `monitoringStatus === 'success'`, the Cashback screen now shows the success toast *and* navigates back via `goBack()`, plus minor UI polish (design-system `Skeleton` import and background token change to `bg-background-muted`). Tests are expanded in `CardHome.test.tsx` and `Cashback.test.tsx`, and `en.json` adds `cashback_description_metal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddd5192dce9cb0c4dd790b76fc023363a345406b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->