### PR TITLE
fix: sourcemap upload to bitrise for react native profiler usage

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2374,6 +2374,15 @@ workflows:
             - pipeline_intermediate_files: $PROJECT_LOCATION/app/build/outputs/bundle/$OUTPUT_PATH/$RENAMED_AAB_FILE:BITRISE_PLAY_STORE_ABB_PATH
             - deploy_path: $PROJECT_LOCATION/app/build/outputs/bundle/$OUTPUT_PATH/$RENAMED_AAB_FILE
           title: Bitrise Deploy AAB
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: false
+          is_skippable: true
+          run_if: '{{not (enveq "IS_DEV_BUILD" "true")}}'
+          inputs:
+            - deploy_path: $PROJECT_LOCATION/app/build/generated/sourcemaps/react/$OUTPUT_PATH
+            - is_compress: true
+            - zip_name: Android_Sourcemaps_$OUTPUT_PATH
+          title: Deploy Android Sourcemaps
       - script@1:
           title: Prepare Android build outputs for caching
           run_if: '{{and (getenv "ANDROID_PR_BUILD_CACHE_KEY" | ne "") (getenv "SHARE_WITH_DETOX" | eq "true")}}'
@@ -3050,6 +3059,14 @@ workflows:
           inputs:
             - deploy_path: ios/build/$RENAMED_ARCHIVE_FILE
           title: Deploy Symbols File
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: false
+          is_skippable: true
+          run_if: '{{not (enveq "IS_SIM_BUILD" "true")}}' # Only run for physical builds
+          inputs:
+            - pipeline_intermediate_files: sourcemaps/ios/index.js.map:BITRISE_APP_STORE_SOURCEMAP_PATH
+            - deploy_path: sourcemaps/ios/index.js.map
+          title: Deploy Source Map
       - save-cache@1:
           title: Save iOS PR Build Cache
           run_if: '{{and (getenv "IOS_PR_BUILD_CACHE_KEY" | ne "") (getenv "SHARE_WITH_DETOX" | eq "true")}}'

--- a/scripts/ios/bundle-js-and-sentry-upload.sh
+++ b/scripts/ios/bundle-js-and-sentry-upload.sh
@@ -26,6 +26,11 @@ export SENTRY_DISABLE_AUTO_UPLOAD=${SENTRY_DISABLE_AUTO_UPLOAD:-"true"}
 export SENTRY_DIST=$CURRENT_PROJECT_VERSION
 export SENTRY_RELEASE="$PRODUCT_BUNDLE_IDENTIFIER@$MARKETING_VERSION+$SENTRY_DIST"
 
+# Write source map to a fixed path so Bitrise (and other CI) can deploy it.
+# react-native-xcode.sh runs with CWD = PROJECT_ROOT (repo root), so the path
+# must be relative to repo root, not ios/.
+mkdir -p ../sourcemaps/ios
+export SOURCEMAP_FILE="${SOURCEMAP_FILE:-sourcemaps/ios/index.js.map}"
 
 # Generate JS bundle and upload Sentry source maps
 REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"

--- a/scripts/ios/bundle-js-and-sentry-upload.sh
+++ b/scripts/ios/bundle-js-and-sentry-upload.sh
@@ -26,11 +26,16 @@ export SENTRY_DISABLE_AUTO_UPLOAD=${SENTRY_DISABLE_AUTO_UPLOAD:-"true"}
 export SENTRY_DIST=$CURRENT_PROJECT_VERSION
 export SENTRY_RELEASE="$PRODUCT_BUNDLE_IDENTIFIER@$MARKETING_VERSION+$SENTRY_DIST"
 
-# Write source map to a fixed path so Bitrise (and other CI) can deploy it.
-# react-native-xcode.sh runs with CWD = PROJECT_ROOT (repo root), so the path
-# must be relative to repo root, not ios/.
-mkdir -p ../sourcemaps/ios
-export SOURCEMAP_FILE="${SOURCEMAP_FILE:-sourcemaps/ios/index.js.map}"
+# Write source map to a fixed absolute path so Bitrise (and other CI) can
+# deploy it AND Sentry CLI can locate it for upload.
+# Using a relative path breaks Sentry: react-native-xcode.sh writes the file
+# with CWD=repo_root, but sentry-cli resolves SOURCEMAP_FILE relative to its
+# own CWD (ios/), causing a path mismatch. An absolute path anchored on
+# $PROJECT_DIR (set by Xcode to the ios/ directory) is unambiguous for all
+# sub-processes.
+REPO_ROOT="$(cd "${PROJECT_DIR}/.." && pwd)"
+mkdir -p "$REPO_ROOT/sourcemaps/ios"
+export SOURCEMAP_FILE="${SOURCEMAP_FILE:-$REPO_ROOT/sourcemaps/ios/index.js.map}"
 
 # Generate JS bundle and upload Sentry source maps
 REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
revert of https://github.com/MetaMask/metamask-mobile/pull/25793 (only the part where sourcemaps are not uploaded to bitrise)
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI build artifacts and iOS bundling script paths; risk is mainly build/pipeline breakage or missing sourcemaps if paths/envs differ across workflows.
> 
> **Overview**
> Restores/introduces Bitrise deployment of React Native sourcemaps for **Android** and **iOS** builds so they’re available as CI artifacts (and can be used for profiling/debugging).
> 
> On iOS, updates `scripts/ios/bundle-js-and-sentry-upload.sh` to write the JS sourcemap to a stable absolute path under `sourcemaps/ios/index.js.map` (anchored at repo root) to avoid CWD-related path mismatches during Sentry upload, and adds a Bitrise step to deploy that file via `BITRISE_APP_STORE_SOURCEMAP_PATH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f39ba219f59133cdcd002bb69b25dcd603259d58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->