### PR TITLE
test: simplify the input in order to avoid flakiness

### DIFF
--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -57,7 +57,17 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         const domain = 'metamask.domain';
         await RedesignedSendView.enterZeroAmount();
         await RedesignedSendView.pressContinueButton();
-        await RedesignedSendView.inputRecipientAddress(domain);
+
+        // Manually replacing the test to avoid flakiness from the '\n' input
+        // added to the end of the text to hide the keyboard
+        await Gestures.replaceText(
+          RedesignedSendView.recipientAddressInput,
+          domain,
+          {
+            elemDescription: 'Enter recipient address',
+          },
+        );
+
         await RedesignedSendView.pressReviewButton();
         await TransactionConfirmView.tapAdvancedDetails();
 
@@ -66,6 +76,10 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
             domain,
             device.getPlatform() === 'ios' ? 1 : 0,
           ),
+          {
+            elemDescription: 'Recipient address',
+            delay: 1000, // There's a animation that can cause flakiness
+          },
         );
 
         await Assertions.expectTextDisplayed(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR aims to fix a flaky flask test where flakiness was being caused by the framework and the way `typeText` is implemented.
Because this change is only affecting this flask test for now, the change was done one the test itself and not on the page object until the actual root cause is found.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an E2E smoke test, adjusting input/tap timing to reduce flakiness without affecting app runtime behavior.
> 
> **Overview**
> Improves stability of the name-lookup snap smoke test by replacing `RedesignedSendView.inputRecipientAddress()` with a direct `Gestures.replaceText()` to avoid flaky newline/keyboard behavior.
> 
> Adds explicit gesture metadata and a 1s delayed `waitAndTap` when selecting the recipient domain in advanced details to reduce animation-related flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d72450d456a7b33500888d0e2d2d6bb9c133a70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->