### PR TITLE
test: color-no-hex rewards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -117,19 +117,12 @@ module.exports = {
       },
     },
     {
-      files: ['app/components/UI/Card/**/*.{js,jsx,ts,tsx}'],
-      rules: {
-        '@metamask/design-tokens/color-no-hex': 'error',
-      },
-    },
-    {
-      files: ['app/components/Snaps/**/*.{js,jsx,ts,tsx}'],
-      rules: {
-        '@metamask/design-tokens/color-no-hex': 'error',
-      },
-    },
-    {
-      files: ['app/components/UI/Predict/**/*.{js,jsx,ts,tsx}'],
+      files: [
+        'app/components/UI/Card/**/*.{js,jsx,ts,tsx}',
+        'app/components/Snaps/**/*.{js,jsx,ts,tsx}',
+        'app/components/UI/Predict/**/*.{js,jsx,ts,tsx}',
+        'app/components/UI/Rewards/**/*.{js,jsx,ts,tsx}',
+      ],
       rules: {
         '@metamask/design-tokens/color-no-hex': 'error',
       },

--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -100,14 +100,12 @@ jest.mock('../../Views/ErrorBoundary', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      primary: '#000',
-      background: '#fff',
-    },
-  }),
-}));
+jest.mock('../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock getNavigationOptionsTitle
 jest.mock('../Navbar', () => ({

--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -106,14 +106,12 @@ const mockSelectSnapshotsRewardsEnabledFlag =
   >;
 
 // Mock theme
-jest.mock('../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      primary: '#000',
-      background: '#fff',
-    },
-  }),
-}));
+jest.mock('../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock react-native-safe-area-context
 jest.mock('react-native-safe-area-context', () => {

--- a/app/components/UI/Rewards/Views/RewardsReferralView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsReferralView.test.tsx
@@ -29,14 +29,12 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      primary: '#000',
-      background: '#fff',
-    },
-  }),
-}));
+jest.mock('../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock i18n
 jest.mock('../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
@@ -26,30 +26,11 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
-<<<<<<< HEAD
 // Mock react-native-safe-area-context (override SafeAreaView only; keep SafeAreaProvider etc. for stack)
 jest.mock('react-native-safe-area-context', () => {
   const React = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
   const actual = jest.requireActual('react-native-safe-area-context');
-=======
-// Mock theme
-jest.mock('../../../../util/theme', () => {
-  const { mockTheme } = jest.requireActual('../../../../util/theme');
-  return {
-    useTheme: () => mockTheme,
-  };
-});
-
-// Mock getNavigationOptionsTitle
-jest.mock('../../Navbar', () => ({
-  getNavigationOptionsTitle: jest.fn(() => ({ title: 'Settings' })),
-}));
-
-// Mock design system components
-jest.mock('@metamask/design-system-react-native', () => {
-  const { View, Text } = jest.requireActual('react-native');
->>>>>>> 30bd473975 (test: migrate color-no-hex for rewards codeowner batch)
   return {
     ...actual,
     useSafeAreaInsets: jest.fn(() => ({

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
@@ -26,11 +26,30 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+<<<<<<< HEAD
 // Mock react-native-safe-area-context (override SafeAreaView only; keep SafeAreaProvider etc. for stack)
 jest.mock('react-native-safe-area-context', () => {
   const React = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
   const actual = jest.requireActual('react-native-safe-area-context');
+=======
+// Mock theme
+jest.mock('../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
+
+// Mock getNavigationOptionsTitle
+jest.mock('../../Navbar', () => ({
+  getNavigationOptionsTitle: jest.fn(() => ({ title: 'Settings' })),
+}));
+
+// Mock design system components
+jest.mock('@metamask/design-system-react-native', () => {
+  const { View, Text } = jest.requireActual('react-native');
+>>>>>>> 30bd473975 (test: migrate color-no-hex for rewards codeowner batch)
   return {
     ...actual,
     useSafeAreaInsets: jest.fn(() => ({

--- a/app/components/UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet.test.tsx
+++ b/app/components/UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet.test.tsx
@@ -102,15 +102,12 @@ jest.mock('../../hooks/useLineaSeasonOneTokenReward', () => ({
 }));
 
 // Mock useTheme
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      text: {
-        alternative: '#666666',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock i18n
 jest.mock('../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingNoActiveSeasonStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingNoActiveSeasonStep.test.tsx
@@ -48,15 +48,12 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: {
-        muted: '#f5f5f5',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock strings
 jest.mock('../../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep.test.tsx
@@ -42,23 +42,12 @@ jest.mock('react-redux', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: {
-        muted: '#f5f5f5',
-        default: '#ffffff',
-      },
-      text: {
-        primary: '#000000',
-        alternative: '#666666',
-      },
-      border: {
-        muted: '#e0e0e0',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock rewards auth hook
 const mockOptin = jest.fn();

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep1.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep1.test.tsx
@@ -29,15 +29,12 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: {
-        muted: '#f5f5f5',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock strings
 jest.mock('../../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep2.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep2.test.tsx
@@ -29,15 +29,12 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: {
-        muted: '#f5f5f5',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock strings
 jest.mock('../../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep3.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep3.test.tsx
@@ -29,15 +29,12 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: {
-        muted: '#f5f5f5',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock strings
 jest.mock('../../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep4.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep4.test.tsx
@@ -43,15 +43,12 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: {
-        muted: '#f5f5f5',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock strings
 jest.mock('../../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Onboarding/testUtils.ts
+++ b/app/components/UI/Rewards/components/Onboarding/testUtils.ts
@@ -182,20 +182,3 @@ export const mockAccount = {
     },
   },
 };
-
-// Mock theme
-export const mockTheme = {
-  colors: {
-    background: {
-      muted: '#f5f5f5',
-      default: '#ffffff',
-    },
-    text: {
-      primary: '#000000',
-      alternative: '#666666',
-    },
-    border: {
-      muted: '#e0e0e0',
-    },
-  },
-};

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.test.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.test.tsx
@@ -52,19 +52,12 @@ const mockUseUnlockedRewards = useUnlockedRewards as jest.MockedFunction<
 >;
 
 // Mock useTheme
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: () => ({
-    themeAppearance: 'light',
-    colors: {
-      background: {
-        default: '#FFFFFF',
-      },
-      text: {
-        muted: '#999999',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock i18n
 jest.mock('../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/RewardPointsAnimation.stories.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/RewardPointsAnimation.stories.tsx
@@ -45,6 +45,7 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   primaryButton: {
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     backgroundColor: '#007AFF',
     padding: 10,
     borderRadius: 5,
@@ -52,6 +53,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   secondaryButton: {
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     backgroundColor: '#6C757D',
     padding: 10,
     borderRadius: 5,

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/RewardPointsAnimation.stories.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/RewardPointsAnimation.stories.tsx
@@ -1,14 +1,12 @@
 /* eslint-disable react/display-name */
-/* eslint-disable react-native/no-inline-styles */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useCallback, useEffect } from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { View } from 'react-native';
 import RewardPointsAnimationComponent, { RewardAnimationState } from './index';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
-  FontWeight,
-  Text,
-  TextVariant,
+  Button,
+  ButtonSize,
+  ButtonVariant,
 } from '@metamask/design-system-react-native';
 
 /**
@@ -27,49 +25,12 @@ const RewardPointsAnimationMeta = {
       control: { type: 'number' },
       description: 'Animation duration in milliseconds',
     },
-    variant: {
-      control: { type: 'select' },
-      options: ['BodyMD', 'BodyLG', 'HeadingMd'],
-      description: 'Text variant for styling',
-    },
   },
 };
 
 export default RewardPointsAnimationMeta;
 
-const styles = StyleSheet.create({
-  container: {
-    padding: 24,
-  },
-  buttonContainer: {
-    marginTop: 20,
-    gap: 10,
-  },
-  buttonRow: {
-    flexDirection: 'row',
-    gap: 10,
-  },
-  button: {
-    padding: 10,
-    borderRadius: 5,
-    minWidth: 100,
-    alignItems: 'center',
-  },
-  animationContainer: {
-    padding: 20,
-    paddingHorizontal: 50,
-    width: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    alignSelf: 'center',
-  },
-});
-
-const InteractiveStory = (args: {
-  value: number;
-  duration: number;
-  variant?: any;
-}) => {
+const InteractiveStory = (args: { value: number; duration: number }) => {
   const tw = useTailwind();
   const [currentValue, setCurrentValue] = useState(0);
   const [animationState, setAnimationState] = useState<RewardAnimationState>(
@@ -120,9 +81,11 @@ const InteractiveStory = (args: {
   }, [handleIdle]);
 
   return (
-    <View style={styles.container}>
+    <View style={tw`p-6`}>
       {/* Animation display */}
-      <View style={styles.animationContainer}>
+      <View
+        style={tw`w-full items-center justify-center self-center p-5 px-[50px]`}
+      >
         <RewardPointsAnimationComponent
           {...args}
           value={currentValue}
@@ -131,58 +94,30 @@ const InteractiveStory = (args: {
       </View>
 
       {/* Control buttons for state demonstration */}
-      <View style={styles.buttonContainer}>
-        <View style={styles.buttonRow}>
-          <TouchableOpacity
-            style={[styles.button, tw`bg-primary-default`]}
-            onPress={handleLoading}
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Bold}
-              twClassName="text-background-default"
-            >
-              Loading
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.button, tw`bg-text-alternative`]}
+      <View style={tw`mt-5 gap-2`}>
+        <View style={tw`flex-row gap-2`}>
+          <Button size={ButtonSize.Md} onPress={handleLoading}>
+            Loading
+          </Button>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Md}
             onPress={simulateApiCall}
           >
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Bold}
-              twClassName="text-background-default"
-            >
-              Simulate API call
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.button, tw`bg-text-alternative`]}
+            Simulate API call
+          </Button>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Md}
             onPress={handleError}
           >
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Bold}
-              twClassName="text-background-default"
-            >
-              Error
-            </Text>
-          </TouchableOpacity>
+            Error
+          </Button>
         </View>
-        <View style={styles.buttonRow}>
-          <TouchableOpacity
-            style={[styles.button, tw`bg-primary-default`]}
-            onPress={handleIdle}
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Bold}
-              twClassName="text-background-default"
-            >
-              Set random value
-            </Text>
-          </TouchableOpacity>
+        <View style={tw`flex-row gap-2`}>
+          <Button size={ButtonSize.Md} onPress={handleIdle}>
+            Set random value
+          </Button>
         </View>
       </View>
     </View>

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/RewardPointsAnimation.stories.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/RewardPointsAnimation.stories.tsx
@@ -1,10 +1,15 @@
 /* eslint-disable react/display-name */
 /* eslint-disable react-native/no-inline-styles */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable react-native/no-color-literals */
 import React, { useState, useCallback, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import RewardPointsAnimationComponent, { RewardAnimationState } from './index';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  FontWeight,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 
 /**
  * Storybook configuration for RewardPointsAnimation component
@@ -44,25 +49,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 10,
   },
-  primaryButton: {
-    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-    backgroundColor: '#007AFF',
+  button: {
     padding: 10,
     borderRadius: 5,
     minWidth: 100,
     alignItems: 'center',
-  },
-  secondaryButton: {
-    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-    backgroundColor: '#6C757D',
-    padding: 10,
-    borderRadius: 5,
-    minWidth: 100,
-    alignItems: 'center',
-  },
-  buttonText: {
-    color: 'white',
-    fontWeight: 'bold',
   },
   animationContainer: {
     padding: 20,
@@ -79,6 +70,7 @@ const InteractiveStory = (args: {
   duration: number;
   variant?: any;
 }) => {
+  const tw = useTailwind();
   const [currentValue, setCurrentValue] = useState(0);
   const [animationState, setAnimationState] = useState<RewardAnimationState>(
     RewardAnimationState.Idle,
@@ -142,27 +134,54 @@ const InteractiveStory = (args: {
       <View style={styles.buttonContainer}>
         <View style={styles.buttonRow}>
           <TouchableOpacity
-            style={styles.primaryButton}
+            style={[styles.button, tw`bg-primary-default`]}
             onPress={handleLoading}
           >
-            <Text style={styles.buttonText}>Loading</Text>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Bold}
+              twClassName="text-background-default"
+            >
+              Loading
+            </Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.secondaryButton}
+            style={[styles.button, tw`bg-text-alternative`]}
             onPress={simulateApiCall}
           >
-            <Text style={styles.buttonText}>Simulate API call</Text>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Bold}
+              twClassName="text-background-default"
+            >
+              Simulate API call
+            </Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.secondaryButton}
+            style={[styles.button, tw`bg-text-alternative`]}
             onPress={handleError}
           >
-            <Text style={styles.buttonText}>Error</Text>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Bold}
+              twClassName="text-background-default"
+            >
+              Error
+            </Text>
           </TouchableOpacity>
         </View>
         <View style={styles.buttonRow}>
-          <TouchableOpacity style={styles.primaryButton} onPress={handleIdle}>
-            <Text style={styles.buttonText}>Set random value</Text>
+          <TouchableOpacity
+            style={[styles.button, tw`bg-primary-default`]}
+            onPress={handleIdle}
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Bold}
+              twClassName="text-background-default"
+            >
+              Set random value
+            </Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/index.test.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/index.test.tsx
@@ -26,16 +26,12 @@ jest.mock('../../../../../component-library/hooks', () => ({
   })),
 }));
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn(() => ({
-    colors: {
-      text: {
-        default: '#000000',
-        alternative: '#666666',
-      },
-    },
-  })),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: jest.fn(() => mockTheme),
+  };
+});
 
 jest.mock('rive-react-native', () => ({
   __esModule: true,

--- a/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.test.tsx
+++ b/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.test.tsx
@@ -4,6 +4,8 @@ import RewardsReferralCodeTag from './RewardsReferralCodeTag';
 import ClipboardManager from '../../../../../core/ClipboardManager';
 import { useStyles } from '../../../../../component-library/hooks';
 
+const { mockTheme } = jest.requireActual('../../../../../util/theme');
+
 jest.mock('../../../../../component-library/hooks', () => ({
   useStyles: jest.fn((_styleSheet, params) => ({
     styles: {
@@ -62,7 +64,7 @@ describe('RewardsReferralCodeTag', () => {
   });
 
   it('applies custom backgroundColor when provided', () => {
-    const customBackgroundColor = '#FF0000';
+    const customBackgroundColor = mockTheme.colors.error.default;
 
     render(
       <RewardsReferralCodeTag
@@ -80,7 +82,7 @@ describe('RewardsReferralCodeTag', () => {
   });
 
   it('applies custom fontColor when provided', () => {
-    const customFontColor = '#00FF00';
+    const customFontColor = mockTheme.colors.success.default;
 
     render(
       <RewardsReferralCodeTag

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
@@ -69,21 +69,12 @@ jest.mock('../../hooks/useSeasonStatus', () => ({
 }));
 
 // Mock useTheme
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn(() => ({
-    colors: {
-      background: {
-        alternative: '#f5f5f5',
-        default: '#ffffff',
-        section: '#f9f9f9',
-      },
-      text: {
-        primary: '#000000',
-        alternative: '#666666',
-      },
-    },
-  })),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: jest.fn(() => mockTheme),
+  };
+});
 
 // Mock Tailwind
 jest.mock('@metamask/design-system-twrnc-preset', () => ({

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
@@ -219,15 +219,12 @@ jest.mock('../../hooks/useApplyReferralCode', () => ({
   useApplyReferralCode: jest.fn(),
 }));
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn(() => ({
-    colors: {
-      background: { muted: '#f5f5f5' },
-      border: { muted: '#e0e0e0' },
-      error: { default: '#ff0000' },
-    },
-  })),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: jest.fn(() => mockTheme),
+  };
+});
 
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn((callback) => callback()),

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroup.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroup.test.tsx
@@ -35,15 +35,12 @@ jest.mock('../../../../../../locales/i18n', () => ({
   },
 }));
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn(() => ({
-    colors: {
-      icon: {
-        default: '#000000',
-      },
-    },
-  })),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: jest.fn(() => mockTheme),
+  };
+});
 
 jest.mock('lodash', () => ({
   isEmpty: jest.fn((value: unknown) => {

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.test.tsx
@@ -52,18 +52,12 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => key),
 }));
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn(() => ({
-    colors: {
-      primary: {
-        default: '#037DD6',
-      },
-      background: {
-        alternative: '#F7F9FA',
-      },
-    },
-  })),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: jest.fn(() => mockTheme),
+  };
+});
 
 // Mock FlashList
 jest.mock('@shopify/flash-list', () => {

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.test.tsx
@@ -41,16 +41,12 @@ jest.mock('../../../../../../reducers/rewards/selectors', () => ({
 }));
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    themeAppearance: 'light',
-    colors: {
-      grey: {
-        700: '#374151',
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 // Mock useTailwind
 jest.mock('@metamask/design-system-twrnc-preset', () => ({

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.test.tsx
@@ -125,12 +125,15 @@ const mockSelectSeasonStartDate = selectSeasonStartDate as jest.MockedFunction<
 >;
 
 // Mock theme
-jest.mock('../../../../../../util/theme', () => ({
-  useTheme: () => ({
-    themeAppearance: 'light',
-    brandColors: { grey700: '#374151' },
-  }),
-}));
+jest.mock('../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+  return {
+    useTheme: () => ({
+      themeAppearance: 'light',
+      brandColors: mockTheme.brandColors,
+    }),
+  };
+});
 
 // Mock i18n
 jest.mock('../../../../../../../locales/i18n', () => ({

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.test.tsx
@@ -161,6 +161,14 @@ const mockFormatTimeRemaining = jest.requireMock(
   '../../../utils/formatUtils',
 ).formatTimeRemaining;
 
+/* eslint-disable @metamask/design-tokens/color-no-hex -- domain-specific mock API colors */
+const MOCK_BOOST_COLORS = {
+  swap: '#FF6B35',
+  seasonLong: '#4A90E2',
+  noEndDate: '#50C878',
+} as const;
+/* eslint-enable @metamask/design-tokens/color-no-hex */
+
 // Mock React Native components
 jest.mock('react-native', () => {
   const RN = jest.requireActual('react-native');
@@ -202,8 +210,7 @@ const mockBoost: PointsBoostDto = {
   seasonLong: false,
   startDate: '2024-01-01',
   endDate: '2024-12-31',
-  // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-  backgroundColor: '#FF6B35',
+  backgroundColor: MOCK_BOOST_COLORS.swap,
 };
 
 const mockSeasonLongBoost: PointsBoostDto = {
@@ -215,8 +222,7 @@ const mockSeasonLongBoost: PointsBoostDto = {
   },
   boostBips: 1000,
   seasonLong: true,
-  // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-  backgroundColor: '#4A90E2',
+  backgroundColor: MOCK_BOOST_COLORS.seasonLong,
 };
 
 const mockBoostWithoutEndDate: PointsBoostDto = {
@@ -228,8 +234,7 @@ const mockBoostWithoutEndDate: PointsBoostDto = {
   },
   boostBips: 250,
   seasonLong: false,
-  // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-  backgroundColor: '#50C878',
+  backgroundColor: MOCK_BOOST_COLORS.noEndDate,
 };
 
 describe('ActiveBoosts', () => {

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.test.tsx
@@ -202,6 +202,7 @@ const mockBoost: PointsBoostDto = {
   seasonLong: false,
   startDate: '2024-01-01',
   endDate: '2024-12-31',
+  // eslint-disable-next-line @metamask/design-tokens/color-no-hex
   backgroundColor: '#FF6B35',
 };
 
@@ -214,6 +215,7 @@ const mockSeasonLongBoost: PointsBoostDto = {
   },
   boostBips: 1000,
   seasonLong: true,
+  // eslint-disable-next-line @metamask/design-tokens/color-no-hex
   backgroundColor: '#4A90E2',
 };
 
@@ -226,6 +228,7 @@ const mockBoostWithoutEndDate: PointsBoostDto = {
   },
   boostBips: 250,
   seasonLong: false,
+  // eslint-disable-next-line @metamask/design-tokens/color-no-hex
   backgroundColor: '#50C878',
 };
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/BonusCodeBottomSheet.test.tsx
@@ -120,9 +120,12 @@ jest.mock('../../../../hooks/useRewardsToast', () => ({
   }),
 }));
 
-jest.mock('../../../../../../../util/theme', () => ({
-  useTheme: () => ({ colors: { icon: { default: '#000000' } } }),
-}));
+jest.mock('../../../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../../../util/theme');
+  return {
+    useTheme: () => mockTheme,
+  };
+});
 
 const mockUseValidateBonusCode = useValidateBonusCode as jest.MockedFunction<
   typeof useValidateBonusCode

--- a/app/components/UI/Rewards/components/ThemeImageComponent/RewardsThemeImageComponent.test.tsx
+++ b/app/components/UI/Rewards/components/ThemeImageComponent/RewardsThemeImageComponent.test.tsx
@@ -22,6 +22,7 @@ jest.mock('../../../../../util/theme', () => ({
 }));
 
 import RewardsThemeImageComponent from './RewardsThemeImageComponent';
+const { mockTheme } = jest.requireActual('../../../../../util/theme');
 
 // Helper function to render with Redux Provider
 const renderWithProvider = (component: React.ReactElement) =>
@@ -56,21 +57,14 @@ describe('RewardsThemeImageComponent', () => {
     darkModeUrl: 'https://example.com/dark.png',
   };
 
-  const mockTheme = {
-    colors: {
-      primary: {
-        default: '#037DD6',
-      },
-    },
+  const mockRewardsTheme = {
+    ...mockTheme,
     themeAppearance: 'light',
-    brandColors: {},
-    typography: {},
-    shadows: {},
   } as any;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseTheme.mockReturnValue(mockTheme);
+    mockUseTheme.mockReturnValue(mockRewardsTheme);
   });
 
   it('renders Image and ActivityIndicator on initial render', () => {

--- a/app/components/UI/Rewards/hooks/useActivePointsBoosts.test.ts
+++ b/app/components/UI/Rewards/hooks/useActivePointsBoosts.test.ts
@@ -77,6 +77,7 @@ describe('useActivePointsBoosts', () => {
       },
       boostBips: 1000,
       seasonLong: true,
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
       backgroundColor: '#FF0000',
     },
     {
@@ -90,6 +91,7 @@ describe('useActivePointsBoosts', () => {
       seasonLong: false,
       startDate: '2024-01-01',
       endDate: '2024-01-31',
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
       backgroundColor: '#00FF00',
     },
   ];

--- a/app/components/UI/Rewards/hooks/useActivePointsBoosts.test.ts
+++ b/app/components/UI/Rewards/hooks/useActivePointsBoosts.test.ts
@@ -51,6 +51,13 @@ jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
 }));
 
+/* eslint-disable @metamask/design-tokens/color-no-hex -- domain-specific mock API colors */
+const MOCK_ACTIVE_BOOST_COLORS = {
+  primary: '#FF0000',
+  secondary: '#00FF00',
+} as const;
+/* eslint-enable @metamask/design-tokens/color-no-hex */
+
 describe('useActivePointsBoosts', () => {
   const mockDispatch = jest.fn();
   const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
@@ -77,8 +84,7 @@ describe('useActivePointsBoosts', () => {
       },
       boostBips: 1000,
       seasonLong: true,
-      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-      backgroundColor: '#FF0000',
+      backgroundColor: MOCK_ACTIVE_BOOST_COLORS.primary,
     },
     {
       id: 'boost-2',
@@ -91,8 +97,7 @@ describe('useActivePointsBoosts', () => {
       seasonLong: false,
       startDate: '2024-01-01',
       endDate: '2024-01-31',
-      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-      backgroundColor: '#00FF00',
+      backgroundColor: MOCK_ACTIVE_BOOST_COLORS.secondary,
     },
   ];
 


### PR DESCRIPTION
## **Description**

This PR is the Rewards-only split of the `color-no-hex` batch work, extracted from the original umbrella PR #26651.

Scope:
- Rewards files only (`app/components/UI/Rewards/**`)
- temporary eslint rollout override for `app/components/UI/Rewards/**/*.{js,jsx,ts,tsx}`
- includes replacing straightforward mock color suppressions with `mockTheme` in a subset of Rewards tests

Reference PR: https://github.com/MetaMask/metamask-mobile/pull/26651

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: color-no-hex rewards batch

  Scenario: validate rewards lint and tests
    Given this branch is checked out
    When running eslint for Rewards scope
    Then there are no lint errors

    When running jest for Rewards scope with snapshot updates
    Then tests pass
```

## **Screenshots/Recordings**

### **Before**
N/A (test/lint/config updates only)

### **After**
N/A (test/lint/config updates only)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low runtime risk since changes are limited to ESLint configuration plus test/story updates; main risk is CI/dev friction if any remaining Rewards hex literals trigger the newly-enforced lint rule.
> 
> **Overview**
> **Enforces `@metamask/design-tokens/color-no-hex` for Rewards UI code.** Updates `.eslintrc.js` to include `app/components/UI/Rewards/**/*` in the folders where hex colors are treated as lint errors.
> 
> **Aligns Rewards tests/stories with the rule.** Rewards tests now mock `useTheme` by reusing the shared `mockTheme` (and remove a local onboarding `mockTheme` helper), and a Rewards Storybook story (`RewardPointsAnimation`) is refactored to use Tailwind/design-system `Button`s instead of inline styles/hex colors, with a couple of tests explicitly scoping hex-only mock API colors behind lint disables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a5d5c1ef3c117c66fdd07872df82fc489985492. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->