### PR TITLE
fix: text alignment in asset picker

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -321,7 +321,7 @@ describe('TokenSelectorItem', () => {
   });
 
   describe('text truncation', () => {
-    it('truncates long token names to 2 lines', () => {
+    it('truncates long token names to 1 line', () => {
       const token = createMockTokenWithBalance({
         name: 'Very Long Token Name That Should Be Truncated',
       });
@@ -334,7 +334,7 @@ describe('TokenSelectorItem', () => {
         'Very Long Token Name That Should Be Truncated',
       );
 
-      expect(tokenNameElement.props.numberOfLines).toBe(2);
+      expect(tokenNameElement.props.numberOfLines).toBe(1);
     });
 
     it('applies tail ellipsize mode to token names', () => {
@@ -351,6 +351,35 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(tokenNameElement.props.ellipsizeMode).toBe('tail');
+    });
+
+    it('renders token balance in a single line', () => {
+      const token = createMockTokenWithBalance({
+        balance: '50.0',
+        symbol: 'TOKEN',
+      });
+
+      const { getByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      const tokenBalanceElement = getByText('50 TOKEN');
+
+      expect(tokenBalanceElement.props.numberOfLines).toBe(1);
+    });
+
+    it('renders fiat balance in a single line', () => {
+      const token = createMockTokenWithBalance({
+        balanceFiat: '$1,234.56',
+      });
+
+      const { getByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      const fiatBalanceElement = getByText('$1,234.56');
+
+      expect(fiatBalanceElement.props.numberOfLines).toBe(1);
     });
   });
 });

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -28,11 +28,7 @@ import Text, {
 } from '../../../../component-library/components/Texts/Text';
 import { Box } from '../../Box/Box';
 import { ethers } from 'ethers';
-import {
-  AlignItems,
-  FlexDirection,
-  JustifyContent,
-} from '../../Box/box.types';
+import { AlignItems, FlexDirection, JustifyContent } from '../../Box/box.types';
 import StockBadge from '../../shared/StockBadge';
 import { useStyles } from '../../../../component-library/hooks';
 import { Theme } from '../../../../util/theme/models';

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -28,7 +28,11 @@ import Text, {
 } from '../../../../component-library/components/Texts/Text';
 import { Box } from '../../Box/Box';
 import { ethers } from 'ethers';
-import { AlignItems, FlexDirection } from '../../Box/box.types';
+import {
+  AlignItems,
+  FlexDirection,
+  JustifyContent,
+} from '../../Box/box.types';
 import StockBadge from '../../shared/StockBadge';
 import { useStyles } from '../../../../component-library/hooks';
 import { Theme } from '../../../../util/theme/models';
@@ -57,6 +61,8 @@ const createStyles = ({
   StyleSheet.create({
     tokenInfo: {
       flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
       marginLeft: 8,
     },
     container: {
@@ -82,9 +88,21 @@ const createStyles = ({
       paddingVertical: 10,
       alignItems: 'flex-start',
     },
-    balance: {
-      flex: 1,
-      alignItems: 'flex-end',
+    tokenMainInfo: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flexShrink: 1,
+      minWidth: 0,
+      marginRight: 8,
+    },
+    rightValue: {
+      flexShrink: 0,
+      textAlign: 'right',
+    },
+    tokenName: {
+      flexShrink: 1,
+      minWidth: 0,
+      marginRight: 8,
     },
     skeleton: {
       width: 50,
@@ -142,7 +160,11 @@ const FiatBalanceView = ({
     return <View style={styles.skeleton} />;
   }
 
-  return <Text variant={TextVariant.BodyLGMedium}>{balance}</Text>;
+  return (
+    <Text variant={TextVariant.BodyLGMedium} numberOfLines={1}>
+      {balance}
+    </Text>
+  );
 };
 
 export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
@@ -175,7 +197,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
     return parseAmount(balance, 5) || balance;
   };
 
-  const balanceWithSymbol = token.balance
+  const cryptoBalance = token.balance
     ? `${formatTokenBalance(token.balance)} ${token.symbol}`
     : undefined;
 
@@ -185,7 +207,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   const { isStockToken } = useRWAToken();
 
   const balance = shouldShowBalance ? fiatValue : undefined;
-  const secondaryBalance = shouldShowBalance ? balanceWithSymbol : undefined;
+  const secondaryBalance = shouldShowBalance ? cryptoBalance : undefined;
 
   const label = token.accountType
     ? ACCOUNT_TYPE_LABELS[token.accountType]
@@ -237,7 +259,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             />
           </BadgeWrapper>
 
-          {/* Token symbol and name */}
+          {/* Token symbol/name on the left, balances on the right (extension layout pattern) */}
           <Box
             style={styles.tokenInfo}
             flexDirection={FlexDirection.Column}
@@ -246,48 +268,64 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             <Box
               flexDirection={FlexDirection.Row}
               alignItems={AlignItems.center}
-              gap={4}
+              justifyContent={JustifyContent.spaceBetween}
             >
-              <Text variant={TextVariant.BodyLGMedium}>{token.symbol}</Text>
-              {label && <Tag label={label} />}
-              {showNoFeeBadge && (
-                <TagBase
-                  shape={TagShape.Rectangle}
-                  severity={TagSeverity.Info}
-                  textProps={{ variant: TextVariant.BodyXS }}
-                  style={styles.noFeeBadge}
-                >
-                  {strings('bridge.no_mm_fee')}
-                </TagBase>
-              )}
-            </Box>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              numberOfLines={2}
-              ellipsizeMode="tail"
-            >
-              {token.name}
-            </Text>
-            {isStockToken(token as BridgeToken) && <StockBadge token={token} />}
-          </Box>
-
-          {/* Token balance and fiat value */}
-          <Box style={styles.balance} gap={4}>
-            <FiatBalanceView balance={balance} isSelected={isSelected} />
-            {secondaryBalance ? (
-              secondaryBalance === TOKEN_BALANCE_LOADING ||
-              secondaryBalance === TOKEN_BALANCE_LOADING_UPPERCASE ? (
-                <View style={styles.skeleton} />
-              ) : (
+              <Box style={styles.tokenMainInfo} gap={4}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyLGMedium}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
                 >
-                  {secondaryBalance}
+                  {token.symbol}
                 </Text>
-              )
-            ) : null}
+                {label && <Tag label={label} />}
+                {showNoFeeBadge && (
+                  <TagBase
+                    shape={TagShape.Rectangle}
+                    severity={TagSeverity.Info}
+                    textProps={{ variant: TextVariant.BodyXS }}
+                    style={styles.noFeeBadge}
+                  >
+                    {strings('bridge.no_mm_fee')}
+                  </TagBase>
+                )}
+              </Box>
+
+              {secondaryBalance ? (
+                secondaryBalance === TOKEN_BALANCE_LOADING ||
+                secondaryBalance === TOKEN_BALANCE_LOADING_UPPERCASE ? (
+                  <View style={styles.skeleton} />
+                ) : (
+                  <Text
+                    variant={TextVariant.BodyMD}
+                    color={TextColor.Alternative}
+                    numberOfLines={1}
+                    style={styles.rightValue}
+                  >
+                    {secondaryBalance}
+                  </Text>
+                )
+              ) : null}
+            </Box>
+
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              justifyContent={JustifyContent.spaceBetween}
+            >
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                style={styles.tokenName}
+              >
+                {token.name}
+              </Text>
+
+              <FiatBalanceView balance={balance} isSelected={isSelected} />
+            </Box>
+            {isStockToken(token as BridgeToken) && <StockBadge token={token} />}
           </Box>
         </Box>
       </TouchableOpacity>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR aligns the mobile asset picker token row layout and text-wrapping behavior with `metamask-extension` to fix wrapping/spacing issues in `TokenSelectorItem`.

It updates the row structure so balances are consistently prioritized on the right, enforces single-line rendering for crypto and fiat balances, and truncates long token names to a single line with tail ellipsis. Tests were updated to reflect the new truncation behavior and to verify single-line balance rendering.

## **Changelog**

CHANGELOG entry: Fixed a bug in the asset picker where token and balance text could wrap incorrectly by aligning mobile layout and truncation behavior with extension.

## **Related issues**

Fixes: SWAPS-4154

## **Manual testing steps**

```gherkin
Feature: Asset picker text layout parity with extension

  Scenario: user views token row with long token name
    Given the user is on the Swap/Bridge asset picker
    And at least one token has a long name and non-zero balances
    When the token list is rendered
    Then the token name is truncated to 1 line with tail ellipsis
    And the crypto balance is displayed on a single line on the right
    And the fiat balance is displayed on a single line on the right
    And there is no excessive empty space between token info and balances

  Scenario: user views token row while balances are loading
    Given the user is on the Swap/Bridge asset picker
    And token balances are in loading state
    When the token list is rendered
    Then loading placeholders render without wrapping text to a second line
    And row alignment remains consistent
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout tweaks to `TokenSelectorItem` (flex/shrink, single-line truncation, right-aligned balances) with updated tests; low risk aside from potential visual regressions on edge-case token names/balances.
> 
> **Overview**
> Updates `TokenSelectorItem` layout to follow a left-details/right-values pattern: token symbol/name are constrained to a single truncated line while crypto/fiat balances render as single-line, right-aligned values.
> 
> Adds flex/shrink and `minWidth: 0` styling to prevent overflow, updates fiat balance rendering to `numberOfLines={1}`, and adjusts/extends tests to assert the new truncation and single-line balance behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8ae3e0249e6b7de4ae778385e510ce439be4389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->