### PR TITLE
feat: MUSD-394 bring back MetaMaskFeeRow for mUSD conversion confirmations

### DIFF
--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -86,11 +86,11 @@ describe('BridgeFeeRow', () => {
     expect(getByTestId(ConfirmationRowComponentIDs.NETWORK_FEE)).toBeDefined();
     expect(getByText('$0.23')).toBeDefined();
     expect(queryByText('$1.23')).toBeNull();
-    expect(queryByTestId('metamask-fee-row')).toBeNull();
+    expect(getByTestId('metamask-fee-row')).toBeDefined();
     expect(queryByTestId('bridge-fee-row')).toBeNull();
   });
 
-  it('renders skeleton if musdConversion network fee is loading', () => {
+  it('renders skeletons if musdConversion fees are loading', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
 
     const { getByTestId, queryByTestId, queryByText } = render({
@@ -98,7 +98,9 @@ describe('BridgeFeeRow', () => {
     });
 
     expect(getByTestId('network-fee-row-skeleton')).toBeDefined();
+    expect(getByTestId('metamask-fee-row-skeleton')).toBeDefined();
     expect(queryByTestId(ConfirmationRowComponentIDs.NETWORK_FEE)).toBeNull();
+    expect(queryByTestId('metamask-fee-row')).toBeNull();
     expect(queryByText('$0.23')).toBeNull();
   });
 

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -22,7 +22,10 @@ import {
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
 import { BigNumber } from 'bignumber.js';
-import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
+import InfoRow, {
+  InfoRowSkeleton,
+  InfoRowVariant,
+} from '../../UI/info-row/info-row';
 import AlertRow from '../../UI/info-row/alert-row';
 import { RowAlertKey } from '../../UI/info-row/alert-row/constants';
 import { useAlerts } from '../../../context/alert-system-context';
@@ -43,11 +46,14 @@ export function BridgeFeeRow() {
 
   if (hasTransactionType(transactionMetadata, NETWORK_FEE_ONLY_TYPES)) {
     return (
-      <NetworkFeeRow
-        totals={totals}
-        hasAlert={hasAlert}
-        isLoading={isLoading}
-      />
+      <>
+        <NetworkFeeRow
+          totals={totals}
+          hasAlert={hasAlert}
+          isLoading={isLoading}
+        />
+        <MetaMaskFeeRow quotes={quotes} totals={totals} isLoading={isLoading} />
+      </>
     );
   }
 
@@ -260,5 +266,40 @@ function FeesTooltip({
         <Text color={TextColor.Alternative}>{metaMaskFeeUsd}</Text>
       </Box>
     </Box>
+  );
+}
+
+function MetaMaskFeeRow({
+  quotes,
+  totals,
+  isLoading,
+}: {
+  quotes?: TransactionPayQuote<Json>[];
+  totals?: TransactionPayTotals;
+  isLoading: boolean;
+}) {
+  const formatFiat = useFiatFormatter({ currency: 'usd' });
+
+  const hasQuotes = Boolean(quotes?.length);
+
+  const metamaskFeeUsd = useMemo(
+    () => formatFiat(new BigNumber(totals?.fees.metaMask.usd ?? 0)),
+    [totals, formatFiat],
+  );
+
+  if (isLoading) return <InfoRowSkeleton testId="metamask-fee-row-skeleton" />;
+
+  if (!hasQuotes) return null;
+
+  return (
+    <InfoRow
+      testID="metamask-fee-row"
+      label={strings('confirm.label.metamask_fee')}
+      rowVariant={InfoRowVariant.Small}
+    >
+      <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        {metamaskFeeUsd}
+      </Text>
+    </InfoRow>
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR brings back the `MetaMaskFeeRow` that was deleted in https://github.com/MetaMask/metamask-mobile/pull/26637. 

The mUSD conversion flow requires this row to be present.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed missing MetaMask Fee Row that was accidentally removed from mUSD conversion confirmations

## **Related issues**

Fixes: [MUSD-394: Bring back MetaMask Fee row to mUSD conversion confirmations](https://consensyssoftware.atlassian.net/browse/MUSD-394)

## **Manual testing steps**

```gherkin
Feature: MetaMask fee row on mUSD conversion confirmations

  Scenario: user sees MetaMask fee on mUSD conversion confirmation
    Given user is on the mUSD conversion confirmation screen with a quote loaded

    When user views the fee breakdown
    Then user sees a separate "MetaMask fee" row below the "Network fee" row

  Scenario: user sees loading state for MetaMask fee
    Given user is on the mUSD conversion confirmation screen and quotes are loading

    When user views the fee breakdown
    Then user sees skeleton loaders for both Network fee and MetaMask fee rows

  Scenario: user sees no MetaMask fee when no quotes available
    Given user is on the mUSD conversion confirmation screen with no quotes

    When user views the fee breakdown
    Then the MetaMask fee row is not displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Row was missing in both mUSD conversion confirmations.

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
### mUSD Custom Convert
<img width="506" height="1037" alt="image" src="https://github.com/user-attachments/assets/649247e0-32bd-47da-831e-79d6ea9d8de2" />

### mUSD Quick Convert
<img width="506" height="1037" alt="image" src="https://github.com/user-attachments/assets/4206eada-fe6e-4c37-9120-fb8fc2290c30" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change limited to the confirmation fee breakdown for `musdConversion`, plus corresponding test updates. Main risk is incorrect/duplicated fee display if quote/loading state assumptions are wrong.
> 
> **Overview**
> For `TransactionType.musdConversion` confirmations, the fee breakdown now renders a separate **MetaMask fee** row beneath the **Network fee** row (with its own `InfoRowSkeleton` while fees are loading), instead of omitting it.
> 
> Updates `BridgeFeeRow` tests to assert the MetaMask fee row is shown for mUSD conversions, hidden when no quotes exist, and that both network and MetaMask fee skeletons render during loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb9806d5e03af8681ec8578459ff2325a746c7ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->