### PR TITLE
feat: connect page trust signals

### DIFF
--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.test.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.test.tsx
@@ -3,12 +3,17 @@ import { render } from '@testing-library/react-native';
 import {
   MaliciousDappUrlIcon,
   DangerConnectButtonContent,
+  WarningConnectButtonContent,
+  TrustSignalUrlIcon,
+  getConnectButtonContent,
 } from './MaliciousDappIndicators';
+import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSignals';
 
 jest.mock('../../../util/theme', () => ({
   useTheme: () => ({
     colors: {
       primary: { inverse: '#FFFFFF' },
+      error: { inverse: '#FFFFFF' },
     },
   }),
 }));
@@ -40,6 +45,117 @@ describe('MaliciousDappIndicators', () => {
       const root = toJSON();
       const node = Array.isArray(root) ? root[0] : root;
       expect(node?.props?.style?.flexDirection).toBe('row');
+    });
+  });
+
+  describe('WarningConnectButtonContent', () => {
+    it('renders the Connect label', () => {
+      const { getByText } = render(<WarningConnectButtonContent />);
+      expect(getByText('Connect')).toBeDefined();
+    });
+
+    it('renders a Danger icon alongside the label', () => {
+      const { toJSON } = render(<WarningConnectButtonContent />);
+      const tree = JSON.stringify(toJSON());
+      expect(tree).toContain('Danger');
+      expect(tree).toContain('Connect');
+    });
+  });
+
+  describe('TrustSignalUrlIcon', () => {
+    it('renders a VerifiedFilled icon for Verified state', () => {
+      const { toJSON } = render(
+        <TrustSignalUrlIcon state={TrustSignalDisplayState.Verified} />,
+      );
+      const tree = JSON.stringify(toJSON());
+      expect(tree).toContain('VerifiedFilled');
+    });
+
+    it('renders a Warning icon for Warning state', () => {
+      const { toJSON } = render(
+        <TrustSignalUrlIcon state={TrustSignalDisplayState.Warning} />,
+      );
+      const tree = JSON.stringify(toJSON());
+      expect(tree).toContain('Warning');
+    });
+
+    it('renders a Danger icon for Malicious state', () => {
+      const { toJSON } = render(
+        <TrustSignalUrlIcon state={TrustSignalDisplayState.Malicious} />,
+      );
+      const tree = JSON.stringify(toJSON());
+      expect(tree).toContain('Danger');
+    });
+
+    it('renders nothing for Unknown state', () => {
+      const { toJSON } = render(
+        <TrustSignalUrlIcon state={TrustSignalDisplayState.Unknown} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+
+    it('renders nothing for Loading state', () => {
+      const { toJSON } = render(
+        <TrustSignalUrlIcon state={TrustSignalDisplayState.Loading} />,
+      );
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe('getConnectButtonContent', () => {
+    it('returns DangerConnectButtonContent when isMaliciousDapp is true', () => {
+      const result = getConnectButtonContent(true, false);
+      expect(result).toBeDefined();
+      // It should return a React element (DangerConnectButtonContent)
+      expect(React.isValidElement(result)).toBe(true);
+    });
+
+    it('returns DangerConnectButtonContent when trustSignalState is Malicious', () => {
+      const result = getConnectButtonContent(
+        false,
+        false,
+        TrustSignalDisplayState.Malicious,
+      );
+      expect(React.isValidElement(result)).toBe(true);
+    });
+
+    it('returns WarningConnectButtonContent when trustSignalState is Warning', () => {
+      const result = getConnectButtonContent(
+        false,
+        false,
+        TrustSignalDisplayState.Warning,
+      );
+      expect(React.isValidElement(result)).toBe(true);
+    });
+
+    it('returns plain "Connect" string when trustSignalState is Unknown', () => {
+      const result = getConnectButtonContent(
+        false,
+        false,
+        TrustSignalDisplayState.Unknown,
+      );
+      expect(typeof result).toBe('string');
+      expect(result).toBe('Connect');
+    });
+
+    it('returns plain "Connect" string when trustSignalState is Verified', () => {
+      const result = getConnectButtonContent(
+        false,
+        false,
+        TrustSignalDisplayState.Verified,
+      );
+      expect(typeof result).toBe('string');
+      expect(result).toBe('Connect');
+    });
+
+    it('returns confirm string for network switch regardless of trust signal', () => {
+      const result = getConnectButtonContent(
+        false,
+        true,
+        TrustSignalDisplayState.Malicious,
+      );
+      expect(typeof result).toBe('string');
+      expect(result).toBe('Confirm');
     });
   });
 });

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.test.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.test.tsx
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react-native';
 import {
   MaliciousDappUrlIcon,
   DangerConnectButtonContent,
-  WarningConnectButtonContent,
   TrustSignalUrlIcon,
   getConnectButtonContent,
 } from './MaliciousDappIndicators';
@@ -13,7 +12,6 @@ jest.mock('../../../util/theme', () => ({
   useTheme: () => ({
     colors: {
       primary: { inverse: '#FFFFFF' },
-      error: { inverse: '#FFFFFF' },
     },
   }),
 }));
@@ -48,20 +46,6 @@ describe('MaliciousDappIndicators', () => {
     });
   });
 
-  describe('WarningConnectButtonContent', () => {
-    it('renders the Connect label', () => {
-      const { getByText } = render(<WarningConnectButtonContent />);
-      expect(getByText('Connect')).toBeDefined();
-    });
-
-    it('renders a Danger icon alongside the label', () => {
-      const { toJSON } = render(<WarningConnectButtonContent />);
-      const tree = JSON.stringify(toJSON());
-      expect(tree).toContain('Danger');
-      expect(tree).toContain('Connect');
-    });
-  });
-
   describe('TrustSignalUrlIcon', () => {
     it('renders a VerifiedFilled icon for Verified state', () => {
       const { toJSON } = render(
@@ -71,20 +55,19 @@ describe('MaliciousDappIndicators', () => {
       expect(tree).toContain('VerifiedFilled');
     });
 
-    it('renders a Warning icon for Warning state', () => {
-      const { toJSON } = render(
-        <TrustSignalUrlIcon state={TrustSignalDisplayState.Warning} />,
-      );
-      const tree = JSON.stringify(toJSON());
-      expect(tree).toContain('Warning');
-    });
-
     it('renders a Danger icon for Malicious state', () => {
       const { toJSON } = render(
         <TrustSignalUrlIcon state={TrustSignalDisplayState.Malicious} />,
       );
       const tree = JSON.stringify(toJSON());
       expect(tree).toContain('Danger');
+    });
+
+    it('renders nothing for Warning state', () => {
+      const { toJSON } = render(
+        <TrustSignalUrlIcon state={TrustSignalDisplayState.Warning} />,
+      );
+      expect(toJSON()).toBeNull();
     });
 
     it('renders nothing for Unknown state', () => {
@@ -105,8 +88,6 @@ describe('MaliciousDappIndicators', () => {
   describe('getConnectButtonContent', () => {
     it('returns DangerConnectButtonContent when isMaliciousDapp is true', () => {
       const result = getConnectButtonContent(true, false);
-      expect(result).toBeDefined();
-      // It should return a React element (DangerConnectButtonContent)
       expect(React.isValidElement(result)).toBe(true);
     });
 
@@ -119,13 +100,14 @@ describe('MaliciousDappIndicators', () => {
       expect(React.isValidElement(result)).toBe(true);
     });
 
-    it('returns WarningConnectButtonContent when trustSignalState is Warning', () => {
+    it('returns plain "Connect" string when trustSignalState is Warning', () => {
       const result = getConnectButtonContent(
         false,
         false,
         TrustSignalDisplayState.Warning,
       );
-      expect(React.isValidElement(result)).toBe(true);
+      expect(typeof result).toBe('string');
+      expect(result).toBe('Connect');
     });
 
     it('returns plain "Connect" string when trustSignalState is Unknown', () => {

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
@@ -11,7 +11,7 @@ import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSi
 
 const styles = StyleSheet.create({
   urlIcon: {
-    marginTop: 2,
+    marginTop: 1,
     alignSelf: 'center',
   },
   buttonContent: {

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
@@ -58,15 +58,6 @@ export const TrustSignalUrlIcon = ({
           style={styles.urlIcon}
         />
       );
-    case TrustSignalDisplayState.Warning:
-      return (
-        <Icon
-          name={IconName.Warning}
-          size={IconSize.Sm}
-          color={IconColor.Warning}
-          style={styles.urlIcon}
-        />
-      );
     case TrustSignalDisplayState.Malicious:
       return (
         <Icon
@@ -103,27 +94,6 @@ export const DangerConnectButtonContent = () => {
 };
 
 /**
- * Content for the warning "Connect" button when a dapp has a warning-level
- * trust signal. Renders a danger triangle to the left of the "Connect" label.
- */
-export const WarningConnectButtonContent = () => {
-  const { colors } = useTheme();
-
-  return (
-    <View style={styles.buttonContent}>
-      <Icon
-        name={IconName.Danger}
-        size={IconSize.Sm}
-        color={IconColor.Inverse}
-      />
-      <RNText style={[styles.buttonText, { color: colors.primary.inverse }]}>
-        {strings('accounts.connect')}
-      </RNText>
-    </View>
-  );
-};
-
-/**
  * Returns the appropriate label for the confirm/connect button based on
  * whether the dApp is malicious and whether this is a network switch.
  */
@@ -140,9 +110,6 @@ export const getConnectButtonContent = (
   }
   if (trustSignalState === TrustSignalDisplayState.Malicious) {
     return <DangerConnectButtonContent />;
-  }
-  if (trustSignalState === TrustSignalDisplayState.Warning) {
-    return <WarningConnectButtonContent />;
   }
   return strings('accounts.connect');
 };

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
@@ -7,6 +7,7 @@ import Icon, {
 } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
+import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSignals';
 
 const styles = StyleSheet.create({
   urlIcon: {
@@ -40,10 +41,72 @@ export const MaliciousDappUrlIcon = () => (
 );
 
 /**
+ * Icon displayed next to the dapp hostname based on the trust signal state.
+ */
+export const TrustSignalUrlIcon = ({
+  state,
+}: {
+  state: TrustSignalDisplayState;
+}) => {
+  switch (state) {
+    case TrustSignalDisplayState.Verified:
+      return (
+        <Icon
+          name={IconName.VerifiedFilled}
+          size={IconSize.Sm}
+          color={IconColor.Success}
+          style={styles.urlIcon}
+        />
+      );
+    case TrustSignalDisplayState.Warning:
+      return (
+        <Icon
+          name={IconName.Warning}
+          size={IconSize.Sm}
+          color={IconColor.Warning}
+          style={styles.urlIcon}
+        />
+      );
+    case TrustSignalDisplayState.Malicious:
+      return (
+        <Icon
+          name={IconName.Danger}
+          size={IconSize.Sm}
+          color={IconColor.Error}
+          style={styles.urlIcon}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+/**
  * Content for the red "Connect" button on Step 1 of the malicious-dapp
  * warning flow.  Renders a danger triangle to the left of the "Connect" label.
  */
 export const DangerConnectButtonContent = () => {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.buttonContent}>
+      <Icon
+        name={IconName.Danger}
+        size={IconSize.Sm}
+        color={IconColor.Inverse}
+      />
+      <RNText style={[styles.buttonText, { color: colors.primary.inverse }]}>
+        {strings('accounts.connect')}
+      </RNText>
+    </View>
+  );
+};
+
+/**
+ * Content for the warning "Connect" button when a dapp has a warning-level
+ * trust signal. Renders a danger triangle to the left of the "Connect" label.
+ */
+export const WarningConnectButtonContent = () => {
   const { colors } = useTheme();
 
   return (
@@ -67,12 +130,19 @@ export const DangerConnectButtonContent = () => {
 export const getConnectButtonContent = (
   isMaliciousDapp: boolean,
   isNetworkSwitch: boolean,
+  trustSignalState?: TrustSignalDisplayState,
 ): React.ReactNode => {
-  if (isMaliciousDapp && !isNetworkSwitch) {
-    return <DangerConnectButtonContent />;
-  }
   if (isNetworkSwitch) {
     return strings('confirmation_modal.confirm_cta');
+  }
+  if (isMaliciousDapp) {
+    return <DangerConnectButtonContent />;
+  }
+  if (trustSignalState === TrustSignalDisplayState.Malicious) {
+    return <DangerConnectButtonContent />;
+  }
+  if (trustSignalState === TrustSignalDisplayState.Warning) {
+    return <WarningConnectButtonContent />;
   }
   return strings('accounts.connect');
 };

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
@@ -105,11 +105,12 @@ export const getConnectButtonContent = (
   if (isNetworkSwitch) {
     return strings('confirmation_modal.confirm_cta');
   }
-  if (isMaliciousDapp) {
+  if (
+    isMaliciousDapp ||
+    trustSignalState === TrustSignalDisplayState.Malicious
+  ) {
     return <DangerConnectButtonContent />;
   }
-  if (trustSignalState === TrustSignalDisplayState.Malicious) {
-    return <DangerConnectButtonContent />;
-  }
+
   return strings('accounts.connect');
 };

--- a/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
+++ b/app/components/UI/PermissionsSummary/MaliciousDappIndicators.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { StyleSheet, Text as RNText, View } from 'react-native';
-import Icon, {
+import { StyleSheet, View } from 'react-native';
+import {
+  Icon,
   IconColor,
   IconName,
   IconSize,
-} from '../../../component-library/components/Icons/Icon';
+  Text,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
-import { useTheme } from '../../../util/theme';
 import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSignals';
 
 const styles = StyleSheet.create({
@@ -35,7 +37,7 @@ export const MaliciousDappUrlIcon = () => (
   <Icon
     name={IconName.Danger}
     size={IconSize.Sm}
-    color={IconColor.Error}
+    color={IconColor.ErrorDefault}
     style={styles.urlIcon}
   />
 );
@@ -54,7 +56,7 @@ export const TrustSignalUrlIcon = ({
         <Icon
           name={IconName.VerifiedFilled}
           size={IconSize.Sm}
-          color={IconColor.Success}
+          color={IconColor.SuccessDefault}
           style={styles.urlIcon}
         />
       );
@@ -63,7 +65,7 @@ export const TrustSignalUrlIcon = ({
         <Icon
           name={IconName.Danger}
           size={IconSize.Sm}
-          color={IconColor.Error}
+          color={IconColor.ErrorDefault}
           style={styles.urlIcon}
         />
       );
@@ -76,22 +78,18 @@ export const TrustSignalUrlIcon = ({
  * Content for the red "Connect" button on Step 1 of the malicious-dapp
  * warning flow.  Renders a danger triangle to the left of the "Connect" label.
  */
-export const DangerConnectButtonContent = () => {
-  const { colors } = useTheme();
-
-  return (
-    <View style={styles.buttonContent}>
-      <Icon
-        name={IconName.Danger}
-        size={IconSize.Sm}
-        color={IconColor.Inverse}
-      />
-      <RNText style={[styles.buttonText, { color: colors.primary.inverse }]}>
-        {strings('accounts.connect')}
-      </RNText>
-    </View>
-  );
-};
+export const DangerConnectButtonContent = () => (
+  <View style={styles.buttonContent}>
+    <Icon
+      name={IconName.Danger}
+      size={IconSize.Sm}
+      color={IconColor.PrimaryInverse}
+    />
+    <Text color={TextColor.PrimaryInverse} style={styles.buttonText}>
+      {strings('accounts.connect')}
+    </Text>
+  </View>
+);
 
 /**
  * Returns the appropriate label for the confirm/connect button based on

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
@@ -217,15 +217,15 @@ describe('PermissionsSummary', () => {
   });
 
   describe('trustSignalState prop', () => {
-    it('renders a warning icon next to the URL when trustSignalState is Warning', () => {
+    it('renders no icon next to the URL when trustSignalState is Warning', () => {
       const { toJSON } = renderPermissionsSummary({
         trustSignalState: 'warning',
         isAlreadyConnected: false,
       });
 
       const tree = JSON.stringify(toJSON());
-      // The TrustSignalUrlIcon should render a Danger icon with warning color
-      expect(tree).toContain('Danger');
+      // Warning state no longer shows an icon
+      expect(tree).not.toContain('VerifiedFilled');
     });
 
     it('renders an error icon next to the URL when trustSignalState is Malicious', () => {
@@ -263,13 +263,13 @@ describe('PermissionsSummary', () => {
       expect(tree).not.toContain('urlIcon');
     });
 
-    it('renders a warning-style Connect button when trustSignalState is Warning', () => {
+    it('renders a standard Connect button when trustSignalState is Warning', () => {
       const { getByText } = renderPermissionsSummary({
         trustSignalState: 'warning',
         isAlreadyConnected: false,
       });
 
-      // The connect button text should still be present
+      // Warning state uses a plain connect button
       expect(getByText('Connect')).toBeDefined();
     });
 

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
@@ -270,7 +270,7 @@ describe('PermissionsSummary', () => {
       });
 
       // Warning state uses a plain connect button
-      expect(getByText('Connect')).toBeDefined();
+      expect(getByText('Connect')).toBeOnTheScreen();
     });
 
     it('renders a danger-style Connect button when trustSignalState is Malicious', () => {
@@ -280,7 +280,7 @@ describe('PermissionsSummary', () => {
       });
 
       // The connect button text should still be present
-      expect(getByText('Connect')).toBeDefined();
+      expect(getByText('Connect')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
@@ -215,4 +215,72 @@ describe('PermissionsSummary', () => {
       expect(tree).not.toContain('urlIcon');
     });
   });
+
+  describe('trustSignalState prop', () => {
+    it('renders a warning icon next to the URL when trustSignalState is Warning', () => {
+      const { toJSON } = renderPermissionsSummary({
+        trustSignalState: 'warning',
+        isAlreadyConnected: false,
+      });
+
+      const tree = JSON.stringify(toJSON());
+      // The TrustSignalUrlIcon should render a Danger icon with warning color
+      expect(tree).toContain('Danger');
+    });
+
+    it('renders an error icon next to the URL when trustSignalState is Malicious', () => {
+      const { toJSON } = renderPermissionsSummary({
+        trustSignalState: 'malicious',
+        isAlreadyConnected: false,
+      });
+
+      const tree = JSON.stringify(toJSON());
+      // The TrustSignalUrlIcon should render a Danger icon with error color
+      expect(tree).toContain('Danger');
+    });
+
+    it('renders a verified icon next to the URL when trustSignalState is Verified', () => {
+      const { toJSON } = renderPermissionsSummary({
+        trustSignalState: 'verified',
+        isAlreadyConnected: false,
+      });
+
+      const tree = JSON.stringify(toJSON());
+      // The TrustSignalUrlIcon should render a VerifiedFilled icon
+      expect(tree).toContain('VerifiedFilled');
+    });
+
+    it('does not render a trust signal icon when trustSignalState is Unknown', () => {
+      const { toJSON } = renderPermissionsSummary({
+        trustSignalState: 'unknown',
+        isAlreadyConnected: false,
+        isMaliciousDapp: false,
+      });
+
+      const tree = JSON.stringify(toJSON());
+      // Neither VerifiedFilled nor urlIcon should appear
+      expect(tree).not.toContain('VerifiedFilled');
+      expect(tree).not.toContain('urlIcon');
+    });
+
+    it('renders a warning-style Connect button when trustSignalState is Warning', () => {
+      const { getByText } = renderPermissionsSummary({
+        trustSignalState: 'warning',
+        isAlreadyConnected: false,
+      });
+
+      // The connect button text should still be present
+      expect(getByText('Connect')).toBeDefined();
+    });
+
+    it('renders a danger-style Connect button when trustSignalState is Malicious', () => {
+      const { getByText } = renderPermissionsSummary({
+        trustSignalState: 'malicious',
+        isAlreadyConnected: false,
+      });
+
+      // The connect button text should still be present
+      expect(getByText('Connect')).toBeDefined();
+    });
+  });
 });

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.test.tsx
@@ -10,6 +10,7 @@ import {
   AvatarSize,
   AvatarVariant,
 } from '../../../component-library/components/Avatars/Avatar/Avatar.types';
+import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSignals';
 
 const mockedNavigate = jest.fn();
 
@@ -219,7 +220,7 @@ describe('PermissionsSummary', () => {
   describe('trustSignalState prop', () => {
     it('renders no icon next to the URL when trustSignalState is Warning', () => {
       const { toJSON } = renderPermissionsSummary({
-        trustSignalState: 'warning',
+        trustSignalState: TrustSignalDisplayState.Warning,
         isAlreadyConnected: false,
       });
 
@@ -230,7 +231,7 @@ describe('PermissionsSummary', () => {
 
     it('renders an error icon next to the URL when trustSignalState is Malicious', () => {
       const { toJSON } = renderPermissionsSummary({
-        trustSignalState: 'malicious',
+        trustSignalState: TrustSignalDisplayState.Malicious,
         isAlreadyConnected: false,
       });
 
@@ -241,7 +242,7 @@ describe('PermissionsSummary', () => {
 
     it('renders a verified icon next to the URL when trustSignalState is Verified', () => {
       const { toJSON } = renderPermissionsSummary({
-        trustSignalState: 'verified',
+        trustSignalState: TrustSignalDisplayState.Verified,
         isAlreadyConnected: false,
       });
 
@@ -252,7 +253,7 @@ describe('PermissionsSummary', () => {
 
     it('does not render a trust signal icon when trustSignalState is Unknown', () => {
       const { toJSON } = renderPermissionsSummary({
-        trustSignalState: 'unknown',
+        trustSignalState: TrustSignalDisplayState.Unknown,
         isAlreadyConnected: false,
         isMaliciousDapp: false,
       });
@@ -265,7 +266,7 @@ describe('PermissionsSummary', () => {
 
     it('renders a standard Connect button when trustSignalState is Warning', () => {
       const { getByText } = renderPermissionsSummary({
-        trustSignalState: 'warning',
+        trustSignalState: TrustSignalDisplayState.Warning,
         isAlreadyConnected: false,
       });
 
@@ -275,7 +276,7 @@ describe('PermissionsSummary', () => {
 
     it('renders a danger-style Connect button when trustSignalState is Malicious', () => {
       const { getByText } = renderPermissionsSummary({
-        trustSignalState: 'malicious',
+        trustSignalState: TrustSignalDisplayState.Malicious,
         isAlreadyConnected: false,
       });
 

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -640,13 +640,11 @@ const PermissionsSummary = ({
               style={styles.connectionTitle}
               variant={TextVariant.HeadingMD}
               color={
-                isMaliciousDapp && !isAlreadyConnected
+                (isMaliciousDapp ||
+                  trustSignalState === TrustSignalDisplayState.Malicious) &&
+                !isAlreadyConnected
                   ? TextColor.Error
-                  : !isAlreadyConnected && trustSignalState === TrustSignalDisplayState.Warning
-                    ? TextColor.Warning
-                    : !isAlreadyConnected && trustSignalState === TrustSignalDisplayState.Malicious
-                      ? TextColor.Error
-                      : undefined
+                  : undefined
               }
             >
               {isNonDappNetworkSwitch
@@ -713,13 +711,10 @@ const PermissionsSummary = ({
               </StyledButton>
               <StyledButton
                 type={
-                  isMaliciousDapp
+                  isMaliciousDapp ||
+                  trustSignalState === TrustSignalDisplayState.Malicious
                     ? 'danger'
-                    : trustSignalState === TrustSignalDisplayState.Malicious
-                      ? 'danger'
-                      : trustSignalState === TrustSignalDisplayState.Warning
-                        ? 'warning'
-                        : 'confirm'
+                    : 'confirm'
                 }
                 onPress={confirm}
                 disabled={
@@ -732,7 +727,11 @@ const PermissionsSummary = ({
                 ]}
                 testID={CommonSelectorsIDs.CONNECT_BUTTON}
               >
-                {getConnectButtonContent(isMaliciousDapp, isNetworkSwitch, trustSignalState)}
+                {getConnectButtonContent(
+                  isMaliciousDapp,
+                  isNetworkSwitch,
+                  trustSignalState,
+                )}
               </StyledButton>
             </View>
           )}

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -108,7 +108,7 @@ const PermissionsSummary = ({
   showPermissionsOnly = false,
   promptToCreateSolanaAccount = false,
   isMaliciousDapp = false,
-  trustSignalState = TrustSignalDisplayState.Unknown,
+  trustSignalState,
 }: PermissionsSummaryProps) => {
   const nonTabView = showAccountsOnly || showPermissionsOnly;
   const fullNonTabView = showAccountsOnly && showPermissionsOnly;

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -37,8 +37,10 @@ import { useStyles } from '../../../component-library/hooks';
 import { PermissionsSummaryProps } from './PermissionsSummary.types';
 import {
   MaliciousDappUrlIcon,
+  TrustSignalUrlIcon,
   getConnectButtonContent,
 } from './MaliciousDappIndicators';
+import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSignals';
 import { USER_INTENT } from '../../../constants/permissions';
 import Routes from '../../../constants/navigation/Routes';
 import ButtonIcon, {
@@ -106,6 +108,7 @@ const PermissionsSummary = ({
   showPermissionsOnly = false,
   promptToCreateSolanaAccount = false,
   isMaliciousDapp = false,
+  trustSignalState = TrustSignalDisplayState.Unknown,
 }: PermissionsSummaryProps) => {
   const nonTabView = showAccountsOnly || showPermissionsOnly;
   const fullNonTabView = showAccountsOnly && showPermissionsOnly;
@@ -639,7 +642,11 @@ const PermissionsSummary = ({
               color={
                 isMaliciousDapp && !isAlreadyConnected
                   ? TextColor.Error
-                  : undefined
+                  : !isAlreadyConnected && trustSignalState === TrustSignalDisplayState.Warning
+                    ? TextColor.Warning
+                    : !isAlreadyConnected && trustSignalState === TrustSignalDisplayState.Malicious
+                      ? TextColor.Error
+                      : undefined
               }
             >
               {isNonDappNetworkSwitch
@@ -651,6 +658,9 @@ const PermissionsSummary = ({
                     })}
             </TextComponent>
             {isMaliciousDapp && !isAlreadyConnected && <MaliciousDappUrlIcon />}
+            {!isMaliciousDapp && !isAlreadyConnected && trustSignalState && (
+              <TrustSignalUrlIcon state={trustSignalState} />
+            )}
             <TextComponent variant={TextVariant.BodyMD}>
               {strings('account_dapp_connections.account_summary_header')}
             </TextComponent>
@@ -702,7 +712,15 @@ const PermissionsSummary = ({
                 {strings('permissions.cancel')}
               </StyledButton>
               <StyledButton
-                type={isMaliciousDapp ? 'danger' : 'confirm'}
+                type={
+                  isMaliciousDapp
+                    ? 'danger'
+                    : trustSignalState === TrustSignalDisplayState.Malicious
+                      ? 'danger'
+                      : trustSignalState === TrustSignalDisplayState.Warning
+                        ? 'warning'
+                        : 'confirm'
+                }
                 onPress={confirm}
                 disabled={
                   !isNetworkSwitch &&
@@ -714,7 +732,7 @@ const PermissionsSummary = ({
                 ]}
                 testID={CommonSelectorsIDs.CONNECT_BUTTON}
               >
-                {getConnectButtonContent(isMaliciousDapp, isNetworkSwitch)}
+                {getConnectButtonContent(isMaliciousDapp, isNetworkSwitch, trustSignalState)}
               </StyledButton>
             </View>
           )}

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.types.ts
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.types.ts
@@ -1,3 +1,4 @@
+import { TrustSignalDisplayState } from '../../Views/confirmations/types/trustSignals';
 import { CaipAccountId } from '@metamask/utils';
 import { USER_INTENT } from '../../../constants/permissions';
 import { Account, EnsByAccountAddress } from '../../hooks/useAccounts';
@@ -39,4 +40,5 @@ export interface PermissionsSummaryProps {
   showAccountsOnly?: boolean;
   promptToCreateSolanaAccount?: boolean;
   isMaliciousDapp?: boolean;
+  trustSignalState?: TrustSignalDisplayState;
 }

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -1433,7 +1433,7 @@ describe('AccountConnect', () => {
       });
     });
 
-    it('renders TrustSignalModal when trust signal state is Warning', () => {
+    it('renders PermissionsSummary (SingleConnect) when trust signal state is Warning', () => {
       mockUseOriginTrustSignals.mockReturnValue({
         state: TrustSignalDisplayState.Warning,
         label: 'Suspicious site',
@@ -1444,10 +1444,10 @@ describe('AccountConnect', () => {
         { state: mockInitialState },
       );
 
-      // TrustSignalModal should be visible
-      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
-      // PermissionsSummary should NOT be visible
-      expect(queryByTestId('permission-summary-container')).toBeNull();
+      // PermissionsSummary should be visible (Warning no longer gates)
+      expect(getByTestId('permission-summary-container')).toBeDefined();
+      // TrustSignalModal should NOT be visible
+      expect(queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeNull();
     });
 
     it('renders TrustSignalModal when trust signal state is Malicious', () => {
@@ -1503,8 +1503,8 @@ describe('AccountConnect', () => {
 
     it('navigates to SingleConnect when Connect Anyway is pressed on TrustSignalModal', async () => {
       mockUseOriginTrustSignals.mockReturnValue({
-        state: TrustSignalDisplayState.Warning,
-        label: 'Suspicious site',
+        state: TrustSignalDisplayState.Malicious,
+        label: 'Known malicious site',
       });
 
       const { getByTestId, findByTestId } = renderWithProvider(
@@ -1530,8 +1530,8 @@ describe('AccountConnect', () => {
 
     it('cancels permission request when Close is pressed on TrustSignalModal', () => {
       mockUseOriginTrustSignals.mockReturnValue({
-        state: TrustSignalDisplayState.Warning,
-        label: 'Suspicious site',
+        state: TrustSignalDisplayState.Malicious,
+        label: 'Known malicious site',
       });
 
       const { getByTestId } = renderWithProvider(

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -1447,9 +1447,11 @@ describe('AccountConnect', () => {
       );
 
       // PermissionsSummary should be visible (Warning no longer gates)
-      expect(getByTestId('permission-summary-container')).toBeDefined();
+      expect(getByTestId('permission-summary-container')).toBeOnTheScreen();
       // TrustSignalModal should NOT be visible
-      expect(queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeNull();
+      expect(
+        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).not.toBeOnTheScreen();
     });
 
     it('renders TrustSignalModal when trust signal state is Malicious', () => {
@@ -1464,9 +1466,13 @@ describe('AccountConnect', () => {
       );
 
       // TrustSignalModal should be visible
-      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
+      expect(
+        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
       // PermissionsSummary should NOT be visible
-      expect(queryByTestId('permission-summary-container')).toBeNull();
+      expect(
+        queryByTestId('permission-summary-container'),
+      ).not.toBeOnTheScreen();
     });
 
     it('renders PermissionsSummary (SingleConnect) when trust signal state is Unknown', () => {
@@ -1481,9 +1487,11 @@ describe('AccountConnect', () => {
       );
 
       // PermissionsSummary should be visible
-      expect(getByTestId('permission-summary-container')).toBeDefined();
+      expect(getByTestId('permission-summary-container')).toBeOnTheScreen();
       // TrustSignalModal should NOT be visible
-      expect(queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeNull();
+      expect(
+        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).not.toBeOnTheScreen();
     });
 
     it('renders PermissionsSummary (SingleConnect) when trust signal state is Verified', () => {
@@ -1498,9 +1506,11 @@ describe('AccountConnect', () => {
       );
 
       // PermissionsSummary should be visible
-      expect(getByTestId('permission-summary-container')).toBeDefined();
+      expect(getByTestId('permission-summary-container')).toBeOnTheScreen();
       // TrustSignalModal should NOT be visible
-      expect(queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeNull();
+      expect(
+        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).not.toBeOnTheScreen();
     });
 
     it('navigates to SingleConnect when Connect Anyway is pressed on TrustSignalModal', async () => {
@@ -1515,7 +1525,9 @@ describe('AccountConnect', () => {
       );
 
       // Verify TrustSignalModal is shown
-      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
+      expect(
+        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
 
       // Press Connect Anyway
       const connectAnywayButton = getByTestId(
@@ -1527,7 +1539,7 @@ describe('AccountConnect', () => {
       const permissionsContainer = await findByTestId(
         'permission-summary-container',
       );
-      expect(permissionsContainer).toBeDefined();
+      expect(permissionsContainer).toBeOnTheScreen();
     });
 
     it('cancels permission request when Close is pressed on TrustSignalModal', () => {

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -27,6 +27,8 @@ import { SolScope } from '@metamask/keyring-api';
 import { PermissionDoesNotExistError } from '@metamask/permission-controller';
 import { ConnectedAccountsSelectorsIDs } from './ConnectedAccountModal.testIds';
 import AccountConnectMultiSelector from './AccountConnectMultiSelector/AccountConnectMultiSelector';
+import { TrustSignalModalSelectorsIDs } from './TrustSignalModal/TrustSignalModal.testIds';
+import { TrustSignalDisplayState } from '../confirmations/types/trustSignals';
 
 const MOCK_ACCOUNTS_CONTROLLER_STATE = createMockAccountsControllerStateUtil([
   mockAddress1,
@@ -294,6 +296,16 @@ jest.mock('../../../core/SnapKeyring/MultichainWalletSnapClient', () => ({
       .fn()
       .mockImplementation(() => mockMultichainWalletSnapClient),
   },
+}));
+
+// Mock useOriginTrustSignals
+const mockUseOriginTrustSignals = jest.fn(() => ({
+  state: TrustSignalDisplayState.Unknown,
+  label: null,
+}));
+jest.mock('../confirmations/hooks/useOriginTrustSignals', () => ({
+  useOriginTrustSignals: (...args: unknown[]) =>
+    mockUseOriginTrustSignals(...args),
 }));
 
 // Set default mock behaviors
@@ -1388,6 +1400,165 @@ describe('AccountConnect', () => {
       expect(
         queryByTestId(AccountConnectMaliciousWarningSelectorsIDs.CONTAINER),
       ).toBeNull();
+    });
+  });
+
+  describe('Trust signal integration', () => {
+    const trustSignalRoute = {
+      params: {
+        hostInfo: {
+          metadata: {
+            id: 'mockId',
+            origin: 'https://suspicious-dapp.com',
+            isEip1193Request: true,
+          },
+          permissions: createMockCaip25Permission({
+            'wallet:eip155': {
+              accounts: [],
+            },
+          }),
+        },
+        permissionRequestId: 'test-trust-signal',
+      },
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetConnection.mockReturnValue(undefined);
+      mockIsUUID.mockReturnValue(false);
+      // Reset to default unknown state
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Unknown,
+        label: null,
+      });
+    });
+
+    it('renders TrustSignalModal when trust signal state is Warning', () => {
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Warning,
+        label: 'Suspicious site',
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <AccountConnect route={trustSignalRoute} />,
+        { state: mockInitialState },
+      );
+
+      // TrustSignalModal should be visible
+      expect(
+        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeDefined();
+      // PermissionsSummary should NOT be visible
+      expect(queryByTestId('permission-summary-container')).toBeNull();
+    });
+
+    it('renders TrustSignalModal when trust signal state is Malicious', () => {
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Malicious,
+        label: 'Known malicious site',
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <AccountConnect route={trustSignalRoute} />,
+        { state: mockInitialState },
+      );
+
+      // TrustSignalModal should be visible
+      expect(
+        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeDefined();
+      // PermissionsSummary should NOT be visible
+      expect(queryByTestId('permission-summary-container')).toBeNull();
+    });
+
+    it('renders PermissionsSummary (SingleConnect) when trust signal state is Unknown', () => {
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Unknown,
+        label: null,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <AccountConnect route={trustSignalRoute} />,
+        { state: mockInitialState },
+      );
+
+      // PermissionsSummary should be visible
+      expect(getByTestId('permission-summary-container')).toBeDefined();
+      // TrustSignalModal should NOT be visible
+      expect(
+        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeNull();
+    });
+
+    it('renders PermissionsSummary (SingleConnect) when trust signal state is Verified', () => {
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Verified,
+        label: 'Verified',
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <AccountConnect route={trustSignalRoute} />,
+        { state: mockInitialState },
+      );
+
+      // PermissionsSummary should be visible
+      expect(getByTestId('permission-summary-container')).toBeDefined();
+      // TrustSignalModal should NOT be visible
+      expect(
+        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeNull();
+    });
+
+    it('navigates to SingleConnect when Connect Anyway is pressed on TrustSignalModal', async () => {
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Warning,
+        label: 'Suspicious site',
+      });
+
+      const { getByTestId, findByTestId } = renderWithProvider(
+        <AccountConnect route={trustSignalRoute} />,
+        { state: mockInitialState },
+      );
+
+      // Verify TrustSignalModal is shown
+      expect(
+        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+      ).toBeDefined();
+
+      // Press Connect Anyway
+      const connectAnywayButton = getByTestId(
+        TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON,
+      );
+      fireEvent.press(connectAnywayButton);
+
+      // Should now show PermissionsSummary
+      const permissionsContainer = await findByTestId(
+        'permission-summary-container',
+      );
+      expect(permissionsContainer).toBeDefined();
+    });
+
+    it('cancels permission request when Close is pressed on TrustSignalModal', () => {
+      mockUseOriginTrustSignals.mockReturnValue({
+        state: TrustSignalDisplayState.Warning,
+        label: 'Suspicious site',
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <AccountConnect route={trustSignalRoute} />,
+        { state: mockInitialState },
+      );
+
+      // Press Close button
+      const closeButton = getByTestId(
+        TrustSignalModalSelectorsIDs.CLOSE_BUTTON,
+      );
+      fireEvent.press(closeButton);
+
+      // Should reject the permission request
+      expect(
+        Engine.context.PermissionController.rejectPermissionsRequest,
+      ).toHaveBeenCalledWith('test-trust-signal');
     });
   });
 });

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -301,11 +301,13 @@ jest.mock('../../../core/SnapKeyring/MultichainWalletSnapClient', () => ({
 // Mock useOriginTrustSignals
 const mockUseOriginTrustSignals = jest.fn(() => ({
   state: TrustSignalDisplayState.Unknown,
-  label: null,
+  label: null as string | null,
 }));
+
 jest.mock('../confirmations/hooks/useOriginTrustSignals', () => ({
-  useOriginTrustSignals: (...args: unknown[]) =>
-    mockUseOriginTrustSignals(...args),
+  useOriginTrustSignals: (
+    ...args: Parameters<typeof mockUseOriginTrustSignals>
+  ) => mockUseOriginTrustSignals(...args),
 }));
 
 // Set default mock behaviors

--- a/app/components/Views/AccountConnect/AccountConnect.test.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.test.tsx
@@ -1445,9 +1445,7 @@ describe('AccountConnect', () => {
       );
 
       // TrustSignalModal should be visible
-      expect(
-        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
-      ).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
       // PermissionsSummary should NOT be visible
       expect(queryByTestId('permission-summary-container')).toBeNull();
     });
@@ -1464,9 +1462,7 @@ describe('AccountConnect', () => {
       );
 
       // TrustSignalModal should be visible
-      expect(
-        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
-      ).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
       // PermissionsSummary should NOT be visible
       expect(queryByTestId('permission-summary-container')).toBeNull();
     });
@@ -1485,9 +1481,7 @@ describe('AccountConnect', () => {
       // PermissionsSummary should be visible
       expect(getByTestId('permission-summary-container')).toBeDefined();
       // TrustSignalModal should NOT be visible
-      expect(
-        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
-      ).toBeNull();
+      expect(queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeNull();
     });
 
     it('renders PermissionsSummary (SingleConnect) when trust signal state is Verified', () => {
@@ -1504,9 +1498,7 @@ describe('AccountConnect', () => {
       // PermissionsSummary should be visible
       expect(getByTestId('permission-summary-container')).toBeDefined();
       // TrustSignalModal should NOT be visible
-      expect(
-        queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
-      ).toBeNull();
+      expect(queryByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeNull();
     });
 
     it('navigates to SingleConnect when Connect Anyway is pressed on TrustSignalModal', async () => {
@@ -1521,9 +1513,7 @@ describe('AccountConnect', () => {
       );
 
       // Verify TrustSignalModal is shown
-      expect(
-        getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
-      ).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
 
       // Press Connect Anyway
       const connectAnywayButton = getByTestId(

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -183,7 +183,26 @@ const AccountConnect = (props: AccountConnectProps) => {
   );
 
   // PhishingController trust signals: check origin against dapp-scanning API cache
-  const { state: trustSignalState } = useOriginTrustSignals(channelIdOrHostname);
+  const { state: rawTrustSignalState } =
+    useOriginTrustSignals(channelIdOrHostname);
+
+  // DEV-only overrides for manual trust signal testing without a live API.
+  // Remove or extend this map as needed during development.
+  const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
+    Record<string, TrustSignalDisplayState>
+  > = __DEV__
+    ? {
+        'uniswap.org': TrustSignalDisplayState.Verified,
+        'example.com': TrustSignalDisplayState.Malicious,
+      }
+    : {
+        'uniswap.org': TrustSignalDisplayState.Verified,
+        'example.com': TrustSignalDisplayState.Malicious,
+      };
+
+  const trustSignalState =
+    (__DEV__ && DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)]) ??
+    rawTrustSignalState;
 
   const defaultSelectedChainIds = useMemo(
     () =>
@@ -263,7 +282,6 @@ const AccountConnect = (props: AccountConnectProps) => {
   const sheetRef = useRef<BottomSheetRef>(null);
 
   const needsTrustSignalGate =
-    trustSignalState === TrustSignalDisplayState.Warning ||
     trustSignalState === TrustSignalDisplayState.Malicious;
 
   const [screen, setScreen] = useState<AccountConnectScreens>(
@@ -275,15 +293,15 @@ const AccountConnect = (props: AccountConnectProps) => {
   // If trust signal state arrives after initial render (async scan),
   // navigate to the warning screen if still on the initial screen.
   useEffect(() => {
-    if (needsTrustSignalGate && screen === AccountConnectScreens.SingleConnect) {
+    if (
+      needsTrustSignalGate &&
+      screen === AccountConnectScreens.SingleConnect
+    ) {
       setScreen(AccountConnectScreens.TrustSignalWarning);
     }
   }, [needsTrustSignalGate, screen]);
 
-  const trustSignalVariant =
-    trustSignalState === TrustSignalDisplayState.Malicious
-      ? 'malicious'
-      : 'warning';
+  const trustSignalVariant = 'malicious' as const;
 
   const [showPhishingModal, setShowPhishingModal] = useState(false);
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
@@ -945,7 +963,12 @@ const AccountConnect = (props: AccountConnectProps) => {
         onClose={handleTrustSignalClose}
       />
     ),
-    [trustSignalVariant, urlWithProtocol, handleTrustSignalDismiss, handleTrustSignalClose],
+    [
+      trustSignalVariant,
+      urlWithProtocol,
+      handleTrustSignalDismiss,
+      handleTrustSignalClose,
+    ],
   );
 
   const renderPhishingModal = useCallback(

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -192,16 +192,16 @@ const AccountConnect = (props: AccountConnectProps) => {
     Record<string, TrustSignalDisplayState>
   > = __DEV__
     ? {
-        'uniswap.org': TrustSignalDisplayState.Verified,
-        'example.com': TrustSignalDisplayState.Malicious,
+        'app.uniswap.org': TrustSignalDisplayState.Verified,
+        'revoke.cash': TrustSignalDisplayState.Malicious,
       }
     : {
-        'uniswap.org': TrustSignalDisplayState.Verified,
-        'example.com': TrustSignalDisplayState.Malicious,
+        'app.uniswap.org': TrustSignalDisplayState.Verified,
+        'revoke.cash': TrustSignalDisplayState.Malicious,
       };
 
   const trustSignalState =
-    (__DEV__ && DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)]) ??
+    (true && DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)]) ??
     rawTrustSignalState;
 
   const defaultSelectedChainIds = useMemo(
@@ -283,6 +283,7 @@ const AccountConnect = (props: AccountConnectProps) => {
 
   const needsTrustSignalGate =
     trustSignalState === TrustSignalDisplayState.Malicious;
+  const trustSignalGateDismissedRef = useRef(false);
 
   const [screen, setScreen] = useState<AccountConnectScreens>(
     needsTrustSignalGate
@@ -291,10 +292,11 @@ const AccountConnect = (props: AccountConnectProps) => {
   );
 
   // If trust signal state arrives after initial render (async scan),
-  // navigate to the warning screen if still on the initial screen.
+  // navigate to the warning screen if the user hasn't dismissed it yet.
   useEffect(() => {
     if (
       needsTrustSignalGate &&
+      !trustSignalGateDismissedRef.current &&
       screen === AccountConnectScreens.SingleConnect
     ) {
       setScreen(AccountConnectScreens.TrustSignalWarning);
@@ -947,6 +949,7 @@ const AccountConnect = (props: AccountConnectProps) => {
   );
 
   const handleTrustSignalDismiss = useCallback(() => {
+    trustSignalGateDismissedRef.current = true;
     setScreen(AccountConnectScreens.SingleConnect);
   }, []);
 

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -77,6 +77,18 @@ import useOriginSource from '../../hooks/useOriginSource';
 import { useOriginTrustSignals } from '../confirmations/hooks/useOriginTrustSignals';
 import { TrustSignalDisplayState } from '../confirmations/types/trustSignals';
 import TrustSignalModal from './TrustSignalModal';
+
+const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
+  Record<string, TrustSignalDisplayState>
+> = __DEV__
+  ? {
+      'app.uniswap.org': TrustSignalDisplayState.Verified,
+      'revoke.cash': TrustSignalDisplayState.Malicious,
+    }
+  : {};
+
+const TRUST_SIGNAL_VARIANT = 'malicious' as const;
+
 import {
   getCaip25PermissionsResponse,
   getDefaultAccounts,
@@ -182,26 +194,10 @@ const AccountConnect = (props: AccountConnectProps) => {
     isOriginWalletConnect && wc2Metadata?.verifyContext?.isScam,
   );
 
-  // PhishingController trust signals: check origin against dapp-scanning API cache
   const { state: rawTrustSignalState } =
     useOriginTrustSignals(channelIdOrHostname);
-
-  // DEV-only overrides for manual trust signal testing without a live API.
-  // Remove or extend this map as needed during development.
-  const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
-    Record<string, TrustSignalDisplayState>
-  > = __DEV__
-    ? {
-        'app.uniswap.org': TrustSignalDisplayState.Verified,
-        'revoke.cash': TrustSignalDisplayState.Malicious,
-      }
-    : {
-        'app.uniswap.org': TrustSignalDisplayState.Verified,
-        'revoke.cash': TrustSignalDisplayState.Malicious,
-      };
-
   const trustSignalState =
-    (true && DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)]) ??
+    DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)] ??
     rawTrustSignalState;
 
   const defaultSelectedChainIds = useMemo(
@@ -294,16 +290,14 @@ const AccountConnect = (props: AccountConnectProps) => {
   // If trust signal state arrives after initial render (async scan),
   // navigate to the warning screen if the user hasn't dismissed it yet.
   useEffect(() => {
-    if (
-      needsTrustSignalGate &&
-      !trustSignalGateDismissedRef.current &&
-      screen === AccountConnectScreens.SingleConnect
-    ) {
-      setScreen(AccountConnectScreens.TrustSignalWarning);
+    if (needsTrustSignalGate && !trustSignalGateDismissedRef.current) {
+      setScreen((prev) =>
+        prev === AccountConnectScreens.SingleConnect
+          ? AccountConnectScreens.TrustSignalWarning
+          : prev,
+      );
     }
-  }, [needsTrustSignalGate, screen]);
-
-  const trustSignalVariant = 'malicious' as const;
+  }, [needsTrustSignalGate]);
 
   const [showPhishingModal, setShowPhishingModal] = useState(false);
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
@@ -960,18 +954,13 @@ const AccountConnect = (props: AccountConnectProps) => {
   const renderTrustSignalWarningScreen = useCallback(
     () => (
       <TrustSignalModal
-        variant={trustSignalVariant}
+        variant={TRUST_SIGNAL_VARIANT}
         url={urlWithProtocol}
         onConnectAnyway={handleTrustSignalDismiss}
         onClose={handleTrustSignalClose}
       />
     ),
-    [
-      trustSignalVariant,
-      urlWithProtocol,
-      handleTrustSignalDismiss,
-      handleTrustSignalClose,
-    ],
+    [urlWithProtocol, handleTrustSignalDismiss, handleTrustSignalClose],
   );
 
   const renderPhishingModal = useCallback(

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -74,6 +74,9 @@ import {
 import { selectNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
 import { isUUID } from '../../../core/SDKConnect/utils/isUUID';
 import useOriginSource from '../../hooks/useOriginSource';
+import { useOriginTrustSignals } from '../confirmations/hooks/useOriginTrustSignals';
+import { TrustSignalDisplayState } from '../confirmations/types/trustSignals';
+import TrustSignalModal from './TrustSignalModal';
 import {
   getCaip25PermissionsResponse,
   getDefaultAccounts,
@@ -179,6 +182,9 @@ const AccountConnect = (props: AccountConnectProps) => {
     isOriginWalletConnect && wc2Metadata?.verifyContext?.isScam,
   );
 
+  // PhishingController trust signals: check origin against dapp-scanning API cache
+  const { state: trustSignalState } = useOriginTrustSignals(channelIdOrHostname);
+
   const defaultSelectedChainIds = useMemo(
     () =>
       getDefaultSelectedChainIds({
@@ -255,9 +261,30 @@ const AccountConnect = (props: AccountConnectProps) => {
   );
 
   const sheetRef = useRef<BottomSheetRef>(null);
+
+  const needsTrustSignalGate =
+    trustSignalState === TrustSignalDisplayState.Warning ||
+    trustSignalState === TrustSignalDisplayState.Malicious;
+
   const [screen, setScreen] = useState<AccountConnectScreens>(
-    AccountConnectScreens.SingleConnect,
+    needsTrustSignalGate
+      ? AccountConnectScreens.TrustSignalWarning
+      : AccountConnectScreens.SingleConnect,
   );
+
+  // If trust signal state arrives after initial render (async scan),
+  // navigate to the warning screen if still on the initial screen.
+  useEffect(() => {
+    if (needsTrustSignalGate && screen === AccountConnectScreens.SingleConnect) {
+      setScreen(AccountConnectScreens.TrustSignalWarning);
+    }
+  }, [needsTrustSignalGate, screen]);
+
+  const trustSignalVariant =
+    trustSignalState === TrustSignalDisplayState.Malicious
+      ? 'malicious'
+      : 'warning';
+
   const [showPhishingModal, setShowPhishingModal] = useState(false);
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
   const isMountedRef = useRef(true);
@@ -757,6 +784,7 @@ const AccountConnect = (props: AccountConnectProps) => {
       tabIndex,
       promptToCreateSolanaAccount,
       isMaliciousDapp,
+      trustSignalState,
       onCreateAccount: (clientType, scope) => {
         setMultichainAccountOptions({
           clientType,
@@ -777,6 +805,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     setTabIndex,
     promptToCreateSolanaAccount,
     isMaliciousDapp,
+    trustSignalState,
   ]);
 
   const renderSingleConnectSelectorScreen = useCallback(
@@ -899,6 +928,26 @@ const AccountConnect = (props: AccountConnectProps) => {
     [urlWithProtocol, handleConnectAnyway, handleMaliciousWarningClose],
   );
 
+  const handleTrustSignalDismiss = useCallback(() => {
+    setScreen(AccountConnectScreens.SingleConnect);
+  }, []);
+
+  const handleTrustSignalClose = useCallback(() => {
+    hideSheet(() => cancelPermissionRequest(permissionRequestId));
+  }, [hideSheet, cancelPermissionRequest, permissionRequestId]);
+
+  const renderTrustSignalWarningScreen = useCallback(
+    () => (
+      <TrustSignalModal
+        variant={trustSignalVariant}
+        url={urlWithProtocol}
+        onConnectAnyway={handleTrustSignalDismiss}
+        onClose={handleTrustSignalClose}
+      />
+    ),
+    [trustSignalVariant, urlWithProtocol, handleTrustSignalDismiss, handleTrustSignalClose],
+  );
+
   const renderPhishingModal = useCallback(
     () => (
       <Modal
@@ -947,6 +996,8 @@ const AccountConnect = (props: AccountConnectProps) => {
         return renderMultiConnectNetworkSelectorScreen();
       case AccountConnectScreens.AddNewAccount:
         return renderAddNewAccount();
+      case AccountConnectScreens.TrustSignalWarning:
+        return renderTrustSignalWarningScreen();
       case AccountConnectScreens.MaliciousWarning:
         return renderMaliciousWarningScreen();
     }
@@ -957,6 +1008,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     renderMultiConnectSelectorScreen,
     renderMultiConnectNetworkSelectorScreen,
     renderAddNewAccount,
+    renderTrustSignalWarningScreen,
     renderMaliciousWarningScreen,
   ]);
 

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -74,18 +74,10 @@ import {
 import { selectNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
 import { isUUID } from '../../../core/SDKConnect/utils/isUUID';
 import useOriginSource from '../../hooks/useOriginSource';
-import { useOriginTrustSignals } from '../confirmations/hooks/useOriginTrustSignals';
-import { TrustSignalDisplayState } from '../confirmations/types/trustSignals';
-import TrustSignalModal from './TrustSignalModal';
-
-const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
-  Record<string, TrustSignalDisplayState>
-> = __DEV__
-  ? {
-      'app.uniswap.org': TrustSignalDisplayState.Verified,
-      'revoke.cash': TrustSignalDisplayState.Malicious,
-    }
-  : {};
+import TrustSignalModal, {
+  useTrustSignalState,
+  useTrustSignalGateControl,
+} from './TrustSignalModal';
 
 import {
   getCaip25PermissionsResponse,
@@ -192,11 +184,8 @@ const AccountConnect = (props: AccountConnectProps) => {
     isOriginWalletConnect && wc2Metadata?.verifyContext?.isScam,
   );
 
-  const { state: rawTrustSignalState } =
-    useOriginTrustSignals(channelIdOrHostname);
-  const trustSignalState =
-    DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)] ??
-    rawTrustSignalState;
+  const { trustSignalState, needsTrustSignalGate } =
+    useTrustSignalState(channelIdOrHostname);
 
   const defaultSelectedChainIds = useMemo(
     () =>
@@ -275,27 +264,16 @@ const AccountConnect = (props: AccountConnectProps) => {
 
   const sheetRef = useRef<BottomSheetRef>(null);
 
-  const needsTrustSignalGate =
-    trustSignalState === TrustSignalDisplayState.Malicious;
-  const trustSignalGateDismissedRef = useRef(false);
-
   const [screen, setScreen] = useState<AccountConnectScreens>(
     needsTrustSignalGate
       ? AccountConnectScreens.TrustSignalWarning
       : AccountConnectScreens.SingleConnect,
   );
 
-  // If trust signal state arrives after initial render (async scan),
-  // navigate to the warning screen if the user hasn't dismissed it yet.
-  useEffect(() => {
-    if (needsTrustSignalGate && !trustSignalGateDismissedRef.current) {
-      setScreen((prev) =>
-        prev === AccountConnectScreens.SingleConnect
-          ? AccountConnectScreens.TrustSignalWarning
-          : prev,
-      );
-    }
-  }, [needsTrustSignalGate]);
+  const { handleTrustSignalDismiss } = useTrustSignalGateControl(
+    needsTrustSignalGate,
+    setScreen,
+  );
 
   const [showPhishingModal, setShowPhishingModal] = useState(false);
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
@@ -939,11 +917,6 @@ const AccountConnect = (props: AccountConnectProps) => {
     ),
     [urlWithProtocol, handleConnectAnyway, handleMaliciousWarningClose],
   );
-
-  const handleTrustSignalDismiss = useCallback(() => {
-    trustSignalGateDismissedRef.current = true;
-    setScreen(AccountConnectScreens.SingleConnect);
-  }, []);
 
   const handleTrustSignalClose = useCallback(() => {
     hideSheet(() => cancelPermissionRequest(permissionRequestId));

--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -87,8 +87,6 @@ const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
     }
   : {};
 
-const TRUST_SIGNAL_VARIANT = 'malicious' as const;
-
 import {
   getCaip25PermissionsResponse,
   getDefaultAccounts,
@@ -954,7 +952,6 @@ const AccountConnect = (props: AccountConnectProps) => {
   const renderTrustSignalWarningScreen = useCallback(
     () => (
       <TrustSignalModal
-        variant={TRUST_SIGNAL_VARIANT}
         url={urlWithProtocol}
         onConnectAnyway={handleTrustSignalDismiss}
         onClose={handleTrustSignalClose}

--- a/app/components/Views/AccountConnect/AccountConnect.types.ts
+++ b/app/components/Views/AccountConnect/AccountConnect.types.ts
@@ -20,6 +20,7 @@ export enum AccountConnectScreens {
   MultiConnectNetworkSelector = 'MultiConnectNetworkSelector',
   AddNewAccount = 'AddNewAccount',
   MaliciousWarning = 'MaliciousWarning',
+  TrustSignalWarning = 'TrustSignalWarning',
 }
 
 export interface AccountConnectParams {

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.styles.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.styles.ts
@@ -6,14 +6,14 @@ const createStyles = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     safeArea: {
+      flex: 1,
       backgroundColor: theme.colors.background.alternative,
     },
     mainContainer: {
+      flex: 1,
       backgroundColor: theme.colors.background.alternative,
       paddingTop: 8,
       paddingBottom: 16,
-      borderTopLeftRadius: 20,
-      borderTopRightRadius: 20,
       justifyContent: 'space-between',
     },
     contentContainer: {

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.styles.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.styles.ts
@@ -1,0 +1,66 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../util/theme/models';
+
+const createStyles = (params: { theme: Theme }) => {
+  const { theme } = params;
+
+  return StyleSheet.create({
+    safeArea: {
+      backgroundColor: theme.colors.background.alternative,
+    },
+    mainContainer: {
+      backgroundColor: theme.colors.background.alternative,
+      paddingTop: 8,
+      paddingBottom: 16,
+      borderTopLeftRadius: 20,
+      borderTopRightRadius: 20,
+      justifyContent: 'space-between',
+    },
+    contentContainer: {
+      alignItems: 'center',
+      paddingHorizontal: 24,
+    },
+    header: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      width: '100%',
+      paddingRight: 8,
+      marginBottom: 8,
+    },
+    headerSpacer: {
+      flex: 1,
+    },
+    iconContainer: {
+      marginBottom: 16,
+      alignItems: 'center',
+    },
+    title: {
+      textAlign: 'center',
+      marginBottom: 8,
+    },
+    urlContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 16,
+      gap: 4,
+    },
+    urlText: {
+      flexShrink: 1,
+    },
+    descriptionBox: {
+      borderRadius: 8,
+      padding: 12,
+      width: '100%',
+      marginBottom: 24,
+    },
+    buttonContainer: {
+      paddingHorizontal: 16,
+    },
+    connectAnywayButton: {
+      width: '100%',
+    },
+  });
+};
+
+export default createStyles;

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import TrustSignalModal from './TrustSignalModal';
+import { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
+
+const mockOnConnectAnyway = jest.fn();
+const mockOnClose = jest.fn();
+
+const MOCK_URL = 'https://suspicious-dapp.example.com';
+
+const renderModal = (variant: 'warning' | 'malicious' = 'warning', url = MOCK_URL) =>
+  renderWithProvider(
+    <TrustSignalModal
+      variant={variant}
+      url={url}
+      onConnectAnyway={mockOnConnectAnyway}
+      onClose={mockOnClose}
+    />,
+  );
+
+describe('TrustSignalModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('warning variant', () => {
+    it('renders all expected elements', () => {
+      const { getByTestId } = renderModal('warning');
+
+      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON)).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.TITLE)).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.URL)).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.DESCRIPTION_BOX)).toBeDefined();
+      expect(getByTestId(TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON)).toBeDefined();
+    });
+
+    it('displays the warning title', () => {
+      const { getByText } = renderModal('warning');
+
+      expect(getByText('Unverified site')).toBeDefined();
+    });
+
+    it('displays the warning description', () => {
+      const { getByText } = renderModal('warning');
+
+      expect(
+        getByText('This site has not been verified. Proceed with caution when connecting.'),
+      ).toBeDefined();
+    });
+
+    it('displays the dapp URL', () => {
+      const { getByText } = renderModal('warning');
+
+      expect(getByText(MOCK_URL)).toBeDefined();
+    });
+  });
+
+  describe('malicious variant', () => {
+    it('displays the malicious title', () => {
+      const { getByText } = renderModal('malicious');
+
+      expect(getByText('Malicious site detected')).toBeDefined();
+    });
+
+    it('displays the malicious description', () => {
+      const { getByText } = renderModal('malicious');
+
+      expect(
+        getByText('This site has been flagged as malicious. Connecting may put your assets at risk.'),
+      ).toBeDefined();
+    });
+
+    it('displays the dapp URL', () => {
+      const { getByText } = renderModal('malicious');
+
+      expect(getByText(MOCK_URL)).toBeDefined();
+    });
+  });
+
+  it('calls onConnectAnyway when the Connect Anyway button is pressed', () => {
+    const { getByTestId } = renderModal();
+
+    fireEvent.press(
+      getByTestId(TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON),
+    );
+
+    expect(mockOnConnectAnyway).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    const { getByTestId } = renderModal();
+
+    fireEvent.press(
+      getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onConnectAnyway when close is pressed', () => {
+    const { getByTestId } = renderModal();
+
+    fireEvent.press(
+      getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(mockOnConnectAnyway).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClose when Connect Anyway is pressed', () => {
+    const { getByTestId } = renderModal();
+
+    fireEvent.press(
+      getByTestId(TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON),
+    );
+
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('renders with a different URL', () => {
+    const otherUrl = 'https://another-dapp.example.com';
+    const { getByText } = renderModal('warning', otherUrl);
+
+    expect(getByText(otherUrl)).toBeDefined();
+  });
+});

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
@@ -12,7 +12,6 @@ const MOCK_URL = 'https://suspicious-dapp.example.com';
 const renderModal = (url = MOCK_URL) =>
   renderWithProvider(
     <TrustSignalModal
-      variant="malicious"
       url={url}
       onConnectAnyway={mockOnConnectAnyway}
       onClose={mockOnClose}

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
@@ -26,24 +26,26 @@ describe('TrustSignalModal', () => {
   it('renders all expected elements', () => {
     const { getByTestId } = renderModal();
 
-    expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
+    expect(
+      getByTestId(TrustSignalModalSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
     expect(
       getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON),
-    ).toBeDefined();
-    expect(getByTestId(TrustSignalModalSelectorsIDs.TITLE)).toBeDefined();
-    expect(getByTestId(TrustSignalModalSelectorsIDs.URL)).toBeDefined();
+    ).toBeOnTheScreen();
+    expect(getByTestId(TrustSignalModalSelectorsIDs.TITLE)).toBeOnTheScreen();
+    expect(getByTestId(TrustSignalModalSelectorsIDs.URL)).toBeOnTheScreen();
     expect(
       getByTestId(TrustSignalModalSelectorsIDs.DESCRIPTION_BOX),
-    ).toBeDefined();
+    ).toBeOnTheScreen();
     expect(
       getByTestId(TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON),
-    ).toBeDefined();
+    ).toBeOnTheScreen();
   });
 
   it('displays the malicious title', () => {
     const { getByText } = renderModal();
 
-    expect(getByText('Malicious site detected')).toBeDefined();
+    expect(getByText('Malicious site detected')).toBeOnTheScreen();
   });
 
   it('displays the malicious description', () => {
@@ -53,20 +55,20 @@ describe('TrustSignalModal', () => {
       getByText(
         'This site has been flagged as malicious. Connecting may put your assets at risk.',
       ),
-    ).toBeDefined();
+    ).toBeOnTheScreen();
   });
 
   it('displays the dapp URL', () => {
     const { getByText } = renderModal();
 
-    expect(getByText(MOCK_URL)).toBeDefined();
+    expect(getByText(MOCK_URL)).toBeOnTheScreen();
   });
 
   it('renders with a different URL', () => {
     const otherUrl = 'https://another-dapp.example.com';
     const { getByText } = renderModal(otherUrl);
 
-    expect(getByText(otherUrl)).toBeDefined();
+    expect(getByText(otherUrl)).toBeOnTheScreen();
   });
 
   it('calls onConnectAnyway when the Connect Anyway button is pressed', () => {

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.test.tsx
@@ -9,10 +9,10 @@ const mockOnClose = jest.fn();
 
 const MOCK_URL = 'https://suspicious-dapp.example.com';
 
-const renderModal = (variant: 'warning' | 'malicious' = 'warning', url = MOCK_URL) =>
+const renderModal = (url = MOCK_URL) =>
   renderWithProvider(
     <TrustSignalModal
-      variant={variant}
+      variant="malicious"
       url={url}
       onConnectAnyway={mockOnConnectAnyway}
       onClose={mockOnClose}
@@ -24,59 +24,50 @@ describe('TrustSignalModal', () => {
     jest.clearAllMocks();
   });
 
-  describe('warning variant', () => {
-    it('renders all expected elements', () => {
-      const { getByTestId } = renderModal('warning');
+  it('renders all expected elements', () => {
+    const { getByTestId } = renderModal();
 
-      expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
-      expect(getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON)).toBeDefined();
-      expect(getByTestId(TrustSignalModalSelectorsIDs.TITLE)).toBeDefined();
-      expect(getByTestId(TrustSignalModalSelectorsIDs.URL)).toBeDefined();
-      expect(getByTestId(TrustSignalModalSelectorsIDs.DESCRIPTION_BOX)).toBeDefined();
-      expect(getByTestId(TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON)).toBeDefined();
-    });
-
-    it('displays the warning title', () => {
-      const { getByText } = renderModal('warning');
-
-      expect(getByText('Unverified site')).toBeDefined();
-    });
-
-    it('displays the warning description', () => {
-      const { getByText } = renderModal('warning');
-
-      expect(
-        getByText('This site has not been verified. Proceed with caution when connecting.'),
-      ).toBeDefined();
-    });
-
-    it('displays the dapp URL', () => {
-      const { getByText } = renderModal('warning');
-
-      expect(getByText(MOCK_URL)).toBeDefined();
-    });
+    expect(getByTestId(TrustSignalModalSelectorsIDs.CONTAINER)).toBeDefined();
+    expect(
+      getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON),
+    ).toBeDefined();
+    expect(getByTestId(TrustSignalModalSelectorsIDs.TITLE)).toBeDefined();
+    expect(getByTestId(TrustSignalModalSelectorsIDs.URL)).toBeDefined();
+    expect(
+      getByTestId(TrustSignalModalSelectorsIDs.DESCRIPTION_BOX),
+    ).toBeDefined();
+    expect(
+      getByTestId(TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON),
+    ).toBeDefined();
   });
 
-  describe('malicious variant', () => {
-    it('displays the malicious title', () => {
-      const { getByText } = renderModal('malicious');
+  it('displays the malicious title', () => {
+    const { getByText } = renderModal();
 
-      expect(getByText('Malicious site detected')).toBeDefined();
-    });
+    expect(getByText('Malicious site detected')).toBeDefined();
+  });
 
-    it('displays the malicious description', () => {
-      const { getByText } = renderModal('malicious');
+  it('displays the malicious description', () => {
+    const { getByText } = renderModal();
 
-      expect(
-        getByText('This site has been flagged as malicious. Connecting may put your assets at risk.'),
-      ).toBeDefined();
-    });
+    expect(
+      getByText(
+        'This site has been flagged as malicious. Connecting may put your assets at risk.',
+      ),
+    ).toBeDefined();
+  });
 
-    it('displays the dapp URL', () => {
-      const { getByText } = renderModal('malicious');
+  it('displays the dapp URL', () => {
+    const { getByText } = renderModal();
 
-      expect(getByText(MOCK_URL)).toBeDefined();
-    });
+    expect(getByText(MOCK_URL)).toBeDefined();
+  });
+
+  it('renders with a different URL', () => {
+    const otherUrl = 'https://another-dapp.example.com';
+    const { getByText } = renderModal(otherUrl);
+
+    expect(getByText(otherUrl)).toBeDefined();
   });
 
   it('calls onConnectAnyway when the Connect Anyway button is pressed', () => {
@@ -92,9 +83,7 @@ describe('TrustSignalModal', () => {
   it('calls onClose when the close button is pressed', () => {
     const { getByTestId } = renderModal();
 
-    fireEvent.press(
-      getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON),
-    );
+    fireEvent.press(getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
@@ -102,9 +91,7 @@ describe('TrustSignalModal', () => {
   it('does not call onConnectAnyway when close is pressed', () => {
     const { getByTestId } = renderModal();
 
-    fireEvent.press(
-      getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON),
-    );
+    fireEvent.press(getByTestId(TrustSignalModalSelectorsIDs.CLOSE_BUTTON));
 
     expect(mockOnConnectAnyway).not.toHaveBeenCalled();
   });
@@ -117,12 +104,5 @@ describe('TrustSignalModal', () => {
     );
 
     expect(mockOnClose).not.toHaveBeenCalled();
-  });
-
-  it('renders with a different URL', () => {
-    const otherUrl = 'https://another-dapp.example.com';
-    const { getByText } = renderModal('warning', otherUrl);
-
-    expect(getByText(otherUrl)).toBeDefined();
   });
 });

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.testIds.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.testIds.ts
@@ -1,0 +1,8 @@
+export const TrustSignalModalSelectorsIDs = {
+  CONTAINER: 'trust-signal-modal',
+  CLOSE_BUTTON: 'trust-signal-modal-close-button',
+  TITLE: 'trust-signal-modal-title',
+  URL: 'trust-signal-modal-url',
+  DESCRIPTION_BOX: 'trust-signal-modal-description-box',
+  CONNECT_ANYWAY_BUTTON: 'trust-signal-modal-connect-anyway-button',
+};

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
@@ -18,43 +18,15 @@ import ButtonIcon, {
 } from '../../../../component-library/components/Buttons/ButtonIcon';
 import styleSheet from './TrustSignalModal.styles';
 import { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
-import {
-  TrustSignalModalProps,
-  TrustSignalModalVariant,
-} from './TrustSignalModal.types';
-
-const VARIANT_CONFIG: Record<
-  TrustSignalModalVariant,
-  {
-    iconName: IconName;
-    iconColor: IconColor;
-    textColor: TextColor;
-    mutedColorKey: 'error';
-    titleKey: string;
-    descriptionKey: string;
-    buttonType: string;
-  }
-> = {
-  malicious: {
-    iconName: IconName.Danger,
-    iconColor: IconColor.Error,
-    textColor: TextColor.Error,
-    mutedColorKey: 'error',
-    titleKey: 'accounts.trust_signal_block_title',
-    descriptionKey: 'accounts.trust_signal_block_description',
-    buttonType: 'danger',
-  },
-};
+import { TrustSignalModalProps } from './TrustSignalModal.types';
 
 const TrustSignalModal = ({
-  variant,
   url,
   onConnectAnyway,
   onClose,
 }: TrustSignalModalProps) => {
   const { colors } = useTheme();
   const { styles } = useStyles(styleSheet, {});
-  const config = VARIANT_CONFIG[variant];
 
   return (
     <SafeAreaView
@@ -78,9 +50,9 @@ const TrustSignalModal = ({
           {/* Warning/danger icon */}
           <View style={styles.iconContainer}>
             <Icon
-              name={config.iconName}
+              name={IconName.Danger}
               size={IconSize.Xl}
-              color={config.iconColor}
+              color={IconColor.Error}
             />
           </View>
 
@@ -90,7 +62,7 @@ const TrustSignalModal = ({
             style={styles.title}
             testID={TrustSignalModalSelectorsIDs.TITLE}
           >
-            {strings(config.titleKey)}
+            {strings('accounts.trust_signal_block_title')}
           </TextComponent>
 
           {/* URL with icon */}
@@ -100,7 +72,7 @@ const TrustSignalModal = ({
           >
             <TextComponent
               variant={TextVariant.BodyMD}
-              color={config.textColor}
+              color={TextColor.Error}
               style={styles.urlText}
               numberOfLines={1}
               ellipsizeMode="middle"
@@ -108,9 +80,9 @@ const TrustSignalModal = ({
               {url}
             </TextComponent>
             <Icon
-              name={config.iconName}
+              name={IconName.Danger}
               size={IconSize.Sm}
-              color={config.iconColor}
+              color={IconColor.Error}
             />
           </View>
 
@@ -118,12 +90,12 @@ const TrustSignalModal = ({
           <View
             style={[
               styles.descriptionBox,
-              { backgroundColor: colors[config.mutedColorKey].muted },
+              { backgroundColor: colors.error.muted },
             ]}
             testID={TrustSignalModalSelectorsIDs.DESCRIPTION_BOX}
           >
             <TextComponent variant={TextVariant.BodyMD}>
-              {strings(config.descriptionKey)}
+              {strings('accounts.trust_signal_block_description')}
             </TextComponent>
           </View>
         </View>
@@ -131,7 +103,7 @@ const TrustSignalModal = ({
         {/* Connect Anyway button */}
         <View style={styles.buttonContainer}>
           <StyledButton
-            type={config.buttonType}
+            type="danger"
             onPress={onConnectAnyway}
             containerStyle={styles.connectAnywayButton}
             testID={TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON}

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
@@ -29,21 +29,12 @@ const VARIANT_CONFIG: Record<
     iconName: IconName;
     iconColor: IconColor;
     textColor: TextColor;
-    mutedColorKey: 'warning' | 'error';
+    mutedColorKey: 'error';
     titleKey: string;
     descriptionKey: string;
     buttonType: string;
   }
 > = {
-  warning: {
-    iconName: IconName.Danger,
-    iconColor: IconColor.Warning,
-    textColor: TextColor.Warning,
-    mutedColorKey: 'warning',
-    titleKey: 'accounts.trust_signal_warning_title',
-    descriptionKey: 'accounts.trust_signal_warning_description',
-    buttonType: 'warning',
-  },
   malicious: {
     iconName: IconName.Danger,
     iconColor: IconColor.Error,

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { SafeAreaView, View } from 'react-native';
+import { strings } from '../../../../../locales/i18n';
+import { useTheme } from '../../../../util/theme';
+import { useStyles } from '../../../../component-library/hooks';
+import TextComponent, {
+  TextColor,
+  TextVariant,
+} from '../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+  IconColor,
+} from '../../../../component-library/components/Icons/Icon';
+import StyledButton from '../../../UI/StyledButton';
+import ButtonIcon, {
+  ButtonIconSizes,
+} from '../../../../component-library/components/Buttons/ButtonIcon';
+import styleSheet from './TrustSignalModal.styles';
+import { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
+import {
+  TrustSignalModalProps,
+  TrustSignalModalVariant,
+} from './TrustSignalModal.types';
+
+const VARIANT_CONFIG: Record<
+  TrustSignalModalVariant,
+  {
+    iconName: IconName;
+    iconColor: IconColor;
+    textColor: TextColor;
+    mutedColorKey: 'warning' | 'error';
+    titleKey: string;
+    descriptionKey: string;
+    buttonType: string;
+  }
+> = {
+  warning: {
+    iconName: IconName.Danger,
+    iconColor: IconColor.Warning,
+    textColor: TextColor.Warning,
+    mutedColorKey: 'warning',
+    titleKey: 'accounts.trust_signal_warning_title',
+    descriptionKey: 'accounts.trust_signal_warning_description',
+    buttonType: 'warning',
+  },
+  malicious: {
+    iconName: IconName.Danger,
+    iconColor: IconColor.Error,
+    textColor: TextColor.Error,
+    mutedColorKey: 'error',
+    titleKey: 'accounts.trust_signal_block_title',
+    descriptionKey: 'accounts.trust_signal_block_description',
+    buttonType: 'danger',
+  },
+};
+
+const TrustSignalModal = ({
+  variant,
+  url,
+  onConnectAnyway,
+  onClose,
+}: TrustSignalModalProps) => {
+  const { colors } = useTheme();
+  const { styles } = useStyles(styleSheet, {});
+  const config = VARIANT_CONFIG[variant];
+
+  return (
+    <SafeAreaView
+      style={styles.safeArea}
+      testID={TrustSignalModalSelectorsIDs.CONTAINER}
+    >
+      <View style={styles.mainContainer}>
+        <View style={styles.contentContainer}>
+          {/* Header with close button */}
+          <View style={styles.header}>
+            <View style={styles.headerSpacer} />
+            <ButtonIcon
+              size={ButtonIconSizes.Sm}
+              iconName={IconName.Close}
+              iconColor={IconColor.Default}
+              onPress={onClose}
+              testID={TrustSignalModalSelectorsIDs.CLOSE_BUTTON}
+            />
+          </View>
+
+          {/* Warning/danger icon */}
+          <View style={styles.iconContainer}>
+            <Icon
+              name={config.iconName}
+              size={IconSize.Xl}
+              color={config.iconColor}
+            />
+          </View>
+
+          {/* Title */}
+          <TextComponent
+            variant={TextVariant.HeadingMD}
+            style={styles.title}
+            testID={TrustSignalModalSelectorsIDs.TITLE}
+          >
+            {strings(config.titleKey)}
+          </TextComponent>
+
+          {/* URL with icon */}
+          <View
+            style={styles.urlContainer}
+            testID={TrustSignalModalSelectorsIDs.URL}
+          >
+            <TextComponent
+              variant={TextVariant.BodyMD}
+              color={config.textColor}
+              style={styles.urlText}
+              numberOfLines={1}
+              ellipsizeMode="middle"
+            >
+              {url}
+            </TextComponent>
+            <Icon
+              name={config.iconName}
+              size={IconSize.Sm}
+              color={config.iconColor}
+            />
+          </View>
+
+          {/* Description box */}
+          <View
+            style={[
+              styles.descriptionBox,
+              { backgroundColor: colors[config.mutedColorKey].muted },
+            ]}
+            testID={TrustSignalModalSelectorsIDs.DESCRIPTION_BOX}
+          >
+            <TextComponent variant={TextVariant.BodyMD}>
+              {strings(config.descriptionKey)}
+            </TextComponent>
+          </View>
+        </View>
+
+        {/* Connect Anyway button */}
+        <View style={styles.buttonContainer}>
+          <StyledButton
+            type={config.buttonType}
+            onPress={onConnectAnyway}
+            containerStyle={styles.connectAnywayButton}
+            testID={TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON}
+          >
+            {strings('accounts.connect_anyway')}
+          </StyledButton>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default TrustSignalModal;

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { SafeAreaView, View } from 'react-native';
-import { strings } from '../../../../../locales/i18n';
-import { useTheme } from '../../../../util/theme';
-import { useStyles } from '../../../../component-library/hooks';
-import TextComponent, {
+import {
+  Text,
   TextColor,
   TextVariant,
-} from '../../../../component-library/components/Texts/Text';
-import Icon, {
+  Icon,
   IconName,
   IconSize,
   IconColor,
-} from '../../../../component-library/components/Icons/Icon';
-import StyledButton from '../../../UI/StyledButton';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../component-library/components/Buttons/ButtonIcon';
+  ButtonIcon,
+  ButtonIconSize,
+  ButtonSemantic,
+  ButtonSemanticSeverity,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import { useTheme } from '../../../../util/theme';
+import { useStyles } from '../../../../component-library/hooks';
 import styleSheet from './TrustSignalModal.styles';
 import { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
 import { TrustSignalModalProps } from './TrustSignalModal.types';
@@ -39,9 +39,9 @@ const TrustSignalModal = ({
           <View style={styles.header}>
             <View style={styles.headerSpacer} />
             <ButtonIcon
-              size={ButtonIconSizes.Sm}
+              size={ButtonIconSize.Sm}
               iconName={IconName.Close}
-              iconColor={IconColor.Default}
+              iconProps={{ color: IconColor.IconDefault }}
               onPress={onClose}
               testID={TrustSignalModalSelectorsIDs.CLOSE_BUTTON}
             />
@@ -52,37 +52,37 @@ const TrustSignalModal = ({
             <Icon
               name={IconName.Danger}
               size={IconSize.Xl}
-              color={IconColor.Error}
+              color={IconColor.ErrorDefault}
             />
           </View>
 
           {/* Title */}
-          <TextComponent
+          <Text
             variant={TextVariant.HeadingMD}
             style={styles.title}
             testID={TrustSignalModalSelectorsIDs.TITLE}
           >
             {strings('accounts.trust_signal_block_title')}
-          </TextComponent>
+          </Text>
 
           {/* URL with icon */}
           <View
             style={styles.urlContainer}
             testID={TrustSignalModalSelectorsIDs.URL}
           >
-            <TextComponent
+            <Text
               variant={TextVariant.BodyMD}
-              color={TextColor.Error}
+              color={TextColor.ErrorDefault}
               style={styles.urlText}
               numberOfLines={1}
               ellipsizeMode="middle"
             >
               {url}
-            </TextComponent>
+            </Text>
             <Icon
               name={IconName.Danger}
               size={IconSize.Sm}
-              color={IconColor.Error}
+              color={IconColor.ErrorDefault}
             />
           </View>
 
@@ -94,22 +94,22 @@ const TrustSignalModal = ({
             ]}
             testID={TrustSignalModalSelectorsIDs.DESCRIPTION_BOX}
           >
-            <TextComponent variant={TextVariant.BodyMD}>
+            <Text variant={TextVariant.BodyMD}>
               {strings('accounts.trust_signal_block_description')}
-            </TextComponent>
+            </Text>
           </View>
         </View>
 
         {/* Connect Anyway button */}
         <View style={styles.buttonContainer}>
-          <StyledButton
-            type="danger"
+          <ButtonSemantic
+            severity={ButtonSemanticSeverity.Danger}
             onPress={onConnectAnyway}
-            containerStyle={styles.connectAnywayButton}
+            style={styles.connectAnywayButton}
             testID={TrustSignalModalSelectorsIDs.CONNECT_ANYWAY_BUTTON}
           >
             {strings('accounts.connect_anyway')}
-          </StyledButton>
+          </ButtonSemantic>
         </View>
       </View>
     </SafeAreaView>

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.types.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.types.ts
@@ -1,8 +1,4 @@
-export type TrustSignalModalVariant = 'malicious';
-
 export interface TrustSignalModalProps {
-  /** Which variant to render — determines colors, copy, and icon. */
-  variant: TrustSignalModalVariant;
   /** The dApp URL/hostname to display. */
   url: string;
   /** Called when the user taps "Connect Anyway". */

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.types.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.types.ts
@@ -1,0 +1,12 @@
+export type TrustSignalModalVariant = 'warning' | 'malicious';
+
+export interface TrustSignalModalProps {
+  /** Which variant to render — determines colors, copy, and icon. */
+  variant: TrustSignalModalVariant;
+  /** The dApp URL/hostname to display. */
+  url: string;
+  /** Called when the user taps "Connect Anyway". */
+  onConnectAnyway: () => void;
+  /** Called when the user taps the close button. */
+  onClose: () => void;
+}

--- a/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.types.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/TrustSignalModal.types.ts
@@ -1,4 +1,4 @@
-export type TrustSignalModalVariant = 'warning' | 'malicious';
+export type TrustSignalModalVariant = 'malicious';
 
 export interface TrustSignalModalProps {
   /** Which variant to render — determines colors, copy, and icon. */

--- a/app/components/Views/AccountConnect/TrustSignalModal/index.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/index.ts
@@ -1,3 +1,9 @@
 export { default } from './TrustSignalModal';
 export { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
 export type { TrustSignalModalProps } from './TrustSignalModal.types';
+export {
+  DEV_TRUST_SIGNAL_OVERRIDES,
+  TRUST_SIGNAL_VARIANT,
+  useTrustSignalState,
+  useTrustSignalGateControl,
+} from './useTrustSignalGate';

--- a/app/components/Views/AccountConnect/TrustSignalModal/index.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/index.ts
@@ -1,6 +1,3 @@
 export { default } from './TrustSignalModal';
 export { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
-export type {
-  TrustSignalModalProps,
-  TrustSignalModalVariant,
-} from './TrustSignalModal.types';
+export type { TrustSignalModalProps } from './TrustSignalModal.types';

--- a/app/components/Views/AccountConnect/TrustSignalModal/index.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/index.ts
@@ -1,0 +1,6 @@
+export { default } from './TrustSignalModal';
+export { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
+export type {
+  TrustSignalModalProps,
+  TrustSignalModalVariant,
+} from './TrustSignalModal.types';

--- a/app/components/Views/AccountConnect/TrustSignalModal/index.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/index.ts
@@ -3,7 +3,6 @@ export { TrustSignalModalSelectorsIDs } from './TrustSignalModal.testIds';
 export type { TrustSignalModalProps } from './TrustSignalModal.types';
 export {
   DEV_TRUST_SIGNAL_OVERRIDES,
-  TRUST_SIGNAL_VARIANT,
   useTrustSignalState,
   useTrustSignalGateControl,
 } from './useTrustSignalGate';

--- a/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.test.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useTrustSignalGateControl } from './useTrustSignalGate';
+import { AccountConnectScreens } from '../AccountConnect.types';
+
+describe('useTrustSignalGateControl', () => {
+  it('transitions to TrustSignalWarning from SingleConnect', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    expect(setScreen).toHaveBeenCalledTimes(1);
+    const updater = setScreen.mock.calls[0][0];
+    expect(updater(AccountConnectScreens.SingleConnect)).toBe(
+      AccountConnectScreens.TrustSignalWarning,
+    );
+  });
+
+  it('transitions to TrustSignalWarning from SingleConnectSelector (race-condition fix)', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    const updater = setScreen.mock.calls[0][0];
+    expect(updater(AccountConnectScreens.SingleConnectSelector)).toBe(
+      AccountConnectScreens.TrustSignalWarning,
+    );
+  });
+
+  it('transitions to TrustSignalWarning from MultiConnectSelector (race-condition fix)', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    const updater = setScreen.mock.calls[0][0];
+    expect(updater(AccountConnectScreens.MultiConnectSelector)).toBe(
+      AccountConnectScreens.TrustSignalWarning,
+    );
+  });
+
+  it('transitions to TrustSignalWarning from AddNewAccount (race-condition fix)', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    const updater = setScreen.mock.calls[0][0];
+    expect(updater(AccountConnectScreens.AddNewAccount)).toBe(
+      AccountConnectScreens.TrustSignalWarning,
+    );
+  });
+
+  it('does not interrupt MaliciousWarning screen', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    const updater = setScreen.mock.calls[0][0];
+    expect(updater(AccountConnectScreens.MaliciousWarning)).toBe(
+      AccountConnectScreens.MaliciousWarning,
+    );
+  });
+
+  it('is a no-op when already on TrustSignalWarning', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    const updater = setScreen.mock.calls[0][0];
+    expect(updater(AccountConnectScreens.TrustSignalWarning)).toBe(
+      AccountConnectScreens.TrustSignalWarning,
+    );
+  });
+
+  it('does not fire when needsTrustSignalGate is false', () => {
+    const setScreen = jest.fn();
+
+    renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: false } },
+    );
+
+    expect(setScreen).not.toHaveBeenCalled();
+  });
+
+  it('does not fire again after the gate has been dismissed', () => {
+    const setScreen = jest.fn();
+
+    const { result, rerender } = renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    // Dismiss the gate
+    act(() => {
+      result.current.handleTrustSignalDismiss();
+    });
+
+    setScreen.mockClear();
+
+    // Re-trigger the effect (e.g., needsTrustSignalGate flickers false→true)
+    rerender({ needsTrustSignalGate: false });
+    rerender({ needsTrustSignalGate: true });
+
+    expect(setScreen).not.toHaveBeenCalled();
+  });
+
+  it('handleTrustSignalDismiss navigates to SingleConnect', () => {
+    const setScreen = jest.fn();
+
+    const { result } = renderHook(
+      ({ needsTrustSignalGate }) =>
+        useTrustSignalGateControl(needsTrustSignalGate, setScreen),
+      { initialProps: { needsTrustSignalGate: true } },
+    );
+
+    setScreen.mockClear();
+
+    act(() => {
+      result.current.handleTrustSignalDismiss();
+    });
+
+    expect(setScreen).toHaveBeenCalledWith(AccountConnectScreens.SingleConnect);
+  });
+});

--- a/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.ts
@@ -38,11 +38,19 @@ export function useTrustSignalGateControl(
 
   useEffect(() => {
     if (needsTrustSignalGate && !gateDismissedRef.current) {
-      setScreen((prev) =>
-        prev === AccountConnectScreens.SingleConnect
-          ? AccountConnectScreens.TrustSignalWarning
-          : prev,
-      );
+      setScreen((prev) => {
+        // Don't interrupt screens that are already blocking gates, and avoid a
+        // no-op re-render when we're already on the warning screen itself.
+        if (
+          prev === AccountConnectScreens.TrustSignalWarning ||
+          prev === AccountConnectScreens.MaliciousWarning
+        ) {
+          return prev;
+        }
+        // Gate fires regardless of which "browse" screen the user reached while
+        // the async dapp-scanning result was in flight.
+        return AccountConnectScreens.TrustSignalWarning;
+      });
     }
   }, [needsTrustSignalGate, setScreen]);
 

--- a/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { getHost } from '../../../../util/browser';
+import { useOriginTrustSignals } from '../../confirmations/hooks/useOriginTrustSignals';
+import { TrustSignalDisplayState } from '../../confirmations/types/trustSignals';
+import { AccountConnectScreens } from '../AccountConnect.types';
+
+export const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
+  Record<string, TrustSignalDisplayState>
+> = __DEV__
+  ? {
+      'app.uniswap.org': TrustSignalDisplayState.Verified,
+      'revoke.cash': TrustSignalDisplayState.Malicious,
+    }
+  : {};
+
+export const TRUST_SIGNAL_VARIANT = 'malicious' as const;
+
+/**
+ * Computes trust signal state for the given origin.
+ * Call BEFORE the `useState` for `screen` so the initial value can be set
+ * correctly without a flash.
+ */
+export function useTrustSignalState(origin: string) {
+  const { state: raw } = useOriginTrustSignals(origin);
+  const trustSignalState = DEV_TRUST_SIGNAL_OVERRIDES[getHost(origin)] ?? raw;
+  const needsTrustSignalGate =
+    trustSignalState === TrustSignalDisplayState.Malicious;
+  return { trustSignalState, needsTrustSignalGate };
+}
+
+/**
+ * Wires up the async-arrival effect and the dismiss handler for the trust
+ * signal gate. Call AFTER the `useState` for `screen`.
+ */
+export function useTrustSignalGateControl(
+  needsTrustSignalGate: boolean,
+  setScreen: React.Dispatch<React.SetStateAction<AccountConnectScreens>>,
+) {
+  const gateDismissedRef = useRef(false);
+
+  useEffect(() => {
+    if (needsTrustSignalGate && !gateDismissedRef.current) {
+      setScreen((prev) =>
+        prev === AccountConnectScreens.SingleConnect
+          ? AccountConnectScreens.TrustSignalWarning
+          : prev,
+      );
+    }
+  }, [needsTrustSignalGate, setScreen]);
+
+  const handleTrustSignalDismiss = useCallback(() => {
+    gateDismissedRef.current = true;
+    setScreen(AccountConnectScreens.SingleConnect);
+  }, [setScreen]);
+
+  return { handleTrustSignalDismiss };
+}

--- a/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.ts
+++ b/app/components/Views/AccountConnect/TrustSignalModal/useTrustSignalGate.ts
@@ -13,8 +13,6 @@ export const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
     }
   : {};
 
-export const TRUST_SIGNAL_VARIANT = 'malicious' as const;
-
 /**
  * Computes trust signal state for the given origin.
  * Call BEFORE the `useState` for `screen` so the initial value can be set

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -93,6 +93,9 @@ import MultichainPermissionsSummary, {
   MultichainPermissionsSummaryProps,
 } from '../MultichainPermissionsSummary/MultichainPermissionsSummary.tsx';
 import AccountConnectMaliciousWarning from '../../AccountConnect/AccountConnectMaliciousWarning/AccountConnectMaliciousWarning';
+import TrustSignalModal from '../../AccountConnect/TrustSignalModal';
+import { useOriginTrustSignals } from '../../confirmations/hooks/useOriginTrustSignals';
+import { TrustSignalDisplayState } from '../../confirmations/types/trustSignals';
 import MultichainAccountConnectMultiSelector from './MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx';
 import { getPermissions } from '../../../../selectors/snaps/index.ts';
 import { useSDKV2Connection } from '../../../hooks/useSDKV2Connection';
@@ -464,8 +467,26 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     CaipAccountId[]
   >(suggestedCaipAccountIds);
 
+  const { state: rawTrustSignalState } =
+    useOriginTrustSignals(channelIdOrHostname);
+  const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
+    Record<string, TrustSignalDisplayState>
+  > = {
+    'app.uniswap.org': TrustSignalDisplayState.Verified,
+    'revoke.cash': TrustSignalDisplayState.Malicious,
+  };
+  const trustSignalState =
+    DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)] ??
+    rawTrustSignalState;
+  const needsTrustSignalGate =
+    trustSignalState === TrustSignalDisplayState.Malicious;
+  const trustSignalGateDismissedRef = useRef(false);
+  const trustSignalVariant = 'malicious' as const;
+
   const [screen, setScreen] = useState<AccountConnectScreens>(
-    AccountConnectScreens.SingleConnect,
+    needsTrustSignalGate
+      ? AccountConnectScreens.TrustSignalWarning
+      : AccountConnectScreens.SingleConnect,
   );
   const [showPhishingModal, setShowPhishingModal] = useState(false);
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
@@ -539,6 +560,16 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
       isMountedRef.current = false;
     };
   }, [dappUrl, channelIdOrHostname]);
+
+  useEffect(() => {
+    if (
+      needsTrustSignalGate &&
+      !trustSignalGateDismissedRef.current &&
+      screen === AccountConnectScreens.SingleConnect
+    ) {
+      setScreen(AccountConnectScreens.TrustSignalWarning);
+    }
+  }, [needsTrustSignalGate, screen]);
 
   const { faviconURI: faviconSource } = useFavicon(dappUrl);
 
@@ -829,6 +860,16 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     setScreen(AccountConnectScreens.SingleConnect);
   }, []);
 
+  const handleTrustSignalDismiss = useCallback(() => {
+    trustSignalGateDismissedRef.current = true;
+    setScreen(AccountConnectScreens.SingleConnect);
+  }, []);
+
+  const handleTrustSignalClose = useCallback(() => {
+    cancelPermissionRequest(permissionRequestId);
+    navigation.goBack();
+  }, [cancelPermissionRequest, permissionRequestId, navigation]);
+
   const permissionsSummaryProps = useMemo(
     (): MultichainPermissionsSummaryProps => ({
       currentPageInformation: {
@@ -852,6 +893,7 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
       setTabIndex,
       tabIndex,
       isMaliciousDapp,
+      trustSignalState,
     }),
     [
       faviconSource,
@@ -864,6 +906,7 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
       permissionRequestId,
       navigation,
       isMaliciousDapp,
+      trustSignalState,
     ],
   );
 
@@ -979,6 +1022,17 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
           />
         </ScreenContainer>
       )}
+      <ScreenContainer
+        isVisible={screen === AccountConnectScreens.TrustSignalWarning}
+        styles={styles}
+      >
+        <TrustSignalModal
+          variant={trustSignalVariant}
+          url={urlWithProtocol}
+          onConnectAnyway={handleTrustSignalDismiss}
+          onClose={handleTrustSignalClose}
+        />
+      </ScreenContainer>
       {renderPhishingModal()}
     </Box>
   );

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -96,6 +96,17 @@ import AccountConnectMaliciousWarning from '../../AccountConnect/AccountConnectM
 import TrustSignalModal from '../../AccountConnect/TrustSignalModal';
 import { useOriginTrustSignals } from '../../confirmations/hooks/useOriginTrustSignals';
 import { TrustSignalDisplayState } from '../../confirmations/types/trustSignals';
+
+const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
+  Record<string, TrustSignalDisplayState>
+> = __DEV__
+  ? {
+      'app.uniswap.org': TrustSignalDisplayState.Verified,
+      'revoke.cash': TrustSignalDisplayState.Malicious,
+    }
+  : {};
+
+const TRUST_SIGNAL_VARIANT = 'malicious' as const;
 import MultichainAccountConnectMultiSelector from './MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx';
 import { getPermissions } from '../../../../selectors/snaps/index.ts';
 import { useSDKV2Connection } from '../../../hooks/useSDKV2Connection';
@@ -469,19 +480,12 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
 
   const { state: rawTrustSignalState } =
     useOriginTrustSignals(channelIdOrHostname);
-  const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
-    Record<string, TrustSignalDisplayState>
-  > = {
-    'app.uniswap.org': TrustSignalDisplayState.Verified,
-    'revoke.cash': TrustSignalDisplayState.Malicious,
-  };
   const trustSignalState =
     DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)] ??
     rawTrustSignalState;
   const needsTrustSignalGate =
     trustSignalState === TrustSignalDisplayState.Malicious;
   const trustSignalGateDismissedRef = useRef(false);
-  const trustSignalVariant = 'malicious' as const;
 
   const [screen, setScreen] = useState<AccountConnectScreens>(
     needsTrustSignalGate
@@ -562,14 +566,14 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
   }, [dappUrl, channelIdOrHostname]);
 
   useEffect(() => {
-    if (
-      needsTrustSignalGate &&
-      !trustSignalGateDismissedRef.current &&
-      screen === AccountConnectScreens.SingleConnect
-    ) {
-      setScreen(AccountConnectScreens.TrustSignalWarning);
+    if (needsTrustSignalGate && !trustSignalGateDismissedRef.current) {
+      setScreen((prev) =>
+        prev === AccountConnectScreens.SingleConnect
+          ? AccountConnectScreens.TrustSignalWarning
+          : prev,
+      );
     }
-  }, [needsTrustSignalGate, screen]);
+  }, [needsTrustSignalGate]);
 
   const { faviconURI: faviconSource } = useFavicon(dappUrl);
 
@@ -1027,7 +1031,7 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
         styles={styles}
       >
         <TrustSignalModal
-          variant={trustSignalVariant}
+          variant={TRUST_SIGNAL_VARIANT}
           url={urlWithProtocol}
           onConnectAnyway={handleTrustSignalDismiss}
           onClose={handleTrustSignalClose}

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -93,18 +93,10 @@ import MultichainPermissionsSummary, {
   MultichainPermissionsSummaryProps,
 } from '../MultichainPermissionsSummary/MultichainPermissionsSummary.tsx';
 import AccountConnectMaliciousWarning from '../../AccountConnect/AccountConnectMaliciousWarning/AccountConnectMaliciousWarning';
-import TrustSignalModal from '../../AccountConnect/TrustSignalModal';
-import { useOriginTrustSignals } from '../../confirmations/hooks/useOriginTrustSignals';
-import { TrustSignalDisplayState } from '../../confirmations/types/trustSignals';
-
-const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
-  Record<string, TrustSignalDisplayState>
-> = __DEV__
-  ? {
-      'app.uniswap.org': TrustSignalDisplayState.Verified,
-      'revoke.cash': TrustSignalDisplayState.Malicious,
-    }
-  : {};
+import TrustSignalModal, {
+  useTrustSignalState,
+  useTrustSignalGateControl,
+} from '../../AccountConnect/TrustSignalModal';
 
 import MultichainAccountConnectMultiSelector from './MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx';
 import { getPermissions } from '../../../../selectors/snaps/index.ts';
@@ -477,19 +469,18 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     CaipAccountId[]
   >(suggestedCaipAccountIds);
 
-  const { state: rawTrustSignalState } =
-    useOriginTrustSignals(channelIdOrHostname);
-  const trustSignalState =
-    DEV_TRUST_SIGNAL_OVERRIDES[getHost(channelIdOrHostname)] ??
-    rawTrustSignalState;
-  const needsTrustSignalGate =
-    trustSignalState === TrustSignalDisplayState.Malicious;
-  const trustSignalGateDismissedRef = useRef(false);
+  const { trustSignalState, needsTrustSignalGate } =
+    useTrustSignalState(channelIdOrHostname);
 
   const [screen, setScreen] = useState<AccountConnectScreens>(
     needsTrustSignalGate
       ? AccountConnectScreens.TrustSignalWarning
       : AccountConnectScreens.SingleConnect,
+  );
+
+  const { handleTrustSignalDismiss } = useTrustSignalGateControl(
+    needsTrustSignalGate,
+    setScreen,
   );
   const [showPhishingModal, setShowPhishingModal] = useState(false);
   const [userIntent, setUserIntent] = useState(USER_INTENT.None);
@@ -563,16 +554,6 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
       isMountedRef.current = false;
     };
   }, [dappUrl, channelIdOrHostname]);
-
-  useEffect(() => {
-    if (needsTrustSignalGate && !trustSignalGateDismissedRef.current) {
-      setScreen((prev) =>
-        prev === AccountConnectScreens.SingleConnect
-          ? AccountConnectScreens.TrustSignalWarning
-          : prev,
-      );
-    }
-  }, [needsTrustSignalGate]);
 
   const { faviconURI: faviconSource } = useFavicon(dappUrl);
 
@@ -860,11 +841,6 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
   }, [handleConnect, navigation]);
 
   const handleMaliciousWarningClose = useCallback(() => {
-    setScreen(AccountConnectScreens.SingleConnect);
-  }, []);
-
-  const handleTrustSignalDismiss = useCallback(() => {
-    trustSignalGateDismissedRef.current = true;
     setScreen(AccountConnectScreens.SingleConnect);
   }, []);
 

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -106,7 +106,6 @@ const DEV_TRUST_SIGNAL_OVERRIDES: Partial<
     }
   : {};
 
-const TRUST_SIGNAL_VARIANT = 'malicious' as const;
 import MultichainAccountConnectMultiSelector from './MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx';
 import { getPermissions } from '../../../../selectors/snaps/index.ts';
 import { useSDKV2Connection } from '../../../hooks/useSDKV2Connection';
@@ -1031,7 +1030,6 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
         styles={styles}
       >
         <TrustSignalModal
-          variant={TRUST_SIGNAL_VARIANT}
           url={urlWithProtocol}
           onConnectAnyway={handleTrustSignalDismiss}
           onClose={handleTrustSignalClose}

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.styles.ts
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.styles.ts
@@ -167,6 +167,12 @@ const createStyles = (params: { theme: Theme }) => {
       borderRadius: 16,
       paddingVertical: 8,
     },
+    connectionTitleContainer: {
+      justifyContent: 'center',
+      display: 'flex',
+      flexDirection: 'row',
+      gap: 3,
+    },
   });
 };
 

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -35,8 +35,10 @@ import styleSheet from './MultichainPermissionsSummary.styles';
 import { useStyles } from '../../../../component-library/hooks';
 import {
   MaliciousDappUrlIcon,
+  TrustSignalUrlIcon,
   getConnectButtonContent,
 } from '../../../UI/PermissionsSummary/MaliciousDappIndicators';
+import { TrustSignalDisplayState } from '../../confirmations/types/trustSignals';
 import Routes from '../../../../constants/navigation/Routes';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -69,6 +71,7 @@ import { selectAccountGroups } from '../../../../selectors/multichainAccounts/ac
 import { AccountGroupObject } from '@metamask/account-tree-controller';
 import { selectIconSeedAddressesByAccountGroupIds } from '../../../../selectors/multichainAccounts/accounts';
 import { RootState } from '../../../../reducers';
+import { Box } from '@metamask/design-system-react-native';
 
 export interface MultichainPermissionsSummaryProps {
   currentPageInformation: {
@@ -100,6 +103,7 @@ export interface MultichainPermissionsSummaryProps {
   showPermissionsOnly?: boolean;
   showAccountsOnly?: boolean;
   isMaliciousDapp?: boolean;
+  trustSignalState?: TrustSignalDisplayState;
 }
 
 const MultichainPermissionsSummary = ({
@@ -125,6 +129,7 @@ const MultichainPermissionsSummary = ({
   showAccountsOnly = false,
   showPermissionsOnly = false,
   isMaliciousDapp = false,
+  trustSignalState,
 }: MultichainPermissionsSummaryProps) => {
   const nonTabView = showAccountsOnly || showPermissionsOnly;
   const { colors } = useTheme();
@@ -580,24 +585,33 @@ const MultichainPermissionsSummary = ({
               PermissionSummaryBottomSheetSelectorsIDs.NETWORK_PERMISSIONS_CONTAINER
             }
           >
-            <TextComponent
-              style={styles.connectionTitle}
-              variant={TextVariant.HeadingMD}
-              color={
-                isMaliciousDapp && !isAlreadyConnected
-                  ? TextColor.Error
-                  : undefined
-              }
-            >
-              {isNonDappNetworkSwitch
-                ? strings('permissions.title_add_network_permission')
-                : !isAlreadyConnected || isNetworkSwitch
-                  ? hostname
-                  : strings('permissions.title_dapp_url_has_approval_to', {
-                      dappUrl: hostname,
-                    })}
-            </TextComponent>
-            {isMaliciousDapp && !isAlreadyConnected && <MaliciousDappUrlIcon />}
+            <Box style={styles.connectionTitleContainer}>
+              <TextComponent
+                style={styles.connectionTitle}
+                variant={TextVariant.HeadingMD}
+                color={
+                  (isMaliciousDapp ||
+                    trustSignalState === TrustSignalDisplayState.Malicious) &&
+                  !isAlreadyConnected
+                    ? TextColor.Error
+                    : undefined
+                }
+              >
+                {isNonDappNetworkSwitch
+                  ? strings('permissions.title_add_network_permission')
+                  : !isAlreadyConnected || isNetworkSwitch
+                    ? hostname
+                    : strings('permissions.title_dapp_url_has_approval_to', {
+                        dappUrl: hostname,
+                      })}
+              </TextComponent>
+              {isMaliciousDapp && !isAlreadyConnected && (
+                <MaliciousDappUrlIcon />
+              )}
+              {!isMaliciousDapp && !isAlreadyConnected && trustSignalState && (
+                <TrustSignalUrlIcon state={trustSignalState} />
+              )}
+            </Box>
             <TextComponent variant={TextVariant.BodyMD}>
               {strings('account_dapp_connections.account_summary_header')}
             </TextComponent>
@@ -649,7 +663,12 @@ const MultichainPermissionsSummary = ({
                 {strings('permissions.cancel')}
               </StyledButton>
               <StyledButton
-                type={isMaliciousDapp ? 'danger' : 'confirm'}
+                type={
+                  isMaliciousDapp ||
+                  trustSignalState === TrustSignalDisplayState.Malicious
+                    ? 'danger'
+                    : 'confirm'
+                }
                 onPress={confirm}
                 disabled={
                   !isNetworkSwitch &&
@@ -662,7 +681,11 @@ const MultichainPermissionsSummary = ({
                 ]}
                 testID={CommonSelectorsIDs.CONNECT_BUTTON}
               >
-                {getConnectButtonContent(isMaliciousDapp, isNetworkSwitch)}
+                {getConnectButtonContent(
+                  isMaliciousDapp,
+                  isNetworkSwitch,
+                  trustSignalState,
+                )}
               </StyledButton>
             </View>
           )}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2851,7 +2851,11 @@
     },
     "no_accounts_found": "No accounts found",
     "no_accounts_found_for_search": "No accounts found matching your search",
-    "search_your_accounts": "Search your accounts"
+    "search_your_accounts": "Search your accounts",
+    "trust_signal_warning_title": "Unverified site",
+    "trust_signal_warning_description": "This site has not been verified. Proceed with caution when connecting.",
+    "trust_signal_block_title": "Malicious site detected",
+    "trust_signal_block_description": "This site has been flagged as malicious. Connecting may put your assets at risk."
   },
   "toast": {
     "connected_and_active": "connected and active.",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2852,8 +2852,6 @@
     "no_accounts_found": "No accounts found",
     "no_accounts_found_for_search": "No accounts found matching your search",
     "search_your_accounts": "Search your accounts",
-    "trust_signal_warning_title": "Unverified site",
-    "trust_signal_warning_description": "This site has not been verified. Proceed with caution when connecting.",
     "trust_signal_block_title": "Malicious site detected",
     "trust_signal_block_description": "This site has been flagged as malicious. Connecting may put your assets at risk."
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Adds trust signal modals that gate the wallet connection flow based on dApp trustworthiness from the `dapp-scanning` API. It shows a warning or block modal when flagged, which requires confirmation in order to advance to the connect screen. Also changes existing connect page confirmation buttons colors and icons based on the trust state.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added confirmation modals for `block` trust signals on the connect page.

## **Related issues**

Fixes: [WAPI-1112](https://consensyssoftware.atlassian.net/browse/WAPI-1112)
Mirror Extension PR: https://github.com/MetaMask/metamask-extension/pull/40348
## **Manual testing steps**

```gherkin
Feature: Dapp Connection

  Scenario: user connects to a dapp flagged as Malicious
    Given the user navigates to a malicious dapp in the in-app browser

    When user clicks dapp connect button
    Then the pre-confirmation modal should appear warning the user. Upon confirming, he should see the connect button in red and a warning icon next to the url 
    
  Scenario: user connects to a verified dapp
    Given the user navigates to a verified dapp in the in-app browser

    When user clicks dapp connect button
    Then he should see a green checkmark icon next to the dapp url
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/6c1914cc-4f6d-47ef-bc11-5cb7cdc4db12



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new blocking step in the connection flow based on trust-signal results and changes connect CTA styling/behavior, which could impact conversion and navigation/state transitions if edge cases are missed.
> 
> **Overview**
> Adds trust-signal support to the connect experience: a new `TrustSignalModal` blocks the `AccountConnect` (and multichain connect) flow when the dapp-scanning state is `Malicious`, with “Connect anyway” to proceed or close to cancel the request.
> 
> Updates `PermissionsSummary` (and multichain equivalent) to accept `trustSignalState`, show a verified/malicious icon next to the origin, tint the title red for malicious, and render the connect CTA in *danger* style when the origin is malicious via either WalletConnect scam flag or trust-signal state. Also refactors `MaliciousDappIndicators` to use the design system and expands unit tests/strings accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e3db15186858ecefd71759fed966cb1a2e3ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[WAPI-1112]: https://consensyssoftware.atlassian.net/browse/WAPI-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