### PR TITLE
feat(tron): display TRX ready for withdrawal

### DIFF
--- a/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/EarnBalance.test.tsx
@@ -5,8 +5,6 @@ import StakingBalance from '../../../Stake/components/StakingBalance/StakingBala
 import { TokenI } from '../../../Tokens/types';
 import EarnLendingBalance from '../EarnLendingBalance';
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
-import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
-import TronStakingButtons from '../Tron/TronStakingButtons';
 import { selectIsMusdConversionFlowEnabledFlag } from '../../selectors/featureFlags';
 
 /**
@@ -24,16 +22,6 @@ jest.mock(
     selectTrxStakingEnabled: jest.fn(),
   }),
 );
-
-jest.mock('../../../../../selectors/assets/assets-list', () => ({
-  ...jest.requireActual('../../../../../selectors/assets/assets-list'),
-  selectTronSpecialAssetsBySelectedAccountGroup: jest.fn(),
-}));
-
-jest.mock('../Tron/TronStakingButtons', () => ({
-  __esModule: true,
-  default: jest.fn(() => null),
-}));
 
 jest.mock('../../../../../selectors/earnController', () => ({
   ...jest.requireActual('../../../../../selectors/earnController'),
@@ -128,35 +116,10 @@ const mockUseMusdConversionEligibility =
     typeof useMusdConversionEligibility
   >;
 
-jest.mock('../../hooks/useTronStakeApy', () => ({
-  __esModule: true,
-  default: jest.fn().mockReturnValue({
-    apyPercent: '4.5%',
-    isLoading: false,
-    error: null,
-  }),
-}));
-
-const createEmptySpecialAssetsMap = () => ({
-  energy: undefined,
-  bandwidth: undefined,
-  maxEnergy: undefined,
-  maxBandwidth: undefined,
-  stakedTrxForEnergy: undefined,
-  stakedTrxForBandwidth: undefined,
-  totalStakedTrx: 0,
-  trxReadyForWithdrawal: undefined,
-  trxStakingRewards: undefined,
-  trxInLockPeriod: undefined,
-});
-
 describe('EarnBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (jest.mocked(selectTrxStakingEnabled) as jest.Mock).mockReturnValue(false);
-    (
-      jest.mocked(selectTronSpecialAssetsBySelectedAccountGroup) as jest.Mock
-    ).mockReturnValue(createEmptySpecialAssetsMap());
   });
 
   describe('Ethereum Mainnet', () => {
@@ -253,10 +216,8 @@ describe('EarnBalance', () => {
 
   describe('TRON', () => {
     const mockFlag = selectTrxStakingEnabled as unknown as jest.Mock;
-    const mockTronResources =
-      selectTronSpecialAssetsBySelectedAccountGroup as unknown as jest.Mock;
 
-    it('renders TRON stake button with aprText for TRX without staked positions', () => {
+    it('renders nothing for TRX when Tron staking is enabled', () => {
       const trx: Partial<TokenI> = {
         chainId: 'tron:728126428',
         ticker: 'TRX',
@@ -264,19 +225,17 @@ describe('EarnBalance', () => {
       };
 
       mockFlag.mockReturnValue(true);
-      mockTronResources.mockReturnValue(createEmptySpecialAssetsMap());
 
-      renderWithProvider(<EarnBalance asset={trx as TokenI} />);
+      const { toJSON } = renderWithProvider(
+        <EarnBalance asset={trx as TokenI} />,
+      );
 
-      expect(TronStakingButtons).toHaveBeenCalled();
-      const props = (TronStakingButtons as jest.Mock).mock.calls[0][0];
-      expect(props.asset).toBe(trx);
-      expect(props.aprText).toBe('4.5%');
-      expect(props.showUnstake).toBeUndefined();
-      expect(props.hasStakedPositions).toBeUndefined();
+      expect(toJSON()).toBeNull();
+      expect(StakingBalance).not.toHaveBeenCalled();
+      expect(EarnLendingBalance).not.toHaveBeenCalled();
     });
 
-    it('renders TRON stake more and unstake for sTRX with staked positions', () => {
+    it('renders nothing for sTRX when Tron staking is enabled', () => {
       const strx: Partial<TokenI> = {
         chainId: 'tron:728126428',
         ticker: 'sTRX',
@@ -285,20 +244,14 @@ describe('EarnBalance', () => {
       };
 
       mockFlag.mockReturnValue(true);
-      mockTronResources.mockReturnValue({
-        ...createEmptySpecialAssetsMap(),
-        stakedTrxForEnergy: { symbol: 'strx-energy', balance: '1' },
-        stakedTrxForBandwidth: { symbol: 'strx-bandwidth', balance: '2' },
-        totalStakedTrx: 3,
-      });
 
-      renderWithProvider(<EarnBalance asset={strx as TokenI} />);
+      const { toJSON } = renderWithProvider(
+        <EarnBalance asset={strx as TokenI} />,
+      );
 
-      expect(TronStakingButtons).toHaveBeenCalled();
-      const props = (TronStakingButtons as jest.Mock).mock.calls[0][0];
-      expect(props.asset).toBe(strx);
-      expect(props.showUnstake).toBe(true);
-      expect(props.hasStakedPositions).toBe(true);
+      expect(toJSON()).toBeNull();
+      expect(StakingBalance).not.toHaveBeenCalled();
+      expect(EarnLendingBalance).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Earn/components/EarnBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/index.tsx
@@ -7,11 +7,7 @@ import { TokenI } from '../../../Tokens/types';
 import EarnLendingBalance from '../EarnLendingBalance';
 import { selectIsStakeableToken } from '../../../Stake/selectors/stakeableTokens';
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
-import TronStakingButtons from '../Tron/TronStakingButtons';
-import { selectTronSpecialAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
-import { hasStakedTrxPositions as hasStakedTrxPositionsUtil } from '../../utils/tron';
-import useTronStakeApy from '../../hooks/useTronStakeApy';
 ///: END:ONLY_INCLUDE_IF
 import { useMusdConversionTokens } from '../../hooks/useMusdConversionTokens';
 import { useMusdConversionEligibility } from '../../hooks/useMusdConversionEligibility';
@@ -38,43 +34,12 @@ const EarnBalance = ({ asset }: EarnBalanceProps) => {
 
   const { isConversionToken } = useMusdConversionTokens();
   const { isEligible: isGeoEligible } = useMusdConversionEligibility();
+  
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
-
   const isTron = asset?.chainId?.startsWith('tron:');
-  const isNativeTrx =
-    isTron && (asset?.ticker === 'TRX' || asset?.symbol === 'TRX');
-  const isStakedTrxAsset =
-    isTron && (asset?.ticker === 'sTRX' || asset?.symbol === 'sTRX');
-
-  const tronSpecialAssets = useSelector(
-    selectTronSpecialAssetsBySelectedAccountGroup,
-  );
-  const hasStakedTrxPositions = React.useMemo(
-    () => hasStakedTrxPositionsUtil(tronSpecialAssets),
-    [tronSpecialAssets],
-  );
-
-  const { apyPercent: tronApyPercent } = useTronStakeApy();
 
   if (isTron && isTrxStakingEnabled) {
-    if (hasStakedTrxPositions && isStakedTrxAsset) {
-      // sTRX row: show Unstake + Stake more
-      return (
-        <TronStakingButtons asset={asset} showUnstake hasStakedPositions />
-      );
-    }
-
-    if (!hasStakedTrxPositions && isNativeTrx) {
-      // TRX native row: show CTA + single Stake button
-      return (
-        <TronStakingButtons
-          asset={asset}
-          aprText={tronApyPercent ?? undefined}
-        />
-      );
-    }
-
     return null;
   }
   ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/Earn/components/EarnBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/index.tsx
@@ -34,7 +34,7 @@ const EarnBalance = ({ asset }: EarnBalanceProps) => {
 
   const { isConversionToken } = useMusdConversionTokens();
   const { isEligible: isGeoEligible } = useMusdConversionEligibility();
-  
+
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
   const isTron = asset?.chainId?.startsWith('tron:');

--- a/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.test.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.test.tsx
@@ -31,9 +31,6 @@ jest.mock('../../../../../../component-library/hooks', () => ({
     styles: {
       balanceButtonsContainer: {},
       balanceActionButton: {},
-      ctaContent: {},
-      ctaTitle: {},
-      ctaText: {},
       buttonsRow: {},
     },
   }),
@@ -69,10 +66,6 @@ jest.mock('../../../../Stake/hooks/useStakingEligibility', () => ({
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
-      'stake.stake_your_trx_cta.title': 'Stake your TRX',
-      'stake.stake_your_trx_cta.description_start': 'Earn up to ',
-      'stake.stake_your_trx_cta.description_end': ' annually',
-      'stake.stake_your_trx_cta.earn_button': 'Stake',
       'stake.stake_more': 'Stake more',
       'stake.unstake': 'Unstake',
     };
@@ -108,12 +101,15 @@ describe('TronStakingButtons', () => {
     isStaked: false,
   } as TokenI;
 
-  it('navigates to stake screen with base asset TRX when not staked and uses default hasStakedPositions', () => {
-    const { getByTestId, getByText } = render(
-      <TronStakingButtons asset={baseAsset} showUnstake={false} />,
-    );
+  it('renders both Unstake and Stake more buttons', () => {
+    const { getByText } = render(<TronStakingButtons asset={baseAsset} />);
 
-    expect(getByText('Stake')).toBeOnTheScreen();
+    expect(getByText('Unstake')).toBeOnTheScreen();
+    expect(getByText('Stake more')).toBeOnTheScreen();
+  });
+
+  it('navigates to stake screen on Stake more press', () => {
+    const { getByTestId } = render(<TronStakingButtons asset={baseAsset} />);
 
     fireEvent.press(getByTestId('stake-more-button'));
 
@@ -131,7 +127,18 @@ describe('TronStakingButtons', () => {
     });
   });
 
-  it('navigates to stake with synthesized TRX when asset is staked TRX without nativeAsset', () => {
+  it('navigates to unstake screen on Unstake press', () => {
+    const { getByTestId } = render(<TronStakingButtons asset={baseAsset} />);
+
+    fireEvent.press(getByTestId('unstake-button'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
+      screen: Routes.STAKING.UNSTAKE,
+      params: { token: baseAsset },
+    });
+  });
+
+  it('resolves base asset from selector when asset is staked TRX', () => {
     const stakedTrx = {
       ...baseAsset,
       symbol: 'sTRX',
@@ -149,34 +156,17 @@ describe('TronStakingButtons', () => {
       selector({} as unknown as ReturnType<typeof Object>),
     );
 
-    const { getByTestId } = render(
-      <TronStakingButtons asset={stakedTrx} hasStakedPositions />,
-    );
+    const { getByTestId } = render(<TronStakingButtons asset={stakedTrx} />);
+
     fireEvent.press(getByTestId('stake-more-button'));
 
-    expect(mockNavigate).toHaveBeenCalled();
     const call = mockNavigate.mock.calls.find((c) => c[0] === 'StakeScreens');
-    expect(call?.[1]?.screen).toBe(Routes.STAKING.STAKE);
     const tokenArg = call?.[1]?.params?.token;
     expect(tokenArg.symbol).toBe('TRX');
-    expect(tokenArg.ticker).toBe('TRX');
     expect(tokenArg.isStaked).toBe(false);
   });
 
-  it('shows Unstake button when showUnstake is true and navigates on press', () => {
-    const { getByTestId } = render(
-      <TronStakingButtons asset={baseAsset} showUnstake hasStakedPositions />,
-    );
-
-    fireEvent.press(getByTestId('unstake-button'));
-
-    expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
-      screen: Routes.STAKING.UNSTAKE,
-      params: { token: baseAsset },
-    });
-  });
-
-  it('does not render stake button when user is not eligible', () => {
+  it('hides Stake more button when user is not eligible', () => {
     mockUseStakingEligibility.mockReturnValue({
       isEligible: false,
       isLoadingEligibility: false,
@@ -184,90 +174,11 @@ describe('TronStakingButtons', () => {
       refreshPooledStakingEligibility: jest.fn(),
     });
 
-    const { queryByTestId } = render(<TronStakingButtons asset={baseAsset} />);
+    const { queryByTestId, getByTestId } = render(
+      <TronStakingButtons asset={baseAsset} />,
+    );
 
     expect(queryByTestId('stake-more-button')).toBeNull();
-  });
-
-  it('renders unstake button when user is not eligible and has active staked position', () => {
-    mockUseStakingEligibility.mockReturnValue({
-      isEligible: false,
-      isLoadingEligibility: false,
-      error: null,
-      refreshPooledStakingEligibility: jest.fn(),
-    });
-
-    const { queryByTestId } = render(
-      <TronStakingButtons asset={baseAsset} showUnstake hasStakedPositions />,
-    );
-
-    expect(queryByTestId('unstake-button')).toBeOnTheScreen();
-  });
-
-  describe('CTA section', () => {
-    it('renders CTA title and description without aprText when hasStakedPositions is false', () => {
-      const { getByText } = render(
-        <TronStakingButtons asset={baseAsset} hasStakedPositions={false} />,
-      );
-
-      expect(getByText('Stake your TRX')).toBeOnTheScreen();
-      expect(getByText(/Earn up to/)).toBeOnTheScreen();
-      expect(getByText(/annually/)).toBeOnTheScreen();
-    });
-
-    it('renders CTA with APR value when aprText is provided', () => {
-      const { getByText } = render(
-        <TronStakingButtons
-          asset={baseAsset}
-          hasStakedPositions={false}
-          aprText="4.5%"
-        />,
-      );
-
-      expect(getByText('Stake your TRX')).toBeOnTheScreen();
-      expect(getByText('4.5%')).toBeOnTheScreen();
-    });
-
-    it('does not render CTA section when hasStakedPositions is true', () => {
-      const { queryByText } = render(
-        <TronStakingButtons
-          asset={baseAsset}
-          hasStakedPositions
-          aprText="4.5%"
-        />,
-      );
-
-      expect(queryByText('Stake your TRX')).toBeNull();
-    });
-
-    it('does not render CTA section when user is not eligible', () => {
-      mockUseStakingEligibility.mockReturnValue({
-        isEligible: false,
-        isLoadingEligibility: false,
-        error: null,
-        refreshPooledStakingEligibility: jest.fn(),
-      });
-
-      const { queryByText } = render(
-        <TronStakingButtons asset={baseAsset} hasStakedPositions={false} />,
-      );
-
-      expect(queryByText('Stake your TRX')).toBeNull();
-    });
-  });
-
-  it('renders nothing when user is not eligible and has no active positions', () => {
-    mockUseStakingEligibility.mockReturnValue({
-      isEligible: false,
-      isLoadingEligibility: false,
-      error: null,
-      refreshPooledStakingEligibility: jest.fn(),
-    });
-
-    const { toJSON } = render(
-      <TronStakingButtons asset={baseAsset} hasStakedPositions={false} />,
-    );
-
-    expect(toJSON()).toBeNull();
+    expect(getByTestId('unstake-button')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.test.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.test.tsx
@@ -7,6 +7,7 @@ import { TokenI } from '../../../../Tokens/types';
 import { selectAsset } from '../../../../../../selectors/assets/assets-list';
 import useStakingEligibility from '../../../../Stake/hooks/useStakingEligibility';
 import { EVENT_LOCATIONS } from '../../../../Stake/constants/events';
+import { TronStakingButtonsTestIds } from './TronStakingButtons.testIds';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -111,7 +112,7 @@ describe('TronStakingButtons', () => {
   it('navigates to stake screen on Stake more press', () => {
     const { getByTestId } = render(<TronStakingButtons asset={baseAsset} />);
 
-    fireEvent.press(getByTestId('stake-more-button'));
+    fireEvent.press(getByTestId(TronStakingButtonsTestIds.STAKE_MORE_BUTTON));
 
     expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
       screen: Routes.STAKING.STAKE,
@@ -130,7 +131,7 @@ describe('TronStakingButtons', () => {
   it('navigates to unstake screen on Unstake press', () => {
     const { getByTestId } = render(<TronStakingButtons asset={baseAsset} />);
 
-    fireEvent.press(getByTestId('unstake-button'));
+    fireEvent.press(getByTestId(TronStakingButtonsTestIds.UNSTAKE_BUTTON));
 
     expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
       screen: Routes.STAKING.UNSTAKE,
@@ -158,7 +159,7 @@ describe('TronStakingButtons', () => {
 
     const { getByTestId } = render(<TronStakingButtons asset={stakedTrx} />);
 
-    fireEvent.press(getByTestId('stake-more-button'));
+    fireEvent.press(getByTestId(TronStakingButtonsTestIds.STAKE_MORE_BUTTON));
 
     const call = mockNavigate.mock.calls.find((c) => c[0] === 'StakeScreens');
     const tokenArg = call?.[1]?.params?.token;
@@ -178,7 +179,11 @@ describe('TronStakingButtons', () => {
       <TronStakingButtons asset={baseAsset} />,
     );
 
-    expect(queryByTestId('stake-more-button')).toBeNull();
-    expect(getByTestId('unstake-button')).toBeOnTheScreen();
+    expect(
+      queryByTestId(TronStakingButtonsTestIds.STAKE_MORE_BUTTON),
+    ).toBeNull();
+    expect(
+      getByTestId(TronStakingButtonsTestIds.UNSTAKE_BUTTON),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.testIds.ts
+++ b/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.testIds.ts
@@ -1,0 +1,4 @@
+export enum TronStakingButtonsTestIds {
+  UNSTAKE_BUTTON = 'tron-staking-unstake-button',
+  STAKE_MORE_BUTTON = 'tron-staking-stake-more-button',
+}

--- a/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '../../../../../../util/theme';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { TokenI } from '../../../../Tokens/types';
 import styleSheet from './TronStakingButtons.styles';
+import { TronStakingButtonsTestIds } from './TronStakingButtons.testIds';
 import { strings } from '../../../../../../../locales/i18n';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
@@ -78,7 +79,7 @@ const TronStakingButtons = ({ asset }: TronStakingButtonsProps) => {
     <View style={styles.balanceButtonsContainer}>
       <View style={styles.buttonsRow}>
         <Button
-          testID={'unstake-button'}
+          testID={TronStakingButtonsTestIds.UNSTAKE_BUTTON}
           style={styles.balanceActionButton}
           variant={ButtonVariants.Secondary}
           label={strings('stake.unstake')}
@@ -86,7 +87,7 @@ const TronStakingButtons = ({ asset }: TronStakingButtonsProps) => {
         />
         {isEligible && (
           <Button
-            testID={'stake-more-button'}
+            testID={TronStakingButtonsTestIds.STAKE_MORE_BUTTON}
             style={styles.balanceActionButton}
             variant={ButtonVariants.Secondary}
             label={strings('stake.stake_more')}

--- a/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingButtons/TronStakingButtons.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { View, ViewProps } from 'react-native';
+import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import Button, {
   ButtonVariants,
 } from '../../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { useTheme } from '../../../../../../util/theme';
 import Routes from '../../../../../../constants/navigation/Routes';
@@ -23,19 +19,11 @@ import { RootState } from '../../../../../../reducers';
 import { selectAsset } from '../../../../../../selectors/assets/assets-list';
 import useStakingEligibility from '../../../../Stake/hooks/useStakingEligibility';
 
-interface TronStakingButtonsProps extends Pick<ViewProps, 'style'> {
+interface TronStakingButtonsProps {
   asset: TokenI;
-  showUnstake?: boolean;
-  hasStakedPositions?: boolean;
-  aprText?: string;
 }
 
-const TronStakingButtons = ({
-  asset,
-  showUnstake = false,
-  hasStakedPositions = false,
-  aprText,
-}: TronStakingButtonsProps) => {
+const TronStakingButtons = ({ asset }: TronStakingButtonsProps) => {
   const theme = useTheme();
   const { styles } = useStyles(styleSheet, { theme });
   const navigation = useNavigation();
@@ -86,45 +74,22 @@ const TronStakingButtons = ({
     });
   };
 
-  // Block deposits for ineligible users unless they have an active staked position
-  if (!isEligible && !hasStakedPositions) {
-    return null;
-  }
-
   return (
     <View style={styles.balanceButtonsContainer}>
-      {!hasStakedPositions && isEligible && (
-        <View style={styles.ctaContent}>
-          <Text variant={TextVariant.HeadingMD} style={styles.ctaTitle}>
-            {strings('stake.stake_your_trx_cta.title')}
-          </Text>
-          <Text style={styles.ctaText}>
-            {strings('stake.stake_your_trx_cta.description_start')}
-            {aprText ? <Text color={TextColor.Success}>{aprText}</Text> : null}
-            {strings('stake.stake_your_trx_cta.description_end')}
-          </Text>
-        </View>
-      )}
       <View style={styles.buttonsRow}>
-        {showUnstake ? (
-          <Button
-            testID={'unstake-button'}
-            style={styles.balanceActionButton}
-            variant={ButtonVariants.Secondary}
-            label={strings('stake.unstake')}
-            onPress={onUnstakePress}
-          />
-        ) : null}
+        <Button
+          testID={'unstake-button'}
+          style={styles.balanceActionButton}
+          variant={ButtonVariants.Secondary}
+          label={strings('stake.unstake')}
+          onPress={onUnstakePress}
+        />
         {isEligible && (
           <Button
             testID={'stake-more-button'}
             style={styles.balanceActionButton}
             variant={ButtonVariants.Secondary}
-            label={
-              hasStakedPositions
-                ? strings('stake.stake_more')
-                : strings('stake.stake_your_trx_cta.earn_button')
-            }
+            label={strings('stake.stake_more')}
             onPress={onStakePress}
           />
         )}

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.styles.ts
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.styles.ts
@@ -3,19 +3,25 @@ import { Theme } from '../../../../../../util/theme/models';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
-    balanceButtonsContainer: {
+    container: {
       marginTop: 16,
       padding: 16,
       borderRadius: 12,
       backgroundColor: params.theme.colors.background.section,
     },
-    buttonsRow: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      gap: 16,
+    ctaContent: {
+      alignItems: 'center',
+      marginBottom: 16,
+      gap: 4,
     },
-    balanceActionButton: {
-      flex: 1,
+    ctaTitle: {
+      textAlign: 'center',
+    },
+    ctaText: {
+      textAlign: 'center',
+    },
+    earnButton: {
+      width: '100%',
     },
   });
 

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.test.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.test.tsx
@@ -4,6 +4,7 @@ import TronStakingCta from './TronStakingCta';
 import { TronStakingCtaTestIds } from './TronStakingCta.testIds';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { TokenI } from '../../../../Tokens/types';
+import useStakingEligibility from '../../../../Stake/hooks/useStakingEligibility';
 
 const mockNavigate = jest.fn();
 
@@ -41,6 +42,15 @@ jest.mock('../../../../../../util/trace', () => ({
   TraceName: { EarnDepositScreen: 'EarnDepositScreen' },
 }));
 
+jest.mock('../../../../Stake/hooks/useStakingEligibility', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseStakingEligibility = useStakingEligibility as jest.MockedFunction<
+  typeof useStakingEligibility
+>;
+
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
@@ -61,12 +71,18 @@ describe('TronStakingCta', () => {
     ticker: 'TRX',
   } as TokenI;
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStakingEligibility.mockReturnValue({
+      isEligible: true,
+      isLoadingEligibility: false,
+      error: null,
+      refreshPooledStakingEligibility: jest.fn(),
+    });
+  });
 
   it('renders CTA title and description', () => {
-    const { getByText } = render(
-      <TronStakingCta asset={asset} />,
-    );
+    const { getByText } = render(<TronStakingCta asset={asset} />);
 
     expect(getByText('Stake your TRX')).toBeOnTheScreen();
     expect(getByText(/Earn up to/)).toBeOnTheScreen();
@@ -82,9 +98,7 @@ describe('TronStakingCta', () => {
   });
 
   it('navigates to stake screen on Earn button press', () => {
-    const { getByTestId } = render(
-      <TronStakingCta asset={asset} />,
-    );
+    const { getByTestId } = render(<TronStakingCta asset={asset} />);
 
     fireEvent.press(getByTestId(TronStakingCtaTestIds.EARN_BUTTON));
 
@@ -92,5 +106,18 @@ describe('TronStakingCta', () => {
       screen: Routes.STAKING.STAKE,
       params: { token: asset },
     });
+  });
+
+  it('renders nothing when user is not eligible', () => {
+    mockUseStakingEligibility.mockReturnValue({
+      isEligible: false,
+      isLoadingEligibility: false,
+      error: null,
+      refreshPooledStakingEligibility: jest.fn(),
+    });
+
+    const { toJSON } = render(<TronStakingCta asset={asset} />);
+
+    expect(toJSON()).toBeNull();
   });
 });

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.test.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import TronStakingCta from './TronStakingCta';
+import { TronStakingCtaTestIds } from './TronStakingCta.testIds';
+import Routes from '../../../../../../constants/navigation/Routes';
+import { TokenI } from '../../../../Tokens/types';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../../../../../../component-library/hooks', () => ({
+  useStyles: () => ({
+    styles: {
+      container: {},
+      ctaContent: {},
+      ctaTitle: {},
+      ctaText: {},
+      earnButton: {},
+    },
+  }),
+}));
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: () => ({
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    }),
+  }),
+}));
+
+jest.mock('../../../../../../util/trace', () => ({
+  trace: jest.fn(),
+  TraceName: { EarnDepositScreen: 'EarnDepositScreen' },
+}));
+
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const map: Record<string, string> = {
+      'stake.stake_your_trx_cta.title': 'Stake your TRX',
+      'stake.stake_your_trx_cta.description_start': 'Earn up to ',
+      'stake.stake_your_trx_cta.description_end': ' annually',
+      'stake.stake_your_trx_cta.earn_button': 'Earn',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+describe('TronStakingCta', () => {
+  const asset = {
+    address: '0xtron',
+    chainId: 'tron:111',
+    symbol: 'TRX',
+    ticker: 'TRX',
+  } as TokenI;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders CTA title and description', () => {
+    const { getByText } = render(
+      <TronStakingCta asset={asset} />,
+    );
+
+    expect(getByText('Stake your TRX')).toBeOnTheScreen();
+    expect(getByText(/Earn up to/)).toBeOnTheScreen();
+    expect(getByText(/annually/)).toBeOnTheScreen();
+  });
+
+  it('renders APR text when provided', () => {
+    const { getByText } = render(
+      <TronStakingCta asset={asset} aprText="4.5%" />,
+    );
+
+    expect(getByText('4.5%')).toBeOnTheScreen();
+  });
+
+  it('navigates to stake screen on Earn button press', () => {
+    const { getByTestId } = render(
+      <TronStakingCta asset={asset} />,
+    );
+
+    fireEvent.press(getByTestId(TronStakingCtaTestIds.EARN_BUTTON));
+
+    expect(mockNavigate).toHaveBeenCalledWith('StakeScreens', {
+      screen: Routes.STAKING.STAKE,
+      params: { token: asset },
+    });
+  });
+});

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.testIds.ts
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.testIds.ts
@@ -1,0 +1,4 @@
+export enum TronStakingCtaTestIds {
+  CONTAINER = 'tron-staking-cta',
+  EARN_BUTTON = 'tron-staking-cta-earn-button',
+}

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import Button, {
+  ButtonVariants,
+} from '../../../../../../component-library/components/Buttons/Button';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../../component-library/hooks';
+import { useTheme } from '../../../../../../util/theme';
+import Routes from '../../../../../../constants/navigation/Routes';
+import { TokenI } from '../../../../Tokens/types';
+import styleSheet from './TronStakingCta.styles';
+import { TronStakingCtaTestIds } from './TronStakingCta.testIds';
+import { strings } from '../../../../../../../locales/i18n';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { EVENT_LOCATIONS } from '../../../../../UI/Stake/constants/events';
+import { trace, TraceName } from '../../../../../../util/trace';
+
+interface TronStakingCtaProps {
+  asset: TokenI;
+  aprText?: string;
+}
+
+const TronStakingCta = ({ asset, aprText }: TronStakingCtaProps) => {
+  const theme = useTheme();
+  const { styles } = useStyles(styleSheet, { theme });
+  const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const onStakePress = () => {
+    trace({ name: TraceName.EarnDepositScreen });
+    navigation.navigate('StakeScreens', {
+      screen: Routes.STAKING.STAKE,
+      params: { token: asset },
+    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.STAKE_BUTTON_CLICKED)
+        .addProperties({
+          location: EVENT_LOCATIONS.HOME_SCREEN,
+          text: 'Stake',
+          token: asset.symbol,
+        })
+        .build(),
+    );
+  };
+
+  return (
+    <View style={styles.container} testID={TronStakingCtaTestIds.CONTAINER}>
+      <View style={styles.ctaContent}>
+        <Text variant={TextVariant.HeadingMD} style={styles.ctaTitle}>
+          {strings('stake.stake_your_trx_cta.title')}
+        </Text>
+        <Text style={styles.ctaText}>
+          {strings('stake.stake_your_trx_cta.description_start')}
+          {aprText ? <Text color={TextColor.Success}>{aprText}</Text> : null}
+          {strings('stake.stake_your_trx_cta.description_end')}
+        </Text>
+      </View>
+      <Button
+        testID={TronStakingCtaTestIds.EARN_BUTTON}
+        style={styles.earnButton}
+        variant={ButtonVariants.Secondary}
+        label={strings('stake.stake_your_trx_cta.earn_button')}
+        onPress={onStakePress}
+      />
+    </View>
+  );
+};
+
+export default TronStakingCta;

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.tsx
@@ -19,6 +19,7 @@ import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { EVENT_LOCATIONS } from '../../../../../UI/Stake/constants/events';
 import { trace, TraceName } from '../../../../../../util/trace';
+import useStakingEligibility from '../../../../Stake/hooks/useStakingEligibility';
 
 interface TronStakingCtaProps {
   asset: TokenI;
@@ -30,6 +31,11 @@ const TronStakingCta = ({ asset, aprText }: TronStakingCtaProps) => {
   const { styles } = useStyles(styleSheet, { theme });
   const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const { isEligible } = useStakingEligibility();
+
+  if (!isEligible) {
+    return null;
+  }
 
   const onStakePress = () => {
     trace({ name: TraceName.EarnDepositScreen });

--- a/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.test.tsx
+++ b/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import TronUnstakedBanner from './TronUnstakedBanner';
+import { TronUnstakedBannerTestIds } from './TronUnstakedBanner.testIds';
+import { strings } from '../../../../../../../locales/i18n';
+
+describe('TronUnstakedBanner', () => {
+  it('renders the claim text with the given amount', () => {
+    const { getByTestId } = render(<TronUnstakedBanner amount="100" />);
+
+    const expected = strings('stake.tron.has_claimable_trx', {
+      amount: '100',
+    });
+    expect(getByTestId(TronUnstakedBannerTestIds.BANNER_TEXT)).toHaveTextContent(
+      expected,
+    );
+  });
+
+  it('renders with a different amount', () => {
+    const { getByTestId } = render(<TronUnstakedBanner amount="2,500" />);
+
+    const expected = strings('stake.tron.has_claimable_trx', {
+      amount: '2,500',
+    });
+    expect(getByTestId(TronUnstakedBannerTestIds.BANNER_TEXT)).toHaveTextContent(
+      expected,
+    );
+  });
+});

--- a/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.test.tsx
+++ b/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.test.tsx
@@ -11,9 +11,9 @@ describe('TronUnstakedBanner', () => {
     const expected = strings('stake.tron.has_claimable_trx', {
       amount: '100',
     });
-    expect(getByTestId(TronUnstakedBannerTestIds.BANNER_TEXT)).toHaveTextContent(
-      expected,
-    );
+    expect(
+      getByTestId(TronUnstakedBannerTestIds.BANNER_TEXT),
+    ).toHaveTextContent(expected);
   });
 
   it('renders with a different amount', () => {
@@ -22,8 +22,8 @@ describe('TronUnstakedBanner', () => {
     const expected = strings('stake.tron.has_claimable_trx', {
       amount: '2,500',
     });
-    expect(getByTestId(TronUnstakedBannerTestIds.BANNER_TEXT)).toHaveTextContent(
-      expected,
-    );
+    expect(
+      getByTestId(TronUnstakedBannerTestIds.BANNER_TEXT),
+    ).toHaveTextContent(expected);
   });
 });

--- a/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.testIds.ts
+++ b/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.testIds.ts
@@ -1,0 +1,3 @@
+export enum TronUnstakedBannerTestIds {
+  BANNER_TEXT = 'tron-unstaked-banner',
+}

--- a/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.tsx
+++ b/app/components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import Banner, {
+  BannerAlertSeverity,
+  BannerVariant,
+} from '../../../../../../component-library/components/Banners/Banner';
+import { Text } from '@metamask/design-system-react-native';
+import { TronUnstakedBannerTestIds } from './TronUnstakedBanner.testIds';
+
+interface TronUnstakedBannerProps {
+  amount: string;
+}
+
+const TronUnstakedBanner = ({ amount }: TronUnstakedBannerProps) => (
+  <Banner
+    severity={BannerAlertSeverity.Success}
+    variant={BannerVariant.Alert}
+    description={
+      <Text testID={TronUnstakedBannerTestIds.BANNER_TEXT}>
+        {strings('stake.tron.has_claimable_trx', { amount })}
+      </Text>
+    }
+  />
+);
+
+export default TronUnstakedBanner;

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -139,6 +139,7 @@ const TokenDetails: React.FC<{
     isTronNative,
     stakedTrxAsset,
     inLockPeriodBalance,
+    readyForWithdrawalBalance,
     ///: END:ONLY_INCLUDE_IF
   } = useTokenBalance(token);
 
@@ -212,6 +213,7 @@ const TokenDetails: React.FC<{
         isTronNative={isTronNative}
         stakedTrxAsset={stakedTrxAsset}
         inLockPeriodBalance={inLockPeriodBalance}
+        readyForWithdrawalBalance={readyForWithdrawalBalance}
         ///: END:ONLY_INCLUDE_IF
       />
       <ActivityHeader

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -63,6 +63,10 @@ import { formatAddressToAssetId } from '@metamask/bridge-controller';
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import TronEnergyBandwidthDetail from '../../AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail';
 import TronUnstakingBanner from '../../Earn/components/Tron/TronUnstakingBanner/TronUnstakingBanner';
+import TronUnstakedBanner from '../../Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner';
+import TronStakingButtons from '../../Earn/components/Tron/TronStakingButtons/TronStakingButtons';
+import TronStakingCta from '../../Earn/components/Tron/TronStakingCta/TronStakingCta';
+import useTronStakeApy from '../../Earn/hooks/useTronStakeApy';
 ///: END:ONLY_INCLUDE_IF
 import MarketClosedActionButton from '../../AssetOverview/MarketClosedActionButton';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
@@ -162,6 +166,7 @@ export interface AssetOverviewContentProps {
   isTronNative?: boolean;
   stakedTrxAsset?: TokenI;
   inLockPeriodBalance?: string;
+  readyForWithdrawalBalance?: string;
   onMarketInsightsDisplayResolved?: (isDisplayed: boolean) => void;
 }
 
@@ -200,6 +205,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
   isTronNative,
   stakedTrxAsset,
   inLockPeriodBalance,
+  readyForWithdrawalBalance,
   onMarketInsightsDisplayResolved,
 }) => {
   const { styles } = useStyles(styleSheet, {});
@@ -340,6 +346,10 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
       id: marketInsightsCaip19Id,
     });
   }
+
+  ///: BEGIN:ONLY_INCLUDE_IF(tron)
+  const { apyPercent: tronApyPercent } = useTronStakeApy();
+  ///: END:ONLY_INCLUDE_IF
 
   const goToBrowserUrl = (url: string) => {
     const [screen, params] = createWebviewNavDetails({
@@ -540,9 +550,39 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
           }
           {
             ///: BEGIN:ONLY_INCLUDE_IF(tron)
+            isTronNative && readyForWithdrawalBalance && (
+              <View style={styles.bannerWrapper}>
+                <TronUnstakedBanner amount={readyForWithdrawalBalance} />
+              </View>
+            )
+            ///: END:ONLY_INCLUDE_IF
+          }
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(tron)
             isTronNative && inLockPeriodBalance && (
               <View style={styles.bannerWrapper}>
                 <TronUnstakingBanner amount={inLockPeriodBalance} />
+              </View>
+            )
+            ///: END:ONLY_INCLUDE_IF
+          }
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(tron)
+            isTronNative && stakedTrxAsset && (
+              <View style={styles.bannerWrapper}>
+                <TronStakingButtons asset={stakedTrxAsset} />
+              </View>
+            )
+            ///: END:ONLY_INCLUDE_IF
+          }
+          {
+            ///: BEGIN:ONLY_INCLUDE_IF(tron)
+            isTronNative && !stakedTrxAsset && (
+              <View style={styles.bannerWrapper}>
+                <TronStakingCta
+                  asset={token}
+                  aprText={tronApyPercent ?? undefined}
+                />
               </View>
             )
             ///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
@@ -289,4 +289,133 @@ describe('useTokenBalance', () => {
 
     expect(result.current.inLockPeriodBalance).toBeUndefined();
   });
+
+  it('returns ready-for-withdrawal balance for Tron native token', () => {
+    const tronToken = {
+      address: '',
+      chainId: TRON_MAINNET_CHAIN_ID,
+      ticker: 'TRX',
+      symbol: 'TRX',
+    } as TokenI;
+
+    mockSelectAsset.mockReturnValue({
+      balance: '1000',
+      balanceFiat: '$100.00',
+      symbol: 'TRX',
+    } as TokenI);
+
+    mockSelectTronResources.mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
+      trxReadyForWithdrawal: createMockTronAsset(
+        'trx-ready-for-withdrawal',
+        '10',
+      ),
+    });
+
+    const { result } = renderHookWithProvider(() => useTokenBalance(tronToken));
+
+    expect(result.current.readyForWithdrawalBalance).toBe('10');
+  });
+
+  it('returns undefined for ready-for-withdrawal when balance is zero', () => {
+    const tronToken = {
+      address: '',
+      chainId: TRON_MAINNET_CHAIN_ID,
+      ticker: 'TRX',
+      symbol: 'TRX',
+    } as TokenI;
+
+    mockSelectAsset.mockReturnValue({
+      balance: '1000',
+      balanceFiat: '$100.00',
+      symbol: 'TRX',
+    } as TokenI);
+
+    mockSelectTronResources.mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
+      trxReadyForWithdrawal: createMockTronAsset(
+        'trx-ready-for-withdrawal',
+        '0',
+      ),
+    });
+
+    const { result } = renderHookWithProvider(() => useTokenBalance(tronToken));
+
+    expect(result.current.readyForWithdrawalBalance).toBeUndefined();
+  });
+
+  it('returns undefined for ready-for-withdrawal when balance is non-numeric', () => {
+    const tronToken = {
+      address: '',
+      chainId: TRON_MAINNET_CHAIN_ID,
+      ticker: 'TRX',
+      symbol: 'TRX',
+    } as TokenI;
+
+    mockSelectAsset.mockReturnValue({
+      balance: '1000',
+      balanceFiat: '$100.00',
+      symbol: 'TRX',
+    } as TokenI);
+
+    mockSelectTronResources.mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
+      trxReadyForWithdrawal: createMockTronAsset(
+        'trx-ready-for-withdrawal',
+        'not-a-number',
+      ),
+    });
+
+    const { result } = renderHookWithProvider(() => useTokenBalance(tronToken));
+
+    expect(result.current.readyForWithdrawalBalance).toBeUndefined();
+  });
+
+  it('returns undefined for ready-for-withdrawal when balance is empty string', () => {
+    const tronToken = {
+      address: '',
+      chainId: TRON_MAINNET_CHAIN_ID,
+      ticker: 'TRX',
+      symbol: 'TRX',
+    } as TokenI;
+
+    mockSelectAsset.mockReturnValue({
+      balance: '1000',
+      balanceFiat: '$100.00',
+      symbol: 'TRX',
+    } as TokenI);
+
+    mockSelectTronResources.mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
+      trxReadyForWithdrawal: createMockTronAsset(
+        'trx-ready-for-withdrawal',
+        '',
+      ),
+    });
+
+    const { result } = renderHookWithProvider(() => useTokenBalance(tronToken));
+
+    expect(result.current.readyForWithdrawalBalance).toBeUndefined();
+  });
+
+  it('returns undefined for ready-for-withdrawal when resources are not available', () => {
+    const tronToken = {
+      address: '',
+      chainId: TRON_MAINNET_CHAIN_ID,
+      ticker: 'TRX',
+      symbol: 'TRX',
+    } as TokenI;
+
+    mockSelectAsset.mockReturnValue({
+      balance: '1000',
+      balanceFiat: '$100.00',
+      symbol: 'TRX',
+    } as TokenI);
+
+    mockSelectTronResources.mockReturnValue(createEmptySpecialAssetsMap());
+
+    const { result } = renderHookWithProvider(() => useTokenBalance(tronToken));
+
+    expect(result.current.readyForWithdrawalBalance).toBeUndefined();
+  });
 });

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
@@ -23,6 +23,7 @@ export interface UseTokenBalanceResult {
   isTronNative: boolean;
   stakedTrxAsset: TokenI | undefined;
   inLockPeriodBalance: string | undefined;
+  readyForWithdrawalBalance: string | undefined;
   ///: END:ONLY_INCLUDE_IF
 }
 
@@ -36,19 +37,28 @@ export const useTokenBalance = (token: TokenI): UseTokenBalanceResult => {
   );
 
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  const { stakedTrxForEnergy, stakedTrxForBandwidth, trxInLockPeriod } =
-    useSelector(selectTronSpecialAssetsBySelectedAccountGroup);
+  const {
+    stakedTrxForEnergy,
+    stakedTrxForBandwidth,
+    trxInLockPeriod,
+    trxReadyForWithdrawal,
+  } = useSelector(selectTronSpecialAssetsBySelectedAccountGroup);
 
   const isTronNative =
     token.ticker === 'TRX' && String(token.chainId).startsWith('tron:');
 
-  const stakedTrxAsset = isTronNative
-    ? createStakedTrxAsset(
-        token,
-        stakedTrxForEnergy?.balance,
-        stakedTrxForBandwidth?.balance,
-      )
-    : undefined;
+  const totalStaked =
+    (Number(stakedTrxForEnergy?.balance) || 0) +
+    (Number(stakedTrxForBandwidth?.balance) || 0);
+
+  const stakedTrxAsset =
+    isTronNative && totalStaked > 0
+      ? createStakedTrxAsset(
+          token,
+          stakedTrxForEnergy?.balance,
+          stakedTrxForBandwidth?.balance,
+        )
+      : undefined;
 
   const parsedInLockPeriod = trxInLockPeriod
     ? parseFloat(trxInLockPeriod.balance)
@@ -56,6 +66,17 @@ export const useTokenBalance = (token: TokenI): UseTokenBalanceResult => {
   const inLockPeriodBalance =
     isTronNative && parsedInLockPeriod > 0
       ? formatWithThreshold(parsedInLockPeriod, 0.00001, I18n.locale, {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 5,
+        }) || undefined
+      : undefined;
+
+  const parsedReadyForWithdrawal = trxReadyForWithdrawal
+    ? parseFloat(trxReadyForWithdrawal.balance)
+    : 0;
+  const readyForWithdrawalBalance =
+    isTronNative && parsedReadyForWithdrawal > 0
+      ? formatWithThreshold(parsedReadyForWithdrawal, 0.00001, I18n.locale, {
           minimumFractionDigits: 0,
           maximumFractionDigits: 5,
         }) || undefined
@@ -74,6 +95,7 @@ export const useTokenBalance = (token: TokenI): UseTokenBalanceResult => {
     isTronNative,
     stakedTrxAsset,
     inLockPeriodBalance,
+    readyForWithdrawalBalance,
     ///: END:ONLY_INCLUDE_IF
   };
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6094,7 +6094,8 @@
       "errors": {
         "insufficient_balance": "You don't have enough resource balance to do this action."
       },
-      "trx_unstaking_in_progress": "Unstaking {{amount}} TRX in progress. It takes 14 days for unstaking."
+      "trx_unstaking_in_progress": "Unstaking {{amount}} TRX in progress. It takes 14 days for unstaking.",
+      "has_claimable_trx": "You can claim {{amount}} TRX. Once claimed you'll get TRX back in your wallet."
     },
     "stake_eth": "Stake ETH",
     "unstake_eth": "Unstake ETH",


### PR DESCRIPTION
## **Description**

Display TRX that has completed the unstaking lock period and is ready for withdrawal on the token details view. Refactor Tron staking UI so `AssetOverviewContent` orchestrates all Tron staking components directly.

### Added

- **`TronUnstakedBanner` component** — Info-only success banner displaying "You can claim X TRX..." when TRX has completed the 14-day unstaking lock period and is ready for withdrawal. No action button (claim button deferred to NEB-576).
- **`TronStakingCta` component** — "Stake your TRX" promotional CTA with APR percentage and an "Earn" button, shown to eligible users who have no staked TRX positions. Gated behind `useStakingEligibility` so geo-blocked users never see it.
- **`readyForWithdrawalBalance` derivation in `useTokenBalance`** — Parses `trxReadyForWithdrawal` from the Tron special assets selector and exposes it as a formatted string (only when > 0 and numeric).
- **`stake.tron.has_claimable_trx` locale string** — New i18n key for the claimable TRX banner text.
- **Unit tests** for `TronUnstakedBanner`, `TronStakingCta` (including eligibility guard), and `readyForWithdrawalBalance` edge cases in `useTokenBalance`.

### Changed

- **`AssetOverviewContent` is now the orchestrator for all Tron staking UI.** It directly renders, in order: native Balance → staked Balance → `TronUnstakedBanner` → `TronUnstakingBanner` → `TronStakingButtons` (if staked) or `TronStakingCta` (if not staked). Previously, staking buttons/CTA were rendered inside `EarnBalance`.
- **`EarnBalance` no longer renders any Tron staking UI.** When the Tron staking flag is enabled and the asset is a Tron chain asset, it returns `null` — all Tron staking rendering responsibility moved to `AssetOverviewContent`.
- **`TronStakingButtons` simplified** — Removed `showUnstake`, `hasStakedPositions`, and `aprText` props. The CTA section was extracted into the new `TronStakingCta`. Now always renders "Unstake" and conditionally renders "Stake more" based on `useStakingEligibility`. Removed the `if (!isEligible && !hasStakedPositions) return null` early exit since the parent now controls when to render it.
- **`useTokenBalance` guards `stakedTrxAsset` with `totalStaked > 0`** — Previously `createStakedTrxAsset` was always called for Tron native tokens, producing a truthy object even with zero balance. Now `stakedTrxAsset` is `undefined` when no TRX is actually staked, which correctly drives the conditional rendering in `AssetOverviewContent`.

**Note:** This PR intentionally does not include a claim button. The button and snap interaction are in NEB-576.

## **Changelog**

CHANGELOG entry: Added a banner to display TRX that is ready for withdrawal on the token details view

## **Related issues**

Refs: NEB-582

## **Manual testing steps**

```gherkin
Feature: TRX ready for withdrawal display

  Scenario: user views TRX token details with TRX ready for withdrawal
    Given user has TRX that has completed the 14-day unstaking lock period

    When user navigates to the TRX token details view
    Then a success banner is displayed showing "You can claim X TRX. Once claimed you'll get TRX back in your wallet."
    And no action button is displayed in the banner

  Scenario: user views TRX token details without TRX ready for withdrawal
    Given user has no TRX ready for withdrawal

    When user navigates to the TRX token details view
    Then no claim banner is displayed
```

## **Screenshots/Recordings**

### **Before**

N/A - new feature

### **After**

<img width="507" height="950" alt="Screenshot 2026-03-09 at 22 42 19" src="https://github.com/user-attachments/assets/31892885-023f-4a62-be3e-c04978b05348" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Tron token details balance derivation and reorganizes staking/unstaking UI rendering paths, which could affect when/where staking CTAs and banners appear for TRX users; changes are UI/formatting focused with test coverage.
> 
> **Overview**
> Adds a Tron-only “claimable TRX” success banner on the token details view by deriving a new `readyForWithdrawalBalance` from `trxReadyForWithdrawal` in `useTokenBalance` (with numeric/zero guards) and wiring it through `TokenDetails` into `AssetOverviewContent`.
> 
> Refactors Tron staking UI ownership: `AssetOverviewContent` now directly renders Tron staking/unstaking components (including a new `TronStakingCta` for eligible users with no staked TRX), while `EarnBalance` no longer renders any Tron staking UI and returns `null` when Tron staking is enabled.
> 
> Simplifies `TronStakingButtons` by removing CTA-related props/markup, always showing Unstake and conditionally showing “Stake more” based on eligibility, and introduces shared test IDs; adds/updates unit tests and introduces the new `stake.tron.has_claimable_trx` locale string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fbff82b175ceaa02ff1217d4f4d43bd7b55ab7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->