### PR TITLE
feat: add E2E test builder skill

### DIFF
--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: e2e-test
+description:
+  Add and fix Detox E2E tests (smoke and regression) for MetaMask Mobile using
+  withFixtures, Page Objects, and tests/framework. Use when creating a new spec,
+  fixing a failing E2E test, or adding page objects and selectors.
+---
+
+# E2E Test Builder — Skill
+
+> **One source of truth** for adding Detox E2E tests to MetaMask Mobile.
+> Applies to: Claude Code (`.claude/commands/e2e-test.md`), Cursor, Copilot, Windsurf, and other AI agents.
+
+**Before writing or changing any E2E code:** read this skill once, then open the reference(s) indicated by the decision tree for your task.
+
+## What This Skill Does
+
+Guides you through adding a new E2E regression or smoke test end-to-end:
+
+1. Plans the test (type, location, infrastructure needed)
+2. Creates or reuses Page Objects and selectors
+3. Writes the spec using the mandatory framework patterns and the **correct tag** (see Golden rule 8; check `tests/tags.js` and existing specs in the feature folder)
+4. Runs lint and type checks
+5. Executes the test locally via Detox
+6. Iterates until the test passes
+
+Your job is to figure out whether the user needs to **write a new spec**, **fix a failing test**, or **add page objects/selectors**, then follow the corresponding path and open the relevant reference when that path indicates.
+
+**Decision tree — which reference to use:**
+
+```
+Task → What do you need?
+├─ Write new spec or add test steps
+│  → Open references/writing-tests.md (spec structure, templates, FixtureBuilder patterns)
+│  → If you need POM/selectors: also open references/page-objects.md
+│  → If you need API or feature-flag mocks: also open references/mocking.md
+│  → After writing: run lint/tsc, then open references/running-tests.md to run and debug
+│
+├─ Create or update Page Objects / selectors
+│  → Open references/page-objects.md (POM structure, Matchers, Gestures, Assertions, selector conventions)
+│  → When writing the spec: open references/writing-tests.md
+│
+├─ Mock API or feature flags
+│  → Open references/mocking.md (testSpecificMock, setupRemoteFeatureFlagsMock, setupMockRequest)
+│  → When writing the spec: open references/writing-tests.md
+│
+└─ Run tests, debug failures, or self-review
+   → Open references/running-tests.md (build check, detox commands, common failures, retry patterns)
+```
+
+Do not read the full reference files until the decision tree or workflow sends you there.
+
+---
+
+## 10 Golden Rules
+
+1. **Always use `withFixtures`** — every spec must be wrapped; no exceptions
+2. **Always use Page Object Model** — no `element(by.id())` in spec files
+3. **Always import from `tests/framework/index.ts`** — never from individual files
+4. **Always add `description`** to every `Gestures.*` and `Assertions.*` call
+5. **Never use `TestHelpers.delay()`** — use `Assertions.*` which has auto-retry
+6. **Use `FixtureBuilder` for state** — do not set state through UI interactions
+7. **Selectors live in `*.testIds.ts`** (co-located) or `tests/selectors/` (legacy)
+8. **Tag correctly** — Use the tag that matches your feature and test type. Options include `SmokeE2E`, `SmokeTrade`, `SmokePredictions`, `SmokePerps`, `SmokeConfirmations`, `RegressionTrade`, `RegressionWallet`, etc. Check **`tests/tags.js`** for the full list and descriptions, and **existing specs in the same feature folder** to see which tag they use.
+9. **Descriptive test names** — no 'should' prefix (e.g., `'opens market details'`)
+10. **Fix lint/tsc before running** — never run with known errors
+
+---
+
+## Workflow Overview
+
+```
+Step 0 → Understand requirement + choose type (smoke/regression)
+Step 1 → Discover / create Page Objects and selectors
+Step 2 → Write the spec (withFixtures + POM + correct tag)
+Step 3 → Lint + TSC (fix all errors)
+Step 4 → Run detox test locally
+Step 5 → Iterate (fix → lint → run) until green
+```
+
+---
+
+## Reference files (when to use)
+
+Documentation is split by **action**. Open only the reference that matches what you are doing.
+
+| Action                                        | File                                                       | When to open it                                                                                   |
+| --------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Writing or updating a spec**                | [references/writing-tests.md](references/writing-tests.md) | New spec file, spec structure, FixtureBuilder patterns, smoke/regression templates.               |
+| **Page Objects and selectors**                | [references/page-objects.md](references/page-objects.md)   | Create or update POM classes, selector/testId conventions, Matchers/Gestures/Assertions API.      |
+| **API and feature flag mocking**              | [references/mocking.md](references/mocking.md)             | testSpecificMock, setupRemoteFeatureFlagsMock, setupMockRequest, shared mock files.               |
+| **Running tests, debugging, fixing failures** | [references/running-tests.md](references/running-tests.md) | Build check, detox run commands, lint/tsc, common failures table, retry patterns, iteration loop. |

