### PR TITLE
fix(TMCU-499): fire Ramps Button Clicked event on token empty state Buy

### DIFF
--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.test.tsx
@@ -7,6 +7,7 @@ import { TokenDetailsSource } from '../../../../../UI/TokenDetails/constants/con
 
 const mockNavigate = jest.fn();
 const mockGoToBuy = jest.fn();
+const mockTrackBuyButtonClicked = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -21,6 +22,12 @@ jest.mock('@react-navigation/native', () => {
 jest.mock('../../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: () => ({
     goToBuy: mockGoToBuy,
+  }),
+}));
+
+jest.mock('../hooks', () => ({
+  useRampsButtonClickedEvent: () => ({
+    trackBuyButtonClicked: mockTrackBuyButtonClicked,
   }),
 }));
 
@@ -248,6 +255,16 @@ describe('PopularTokenRow', () => {
       expect(mockGoToBuy).toHaveBeenCalledWith({
         assetId: 'eip155:1/erc20:0x1234567890abcdef1234567890abcdef12345678',
       });
+    });
+
+    it('fires Ramps Button Clicked analytics event when Buy is pressed', () => {
+      const token = createMockToken();
+
+      renderWithProvider(<PopularTokenRow token={token} />);
+
+      fireEvent.press(screen.getByText('Buy'));
+
+      expect(mockTrackBuyButtonClicked).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.tsx
@@ -27,6 +27,7 @@ import { useRampNavigation } from '../../../../../UI/Ramp/hooks/useRampNavigatio
 import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
 import { strings } from '../../../../../../../locales/i18n';
 import type { PopularToken } from '../hooks/usePopularTokens';
+import { useRampsButtonClickedEvent } from '../hooks';
 import { TokenDetailsSource } from '../../../../../UI/TokenDetails/constants/constants';
 
 // Zero address used for native EVM tokens (ETH, BNB, etc.)
@@ -145,6 +146,7 @@ const formatPercentageChange = (
 const PopularTokenRow: React.FC<PopularTokenRowProps> = ({ token }) => {
   const navigation = useNavigation();
   const { goToBuy } = useRampNavigation();
+  const { trackBuyButtonClicked } = useRampsButtonClickedEvent();
   const currentCurrency = useSelector(selectCurrentCurrency);
 
   const handleRowPress = useCallback(() => {
@@ -165,8 +167,9 @@ const PopularTokenRow: React.FC<PopularTokenRowProps> = ({ token }) => {
   }, [navigation, token.assetId, token.symbol]);
 
   const handleBuy = useCallback(() => {
+    trackBuyButtonClicked();
     goToBuy({ assetId: token.assetId });
-  }, [goToBuy, token.assetId]);
+  }, [trackBuyButtonClicked, goToBuy, token.assetId]);
 
   const priceDisplay = useMemo(() => {
     if (token.price === undefined) {

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/index.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useIsZeroBalanceAccount } from './useIsZeroBalanceAccount';
 export { usePopularTokens } from './usePopularTokens';
 export type { PopularToken } from './usePopularTokens';
+export { useRampsButtonClickedEvent } from './useRampsButtonClickedEvent';

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.test.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.test.ts
@@ -1,0 +1,137 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useRampsButtonClickedEvent } from './useRampsButtonClickedEvent';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn().mockReturnThis();
+const mockBuild = jest.fn().mockReturnValue({ event: 'built' });
+const mockCreateEventBuilder = jest.fn(() => ({
+  addProperties: mockAddProperties,
+  build: mockBuild,
+}));
+
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+const mockUseRampsButtonClickData = jest.fn();
+jest.mock('../../../../../UI/Ramp/hooks/useRampsButtonClickData', () => ({
+  useRampsButtonClickData: () => mockUseRampsButtonClickData(),
+}));
+
+const mockUseRampsUnifiedV1Enabled = jest.fn();
+jest.mock('../../../../../UI/Ramp/hooks/useRampsUnifiedV1Enabled', () => ({
+  __esModule: true,
+  default: () => mockUseRampsUnifiedV1Enabled(),
+}));
+
+const mockUseRampsUnifiedV2Enabled = jest.fn();
+jest.mock('../../../../../UI/Ramp/hooks/useRampsUnifiedV2Enabled', () => ({
+  __esModule: true,
+  default: () => mockUseRampsUnifiedV2Enabled(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector: (...args: unknown[]) => unknown) =>
+    selector({} as never),
+  ),
+}));
+
+jest.mock('../../../../../../reducers/fiatOrders', () => ({
+  getDetectedGeolocation: () => 'US',
+}));
+
+const defaultButtonClickData = {
+  ramp_routing: 'SMART_ROUTING' as const,
+  is_authenticated: false,
+  preferred_provider: undefined,
+  order_count: 0,
+};
+
+describe('useRampsButtonClickedEvent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRampsButtonClickData.mockReturnValue(defaultButtonClickData);
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
+    mockUseRampsUnifiedV2Enabled.mockReturnValue(false);
+  });
+
+  it('fires RAMPS_BUTTON_CLICKED with ramp_type BUY when both unified flags are off', () => {
+    const { result } = renderHook(() => useRampsButtonClickedEvent());
+
+    act(() => {
+      result.current.trackBuyButtonClicked();
+    });
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.RAMPS_BUTTON_CLICKED,
+    );
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      button_text: 'Buy',
+      location: 'TokensSection',
+      ramp_type: 'BUY',
+      region: 'US',
+      ramp_routing: 'SMART_ROUTING',
+      is_authenticated: false,
+      preferred_provider: undefined,
+      order_count: 0,
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith({ event: 'built' });
+  });
+
+  it('fires with ramp_type UNIFIED_BUY when V1 is enabled', () => {
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(true);
+
+    const { result } = renderHook(() => useRampsButtonClickedEvent());
+
+    act(() => {
+      result.current.trackBuyButtonClicked();
+    });
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ ramp_type: 'UNIFIED_BUY' }),
+    );
+  });
+
+  it('fires with ramp_type UNIFIED_BUY_2 when V2 is enabled', () => {
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(true);
+    mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
+
+    const { result } = renderHook(() => useRampsButtonClickedEvent());
+
+    act(() => {
+      result.current.trackBuyButtonClicked();
+    });
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ ramp_type: 'UNIFIED_BUY_2' }),
+    );
+  });
+
+  it('includes authentication and order data from useRampsButtonClickData', () => {
+    mockUseRampsButtonClickData.mockReturnValue({
+      ramp_routing: undefined,
+      is_authenticated: true,
+      preferred_provider: 'transak',
+      order_count: 3,
+    });
+
+    const { result } = renderHook(() => useRampsButtonClickedEvent());
+
+    act(() => {
+      result.current.trackBuyButtonClicked();
+    });
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        is_authenticated: true,
+        preferred_provider: 'transak',
+        order_count: 3,
+        ramp_routing: undefined,
+      }),
+    );
+  });
+});

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { useRampsButtonClickData } from '../../../../../UI/Ramp/hooks/useRampsButtonClickData';
+import useRampsUnifiedV1Enabled from '../../../../../UI/Ramp/hooks/useRampsUnifiedV1Enabled';
+import useRampsUnifiedV2Enabled from '../../../../../UI/Ramp/hooks/useRampsUnifiedV2Enabled';
+import { getDetectedGeolocation } from '../../../../../../reducers/fiatOrders';
+
+/**
+ * Encapsulates the `Ramps Button Clicked` analytics event for the
+ * Tokens Section empty state. Feature-flag-dependent properties
+ * (ramp_type) are resolved internally so callers only need to invoke
+ * the returned callback.
+ */
+export const useRampsButtonClickedEvent = () => {
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const buttonClickData = useRampsButtonClickData();
+  const rampUnifiedV1Enabled = useRampsUnifiedV1Enabled();
+  const isV2UnifiedEnabled = useRampsUnifiedV2Enabled();
+  const region = useSelector(getDetectedGeolocation);
+
+  const trackBuyButtonClicked = useCallback(() => {
+    const rampType = isV2UnifiedEnabled
+      ? 'UNIFIED_BUY_2'
+      : rampUnifiedV1Enabled
+        ? 'UNIFIED_BUY'
+        : 'BUY';
+
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_BUTTON_CLICKED)
+        .addProperties({
+          button_text: 'Buy',
+          location: 'TokensSection',
+          ramp_type: rampType,
+          region,
+          ramp_routing: buttonClickData.ramp_routing,
+          is_authenticated: buttonClickData.is_authenticated,
+          preferred_provider: buttonClickData.preferred_provider,
+          order_count: buttonClickData.order_count,
+        })
+        .build(),
+    );
+  }, [
+    trackEvent,
+    createEventBuilder,
+    isV2UnifiedEnabled,
+    rampUnifiedV1Enabled,
+    region,
+    buttonClickData,
+  ]);
+
+  return { trackBuyButtonClicked };
+};


