### PR TITLE
fix: use ref for `targetWalletType` in `useHardwareWallet` system

### DIFF
--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -195,7 +195,10 @@ export const useDeviceConnectionFlow = ({
         pendingReadyResolveRef.current = null;
       }
 
-      const targetType = walletType ?? HardwareWalletType.Ledger;
+      const targetType =
+        refs.targetWalletTypeRef.current ??
+        walletType ??
+        HardwareWalletType.Ledger;
 
       if (!targetDeviceId) {
         setters.setDeviceId(null);

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
@@ -52,6 +52,7 @@ describe('useDeviceEventHandlers', () => {
       adapterRef: { current: mockAdapter },
       isConnectingRef: { current: false },
       abortControllerRef: { current: null },
+      targetWalletTypeRef: { current: null },
     };
 
     // Track last connection state for assertion

--- a/app/core/HardwareWallet/hooks/useHardwareWalletStateManager.ts
+++ b/app/core/HardwareWallet/hooks/useHardwareWalletStateManager.ts
@@ -30,6 +30,8 @@ export interface HardwareWalletRefs {
   isConnectingRef: React.MutableRefObject<boolean>;
   /** AbortController for cancelling in-flight connection operations. */
   abortControllerRef: React.MutableRefObject<AbortController | null>;
+  /** Synchronously-updated mirror of targetWalletType for use in callbacks. */
+  targetWalletTypeRef: React.MutableRefObject<HardwareWalletType | null>;
 }
 
 /** State setter functions exposed by the state manager. */
@@ -79,6 +81,7 @@ export const useHardwareWalletStateManager =
     const adapterRef = useRef<HardwareWalletAdapter | null>(null);
     const isConnectingRef = useRef<boolean>(false);
     const abortControllerRef = useRef<AbortController | null>(null);
+    const targetWalletTypeRef = useRef<HardwareWalletType | null>(null);
 
     const selectedAccount = useSelector(selectSelectedInternalAccount);
 
@@ -104,7 +107,20 @@ export const useHardwareWalletStateManager =
         adapterRef,
         isConnectingRef,
         abortControllerRef,
+        targetWalletTypeRef,
       }),
+      [],
+    );
+
+    const setTargetWalletTypeSync = useCallback(
+      (value: React.SetStateAction<HardwareWalletType | null>) => {
+        const newValue =
+          typeof value === 'function'
+            ? value(targetWalletTypeRef.current)
+            : value;
+        targetWalletTypeRef.current = newValue;
+        setTargetWalletType(newValue);
+      },
       [],
     );
 
@@ -112,15 +128,16 @@ export const useHardwareWalletStateManager =
       () => ({
         setConnectionState,
         setDeviceId,
-        setTargetWalletType,
+        setTargetWalletType: setTargetWalletTypeSync,
       }),
-      [],
+      [setTargetWalletTypeSync],
     );
 
     const resetState = useCallback(() => {
       setConnectionState({ status: ConnectionStatus.Disconnected });
       setDeviceId(null);
       setTargetWalletType(null);
+      targetWalletTypeRef.current = null;
       isConnectingRef.current = false;
       adapterRef.current = null;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

no manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hardware wallet connection state/adapter selection logic; a stale or mis-synced ref could cause connecting with the wrong adapter type or inconsistent connection state, though the change is small and localized.
> 
> **Overview**
> Ensures hardware-wallet connection flow uses a synchronously updated `targetWalletType` by introducing `targetWalletTypeRef` in `useHardwareWalletStateManager` and wiring `setTargetWalletType` through a sync setter that updates both state and the ref.
> 
> Updates `useDeviceConnectionFlow.ensureDeviceReady` to prefer `refs.targetWalletTypeRef.current` when choosing the adapter type, clears the ref during `resetState`, and adjusts `useDeviceEventHandlers` tests to include the new ref in mocked `HardwareWalletRefs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d445c8f9eb4c9b7dfbfaa139bbb354892c06db4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->