### PR TITLE
feat: Bitcoin wallet standard

### DIFF
--- a/fingerprint.config.js
+++ b/fingerprint.config.js
@@ -82,6 +82,11 @@ const config = {
       reasons: ['Detect build configuration changes.'],
     },
     {
+      type: 'dir',
+      filePath: './scripts/inpage-bridge',
+      reasons: ['Detect inpage provider changes bundled into native apps.'],
+    },
+    {
       type: 'file',
       filePath: './scripts/setup.mjs',
       reasons: ['Detect setup script changes.'],

--- a/package.json
+++ b/package.json
@@ -548,6 +548,7 @@
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/providers": "^18.3.1",
     "@metamask/test-dapp": "9.5.0",
+    "@metamask/test-dapp-bitcoin": "^0.2.0",
     "@metamask/test-dapp-multichain": "^0.17.1",
     "@metamask/test-dapp-solana": "^0.3.0",
     "@octokit/rest": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "@metamask/assets-controllers": "^103.1.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.10.1",
+    "@metamask/bitcoin-wallet-standard": "^1.0.0",
     "@metamask/bridge-controller": "^70.0.0",
     "@metamask/bridge-status-controller": "^70.0.4",
     "@metamask/chain-agnostic-permission": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -578,6 +578,7 @@
     "@metamask/providers": "^18.3.1",
     "@metamask/skills": "^0.1.0",
     "@metamask/test-dapp": "9.5.0",
+    "@metamask/test-dapp-bitcoin": "^0.2.0",
     "@metamask/test-dapp-multichain": "^0.17.1",
     "@metamask/test-dapp-solana": "^0.3.0",
     "@octokit/rest": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.0.5",
     "@metamask/multichain-account-service": "^10.0.2",
-    "@metamask/multichain-api-client": "^0.10.1",
+    "@metamask/multichain-api-client": "^0.11.0",
     "@metamask/multichain-api-middleware": "^3.1.1",
     "@metamask/multichain-network-controller": "^3.1.0",
     "@metamask/multichain-transactions-controller": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.12.0",
+    "@metamask/bitcoin-wallet-standard": "^1.0.0",
     "@metamask/bridge-controller": "^75.1.0",
     "@metamask/bridge-status-controller": "^72.1.0",
     "@metamask/chain-agnostic-permission": "^1.5.0",

--- a/scripts/inpage-bridge/src/bitcoinWalletStandard.js
+++ b/scripts/inpage-bridge/src/bitcoinWalletStandard.js
@@ -1,0 +1,15 @@
+const { getMultichainClient, getWindowPostMessageTransport } = require('@metamask/multichain-api-client');
+const { registerBitcoinWalletStandard } = require('@metamask/bitcoin-wallet-standard');
+
+const injectBitcoinWalletStandard = () => {
+  console.log('injectBitcoinWalletStandard');
+  const multichainClient = getMultichainClient({
+    transport: getWindowPostMessageTransport(),
+  });
+  registerBitcoinWalletStandard({
+    client: multichainClient,
+    walletName: process.env.METAMASK_BUILD_NAME,
+  });
+};
+
+export default injectBitcoinWalletStandard;

--- a/scripts/inpage-bridge/src/bitcoinWalletStandard.js
+++ b/scripts/inpage-bridge/src/bitcoinWalletStandard.js
@@ -2,7 +2,6 @@ const { getMultichainClient, getWindowPostMessageTransport } = require('@metamas
 const { registerBitcoinWalletStandard } = require('@metamask/bitcoin-wallet-standard');
 
 const injectBitcoinWalletStandard = () => {
-  console.log('injectBitcoinWalletStandard');
   const multichainClient = getMultichainClient({
     transport: getWindowPostMessageTransport(),
   });

--- a/scripts/inpage-bridge/src/index.js
+++ b/scripts/inpage-bridge/src/index.js
@@ -1,10 +1,12 @@
 
 import injectInpageProvider from './provider';
 import injectSolanaWalletStandard from './solanaWalletStandard';
+import injectBitcoinWalletStandard from './bitcoinWalletStandard';
 
 if (shouldInject()) {
   injectInpageProvider();
   injectSolanaWalletStandard();
+  injectBitcoinWalletStandard();
   start();
 }
 

--- a/tests/flows/bitcoin-connection.flow.ts
+++ b/tests/flows/bitcoin-connection.flow.ts
@@ -1,0 +1,56 @@
+import BrowserView from '../page-objects/Browser/BrowserView';
+import ConnectBottomSheet from '../page-objects/Browser/ConnectBottomSheet';
+import ConnectedAccountsModal from '../page-objects/Browser/ConnectedAccountsModal';
+import BitcoinTestDApp from '../page-objects/Browser/BitcoinTestDapp';
+import Assertions from '../framework/Assertions';
+import { navigateToBrowserView } from './browser.flow';
+
+export const account1Short = 'bc1q...yump';
+
+export const signedMessageStandard =
+  '271486823211510961053671593213121630193816218985222159577512714825421410039180175314517251232893341221418210218699217951999213157247101787166209162102702122391448617217326133312849199212551951866224105551902392399522115638752383224419341608718511954214130102';
+
+/**
+ * Connects the Bitcoin test dapp to the wallet.
+ *
+ * @param options.selectAllAccounts - Whether we connect with all accounts or only the default one
+ */
+export const connectBitcoinTestDapp = async (
+  options: {
+    selectAllAccounts?: boolean;
+    assert?: () => Promise<void>;
+  } = {},
+): Promise<void> => {
+  const { selectAllAccounts, assert } = options;
+
+  const header = BitcoinTestDApp.getHeader();
+  await header.connect();
+  await header.selectMetaMask();
+  await header.selectStandard();
+
+  if (selectAllAccounts) {
+    await ConnectedAccountsModal.tapAccountListBottomSheet();
+    await ConnectBottomSheet.tapSelectAllButton();
+    await ConnectBottomSheet.tapAccountConnectMultiSelectButton();
+  }
+
+  if (assert) {
+    await assert();
+  }
+
+  await ConnectBottomSheet.tapConnectButton();
+};
+
+export const navigateToBitcoinTestDApp = async (): Promise<void> => {
+  await navigateToBrowserView();
+  await Assertions.expectElementToBeVisible(BrowserView.browserScreenID);
+  await BitcoinTestDApp.navigateToBitcoinTestDApp();
+};
+
+export const assertIsSignedTransaction = async (signedTransaction: string) => {
+  if (!/^.{88}$/.test(signedTransaction)) {
+    throw new Error(
+      `Signed transaction does not match regex: ${signedTransaction}`,
+    );
+  }
+};

--- a/tests/flows/bitcoin-connection.flow.ts
+++ b/tests/flows/bitcoin-connection.flow.ts
@@ -46,11 +46,3 @@ export const navigateToBitcoinTestDApp = async (): Promise<void> => {
   await Assertions.expectElementToBeVisible(BrowserView.browserScreenID);
   await BitcoinTestDApp.navigateToBitcoinTestDApp();
 };
-
-export const assertIsSignedTransaction = async (signedTransaction: string) => {
-  if (!/^.{88}$/.test(signedTransaction)) {
-    throw new Error(
-      `Signed transaction does not match regex: ${signedTransaction}`,
-    );
-  }
-};

--- a/tests/flows/solana-connection.flow.ts
+++ b/tests/flows/solana-connection.flow.ts
@@ -43,11 +43,3 @@ export const navigateToSolanaTestDApp = async (): Promise<void> => {
   await Assertions.expectElementToBeVisible(BrowserView.browserScreenID);
   await SolanaTestDApp.navigateToSolanaTestDApp();
 };
-
-export const assertIsSignedTransaction = async (signedTransaction: string) => {
-  if (!/^.{88}$/.test(signedTransaction)) {
-    throw new Error(
-      `Signed transaction does not match regex: ${signedTransaction}`,
-    );
-  }
-};

--- a/tests/framework/Constants.ts
+++ b/tests/framework/Constants.ts
@@ -70,6 +70,15 @@ export const DEFAULT_SOLANA_TEST_DAPP_PATH = path.join(
   'dist',
 );
 
+export const DEFAULT_BITCOIN_TEST_DAPP_PATH = path.join(
+  '..',
+  '..',
+  'node_modules',
+  '@metamask',
+  'test-dapp-bitcoin',
+  'dist',
+);
+
 export const DEFAULT_BROWSER_PLAYGROUND_PATH = path.join(
   '..',
   '..',
@@ -104,6 +113,7 @@ export enum DappVariants {
   TEST_DAPP = 'test-dapp',
   MULTICHAIN_TEST_DAPP = 'multichain-test-dapp',
   SOLANA_TEST_DAPP = 'solana-test-dapp',
+  BITCOIN_TEST_DAPP = 'bitcoin-test-dapp',
   BROWSER_PLAYGROUND = 'browser-playground',
 }
 
@@ -116,6 +126,9 @@ export const TestDapps = {
   },
   [DappVariants.SOLANA_TEST_DAPP]: {
     dappPath: path.resolve(__dirname, DEFAULT_SOLANA_TEST_DAPP_PATH),
+  },
+  [DappVariants.BITCOIN_TEST_DAPP]: {
+    dappPath: path.resolve(__dirname, DEFAULT_BITCOIN_TEST_DAPP_PATH),
   },
   [DappVariants.BROWSER_PLAYGROUND]: {
     dappPath: path.resolve(__dirname, DEFAULT_BROWSER_PLAYGROUND_PATH),

--- a/tests/framework/Constants.ts
+++ b/tests/framework/Constants.ts
@@ -87,6 +87,15 @@ export const DEFAULT_SOLANA_TEST_DAPP_PATH = path.join(
   'dist',
 );
 
+export const DEFAULT_BITCOIN_TEST_DAPP_PATH = path.join(
+  '..',
+  '..',
+  'node_modules',
+  '@metamask',
+  'test-dapp-bitcoin',
+  'dist',
+);
+
 export const DEFAULT_BROWSER_PLAYGROUND_PATH = path.join(
   '..',
   '..',
@@ -121,6 +130,7 @@ export enum DappVariants {
   TEST_DAPP = 'test-dapp',
   MULTICHAIN_TEST_DAPP = 'multichain-test-dapp',
   SOLANA_TEST_DAPP = 'solana-test-dapp',
+  BITCOIN_TEST_DAPP = 'bitcoin-test-dapp',
   BROWSER_PLAYGROUND = 'browser-playground',
 }
 
@@ -133,6 +143,9 @@ export const TestDapps = {
   },
   [DappVariants.SOLANA_TEST_DAPP]: {
     dappPath: path.resolve(__dirname, DEFAULT_SOLANA_TEST_DAPP_PATH),
+  },
+  [DappVariants.BITCOIN_TEST_DAPP]: {
+    dappPath: path.resolve(__dirname, DEFAULT_BITCOIN_TEST_DAPP_PATH),
   },
   [DappVariants.BROWSER_PLAYGROUND]: {
     dappPath: path.resolve(__dirname, DEFAULT_BROWSER_PLAYGROUND_PATH),

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -114,6 +114,17 @@ async function handleDapps(
           }),
         );
         break;
+      case DappVariants.BITCOIN_TEST_DAPP:
+        dappServer.push(
+          new DappServer({
+            dappCounter: i,
+            rootDirectory:
+              dapp.dappPath ||
+              TestDapps[DappVariants.BITCOIN_TEST_DAPP].dappPath,
+            dappVariant: DappVariants.BITCOIN_TEST_DAPP,
+          }),
+        );
+        break;
       case DappVariants.BROWSER_PLAYGROUND:
         dappServer.push(
           new DappServer({

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -121,6 +121,17 @@ async function handleDapps(
           }),
         );
         break;
+      case DappVariants.BITCOIN_TEST_DAPP:
+        dappServer.push(
+          new DappServer({
+            dappCounter: i,
+            rootDirectory:
+              dapp.dappPath ||
+              TestDapps[DappVariants.BITCOIN_TEST_DAPP].dappPath,
+            dappVariant: DappVariants.BITCOIN_TEST_DAPP,
+          }),
+        );
+        break;
       case DappVariants.BROWSER_PLAYGROUND:
         dappServer.push(
           new DappServer({

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -1,0 +1,200 @@
+import { dataTestIds } from '@metamask/test-dapp-bitcoin';
+import { getDappUrl } from '../../framework/fixtures/FixtureUtils';
+import Matchers from '../../framework/Matchers';
+import { BrowserViewSelectorsIDs } from '../../../app/components/Views/BrowserTab/BrowserView.testIds';
+import Gestures from '../../framework/Gestures';
+import Browser from './BrowserView';
+import Utilities, { BASE_DEFAULTS } from '../../framework/Utilities';
+/**
+ * Get a test element by data-testid
+ * @param dataTestId - The data-testid of the element
+ * @param options.tag - The tag of the element having the data-testid attribute (e.g. 'div', 'input', etc.). Defaults to 'div'
+ * @param options.extraXPath - The extra xpath to the element (e.g. '/div/button'), useful for accessing elements we aren't able to assign a data-testid to
+ * @returns The test element
+ */
+function getTestElement(
+  dataTestId: string,
+  options: { extraXPath?: string; tag?: string } = {},
+): Promise<DetoxElement | WebElement> {
+  const { tag = 'div', extraXPath = '' } = options;
+  const xpath = `//${tag}[@data-testid="${dataTestId}"]${extraXPath}`;
+
+  return Matchers.getElementByXPath(
+    BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+    xpath,
+  );
+}
+
+class BitcoinTestDapp {
+  get connectButtonSelector(): WebElement {
+    return getTestElement(dataTestIds.testPage.header.connect, {
+      tag: 'button',
+    });
+  }
+
+  get disconnectButtonSelector(): WebElement {
+    return getTestElement(dataTestIds.testPage.header.disconnect, {
+      tag: 'button',
+    });
+  }
+
+  get walletButtonSelector(): WebElement {
+    return getTestElement(
+      dataTestIds.testPage.walletSelectionModal.walletOption,
+      {
+        tag: 'button',
+      },
+    );
+  }
+
+  get standardButtonSelector(): WebElement {
+    return getTestElement(
+      dataTestIds.testPage.walletSelectionModal.standardButton,
+      {
+        tag: 'button',
+      },
+    );
+  }
+
+  get signMessageButtonSelector(): WebElement {
+    return getTestElement(dataTestIds.testPage.signMessage.signMessage, {
+      tag: 'button',
+    });
+  }
+
+  get confirmSignMessageButtonSelector(): WebElement {
+    return Matchers.getElementByText('Approve');
+  }
+
+  async navigateToBitcoinTestDApp(): Promise<void> {
+    await Browser.tapUrlInputBox();
+
+    await Browser.navigateToURL(getDappUrl(0));
+
+    await waitFor(element(by.id(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID)))
+      .toBeVisible()
+      .withTimeout(10000);
+  }
+
+  async reloadBitcoinTestDApp(): Promise<void> {
+    await Browser.reloadTab();
+  }
+
+  /**
+   * Tap a button in the WebView
+   */
+  async tapButton(webElement: WebElement): Promise<void> {
+    await Gestures.scrollToWebViewPort(webElement);
+    await Gestures.tap(webElement);
+  }
+
+  getHeader() {
+    return {
+      connect: async () => {
+        await this.tapButton(this.connectButtonSelector);
+      },
+      disconnect: async () => {
+        console.log('trying to disconnect');
+        await this.tapButton(this.disconnectButtonSelector);
+      },
+      selectMetaMask: async () => {
+        await this.tapButton(this.walletButtonSelector);
+      },
+      selectStandard: async () => {
+        await this.tapButton(this.standardButtonSelector);
+      },
+      getConnectionStatus: async () => {
+        const connectionStatusDiv = await getTestElement(
+          dataTestIds.testPage.header.connectionStatus,
+        );
+        return await connectionStatusDiv.getText();
+      },
+      getAccount: async () => {
+        const account = await getTestElement(
+          dataTestIds.testPage.header.account,
+          { extraXPath: '/a' },
+        );
+        return await account.getText();
+      },
+    };
+  }
+
+  async signMessage(): Promise<void> {
+    await this.tapButton(this.signMessageButtonSelector);
+  }
+
+  async verifyConnectedAccount(connectionStatus: string): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        const account = await getTestElement(
+          dataTestIds.testPage.header.account,
+          {
+            extraXPath: '/a',
+          },
+        );
+        const actualText = await account.getText();
+
+        if (actualText !== connectionStatus) {
+          throw new Error(
+            `Expected text containing "${connectionStatus}" but got "${actualText}"`,
+          );
+        }
+      },
+      {
+        timeout: BASE_DEFAULTS.timeout,
+        description: 'Verify connection status',
+      },
+    );
+  }
+
+  async verifyConnectionStatus(connectionStatus: string): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        const connectionStatusDiv = await getTestElement(
+          dataTestIds.testPage.header.connectionStatus,
+        );
+        const actualText = await connectionStatusDiv.getText();
+
+        if (actualText !== connectionStatus) {
+          throw new Error(
+            `Expected text containing "${connectionStatus}" but got "${actualText}"`,
+          );
+        }
+      },
+      {
+        timeout: BASE_DEFAULTS.timeout,
+        description: 'Verify connection status',
+      },
+    );
+  }
+
+  async verifySignedMessage(signedMessage: string): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        const signedMessageElement = await getTestElement(
+          dataTestIds.testPage.signMessage.signedMessage,
+          {
+            tag: 'pre',
+          },
+        );
+        const actualText = await signedMessageElement.getText();
+
+        if (actualText !== signedMessage) {
+          throw new Error(
+            `Expected text containing "${signedMessage}" but got "${actualText}"`,
+          );
+        }
+      },
+      {
+        timeout: BASE_DEFAULTS.timeout,
+        description: 'Verify signed message',
+      },
+    );
+  }
+
+  async confirmSignMessage(): Promise<void> {
+    await Gestures.waitAndTap(this.confirmSignMessageButtonSelector);
+  }
+}
+
+export default new BitcoinTestDapp();

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -143,7 +143,6 @@ class BitcoinTestDapp {
         await this.openWalletSelectionModal();
       },
       disconnect: async () => {
-        console.log('trying to disconnect');
         await this.tapButton(this.disconnectButtonSelector);
       },
       selectMetaMask: async () => {

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -103,8 +103,11 @@ class BitcoinTestDapp {
   async waitForDappLoaded(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
+        const connectionStatusDiv = await getTestElement(
+          dataTestIds.testPage.header.connectionStatus,
+        );
         // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
-        await (expect(await this.connectButtonSelector) as any).toExist();
+        await (expect(connectionStatusDiv) as any).toExist();
       },
       {
         timeout: 30_000,

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -74,6 +74,8 @@ class BitcoinTestDapp {
     await waitFor(element(by.id(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID)))
       .toBeVisible()
       .withTimeout(10000);
+
+    await this.waitForDappLoaded();
   }
 
   async reloadBitcoinTestDApp(): Promise<void> {
@@ -86,6 +88,19 @@ class BitcoinTestDapp {
   async tapButton(webElement: WebElement): Promise<void> {
     await Gestures.scrollToWebViewPort(webElement);
     await Gestures.tap(webElement);
+  }
+
+  async waitForDappLoaded(): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
+        await (expect(await this.connectButtonSelector) as any).toExist();
+      },
+      {
+        timeout: 30_000,
+        description: 'Bitcoin test dapp to load',
+      },
+    );
   }
 
   getHeader() {

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -103,11 +103,7 @@ class BitcoinTestDapp {
   async waitForDappLoaded(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        const connectionStatusDiv = await getTestElement(
-          dataTestIds.testPage.header.connectionStatus,
-        );
-        // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
-        await (expect(connectionStatusDiv) as any).toExist();
+        await this.getHeader().getConnectionStatus();
       },
       {
         timeout: 30_000,

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -80,14 +80,24 @@ class BitcoinTestDapp {
 
   async reloadBitcoinTestDApp(): Promise<void> {
     await Browser.reloadTab();
+    await this.waitForDappLoaded();
   }
 
   /**
    * Tap a button in the WebView
    */
   async tapButton(webElement: WebElement): Promise<void> {
-    await Gestures.scrollToWebViewPort(webElement);
-    await Gestures.tap(webElement);
+    await Utilities.executeWithRetry(
+      async () => {
+        // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
+        await (expect(await webElement) as any).toExist();
+        await (await webElement).tap();
+      },
+      {
+        timeout: BASE_DEFAULTS.timeout,
+        description: 'Tap Bitcoin test dapp button',
+      },
+    );
   }
 
   async waitForDappLoaded(): Promise<void> {
@@ -103,10 +113,35 @@ class BitcoinTestDapp {
     );
   }
 
+  async waitForWalletOption(): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        // eslint-disable-next-line jest/valid-expect, @typescript-eslint/no-explicit-any
+        await (expect(await this.walletButtonSelector) as any).toExist();
+      },
+      {
+        timeout: BASE_DEFAULTS.timeout,
+        description: 'Bitcoin test dapp wallet option to appear',
+      },
+    );
+  }
+
+  async openWalletSelectionModal(): Promise<void> {
+    await this.tapButton(this.connectButtonSelector);
+
+    try {
+      await this.waitForWalletOption();
+    } catch (error) {
+      await this.reloadBitcoinTestDApp();
+      await this.tapButton(this.connectButtonSelector);
+      await this.waitForWalletOption();
+    }
+  }
+
   getHeader() {
     return {
       connect: async () => {
-        await this.tapButton(this.connectButtonSelector);
+        await this.openWalletSelectionModal();
       },
       disconnect: async () => {
         console.log('trying to disconnect');

--- a/tests/selectors/Browser/BitcoinTestDapp.selectors.ts
+++ b/tests/selectors/Browser/BitcoinTestDapp.selectors.ts
@@ -1,0 +1,15 @@
+/**
+ * IDs for web elements in the Bitcoin Test Dapp
+ */
+export interface BitcoinTestDappWebIDs {
+  WALLET_BUTTON: string;
+  CONFIRM_SIGN_MESSAGE_BUTTON: string;
+}
+
+/**
+ * Web element IDs for the Bitcoin Test Dapp
+ */
+export const BitcoinTestDappSelectorsWebIDs: BitcoinTestDappWebIDs = {
+  WALLET_BUTTON: '.wallet-adapter-modal-list .wallet-adapter-button', // Important space between classes to indicate a parent-child relationship
+  CONFIRM_SIGN_MESSAGE_BUTTON: 'confirmation-confirm-snap-footer-button',
+};

--- a/tests/selectors/Browser/BitcoinTestDapp.selectors.ts
+++ b/tests/selectors/Browser/BitcoinTestDapp.selectors.ts
@@ -5,11 +5,3 @@ export interface BitcoinTestDappWebIDs {
   WALLET_BUTTON: string;
   CONFIRM_SIGN_MESSAGE_BUTTON: string;
 }
-
-/**
- * Web element IDs for the Bitcoin Test Dapp
- */
-export const BitcoinTestDappSelectorsWebIDs: BitcoinTestDappWebIDs = {
-  WALLET_BUTTON: '.wallet-adapter-modal-list .wallet-adapter-button', // Important space between classes to indicate a parent-child relationship
-  CONFIRM_SIGN_MESSAGE_BUTTON: 'confirmation-confirm-snap-footer-button',
-};

--- a/tests/smoke/multichain/btc-wallet-standard/connect.spec.ts
+++ b/tests/smoke/multichain/btc-wallet-standard/connect.spec.ts
@@ -1,0 +1,46 @@
+import { SmokeNetworkExpansion } from '../../../tags';
+import BitcoinTestDapp from '../../../page-objects/Browser/BitcoinTestDapp';
+import {
+  account1Short,
+  connectBitcoinTestDapp,
+  navigateToBitcoinTestDApp,
+} from '../../../flows/bitcoin-connection.flow';
+import { loginToApp } from '../../../flows/wallet.flow';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { DappVariants } from '../../../framework/Constants';
+
+describe(SmokeNetworkExpansion('Bitcoin Wallet Standard E2E - Connect'), () => {
+  beforeAll(async () => {
+    jest.setTimeout(150000);
+  });
+
+  it('Connects & disconnects from Bitcoin test dapp', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        dapps: [
+          {
+            dappVariant: DappVariants.BITCOIN_TEST_DAPP,
+          },
+        ],
+      },
+      async () => {
+        await loginToApp();
+        await navigateToBitcoinTestDApp();
+
+        await connectBitcoinTestDapp();
+
+        // Check we're connected
+        await BitcoinTestDapp.verifyConnectedAccount(account1Short);
+        await BitcoinTestDapp.verifyConnectionStatus('Connected');
+
+        const header = BitcoinTestDapp.getHeader();
+        await header.disconnect();
+
+        await BitcoinTestDapp.verifyConnectionStatus('Not connected');
+      },
+    );
+  });
+});

--- a/tests/smoke/multichain/btc-wallet-standard/connect.spec.ts
+++ b/tests/smoke/multichain/btc-wallet-standard/connect.spec.ts
@@ -43,4 +43,32 @@ describe(SmokeNetworkExpansion('Bitcoin Wallet Standard E2E - Connect'), () => {
       },
     );
   });
+
+  it('Stays connected after page refresh', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        dapps: [
+          {
+            dappVariant: DappVariants.BITCOIN_TEST_DAPP,
+          },
+        ],
+      },
+      async () => {
+        await loginToApp();
+        await navigateToBitcoinTestDApp();
+
+        await connectBitcoinTestDapp();
+
+        await BitcoinTestDapp.verifyConnectedAccount(account1Short);
+        await BitcoinTestDapp.verifyConnectionStatus('Connected');
+
+        await BitcoinTestDapp.reloadBitcoinTestDApp();
+
+        await BitcoinTestDapp.verifyConnectedAccount(account1Short);
+        await BitcoinTestDapp.verifyConnectionStatus('Connected');
+      },
+    );
+  });
 });