--- a/.agents/skills/e2e-test/agents/openai.yaml
+++ b/.agents/skills/e2e-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "E2E Test"
+  short_description: "Add and fix Detox E2E smoke/regression tests for MetaMask Mobile."
+  default_prompt: "Use $e2e-test to add or fix E2E tests with withFixtures, Page Objects, and the tests/framework."

--- a/.agents/skills/e2e-test/references/mocking.md
+++ b/.agents/skills/e2e-test/references/mocking.md
@@ -1,0 +1,141 @@
+# API & Feature Flag Mocking — Reference
+
+## How Mocking Works
+
+All E2E tests run with a proxy mock server. Requests not matched by a mock reach the real network, but the test framework warns you (and will soon enforce this). Always mock external APIs your feature calls.
+
+## testSpecificMock Pattern
+
+Pass to `withFixtures` to apply mocks only for that test:
+
+```typescript
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { setupMockRequest } from '../../api-mocking/mockHelpers';
+
+const testSpecificMock = async (mockServer: Mockttp) => {
+  // Feature flags
+  await setupRemoteFeatureFlagsMock(mockServer, { myFeatureEnabled: true });
+
+  // GET request
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: 'https://api.example.com/data',
+    response: { items: [] },
+    responseCode: 200,
+  });
+};
+
+await withFixtures({ fixture: ..., testSpecificMock }, async () => { ... });
+```
+
+## Feature Flag Mocking
+
+```typescript
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+
+// Simple boolean flags
+await setupRemoteFeatureFlagsMock(mockServer, {
+  predictTradingEnabled: true,
+  carouselBanners: false,
+});
+
+// Nested flags
+await setupRemoteFeatureFlagsMock(mockServer, {
+  bridgeConfig: { support: true, refreshRate: 5000 },
+});
+
+// Flask distribution
+await setupRemoteFeatureFlagsMock(mockServer, { perpsEnabled: true }, 'flask');
+
+// Combine predefined configs
+import { confirmationsRedesignedFeatureFlags } from '../../api-mocking/mock-responses/feature-flags-mocks';
+await setupRemoteFeatureFlagsMock(
+  mockServer,
+  Object.assign({}, ...confirmationsRedesignedFeatureFlags, { myFlag: true }),
+);
+```
+
+## HTTP Request Mocking
+
+```typescript
+import {
+  setupMockRequest,
+  setupMockPostRequest,
+} from '../../api-mocking/mockHelpers';
+
+// GET
+await setupMockRequest(mockServer, {
+  requestMethod: 'GET',
+  url: 'https://api.example.com/resource',
+  response: { data: [] },
+  responseCode: 200,
+});
+
+// POST with body validation
+await setupMockPostRequest(
+  mockServer,
+  'https://api.example.com/submit',
+  { amount: '1000000000000000000' }, // expected request body
+  { success: true }, // response
+  { statusCode: 201, ignoreFields: ['timestamp', 'nonce'] },
+);
+```
+
+## Shared Mock Response Files
+
+For mocks used across multiple tests, create a file in `tests/api-mocking/mock-responses/`:
+
+```typescript
+// tests/api-mocking/mock-responses/predict-mocks.ts
+import { MockApiEndpoint } from '../framework/types';
+
+export const PREDICT_MOCKS = {
+  GET: [
+    {
+      urlEndpoint: 'https://predict.api.metamask.io/markets',
+      responseCode: 200,
+      response: { markets: [{ id: 'btc-usd', name: 'BTC above $100k?' }] },
+    },
+  ] as MockApiEndpoint[],
+};
+```
+
+Then pass directly to `withFixtures`:
+
+```typescript
+await withFixtures({ fixture: ..., testSpecificMock: PREDICT_MOCKS }, async () => { ... });
+```
+
+## Controller-Level Mocking (Advanced)
+
+Only needed when the feature uses SDKs with complex transport (WebSockets, custom protocols) that can't be intercepted at the HTTP level.
+
+- Implement a mixin in `tests/controller-mocking/mock-config/`
+- See `tests/docs/CONTROLLER_MOCKING.md` for details
+- Prefer HTTP-level mocking whenever possible
+
+## Debugging Unmocked Requests
+
+Check test output for warnings like:
+
+```
+⚠️  Unmocked request: GET https://api.example.com/resource
+```
+
+Add a mock for every such request to ensure test determinism.
+
+## Features using WebSockets or complex transport
+
+Some features depend on **WebSockets** or other non-HTTP transport (e.g. Perps/HyperLiquid, real-time data). The HTTP mock server cannot intercept these. The repo uses two patterns:
+
+1. **Controller-level mocking** — A mixin under `tests/controller-mocking/mock-config/` replaces provider SDK touchpoints so E2E runs with stable, test-controlled data. Example: `perps-controller-mixin.ts` for HyperLiquid. See **`tests/docs/CONTROLLER_MOCKING.md`** for when and how to use it.
+2. **Command queue / test server** — Tests that need to drive the app (e.g. inject state or commands) can use **`CommandQueueServer`** (`tests/framework/fixtures/CommandQueueServer.ts`). Enable it in the fixture with `useCommandQueueServer: true`. Used by Perps specs (e.g. `tests/smoke/perps/perps-add-funds.spec.ts`, `tests/regression/perps/perps-limit-long-fill.spec.ts`). The app consumes the queue in E2E context.
+
+**When adding support for a new feature that uses WebSockets or similar:**
+
+- Follow the **same pattern** as existing features (controller mixin and/or CommandQueueServer).
+- Implement under `tests/controller-mocking/mock-config/` or extend the command-queue protocol as needed.
+- Add or update **tests/specs** that cover the mock infrastructure and the E2E flow.
+
+Prefer HTTP mocking whenever the feature’s API is plain HTTP; use controller mocking or the command server only when necessary.

