### PR TITLE
chore: Align iOS development provisioning profile names and remove failing expo dev builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -130,7 +130,7 @@ pipelines:
         - pr_check_build_cache
   expo_dev_pipeline:
     stages:
-      - create_build_qa_and_expo: {}
+      - create_build_dev_expo: {}
       # - app_launch_times_test_stage: {}
   #Main expo pipeline
   expo_main_pipeline:
@@ -254,13 +254,11 @@ stages:
   deploy_android_release:
     workflows:
       - deploy_android_to_store: {}
-  create_build_qa_and_expo:
+  create_build_dev_expo:
     workflows:
       - build_android_devbuild: {}
-      - build_android_qa: {}
       - build_ios_devbuild: {}
       - build_ios_simbuild: {}
-      - build_ios_qa: {}
   create_build_main_expo:
     workflows:
       - build_android_devbuild: {}

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -1330,8 +1330,8 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.metamask.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = MetaMask;
-				PROVISIONING_PROFILE_SPECIFIER = "match Development io.metamask.MetaMask";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development io.metamask.MetaMask";
+				PROVISIONING_PROFILE_SPECIFIER = "development-metamask";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "development-metamask";
 				SWIFT_OBJC_BRIDGING_HEADER = "MetaMask-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Align iOS development provisioning profile name to be `development-metamask` and remove the QA builds from expo dev builds pipeline in Bitrise. These changes resolves the issue where `build_ios_devbuild` failed from an invalid certification. Under the hood, we've rolled and applied a new development cert and provisioning profile

Successful build - https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/ae66cb02-de4b-4e86-8295-e4906f20ae9a

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-381

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes iOS code-signing configuration and CI pipeline composition; misconfiguration could break dev builds in Bitrise/Xcode but does not affect runtime app behavior.
> 
> **Overview**
> **Fixes iOS dev build signing and reduces Expo dev CI workload.**
> 
> Updates the iOS Xcode project Debug configuration to use the `development-metamask` provisioning profile instead of the previous `match Development io.metamask.MetaMask` specifier.
> 
> Adjusts Bitrise `expo_dev_pipeline` to run a new `create_build_dev_expo` stage that builds only dev/simulator artifacts, dropping the QA build workflows that were previously included in the Expo dev pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54b92967d214f5715d606ee6fbcc4b446ce2433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->