### PR TITLE
test(component-view): add empty state and retry tests for TrendingView

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -198,6 +198,79 @@ describeForPlatforms('TrendingTokensFullView - Component Tests', () => {
   });
 
   itForPlatforms(
+    'displays empty state when trending API returns no tokens on full view',
+    async () => {
+      let callCount = 0;
+      getTrendingTokensMock.mockImplementation(async () => {
+        callCount += 1;
+        return callCount === 1 ? mockTrendingTokensData : [];
+      });
+
+      const { findByTestId, getByTestId } = renderTrendingViewWithRoutes();
+
+      await waitFor(() => {
+        expect(
+          getByTestId(TrendingViewSelectorsIDs.TRENDING_FEED_SCROLL_VIEW),
+        ).toBeOnTheScreen();
+      });
+
+      const viewAllButton = getByTestId('section-header-view-all-tokens');
+      fireEvent.press(viewAllButton);
+
+      await waitFor(() => {
+        expect(getByTestId('trending-tokens-header')).toBeOnTheScreen();
+      });
+
+      const emptyState = await findByTestId('empty-error-trending-state');
+      expect(emptyState).toBeOnTheScreen();
+    },
+  );
+
+  itForPlatforms(
+    'user sees tokens after retrying from empty state',
+    async () => {
+      let callCount = 0;
+      getTrendingTokensMock.mockImplementation(async () => {
+        callCount += 1;
+        return callCount === 1 ? mockTrendingTokensData : [];
+      });
+
+      const { findByTestId, getByTestId } = renderTrendingViewWithRoutes();
+
+      await waitFor(() => {
+        expect(
+          getByTestId(TrendingViewSelectorsIDs.TRENDING_FEED_SCROLL_VIEW),
+        ).toBeOnTheScreen();
+      });
+
+      const viewAllButton = getByTestId('section-header-view-all-tokens');
+      fireEvent.press(viewAllButton);
+
+      const emptyState = await findByTestId('empty-error-trending-state');
+      expect(emptyState).toBeOnTheScreen();
+
+      getTrendingTokensMock.mockResolvedValue(mockTrendingTokensData);
+
+      const retryButton = getByTestId(
+        'empty-error-trending-state--retry-button',
+      );
+      fireEvent.press(retryButton);
+
+      await waitFor(
+        async () => {
+          const ethereumRow = await findByTestId(
+            'trending-token-row-item-eip155:1/erc20:0x0000000000000000000000000000000000000000',
+          );
+          expect(ethereumRow).toBeOnTheScreen();
+          const scope = within(ethereumRow);
+          expect(scope.getByText('Ethereum')).toBeOnTheScreen();
+        },
+        { timeout: 3000 },
+      );
+    },
+  );
+
+  itForPlatforms(
     'displays only BNB tokens when BNB Chain network filter is selected',
     async () => {
       getTrendingTokensMock.mockImplementation(


### PR DESCRIPTION
## Summary
- Adds component view test for empty state when trending API returns no tokens on full view
- Adds component view test for retry flow from empty state back to token list

## Test plan
- [ ] Run `yarn test:view:one app/components/Views/TrendingView/TrendingView.view.test.tsx`
- [ ] Both new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage for an existing empty/error UI state and retry behavior, with no production logic modifications.
> 
> **Overview**
> Adds new `TrendingTokensFullView` component-view coverage to assert an *empty state* is shown when the trending API returns an empty token list.
> 
> Also adds a retry-flow test that simulates the API returning data after an initial empty response and verifies the token list re-renders after pressing the empty-state retry button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb19cec606f086f3dfcfe39d33004362dcabee43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->