--- a/tests/smoke/multichain/btc-wallet-standard/signMessage.spec.ts
+++ b/tests/smoke/multichain/btc-wallet-standard/signMessage.spec.ts
@@ -1,0 +1,45 @@
+import { SmokeNetworkExpansion } from '../../../tags';
+import BitcoinTestDapp from '../../../page-objects/Browser/BitcoinTestDapp';
+import {
+  signedMessageStandard,
+  connectBitcoinTestDapp,
+  navigateToBitcoinTestDApp,
+} from '../../../flows/bitcoin-connection.flow';
+import { loginToApp } from '../../../flows/wallet.flow';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { DappVariants } from '../../../framework/Constants';
+
+describe(
+  SmokeNetworkExpansion('Bitcoin Wallet Standard E2E - Sign Message'),
+  () => {
+    beforeAll(async () => {
+      jest.setTimeout(150000);
+    });
+
+    it('Signs a message', async () => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder().build(),
+          restartDevice: true,
+          dapps: [
+            {
+              dappVariant: DappVariants.BITCOIN_TEST_DAPP,
+            },
+          ],
+        },
+        async () => {
+          await loginToApp();
+          await navigateToBitcoinTestDApp();
+
+          await connectBitcoinTestDapp();
+
+          await BitcoinTestDapp.signMessage();
+          await BitcoinTestDapp.confirmSignMessage();
+
+          await BitcoinTestDapp.verifySignedMessage(signedMessageStandard);
+        },
+      );
+    });
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10019,6 +10019,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/test-dapp-bitcoin@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/test-dapp-bitcoin@npm:0.2.0"
+  dependencies:
+    "@wallet-standard/base": "npm:^1.1.0"
+    "@wallet-standard/core": "npm:^1.1.1"
+    bitcoinjs-lib: "npm:^7.0.0"
+    buffer: "npm:^6.0.3"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    sats-connect-v3: "npm:sats-connect@^3.5.0"
+    sats-connect-v4: "npm:sats-connect@^4.0.0"
+    vite-plugin-node-polyfills: "npm:^0.22.0"
+  checksum: 10/6a85979e7800f472e75596eebe6ecc916da6de0638db55e7a2714946306bf507dedc063c715b4c75c4e71176c70fd169cfb183552ca3af110bddffc81e7aeb93
+  languageName: node
+  linkType: hard
+
 "@metamask/test-dapp-multichain@npm:^0.17.1":
   version: 0.17.1
   resolution: "@metamask/test-dapp-multichain@npm:0.17.1"
