### PR TITLE
chore: Update a message for Withdraw: Not enough POL

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -358,6 +358,29 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
       expect(result.current).toStrictEqual([]);
     });
+
+    it('uses the standard message (with network switch hint) for non-post-quote flows', () => {
+      useTokenWithBalanceMock.mockReturnValue({
+        ...NATIVE_TOKEN_MOCK,
+        balanceRaw: '99',
+      } as ReturnType<typeof useTokenWithBalance>);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([
+        {
+          key: AlertKeys.InsufficientPayTokenNative,
+          field: RowAlertKey.Amount,
+          isBlocking: true,
+          title: strings('alert_system.insufficient_pay_token_balance.message'),
+          message: strings(
+            'alert_system.insufficient_pay_token_native.message',
+            { ticker: 'ETH' },
+          ),
+          severity: Severity.Danger,
+        },
+      ]);
+    });
   });
 
   describe('for post-quote (withdrawal) flows', () => {
@@ -461,7 +484,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           isBlocking: true,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_native.message',
+            'alert_system.insufficient_pay_token_native_post_quote.message',
             { ticker: 'POL' },
           ),
           severity: Severity.Danger,
@@ -491,7 +514,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           isBlocking: true,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_native.message',
+            'alert_system.insufficient_pay_token_native_post_quote.message',
             { ticker: 'POL' },
           ),
           severity: Severity.Danger,
@@ -528,7 +551,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
           isBlocking: true,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_native.message',
+            'alert_system.insufficient_pay_token_native_post_quote.message',
             { ticker: 'POL' },
           ),
           severity: Severity.Danger,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -179,7 +179,9 @@ export function useInsufficientPayTokenBalanceAlert({
           key: AlertKeys.InsufficientPayTokenNative,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
           message: strings(
-            'alert_system.insufficient_pay_token_native.message',
+            isPostQuote
+              ? 'alert_system.insufficient_pay_token_native_post_quote.message'
+              : 'alert_system.insufficient_pay_token_native.message',
             { ticker },
           ),
         },
@@ -191,6 +193,7 @@ export function useInsufficientPayTokenBalanceAlert({
     isInsufficientForInput,
     isInsufficientForFees,
     isInsufficientForSourceNetwork,
+    isPostQuote,
     ticker,
   ]);
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -103,6 +103,10 @@
       "message": "Not enough {{ticker}} to cover fees. Use a token on another network or add more {{ticker}} to continue.",
       "title": "Insufficient funds"
     },
+    "insufficient_pay_token_native_post_quote": {
+      "message": "Not enough {{ticker}} to cover fees. Add {{ticker}} to continue.",
+      "title": "Insufficient funds for post quote"
+    },
     "no_pay_token_quotes": {
       "message": "This payment route isn't available right now. Try changing the amount, network, or token and we'll find the best option.",
       "title": "No quotes"


### PR DESCRIPTION
## **Description**

The error message shown when a user has insufficient native token (e.g. POL) to cover gas fees during a **Predict Withdraw** was misleading. It suggested switching to a token on another network as a recovery option — which is valid for deposits but not for withdrawals, where the source funds come from the withdrawal transaction itself.

This PR introduces a dedicated copy key for post-quote (withdrawal) flows that omits the network-switch hint, and wires it up in the alert hook.

## **Changelog**

CHANGELOG entry: Fixed incorrect error message shown when there is not enough native token to cover gas fees during a withdrawal.

## **Related issues**

Fixes: #26926

## **Manual testing steps**

```gherkin
Feature: Insufficient native token error message on Predict Withdraw

  Scenario: user sees correct error message when POL balance is too low to cover gas on withdrawal
    Given the user has a Predict account with a balance
    And the user has no POL (or insufficient POL) on their EOA
    When the user navigates to Withdraw and enters an amount
    Then the error message reads "Not enough POL to cover fees. Add POL to continue."
    And the message does NOT mention "Use a token on another network"

  Scenario: deposit flow still shows the full error message
    Given the user has insufficient native token to cover gas on a deposit
    When the user reviews the deposit confirmation
    Then the error message reads "Not enough <ticker> to cover fees. Use a token on another network or add more <ticker> to continue."
```

## **Screenshots/Recordings**

### **Before**

> Not enough POL to cover fees. Use a token on another network or add POL to continue.

### **After**

> Not enough POL to cover fees. Add POL to continue.
<img width="444" height="907" alt="image" src="https://github.com/user-attachments/assets/b7f60f4e-6115-45ee-9629-eb1045a1a679" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes which i18n string is used for an existing blocking alert, plus adds test coverage; no transaction logic or state mutations are altered.
> 
> **Overview**
> Updates the insufficient native-token gas-fee alert copy for *post-quote (withdrawal)* flows to remove the misleading “switch network” hint.
> 
> Adds a new i18n key `alert_system.insufficient_pay_token_native_post_quote.message` and switches `useInsufficientPayTokenBalanceAlert` to choose between the standard vs. post-quote message based on `isPostQuote`, with tests updated to assert both behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df4ee3ae9f432de5f2532f99b888a962812d3643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->