--- a/.agents/skills/e2e-test/references/page-objects.md
+++ b/.agents/skills/e2e-test/references/page-objects.md
@@ -1,0 +1,189 @@
+# Page Objects & Selectors — Reference
+
+## Page Object Location
+
+```
+tests/page-objects/
+└── <Feature>/
+    ├── MyFeatureView.ts        ← main screen PO
+    ├── MyFeatureList.ts        ← list/modal PO
+    └── MyFeatureDetailsView.ts ← detail screen PO
+```
+
+One class per screen or significant UI component.
+
+## Full Page Object Template
+
+```typescript
+// tests/page-objects/Predict/PredictMarketList.ts
+import Matchers from '../../framework/Matchers';
+import Gestures from '../../framework/Gestures';
+import Assertions from '../../framework/Assertions';
+import { Utilities } from '../../framework';
+import { PredictMarketListSelectorsIDs } from '../../../app/components/UI/Predict/PredictMarketList.testIds';
+
+class PredictMarketList {
+  // --- Getters (element references, never interact directly in spec) ---
+
+  get container() {
+    return Matchers.getElementByID(PredictMarketListSelectorsIDs.CONTAINER);
+  }
+
+  get searchInput() {
+    return Matchers.getElementByID(PredictMarketListSelectorsIDs.SEARCH_INPUT);
+  }
+
+  get firstCard() {
+    return Matchers.getElementByID(PredictMarketListSelectorsIDs.FIRST_CARD);
+  }
+
+  // --- Action methods ---
+
+  async tapFirstCard(): Promise<void> {
+    await Gestures.tap(this.firstCard, {
+      description: 'tap first market card',
+    });
+  }
+
+  async typeSearchQuery(query: string): Promise<void> {
+    await Gestures.typeText(this.searchInput, query, {
+      description: `type search query: ${query}`,
+    });
+  }
+
+  // --- Assertion methods ---
+
+  async expectContainerVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.container, {
+      description: 'market list container should be visible',
+    });
+  }
+
+  async expectContainerNotVisible(): Promise<void> {
+    await Assertions.expectElementToNotBeVisible(this.container, {
+      description: 'market list container should not be visible',
+    });
+  }
+
+  // --- Retry pattern for flaky interactions ---
+
+  async tapFirstCardWithRetry(): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        await Gestures.tap(this.firstCard, {
+          timeout: 2000,
+          description: 'tap first card',
+        });
+        await Assertions.expectElementToBeVisible(this.firstCard, {
+          timeout: 2000,
+          description: 'first card visible',
+        });
+      },
+      { timeout: 30000, description: 'tap first card and verify' },
+    );
+  }
+}
+
+export default new PredictMarketList();
+```
+
+## Selector / TestId Conventions
+
+### Preferred: Co-locate with component
+
+```typescript
+// app/components/UI/Predict/PredictMarketList.testIds.ts
+export const PredictMarketListSelectorsIDs = {
+  CONTAINER: 'predict-market-list-container',
+  SEARCH_INPUT: 'predict-market-list-search-input',
+  FIRST_CARD: 'predict-market-list-first-card',
+  CARD_TITLE: 'predict-market-list-card-title',
+} as const;
+```
+
+Then use in the component:
+
+```tsx
+<View testID={PredictMarketListSelectorsIDs.CONTAINER}>
+```
+
+### Legacy: under tests/selectors/
+
+```typescript
+// tests/selectors/Predict/PredictMarketList.selectors.ts
+export const PredictMarketListSelectorsIDs = {
+  CONTAINER: 'predict-market-list-container',
+} as const;
+```
+
+Use co-location for all new code.
+
+### Prefer testID on the component; text/label only when needed
+
+**Prefer adding a `testID` to the component** so the Page Object can use `Matchers.getElementByID()`. Add the `testID` in the app component and define the constant in the co-located `*.testIds.ts` (e.g. `PredictBalanceSelectorsIDs.WITHDRAW_BUTTON`). This keeps selectors stable and independent of copy/locale.
+
+Use **text** (`getElementByText`) or **label** (`getElementByLabel`) selectors only when adding a testID is not feasible (e.g. third-party or legacy component you cannot change). In that case, define the string in a SelectorsText object in the same `*.testIds.ts` (e.g. from locale) and use it in the Page Object.
+
+### Activity / transaction list assertions
+
+To assert that a transaction appears in the Activity list (e.g. after deposit or withdraw):
+
+- Use **ActivitiesView** (`tests/page-objects/Transactions/ActivitiesView.ts`): `tapOnPredictionsTab()`, then match the activity row by its type label.
+- Activity type labels live in **ActivitiesView.testIds.ts** (`ActivitiesViewSelectorsText`, e.g. `PREDICT_DEPOSIT`, `PREDICT_WITHDRAW`). If your transaction type is missing, add it there and a getter in ActivitiesView (e.g. `get predictWithdraw()`), then use `Assertions.expectElementToBeVisible(ActivitiesView.predictWithdraw, { description: '...' })`.
+
+## Matchers API
+
+```typescript
+// By testID (most common)
+Matchers.getElementByID('my-test-id');
+
+// By text
+Matchers.getByText('Submit');
+
+// By label (accessibility)
+Matchers.getElementByLabel('Close button');
+```
+
+## Gestures API
+
+```typescript
+// Tap
+await Gestures.tap(element, { description: 'tap X' });
+
+// Tap with stability check (for animated elements)
+await Gestures.tap(element, {
+  checkStability: true,
+  description: 'tap animated X',
+});
+
+// Tap disabled element
+await Gestures.tap(element, {
+  checkEnabled: false,
+  description: 'tap loading button',
+});
+
+// Type text
+await Gestures.typeText(input, 'hello', { description: 'type hello in input' });
+
+// Swipe
+await Gestures.swipe(element, 'up', 'slow', 0.5, { description: 'swipe up' });
+```
+
+## Assertions API
+
+```typescript
+// Visible
+await Assertions.expectElementToBeVisible(element, { description: '...' });
+
+// Not visible
+await Assertions.expectElementToNotBeVisible(element, { description: '...' });
+
+// Text present on screen
+await Assertions.expectTextDisplayed('some text', { description: '...' });
+
+// With custom timeout
+await Assertions.expectElementToBeVisible(element, {
+  description: '...',
+  timeout: 10000,
+});
+```