@@ -13194,6 +13211,61 @@ __metadata:
   version: 4.41.0
   resolution: "@rollup/rollup-linux-x64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@sats-connect/core@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@sats-connect/core@npm:0.10.0"
+  dependencies:
+    axios: "npm:1.12.0"
+    bitcoin-address-validation: "npm:3.0.0"
+    buffer: "npm:6.0.3"
+    jsontokens: "npm:4.0.1"
+  peerDependencies:
+    valibot: 1.1.0
+  checksum: 10/8c9a25adf995057529a909a8752942dad4fcb822ef4edbd2529e1987e96278de069f43f37aa26a127133597aae2f02e6d5cd9742a1c3ca1df085f55ed3bbe04d
+  languageName: node
+  linkType: hard
+
+"@sats-connect/core@npm:0.6.11":
+  version: 0.6.11
+  resolution: "@sats-connect/core@npm:0.6.11"
+  dependencies:
+    axios: "npm:1.8.4"
+    bitcoin-address-validation: "npm:2.2.3"
+    buffer: "npm:6.0.3"
+    jsontokens: "npm:4.0.1"
+  peerDependencies:
+    valibot: 1.1.0
+  checksum: 10/d7ef2429e471e233aca933b768a585bee6516c19c0d1fe2174e3a0e49bb2e5d4846f1627da2ca0ed3d4e2052c2a6d9804a0638f45b4a8445dba8ba51abbe8e0e
+  languageName: node
+  linkType: hard
+
+"@sats-connect/make-default-provider-config@npm:0.0.10":
+  version: 0.0.10
+  resolution: "@sats-connect/make-default-provider-config@npm:0.0.10"
+  dependencies:
+    "@sats-connect/ui": "npm:^0.0.6"
+    bowser: "npm:^2.11.0"
+  peerDependencies:
+    "@sats-connect/core": "*"
+    typescript: ^5.0.0
+  checksum: 10/3d7a50a562f3e8c4421a06eb7cdd720669ecac3e94ef769062fcc05fd90e517f267eff6b3c22313d88bb99d4bf111bdefe9a8fd8595ee143a03ab9df638271a5
+  languageName: node
+  linkType: hard
+
+"@sats-connect/ui@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@sats-connect/ui@npm:0.0.7"
+  checksum: 10/bbe5a702de824edda0ced3404e4be93761bf35253d9444188dc126eef6f4ddc6b585f0736250b2aa0ea7d3c81e42dcd762393611a355e76c310474b26d94bc49
+  languageName: node
+  linkType: hard
+
+"@sats-connect/ui@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@sats-connect/ui@npm:0.0.6"
+  checksum: 10/d227f354386478f63ca892c5d25b6d445a6803f735d4b861ce271531cecf59797763a33dabcbb5f5d22838a64b5a46fd378d749b60ba0c453406c2c023b92eb9
   languageName: node
   linkType: hard
 
