### PR TITLE
fix(TMCU-539): add horizontal padding to NFT skeleton in full view

### DIFF
--- a/app/components/UI/NftGrid/NftGrid.tsx
+++ b/app/components/UI/NftGrid/NftGrid.tsx
@@ -54,11 +54,13 @@ const NftGridContent = ({
   nftRowList,
   goToAddCollectible,
   isAddNFTEnabled,
+  isFullView = false,
 }: {
   allFilteredCollectibles: Nft[];
   nftRowList: React.ReactNode;
   goToAddCollectible: () => void;
   isAddNFTEnabled: boolean;
+  isFullView?: boolean;
 }) => {
   const isNftFetchingProgress = useSelector(isNftFetchingProgressSelector);
 
@@ -67,7 +69,7 @@ const NftGridContent = ({
   }
 
   if (isNftFetchingProgress) {
-    return <NftGridSkeleton />;
+    return <NftGridSkeleton isFullView={isFullView} />;
   }
 
   return (
@@ -300,6 +302,7 @@ const NftGrid = forwardRef<TabRefreshHandle, NftGridProps>(
           nftRowList={nftRowList}
           goToAddCollectible={goToAddCollectible}
           isAddNFTEnabled={isAddNFTEnabled}
+          isFullView={isFullView}
         />
 
         {/* View all NFTs button - shown when there are more items than maxItems */}

--- a/app/components/UI/NftGrid/NftGridSkeleton.tsx
+++ b/app/components/UI/NftGrid/NftGridSkeleton.tsx
@@ -4,12 +4,12 @@ import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTheme } from '../../../util/theme';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
-const NftGridSkeleton = () => {
+const NftGridSkeleton = ({ isFullView = false }: { isFullView?: boolean }) => {
   const { colors } = useTheme();
   const tw = useTailwind();
 
   return (
-    <View style={tw.style('flex-1 p-1')}>
+    <View style={tw.style('flex-1 pt-1', isFullView ? 'px-4' : 'px-1')}>
       <SkeletonPlaceholder
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}


### PR DESCRIPTION
## **Description**

The NFT grid skeleton loading state had minimal padding (`p-1`) regardless of context, while the actual NFT grid `FlatList` uses `px-4` horizontal padding in full view mode. This caused an inconsistent layout jump when loading finished and the skeleton was replaced by real content.

The fix threads `isFullView` from `NftGrid` through `NftGridContent` to `NftGridSkeleton`, so the skeleton conditionally applies `px-4` in full view and `px-1` in tab/homepage view -- matching the padding of the content it replaces in each context.

## **Changelog**

CHANGELOG entry: Fixed missing horizontal padding on NFT skeleton loading state in full view

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-539

## **Manual testing steps**

```gherkin
Feature: NFT skeleton padding in full view

  Scenario: user sees skeleton with correct padding in NFTs full view
    Given user navigates to the NFTs full view
    And NFTs are being fetched

    When the skeleton loading state is displayed
    Then the skeleton has the same horizontal padding as the NFT grid content

  Scenario: skeleton padding is unchanged in tab/homepage view
    Given user is on the homepage with the NFTs section visible
    And NFTs are being fetched

    When the skeleton loading state is displayed
    Then the skeleton retains minimal horizontal padding (matching tab layout)
```

## **Screenshots/Recordings**

N/A -- padding-only fix, verified via tests.

### **Before**

<img width="300"  src="https://github.com/user-attachments/assets/1fb110de-ed76-4a41-8c8f-be1202db4e12" />


### **After**

<img width="300" src="https://github.com/user-attachments/assets/3c7730bd-76ca-4973-a11a-d8eedf53d1c7" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts loading-state layout; no business logic, data handling, or navigation behavior is modified.
> 
> **Overview**
> Fixes a layout jump in the NFT grid loading state by **matching `NftGridSkeleton` horizontal padding to the rendered grid**.
> 
> Threads `isFullView` from `NftGrid` through `NftGridContent` into `NftGridSkeleton`, where the container now applies `px-4` in full view and `px-1` otherwise (replacing the previous fixed `p-1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afdbe3638f6d30521962501a194be71191146f5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->