### PR TITLE
feat(card): add CardOnboardingStore and CardTokenStore

### DIFF
--- a/app/core/Engine/controllers/card-controller/CardOnboardingStore.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardOnboardingStore.test.ts
@@ -1,0 +1,162 @@
+import SecureKeychain from '../../../SecureKeychain';
+import {
+  CardOnboardingStore,
+  EMPTY_ONBOARDING_DATA,
+} from './CardOnboardingStore';
+
+jest.mock('../../../SecureKeychain');
+jest.mock('../../../../util/Logger');
+
+const mockSecureKeychain = SecureKeychain as jest.Mocked<typeof SecureKeychain>;
+
+describe('CardOnboardingStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('returns null when no data is stored', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
+
+      const result = await CardOnboardingStore.get('baanx');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns onboarding data merged with defaults', async () => {
+      const stored = {
+        onboardingId: 'ob-123',
+        selectedCountry: 'US',
+      };
+
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
+        key: 'CARD_ONBOARDING_baanx',
+        value: JSON.stringify(stored),
+      });
+
+      const result = await CardOnboardingStore.get('baanx');
+
+      expect(result).toStrictEqual({
+        onboardingId: 'ob-123',
+        contactVerificationId: null,
+        consentSetId: null,
+        selectedCountry: 'US',
+      });
+    });
+
+    it('uses the correct keychain scope', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
+
+      await CardOnboardingStore.get('baanx');
+
+      expect(mockSecureKeychain.getSecureItem).toHaveBeenCalledWith({
+        service: 'com.metamask.CARD_ONBOARDING_baanx',
+        accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+    });
+
+    it('returns null on keychain error', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockRejectedValue(
+        new Error('Keychain error'),
+      );
+
+      const result = await CardOnboardingStore.get('baanx');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('merges partial data with existing data', async () => {
+      const existingData = {
+        onboardingId: 'ob-123',
+        contactVerificationId: null,
+        consentSetId: null,
+        selectedCountry: 'US',
+      };
+
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
+        key: 'CARD_ONBOARDING_baanx',
+        value: JSON.stringify(existingData),
+      });
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockResolvedValue(true);
+
+      const result = await CardOnboardingStore.set('baanx', {
+        contactVerificationId: 'ver-456',
+      });
+
+      expect(result).toBe(true);
+      expect(mockSecureKeychain.setSecureItem).toHaveBeenCalledWith(
+        'CARD_ONBOARDING_baanx',
+        JSON.stringify({
+          onboardingId: 'ob-123',
+          contactVerificationId: 'ver-456',
+          consentSetId: null,
+          selectedCountry: 'US',
+        }),
+        expect.objectContaining({
+          service: 'com.metamask.CARD_ONBOARDING_baanx',
+        }),
+      );
+    });
+
+    it('creates from empty when no existing data', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockResolvedValue(true);
+
+      await CardOnboardingStore.set('baanx', {
+        onboardingId: 'ob-new',
+      });
+
+      expect(mockSecureKeychain.setSecureItem).toHaveBeenCalledWith(
+        'CARD_ONBOARDING_baanx',
+        JSON.stringify({
+          ...EMPTY_ONBOARDING_DATA,
+          onboardingId: 'ob-new',
+        }),
+        expect.objectContaining({
+          service: 'com.metamask.CARD_ONBOARDING_baanx',
+        }),
+      );
+    });
+
+    it('returns false on keychain error', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockRejectedValue(
+        new Error('Keychain error'),
+      );
+
+      const result = await CardOnboardingStore.set('baanx', {
+        onboardingId: 'ob-123',
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('remove', () => {
+    it('clears the keychain scope', async () => {
+      (mockSecureKeychain.clearSecureScope as jest.Mock).mockResolvedValue(
+        true,
+      );
+
+      const result = await CardOnboardingStore.remove('baanx');
+
+      expect(result).toBe(true);
+      expect(mockSecureKeychain.clearSecureScope).toHaveBeenCalledWith({
+        service: 'com.metamask.CARD_ONBOARDING_baanx',
+        accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+    });
+
+    it('returns false on failure', async () => {
+      (mockSecureKeychain.clearSecureScope as jest.Mock).mockResolvedValue(
+        false,
+      );
+
+      const result = await CardOnboardingStore.remove('baanx');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/core/Engine/controllers/card-controller/CardOnboardingStore.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardOnboardingStore.test.ts
@@ -55,10 +55,21 @@ describe('CardOnboardingStore', () => {
       });
     });
 
-    it('returns null on keychain error', async () => {
+    it('throws on keychain error to prevent silent data loss in set()', async () => {
       (mockSecureKeychain.getSecureItem as jest.Mock).mockRejectedValue(
         new Error('Keychain error'),
       );
+
+      await expect(CardOnboardingStore.get('baanx')).rejects.toThrow(
+        'Keychain error',
+      );
+    });
+
+    it('returns null on JSON parse error', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
+        key: 'CARD_ONBOARDING_baanx',
+        value: 'invalid-json',
+      });
 
       const result = await CardOnboardingStore.get('baanx');
 
@@ -120,7 +131,7 @@ describe('CardOnboardingStore', () => {
       );
     });
 
-    it('returns false on keychain error', async () => {
+    it('returns false on write error', async () => {
       (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
       (mockSecureKeychain.setSecureItem as jest.Mock).mockRejectedValue(
         new Error('Keychain error'),
@@ -131,6 +142,19 @@ describe('CardOnboardingStore', () => {
       });
 
       expect(result).toBe(false);
+    });
+
+    it('returns false on read error to prevent silent data loss', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockRejectedValue(
+        new Error('Keychain read error'),
+      );
+
+      const result = await CardOnboardingStore.set('baanx', {
+        contactVerificationId: 'ver-456',
+      });
+
+      expect(result).toBe(false);
+      expect(mockSecureKeychain.setSecureItem).not.toHaveBeenCalled();
     });
   });
 

--- a/app/core/Engine/controllers/card-controller/CardOnboardingStore.ts
+++ b/app/core/Engine/controllers/card-controller/CardOnboardingStore.ts
@@ -1,0 +1,100 @@
+import SecureKeychain from '../../../SecureKeychain';
+import Logger from '../../../../util/Logger';
+
+const KEYCHAIN_PREFIX = 'com.metamask.CARD_ONBOARDING';
+
+/**
+ * Onboarding session data stored in SecureKeychain, keyed by provider ID.
+ */
+export interface CardOnboardingData {
+  onboardingId: string | null;
+  contactVerificationId: string | null;
+  consentSetId: string | null;
+  selectedCountry: string | null;
+}
+
+export const EMPTY_ONBOARDING_DATA: CardOnboardingData = {
+  onboardingId: null,
+  contactVerificationId: null,
+  consentSetId: null,
+  selectedCountry: null,
+};
+
+function scopeOptions(providerId: string) {
+  return {
+    service: `${KEYCHAIN_PREFIX}_${providerId}`,
+    accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  };
+}
+
+/**
+ * SecureKeychain wrapper for Card onboarding session data.
+ */
+export const CardOnboardingStore = {
+  async get(providerId: string): Promise<CardOnboardingData | null> {
+    try {
+      const item = await SecureKeychain.getSecureItem(scopeOptions(providerId));
+      if (!item) return null;
+
+      const data: Partial<CardOnboardingData> = JSON.parse(item.value);
+      return {
+        ...EMPTY_ONBOARDING_DATA,
+        ...data,
+      };
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: providerId },
+        context: {
+          name: 'CardOnboardingStore',
+          data: { method: 'get' },
+        },
+      });
+      return null;
+    }
+  },
+
+  async set(
+    providerId: string,
+    data: Partial<CardOnboardingData>,
+  ): Promise<boolean> {
+    try {
+      const current =
+        (await CardOnboardingStore.get(providerId)) ?? EMPTY_ONBOARDING_DATA;
+      const merged = { ...current, ...data };
+
+      const result = await SecureKeychain.setSecureItem(
+        `CARD_ONBOARDING_${providerId}`,
+        JSON.stringify(merged),
+        scopeOptions(providerId),
+      );
+      return result !== false;
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: providerId },
+        context: {
+          name: 'CardOnboardingStore',
+          data: { method: 'set' },
+        },
+      });
+      return false;
+    }
+  },
+
+  async remove(providerId: string): Promise<boolean> {
+    try {
+      const result = await SecureKeychain.clearSecureScope(
+        scopeOptions(providerId),
+      );
+      return result !== false;
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: providerId },
+        context: {
+          name: 'CardOnboardingStore',
+          data: { method: 'remove' },
+        },
+      });
+      return false;
+    }
+  },
+};