@@ -19910,7 +19982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wallet-standard/core@npm:^1.0.3":
+"@wallet-standard/core@npm:^1.0.3, @wallet-standard/core@npm:^1.1.1":
   version: 1.1.1
   resolution: "@wallet-standard/core@npm:1.1.1"
   dependencies:
@@ -23142,6 +23214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base58-js@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "base58-js@npm:3.0.3"
+  checksum: 10/62bad85b233290102ec3acdd47f604a3f657e20c1cb8a2de960c645f5f34d4a15806ece82e0fec75af5c66ea020d37be3c9daa00b92652570b7c43c4ecf7224a
+  languageName: node
+  linkType: hard
+
 "base58check@npm:^2.0.0":
   version: 2.0.0
   resolution: "base58check@npm:2.0.0"
@@ -23327,6 +23406,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bip174@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bip174@npm:3.0.0"
+  dependencies:
+    uint8array-tools: "npm:^0.0.9"
+    varuint-bitcoin: "npm:^2.0.0"
+  checksum: 10/b698437e5461cd1f02fc2f24bc074684909cf59ecd85da246000473d88c7a9bf7c2fe62b88ac84af33c3c1c60b17d7a85fb17e5cfa17d0053fb3d9fa0f7ea844
+  languageName: node
+  linkType: hard
+
 "bip66@npm:^2.0.0":
   version: 2.0.0
   resolution: "bip66@npm:2.0.0"