--- a/.agents/skills/e2e-test/references/running-tests.md
+++ b/.agents/skills/e2e-test/references/running-tests.md
@@ -1,0 +1,123 @@
+# Running & Debugging E2E Tests — Reference
+
+## Step 1: Verify the Build Exists
+
+**Always check before running.** The binary path comes from `.detoxrc.js`:
+
+```bash
+# Check default iOS debug build path
+ls ios/build/Build/Products/Debug-iphonesimulator/MetaMask.app 2>/dev/null \
+  && echo "✅ Build found — ready to run" \
+  || echo "❌ Build missing"
+
+# If PREBUILT_IOS_APP_PATH is set (CI pre-built binary), check that instead
+[ -n "$PREBUILT_IOS_APP_PATH" ] && \
+  ls "$PREBUILT_IOS_APP_PATH" 2>/dev/null \
+  && echo "✅ Pre-built binary found" \
+  || echo "❌ PREBUILT_IOS_APP_PATH set but binary not found at: $PREBUILT_IOS_APP_PATH"
+```
+
+**If the build is missing**, do **not** run the build yourself. Warn the user that a debug build is required (~20-30 min for iOS) and show them the command so they can run it themselves:
+
+```bash
+# iOS debug build (simulator, no device needed)
+yarn test:e2e:ios:debug:build
+
+# Android debug build (requires emulator)
+yarn test:e2e:android:debug:build
+```
+
+> Prefer **iOS** for local runs: simulator builds need no physical device and tests execute with zero manual interaction.
+
+## Step 2: Run a Specific Spec
+
+```bash
+# iOS — run one spec file (preferred for local runs)
+IS_TEST='true' NODE_OPTIONS='--experimental-vm-modules' \
+  detox test -c ios.sim.main \
+  --testPathPattern="tests/regression/predict/predict-buy-flow.spec.ts"
+
+# iOS — run a specific test by name
+IS_TEST='true' NODE_OPTIONS='--experimental-vm-modules' \
+  detox test -c ios.sim.main \
+  --testPathPattern="tests/regression/predict/predict-buy-flow.spec.ts" \
+  --testNamePattern="opens market details from market list"
+
+# Android — run one spec file (requires running emulator)
+IS_TEST='true' NODE_OPTIONS='--experimental-vm-modules' \
+  detox test -c android.emu.main \
+  --testPathPattern="tests/regression/predict/predict-buy-flow.spec.ts"
+```
+
+## Run All Tests for a Feature
+
+```bash
+IS_TEST='true' NODE_OPTIONS='--experimental-vm-modules' \
+  detox test -c ios.sim.main \
+  --testPathPattern="tests/regression/predict/"
+```
+
+## Lint & Type Check (Run Before Every Test Execution)
+
+```bash
+# Lint a specific file
+yarn lint tests/regression/predict/predict-buy-flow.spec.ts --fix
+yarn lint tests/page-objects/Predict/PredictMarketList.ts --fix
+
+# Lint all new files together
+yarn lint tests/regression/predict/ tests/page-objects/Predict/ --fix
+
+# TypeScript check (whole project)
+yarn lint:tsc
+```
+
+## Common Failures & Fixes
+
+| Failure                       | Cause                                     | Fix                                                                   |
+| ----------------------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| `Error: element not found`    | Wrong testID string, element not rendered | Check selector constant, verify `testID` in component                 |
+| `Error: element not enabled`  | Button disabled or loading state          | Add `checkEnabled: false` to the `Gestures.tap` call                  |
+| `Timeout waiting for element` | Element renders but too slowly            | Add logger; check feature flag mock; increase `timeout` in Assertions |
+| `Animation/stability error`   | UI animating when tap is attempted        | Add `checkStability: true` to `Gestures.tap`                          |
+| `Unmocked API request`        | Network call not intercepted              | Add the URL to `testSpecificMock`                                     |
+| `Feature flag not enabled`    | Feature hidden by flag                    | Add `setupRemoteFeatureFlagsMock` in `testSpecificMock`               |
+| `loginToApp timeout`          | Onboarding modal or slow load             | Ensure `restartDevice: true` in `withFixtures`                        |
+
+## Retry for Flaky Interactions
+
+Use `Utilities.executeWithRetry` for inherently unstable taps (carousels, animated modals):
+
+```typescript
+import { Utilities } from '../../framework';
+
+async tapButtonWithRetry(): Promise<void> {
+  await Utilities.executeWithRetry(
+    async () => {
+      await Gestures.tap(this.button, { timeout: 2000, description: 'tap button' });
+      await Assertions.expectElementToBeVisible(this.nextScreen, {
+        timeout: 2000,
+        description: 'next screen visible',
+      });
+    },
+    {
+      timeout: 30000,
+      description: 'tap button and verify navigation',
+    },
+  );
+}
+```
+
+## Debugging Tips
+
+1. Add `logger.info(...)` calls in the spec to trace execution progress
+2. Check `tests/artifacts/` for screenshots and device logs after a run
+3. If the simulator is in an unexpected state: `detox reset-lock-file` then rebuild
+4. For animation issues: `await device.disableSynchronization()` before the problematic interaction, `await device.enableSynchronization()` after
+
+## Iteration Loop
+
+```
+Fix code → yarn lint --fix → yarn lint:tsc → detox test → read failure → fix → repeat
+```
+
+Never skip the lint step after making changes. TypeScript errors caught early save debugging time.