### PR DESCRIPTION
## **Description**

When a user taps "Buy" on the empty state token row (`PopularTokenRow`), the `Ramps Button Clicked` analytics event was not being fired. This PR adds a `useRampsButtonClickedEvent` hook that encapsulates all the required event properties -- including feature-flag-dependent `ramp_type` (BUY / UNIFIED_BUY / UNIFIED_BUY_2), authentication status, order count, ramp routing, and geolocation region -- following the same pattern used by `BalanceEmptyState` and `FundActionMenu`.

The hook is placed in the Tokens Section hooks folder since the event property values depend on feature flags that may change independently.

## **Changelog**

CHANGELOG entry: Fixed missing Ramps Button Clicked analytics event when tapping Buy on the homepage token empty state

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-499

## **Manual testing steps**

```gherkin
Feature: Ramps Button Clicked analytics on token empty state

  Scenario: user taps Buy on a popular token row
    Given user has a zero-balance account on the homepage
    And the Tokens section shows popular tokens with Buy buttons

    When user taps the Buy button on any token row
    Then the Ramps Button Clicked event fires with correct properties
    And the buy flow opens normally
```

## **Screenshots/Recordings**

N/A -- no UI changes, analytics-only fix.

### **Before**

Tapping Buy on the empty state token row did not fire the `Ramps Button Clicked` event.

### **After**

Tapping Buy fires `Ramps Button Clicked` with `button_text`, `location`, `ramp_type`, `region`, `ramp_routing`, `is_authenticated`, `preferred_provider`, and `order_count`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to emitting an additional analytics event on the Tokens empty-state Buy action and adding unit tests, with no changes to the buy navigation flow.
> 
> **Overview**
> Fixes missing `RAMPS_BUTTON_CLICKED` analytics when tapping **Buy** on the homepage Tokens empty-state row by calling a new `useRampsButtonClickedEvent` hook before `goToBuy`.
> 
> Adds `useRampsButtonClickedEvent` to encapsulate event building (including feature-flag-driven `ramp_type`, region, and ramp/auth/order properties), exports it from the Tokens hooks index, and introduces unit tests for both the hook and the `PopularTokenRow` buy interaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e8fe70809bfdc6df405aecb220c6416f1425e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->