@@ -23345,10 +23434,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bitcoin-address-validation@npm:3.0.0":
+  version: 3.0.0
+  resolution: "bitcoin-address-validation@npm:3.0.0"
+  dependencies:
+    base58-js: "npm:^3.0.2"
+    bech32: "npm:^2.0.0"
+    sha256-uint8array: "npm:^0.10.3"
+  checksum: 10/3703f27501ea9c3bebad2c5a0448850a5c13f4d2df419ae72bfc458ff658283d29cc24e4cb34b99d5c6b5dec4bb58b3897456934213efd7b6f758bc87c81293b
+  languageName: node
+  linkType: hard
+
 "bitcoin-ops@npm:^1.3.0, bitcoin-ops@npm:^1.4.1":
   version: 1.4.1
   resolution: "bitcoin-ops@npm:1.4.1"
   checksum: 10/3daa3303d6af49c0727041b5d7801a20c5806d00f1cc1afa2d53099974e30a7b1e7e9e578723dd25f5e120903f2725c595c0205d5d99a6578ad65213d74d806d
+  languageName: node
+  linkType: hard
+
+"bitcoinjs-lib@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "bitcoinjs-lib@npm:7.0.1"
+  dependencies:
+    "@noble/hashes": "npm:^1.2.0"
+    bech32: "npm:^2.0.0"
+    bip174: "npm:^3.0.0"
+    bs58check: "npm:^4.0.0"
+    uint8array-tools: "npm:^0.0.9"
+    valibot: "npm:^1.2.0"
+    varuint-bitcoin: "npm:^2.0.0"
+  checksum: 10/3656f9c64f38adc946cd6e099faf3e479910c6f1baf1f8188329c73d1b202b260e63e505f201eb0522ef3830f11854804c811f9d89bae50c6fa75d7a7a20f530
   languageName: node
   linkType: hard
 
@@ -34205,7 +34320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsontokens@npm:^4.0.1":
+"jsontokens@npm:4.0.1, jsontokens@npm:^4.0.1":
   version: 4.0.1
   resolution: "jsontokens@npm:4.0.1"
   dependencies:
@@ -35760,6 +35875,7 @@ __metadata:
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/swappable-obj-proxy": "npm:^2.1.0"
     "@metamask/test-dapp": "npm:9.5.0"
+    "@metamask/test-dapp-bitcoin": "npm:^0.2.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^64.0.0"
@@ -42783,6 +42899,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sats-connect-v3@npm:sats-connect@^3.5.0":
+  version: 3.6.1
+  resolution: "sats-connect@npm:3.6.1"
+  dependencies:
+    "@sats-connect/core": "npm:0.6.11"
+    "@sats-connect/make-default-provider-config": "npm:0.0.10"
+    "@sats-connect/ui": "npm:0.0.7"
+    valibot: "npm:1.1.0"
+  checksum: 10/0f6098b0578d4b223729b6164019fafdd84e52859ff7532daf8cdfa6c287ddbfb38139db7cecc49a12d47b4b830777dea39840cef7dc15f61c3187c32d5e1ccc
+  languageName: node
+  linkType: hard
+
+"sats-connect-v4@npm:sats-connect@^4.0.0":
+  version: 4.2.1
+  resolution: "sats-connect@npm:4.2.1"
+  dependencies:
+    "@sats-connect/core": "npm:0.10.0"
+    "@sats-connect/make-default-provider-config": "npm:0.0.10"
+    "@sats-connect/ui": "npm:0.0.7"
+    valibot: "npm:1.1.0"
+  checksum: 10/89dd2c367d348d23e8f8ad8acf2ffb41cc5881722b1b9afde4b674e1280fae2383e412bdc7751641c877a412fcad91684ebb8e5a26695b8f3167944d908df3cc
+  languageName: node
+  linkType: hard
+
 "sax@npm:>=0.6.0":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
@@ -45952,6 +46092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uint8array-tools@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "uint8array-tools@npm:0.0.9"
+  checksum: 10/ea924e6d574f8c24d94400f0635eeffbeb0190fd2e4b781bb8e43b089c799a3d8c11c9b75d7c68524bc7e18f7ffc3d942f122ecf729746ba51612a8463848943
+  languageName: node
+  linkType: hard
+
 "uint8arrays@npm:3.1.0":
   version: 3.1.0
   resolution: "uint8arrays@npm:3.1.0"
@@ -46826,6 +46973,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"valibot@npm:1.1.0":
+  version: 1.1.0
+  resolution: "valibot@npm:1.1.0"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/667c99e3ec2825ea97c20f37add7fe7eb9d15fb338c5f49c166ffba13a6f4516c77c060083e1c6bda77a2275c4d37400b711d284bbea03fd4ae160bbca34112c
+  languageName: node
+  linkType: hard
+
 "valibot@npm:1.2.0":
   version: 1.2.0
   resolution: "valibot@npm:1.2.0"
@@ -46835,6 +46994,18 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/5f9c15e6f5a2b8eae75332a3317e46e995a1763efe1b91e57bc5064e36f0feba734367c88013d53255bdf09fb9204bf3598d2ca0c3f468c8726095b1c3551926
+  languageName: node
+  linkType: hard
+
+"valibot@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "valibot@npm:1.3.1"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/e14d085fa87fbf41f76d040cdcf17e31527f868c8b82f878bc488a5bc3bc81162406c605182fc720473ec6dcff05393b89fb4a921a4206d9f7b6f76e3c93cf34
   languageName: node
   linkType: hard
 
@@ -46920,7 +47091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"varuint-bitcoin@npm:2.0.0":
+"varuint-bitcoin@npm:2.0.0, varuint-bitcoin@npm:^2.0.0":
   version: 2.0.0
   resolution: "varuint-bitcoin@npm:2.0.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,6 +3604,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/bitcoin-wallet-standard-chains@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard-chains@npm:0.0.0"
+  dependencies:
+    "@wallet-standard/base": "npm:^1.0.1"
+  checksum: 10/1193d95599431af7e772eaa1967502871063b1025bfe43443b7c37c0de9fbd6225cf7977a68eef1a43302ede05f0f3a634f01c5e060b53b1e240e8e250a2f156
+  languageName: node
+  linkType: hard
+
+"@exodus/bitcoin-wallet-standard-core@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard-core@npm:0.0.0"
+  dependencies:
+    "@exodus/bitcoin-wallet-standard-chains": "npm:^0.0.0"
+    "@exodus/bitcoin-wallet-standard-features": "npm:^0.0.0"
+  checksum: 10/2294b086cba5b8eb0e0880c8e15f44d7c11bb08f314bbeacda50ee7cfbdc464e6aaefe8ab56b1ed527bc7bb4e83f94425e8ee8bd3c92c3c2e5729284a19c9a3f
+  languageName: node
+  linkType: hard
+
+"@exodus/bitcoin-wallet-standard-features@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard-features@npm:0.0.0"
+  dependencies:
+    "@wallet-standard/base": "npm:^1.0.1"
+    "@wallet-standard/features": "npm:^1.0.3"
+  checksum: 10/877b9dd4965a6b3bd05c2e06e3af0f3a50467ceb4709a09164679a0e383dbf4817170b2c1b6fd1d1b42f70942fd2b4fcfc52929a8d434d232f333610d182beec
+  languageName: node
+  linkType: hard
+
+"@exodus/bitcoin-wallet-standard@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard@npm:0.0.0"
+  dependencies:
+    "@exodus/bitcoin-wallet-standard-core": "npm:^0.0.0"
+  checksum: 10/d723cfc104145334eee7b63afa0698d984b15dc1aae9a3015eb92efd377d4fef765bc6c732582957a3bfa76b1bbac776b2a30384e84266c7ba49160d359361f6
+  languageName: node
+  linkType: hard
+
 "@expensify/react-native-wallet@npm:^0.1.15":
   version: 0.1.15
   resolution: "@expensify/react-native-wallet@npm:0.1.15"
