### PR TITLE
chore: stiky trade button in Market Insights

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -507,7 +507,7 @@ const MarketInsightsView: React.FC = () => {
       </ScrollView>
 
       <Box
-        twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom}px]`}
+        twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom + 8}px]`}
       >
         <Button
           variant={ButtonVariant.Primary}

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -393,7 +393,7 @@ const MarketInsightsView: React.FC = () => {
       <MarketInsightsViewHeader onBackPress={handleBackPress} />
 
       <ScrollView
-        contentContainerStyle={tw.style(`pb-[${insets.bottom + 16}px]`)}
+        contentContainerStyle={tw.style(`pb-4`)}
         showsVerticalScrollIndicator={false}
       >
         <AnimatedSection delay={SECTION_ANIMATION_DELAYS_MS.topArticle}>
@@ -455,7 +455,7 @@ const MarketInsightsView: React.FC = () => {
 
         <Box
           alignItems={BoxAlignItems.Center}
-          twClassName="border-t border-muted px-4 pt-4 pb-5"
+          twClassName="border-t border-muted px-4 pt-4"
           testID={MarketInsightsSelectorsIDs.SOURCES_FOOTER}
         >
           <Box
@@ -504,26 +504,26 @@ const MarketInsightsView: React.FC = () => {
             {strings('market_insights.helpful_prompt')}
           </Text>
         </Box>
-        <Box twClassName="px-4">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            onPress={handleTradePress}
-            testID={MarketInsightsSelectorsIDs.TRADE_BUTTON}
-          >
-            {strings('market_insights.trade_button')}
-          </Button>
-          <Box twClassName="pt-3" alignItems={BoxAlignItems.Center}>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {strings('market_insights.footer_disclaimer')}
-            </Text>
-          </Box>
-        </Box>
       </ScrollView>
+
+      <Box
+        twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom}px]`}
+      >
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={handleTradePress}
+          testID={MarketInsightsSelectorsIDs.TRADE_BUTTON}
+        >
+          {strings('market_insights.trade_button')}
+        </Button>
+        <Box twClassName="pt-3" alignItems={BoxAlignItems.Center}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {strings('market_insights.footer_disclaimer')}
+          </Text>
+        </Box>
+      </Box>
 
       {selectedTrend ? (
         <MarketInsightsTrendSourcesBottomSheet

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -398,7 +398,7 @@ const MarketInsightsView: React.FC = () => {
       >
         <AnimatedSection delay={SECTION_ANIMATION_DELAYS_MS.topArticle}>
           <Box twClassName="px-4 pt-4 pb-3">
-            <Text variant={TextVariant.HeadingLg}>{report.headline}</Text>
+            <Text variant={TextVariant.HeadingMd}>{report.headline}</Text>
           </Box>
 
           <Box twClassName="px-4 pb-6">

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -399,6 +399,7 @@ const MarketInsightsView: React.FC = () => {
       <MarketInsightsViewHeader onBackPress={handleBackPress} />
 
       <ScrollView
+        style={tw.style('flex-1')}
         contentContainerStyle={tw.style(`pb-4`)}
         showsVerticalScrollIndicator={false}
       >

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsViewSkeleton.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsViewSkeleton.tsx
@@ -25,7 +25,7 @@ const MarketInsightsViewSkeleton: React.FC<MarketInsightsViewSkeletonProps> = ({
       <MarketInsightsViewHeader onBackPress={onBackPress} />
 
       <ScrollView
-        contentContainerStyle={tw.style(`pb-[${insets.bottom + 16}px]`)}
+        contentContainerStyle={tw.style(`pb-[${insets.bottom + 8}px]`)}
         showsVerticalScrollIndicator={false}
       >
         <Box twClassName="px-4 pt-4 pb-3" gap={2}>

--- a/app/components/UI/MarketInsights/components/MarketInsightsTrendItem/MarketInsightsTrendItem.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTrendItem/MarketInsightsTrendItem.tsx
@@ -60,7 +60,7 @@ const MarketInsightsTrendItem: React.FC<MarketInsightsTrendItemProps> = ({
       accessibilityRole={onPress ? 'button' : undefined}
     >
       <Text
-        variant={TextVariant.BodyMd}
+        variant={TextVariant.HeadingSm}
         fontWeight={FontWeight.Medium}
         twClassName="mb-2"
       >

--- a/app/components/UI/MarketInsights/components/MarketInsightsTrendSourcesBottomSheet.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTrendSourcesBottomSheet.tsx
@@ -103,7 +103,7 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
             <Box twClassName="flex-1">
               <Box
                 flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.End}
+                alignItems={BoxAlignItems.Start}
                 twClassName="pr-1"
               >
                 <Text
@@ -113,7 +113,7 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
                 >
                   {article.title}
                 </Text>
-                <Box twClassName="pb-1">
+                <Box paddingTop={1}>
                   <Icon
                     name={IconName.Export}
                     size={IconSize.Sm}
@@ -182,7 +182,7 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
             <Box twClassName="flex-1">
               <Box
                 flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.End}
+                alignItems={BoxAlignItems.Start}
                 twClassName="pr-1"
               >
                 <Text
@@ -193,7 +193,7 @@ const MarketInsightsTrendSourcesBottomSheet: React.FC<
                 >
                   {tweet.contentSummary}
                 </Text>
-                <Box twClassName="pb-1">
+                <Box paddingTop={1}>
                   <Icon
                     name={IconName.Export}
                     size={IconSize.Sm}

--- a/app/components/UI/MarketInsights/components/MarketInsightsTweetCard/MarketInsightsTweetCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsTweetCard/MarketInsightsTweetCard.tsx
@@ -38,8 +38,8 @@ const MarketInsightsTweetCard: React.FC<MarketInsightsTweetCardProps> = ({
       testID={testID}
     >
       <Text
-        variant={TextVariant.BodySm}
-        color={TextColor.TextAlternative}
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextDefault}
         twClassName="mb-3"
       >
         {tweet.contentSummary}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Makes Trade button sticky at the bottom of the screen.

<img width="366" height="347" alt="Screenshot 2026-03-05 at 10 29 57" src="https://github.com/user-attachments/assets/871f6692-3f2a-4913-b437-ea1b4c28e4ea" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI layout/typography adjustments in the Market Insights screen; low risk aside from potential spacing/regression on different device safe-area insets.
> 
> **Overview**
> Moves the **Trade** CTA (and disclaimer) out of the `ScrollView` into a fixed bottom footer with safe-area-aware padding, and updates the `ScrollView` padding/styling accordingly.
> 
> Tweaks Market Insights typography and spacing (headline size, trend item title style, tweet card text emphasis) and refines source list row alignment/icon placement; updates skeleton bottom padding to match the new layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76fe6659b17a1da4c2370d84bdcab6a728c289de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->