### PR TITLE
chore: point dev to builds.yml

### DIFF
--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -245,6 +245,12 @@ class AppInformation extends PureComponent {
                   {`Remote Feature Flag Distribution: ${getFeatureFlagAppDistribution()}`}
                 </Text>
                 <Text style={styles.branchInfo}>
+                  {`Rewards API URL: ${process.env.REWARDS_API_URL ?? '—'}`}
+                </Text>
+                <Text style={styles.branchInfo}>
+                  {`MM_PORTFOLIO_URL: ${process.env.MM_PORTFOLIO_URL ?? '—'}`}
+                </Text>
+                <Text style={styles.branchInfo}>
                   {`OTA Updates enabled: ${String(isOTAUpdatesEnabled)}`}
                 </Text>
                 {isOTAUpdatesEnabled && (

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -218,7 +218,7 @@ remapEnvVariable() {
 	if [ -z "${!old_var_name}" ]; then
 		if [ -z "${GITHUB_ACTIONS:-}" ] && [ "${BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY:-false}" != "true" ]; then
 			echo "❌ Required Bitrise secret is missing: $old_var_name"
-			exit 1
+			return 1
 		fi
 		return 0
 	fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -209,12 +209,18 @@ loadBuildConfig() {
 # Legacy env remapping (Bitrise). Used only when GITHUB_ACTIONS is not set.
 # GitHub Actions uses loadBuildConfig + builds.yml; secrets are set with canonical names.
 # ─────────────────────────────────────────────────────────────────────────────
+# Remap Bitrise-style vars (*_DEV, *_QA, *_PROD) to canonical names. Skip when source is unset
+# (local / builds.yml use canonical names in .js.env; no _DEV/_QA needed).
+# Legacy path (not GHA, not builds.yml): missing source var fails fast. Local: set BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY in .js.env to use builds.yml and skip.
 remapEnvVariable() {
 	local old_var_name="$1"
 	local new_var_name="$2"
 	if [ -z "${!old_var_name}" ]; then
-		echo "Error: $old_var_name does not exist in the environment."
-		return 1
+		if [ -z "${GITHUB_ACTIONS:-}" ] && [ "${BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY:-false}" != "true" ]; then
+			echo "❌ Required Bitrise secret is missing: $old_var_name"
+			exit 1
+		fi
+		return 0
 	fi
 	export $new_var_name="${!old_var_name}"
 	unset $old_var_name
@@ -984,8 +990,10 @@ checkParameters "$@"
 printTitle
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Load build configuration: GitHub Actions uses builds.yml; Bitrise uses legacy remap.
-# Both paths supported until Bitrise is deprecated.
+# Load build configuration. Gated by BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY:
+#   true  = GHA (set by workflow) and local (set in .js.env) → use builds.yml
+#   false = Bitrise (unset) → skip builds.yml, use legacy remap only
+# Local: .js.env is applied after loadBuildConfig so it overrides (see below).
 # ─────────────────────────────────────────────────────────────────────────────
 if [ "$PLATFORM" != "expo-update" ]; then
 	# Set flags for main builds
@@ -994,14 +1002,30 @@ if [ "$PLATFORM" != "expo-update" ]; then
 		export PRE_RELEASE=true # Used mostly for iOS, for Android only deletes old APK and installs new one
 	fi
 
-	if [ -n "${GITHUB_ACTIONS:-}" ]; then
-		# GitHub Actions: config from builds.yml (Apply build config step sets env; loadBuildConfig fills any gaps)
-		if ! loadBuildConfig "$METAMASK_BUILD_TYPE" "$METAMASK_ENVIRONMENT"; then
+	# Non-GHA: source .js.env early so BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY is set for the gate (local can opt in)
+	if [ -z "${GITHUB_ACTIONS:-}" ] && [ -e "$JS_ENV_FILE" ]; then
+		source "$JS_ENV_FILE"
+	fi
+
+	BUILD_TYPE_FOR_CONFIG=$(echo "$METAMASK_BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
+	if [ "${BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY:-false}" = "true" ]; then
+		# builds.yml path: GHA or local with flag.
+		if ! loadBuildConfig "$BUILD_TYPE_FOR_CONFIG" "$METAMASK_ENVIRONMENT"; then
 			echo "❌ Build configuration failed. Exiting."
 			exit 1
 		fi
 	else
-		# Bitrise (or local): legacy env remapping (Bitrise secrets use per-env names, e.g. SEGMENT_WRITE_KEY_PROD)
+		echo "⚠️  BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY is not true; skipping builds.yml, using legacy remap / .js.env"
+		echo ""
+	fi
+
+	# Local builds: .js.env overrides builds.yml (takes precedence)
+	if [ -z "${GITHUB_ACTIONS:-}" ] && [ -e "$JS_ENV_FILE" ]; then
+		source "$JS_ENV_FILE"
+	fi
+
+	# Bitrise (or other non-GHA CI): legacy env remapping (secrets use per-env names, e.g. SEGMENT_WRITE_KEY_PROD)
+	if [ -z "${GITHUB_ACTIONS:-}" ]; then
 		if [ "$METAMASK_BUILD_TYPE" == "main" ]; then
 			if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 				remapMainProdEnvVariables


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Start to use builds.yml locally.

If we have `BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY` set to true locally in .js.env then we will use the envs in Builds.yml and .js.env. 

Here are the steps: 
1. Source .js.env (early, for the gate).
2. If flag BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY is true: run loadBuildConfig → applies builds.yml (overwrites env).
3. Source .js.env again → “Local builds: .js.env overrides builds.yml” — so .js.env wins over anything set by builds.yml.
4. Legacy remap runs (Bitrise-style vars).

This way - when we retire BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY, all the local builds will use builds.yml and .js.env
 
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added ability for dev build to use builds.yml as source of truth

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Build configuration for local builds
  As a local developer
  I want build configuration to load from .js.env or builds.yml depending on a flag
  So that I can use builds.yml when I opt in and .js.env always overrides when present

  Scenario: Local without flag uses .js.env only
    Given I am running the build script locally
    And .js.env exists
    And BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY is not set to "true"
    When I run the build script
    Then loadBuildConfig should not run
    And .js.env should be sourced
    And build env should come from .js.env

  Scenario: Local with flag true uses builds.yml then .js.env overrides
    Given I am running the build script locally
    And .js.env exists and sets BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY=true
    When I run the build script
    Then loadBuildConfig should run and load from builds.yml
    And .js.env should be sourced again after that
    And values from .js.env should override values from builds.yml

  Scenario Outline: .js.env overrides builds.yml for same variable
    Given I am running the build script locally with BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY=true
    And builds.yml sets <var> to "<builds_value>"
    And .js.env sets <var> to "<env_value>"
    When I run the build script
    Then the effective <var> should be "<env_value>"

    Examples:
      | var              | builds_value                         | env_value                               |
      | REWARDS_API_URL  | https://rewards.api.cx.metamask.io   | https://rewards.uat-api.cx.metamask.io |
      | MM_PORTFOLIO_URL | https://portfolio.api.cx.metamask.io | https://portfolio.dev-api.cx.metamask.io |

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
Using Pre build
<img width="200" height="400" alt="Simulator Screenshot - iPhone 16 - 2026-03-05 at 12 55 12" src="https://github.com/user-attachments/assets/65815b46-b205-4071-ba74-d8ffee7a163f" />

Using local build (yarn start:ios)
<img width="200" height="400" alt="Simulator Screenshot - iPhone 16 - 2026-03-05 at 15 08 27" src="https://github.com/user-attachments/assets/4c25e3ca-b839-4e54-86f7-ded1b383c74f" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the build pipeline and environment variable precedence, which can break local/CI builds if the gating or sourcing order is wrong. Runtime app changes are limited to extra debug info on the settings screen.
> 
> **Overview**
> **Build configuration changes:** `scripts/build.sh` now conditionally loads `builds.yml` when `BUILDS_ENABLED_WITH_GH_ACTIONS_TEMPORARY=true` (for GitHub Actions and local opt-in), sources `.js.env` early to read the flag, then sources it again afterward so local values override `builds.yml`. Legacy Bitrise env remapping is kept for non-GHA runs, and missing `*_DEV/_QA/_PROD` secrets only hard-fail on the legacy path.
> 
> **Debug visibility:** The hidden environment info section in `AppInformation` now also displays `REWARDS_API_URL` and `MM_PORTFOLIO_URL` (or `—` if unset).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54fe50291b3245f96ff07671f9ca718a8348b19d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->