### PR TITLE
fix(predict): make fee exemption logic feature-flag-driven in PredictMarketDetails cp-7.69.0

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -811,7 +811,7 @@ export const parsePolymarketEvents = (
         recurrence: getRecurrence(event.series),
         endDate: event.endDate,
         category,
-        tags: tags.map((t) => t.label),
+        tags: tags.map((t) => t.slug),
         outcomes: markets.map((market: PolymarketApiMarket) =>
           parsePolymarketMarket(market, event),
         ),

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1146,7 +1146,7 @@ async function waiveFees({
   const market = await getMarketDetailsFromGammaApi({ marketId });
   const { tags } = market;
   const slugs = tags?.map((t) => t.slug);
-  return slugs?.some((slug) => waiveList.includes(slug)) ?? false;
+  return slugs?.some((slug) => waiveList?.includes(slug)) ?? false;
 }
 
 export async function calculateFees({

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1,4 +1,8 @@
-import { selectPredictEnabledFlag, selectPredictHotTabFlag } from '.';
+import {
+  selectPredictEnabledFlag,
+  selectPredictFeeCollectionFlag,
+  selectPredictHotTabFlag,
+} from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import {
   mockedState,
@@ -636,6 +640,155 @@ describe('Predict Feature Flag Selectors', () => {
 
         expect(result).toBeUndefined();
       });
+    });
+  });
+
+  describe('selectPredictFeeCollectionFlag', () => {
+    it('returns fee collection config when present in remote feature flags', () => {
+      const feeCollectionConfig = {
+        enabled: true,
+        collector: '0xe6a2026d58eaff3c7ad7ba9386fb143388002382',
+        metamaskFee: 0.03,
+        providerFee: 0.01,
+        waiveList: ['middle-east'],
+        executors: ['0x1234'],
+        permit2Enabled: true,
+      };
+      const stateWithFeeCollection = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictFeeCollection: feeCollectionConfig,
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPredictFeeCollectionFlag(stateWithFeeCollection);
+
+      expect(result).toEqual(feeCollectionConfig);
+    });
+
+    it('returns default flag when remote flag is missing', () => {
+      const result = selectPredictFeeCollectionFlag(mockedEmptyFlagsState);
+
+      expect(result).toEqual({
+        enabled: true,
+        collector: expect.any(String),
+        metamaskFee: 0.02,
+        providerFee: 0.02,
+        waiveList: [],
+        executors: [],
+        permit2Enabled: false,
+      });
+    });
+
+    it('returns default flag when remote flag is null', () => {
+      const stateWithNullFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictFeeCollection: null,
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPredictFeeCollectionFlag(stateWithNullFlag);
+
+      expect(result).toEqual({
+        enabled: true,
+        collector: expect.any(String),
+        metamaskFee: 0.02,
+        providerFee: 0.02,
+        waiveList: [],
+        executors: [],
+        permit2Enabled: false,
+      });
+    });
+
+    it('returns default flag when controller is undefined', () => {
+      const stateWithUndefinedController = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: undefined,
+          },
+        },
+      };
+
+      const result = selectPredictFeeCollectionFlag(
+        stateWithUndefinedController,
+      );
+
+      expect(result).toEqual({
+        enabled: true,
+        collector: expect.any(String),
+        metamaskFee: 0.02,
+        providerFee: 0.02,
+        waiveList: [],
+        executors: [],
+        permit2Enabled: false,
+      });
+    });
+
+    it('returns remote config with custom waiveList', () => {
+      const stateWithWaiveList = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictFeeCollection: {
+                  enabled: true,
+                  collector: '0xabc',
+                  metamaskFee: 0.05,
+                  providerFee: 0.03,
+                  waiveList: ['middle-east', 'humanitarian'],
+                  executors: [],
+                  permit2Enabled: false,
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPredictFeeCollectionFlag(stateWithWaiveList);
+
+      expect(result.waiveList).toEqual(['middle-east', 'humanitarian']);
+      expect(result.metamaskFee).toBe(0.05);
+      expect(result.providerFee).toBe(0.03);
+    });
+
+    it('returns remote config when fee collection is disabled', () => {
+      const stateWithDisabledFees = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictFeeCollection: {
+                  enabled: false,
+                  collector: '0x0',
+                  metamaskFee: 0,
+                  providerFee: 0,
+                  waiveList: [],
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPredictFeeCollectionFlag(stateWithDisabledFees);
+
+      expect(result.enabled).toBe(false);
     });
   });
 });

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -4,8 +4,11 @@ import {
   VersionGatedFeatureFlag,
   validatedVersionGatedFeatureFlag,
 } from '../../../../../util/remoteFeatureFlag';
