### PR TITLE
feat: MUSD-394 add generic transaction fee row to conversion confirmations

### DIFF
--- a/app/components/Views/confirmations/ConfirmationView.testIds.ts
+++ b/app/components/Views/confirmations/ConfirmationView.testIds.ts
@@ -47,7 +47,6 @@ export const ConfirmationRowComponentIDs = {
   TOTAL: 'total',
   RECEIVE: 'receive',
   TRANSACTION_FEE: 'transaction-fee',
-  NETWORK_FEE: 'network-fee',
   AMOUNT: 'amount',
 } as const;
 

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../hooks/pay/useTransactionPayData';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { Json } from '@metamask/utils';
-import { ConfirmationRowComponentIDs } from '../../../ConfirmationView.testIds';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/metrics/useConfirmationAlertMetrics', () => ({
@@ -76,30 +75,6 @@ describe('BridgeFeeRow', () => {
   it('renders transaction fee', async () => {
     const { getByText } = render();
     expect(getByText('$1.23')).toBeDefined();
-  });
-
-  it('renders network fee row when transaction type is musdConversion', () => {
-    const { getByTestId, getByText, queryByTestId, queryByText } = render({
-      type: TransactionType.musdConversion,
-    });
-
-    expect(getByTestId(ConfirmationRowComponentIDs.NETWORK_FEE)).toBeDefined();
-    expect(getByText('$0.23')).toBeDefined();
-    expect(queryByText('$1.23')).toBeNull();
-    expect(queryByTestId('metamask-fee-row')).toBeNull();
-    expect(queryByTestId('bridge-fee-row')).toBeNull();
-  });
-
-  it('renders skeleton if musdConversion network fee is loading', () => {
-    useIsTransactionPayLoadingMock.mockReturnValue(true);
-
-    const { getByTestId, queryByTestId, queryByText } = render({
-      type: TransactionType.musdConversion,
-    });
-
-    expect(getByTestId('network-fee-row-skeleton')).toBeDefined();
-    expect(queryByTestId(ConfirmationRowComponentIDs.NETWORK_FEE)).toBeNull();
-    expect(queryByText('$0.23')).toBeNull();
   });
 
   it('renders network fee in tooltip', async () => {

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -28,10 +28,7 @@ import { RowAlertKey } from '../../UI/info-row/alert-row/constants';
 import { useAlerts } from '../../../context/alert-system-context';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { ConfirmationRowComponentIDs } from '../../../ConfirmationView.testIds';
-import { IconColor } from '../../../../../../component-library/components/Icons/Icon';
 import { Json } from '@metamask/utils';
-
-const NETWORK_FEE_ONLY_TYPES = [TransactionType.musdConversion];
 
 export function BridgeFeeRow() {
   const transactionMetadata = useTransactionMetadataOrThrow();
@@ -40,16 +37,6 @@ export function BridgeFeeRow() {
   const totals = useTransactionPayTotals();
   const { fieldAlerts } = useAlerts();
   const hasAlert = fieldAlerts.some((a) => a.field === RowAlertKey.PayWithFee);
-
-  if (hasTransactionType(transactionMetadata, NETWORK_FEE_ONLY_TYPES)) {
-    return (
-      <NetworkFeeRow
-        totals={totals}
-        hasAlert={hasAlert}
-        isLoading={isLoading}
-      />
-    );
-  }
 
   return (
     <TransactionFeeRow
@@ -127,45 +114,6 @@ function getNetworkFeeUsdBN({
   if (sourceNetworkUsd == null || targetNetworkUsd == null) return undefined;
 
   return new BigNumber(sourceNetworkUsd).plus(targetNetworkUsd);
-}
-
-function NetworkFeeRow({
-  totals,
-  hasAlert,
-  isLoading,
-}: {
-  totals?: TransactionPayTotals;
-  hasAlert: boolean;
-  isLoading: boolean;
-}) {
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
-
-  const networkFeeUsd = useMemo(() => {
-    const networkFeeUsdBN = getNetworkFeeUsdBN({ totals });
-    return networkFeeUsdBN ? formatFiat(networkFeeUsdBN) : '';
-  }, [totals, formatFiat]);
-
-  if (isLoading) return <InfoRowSkeleton testId="network-fee-row-skeleton" />;
-
-  return (
-    <AlertRow
-      testID="network-fee-row"
-      label={strings('confirm.label.network_fee')}
-      alertField={RowAlertKey.PayWithFee}
-      tooltipTitle={strings('confirm.label.network_fee')}
-      tooltip={strings('confirm.tooltip.network_fee')}
-      tooltipColor={IconColor.Alternative}
-      rowVariant={InfoRowVariant.Small}
-    >
-      <Text
-        variant={TextVariant.BodyMD}
-        color={hasAlert ? TextColor.Error : TextColor.Alternative}
-        testID={ConfirmationRowComponentIDs.NETWORK_FEE}
-      >
-        {networkFeeUsd}
-      </Text>
-    </AlertRow>
-  );
 }
 
 function Tooltip({

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6383,10 +6383,10 @@
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predictions. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_withdraw": {
-        "transaction_fee": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to MUSD."
+        "transaction_fee": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD."
       },
       "musd_conversion": {
-        "transaction_fee": "MetaMask will convert your desired token to mUSD. No MetaMask fee applies when you convert to mUSD."
+        "transaction_fee": "mUSD conversion fees include network costs and may include provider fees. No MetaMask fee applies when you convert to mUSD."
       },
       "title": {
         "transaction_fee": "Fees"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6386,7 +6386,7 @@
         "transaction_fee": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to MUSD."
       },
       "musd_conversion": {
-        "transaction_fee": "mUSD conversion fees include network costs and may include provider fees."
+        "transaction_fee": "MetaMask will convert your desired token to mUSD. No MetaMask fee applies when you convert to mUSD."
       },
       "title": {
         "transaction_fee": "Fees"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Replace the mUSD-specific `NetworkFeeRow` with the generic `TransactionFeeRow` on conversion confirmations, and update the transaction fee tooltip copy to clarify that no MetaMask fee applies.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: replaced mUSD conversion-specific network fee row with the generic transaction fee row and updated fee tooltip copy

## **Related issues**

Fixes: [MUSD-394: Add generic "Transaction Fee" row to conversion confirmations](https://consensyssoftware.atlassian.net/browse/MUSD-394)

## **Manual testing steps**

```gherkin
Feature: Generic transaction fee row for mUSD conversions

  Scenario: user views fee breakdown on mUSD conversion confirmation
    Given user is on the mUSD conversion confirmation screen

    When user views the fee details
    Then the generic transaction fee row is displayed instead of a network-fee-only row
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
mUSD conversions only displayed the "Network Fee"
<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
### Custom conversion input
<img width="493" height="1014" alt="image" src="https://github.com/user-attachments/assets/10ab06f2-ff3c-4039-85c9-da636fef70fc" />
<img width="493" height="1014" alt="image" src="https://github.com/user-attachments/assets/015e4775-64e6-42c7-b303-4142d12a7132" />

### "Max" convert bottom sheet 
<img width="493" height="1014" alt="image" src="https://github.com/user-attachments/assets/e60de70d-94ec-4da8-9cf1-070e18b05f26" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only confirmation changes to fee row rendering and tooltip copy; main risk is mismatched testIDs or fee display expectations in mUSD conversion flows.
> 
> **Overview**
> **mUSD conversion confirmations now use the generic `TransactionFeeRow`** instead of the mUSD-specific `NetworkFeeRow`, so conversions show the same combined transaction fee total (network + provider + MetaMask) and tooltip breakdown as other pay flows.
> 
> Removes the `ConfirmationRowComponentIDs.NETWORK_FEE` selector and deletes the associated `musdConversion` network-fee row/skeleton tests; updates English tooltip copy to clarify *no MetaMask fee applies* for mUSD conversions (and fixes `mUSD` casing in the predict-withdraw tooltip).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd076d6114679e2db95fb4b8c92ab2b8a5c20b4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->