### PR TITLE
test: migrates the first set of page objects to the unified approach

### DIFF
--- a/app/components/Views/Onboarding/Onboarding.testIds.ts
+++ b/app/components/Views/Onboarding/Onboarding.testIds.ts
@@ -21,4 +21,5 @@ export const OnboardingSelectorIDs = {
 
 export const OnboardingSelectorText = {
   SUCCESSFUL_WALLET_RESET: enContent.onboarding.your_wallet,
+  UNLOCK_BUTTON: enContent.onboarding.unlock,
 };

--- a/tests/docs/UNIFIED_GESTURES_MIGRATION.md
+++ b/tests/docs/UNIFIED_GESTURES_MIGRATION.md
@@ -106,6 +106,22 @@ async dismissOnboarding() {
 }
 ```
 
+Both `detox` and `appium` branches are **optional** — you can provide only one when the method only exists for a single framework. This is useful during incremental migration when porting a method that has no equivalent on the other side:
+
+```typescript
+// Only the appium branch is needed — Detox doesn't have this flow
+async waitForScreenToDisplay() {
+  await encapsulatedAction({
+    appium: async () => {
+      const element = await asPlaywrightElement(this.title);
+      await element.waitForDisplayed({ timeout: 15000 });
+    },
+  });
+}
+```
+
+If the active framework doesn't have a matching branch, `encapsulatedAction` throws an error to catch misconfiguration early.
+
 ## Escape Hatch
 
 When the unified approach becomes overly complex for a specific case, you can always use `FrameworkDetector` or `PlatformDetector` directly for custom conditional logic:

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -1,5 +1,6 @@
-import { PlaywrightElement } from './PlaywrightAdapter.ts';
-import { boxedStep } from './Utilities.ts';
+import { PlatformDetector } from './PlatformLocator';
+import { PlaywrightElement } from './PlaywrightAdapter';
+import { boxedStep, getDriver } from './Utilities';
 
 /**
  * PlaywrightGestures - Gesture helpers for WebdriverIO/Playwright
@@ -113,5 +114,26 @@ export default class PlaywrightGestures {
   @boxedStep
   static async scrollIntoView(elem: PlaywrightElement): Promise<void> {
     await elem.unwrap().scrollIntoView();
+  }
+
+  /**
+   * Terminate the app
+   * @param packageName - The package name of the app to terminate (Android only)
+   * @param appId - The app id of the app to terminate (iOS only)
+   */
+  @boxedStep
+  static async terminateApp(
+    packageName?: string,
+    appId?: string,
+  ): Promise<void> {
+    const driver = getDriver();
+    if (!driver) throw new Error('Driver is not available');
+    if ((await PlatformDetector.isAndroid()) && packageName) {
+      await driver.terminateApp(packageName);
+    } else if ((await PlatformDetector.isIOS()) && appId) {
+      await driver.terminateApp(appId);
+    } else {
+      throw new Error('Package name or app id is not available');
+    }
   }
 }

--- a/tests/framework/encapsulatedAction.ts
+++ b/tests/framework/encapsulatedAction.ts
@@ -25,12 +25,14 @@ import { FrameworkDetector } from './FrameworkDetector.ts';
  * ```
  */
 export async function encapsulatedAction(config: {
-  detox: () => Promise<void>;
-  appium: () => Promise<void>;
+  detox?: () => Promise<void>;
+  appium?: () => Promise<void>;
 }): Promise<void> {
-  if (FrameworkDetector.isDetox()) {
+  if (FrameworkDetector.isDetox() && config.detox) {
     await config.detox();
-  } else {
+  } else if (FrameworkDetector.isAppium() && config.appium) {
     await config.appium();
+  } else {
+    throw new Error('No action configuration provided');
   }
 }

--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -1,14 +1,35 @@
 import { LoginViewSelectors } from '../../../app/components/Views/Login/LoginView.testIds';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+  asPlaywrightElement,
+} from '../../framework/EncapsulatedElement';
+import { encapsulatedAction } from '../../framework/encapsulatedAction';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
+import { OnboardingSelectorText } from '../../../app/components/Views/Onboarding/Onboarding.testIds';
 
 class LoginView {
   get container(): DetoxElement {
     return Matchers.getElementByID(LoginViewSelectors.CONTAINER);
   }
 
-  get passwordInput(): DetoxElement {
-    return Matchers.getElementByID(LoginViewSelectors.PASSWORD_INPUT);
+  get passwordInput(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByID(LoginViewSelectors.PASSWORD_INPUT),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT, {
+            exact: true,
+          }),
+        ios: () =>
+          PlaywrightMatchers.getElementByAccessibilityId(
+            LoginViewSelectors.PASSWORD_INPUT,
+          ),
+      },
+    });
   }
 
   get forgotPasswordButton(): DetoxElement {
@@ -19,14 +40,27 @@ class LoginView {
     return Matchers.getElementByID(LoginViewSelectors.REMEMBER_ME_SWITCH);
   }
 
-  get loginButton(): DetoxElement {
-    return Matchers.getElementByID(LoginViewSelectors.LOGIN_BUTTON_ID);
+  get loginButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByID(LoginViewSelectors.LOGIN_BUTTON_ID),
+      appium: () =>
+        PlaywrightMatchers.getElementByText(
+          OnboardingSelectorText.UNLOCK_BUTTON,
+        ),
+    });
+  }
+
+  get title(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByID(LoginViewSelectors.TITLE_ID),
+      appium: () =>
+        PlaywrightMatchers.getElementById(LoginViewSelectors.LOGIN_BUTTON_ID),
+    });
   }
 
   async enterPassword(password: string): Promise<void> {
-    await Gestures.typeText(this.passwordInput, password, {
-      hideKeyboard: true,
-      elemDescription: 'Password Input',
+    await UnifiedGestures.typeText(this.passwordInput, password, {
+      description: 'Password Input',
     });
   }
 
@@ -43,8 +77,17 @@ class LoginView {
   }
 
   async tapLoginButton(): Promise<void> {
-    await Gestures.waitAndTap(this.loginButton, {
-      elemDescription: 'Login Button',
+    await UnifiedGestures.waitAndTap(this.loginButton, {
+      description: 'Login Button',
+    });
+  }
+
+  async waitForScreenToDisplay(): Promise<void> {
+    await encapsulatedAction({
+      appium: async () => {
+        const element = await asPlaywrightElement(this.title);
+        await element.waitForDisplayed({ timeout: 15000 });
+      },
     });
   }
 }

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -18,6 +18,7 @@ import {
   encapsulated,
   EncapsulatedElementType,
   asPlaywrightElement,
+  asDetoxElement,
 } from '../../framework/EncapsulatedElement';
 import { encapsulatedAction } from '../../framework/encapsulatedAction';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
@@ -678,7 +679,7 @@ class WalletView {
 
   // TODO test this
   async getBalanceText(): Promise<string> {
-    const balanceElement = this.totalBalance;
+    const balanceElement = asDetoxElement(this.totalBalance);
     await Assertions.expectElementToBeVisible(balanceElement);
 
     const elem = await balanceElement;

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -14,6 +14,14 @@ import Matchers from '../../framework/Matchers';
 import TestHelpers from '../../helpers.js';
 import Assertions from '../../framework/Assertions';
 import Utilities from '../../framework/Utilities';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+  asPlaywrightElement,
+} from '../../framework/EncapsulatedElement';
+import { encapsulatedAction } from '../../framework/encapsulatedAction';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import { PlatformDetector } from '../../framework/PlatformLocator';
 
 class WalletView {
   static readonly MAX_SCROLL_ITERATIONS = 8;
@@ -100,8 +108,15 @@ class WalletView {
     return Matchers.getElementByID(WalletViewSelectorsIDs.NETWORK_NAME);
   }
 
-  get totalBalance(): DetoxElement | DetoxMatcher {
-    return Matchers.getElementByID(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT);
+  get totalBalance(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT,
+        ),
+    });
   }
 
   get accountName(): DetoxElement {
@@ -569,6 +584,96 @@ class WalletView {
     await Gestures.waitAndTap(this.claimButton, {
       elemDescription: 'Claim Button',
     });
+  }
+
+  async waitForBalanceToStabilize(
+    options: {
+      maxWaitTime?: number;
+      pollInterval?: number;
+      sameResultTimeout?: number;
+    } = {},
+  ): Promise<string> {
+    const {
+      maxWaitTime = 60000,
+      pollInterval = 100,
+      sameResultTimeout = 8000,
+    } = options;
+
+    let result = '';
+    await encapsulatedAction({
+      appium: async () => {
+        const startTime = Date.now();
+        const isIOS = await PlatformDetector.isIOS();
+
+        if (isIOS) {
+          // iOS: Element lookups are extremely slow (15-30s each).
+          // Skip stability loop and just wait for a valid balance once.
+          let previousBalance = '';
+          while (Date.now() - startTime < maxWaitTime) {
+            try {
+              const balanceEl = await asPlaywrightElement(this.totalBalance);
+              const rawBalance = await balanceEl.textContent();
+              const balance = (rawBalance || '').trim();
+              previousBalance = balance;
+
+              if (balance && balance !== '' && balance !== '$0.00') {
+                result = balance;
+                return;
+              }
+            } catch {
+              // Element not found yet, retry
+            }
+            await new Promise((r) => setTimeout(r, 1000));
+          }
+          result = previousBalance;
+          return;
+        }
+
+        // Android: Fast element lookups, use stability polling
+        let previousBalance = '';
+        let sameResultStartTime: number | null = null;
+
+        while (true) {
+          if (Date.now() - startTime > maxWaitTime) {
+            result = previousBalance;
+            return;
+          }
+
+          let currentBalance: string;
+          try {
+            const balanceEl = await asPlaywrightElement(this.totalBalance);
+            const rawBalance = await balanceEl.textContent();
+            currentBalance = (rawBalance || '').trim();
+          } catch {
+            await new Promise((r) => setTimeout(r, pollInterval));
+            continue;
+          }
+
+          if (
+            !currentBalance ||
+            currentBalance === '' ||
+            currentBalance === '$0.00'
+          ) {
+            await new Promise((r) => setTimeout(r, pollInterval));
+            continue;
+          }
+
+          if (currentBalance === previousBalance && sameResultStartTime) {
+            const timeSinceSameResult = Date.now() - sameResultStartTime;
+            if (timeSinceSameResult >= sameResultTimeout) {
+              result = currentBalance;
+              return;
+            }
+          } else {
+            sameResultStartTime = Date.now();
+            previousBalance = currentBalance;
+          }
+
+          await new Promise((r) => setTimeout(r, pollInterval));
+        }
+      },
+    });
+    return result;
   }
 
   // TODO test this

--- a/wdio/screen-objects/LoginScreen.js
+++ b/wdio/screen-objects/LoginScreen.js
@@ -46,6 +46,7 @@ class LoginScreen {
     );
   }
 
+  // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)
   get getPasswordInputElement() {
     if (!this._device) {
       return Selectors.getXpathElementByResourceId(
@@ -63,6 +64,7 @@ class LoginScreen {
     }
   }
 
+  // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)
   get unlockButton() {
     // TODO: update the component to have a testID property and use that instead of text
     if (!this._device) {
@@ -72,6 +74,7 @@ class LoginScreen {
     }
   }
 
+  // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)
   get title() {
     if (!this._device) {
       return Selectors.getXpathElementByResourceId(LoginViewSelectors.TITLE_ID);
@@ -100,6 +103,7 @@ class LoginScreen {
     }
   }
 
+  // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)
   async waitForScreenToDisplay() {
     if (!this._device) {
       const element = await this.title;
@@ -119,6 +123,7 @@ class LoginScreen {
     }
   }
 
+  // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)
   async typePassword(password) {
     //await this.isLoginScreenVisible();
     if (!this._device) {
@@ -131,6 +136,7 @@ class LoginScreen {
     }
   }
 
+  // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)
   async tapUnlockButton() {
     if (!this._device) {
       const element = await this.unlockButton;

--- a/wdio/screen-objects/WalletMainScreen.js
+++ b/wdio/screen-objects/WalletMainScreen.js
@@ -337,6 +337,7 @@ class WalletMainScreen {
     }
   }
 
+  // Migrated to WalletView.ts (tests/page-objects/wallet/WalletView.ts)
   async waitForBalanceToStabilize(options = {}) {
     const {
       maxWaitTime = 60000,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR marks the first phase of the page object migration to the Unified Approach. The old `screen-object` files were not removed, they'll be removed with the migration of the spec files.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1470

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes shared test-framework primitives (`encapsulatedAction`, `PlaywrightGestures`) and refactors core page objects, which may cause CI e2e failures/flakiness across Detox vs Appium paths.
> 
> **Overview**
> Migrates `LoginView` and parts of `WalletView` to the unified page-object approach by switching element getters to `encapsulated()` and actions to `UnifiedGestures`, plus adding an Appium-only `waitForScreenToDisplay()` and a new Appium balance stabilization poller that handles iOS vs Android differently.
> 
> Updates the unified-gestures migration docs and relaxes `encapsulatedAction()` so `detox`/`appium` branches are optional, throwing a clear error when the active framework has no matching branch. Adds `PlaywrightGestures.terminateApp()` and introduces an `OnboardingSelectorText.UNLOCK_BUTTON` string used for Appium text-based matching, while marking legacy WDIO screen-object methods as migrated via comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b857ced99a21aea78647c157cfdba2833b5fc1ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->