### PR TITLE
fix(ramps): remove title from sharedheader

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -109,7 +109,6 @@ const Checkout = () => {
     callbackKey,
   } = params ?? {};
 
-  const headerTitle = providerName ?? '';
   const initialUriRef = useRef(uri);
   const callbackKeyRef = useRef(callbackKey);
   const hasCallbackFlow = Boolean(providerCode && walletAddress);
@@ -127,7 +126,7 @@ const Checkout = () => {
     navigation.setOptions(
       getDepositNavbarOptions(
         navigation,
-        { title: providerName ?? headerTitle },
+        { title: providerName ?? '' },
         theme,
         () => {
           trackEvent(
@@ -146,7 +145,6 @@ const Checkout = () => {
     navigation,
     theme,
     providerName,
-    headerTitle,
     createEventBuilder,
     trackEvent,
     rampRoutingDecision,

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -314,9 +314,7 @@ const Checkout = () => {
         />
       }
       style={styles.headerWithoutPadding}
-    >
-      {headerTitle}
-    </BottomSheetHeader>
+    />
   );
 
   if (error) {

--- a/app/components/UI/Ramp/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
@@ -466,29 +466,7 @@ exports[`Checkout renders error view when no URL is provided 1`] = `
                                   undefined,
                                 ]
                               }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  [
-                                    {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Bold",
-                                      "fontSize": 16,
-                                      "fontWeight": 700,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    },
-                                    {
-                                      "textAlign": "center",
-                                    },
-                                  ]
-                                }
-                                testID="header-title"
-                              >
-                                Test Provider
-                              </Text>
-                            </View>
+                            />
                             <View>
                               <View
                                 onLayout={[Function]}
@@ -1182,29 +1160,7 @@ exports[`Checkout sets and displays error on http error for callback URL 1`] = `
                                   undefined,
                                 ]
                               }
-                            >
-                              <Text
-                                accessibilityRole="text"
-                                style={
-                                  [
-                                    {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Bold",
-                                      "fontSize": 16,
-                                      "fontWeight": 700,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    },
-                                    {
-                                      "textAlign": "center",
-                                    },
-                                  ]
-                                }
-                                testID="header-title"
-                              >
-                                Test Provider
-                              </Text>
-                            </View>
+                            />
                             <View>
                               <View
                                 onLayout={[Function]}


### PR DESCRIPTION
## **Description**

Fixes the Checkout WebView header so the provider title/name (for example, `Moonpay (Staging)`) no longer renders on top of the WebView content.

Per the design, the Checkout screen should only show the close (`X`) button in the shared header. This change removes the rendered title from the `BottomSheetHeader` used in `app/components/UI/Ramp/Views/Checkout/Checkout.tsx`.

## **Changelog**

CHANGELOG entry: Fixed a bug where the Ramp checkout provider title appeared above the WebView content.

## **Related issues**



## **Manual testing steps**

```gherkin
Feature: Ramp checkout header title removal

  Scenario: checkout webview does not show provider title
    Given the user starts the Buy flow and reaches the provider Checkout WebView screen

    When the Checkout screen is displayed
    Then the provider name/title is not shown above the WebView content
    And the close button is still visible in the header
    And the close button still works correctly
```

## **Screenshots/Recordings**

### **Before**

<img width="388" height="296" alt="Screenshot 2026-03-05 080429" src="https://github.com/user-attachments/assets/ab97f344-0fcd-4445-9893-070629a5c7a4" />

### **After**

<img width="380" height="316" alt="Screenshot 2026-03-04 152121" src="https://github.com/user-attachments/assets/b0f201f1-d075-451f-b189-2425791962b4" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that removes a duplicated header title; low risk aside from potential minor navigation header title regressions.
> 
> **Overview**
> Removes the rendered provider title from the `Checkout` screen’s `BottomSheetHeader`, leaving only the close (`X`) button so the WebView content isn’t obscured.
> 
> Simplifies header option setup by dropping the cached `headerTitle` fallback and updates the Jest snapshots to reflect the title-less shared header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75e00bff15c825e3d7a7fd7ca41fd9da45e58a33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->