-import { PredictHotTabFlag } from '../../types/flags';
-import { DEFAULT_HOT_TAB_FLAG } from '../../constants/flags';
+import { PredictFeatureFlags, PredictHotTabFlag } from '../../types/flags';
+import {
+  DEFAULT_FEE_COLLECTION_FLAG,
+  DEFAULT_HOT_TAB_FLAG,
+} from '../../constants/flags';
 import { unwrapRemoteFeatureFlag } from '../../utils/flags';
 
 /**
@@ -104,6 +107,24 @@ export const selectPredictHotTabFlag = createSelector(
       typeof flag.queryParams !== 'string'
     ) {
       return DEFAULT_HOT_TAB_FLAG;
+    }
+
+    return flag;
+  },
+);
+
+/**
+ * Selector for Predict fee collection config flag
+ */
+export const selectPredictFeeCollectionFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const flag = unwrapRemoteFeatureFlag<PredictFeatureFlags['feeCollection']>(
+      remoteFeatureFlags?.predictFeeCollection,
+    );
+
+    if (!flag) {
+      return DEFAULT_FEE_COLLECTION_FLAG;
     }
 
     return flag;

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -592,6 +592,20 @@ function setupPredictMarketDetailsTest(
           PreferencesController: {
             privacyMode: false,
           },
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              predictFeeCollection: {
+                enabled: true,
+                collector: '0xe6a2026d58eaff3c7ad7ba9386fb143388002382',
+                metamaskFee: 0.02,
+                providerFee: 0.02,
+                waiveList: ['middle-east'],
+                executors: [],
+                permit2Enabled: false,
+              },
+            },
+            cacheTimestamp: 0,
+          },
         },
       },
     },