@@ -7948,6 +7986,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/bitcoin-wallet-standard@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/bitcoin-wallet-standard@npm:1.0.0"
+  dependencies:
+    "@exodus/bitcoin-wallet-standard": "npm:^0.0.0"
+    "@metamask/multichain-api-client": "npm:^0.11.0"
+    "@wallet-standard/base": "npm:^1.1.0"
+    "@wallet-standard/features": "npm:^1.1.0"
+    "@wallet-standard/wallet": "npm:^1.1.0"
+    bs58: "npm:^6.0.0"
+    jsontokens: "npm:^4.0.1"
+  checksum: 10/c0484f16aa4e290a47eab7b6a17afd08028a7b1d3d684b17114865b39f53120ef587aa854567659f5fac520bd2b1a5acf0d88e5528a73ea957e2399a2cb05f03
+  languageName: node
+  linkType: hard
+
 "@metamask/bridge-controller@npm:^70.0.0, @metamask/bridge-controller@npm:^70.0.1":
   version: 70.0.1
   resolution: "@metamask/bridge-controller@npm:70.0.1"
@@ -9089,6 +9142,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/multichain-api-client@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@metamask/multichain-api-client@npm:0.11.0"
+  checksum: 10/fee3751b8bfdce08db37be205aa2d78de6544060ccbe57ff790ddf9c0aad830ee6cfb1844e4ea838ce97f0b7851badd0271cb0ec32ac42d3f7d4cfa15ccb1298
+  languageName: node
+  linkType: hard
+
 "@metamask/multichain-api-middleware@npm:1.2.5":
   version: 1.2.5
   resolution: "@metamask/multichain-api-middleware@npm:1.2.5"
@@ -10201,7 +10261,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+  version: 11.10.0
+  resolution: "@metamask/utils@npm:11.10.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    "@types/lodash": "npm:^4.17.20"
+    debug: "npm:^4.3.4"
+    lodash: "npm:^4.17.21"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^11.11.0":
   version: 11.11.0
   resolution: "@metamask/utils@npm:11.11.0"
   dependencies:
@@ -10538,6 +10617,13 @@ __metadata:
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 10/1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:^1.6.3":
+  version: 1.7.2
+  resolution: "@noble/secp256k1@npm:1.7.2"
+  checksum: 10/ce1651f63ebf9269990dbc1002410d63e2f4379fcbf2bb7a567740997852a1fbdb353929e497cd9d09549c28e3edb036ac3905ff20ac5249ad32e64a852af955
   languageName: node
   linkType: hard
 
@@ -34119,6 +34205,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsontokens@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jsontokens@npm:4.0.1"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.2"
+    "@noble/secp256k1": "npm:^1.6.3"
+    base64-js: "npm:^1.5.1"
+  checksum: 10/b1b2dbd29b7f491f31934bd5385555ae11b76ce853141d6b3bb39d54045d0e654d3cdcc159a02765b017b63766b4f7cdb7b1b394be570636c7b942f5f9e781f2
+  languageName: node
+  linkType: hard
+
 "jsonwebtoken@npm:9.0.0":
   version: 9.0.0
   resolution: "jsonwebtoken@npm:9.0.0"
@@ -35557,6 +35654,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.10.1"
+    "@metamask/bitcoin-wallet-standard": "npm:^1.0.0"
     "@metamask/bridge-controller": "npm:^70.0.0"
     "@metamask/bridge-status-controller": "npm:^70.0.4"
     "@metamask/browser-passworder": "npm:^5.0.0"
@@ -36555,7 +36653,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.4":
+  version: 9.0.5
+  resolution: "minimatch@npm:9.0.5"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/dd6a8927b063aca6d910b119e1f2df6d2ce7d36eab91de83167dd136bb85e1ebff97b0d3de1cb08bd1f7e018ca170b4962479fefab5b2a69e2ae12cb2edc8348
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.3, minimatch@npm:^9.0.5":
   version: 9.0.9
   resolution: "minimatch@npm:9.0.9"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10349,6 +10349,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/test-dapp-bitcoin@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/test-dapp-bitcoin@npm:0.2.0"
+  dependencies:
+    "@wallet-standard/base": "npm:^1.1.0"
+    "@wallet-standard/core": "npm:^1.1.1"
+    bitcoinjs-lib: "npm:^7.0.0"
+    buffer: "npm:^6.0.3"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    sats-connect-v3: "npm:sats-connect@^3.5.0"
+    sats-connect-v4: "npm:sats-connect@^4.0.0"
+    vite-plugin-node-polyfills: "npm:^0.22.0"
+  checksum: 10/6a85979e7800f472e75596eebe6ecc916da6de0638db55e7a2714946306bf507dedc063c715b4c75c4e71176c70fd169cfb183552ca3af110bddffc81e7aeb93
+  languageName: node
+  linkType: hard
+
 "@metamask/test-dapp-multichain@npm:^0.17.1":
   version: 0.17.1
   resolution: "@metamask/test-dapp-multichain@npm:0.17.1"
@@ -13502,6 +13519,61 @@ __metadata:
   version: 4.41.0
   resolution: "@rollup/rollup-linux-x64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@sats-connect/core@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@sats-connect/core@npm:0.10.0"
+  dependencies:
+    axios: "npm:1.12.0"
+    bitcoin-address-validation: "npm:3.0.0"
+    buffer: "npm:6.0.3"
+    jsontokens: "npm:4.0.1"
+  peerDependencies:
+    valibot: 1.1.0
+  checksum: 10/8c9a25adf995057529a909a8752942dad4fcb822ef4edbd2529e1987e96278de069f43f37aa26a127133597aae2f02e6d5cd9742a1c3ca1df085f55ed3bbe04d
+  languageName: node
+  linkType: hard
+
+"@sats-connect/core@npm:0.6.11":
+  version: 0.6.11
+  resolution: "@sats-connect/core@npm:0.6.11"
+  dependencies:
+    axios: "npm:1.8.4"
+    bitcoin-address-validation: "npm:2.2.3"
+    buffer: "npm:6.0.3"
+    jsontokens: "npm:4.0.1"
+  peerDependencies:
+    valibot: 1.1.0
+  checksum: 10/d7ef2429e471e233aca933b768a585bee6516c19c0d1fe2174e3a0e49bb2e5d4846f1627da2ca0ed3d4e2052c2a6d9804a0638f45b4a8445dba8ba51abbe8e0e
+  languageName: node
+  linkType: hard
+
+"@sats-connect/make-default-provider-config@npm:0.0.10":
+  version: 0.0.10
+  resolution: "@sats-connect/make-default-provider-config@npm:0.0.10"
+  dependencies:
+    "@sats-connect/ui": "npm:^0.0.6"
+    bowser: "npm:^2.11.0"
+  peerDependencies:
+    "@sats-connect/core": "*"
+    typescript: ^5.0.0
+  checksum: 10/3d7a50a562f3e8c4421a06eb7cdd720669ecac3e94ef769062fcc05fd90e517f267eff6b3c22313d88bb99d4bf111bdefe9a8fd8595ee143a03ab9df638271a5
+  languageName: node
+  linkType: hard
+
+"@sats-connect/ui@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@sats-connect/ui@npm:0.0.7"
+  checksum: 10/bbe5a702de824edda0ced3404e4be93761bf35253d9444188dc126eef6f4ddc6b585f0736250b2aa0ea7d3c81e42dcd762393611a355e76c310474b26d94bc49
+  languageName: node
+  linkType: hard
+
+"@sats-connect/ui@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@sats-connect/ui@npm:0.0.6"
+  checksum: 10/d227f354386478f63ca892c5d25b6d445a6803f735d4b861ce271531cecf59797763a33dabcbb5f5d22838a64b5a46fd378d749b60ba0c453406c2c023b92eb9
   languageName: node
   linkType: hard
 