--- a/.agents/skills/e2e-test/references/writing-tests.md
+++ b/.agents/skills/e2e-test/references/writing-tests.md
@@ -1,0 +1,122 @@
+# Writing E2E Tests — Reference
+
+## Spec File Location
+
+| Test Type  | Directory                                   | Tag                                                                                    |
+| ---------- | ------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Smoke      | `tests/smoke/<feature>/<name>.spec.ts`      | `SmokeE2E`, `SmokeTrade`, `SmokePredictions`, `SmokePerps`, `SmokeConfirmations`, etc. |
+| Regression | `tests/regression/<feature>/<name>.spec.ts` | `RegressionTrade`, `RegressionWallet`, etc.                                            |
+
+Import tags from `tests/tags.ts`. Check **`tests/tags.js`** for the full list and descriptions. Use the same tag as **existing specs in that feature folder** (e.g. `tests/smoke/predict/` uses `SmokeTrade`).
+
+## Minimal Smoke Spec
+
+```typescript
+import { loginToApp } from '../../flows/wallet.flow';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { SmokeE2E } from '../../tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import MyFeatureView from '../../page-objects/MyFeature/MyFeatureView';
+
+describe(SmokeE2E('My Feature'), () => {
+  it('lands on feature screen after navigation', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+      },
+      async () => {
+        await loginToApp();
+        await MyFeatureView.expectScreenVisible();
+      },
+    );
+  });
+});
+```
+
+## Regression Spec with API Mocking
+
+```typescript
+import { Mockttp } from 'mockttp';
+import { loginToApp } from '../../flows/wallet.flow';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { RegressionTrade } from '../../tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { setupMockRequest } from '../../api-mocking/mockHelpers';
+import MyFeatureList from '../../page-objects/MyFeature/MyFeatureList';
+import MyFeatureDetails from '../../page-objects/MyFeature/MyFeatureDetails';
+import { createLogger, LogLevel } from '../../framework/logger';
+
+const logger = createLogger({ name: 'MyFeatureSpec', level: LogLevel.INFO });
+
+const testSpecificMock = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, { myFeatureEnabled: true });
+  await setupMockRequest(mockServer, {
+    requestMethod: 'GET',
+    url: 'https://api.example.com/my-feature/data',
+    response: { items: [{ id: '1', name: 'Item 1' }] },
+    responseCode: 200,
+  });
+};
+
+describe(RegressionTrade('My Feature Details Flow'), () => {
+  it('opens details from list', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        testSpecificMock,
+      },
+      async () => {
+        logger.info('Starting my feature test');
+        await loginToApp();
+        await MyFeatureList.tapFirstItem();
+        await MyFeatureDetails.expectScreenVisible();
+      },
+    );
+  });
+});
+```
+
+## FixtureBuilder Patterns
+
+```typescript
+// Basic (just logged-in wallet)
+new FixtureBuilder().build();
+
+// With popular networks enabled
+new FixtureBuilder().withPopularNetworks().build();
+
+// With Ganache local network
+new FixtureBuilder().withGanacheNetwork().build();
+
+// With dapp connected
+new FixtureBuilder().withPermissionControllerConnectedToTestDapp().build();
+
+// With specific tokens
+new FixtureBuilder().withTokensControllerERC20().build();
+
+// With contacts
+new FixtureBuilder().withAddressBookControllerContactBob().build();
+```
+
+## Mandatory Rules
+
+- Every spec uses `withFixtures` — no plain `beforeAll` / `afterAll` setup
+- `restartDevice: true` for most tests (clean state)
+- `loginToApp()` always the first call inside the fixture callback
+- Test names: descriptive without 'should' prefix
+- All gestures and assertions include `description`
+- No direct `element(by.id())` calls in specs
+- No `TestHelpers.delay()` or `setTimeout()`
+
+**Synchronization:** Use `device.disableSynchronization()` only when the test hits **timeouts caused by timers or animations** (e.g. confirmation loading, animated modals). Avoid wrapping entire flows by default. Re-enable with `device.enableSynchronization()` after the problematic section. See running-tests.md for the animation tip.
+
+## Before submitting
+
+- [ ] `withFixtures` + correct tag (see table above)
+- [ ] Only Page Object methods in spec; no direct selectors
+- [ ] Every gesture and assertion has a `description`
+- [ ] No `TestHelpers.delay()` or `setTimeout()`
+- [ ] `yarn lint <files>` and `yarn lint:tsc` pass

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: e2e-test
+summary:
+  Add and fix Detox E2E tests (smoke and regression) for MetaMask Mobile using
+  withFixtures, Page Objects, and tests/framework. Use when creating a new spec,
+  fixing a failing E2E test, or adding page objects and selectors.
+---
+
+**BLOCKING REQUIREMENT**: When the user asks anything related to E2E tests, Detox, smoke/regression specs, writing or fixing \*.spec.ts in tests/smoke or tests/regression, page objects, or any mention of the E2E test framework — invoke this skill via the Skill tool **immediately**, before reading any files or exploring the codebase.
+
+Canonical skill (full content, decision tree, references): [.agents/skills/e2e-test/SKILL.md](../../.agents/skills/e2e-test/SKILL.md).

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -14,6 +14,10 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 
 - [tests/component-view/AGENTS.md](component-view/AGENTS.md) — Agent index for component view tests: framework, canonical skill, run commands, enforcement.
 
