### PR TITLE
test: Swap action smoke test

### DIFF
--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -426,7 +426,17 @@ export default class MockServerE2E implements Resource {
           const errorMessage = `Request going to live server: ${translatedUrl}`;
           logger.warn(errorMessage);
           if (request.method === 'POST') {
-            logger.warn(`Request Body: ${await request.body.getText()}`);
+            try {
+              logger.warn(`Request Body: ${await request.body.getText()}`);
+            } catch (bodyError) {
+              if (
+                bodyError instanceof Error &&
+                bodyError.message === 'Aborted'
+              ) {
+                return { statusCode: 499, body: '' };
+              }
+              logger.warn('Failed to read request body for logging');
+            }
           }
           this._server?._liveRequests?.push({
             url: translatedUrl,
@@ -436,7 +446,17 @@ export default class MockServerE2E implements Resource {
         } else if (ALLOWLISTED_URLS.includes(translatedUrl)) {
           logger.warn(`Allowed URL: ${translatedUrl}`);
           if (request.method === 'POST') {
-            logger.warn(`Request Body: ${await request.body.getText()}`);
+            try {
+              logger.warn(`Request Body: ${await request.body.getText()}`);
+            } catch (bodyError) {
+              if (
+                bodyError instanceof Error &&
+                bodyError.message === 'Aborted'
+              ) {
+                return { statusCode: 499, body: '' };
+              }
+              logger.warn('Failed to read request body for logging');
+            }
           }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wrap `request.body.getText()` calls in try-catch blocks to fix flaky `swap-action-smoke` test failures.

The `swap-action-smoke` test was failing due to unprotected `request.body.getText()` calls in `MockServerE2E.ts` (lines 429 and 439). These calls would throw "Aborted" errors when the app's bridge controller cancelled an in-flight request, causing Jest to catch unhandled rejections. Wrapping these calls in try-catch blocks and returning a 499 response on abort prevents the errors from propagating.

---
[Slack Thread](https://consensys.slack.com/archives/C02U025CVU4/p1772698032863329?thread_ts=1772698032.863329&cid=C02U025CVU4)

<p><a href="https://cursor.com/agents/bc-78dd627e-2976-56c5-b272-275d5c3c1a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78dd627e-2976-56c5-b272-275d5c3c1a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->