### PR TITLE
fix: increase homepage section gap from 24px to 48px

### DIFF
--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -72,7 +72,7 @@ const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
   return (
-    <Box gap={6} marginBottom={8} testID="homepage-container">
+    <Box gap={12} marginBottom={8} testID="homepage-container">
       <TokensSection
         ref={tokensSectionRef}
         sectionIndex={getSectionIndex(HomeSectionNames.TOKENS)}


### PR DESCRIPTION
## **Description**

Increases the vertical spacing between homepage sections from 24px (gap=6) to 48px (gap=12) to improve visual separation and match the updated design spec.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Homepage section spacing refinement

## **Manual testing steps**

```gherkin
Feature: Homepage section spacing

  Scenario: user views the homepage
    Given user is on the homepage

    When user scrolls through the sections (Tokens, Perpetuals, Predictions, DeFi, NFTs)
    Then each section has 48px of vertical spacing between them
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/40c3c900-e687-4ee2-97c2-18e4b93e3a70


https://github.com/user-attachments/assets/53b66cbc-cba5-46d1-9ba2-004f86ef4652




### **Before**

Sections had 24px gap between them.

### **After**

Sections have 48px gap between them.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts layout spacing on the homepage; no business logic, data, or security behavior is affected.
> 
> **Overview**
> Increases the vertical spacing between homepage sections by updating the `Homepage` container `Box` `gap` from `6` to `12` (24px → 48px), improving visual separation per the updated design spec.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f13bab5647f4ae83c06f41224e2e7230cea4fad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->