### PR TITLE
feat: Add the "refundTo" param for postQuote transactions

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
@@ -1,8 +1,10 @@
 import { renderHook } from '@testing-library/react-hooks';
+import type { Hex } from '@metamask/utils';
 import { useTransactionPayPostQuote } from './useTransactionPayPostQuote';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayWithdraw } from './useTransactionPayWithdraw';
 import Engine from '../../../../../core/Engine';
+import { computeProxyAddress } from '../../../../UI/Predict/providers/polymarket/safe/utils';
 
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('./useTransactionPayWithdraw');
@@ -13,8 +15,13 @@ jest.mock('../../../../../core/Engine', () => ({
     },
   },
 }));
+jest.mock('../../../../UI/Predict/providers/polymarket/safe/utils', () => ({
+  computeProxyAddress: jest.fn(),
+}));
 
 const TRANSACTION_ID_MOCK = 'transaction-123';
+const FROM_MOCK = '0x1234567890123456789012345678901234567890' as Hex;
+const PROXY_ADDRESS_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
 
 describe('useTransactionPayPostQuote', () => {
   const useTransactionMetadataRequestMock = jest.mocked(
@@ -24,9 +31,11 @@ describe('useTransactionPayPostQuote', () => {
   const setTransactionConfigMock = jest.mocked(
     Engine.context.TransactionPayController.setTransactionConfig,
   );
+  const computeProxyAddressMock = jest.mocked(computeProxyAddress);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    computeProxyAddressMock.mockReturnValue(PROXY_ADDRESS_MOCK);
     useTransactionPayWithdrawMock.mockReturnValue({
       isWithdraw: false,
       canSelectWithdrawToken: false,
@@ -60,6 +69,7 @@ describe('useTransactionPayPostQuote', () => {
   it('sets isPostQuote when canSelectWithdrawToken is true and transactionId exists', () => {
     useTransactionMetadataRequestMock.mockReturnValue({
       id: TRANSACTION_ID_MOCK,
+      txParams: { from: FROM_MOCK },
     } as never);
     useTransactionPayWithdrawMock.mockReturnValue({
       isWithdraw: true,
@@ -74,9 +84,54 @@ describe('useTransactionPayPostQuote', () => {
     );
   });
 
+  it('sets isPostQuote=true and refundTo=proxyAddress in config callback', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      txParams: { from: FROM_MOCK },
+    } as never);
+    useTransactionPayWithdrawMock.mockReturnValue({
+      isWithdraw: true,
+      canSelectWithdrawToken: true,
+    });
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    expect(computeProxyAddressMock).toHaveBeenCalledWith(FROM_MOCK);
+
+    const callback = setTransactionConfigMock.mock.calls[0][1];
+    const config = {} as { isPostQuote?: boolean; refundTo?: Hex };
+    callback(config);
+
+    expect(config.isPostQuote).toBe(true);
+    expect(config.refundTo).toBe(PROXY_ADDRESS_MOCK);
+  });
+
+  it('sets refundTo=undefined when txParams.from is missing', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      txParams: {},
+    } as never);
+    useTransactionPayWithdrawMock.mockReturnValue({
+      isWithdraw: true,
+      canSelectWithdrawToken: true,
+    });
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    expect(computeProxyAddressMock).not.toHaveBeenCalled();
+
+    const callback = setTransactionConfigMock.mock.calls[0][1];
+    const config = {} as { isPostQuote?: boolean; refundTo?: Hex };
+    callback(config);
+
+    expect(config.isPostQuote).toBe(true);
+    expect(config.refundTo).toBeUndefined();
+  });
+
   it('does not call setTransactionConfig twice for the same transactionId', () => {
     useTransactionMetadataRequestMock.mockReturnValue({
       id: TRANSACTION_ID_MOCK,
+      txParams: { from: FROM_MOCK },
     } as never);
     useTransactionPayWithdrawMock.mockReturnValue({
       isWithdraw: true,
@@ -113,6 +168,7 @@ describe('useTransactionPayPostQuote', () => {
     });
     useTransactionMetadataRequestMock.mockReturnValue({
       id: TRANSACTION_ID_MOCK,
+      txParams: { from: FROM_MOCK },
     } as never);
 
     const { rerender } = renderHook(() => useTransactionPayPostQuote());
@@ -120,6 +176,7 @@ describe('useTransactionPayPostQuote', () => {
 
     useTransactionMetadataRequestMock.mockReturnValue({
       id: 'transaction-456',
+      txParams: { from: FROM_MOCK },
     } as never);
     rerender();
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
-import { createProjectLogger } from '@metamask/utils';
-import type { Hex } from '@metamask/utils';
+import { createProjectLogger, type Hex } from '@metamask/utils';
 import { useTransactionPayWithdraw } from './useTransactionPayWithdraw';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { computeProxyAddress } from '../../../../UI/Predict/providers/polymarket/safe/utils';

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
 import { createProjectLogger } from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
 import { useTransactionPayWithdraw } from './useTransactionPayWithdraw';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { computeProxyAddress } from '../../../../UI/Predict/providers/polymarket/safe/utils';
 
 const log = createProjectLogger('transaction-pay-post-quote');
 
@@ -36,20 +38,22 @@ export function useTransactionPayPostQuote(): void {
 
     try {
       const { TransactionPayController } = Engine.context;
+      const from = transactionMeta?.txParams.from as Hex | undefined;
+      const refundTo = from ? computeProxyAddress(from) : undefined;
 
-      // Set isPostQuote=true for post-quote transactions
       TransactionPayController.setTransactionConfig(transactionId, (config) => {
         config.isPostQuote = true;
+        config.refundTo = refundTo;
       });
 
       isSet.current = transactionId;
 
-      log('Initialized post-quote transaction', { transactionId });
+      log('Initialized post-quote transaction', { transactionId, refundTo });
     } catch (error) {
       log('Error initializing post-quote transaction', {
         error,
         transactionId,
       });
     }
-  }, [canSelectWithdrawToken, transactionId]);
+  }, [canSelectWithdrawToken, transactionId, transactionMeta?.txParams.from]);
 }

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -38,7 +38,7 @@ export function useTransactionPayPostQuote(): void {
 
     try {
       const { TransactionPayController } = Engine.context;
-      const from = transactionMeta?.txParams.from as Hex | undefined;
+      const from = transactionMeta?.txParams?.from as Hex | undefined;
       const refundTo = from ? computeProxyAddress(from) : undefined;
 
       TransactionPayController.setTransactionConfig(transactionId, (config) => {
@@ -55,5 +55,5 @@ export function useTransactionPayPostQuote(): void {
         transactionId,
       });
     }
-  }, [canSelectWithdrawToken, transactionId, transactionMeta?.txParams.from]);
+  }, [canSelectWithdrawToken, transactionId, transactionMeta?.txParams?.from]);
 }

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/transaction-controller": "^62.19.0",
-    "@metamask/transaction-pay-controller": "^16.1.2",
+    "@metamask/transaction-pay-controller": "^16.3.0",
     "@metamask/tron-wallet-snap": "1.22.1",
     "@metamask/utils": "^11.8.1",
     "@myx-trade/sdk": "^0.1.265",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7953,6 +7953,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/bridge-controller@npm:^68.0.0":
+  version: 68.0.0
+  resolution: "@metamask/bridge-controller@npm:68.0.0"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^36.0.1"
+    "@metamask/assets-controllers": "npm:^100.0.3"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.3"
+    "@metamask/keyring-api": "npm:^21.5.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.0.4"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/polling-controller": "npm:^16.0.3"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/transaction-controller": "npm:^62.19.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/e92d96c7e421efeadcccdd58c87e3f5b171f3a8eff035dae8fff602b162902652b2738ae4aec62e48b432fefcab1736f69f7a2026ba7686151fafe73601c6a9b
+  languageName: node
+  linkType: hard
+
 "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A67.2.0#~/.yarn/patches/@metamask-bridge-controller-npm-67.2.0-32d3aafe1f.patch":
   version: 67.2.0
   resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A67.2.0#~/.yarn/patches/@metamask-bridge-controller-npm-67.2.0-32d3aafe1f.patch::version=67.2.0&hash=471b7e"
@@ -8004,6 +8036,29 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/b75c377dcb35ccfb5e17f221f0c6f03cf2224b1fa34ba57f9fb0192d40097d699cc1fd9944d526820e4af4c1905a3c2b5bef17c2705822a87b4b135d3823ca91
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@npm:^68.0.0":
+  version: 68.0.0
+  resolution: "@metamask/bridge-status-controller@npm:68.0.0"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^36.0.1"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/bridge-controller": "npm:^68.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.3"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/polling-controller": "npm:^16.0.3"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^62.19.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/e166e890d76aa366c6ec50380879eaf1de641068b1f99d66b45908be72dc23966f82e12083307325eeca72fcf1bef8c8e4864a459db057328fcea84900fefba0
   languageName: node
   linkType: hard
 
@@ -10147,30 +10202,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^16.1.2":
-  version: 16.1.2
-  resolution: "@metamask/transaction-pay-controller@npm:16.1.2"
+"@metamask/transaction-pay-controller@npm:^16.3.0":
+  version: 16.3.0
+  resolution: "@metamask/transaction-pay-controller@npm:16.3.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/assets-controllers": "npm:^100.0.3"
+    "@metamask/assets-controllers": "npm:^100.1.0"
     "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^67.4.0"
-    "@metamask/bridge-status-controller": "npm:^67.0.1"
+    "@metamask/bridge-controller": "npm:^68.0.0"
+    "@metamask/bridge-status-controller": "npm:^68.0.0"
     "@metamask/controller-utils": "npm:^11.19.0"
     "@metamask/gas-fee-controller": "npm:^26.0.3"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
-    "@metamask/transaction-controller": "npm:^62.19.0"
+    "@metamask/transaction-controller": "npm:^62.20.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/d304824be5a3218a28b39ccde514748f38b6ed23d694fee08f562c53dc9c16d3257f6a036bc26b5193db35b5bb3e9d9669b2411ff532285738e7310e81090654
+  checksum: 10/fd432b50040e93616f77f8ee24836cb979c4626853ece95dfa9e27d3b26b231407ce0ded6f8f929e81c482f872dbec6c5bce7bbf2f52580218a0e48f7d4b6562
   languageName: node
   linkType: hard
 
@@ -35486,7 +35541,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^62.19.0"
-    "@metamask/transaction-pay-controller": "npm:^16.1.2"
+    "@metamask/transaction-pay-controller": "npm:^16.3.0"
     "@metamask/tron-wallet-snap": "npm:1.22.1"
     "@metamask/utils": "npm:^11.8.1"
     "@myx-trade/sdk": "npm:^0.1.265"


### PR DESCRIPTION
## **Description**
Adds the "refundTo" param for postQuote transactions, so refunds from Relay will be refunded back to Predict balance. Updates the transaction-pay-controller version, which supports this param.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds the "refundTo" param for postQuote transactions, so refunds from Relay will be refunded back to Predict balance.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/26990

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `refundTo` address into post-quote transaction config and bumps `@metamask/transaction-pay-controller`, which can affect where bridge/relay refunds are sent. Scope is small and covered by unit tests, but it touches payment/bridging transaction configuration.
> 
> **Overview**
> **Post-quote pay transactions now include a refund destination.** `useTransactionPayPostQuote` computes a Predict proxy address from `txParams.from` and sets `config.refundTo` alongside `config.isPostQuote=true` when initializing the transaction.
> 
> Unit tests were expanded to mock `computeProxyAddress` and assert `refundTo` behavior (including the missing-`from` case). Dependencies were updated by bumping `@metamask/transaction-pay-controller` to `16.3.0` (with corresponding lockfile changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bab9856a7740c77b5ebbd6ca67addfea74537d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->