### PR TITLE
feat(networks): enhance form editability checks in NetworkDetailsView

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -105,6 +105,7 @@ const NetworkDetailsView = () => {
 
   const isActionDisabled =
     !formHook.enableAction ||
+    formHook.form.editable === false ||
     validation.disabledByChainId(formHook.form) ||
     validation.disabledBySymbol(formHook.form);
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/NetworkFormFields.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/NetworkFormFields.tsx
@@ -121,7 +121,7 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
   placeholderTextColor,
 }) => {
   const {
-    form: { nickname },
+    form: { nickname, editable },
     isAnyModalVisible,
     onNicknameChange,
     autoFillNameField,
@@ -144,7 +144,7 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
         autoCapitalize="none"
         autoCorrect={false}
         value={nickname}
-        isDisabled={isAnyModalVisible}
+        isDisabled={isAnyModalVisible || editable === false}
         onChangeText={onNicknameChange}
         placeholder={strings('app_settings.network_name_placeholder')}
         placeholderTextColor={placeholderTextColor}
@@ -200,7 +200,7 @@ const NetworkChainSymbolFields: React.FC<NetworkChainSymbolFieldsProps> = ({
   placeholderTextColor,
 }) => {
   const {
-    form: { chainId, ticker, addMode },
+    form: { chainId, ticker, addMode, editable },
     isAnyModalVisible,
     onChainIDChange,
     onTickerChange,
@@ -265,7 +265,7 @@ const NetworkChainSymbolFields: React.FC<NetworkChainSymbolFieldsProps> = ({
           autoCapitalize="none"
           autoCorrect={false}
           value={ticker}
-          isDisabled={isAnyModalVisible}
+          isDisabled={isAnyModalVisible || editable === false}
           onChangeText={onTickerChange}
           onBlur={handleSymbolBlur}
           onFocus={onSymbolFocused}

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.test.ts
@@ -112,6 +112,29 @@ describe('useNetworkForm', () => {
       expect(result.current.form.rpcUrl).toBe(
         'https://mainnet.infura.io/v3/key',
       );
+      // Built-in network (mainnet) is not editable regardless of entry point
+      expect(result.current.form.editable).toBe(false);
+    });
+
+    it('sets editable true when opened by RPC URL for non-built-in network', () => {
+      const customConfigs = {
+        '0x89': {
+          chainId: '0x89',
+          name: 'Polygon',
+          nativeCurrency: 'MATIC',
+          rpcEndpoints: [{ url: 'https://polygon-rpc.com', type: 'custom' }],
+          defaultRpcEndpointIndex: 0,
+          blockExplorerUrls: [],
+        },
+      };
+      mockUseSelector.mockReturnValue(customConfigs);
+
+      const { result } = renderHook(() =>
+        useNetworkForm({ network: 'https://polygon-rpc.com' }),
+      );
+
+      expect(result.current.form.addMode).toBe(false);
+      expect(result.current.form.nickname).toBe('Polygon');
       expect(result.current.form.editable).toBe(true);
     });
   });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
@@ -192,7 +192,16 @@ export const useNetworkForm = (
             );
           },
         );
-        editable = true;
+        // Use same rules as network selector: built-in networks are not editable
+        const builtInChainIds = allNetworks
+          .map(
+            (net) =>
+              (Networks as Record<string, { chainId?: string }>)[net]?.chainId,
+          )
+          .filter(Boolean) as string[];
+        editable =
+          !networkConfiguration?.chainId ||
+          !builtInChainIds.includes(networkConfiguration.chainId);
       }
 
       const chainId = networkConfiguration?.chainId;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Bug fix:** When editing a custom network (e.g. one added from Popular networks like zkSync Era) and tapping Save, nothing happened. The cause was passing `replacementSelectedRpcEndpointIndex: -1` to `NetworkController.updateNetwork` when URL normalization (e.g. http → https) made the form RPC URL not match any entry in `rpcEndpoints`, so the controller rejected the update.

- **useNetworkOperations**: Compute a valid index by trying both corrected and original RPC URL; if neither matches, use `selectedRpcEndpointIndex` from the form (clamped to a valid range). Only pass `replacementSelectedRpcEndpointIndex` when it is ≥ 0.

**UX improvement:** In Networks Management, for networks with multiple RPC URLs, tapping the RPC URL or the down arrow previously opened network details. It now opens the same RPC selection bottom sheet as in the Network Selector. Choosing an RPC updates the default RPC for that network and closes the sheet (no active network switch, no navigation).

- **RpcSelectionModal**: Added optional `onRpcSelectCustom` callback. When provided (e.g. from Networks Management), the modal calls it and closes instead of switching active network and navigating to wallet.
- **NetworksManagementView**: Renders `RpcSelectionModal`, wires `onTextClick` on the network cell (when `hasMultipleRpcs`) to open it, and passes `onRpcSelectCustom` that updates `defaultRpcEndpointIndex` via `NetworkController.updateNetwork`.

**Tests:** RpcSelectionModal test for `onRpcSelectCustom` path; useNetworkOperations test that the update path passes a valid `replacementSelectedRpcEndpointIndex`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed saving network details for custom networks (e.g. added from Popular list) when the Save button had no effect

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-531
https://consensyssoftware.atlassian.net/browse/TMCU-530

## **Manual testing steps**

```gherkin
Feature: Network details save and RPC selection in Networks Management

  Scenario: Save works for custom network (e.g. zkSync Era) after editing name
    Given the user has added a network from Popular networks (e.g. zkSync Era)
    When the user opens that network in Network details and changes the network name
    And the user taps Save
    Then the network name is updated and the user is taken back as expected

  Scenario: Multiple RPCs – tapping RPC URL/arrow opens RPC selection sheet
    Given the user has a network with more than one RPC URL (e.g. Ethereum Mainnet with multiple endpoints)
    When the user is on Settings → Networks (Networks Management)
    And the user taps the RPC URL or down arrow for that network
    Then the RPC selection bottom sheet opens (same as in Network Selector)
    And the user can select a different RPC; the default updates and the sheet closes
    And the user remains on Networks Management (no navigation to wallet)

  Scenario: Tapping the main row still opens network details
    Given the user is on Settings → Networks
    When the user taps the network name/row (not the RPC URL area)
    Then the Network details screen opens as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/47fb2146-730b-48a7-a2a9-5e8daadd63f7


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/36299d69-a982-4b3d-a2f1-9d2118d54005


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the editability gating for network details, which can disable Save and inputs if a network is classified as built-in; misclassification would block editing but does not impact security or funds.
> 
> **Overview**
> **Network Details editability is now consistently enforced.** `NetworkDetailsView` disables the Save action when `form.editable === false`, and the Network Name/Symbol inputs are also disabled when the network is non-editable.
> 
> `useNetworkForm` now determines `editable` for RPC-URL entry points by checking whether the matched network’s `chainId` is one of the built-in networks (mirroring the network selector rules), and tests were updated/added to cover built-in vs custom networks opened via RPC URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 037a1a2bc740ce94466426db3fd783d3b19ac886. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->