@@ -3197,10 +3211,10 @@ describe('PredictMarketDetails', () => {
   });
 
   describe('Fee Exemption Display', () => {
-    it('displays fee exemption message when market has Middle East tag', () => {
-      const marketWithMiddleEastTag = createMockMarket({
+    it('displays fee exemption message when market tag matches waiveList', () => {
+      const marketWithWaivedTag = createMockMarket({
         status: 'open',
-        tags: ['Middle East'],
+        tags: ['middle-east'],
         outcomes: [
           {
             id: 'outcome-1',
@@ -3214,17 +3228,17 @@ describe('PredictMarketDetails', () => {
         ],
       });
 
-      setupPredictMarketDetailsTest(marketWithMiddleEastTag);
+      setupPredictMarketDetailsTest(marketWithWaivedTag);
 
       expect(
         screen.getByText('predict.market_details.fee_exemption'),
       ).toBeOnTheScreen();
     });
 
-    it('hides fee exemption message when market does not have Middle East tag', () => {
-      const marketWithoutMiddleEastTag = createMockMarket({
+    it('hides fee exemption message when market tags do not match waiveList', () => {
+      const marketWithNonWaivedTags = createMockMarket({
         status: 'open',
-        tags: ['Sports', 'Politics'],
+        tags: ['sports', 'politics'],
         outcomes: [
           {
             id: 'outcome-1',
@@ -3238,7 +3252,7 @@ describe('PredictMarketDetails', () => {
         ],
       });
 
-      setupPredictMarketDetailsTest(marketWithoutMiddleEastTag);
+      setupPredictMarketDetailsTest(marketWithNonWaivedTags);
 
       expect(
         screen.queryByText('predict.market_details.fee_exemption'),
@@ -3293,10 +3307,10 @@ describe('PredictMarketDetails', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('displays fee exemption message when Middle East tag exists among multiple tags', () => {
+    it('displays fee exemption message when waiveList tag exists among multiple tags', () => {
       const marketWithMultipleTags = createMockMarket({
         status: 'open',
-        tags: ['Politics', 'Middle East', 'International'],
+        tags: ['politics', 'middle-east', 'international'],
         outcomes: [
           {
             id: 'outcome-1',
@@ -3317,10 +3331,10 @@ describe('PredictMarketDetails', () => {
       ).toBeOnTheScreen();
     });
 
-    it('displays fee exemption message when market is closed with Middle East tag', () => {
-      const closedMarketWithMiddleEastTag = createMockMarket({
+    it('displays fee exemption message when market is closed with waiveList tag', () => {
+      const closedMarketWithWaivedTag = createMockMarket({
         status: 'closed',
-        tags: ['Middle East'],
+        tags: ['middle-east'],
         outcomes: [
           {
             id: 'outcome-1',
@@ -3331,23 +3345,23 @@ describe('PredictMarketDetails', () => {
         ],
       });
 
-      setupPredictMarketDetailsTest(closedMarketWithMiddleEastTag);
+      setupPredictMarketDetailsTest(closedMarketWithWaivedTag);
 
-      // Note: The component currently shows the fee exemption message for closed markets
-      // if they have the Middle East tag. This behavior matches the current implementation.
+      // Note: The component shows the fee exemption message for closed markets
+      // if they have a tag matching the waiveList. This matches the current implementation.
       expect(
         screen.getByText('predict.market_details.fee_exemption'),
       ).toBeOnTheScreen();
     });
 
-    it('removes fee exemption message when market updates without Middle East tag', async () => {
+    it('removes fee exemption message when market updates without waiveList tag', async () => {
       const { usePredictMarket } = jest.requireMock(
         '../../hooks/usePredictMarket',
       );
 
-      const marketWithMiddleEastTag = createMockMarket({
+      const marketWithWaivedTag = createMockMarket({
         status: 'open',
-        tags: ['Middle East', 'Politics'],
+        tags: ['middle-east', 'politics'],
         outcomes: [
           {
             id: 'outcome-1',
@@ -3361,17 +3375,15 @@ describe('PredictMarketDetails', () => {
         ],
       });
 
-      const { rerender } = setupPredictMarketDetailsTest(
-        marketWithMiddleEastTag,
-      );
+      const { rerender } = setupPredictMarketDetailsTest(marketWithWaivedTag);
 
       expect(
         screen.getByText('predict.market_details.fee_exemption'),
       ).toBeOnTheScreen();
 
-      const marketWithoutMiddleEastTag = createMockMarket({
+      const marketWithoutWaivedTag = createMockMarket({
         status: 'open',
-        tags: ['Politics'],
+        tags: ['politics'],
         outcomes: [
           {
             id: 'outcome-1',
@@ -3386,7 +3398,7 @@ describe('PredictMarketDetails', () => {
       });
 
       usePredictMarket.mockReturnValue({
-        market: marketWithoutMiddleEastTag,
+        market: marketWithoutWaivedTag,
         isFetching: false,
         refetch: jest.fn(),
       });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -47,6 +47,8 @@ import PredictMarketDetailsTabContent from './components/PredictMarketDetailsTab
 import { useChartData } from './hooks/useChartData';
 import { useOutcomeResolution } from './hooks/useOutcomeResolution';
 import { useOpenOutcomes } from './hooks/useOpenOutcomes';
+import { useSelector } from 'react-redux';
+import { selectPredictFeeCollectionFlag } from '../../selectors/featureFlags';
 
 // Use theme tokens instead of hex values for multi-series charts
 
@@ -128,8 +130,11 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     enabled: !isMarketFetching && Boolean(resolvedMarketId),
   });
 
-  // check if market has fee exemption (note: worth moveing to a const or util at some point))
-  const isFeeExemption = market?.tags?.includes('Middle East') ?? false;
+  const feeCollectionConfig = useSelector(selectPredictFeeCollectionFlag);
+  const isFeeExemption =
+    market?.tags?.some((slug) =>
+      feeCollectionConfig.waiveList.includes(slug),
+    ) ?? false;
 
   // Tabs become ready when both market and positions queries have resolved
   const tabsReady = useMemo(

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -133,7 +133,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const feeCollectionConfig = useSelector(selectPredictFeeCollectionFlag);
   const isFeeExemption =
     market?.tags?.some((slug) =>
-      feeCollectionConfig.waiveList.includes(slug),
+      feeCollectionConfig.waiveList?.includes(slug),
     ) ?? false;
 
   // Tabs become ready when both market and positions queries have resolved


### PR DESCRIPTION
## **Description**

The fee exemption logic in `PredictMarketDetails` was hardcoded to check for a `'Middle East'` tag label, while `PredictController` and `PolymarketProvider` already used a feature-flag-driven approach via `feeCollection.waiveList`. This PR aligns the UI layer with the existing pattern:

- **`parsePolymarketEvents`**: Switch tag mapping from `t.label` to `t.slug` so parsed market tags match the slug-based `waiveList` entries used by `waiveFees()`
- **`selectPredictFeeCollectionFlag`**: New selector that reads the `predictFeeCollection` remote feature flag, falling back to `DEFAULT_FEE_COLLECTION_FLAG`
- **`PredictMarketDetails`**: Replace hardcoded `tags?.includes('Middle East')` with `tags?.some(slug => waiveList.includes(slug))` driven by the selector
- Added defensive optional chaining on `tags` access for safety

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-736](https://consensyssoftware.atlassian.net/browse/PRED-736)

## **Manual testing steps**

```gherkin
Feature: Fee exemption display on market details

  Scenario: user views a market with a tag in the waiveList
    Given the remote feature flag predictFeeCollection has waiveList containing 'middle-east'
    And a market has the tag slug 'middle-east'

    When user navigates to the market details screen
    Then the fee exemption message is displayed

  Scenario: user views a market without waived tags
    Given the remote feature flag predictFeeCollection has waiveList containing 'middle-east'
    And a market only has tag slugs 'sports' and 'politics'

    When user navigates to the market details screen
    Then the fee exemption message is not displayed

  Scenario: user views a market when waiveList is empty
    Given the remote feature flag predictFeeCollection has an empty waiveList
    And a market has any tags

    When user navigates to the market details screen
    Then the fee exemption message is not displayed
```

## **Screenshots/Recordings**

### **Before**

N/A — logic change only, no visual diff

### **After**

N/A — logic change only, no visual diff

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Predict market `tags` from human-readable labels to slugs and uses remote `predictFeeCollection.waiveList` to control fee-exemption UI, which could affect any UI/analytics expecting label-form tags. Logic is straightforward and covered by updated/additional selector and view tests.
> 
> **Overview**
> Aligns fee-exemption behavior in `PredictMarketDetails` with the fee-collection feature flag by replacing the hardcoded `'Middle East'` tag check with a `waiveList` (slug) match from the new `selectPredictFeeCollectionFlag` selector (defaulting to `DEFAULT_FEE_COLLECTION_FLAG`).
> 
> Updates Polymarket parsing to store market `tags` as tag **slugs** (`t.slug`) instead of labels, and adjusts tests to validate the new slug-based exemption behavior plus selector fallbacks when the remote flag is missing/null/undefined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daf0e586384267aced27cefdb4ad4123ef896ac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->