### PR TITLE
chore: upgrade design-system-react-native to 0.10.0 and deprecate legacy components

### DIFF
--- a/app/component-library/components-temp/ActionListItem/ActionListItem.tsx
+++ b/app/component-library/components-temp/ActionListItem/ActionListItem.tsx
@@ -20,6 +20,11 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 // Internal dependencies
 import { ActionListItemProps } from './ActionListItem.types';
 
+/**
+ * @deprecated Please update your code to use `ActionListItem` from `@metamask/design-system-react-native`.
+ * The API may have changed - compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ActionListItem/README.md}
+ */
 const ActionListItem: React.FC<ActionListItemProps> = ({
   label,
   description,

--- a/app/component-library/components-temp/Buttons/ButtonHero/ButtonHero.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonHero/ButtonHero.tsx
@@ -56,6 +56,11 @@ const ButtonHeroInner = ({
  * The useTailwind hook needs to be called inside the ThemeProvider context to get the locked theme.
  * By splitting into two components, we ensure the hook gets the correct theme context for all color calculations.
  */
+/**
+ * @deprecated Please update your code to use `ButtonHero` from `@metamask/design-system-react-native`.
+ * The API may have changed - compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonHero/README.md}
+ */
 const ButtonHero = (props: ButtonBaseProps) => (
   <ThemeProvider theme={Theme.Light}>
     <ButtonHeroInner {...props} />

--- a/app/component-library/components-temp/Buttons/ButtonSemantic/ButtonSemantic.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonSemantic/ButtonSemantic.tsx
@@ -9,6 +9,11 @@ import {
   ButtonSemanticSeverity,
 } from './ButtonSemantic.types';
 
+/**
+ * @deprecated Please update your code to use `ButtonSemantic` from `@metamask/design-system-react-native`.
+ * The API may have changed - compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonSemantic/README.md}
+ */
 const ButtonSemantic: React.FC<ButtonSemanticProps> = ({
   severity,
   size = ButtonSize.Lg,

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
@@ -19,6 +19,11 @@ import {
   BottomSheetHeaderVariant,
 } from './BottomSheetHeader.types';
 
+/**
+ * @deprecated Please update your code to use `BottomSheetHeader` from `@metamask/design-system-react-native`.
+ * The API may have changed - compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BottomSheetHeader/README.md}
+ */
 const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
   style,
   children,

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
@@ -20,6 +20,11 @@ import {
   DEFAULT_BUTTONBASE_LABEL_TEXTVARIANT,
 } from './ButtonBase.constants';
 
+/**
+ * @deprecated Please update your code to use `ButtonBase` from `@metamask/design-system-react-native`.
+ * The API may have changed - compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonBase/README.md}
+ */
 const ButtonBase = ({
   label,
   labelColor = DEFAULT_BUTTONBASE_LABEL_COLOR,

--- a/app/component-library/components/Form/TextField/TextField.tsx
+++ b/app/component-library/components/Form/TextField/TextField.tsx
@@ -27,6 +27,7 @@ import {
  * @deprecated Please update your code to use `TextField` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextField/README.md}
+ * @since @metamask/design-system-react-native@0.9.0
  */
 const TextField = React.forwardRef<TextInput | null, TextFieldProps>(
   (

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "@metamask/core-backend": "^5.0.0",
     "@metamask/delegation-controller": "^2.0.1",
     "@metamask/delegation-deployments": "^0.15.0",
-    "@metamask/design-system-react-native": "^0.8.0",
+    "@metamask/design-system-react-native": "^0.10.0",
     "@metamask/design-system-twrnc-preset": "^0.3.0",
     "@metamask/design-tokens": "^8.2.2",
     "@metamask/earn-controller": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8171,11 +8171,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@metamask/design-system-react-native@npm:0.8.0"
+"@metamask/design-system-react-native@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@metamask/design-system-react-native@npm:0.10.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.2.0"
+    "@metamask/design-system-shared": "npm:^0.3.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8188,16 +8188,16 @@ __metadata:
     react-native-gesture-handler: ">=1.10.3"
     react-native-reanimated: ">=3.3.0"
     react-native-safe-area-context: ">=4.0.0"
-  checksum: 10/378572600ad2ac44d7522c2875585be80148ff51b6aa351143e55d69b102cf03823d3bc36b1c3531e1a5079944b0a88da1cff10a5383766fd6ff89258a4a900d
+  checksum: 10/4b105db890392d9f363ad5a573249980a621a3edb6e6d371cef8e78f8ade378d98c24a1f4d814c815a4f8e30e2978a8c69571f61e9b0983289d1c08e28f02da2
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@metamask/design-system-shared@npm:0.2.0"
+"@metamask/design-system-shared@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@metamask/design-system-shared@npm:0.3.0"
   dependencies:
     "@metamask/utils": "npm:^11.10.0"
-  checksum: 10/8b7436e4c1882495faa1ca402456dfb82247e517c718da0bed0c4daf7ec06ed0e6bfa7fa3c9fa6930b30e4e5f3f8576436f0de27d9a86f97169cab0423285612
+  checksum: 10/2be032b91b10d03ca4e02ba9ff5afc9db763fb865161add83a7e28ef83f165cc3c3edba03f5d600ec95e3014afd0077abcadd75e613792e77c709760813ff749
   languageName: node
   linkType: hard
 
@@ -35394,7 +35394,7 @@ __metadata:
     "@metamask/core-backend": "npm:^5.0.0"
     "@metamask/delegation-controller": "npm:^2.0.1"
     "@metamask/delegation-deployments": "npm:^0.15.0"
-    "@metamask/design-system-react-native": "npm:^0.8.0"
+    "@metamask/design-system-react-native": "npm:^0.10.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.3.0"
     "@metamask/design-tokens": "npm:^8.2.2"
     "@metamask/earn-controller": "npm:^10.0.0"


### PR DESCRIPTION
## **Description**

Upgraded the MetaMask design system React Native package to the latest compatible release and marked legacy components as deprecated.

https://github.com/MetaMask/metamask-design-system/releases

Changes in this PR:
- Upgraded `@metamask/design-system-react-native` from `^0.8.0` to `^0.10.0`
- Updated lockfile resolution to `@metamask/design-system-react-native@0.10.0` and `@metamask/design-system-shared@0.3.0`
- Added missing `@deprecated` JSDoc tags to local overlapping wrappers:
  - `BottomSheetHeader`
  - `ButtonBase`
  - `ActionListItem`
  - `ButtonHero`
  - `ButtonSemantic`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Design system dependency upgrade

  Scenario: install and lint after upgrade
    Given the branch with dependency and JSDoc updates is checked out
    When running yarn install
    Then dependencies resolve successfully with the updated lockfile

    When running eslint on modified component files
    Then lint passes with no errors
```

## **Screenshots/Recordings**

### **Before**

N/A (dependency and JSDoc changes only)

### **After**

N/A (dependency and JSDoc changes only)

General smoke test to ensure mobile still runs as expected

https://github.com/user-attachments/assets/b23b3c36-772c-4da5-8f72-a961271b1d7a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to the design-system dependency bump (and `design-system-shared` transitive update) potentially changing UI behavior or typings at build/runtime. The code changes themselves are limited to JSDoc deprecation annotations.
> 
> **Overview**
> **Upgrades the MetaMask React Native design system dependency** by bumping `@metamask/design-system-react-native` from `^0.8.0` to `^0.10.0` (with corresponding `yarn.lock` updates, including `@metamask/design-system-shared` to `^0.3.0`).
> 
> **Deprecates local legacy/overlapping components** by adding `@deprecated` JSDoc guidance (and upstream README links) to `ActionListItem`, `ButtonHero`, `ButtonSemantic`, `BottomSheetHeader`, and `ButtonBase`; `TextField`’s deprecation docs are also updated with a `@since` tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff051dd8f7847f9225395cf89587aa2be137e5ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->