@@ -23233,6 +23305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base58-js@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "base58-js@npm:3.0.3"
+  checksum: 10/62bad85b233290102ec3acdd47f604a3f657e20c1cb8a2de960c645f5f34d4a15806ece82e0fec75af5c66ea020d37be3c9daa00b92652570b7c43c4ecf7224a
+  languageName: node
+  linkType: hard
+
 "base58check@npm:^2.0.0":
   version: 2.0.0
   resolution: "base58check@npm:2.0.0"
@@ -23417,6 +23496,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bip174@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bip174@npm:3.0.0"
+  dependencies:
+    uint8array-tools: "npm:^0.0.9"
+    varuint-bitcoin: "npm:^2.0.0"
+  checksum: 10/b698437e5461cd1f02fc2f24bc074684909cf59ecd85da246000473d88c7a9bf7c2fe62b88ac84af33c3c1c60b17d7a85fb17e5cfa17d0053fb3d9fa0f7ea844
+  languageName: node
+  linkType: hard
+
 "bip66@npm:^2.0.0":
   version: 2.0.0
   resolution: "bip66@npm:2.0.0"
@@ -23435,10 +23524,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bitcoin-address-validation@npm:3.0.0":
+  version: 3.0.0
+  resolution: "bitcoin-address-validation@npm:3.0.0"
+  dependencies:
+    base58-js: "npm:^3.0.2"
+    bech32: "npm:^2.0.0"
+    sha256-uint8array: "npm:^0.10.3"
+  checksum: 10/3703f27501ea9c3bebad2c5a0448850a5c13f4d2df419ae72bfc458ff658283d29cc24e4cb34b99d5c6b5dec4bb58b3897456934213efd7b6f758bc87c81293b
+  languageName: node
+  linkType: hard
+
 "bitcoin-ops@npm:^1.3.0, bitcoin-ops@npm:^1.4.1":
   version: 1.4.1
   resolution: "bitcoin-ops@npm:1.4.1"
   checksum: 10/3daa3303d6af49c0727041b5d7801a20c5806d00f1cc1afa2d53099974e30a7b1e7e9e578723dd25f5e120903f2725c595c0205d5d99a6578ad65213d74d806d
+  languageName: node
+  linkType: hard
+
+"bitcoinjs-lib@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "bitcoinjs-lib@npm:7.0.1"
+  dependencies:
+    "@noble/hashes": "npm:^1.2.0"
+    bech32: "npm:^2.0.0"
+    bip174: "npm:^3.0.0"
+    bs58check: "npm:^4.0.0"
+    uint8array-tools: "npm:^0.0.9"
+    valibot: "npm:^1.2.0"
+    varuint-bitcoin: "npm:^2.0.0"
+  checksum: 10/3656f9c64f38adc946cd6e099faf3e479910c6f1baf1f8188329c73d1b202b260e63e505f201eb0522ef3830f11854804c811f9d89bae50c6fa75d7a7a20f530
   languageName: node
   linkType: hard
 
@@ -33972,7 +34087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsontokens@npm:^4.0.1":
+"jsontokens@npm:4.0.1, jsontokens@npm:^4.0.1":
   version: 4.0.1
   resolution: "jsontokens@npm:4.0.1"
   dependencies:
@@ -35484,6 +35599,7 @@ __metadata:
     "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/swappable-obj-proxy": "npm:^2.1.0"
     "@metamask/test-dapp": "npm:9.5.0"
+    "@metamask/test-dapp-bitcoin": "npm:^0.2.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^67.1.0"
@@ -42463,6 +42579,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sats-connect-v3@npm:sats-connect@^3.5.0":
+  version: 3.6.1
+  resolution: "sats-connect@npm:3.6.1"
+  dependencies:
+    "@sats-connect/core": "npm:0.6.11"
+    "@sats-connect/make-default-provider-config": "npm:0.0.10"
+    "@sats-connect/ui": "npm:0.0.7"
+    valibot: "npm:1.1.0"
+  checksum: 10/0f6098b0578d4b223729b6164019fafdd84e52859ff7532daf8cdfa6c287ddbfb38139db7cecc49a12d47b4b830777dea39840cef7dc15f61c3187c32d5e1ccc
+  languageName: node
+  linkType: hard
+
+"sats-connect-v4@npm:sats-connect@^4.0.0":
+  version: 4.2.1
+  resolution: "sats-connect@npm:4.2.1"
+  dependencies:
+    "@sats-connect/core": "npm:0.10.0"
+    "@sats-connect/make-default-provider-config": "npm:0.0.10"
+    "@sats-connect/ui": "npm:0.0.7"
+    valibot: "npm:1.1.0"
+  checksum: 10/89dd2c367d348d23e8f8ad8acf2ffb41cc5881722b1b9afde4b674e1280fae2383e412bdc7751641c877a412fcad91684ebb8e5a26695b8f3167944d908df3cc
+  languageName: node
+  linkType: hard
+
 "sax@npm:>=0.6.0":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
@@ -45569,6 +45709,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uint8array-tools@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "uint8array-tools@npm:0.0.9"
+  checksum: 10/ea924e6d574f8c24d94400f0635eeffbeb0190fd2e4b781bb8e43b089c799a3d8c11c9b75d7c68524bc7e18f7ffc3d942f122ecf729746ba51612a8463848943
+  languageName: node
+  linkType: hard
+
 "uint8arrays@npm:3.1.0":
   version: 3.1.0
   resolution: "uint8arrays@npm:3.1.0"
@@ -46406,7 +46553,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"valibot@npm:1.3.1":
+"valibot@npm:1.1.0":
+  version: 1.1.0
+  resolution: "valibot@npm:1.1.0"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/667c99e3ec2825ea97c20f37add7fe7eb9d15fb338c5f49c166ffba13a6f4516c77c060083e1c6bda77a2275c4d37400b711d284bbea03fd4ae160bbca34112c
+  languageName: node
+  linkType: hard
+
+"valibot@npm:1.3.1, valibot@npm:^1.2.0":
   version: 1.3.1
   resolution: "valibot@npm:1.3.1"
   peerDependencies:
@@ -46493,7 +46652,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"varuint-bitcoin@npm:2.0.0":
+"varuint-bitcoin@npm:2.0.0, varuint-bitcoin@npm:^2.0.0":
   version: 2.0.0
   resolution: "varuint-bitcoin@npm:2.0.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9351,13 +9351,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-api-client@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "@metamask/multichain-api-client@npm:0.10.1"
-  checksum: 10/adedb90f433cd619eee54943197dc32eb30e461173e928ea698ec70bf8c6780d9ac0bb9b12a22a17f984170841c071d228aa49e6988d5060e8a30e99c433a8f5
-  languageName: node
-  linkType: hard
-
 "@metamask/multichain-api-client@npm:^0.11.0":
   version: 0.11.0
   resolution: "@metamask/multichain-api-client@npm:0.11.0"
@@ -35548,7 +35541,7 @@ __metadata:
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.0.5"
     "@metamask/multichain-account-service": "npm:^10.0.2"
-    "@metamask/multichain-api-client": "npm:^0.10.1"
+    "@metamask/multichain-api-client": "npm:^0.11.0"
     "@metamask/multichain-api-middleware": "npm:^3.1.1"
     "@metamask/multichain-network-controller": "npm:^3.1.0"
     "@metamask/multichain-transactions-controller": "npm:^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3776,6 +3776,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/bitcoin-wallet-standard-chains@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard-chains@npm:0.0.0"
