### PR TITLE
feat: MUSD-379 fixed off center buy/get mUSD button in Primary conversion CTA

### DIFF
--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -205,6 +205,7 @@ const MusdConversionAssetListCta = () => {
 
       <Button
         variant={ButtonVariant.Secondary}
+        style={styles.button}
         onPress={() => handlePress(CTA_CLICK_TARGET.CTA_BUTTON)}
         size={ButtonSize.Sm}
       >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes off center "Buy/Get mUSD" button for primary mUSD conversion CTA
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed off center "Buy/Get mUSD" button for primary mUSD conversion CTA


## **Related issues**

Fixes: [MUSD-379: Get mUSD CTA button off center in long token list](https://consensyssoftware.atlassian.net/browse/MUSD-379)

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="506" height="356" alt="image" src="https://github.com/user-attachments/assets/c686cef6-e1c6-46d3-9454-5046687d03a5" />


### **After**

<!-- [screenshots/recordings] -->
<img width="506" height="356" alt="image" src="https://github.com/user-attachments/assets/48406dc7-12c7-4170-bf15-08198f76ce87" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only tweak that applies an existing `styles.button` rule to the CTA `Button` to correct alignment; no business logic or data flow changes.
> 
> **Overview**
> Fixes the primary mUSD conversion asset-list CTA layout by applying `styles.button` to the `Button`, centering the “Buy/Get mUSD” button within the row for long token lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b9c21596891414757b6c49ab5f8017a89dee4a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->