### PR TITLE
chore: remove error messages from bug report template

### DIFF
--- a/.github/scripts/shared/template.ts
+++ b/.github/scripts/shared/template.ts
@@ -27,7 +27,6 @@ const bugReportIssueTemplateTitles = [
   '### Expected behavior',
   '### Screenshots', // TODO: replace '### Screenshots' by '### Screenshots/Recordings' in January 2024 (as most issues will meet this criteria by then)
   '### Steps to reproduce',
-  '### Error messages or log output',
   '### Version',
   '### Build type',
   '### Device',


### PR DESCRIPTION
## **Description**

Since the field '### Error messages or log output' is not present in Jira, we no longer want to make it a mandatory requirement to recognize the bug report template in GitHub.

Thanks to this change, the issues created by **issuebridge** app (which replicates on GitHub the tickets we create in Jira), should be recognized as bug reports by our GitHub Actions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

NA

## **Manual testing steps**

NA

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the GitHub template-title matcher for bug reports by removing one required heading, which may slightly broaden what issues are auto-labeled as bug reports.
> 
> **Overview**
> Bug report issue template detection is relaxed by dropping the `### Error messages or log output` section from `bugReportIssueTemplateTitles` in `.github/scripts/shared/template.ts`.
> 
> This allows issues missing that heading (e.g., synced from Jira) to still match the bug report template and be processed by the existing labeling workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dfba674f141aa80e5707c70697375ace0dc2188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->