+### E2E Tests (Detox smoke/regression)
+
+- [.agents/skills/e2e-test/SKILL.md](../.agents/skills/e2e-test/SKILL.md) — Canonical skill for adding or fixing E2E specs: workflow, decision tree, references (writing-tests, page-objects, mocking, running-tests).
+
 ## Canonical Sources (read these, do not duplicate)
 
 - [.cursor/rules/e2e-testing-guidelines.mdc](../.cursor/rules/e2e-testing-guidelines.mdc) — Patterns, Page Objects, assertions, gestures, prohibited patterns.


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/e2e-test.md` — new Claude skill (`/e2e-test`) that guides through adding Detox E2E tests end-to-end
- Adds `.ai/skills/e2e-test/` — multi-AI skill definition (Cursor, Copilot, Windsurf) with detailed reference docs

## What the skill does

The skill walks an AI agent through the full E2E test creation loop:

1. **Plan** — determine smoke vs regression, choose feature folder and tag
2. **Infrastructure** — create/reuse Page Objects (`tests/page-objects/`), selectors (`*.testIds.ts`), and API mocks
3. **Write spec** — `withFixtures` + `FixtureBuilder` + POM, mandatory descriptions on all gestures/assertions
4. **Lint + TSC** — run before executing the test
5. **Run locally** — `detox test -c ios.sim.main --testPathPattern=...`
6. **Iterate** — analyze failure → fix → re-lint → re-run until green

## Reference docs structure

```
.ai/skills/e2e-test/
├── SKILL.md                    ← 10 golden rules + workflow overview + quick commands
└── references/
    ├── writing-tests.md        ← spec templates, FixtureBuilder patterns
    ├── page-objects.md         ← POM structure, Matchers/Gestures/Assertions API
    ├── mocking.md              ← testSpecificMock, feature flags, HTTP mocking
    └── running-tests.md        ← detox commands, common failures & fixes, retry pattern
```

## Related

Follows the same pattern as PR #27013 (component-view-test skill reorganization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions and pointer updates; no runtime code paths or test framework behavior changes.
> 
> **Overview**
> Introduces a new canonical `e2e-test` agent skill under `.agents/skills/e2e-test/`, including a decision tree, “golden rules”, and focused reference guides for writing specs, page objects/selectors, mocking, and running/debugging Detox.
> 
> Hooks the skill into agent tooling via `.agents/skills/e2e-test/agents/openai.yaml`, adds a thin redirect/enforcement stub at `.claude/skills/e2e-test/SKILL.md`, and updates `tests/AGENTS.md` to point contributors/agents to the new canonical skill.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3deb799ef3fec9d9349bc336a95ae08b8612f0f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->