### PR TITLE
fix(ramps): re-evaluate preferred provider when orders arrive

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
@@ -3,9 +3,16 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import React from 'react';
 import { useRampsProviders } from './useRampsProviders';
-import { type Provider as RampProvider } from '@metamask/ramps-controller';
+import {
+  type Provider as RampProvider,
+  RampsOrderStatus,
+  type RampsOrder,
+} from '@metamask/ramps-controller';
 import Engine from '../../../../core/Engine';
-import { determinePreferredProvider } from '../utils/determinePreferredProvider';
+import {
+  determinePreferredProvider,
+  completedOrdersFromRampsOrders,
+} from '../utils/determinePreferredProvider';
 import { getOrders, type FiatOrder } from '../../../../reducers/fiatOrders';
 
 jest.mock('../../../../core/Engine', () => ({
@@ -69,7 +76,10 @@ const mockProviders: RampProvider[] = [
   },
 ];
 
-const createMockStore = (providersState = {}) =>
+const createMockStore = (
+  providersState: Record<string, unknown> = {},
+  rampsState: { orders?: unknown[] } = {},
+) =>
   configureStore({
     reducer: {
       engine: () => ({
@@ -82,7 +92,7 @@ const createMockStore = (providersState = {}) =>
               error: null,
               ...providersState,
             },
-            orders: [],
+            orders: rampsState.orders ?? [],
           },
         },
       }),
@@ -257,11 +267,163 @@ describe('useRampsProviders', () => {
       expect(mockDeterminePreferredProvider).not.toHaveBeenCalled();
     });
 
-    it('does not call determinePreferredProvider when selectedProvider is already set', () => {
+    it('does not call determinePreferredProvider when selectedProvider is already set and orders are empty', () => {
       const store = createMockStore({
         data: mockProviders,
         selected: mockProviders[0],
       });
+      mockDeterminePreferredProvider.mockClear();
+
+      renderHook(() => useRampsProviders(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(mockDeterminePreferredProvider).not.toHaveBeenCalled();
+    });
+
+    it('re-evaluates when orders appear after initial evaluation with empty orders', () => {
+      const mockCompletedOrder: RampsOrder = {
+        id: '/providers/provider-2/orders/order-1',
+        providerOrderId: 'order-1',
+        provider: { id: 'provider-2', name: 'Provider 2' },
+        status: RampsOrderStatus.Completed,
+        createdAt: 1000,
+      } as RampsOrder;
+
+      const initialRampsState = {
+        providers: {
+          data: mockProviders,
+          selected: null as RampProvider | null,
+          isLoading: false,
+          error: null,
+        },
+        orders: [] as RampsOrder[],
+      };
+
+      const rampsReducer = (
+        state: typeof initialRampsState | undefined,
+        action: { type: string; payload?: unknown },
+      ) => {
+        const s = state ?? initialRampsState;
+        if (
+          action.type === 'ramps/SET_ORDERS' &&
+          Array.isArray(action.payload)
+        ) {
+          return { ...s, orders: action.payload as RampsOrder[] };
+        }
+        if (
+          action.type === 'ramps/SET_SELECTED_PROVIDER' &&
+          action.payload &&
+          typeof action.payload === 'object' &&
+          'id' in (action.payload as object)
+        ) {
+          return {
+            ...state,
+            providers: {
+              ...state.providers,
+              selected: action.payload as RampProvider,
+            },
+          };
+        }
+        return s;
+      };
+
+      const defaultEngineState = {
+        backgroundState: { RampsController: initialRampsState },
+      };
+      const engineReducer = (
+        state: typeof defaultEngineState | undefined,
+        action: { type: string; payload?: unknown },
+      ) => {
+        const s = state ?? defaultEngineState;
+        return {
+          backgroundState: {
+            RampsController: rampsReducer(
+              s.backgroundState.RampsController,
+              action,
+            ),
+          },
+        };
+      };
+
+      const storeWithReducer = configureStore({
+        reducer: {
+          engine: engineReducer,
+          fiatOrders: () => ({ orders: [] }),
+        },
+      });
+
+      const mockCompletedOrdersFromRampsOrders =
+        completedOrdersFromRampsOrders as jest.MockedFunction<
+          typeof completedOrdersFromRampsOrders
+        >;
+      mockCompletedOrdersFromRampsOrders.mockImplementation((orders) =>
+        orders
+          .filter((o) => o.status === RampsOrderStatus.Completed)
+          .map((o) => ({
+            providerId: o.provider?.id ?? '',
+            completedAt: o.createdAt,
+          })),
+      );
+
+      mockDeterminePreferredProvider
+        .mockReturnValueOnce(mockProviders[0])
+        .mockReturnValueOnce(mockProviders[1]);
+
+      const { rerender } = renderHook(() => useRampsProviders(), {
+        wrapper: wrapper(storeWithReducer),
+      });
+
+      expect(mockDeterminePreferredProvider).toHaveBeenCalledTimes(1);
+      expect(
+        Engine.context.RampsController.setSelectedProvider,
+      ).toHaveBeenCalledWith(mockProviders[0].id);
+
+      act(() => {
+        storeWithReducer.dispatch({
+          type: 'ramps/SET_ORDERS',
+          payload: [mockCompletedOrder],
+        });
+      });
+
+      rerender({});
+
+      expect(mockDeterminePreferredProvider).toHaveBeenCalled();
+      expect(
+        Engine.context.RampsController.setSelectedProvider,
+      ).toHaveBeenCalledWith(mockProviders[0].id);
+      expect(
+        Engine.context.RampsController.setSelectedProvider,
+      ).toHaveBeenLastCalledWith(mockProviders[1].id);
+    });
+
+    it('does not re-evaluate when orders were already present on first run', () => {
+      const mockCompletedOrder: RampsOrder = {
+        id: '/providers/provider-2/orders/order-1',
+        providerOrderId: 'order-1',
+        provider: { id: 'provider-2', name: 'Provider 2' },
+        status: RampsOrderStatus.Completed,
+        createdAt: 1000,
+      } as RampsOrder;
+
+      const mockCompletedOrdersFromRampsOrders =
+        completedOrdersFromRampsOrders as jest.MockedFunction<
+          typeof completedOrdersFromRampsOrders
+        >;
+      mockCompletedOrdersFromRampsOrders.mockImplementation((orders) =>
+        orders
+          .filter((o) => o.status === RampsOrderStatus.Completed)
+          .map((o) => ({
+            providerId: o.provider?.id ?? '',
+            completedAt: o.createdAt,
+          })),
+      );
+
+      const store = createMockStore(
+        { data: mockProviders, selected: mockProviders[1] },
+        { orders: [mockCompletedOrder] },
+      );
+
       mockDeterminePreferredProvider.mockClear();
 
       renderHook(() => useRampsProviders(), {

--- a/app/components/UI/Ramp/hooks/useRampsProviders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.ts
@@ -86,6 +86,9 @@ export function useRampsProviders(): UseRampsProvidersResult {
       if (preferred) {
         setSelectedProvider(preferred);
       }
+      if (hasRunWithEmptyOrdersRef.current && hasOrders) {
+        hasRunWithEmptyOrdersRef.current = false;
+      }
     }
 
     if (!hasOrders) {

--- a/app/components/UI/Ramp/hooks/useRampsProviders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
   selectProviders,
@@ -71,11 +71,25 @@ export function useRampsProviders(): UseRampsProvidersResult {
     [],
   );
 
+  const hasRunWithEmptyOrdersRef = useRef(false);
+
   useEffect(() => {
-    if (providers.length > 0 && !selectedProvider) {
-      setSelectedProvider(
-        determinePreferredProvider(completedOrders, providers),
-      );
+    if (providers.length === 0) return;
+
+    const hasOrders = completedOrders.length > 0;
+
+    const shouldEvaluate =
+      !selectedProvider || (hasRunWithEmptyOrdersRef.current && hasOrders);
+
+    if (shouldEvaluate) {
+      const preferred = determinePreferredProvider(completedOrders, providers);
+      if (preferred) {
+        setSelectedProvider(preferred);
+      }
+    }
+
+    if (!hasOrders) {
+      hasRunWithEmptyOrdersRef.current = true;
     }
   }, [providers, selectedProvider, setSelectedProvider, completedOrders]);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds one-time re-evaluation in useRampsProviders when completed orders were empty on first run but later become available (e.g. after app upgrade, persistence restore, or async order sync). Fixes bug where users who completed a MoonPay order saw PayPal selected on next buy flow because orders array was empty when provider was initially assigned.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes bug with purchase provider auto-selection

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3320


## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider auto-selection logic in the buy flow and can change which provider is preselected after state rehydration/order sync. Scope is small and well-tested, but incorrect conditions could cause unexpected provider switching or extra side effects.
> 
> **Overview**
> **Preferred provider auto-selection is now re-evaluated once when order history arrives late.** `useRampsProviders` tracks whether it previously ran with no completed orders and, if so, re-computes the preferred provider when completed orders later become available, even if a provider was already selected.
> 
> Tests were expanded to simulate orders being injected after initial render and assert the hook re-selects appropriately, while also ensuring no re-evaluation occurs when orders were already present on the first run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0913cfe69d594e9be11e0d0e60196a44eef0bcd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->