+  dependencies:
+    "@wallet-standard/base": "npm:^1.0.1"
+  checksum: 10/1193d95599431af7e772eaa1967502871063b1025bfe43443b7c37c0de9fbd6225cf7977a68eef1a43302ede05f0f3a634f01c5e060b53b1e240e8e250a2f156
+  languageName: node
+  linkType: hard
+
+"@exodus/bitcoin-wallet-standard-core@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard-core@npm:0.0.0"
+  dependencies:
+    "@exodus/bitcoin-wallet-standard-chains": "npm:^0.0.0"
+    "@exodus/bitcoin-wallet-standard-features": "npm:^0.0.0"
+  checksum: 10/2294b086cba5b8eb0e0880c8e15f44d7c11bb08f314bbeacda50ee7cfbdc464e6aaefe8ab56b1ed527bc7bb4e83f94425e8ee8bd3c92c3c2e5729284a19c9a3f
+  languageName: node
+  linkType: hard
+
+"@exodus/bitcoin-wallet-standard-features@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard-features@npm:0.0.0"
+  dependencies:
+    "@wallet-standard/base": "npm:^1.0.1"
+    "@wallet-standard/features": "npm:^1.0.3"
+  checksum: 10/877b9dd4965a6b3bd05c2e06e3af0f3a50467ceb4709a09164679a0e383dbf4817170b2c1b6fd1d1b42f70942fd2b4fcfc52929a8d434d232f333610d182beec
+  languageName: node
+  linkType: hard
+
+"@exodus/bitcoin-wallet-standard@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@exodus/bitcoin-wallet-standard@npm:0.0.0"
+  dependencies:
+    "@exodus/bitcoin-wallet-standard-core": "npm:^0.0.0"
+  checksum: 10/d723cfc104145334eee7b63afa0698d984b15dc1aae9a3015eb92efd377d4fef765bc6c732582957a3bfa76b1bbac776b2a30384e84266c7ba49160d359361f6
+  languageName: node
+  linkType: hard
+
 "@expensify/react-native-wallet@npm:^0.1.15":
   version: 0.1.15
   resolution: "@expensify/react-native-wallet@npm:0.1.15"
@@ -8163,6 +8201,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/bitcoin-wallet-standard@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/bitcoin-wallet-standard@npm:1.0.0"
+  dependencies:
+    "@exodus/bitcoin-wallet-standard": "npm:^0.0.0"
+    "@metamask/multichain-api-client": "npm:^0.11.0"
+    "@wallet-standard/base": "npm:^1.1.0"
+    "@wallet-standard/features": "npm:^1.1.0"
+    "@wallet-standard/wallet": "npm:^1.1.0"
+    bs58: "npm:^6.0.0"
+    jsontokens: "npm:^4.0.1"
+  checksum: 10/c0484f16aa4e290a47eab7b6a17afd08028a7b1d3d684b17114865b39f53120ef587aa854567659f5fac520bd2b1a5acf0d88e5528a73ea957e2399a2cb05f03
+  languageName: node
+  linkType: hard
+
 "@metamask/bridge-controller@npm:^75.0.0, @metamask/bridge-controller@npm:^75.1.0, @metamask/bridge-controller@npm:^75.1.1":
   version: 75.1.1
   resolution: "@metamask/bridge-controller@npm:75.1.1"
@@ -9302,6 +9355,13 @@ __metadata:
   version: 0.10.1
   resolution: "@metamask/multichain-api-client@npm:0.10.1"
   checksum: 10/adedb90f433cd619eee54943197dc32eb30e461173e928ea698ec70bf8c6780d9ac0bb9b12a22a17f984170841c071d228aa49e6988d5060e8a30e99c433a8f5
+  languageName: node
+  linkType: hard
+
+"@metamask/multichain-api-client@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@metamask/multichain-api-client@npm:0.11.0"
+  checksum: 10/fee3751b8bfdce08db37be205aa2d78de6544060ccbe57ff790ddf9c0aad830ee6cfb1844e4ea838ce97f0b7851badd0271cb0ec32ac42d3f7d4cfa15ccb1298
   languageName: node
   linkType: hard
 
@@ -10758,6 +10818,13 @@ __metadata:
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 10/1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:^1.6.3":
+  version: 1.7.2
+  resolution: "@noble/secp256k1@npm:1.7.2"
+  checksum: 10/ce1651f63ebf9269990dbc1002410d63e2f4379fcbf2bb7a567740997852a1fbdb353929e497cd9d09549c28e3edb036ac3905ff20ac5249ad32e64a852af955
   languageName: node
   linkType: hard
 
@@ -33905,6 +33972,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsontokens@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jsontokens@npm:4.0.1"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.2"
+    "@noble/secp256k1": "npm:^1.6.3"
+    base64-js: "npm:^1.5.1"
+  checksum: 10/b1b2dbd29b7f491f31934bd5385555ae11b76ce853141d6b3bb39d54045d0e654d3cdcc159a02765b017b63766b4f7cdb7b1b394be570636c7b942f5f9e781f2
+  languageName: node
+  linkType: hard
+
 "jsonwebtoken@npm:9.0.0":
   version: 9.0.0
   resolution: "jsonwebtoken@npm:9.0.0"
@@ -35294,6 +35372,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
+    "@metamask/bitcoin-wallet-standard": "npm:^1.0.0"
     "@metamask/bridge-controller": "npm:^75.1.0"
     "@metamask/bridge-status-controller": "npm:^72.1.0"
     "@metamask/browser-passworder": "npm:^5.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section
titles
present), all status checks must be currently passing, and the only
expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by
.github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in
rendered
markdown and must NOT be removed or edited without updating the
validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
type=issue-link Section must have a Fixes:/Closes:/Refs: line with a
value.
type=manual-testing Section must have real testing steps or an explicit
N/A.
type=screenshot Section must have evidence (image/URL) or an explicit
N/A.
type=checklist Section must have all checkboxes consciously checked.
required=true|false Whether a missing/invalid section blocks the PR
check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->
This PR adds Bitcoin Wallet Standard connectivity support to MetaMask Mobile.
<!--
Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
<!--
Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

It registers the Bitcoin Wallet Standard provider in the inpage bridge, adds the mobile connection/signing flow needed by Bitcoin-compatible dapps, and extends the E2E coverage with Bitcoin Wallet Standard test dapps and smoke tests for connect, disconnect, and sign message flows.

It also updates Android build fingerprinting/prebuild behavior so E2E APKs include the latest inpage bridge provider bundle instead of reusing stale cached assets.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the
CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing
description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and
accurately)
-->

CHANGELOG entry: Added Bitcoin Wallet Standard connectivity support for compatible dapps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Refs: Bitcoin Wallet Standard connectivity support for MetaMask Mobile.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->
```gherkin
Feature: Bitcoin Wallet Standard connectivity

  Scenario: Connect and disconnect from a Bitcoin test dapp
    Given MetaMask Mobile is installed with the Bitcoin Wallet Standard feature available
    And the Bitcoin Wallet Standard test dapp is open in the in-app browser
    When the user connects MetaMask from the dapp wallet selection modal
    Then the dapp shows MetaMask as connected

    When the user disconnects from the dapp
    Then the dapp shows MetaMask as disconnected

  Scenario: Sign a message from a Bitcoin test dapp
    Given MetaMask Mobile is connected to the Bitcoin Wallet Standard test dapp
    When the user requests a message signature from the dapp
    And the user approves the signature request in MetaMask
    Then the dapp receives a successful signature response
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

### **Before**
N/A

<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR
as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they
are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full
checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I've applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
- Use these [power-user
SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93)
to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production
performance metrics
- See [`trace()`](/app/util/trace.ts) for usage and
[`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274)
for an example

For performance guidelines and tooling, see the [Performance
Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author
checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dapp-facing inpage injection and multichain connect/sign flows (user approvals), though the change follows the established Solana pattern with mostly test and fingerprint updates.
> 
> **Overview**
> Adds **Bitcoin Wallet Standard** exposure in the mobile in-app browser by mirroring the existing Solana wallet-standard inpage path.
> 
> The inpage bridge now registers `@metamask/bitcoin-wallet-standard` via a multichain API client over `window.postMessage`, wired from `bitcoinWalletStandard.js` into `index.js` alongside the ETH and Solana injectors. Dependencies add `@metamask/bitcoin-wallet-standard` and bump `@metamask/multichain-api-client` to `^0.11.0`.
> 
> **Build / CI:** `fingerprint.config.js` includes `./scripts/inpage-bridge` so E2E/native builds pick up inpage provider changes instead of stale bundles.
> 
> **E2E:** Introduces `@metamask/test-dapp-bitcoin`, a `BITCOIN_TEST_DAPP` fixture variant, `bitcoin-connection.flow`, and `BitcoinTestDapp` page object. Smoke tests cover connect/disconnect, persistence after refresh, and sign-message approval. A small unused helper was removed from `solana-connection.flow.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d06ed4e06e307d7b6a7d7cf259f4478cebf1081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->