### PR TITLE
Expired link handling

### DIFF
--- a/app/components/UI/DeepLinkModal/DeepLinkModal.test.tsx
+++ b/app/components/UI/DeepLinkModal/DeepLinkModal.test.tsx
@@ -395,6 +395,7 @@ describe('DeepLinkModal', () => {
     ${'public'}
     ${'private'}
     ${'invalid'}
+    ${'expired'}
   `(
     'calls onBack when back button is pressed for $linkType link',
     async ({ linkType }) => {
@@ -413,4 +414,54 @@ describe('DeepLinkModal', () => {
       expect(mockOnBack).toHaveBeenCalled();
     },
   );
+
+  it('renders expired link UI', () => {
+    (useParams as jest.Mock).mockReturnValue({
+      ...baseParams,
+      linkType: 'expired',
+    });
+    const { getByText, queryByText } = renderScreen(
+      DeepLinkModal,
+      { name: 'DeepLinkModal' },
+      { state: {} },
+    );
+
+    const title = getByText(/This link has expired/i);
+    const description = getByText(
+      /The link you're trying to use is no longer valid/i,
+    );
+    const goToHomeButton = getByText('Go to the home page');
+    const checkbox = queryByText(/Don't remind me again/i);
+
+    expect(title).toBeOnTheScreen();
+    expect(description).toBeOnTheScreen();
+    expect(goToHomeButton).toBeOnTheScreen();
+    expect(checkbox).not.toBeOnTheScreen();
+  });
+
+  it('navigates to home page when primary button is pressed for expired link', async () => {
+    (useParams as jest.Mock).mockReturnValue({
+      ...baseParams,
+      linkType: 'expired',
+      onContinue: mockOnContinue,
+    });
+    const { getByText } = renderScreen(
+      DeepLinkModal,
+      { name: 'DeepLinkModal' },
+      { state: {} },
+    );
+    const continueButton = getByText('Go to the home page');
+
+    await act(async () => {
+      fireEvent.press(continueButton);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('WalletTabHome', {
+      screen: 'WalletTabStackFlow',
+      params: {
+        screen: 'WalletView',
+      },
+    });
+    expect(mockOnContinue).toHaveBeenCalled();
+  });
 });

--- a/app/components/UI/DeepLinkModal/DeepLinkModal.tsx
+++ b/app/components/UI/DeepLinkModal/DeepLinkModal.tsx
@@ -42,7 +42,10 @@ import { DeepLinkModalParams, ModalImageProps } from './types';
 import { DeepLinkModalLinkType } from '../../../core/DeeplinkManager/types/deepLink.types';
 
 const ModalImage = memo<ModalImageProps>(({ linkType, styles }) => {
-  if (linkType === DeepLinkModalLinkType.INVALID) {
+  if (
+    linkType === DeepLinkModalLinkType.INVALID ||
+    linkType === DeepLinkModalLinkType.EXPIRED
+  ) {
     return (
       <View style={styles.pageNotFoundImageContainer}>
         <Image source={pageNotFound} style={styles.pageNotFoundImage} />
@@ -106,7 +109,8 @@ const DeepLinkModal = () => {
 
   const pageTitle =
     params.linkType !== DeepLinkModalLinkType.INVALID &&
-    params.linkType !== DeepLinkModalLinkType.UNSUPPORTED
+    params.linkType !== DeepLinkModalLinkType.UNSUPPORTED &&
+    params.linkType !== DeepLinkModalLinkType.EXPIRED
       ? params.pageTitle
       : undefined;
   const { styles } = useStyles(styleSheet, {});
@@ -145,6 +149,11 @@ const DeepLinkModal = () => {
         description: strings('deep_link_modal.unsupported.description'),
         buttonLabel: strings('deep_link_modal.go_to_home_button'),
       },
+      [DeepLinkModalLinkType.EXPIRED]: {
+        title: strings('deep_link_modal.expired.title'),
+        description: strings('deep_link_modal.expired.description'),
+        buttonLabel: strings('deep_link_modal.go_to_home_button'),
+      },
     }),
     [pageTitle],
   );
@@ -177,9 +186,10 @@ const DeepLinkModal = () => {
     dismissModal(() => {
       if (
         linkType === DeepLinkModalLinkType.INVALID ||
-        linkType === DeepLinkModalLinkType.UNSUPPORTED
+        linkType === DeepLinkModalLinkType.UNSUPPORTED ||
+        linkType === DeepLinkModalLinkType.EXPIRED
       ) {
-        // Navigate to home page for invalid/unsupported links
+        // Navigate to home page for invalid/unsupported/expired links
         navigation.navigate(Routes.WALLET.HOME, {
           screen: Routes.WALLET.TAB_STACK_FLOW,
           params: {

--- a/app/components/UI/DeepLinkModal/types.ts
+++ b/app/components/UI/DeepLinkModal/types.ts
@@ -34,6 +34,12 @@ type UnsupportedLinkParams = CommonLinkParams & {
   pageTitle?: never; // Unsupported links don't have a page title
 };
 
+type ExpiredLinkParams = CommonLinkParams & {
+  linkType: DeepLinkModalLinkType.EXPIRED;
+  onContinue?: () => void; // Optional callback for primary button action (navigate to home)
+  pageTitle?: never; // Expired links don't have a page title
+};
+
 /**
  * Deeplink Modal Params
  */
@@ -41,7 +47,8 @@ export type DeepLinkModalParams =
   | PublicLinkParams
   | PrivateLinkParams
   | InvalidLinkParams
-  | UnsupportedLinkParams;
+  | UnsupportedLinkParams
+  | ExpiredLinkParams;
 
 /**
  * Modal Image Props

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -9,6 +9,7 @@ import {
   INVALID,
   MISSING,
   VALID,
+  EXPIRED,
 } from '../../utils/verifySignature';
 import {
   DeepLinkModalLinkType,
@@ -191,6 +192,7 @@ async function handleUniversalLink({
 
   let isPrivateLink = false;
   let isInvalidLink = false;
+  let isExpiredLink = false;
 
   const action: SUPPORTED_ACTIONS = validatedUrl.pathname.split(
     '/',
@@ -234,6 +236,14 @@ async function handleUniversalLink({
           );
           isPrivateLink = true;
           break;
+        case EXPIRED:
+          DevLogger.log(
+            'DeepLinkManager:parse Expired signature for deeplink',
+            url,
+          );
+          isExpiredLink = true;
+          isPrivateLink = false;
+          break;
         case INVALID:
         case MISSING:
           DevLogger.log(
@@ -255,6 +265,11 @@ async function handleUniversalLink({
     // Invalid domain
     if (isInvalidLink) {
       return DeepLinkModalLinkType.INVALID;
+    }
+
+    // Expired link (signature was valid but has expired)
+    if (isExpiredLink) {
+      return DeepLinkModalLinkType.EXPIRED;
     }
 
     // Unsupported action with valid signature
@@ -404,10 +419,11 @@ async function handleUniversalLink({
       }
 
       // Show modal and track analytics based on user action
-      // For invalid/unsupported links, pass onBack and onContinue callbacks
+      // For invalid/unsupported/expired links, pass onBack and onContinue callbacks
       if (
         linkInstanceType === DeepLinkModalLinkType.INVALID ||
-        linkInstanceType === DeepLinkModalLinkType.UNSUPPORTED
+        linkInstanceType === DeepLinkModalLinkType.UNSUPPORTED ||
+        linkInstanceType === DeepLinkModalLinkType.EXPIRED
       ) {
         const modalParams: DeepLinkModalParams = {
           linkType: linkInstanceType,

--- a/app/core/DeeplinkManager/types/deepLink.types.ts
+++ b/app/core/DeeplinkManager/types/deepLink.types.ts
@@ -75,6 +75,7 @@ export enum DeepLinkModalLinkType {
   PRIVATE = 'private',
   INVALID = 'invalid',
   UNSUPPORTED = 'unsupported',
+  EXPIRED = 'expired',
 }
 
 /**

--- a/app/core/DeeplinkManager/utils/verifySignature.test.ts
+++ b/app/core/DeeplinkManager/utils/verifySignature.test.ts
@@ -3,9 +3,11 @@ import { CryptoKey } from 'react-native-quick-crypto/lib/typescript/src/keys';
 import {
   verifyDeeplinkSignature,
   hasSignature,
+  isDeeplinkExpired,
   MISSING,
   VALID,
   INVALID,
+  EXPIRED,
 } from './verifySignature';
 import AppConstants from '../../AppConstants';
 
@@ -38,6 +40,50 @@ describe('verifySignature', () => {
       expect(MISSING).toBe('MISSING');
       expect(VALID).toBe('VALID');
       expect(INVALID).toBe('INVALID');
+      expect(EXPIRED).toBe('EXPIRED');
+    });
+  });
+
+  describe('isDeeplinkExpired', () => {
+    it('returns false when URL has no exp parameter', () => {
+      const url = new URL('https://example.com?param=value');
+      expect(isDeeplinkExpired(url)).toBe(false);
+    });
+
+    it('returns false when exp parameter is not a valid number', () => {
+      const url = new URL('https://example.com?exp=invalid');
+      expect(isDeeplinkExpired(url)).toBe(false);
+    });
+
+    it('returns false when exp parameter is empty', () => {
+      const url = new URL('https://example.com?exp=');
+      expect(isDeeplinkExpired(url)).toBe(false);
+    });
+
+    it('returns true when exp timestamp is in the past', () => {
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+      const url = new URL(`https://example.com?exp=${pastTimestamp}`);
+      expect(isDeeplinkExpired(url)).toBe(true);
+    });
+
+    it('returns false when exp timestamp is in the future', () => {
+      const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+      const url = new URL(`https://example.com?exp=${futureTimestamp}`);
+      expect(isDeeplinkExpired(url)).toBe(false);
+    });
+
+    it('returns true when exp timestamp is just before current time', () => {
+      const justBeforeNow = Math.floor(Date.now() / 1000) - 1;
+      const url = new URL(`https://example.com?exp=${justBeforeNow}`);
+      expect(isDeeplinkExpired(url)).toBe(true);
+    });
+
+    it('handles exp parameter with other query parameters', () => {
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+      const url = new URL(
+        `https://example.com?param1=value1&exp=${pastTimestamp}&param2=value2`,
+      );
+      expect(isDeeplinkExpired(url)).toBe(true);
     });
   });
 