--- a/app/core/Engine/controllers/card-controller/CardOnboardingStore.ts
+++ b/app/core/Engine/controllers/card-controller/CardOnboardingStore.ts
@@ -31,22 +31,27 @@ function scopeOptions(providerId: string) {
  * SecureKeychain wrapper for Card onboarding session data.
  */
 export const CardOnboardingStore = {
+  /**
+   * Retrieves onboarding data for a provider.
+   * @returns The onboarding data, or null if no data exists.
+   * @throws If a keychain read error occurs (to prevent silent data loss in set()).
+   */
   async get(providerId: string): Promise<CardOnboardingData | null> {
-    try {
-      const item = await SecureKeychain.getSecureItem(scopeOptions(providerId));
-      if (!item) return null;
+    const item = await SecureKeychain.getSecureItem(scopeOptions(providerId));
+    if (!item) return null;
 
+    try {
       const data: Partial<CardOnboardingData> = JSON.parse(item.value);
       return {
         ...EMPTY_ONBOARDING_DATA,
         ...data,
       };
-    } catch (error) {
-      Logger.error(error as Error, {
+    } catch (parseError) {
+      Logger.error(parseError as Error, {
         tags: { feature: 'card', provider: providerId },
         context: {
           name: 'CardOnboardingStore',
-          data: { method: 'get' },
+          data: { method: 'get', reason: 'JSON parse failed' },
         },
       });
       return null;

--- a/app/core/Engine/controllers/card-controller/CardTokenStore.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardTokenStore.test.ts
@@ -1,0 +1,151 @@
+import SecureKeychain from '../../../SecureKeychain';
+import { CardTokenStore } from './CardTokenStore';
+
+jest.mock('../../../SecureKeychain');
+jest.mock('../../../../util/Logger');
+
+const mockSecureKeychain = SecureKeychain as jest.Mocked<typeof SecureKeychain>;
+
+describe('CardTokenStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('returns null when no token is stored', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
+
+      const result = await CardTokenStore.get('baanx');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns token set for baanx provider using legacy scope', async () => {
+      const tokenData = {
+        accessToken: 'access-123',
+        refreshToken: 'refresh-456',
+        accessTokenExpiresAt: Date.now() + 3600000,
+        refreshTokenExpiresAt: Date.now() + 86400000,
+        location: 'us',
+      };
+
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
+        key: 'CARD_TOKENS_baanx',
+        value: JSON.stringify(tokenData),
+      });
+
+      const result = await CardTokenStore.get('baanx');
+
+      expect(result).toStrictEqual(tokenData);
+      expect(mockSecureKeychain.getSecureItem).toHaveBeenCalledWith({
+        service: 'com.metamask.CARD_BAANX_TOKENS',
+        accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+    });
+
+    it('uses provider-specific scope for non-baanx providers', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue(null);
+
+      await CardTokenStore.get('providerB');
+
+      expect(mockSecureKeychain.getSecureItem).toHaveBeenCalledWith({
+        service: 'com.metamask.CARD_TOKENS_providerB',
+        accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+    });
+
+    it('returns null when token data is missing accessToken', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
+        key: 'CARD_TOKENS_baanx',
+        value: JSON.stringify({ accessTokenExpiresAt: Date.now() + 3600000 }),
+      });
+
+      const result = await CardTokenStore.get('baanx');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on keychain error', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockRejectedValue(
+        new Error('Keychain error'),
+      );
+
+      const result = await CardTokenStore.get('baanx');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('stores token set successfully', async () => {
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockResolvedValue(true);
+
+      const tokenSet = {
+        accessToken: 'access-123',
+        accessTokenExpiresAt: Date.now() + 3600000,
+      };
+
+      const result = await CardTokenStore.set('baanx', tokenSet);
+
+      expect(result).toBe(true);
+      expect(mockSecureKeychain.setSecureItem).toHaveBeenCalledWith(
+        'CARD_TOKENS_baanx',
+        JSON.stringify(tokenSet),
+        {
+          service: 'com.metamask.CARD_BAANX_TOKENS',
+          accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+        },
+      );
+    });
+
+    it('returns false when storage fails', async () => {
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockResolvedValue(false);
+
+      const result = await CardTokenStore.set('baanx', {
+        accessToken: 'test',
+        accessTokenExpiresAt: 0,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false on keychain error', async () => {
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockRejectedValue(
+        new Error('Keychain error'),
+      );
+
+      const result = await CardTokenStore.set('baanx', {
+        accessToken: 'test',
+        accessTokenExpiresAt: 0,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes token successfully', async () => {
+      (mockSecureKeychain.clearSecureScope as jest.Mock).mockResolvedValue(
+        true,
+      );
+
+      const result = await CardTokenStore.remove('baanx');
+
+      expect(result).toBe(true);
+      expect(mockSecureKeychain.clearSecureScope).toHaveBeenCalledWith({
+        service: 'com.metamask.CARD_BAANX_TOKENS',
+        accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
+    });
+
+    it('returns false on failure', async () => {
+      (mockSecureKeychain.clearSecureScope as jest.Mock).mockResolvedValue(
+        false,
+      );
+
+      const result = await CardTokenStore.remove('baanx');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/core/Engine/controllers/card-controller/CardTokenStore.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardTokenStore.test.ts
@@ -56,8 +56,25 @@ describe('CardTokenStore', () => {
 
     it('returns null when token data is missing accessToken', async () => {
       (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
-        key: 'CARD_TOKENS_baanx',
-        value: JSON.stringify({ accessTokenExpiresAt: Date.now() + 3600000 }),
+        key: 'CARD_BAANX_TOKENS',
+        value: JSON.stringify({
+          accessTokenExpiresAt: Date.now() + 3600000,
+          location: 'us',
+        }),
+      });
+
+      const result = await CardTokenStore.get('baanx');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when token data is missing location', async () => {
+      (mockSecureKeychain.getSecureItem as jest.Mock).mockResolvedValue({
+        key: 'CARD_BAANX_TOKENS',
+        value: JSON.stringify({
+          accessToken: 'access-123',
+          accessTokenExpiresAt: Date.now() + 3600000,
+        }),
       });
 
       const result = await CardTokenStore.get('baanx');
@@ -77,22 +94,45 @@ describe('CardTokenStore', () => {
   });
 
   describe('set', () => {
-    it('stores token set successfully', async () => {
+    it('stores token set using legacy key for baanx and returns true', async () => {
       (mockSecureKeychain.setSecureItem as jest.Mock).mockResolvedValue(true);
 
       const tokenSet = {
         accessToken: 'access-123',
         accessTokenExpiresAt: Date.now() + 3600000,
+        location: 'us',
       };
 
       const result = await CardTokenStore.set('baanx', tokenSet);
 
       expect(result).toBe(true);
       expect(mockSecureKeychain.setSecureItem).toHaveBeenCalledWith(
-        'CARD_TOKENS_baanx',
+        'CARD_BAANX_TOKENS',
         JSON.stringify(tokenSet),
         {
           service: 'com.metamask.CARD_BAANX_TOKENS',
+          accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+        },
+      );
+    });
+
+    it('stores token set using provider-specific key for non-baanx providers', async () => {
+      (mockSecureKeychain.setSecureItem as jest.Mock).mockResolvedValue(true);
+
+      const tokenSet = {
+        accessToken: 'access-123',
+        accessTokenExpiresAt: Date.now() + 3600000,
+        location: 'eu',
+      };
+
+      const result = await CardTokenStore.set('providerB', tokenSet);
+
+      expect(result).toBe(true);
+      expect(mockSecureKeychain.setSecureItem).toHaveBeenCalledWith(
+        'CARD_TOKENS_providerB',
+        JSON.stringify(tokenSet),
+        {
+          service: 'com.metamask.CARD_TOKENS_providerB',
           accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
         },
       );
@@ -104,6 +144,7 @@ describe('CardTokenStore', () => {
       const result = await CardTokenStore.set('baanx', {
         accessToken: 'test',
         accessTokenExpiresAt: 0,
+        location: 'us',
       });
 
       expect(result).toBe(false);
@@ -117,6 +158,7 @@ describe('CardTokenStore', () => {
       const result = await CardTokenStore.set('baanx', {
         accessToken: 'test',
         accessTokenExpiresAt: 0,
+        location: 'us',
       });
 
       expect(result).toBe(false);
@@ -124,7 +166,7 @@ describe('CardTokenStore', () => {
   });
 
   describe('remove', () => {
-    it('removes token successfully', async () => {
+    it('removes token and returns true', async () => {
       (mockSecureKeychain.clearSecureScope as jest.Mock).mockResolvedValue(
         true,
       );

--- a/app/core/Engine/controllers/card-controller/CardTokenStore.ts
+++ b/app/core/Engine/controllers/card-controller/CardTokenStore.ts
@@ -2,6 +2,7 @@ import SecureKeychain from '../../../SecureKeychain';
 import Logger from '../../../../util/Logger';
 
 const KEYCHAIN_PREFIX = 'com.metamask.CARD_TOKENS';
+const LEGACY_BAANX_KEY = 'CARD_BAANX_TOKENS';
 
 /**
  * Auth token set stored in SecureKeychain, keyed by provider ID.
@@ -11,14 +12,20 @@ export interface CardTokenSet {
   refreshToken?: string;
   accessTokenExpiresAt: number;
   refreshTokenExpiresAt?: number;
-  location?: string;
+  location: string;
+}
+
+function keychainKey(providerId: string): string {
+  return providerId === 'baanx'
+    ? LEGACY_BAANX_KEY
+    : `CARD_TOKENS_${providerId}`;
 }
 
 function scopeOptions(providerId: string) {
   return {
     service:
       providerId === 'baanx'
-        ? 'com.metamask.CARD_BAANX_TOKENS'
+        ? `com.metamask.${LEGACY_BAANX_KEY}`
         : `${KEYCHAIN_PREFIX}_${providerId}`,
     accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
   };
@@ -34,7 +41,9 @@ export const CardTokenStore = {
       if (!item) return null;
 
       const data: Partial<CardTokenSet> = JSON.parse(item.value);
-      if (!data.accessToken || !data.accessTokenExpiresAt) return null;
+      if (!data.accessToken || !data.accessTokenExpiresAt || !data.location) {
+        return null;
+      }
 
       return data as CardTokenSet;
     } catch (error) {
@@ -52,7 +61,7 @@ export const CardTokenStore = {
   async set(providerId: string, tokenSet: CardTokenSet): Promise<boolean> {
     try {
       const result = await SecureKeychain.setSecureItem(
-        `CARD_TOKENS_${providerId}`,
+        keychainKey(providerId),
         JSON.stringify(tokenSet),
         scopeOptions(providerId),
       );

--- a/app/core/Engine/controllers/card-controller/CardTokenStore.ts
+++ b/app/core/Engine/controllers/card-controller/CardTokenStore.ts
@@ -1,0 +1,89 @@
+import SecureKeychain from '../../../SecureKeychain';
+import Logger from '../../../../util/Logger';
+
+const KEYCHAIN_PREFIX = 'com.metamask.CARD_TOKENS';
+
+/**
+ * Auth token set stored in SecureKeychain, keyed by provider ID.
+ */
+export interface CardTokenSet {
+  accessToken: string;
+  refreshToken?: string;
+  accessTokenExpiresAt: number;
+  refreshTokenExpiresAt?: number;
+  location?: string;
+}
+
+function scopeOptions(providerId: string) {
+  return {
+    service:
+      providerId === 'baanx'
+        ? 'com.metamask.CARD_BAANX_TOKENS'
+        : `${KEYCHAIN_PREFIX}_${providerId}`,
+    accessible: SecureKeychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  };
+}
+
+/**
+ * SecureKeychain wrapper for Card provider auth tokens.
+ */
+export const CardTokenStore = {
+  async get(providerId: string): Promise<CardTokenSet | null> {
+    try {
+      const item = await SecureKeychain.getSecureItem(scopeOptions(providerId));
+      if (!item) return null;
+
+      const data: Partial<CardTokenSet> = JSON.parse(item.value);
+      if (!data.accessToken || !data.accessTokenExpiresAt) return null;
+
+      return data as CardTokenSet;
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: providerId },
+        context: {
+          name: 'CardTokenStore',
+          data: { method: 'get' },
+        },
+      });
+      return null;
+    }
+  },
+
+  async set(providerId: string, tokenSet: CardTokenSet): Promise<boolean> {
+    try {
+      const result = await SecureKeychain.setSecureItem(
+        `CARD_TOKENS_${providerId}`,
+        JSON.stringify(tokenSet),
+        scopeOptions(providerId),
+      );
+      return result !== false;
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: providerId },
+        context: {
+          name: 'CardTokenStore',
+          data: { method: 'set' },
+        },
+      });
+      return false;
+    }
+  },
+
+  async remove(providerId: string): Promise<boolean> {
+    try {
+      const result = await SecureKeychain.clearSecureScope(
+        scopeOptions(providerId),
+      );
+      return result !== false;
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: providerId },
+        context: {
+          name: 'CardTokenStore',
+          data: { method: 'remove' },
+        },
+      });
+      return false;
+    }
+  },
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds two SecureKeychain-backed stores for the Card feature. These stores will be used by the `CardController` (merged in #27020) to manage auth tokens and onboarding session data.

**Why**: Card auth tokens already live in SecureKeychain via `cardTokenVault.ts`, but the API is tightly coupled to a single provider. Onboarding session data (`onboardingId`, `contactVerificationId`, `consentSetId`).

**What changed**:

- **`CardTokenStore.ts`** (~90 lines): SecureKeychain wrapper for auth tokens keyed by provider ID. For the legacy provider, reads from the same keychain scope as `cardTokenVault.ts` (`com.metamask.CARD_BAANX_TOKENS`) — zero migration, both old and new code can coexist. New providers get their own scoped keychain entry. Methods: `get(providerId)`, `set(providerId, tokenSet)`, `remove(providerId)`. All errors caught and logged with structured Sentry context.

- **`CardOnboardingStore.ts`** (~100 lines): SecureKeychain wrapper for onboarding session data keyed by provider ID. Stores `onboardingId`, `contactVerificationId`, `consentSetId`, and `selectedCountry`. The `set()` method merges partial data with existing data (read-modify-write). Scope: `com.metamask.CARD_ONBOARDING_{providerId}`. Intentionally **not populated** in this PR — it will only be written to when the new controller code path is active (Phase 1d).

- **`CardTokenStore.test.ts`** (151 lines): 8 tests covering retrieval (null, valid, legacy scope, provider-specific scope, invalid data, keychain error), storage (success, failure, error), and removal.

- **`CardOnboardingStore.test.ts`** (162 lines): 8 tests covering retrieval (null, merged with defaults, correct scope, error), storage (merge with existing, create from empty, error), and removal.

**Important design decision**: Neither store is populated during a Redux migration. Onboarding data stays in Redux until the code path switch (Phase 1d), avoiding stale data issues where old code clears Redux via `dispatch(resetOnboardingState())` but has no knowledge of the keychain store. Auth tokens already exist in keychain — `CardTokenStore` reads the same data, no write needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Keychain stores are inert

  Scenario: No user-facing changes
    Given the user is on any screen in the app
    When the app loads
    Then nothing visually changes
    And the Card feature continues to work as before
    And no data is written to CardTokenStore or CardOnboardingStore

  Scenario: Existing card auth tokens are unaffected
    Given the user is authenticated with the Card feature
    When the app updates to this version
    Then the user remains authenticated
    And cardTokenVault.ts continues to read/write tokens as before
```

## **Screenshots/Recordings**

No UI changes — this is an infrastructure-only PR.

### **Before**

Auth tokens managed by `cardTokenVault.ts`. Onboarding data in plaintext Redux.

### **After**

`CardTokenStore` and `CardOnboardingStore` exist alongside existing code. Neither is actively used yet — they are wired in during Phase 1d (code path switch). Existing behavior is unchanged.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, self-contained storage wrappers with unit tests; no existing call sites are changed, so runtime impact is limited unless/until these stores are wired into the card flow.
> 
> **Overview**
> Adds two new SecureKeychain-backed persistence helpers for the Card feature: `CardTokenStore` for provider-scoped auth token sets (including **legacy Baanx** key/scope compatibility) and `CardOnboardingStore` for provider-scoped onboarding session fields with read-modify-write merging.
> 
> Both stores include structured error logging and defensive parsing/validation, plus comprehensive Jest coverage for success paths, scoping, invalid data, and keychain failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47217149545b0d2b7571394405ad4f64adac2e0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->