### PR TITLE
fix: Disable the Max button for Predict Withdraw

### DIFF
--- a/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PredictWithdrawInfo } from './predict-withdraw-info';
+import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
+import { CustomAmountInfo } from '../custom-amount-info';
+
+jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
+jest.mock('../../../hooks/ui/useNavbar');
+jest.mock('../../../hooks/tokens/useAddToken');
+jest.mock('../custom-amount-info', () => ({
+  CustomAmountInfo: jest.fn(() => null),
+}));
+jest.mock(
+  '../../predict-confirmations/predict-withdraw-balance/predict-withdraw-balance',
+  () => ({
+    PredictWithdrawBalance: () => null,
+  }),
+);
+
+describe('PredictWithdrawInfo', () => {
+  const useTransactionPayWithdrawMock = jest.mocked(useTransactionPayWithdraw);
+  const CustomAmountInfoMock = jest.mocked(CustomAmountInfo);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useTransactionPayWithdrawMock.mockReturnValue({
+      isWithdraw: true,
+      canSelectWithdrawToken: true,
+    });
+  });
+
+  it('does not pass hasMax to CustomAmountInfo', () => {
+    render(<PredictWithdrawInfo />);
+
+    expect(CustomAmountInfoMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ hasMax: true }),
+      expect.anything(),
+    );
+  });
+});

--- a/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.tsx
@@ -23,7 +23,6 @@ export function PredictWithdrawInfo() {
 
   return (
     <CustomAmountInfo
-      hasMax
       currency={PREDICT_CURRENCY}
       disablePay={!canSelectWithdrawToken}
     >


### PR DESCRIPTION
## **Description**
Disables the Max button for Predict Withdraw. We will enable it once we support Max with a Predict balance.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Disable the Max button for Predict Withdraw

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26944

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small UI-prop change that only affects whether the Max button is shown for Predict withdraw, with a focused unit test to prevent regressions.
> 
> **Overview**
> Disables the **Max** button in the Predict Withdraw confirmation flow by no longer passing `hasMax` into `CustomAmountInfo` from `PredictWithdrawInfo`.
> 
> Adds a unit test asserting `PredictWithdrawInfo` does not enable `hasMax`, ensuring the Max control stays off until a Predict balance-backed max is supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b8547ab3d83ba1d15dc5b1a01b71cdeb91db01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->