@@ -92,6 +138,33 @@ describe('verifySignature', () => {
       const url = new URL('https://example.com?sig=');
       const result = await verifyDeeplinkSignature(url);
       expect(result).toBe(MISSING);
+    });
+
+    it('returns EXPIRED when exp timestamp is in the past', async () => {
+      const validSignature = Buffer.from(new Array(64).fill(0)).toString(
+        'base64',
+      );
+      const pastTimestamp = Math.floor(Date.now() / 1000) - 3600;
+      const url = new URL(
+        `https://example.com?sig=${validSignature}&exp=${pastTimestamp}`,
+      );
+      const result = await verifyDeeplinkSignature(url);
+      expect(result).toBe(EXPIRED);
+    });
+
+    it('verifies signature when exp timestamp is in the future', async () => {
+      const validSignature = Buffer.from(new Array(64).fill(0)).toString(
+        'base64',
+      );
+      const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+      const url = new URL(
+        `https://example.com?sig=${validSignature}&exp=${futureTimestamp}`,
+      );
+
+      mockSubtle.verify.mockResolvedValue(true);
+
+      const result = await verifyDeeplinkSignature(url);
+      expect(result).toBe(VALID);
     });
 
     it('returns INVALID when signature has wrong length', async () => {

--- a/app/core/DeeplinkManager/utils/verifySignature.ts
+++ b/app/core/DeeplinkManager/utils/verifySignature.ts
@@ -78,8 +78,13 @@ function canonicalize(url: URL): string {
 export const MISSING = 'MISSING' as const;
 export const VALID = 'VALID' as const;
 export const INVALID = 'INVALID' as const;
+export const EXPIRED = 'EXPIRED' as const;
 
-type VerificationResult = typeof MISSING | typeof VALID | typeof INVALID;
+type VerificationResult =
+  | typeof MISSING
+  | typeof VALID
+  | typeof INVALID
+  | typeof EXPIRED;
 
 let tools: {
   algorithm: SubtleAlgorithm;
@@ -114,12 +119,37 @@ async function lazyGetTools() {
   return tools;
 }
 
+/**
+ * Check if the deeplink has expired based on the 'exp' parameter.
+ * The 'exp' parameter should contain a Unix timestamp in seconds.
+ * @param url - The URL to check for expiration
+ * @returns true if the link has expired, false otherwise
+ */
+export const isDeeplinkExpired = (url: URL): boolean => {
+  const expParam = url.searchParams.get('exp');
+  if (!expParam) {
+    return false;
+  }
+
+  const expirationTimestamp = parseInt(expParam, 10);
+  if (isNaN(expirationTimestamp)) {
+    return false;
+  }
+
+  const currentTimestamp = Math.floor(Date.now() / 1000);
+  return currentTimestamp > expirationTimestamp;
+};
+
 export const verifyDeeplinkSignature = async (
   url: URL,
 ): Promise<VerificationResult> => {
   const signatureStr = url.searchParams.get('sig');
   if (!signatureStr) {
     return MISSING;
+  }
+
+  if (isDeeplinkExpired(url)) {
+    return EXPIRED;
   }
 
   try {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6877,6 +6877,10 @@
       "update_to_store_link": "Update to the latest version of MetaMask",
       "well_take_you_to_right_place": " and we'll take you to the right place."
     },
+    "expired": {
+      "title": "This link has expired",
+      "description": "The link you're trying to use is no longer valid. Please request a new link to continue."
+    },
     "go_to_home_button": "Go to the home page",
     "back_button": "Back",
     "continue_button": "Continue"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add expired link handling for MetaMask Mobile deeplinks to provide clear feedback for users.

Previously, there was no specific handling for expired links, leading to a poor user experience when encountering such links. This PR introduces an `EXPIRED` link type, allowing deeplinks to include an `exp` (expiration timestamp) parameter, and displays an informative modal when a link is no longer valid.

---
[Slack Thread](https://consensys.slack.com/archives/D0AJRKNRT5K/p1772744314852839?thread_ts=1772744314.852839&cid=D0AJRKNRT5K)

<p><a href="https://cursor.com/agents/bc-8585a0e5-6d62-5172-8f80-c61e4bc9d5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8585a0e5-6d62-5172-8f80-c61e4bc9d5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->