### PR TITLE
fix: re-parse unknown `HardwareWalletError`

### DIFF
--- a/app/core/HardwareWallet/errors/parser.test.ts
+++ b/app/core/HardwareWallet/errors/parser.test.ts
@@ -42,6 +42,18 @@ describe('parseErrorByType', () => {
       expect(result.code).toBe(ErrorCode.BluetoothDisabled);
       expect(result).toBeInstanceOf(HardwareWalletError);
     });
+
+    it('re-parses ErrorCode.Unknown objects', () => {
+      const error = {
+        code: ErrorCode.Unknown,
+        message:
+          'Please enable Blind signing or Contract data in the Ethereum app Settings',
+      };
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.DeviceStateBlindSignNotSupported);
+    });
   });
 
   describe('when error is LedgerCommunicationErrors enum', () => {

--- a/app/core/HardwareWallet/errors/parser.ts
+++ b/app/core/HardwareWallet/errors/parser.ts
@@ -292,6 +292,12 @@ export function parseErrorByType(
   }
 
   if (isErrorCodeObject(error)) {
+    if (error.code === ErrorCode.Unknown && isErrorLike(error)) {
+      const reParsed = parseErrorByMessage(error, walletType);
+      if (reParsed) {
+        return reParsed;
+      }
+    }
     const message =
       typeof error.message === 'string' ? error.message : undefined;
     return createHardwareWalletError(error.code, walletType, message);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes Ledger blind signing errors showing as "Something went wrong" instead of "Blind Signing Disabled" during swaps and contract interactions.
`@metamask/eth-ledger-bridge-keyring` wraps the Ledger `TransportStatusError(0x6985)` into a `HardwareWalletError` with `ErrorCode.Unknown` due to a cross-realm instanceof failure in the RN bundle. Our parser accepted that classification without checking the message, which clearly contains "Blind signing".
The fix re-parses `ErrorCode.Unknown` errors by checking the message against known patterns before giving up.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

no manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error classification for `ErrorCode.Unknown` objects, which can affect downstream UI/flows that key off specific error codes. Scope is small and limited to message-based re-parsing before falling back to `Unknown`.
> 
> **Overview**
> Ensures `parseErrorByType` doesn’t blindly accept `{ code: ErrorCode.Unknown, message }` objects: it now attempts `parseErrorByMessage` first and returns a more specific `HardwareWalletError` when the message matches known patterns (notably Ledger blind-signing/contract-data prompts).
> 
> Adds a unit test covering re-parsing an `ErrorCode.Unknown` object into `ErrorCode.DeviceStateBlindSignNotSupported`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386cba381deb95770b636661dbb91ce659e806bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->