### PR TITLE
feat: add @metamask/superstruct as a dependency

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -1,8 +1,22 @@
 import {
+  PredictFeeCollection,
   PredictHotTabFlag,
   PredictLiveSportsFlag,
   PredictMarketHighlightsFlag,
 } from '../types/flags';
+
+export const DEFAULT_FEE_COLLECTION_FLAG = {
+  enabled: true,
+  collector:
+    process.env.METAMASK_ENVIRONMENT === 'dev'
+      ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
+      : '0x100c7b833bbd604a77890783439bbb9d65e31de7',
+  metamaskFee: 0.02, // 2%
+  providerFee: 0.02, // 2%
+  waiveList: [],
+  executors: [],
+  permit2Enabled: false,
+} satisfies PredictFeeCollection;
 
 export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {
   enabled: false,

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -1,22 +1,8 @@
 import {
-  PredictFeeCollection,
   PredictHotTabFlag,
   PredictLiveSportsFlag,
   PredictMarketHighlightsFlag,
 } from '../types/flags';
-
-export const DEFAULT_FEE_COLLECTION_FLAG = {
-  enabled: true,
-  collector:
-    process.env.METAMASK_ENVIRONMENT === 'dev'
-      ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
-      : '0x100c7b833bbd604a77890783439bbb9d65e31de7',
-  metamaskFee: 0.02, // 2%
-  providerFee: 0.02, // 2%
-  waiveList: [],
-  executors: [],
-  permit2Enabled: false,
-} satisfies PredictFeeCollection;
 
 export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {
   enabled: false,

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -101,7 +101,6 @@ import {
   POLYMARKET_PROVIDER_ID,
 } from '../providers/polymarket/constants';
 import {
-  DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
   DEFAULT_MARKET_HIGHLIGHTS_FLAG,
 } from '../constants/flags';
@@ -116,6 +115,8 @@ import {
   validatedVersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
 import { unwrapRemoteFeatureFlag } from '../utils/flags';
+import { create } from '@metamask/superstruct';
+import { PredictFeeCollectionSchema } from '../schemas';
 
 /**
  * State shape for PredictController
@@ -438,10 +439,12 @@ export class PredictController extends BaseController<
         ? rawMarketHighlightsFlag
         : DEFAULT_MARKET_HIGHLIGHTS_FLAG;
 
-    const feeCollection =
+    const feeCollection = create(
       unwrapRemoteFeatureFlag<PredictFeatureFlags['feeCollection']>(
         flags.predictFeeCollection,
-      ) ?? DEFAULT_FEE_COLLECTION_FLAG;
+      ),
+      PredictFeeCollectionSchema,
+    );
 
     const fakOrdersEnabled =
       validatedVersionGatedFeatureFlag(

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -101,6 +101,7 @@ import {
   POLYMARKET_PROVIDER_ID,
 } from '../providers/polymarket/constants';
 import {
+  DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
   DEFAULT_MARKET_HIGHLIGHTS_FLAG,
 } from '../constants/flags';
@@ -115,8 +116,7 @@ import {
   validatedVersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
 import { unwrapRemoteFeatureFlag } from '../utils/flags';
-import { create } from '@metamask/superstruct';
-import { PredictFeeCollectionSchema } from '../schemas';
+import { parse, PredictFeeCollectionSchema } from '../schemas';
 
 /**
  * State shape for PredictController
@@ -439,11 +439,12 @@ export class PredictController extends BaseController<
         ? rawMarketHighlightsFlag
         : DEFAULT_MARKET_HIGHLIGHTS_FLAG;
 
-    const feeCollection = create(
+    const feeCollection = parse(
       unwrapRemoteFeatureFlag<PredictFeatureFlags['feeCollection']>(
         flags.predictFeeCollection,
       ),
       PredictFeeCollectionSchema,
+      DEFAULT_FEE_COLLECTION_FLAG,
     );
 
     const fakOrdersEnabled =

--- a/app/components/UI/Predict/schemas/common.test.ts
+++ b/app/components/UI/Predict/schemas/common.test.ts
@@ -1,0 +1,70 @@
+import { create, StructError } from '@metamask/superstruct';
+import { Hex } from './common';
+
+describe('Hex schema', () => {
+  it('validates a string starting with 0x', () => {
+    const input = '0xabc123';
+
+    const result = create(input, Hex);
+
+    expect(result).toBe('0xabc123');
+  });
+
+  it('validates a minimal 0x string', () => {
+    const input = '0x';
+
+    const result = create(input, Hex);
+
+    expect(result).toBe('0x');
+  });
+
+  it('validates a full-length Ethereum address', () => {
+    const input = '0xe6a2026d58eaff3c7ad7ba9386fb143388002382';
+
+    const result = create(input, Hex);
+
+    expect(result).toBe('0xe6a2026d58eaff3c7ad7ba9386fb143388002382');
+  });
+
+  it('throws for a string without 0x prefix', () => {
+    const input = 'abc123';
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+
+  it('throws for an empty string', () => {
+    const input = '';
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+
+  it('throws for a number value', () => {
+    const input = 123;
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+
+  it('throws for null', () => {
+    const input = null;
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+
+  it('throws for undefined', () => {
+    const input = undefined;
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+
+  it('throws for a boolean value', () => {
+    const input = true;
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+
+  it('throws for an object', () => {
+    const input = { value: '0x123' };
+
+    expect(() => create(input, Hex)).toThrow(StructError);
+  });
+});

--- a/app/components/UI/Predict/schemas/common.test.ts
+++ b/app/components/UI/Predict/schemas/common.test.ts
@@ -1,11 +1,11 @@
 import { create, StructError } from '@metamask/superstruct';
-import { Hex } from './common';
+import { HexSchema } from './common';
 
 describe('Hex schema', () => {
   it('validates a string starting with 0x', () => {
     const input = '0xabc123';
 
-    const result = create(input, Hex);
+    const result = create(input, HexSchema);
 
     expect(result).toBe('0xabc123');
   });
@@ -13,7 +13,7 @@ describe('Hex schema', () => {
   it('validates a minimal 0x string', () => {
     const input = '0x';
 
-    const result = create(input, Hex);
+    const result = create(input, HexSchema);
 
     expect(result).toBe('0x');
   });
@@ -21,7 +21,7 @@ describe('Hex schema', () => {
   it('validates a full-length Ethereum address', () => {
     const input = '0xe6a2026d58eaff3c7ad7ba9386fb143388002382';
 
-    const result = create(input, Hex);
+    const result = create(input, HexSchema);
 
     expect(result).toBe('0xe6a2026d58eaff3c7ad7ba9386fb143388002382');
   });
@@ -29,42 +29,42 @@ describe('Hex schema', () => {
   it('throws for a string without 0x prefix', () => {
     const input = 'abc123';
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 
   it('throws for an empty string', () => {
     const input = '';
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 
   it('throws for a number value', () => {
     const input = 123;
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 
   it('throws for null', () => {
     const input = null;
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 
   it('throws for undefined', () => {
     const input = undefined;
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 
   it('throws for a boolean value', () => {
     const input = true;
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 
   it('throws for an object', () => {
     const input = { value: '0x123' };
 
-    expect(() => create(input, Hex)).toThrow(StructError);
+    expect(() => create(input, HexSchema)).toThrow(StructError);
   });
 });

--- a/app/components/UI/Predict/schemas/common.ts
+++ b/app/components/UI/Predict/schemas/common.ts
@@ -1,0 +1,8 @@
+import { define } from '@metamask/superstruct';
+
+export const Hex = define<`0x${string}`>('Hex', (value) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return value.startsWith('0x');
+});

--- a/app/components/UI/Predict/schemas/common.ts
+++ b/app/components/UI/Predict/schemas/common.ts
@@ -1,6 +1,7 @@
 import { define } from '@metamask/superstruct';
+import { Hex } from '@metamask/utils';
 
-export const HexSchema = define<`0x${string}`>('Hex', (value) => {
+export const HexSchema = define<Hex>('HexSchema', (value) => {
   if (typeof value !== 'string') {
     return false;
   }

--- a/app/components/UI/Predict/schemas/common.ts
+++ b/app/components/UI/Predict/schemas/common.ts
@@ -1,6 +1,6 @@
 import { define } from '@metamask/superstruct';
 
-export const Hex = define<`0x${string}`>('Hex', (value) => {
+export const HexSchema = define<`0x${string}`>('Hex', (value) => {
   if (typeof value !== 'string') {
     return false;
   }

--- a/app/components/UI/Predict/schemas/flags.test.ts
+++ b/app/components/UI/Predict/schemas/flags.test.ts
@@ -1,0 +1,176 @@
+import { create, StructError } from '@metamask/superstruct';
+import { PredictFeeCollectionSchema } from './flags';
+import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
+
+describe('PredictFeeCollectionSchema', () => {
+  describe('defaults', () => {
+    it('returns all defaults when input is undefined', () => {
+      const result = create(undefined, PredictFeeCollectionSchema);
+
+      expect(result).toStrictEqual(DEFAULT_FEE_COLLECTION_FLAG);
+    });
+
+    it('returns all defaults when input is an empty object', () => {
+      const result = create({}, PredictFeeCollectionSchema);
+
+      expect(result).toStrictEqual(DEFAULT_FEE_COLLECTION_FLAG);
+    });
+
+    it('fills missing fields with defaults', () => {
+      const input = { enabled: false };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.enabled).toBe(false);
+      expect(result.collector).toBe(DEFAULT_FEE_COLLECTION_FLAG.collector);
+      expect(result.metamaskFee).toBe(DEFAULT_FEE_COLLECTION_FLAG.metamaskFee);
+      expect(result.providerFee).toBe(DEFAULT_FEE_COLLECTION_FLAG.providerFee);
+      expect(result.waiveList).toStrictEqual(
+        DEFAULT_FEE_COLLECTION_FLAG.waiveList,
+      );
+      expect(result.executors).toStrictEqual(
+        DEFAULT_FEE_COLLECTION_FLAG.executors,
+      );
+      expect(result.permit2Enabled).toBe(
+        DEFAULT_FEE_COLLECTION_FLAG.permit2Enabled,
+      );
+    });
+  });
+
+  describe('valid inputs', () => {
+    it('preserves all provided fields', () => {
+      const input = {
+        enabled: false,
+        collector: '0x1234567890abcdef1234567890abcdef12345678',
+        metamaskFee: 0.05,
+        providerFee: 0.03,
+        waiveList: ['0xaaa', '0xbbb'],
+        executors: ['0xccc'],
+        permit2Enabled: true,
+      };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result).toStrictEqual(input);
+    });
+
+    it('preserves enabled=false override', () => {
+      const input = { enabled: false };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.enabled).toBe(false);
+    });
+
+    it('preserves custom collector address', () => {
+      const input = {
+        collector: '0x0000000000000000000000000000000000000001',
+      };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.collector).toBe(
+        '0x0000000000000000000000000000000000000001',
+      );
+    });
+
+    it('preserves custom fee values', () => {
+      const input = { metamaskFee: 0.1, providerFee: 0 };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.metamaskFee).toBe(0.1);
+      expect(result.providerFee).toBe(0);
+    });
+
+    it('preserves non-empty waiveList', () => {
+      const input = { waiveList: ['0xaaa', '0xbbb'] };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.waiveList).toStrictEqual(['0xaaa', '0xbbb']);
+    });
+
+    it('preserves non-empty executors list', () => {
+      const input = { executors: ['0xexec1', '0xexec2'] };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.executors).toStrictEqual(['0xexec1', '0xexec2']);
+    });
+
+    it('preserves permit2Enabled=true override', () => {
+      const input = { permit2Enabled: true };
+
+      const result = create(input, PredictFeeCollectionSchema);
+
+      expect(result.permit2Enabled).toBe(true);
+    });
+  });
+
+  describe('type validation', () => {
+    it('throws for non-boolean enabled field', () => {
+      const input = { enabled: 'yes' };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for non-string collector field', () => {
+      const input = { collector: 12345 };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for non-number metamaskFee field', () => {
+      const input = { metamaskFee: '0.02' };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for non-number providerFee field', () => {
+      const input = { providerFee: true };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for non-array waiveList field', () => {
+      const input = { waiveList: 'not-an-array' };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for non-array executors field', () => {
+      const input = { executors: 42 };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for non-boolean permit2Enabled field', () => {
+      const input = { permit2Enabled: 'true' };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+
+    it('throws for collector without 0x prefix', () => {
+      const input = { collector: 'not-a-hex-address' };
+
+      expect(() => create(input, PredictFeeCollectionSchema)).toThrow(
+        StructError,
+      );
+    });
+  });
+});

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -6,13 +6,16 @@ import {
   object,
   string,
 } from '@metamask/superstruct';
-import { Hex } from './common';
+import { HexSchema } from './common';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
 
 export const PredictFeeCollectionSchema = defaulted(
   object({
     enabled: defaulted(boolean(), () => DEFAULT_FEE_COLLECTION_FLAG.enabled),
-    collector: defaulted(Hex, () => DEFAULT_FEE_COLLECTION_FLAG.collector),
+    collector: defaulted(
+      HexSchema,
+      () => DEFAULT_FEE_COLLECTION_FLAG.collector,
+    ),
     metamaskFee: defaulted(
       number(),
       () => DEFAULT_FEE_COLLECTION_FLAG.metamaskFee,

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -1,0 +1,23 @@
+import {
+  array,
+  boolean,
+  defaulted,
+  number,
+  object,
+  string,
+} from '@metamask/superstruct';
+import { Hex } from './common';
+
+export const PredictFeeCollectionSchema = object({
+  enabled: defaulted(boolean(), true),
+  collector: defaulted(Hex, () =>
+    process.env.METAMASK_ENVIRONMENT === 'dev'
+      ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
+      : '0x100c7b833bbd604a77890783439bbb9d65e31de7',
+  ),
+  metamaskFee: defaulted(number(), 0.02), // 2%
+  providerFee: defaulted(number(), 0.02),
+  waiveList: defaulted(array(string()), []),
+  executors: defaulted(array(string()), []),
+  permit2Enabled: defaulted(boolean(), false),
+});

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -7,32 +7,29 @@ import {
   string,
 } from '@metamask/superstruct';
 import { Hex } from './common';
-
-const DEFAULT_FEE_COLLECTOR =
-  process.env.METAMASK_ENVIRONMENT === 'dev'
-    ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
-    : '0x100c7b833bbd604a77890783439bbb9d65e31de7';
-
-const DEFAULT_METAMASK_FEE = 0.02; // 2%
-const DEFAULT_PROVIDER_FEE = 0.02; // 2%
+import { DEFAULT_FEE_COLLECTION_FLAG } from '../constants/flags';
 
 export const PredictFeeCollectionSchema = defaulted(
   object({
-    enabled: defaulted(boolean(), () => true),
-    collector: defaulted(Hex, () => DEFAULT_FEE_COLLECTOR),
-    metamaskFee: defaulted(number(), () => DEFAULT_METAMASK_FEE),
-    providerFee: defaulted(number(), () => DEFAULT_PROVIDER_FEE),
-    waiveList: defaulted(array(string()), () => []),
-    executors: defaulted(array(string()), () => []),
+    enabled: defaulted(boolean(), () => DEFAULT_FEE_COLLECTION_FLAG.enabled),
+    collector: defaulted(Hex, () => DEFAULT_FEE_COLLECTION_FLAG.collector),
+    metamaskFee: defaulted(
+      number(),
+      () => DEFAULT_FEE_COLLECTION_FLAG.metamaskFee,
+    ),
+    providerFee: defaulted(
+      number(),
+      () => DEFAULT_FEE_COLLECTION_FLAG.providerFee,
+    ),
+    waiveList: defaulted(
+      array(string()),
+      () => DEFAULT_FEE_COLLECTION_FLAG.waiveList,
+    ),
+    executors: defaulted(
+      array(string()),
+      () => DEFAULT_FEE_COLLECTION_FLAG.executors,
+    ),
     permit2Enabled: defaulted(boolean(), () => false),
   }),
-  () => ({
-    enabled: true,
-    collector: DEFAULT_FEE_COLLECTOR,
-    metamaskFee: DEFAULT_METAMASK_FEE,
-    providerFee: DEFAULT_PROVIDER_FEE,
-    waiveList: [],
-    executors: [],
-    permit2Enabled: false,
-  }),
+  () => DEFAULT_FEE_COLLECTION_FLAG,
 );

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -18,15 +18,15 @@ const DEFAULT_PROVIDER_FEE = 0.02; // 2%
 
 export const PredictFeeCollectionSchema = defaulted(
   object({
-    enabled: defaulted(boolean(), true),
+    enabled: defaulted(boolean(), () => true),
     collector: defaulted(Hex, () => DEFAULT_FEE_COLLECTOR),
-    metamaskFee: defaulted(number(), DEFAULT_METAMASK_FEE),
-    providerFee: defaulted(number(), DEFAULT_PROVIDER_FEE),
-    waiveList: defaulted(array(string()), []),
-    executors: defaulted(array(string()), []),
-    permit2Enabled: defaulted(boolean(), false),
+    metamaskFee: defaulted(number(), () => DEFAULT_METAMASK_FEE),
+    providerFee: defaulted(number(), () => DEFAULT_PROVIDER_FEE),
+    waiveList: defaulted(array(string()), () => []),
+    executors: defaulted(array(string()), () => []),
+    permit2Enabled: defaulted(boolean(), () => false),
   }),
-  {
+  () => ({
     enabled: true,
     collector: DEFAULT_FEE_COLLECTOR,
     metamaskFee: DEFAULT_METAMASK_FEE,
@@ -34,5 +34,5 @@ export const PredictFeeCollectionSchema = defaulted(
     waiveList: [],
     executors: [],
     permit2Enabled: false,
-  },
+  }),
 );

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -8,16 +8,31 @@ import {
 } from '@metamask/superstruct';
 import { Hex } from './common';
 
-export const PredictFeeCollectionSchema = object({
-  enabled: defaulted(boolean(), true),
-  collector: defaulted(Hex, () =>
-    process.env.METAMASK_ENVIRONMENT === 'dev'
-      ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
-      : '0x100c7b833bbd604a77890783439bbb9d65e31de7',
-  ),
-  metamaskFee: defaulted(number(), 0.02), // 2%
-  providerFee: defaulted(number(), 0.02),
-  waiveList: defaulted(array(string()), []),
-  executors: defaulted(array(string()), []),
-  permit2Enabled: defaulted(boolean(), false),
-});
+const DEFAULT_FEE_COLLECTOR =
+  process.env.METAMASK_ENVIRONMENT === 'dev'
+    ? '0xe6a2026d58eaff3c7ad7ba9386fb143388002382'
+    : '0x100c7b833bbd604a77890783439bbb9d65e31de7';
+
+const DEFAULT_METAMASK_FEE = 0.02; // 2%
+const DEFAULT_PROVIDER_FEE = 0.02; // 2%
+
+export const PredictFeeCollectionSchema = defaulted(
+  object({
+    enabled: defaulted(boolean(), true),
+    collector: defaulted(Hex, () => DEFAULT_FEE_COLLECTOR),
+    metamaskFee: defaulted(number(), DEFAULT_METAMASK_FEE),
+    providerFee: defaulted(number(), DEFAULT_PROVIDER_FEE),
+    waiveList: defaulted(array(string()), []),
+    executors: defaulted(array(string()), []),
+    permit2Enabled: defaulted(boolean(), false),
+  }),
+  {
+    enabled: true,
+    collector: DEFAULT_FEE_COLLECTOR,
+    metamaskFee: DEFAULT_METAMASK_FEE,
+    providerFee: DEFAULT_PROVIDER_FEE,
+    waiveList: [],
+    executors: [],
+    permit2Enabled: false,
+  },
+);

--- a/app/components/UI/Predict/schemas/index.ts
+++ b/app/components/UI/Predict/schemas/index.ts
@@ -1,2 +1,4 @@
+export { parse } from './utils';
+
 export { HexSchema } from './common';
 export { PredictFeeCollectionSchema } from './flags';

--- a/app/components/UI/Predict/schemas/index.ts
+++ b/app/components/UI/Predict/schemas/index.ts
@@ -1,0 +1,2 @@
+export { Hex } from './common';
+export { PredictFeeCollectionSchema } from './flags';

--- a/app/components/UI/Predict/schemas/index.ts
+++ b/app/components/UI/Predict/schemas/index.ts
@@ -1,2 +1,2 @@
-export { Hex } from './common';
+export { HexSchema } from './common';
 export { PredictFeeCollectionSchema } from './flags';

--- a/app/components/UI/Predict/schemas/utils.test.ts
+++ b/app/components/UI/Predict/schemas/utils.test.ts
@@ -1,0 +1,100 @@
+import { string, number, defaulted, object } from '@metamask/superstruct';
+import { parse } from './utils';
+import { HexSchema } from './common';
+
+describe('parse', () => {
+  describe('with valid values', () => {
+    it('returns the parsed value for a matching string schema', () => {
+      const input = 'hello';
+
+      const result = parse(input, string());
+
+      expect(result).toBe('hello');
+    });
+
+    it('returns the parsed value for a matching number schema', () => {
+      const input = 42;
+
+      const result = parse(input, number());
+
+      expect(result).toBe(42);
+    });
+
+    it('returns the parsed value for a custom Hex schema', () => {
+      const input = '0xabc';
+
+      const result = parse(input, HexSchema);
+
+      expect(result).toBe('0xabc');
+    });
+
+    it('applies schema defaults for missing fields', () => {
+      const schema = object({
+        name: defaulted(string(), () => 'default-name'),
+        count: defaulted(number(), () => 0),
+      });
+
+      const result = parse({}, schema);
+
+      expect(result).toStrictEqual({ name: 'default-name', count: 0 });
+    });
+  });
+
+  describe('without defaultValue', () => {
+    it('throws with wrapped message for type mismatch', () => {
+      const input = 123;
+
+      expect(() => parse(input, string())).toThrow('Invalid value:');
+    });
+
+    it('throws with wrapped message for null input', () => {
+      const input = null;
+
+      expect(() => parse(input, string())).toThrow('Invalid value:');
+    });
+
+    it('throws with wrapped message for failing custom schema', () => {
+      const input = 'not-hex';
+
+      expect(() => parse(input, HexSchema)).toThrow('Invalid value:');
+    });
+  });
+
+  describe('with defaultValue', () => {
+    it('returns defaultValue when validation fails', () => {
+      const input = 'not-a-number';
+
+      const result = parse(input, number(), 99);
+
+      expect(result).toBe(99);
+    });
+
+    it('returns defaultValue for null input', () => {
+      const result = parse(null, string(), 'fallback');
+
+      expect(result).toBe('fallback');
+    });
+
+    it('returns defaultValue for undefined input', () => {
+      const result = parse(undefined, number(), -1);
+
+      expect(result).toBe(-1);
+    });
+
+    it('returns parsed value when validation passes despite defaultValue being provided', () => {
+      const input = 'valid';
+
+      const result = parse(input, string(), 'fallback');
+
+      expect(result).toBe('valid');
+    });
+
+    it('returns defaultValue for a failing custom Hex schema', () => {
+      const input = 'no-prefix';
+
+      const result = parse(input, HexSchema, '0x0' as `0x${string}`);
+
+      expect(result).toBe('0x0');
+    });
+  });
+});

--- a/app/components/UI/Predict/schemas/utils.ts
+++ b/app/components/UI/Predict/schemas/utils.ts
@@ -1,0 +1,20 @@
+import { create, Struct, StructError } from '@metamask/superstruct';
+
+export function parse<T>(
+  value: unknown,
+  schema: Struct<T, unknown>,
+  defaultValue?: T,
+) {
+  try {
+    return create(value, schema);
+  } catch (error) {
+    if (defaultValue !== undefined) {
+      return defaultValue;
+    }
+    if (error instanceof StructError || error instanceof Error) {
+      throw new Error(`Invalid value: ${error.message}`);
+    } else {
+      throw new Error(`Invalid value: ${error}`);
+    }
+  }
+}

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -1,15 +1,8 @@
-import type { Hex } from '@metamask/utils';
+import { Infer } from '@metamask/superstruct';
+import { PredictFeeCollectionSchema } from '../schemas';
 import { VersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
 
-export interface PredictFeeCollection {
-  enabled: boolean;
-  collector: Hex;
-  metamaskFee: number;
-  providerFee: number;
-  waiveList: string[];
-  executors?: string[];
-  permit2Enabled?: boolean;
-}
+export type PredictFeeCollection = Infer<typeof PredictFeeCollectionSchema>;
 
 export interface PredictLiveSportsFlag {
   enabled: boolean;

--- a/package.json
+++ b/package.json
@@ -510,7 +510,6 @@
     "@google/generative-ai": "^0.24.1",
     "@lavamoat/allow-scripts": "^3.0.4",
     "@lavamoat/git-safe-dependencies": "^0.2.1",
-    "@metamask/abi-utils": "^3.0.0",
     "@metamask/auto-changelog": "^5.3.0",
     "@metamask/browser-passworder": "^5.0.0",
     "@metamask/browser-playground": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -293,6 +293,7 @@
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/stake-sdk": "^3.4.0",
     "@metamask/storage-service": "^1.0.0",
+    "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/transaction-controller": "^62.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35479,6 +35479,7 @@ __metadata:
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@metamask/stake-sdk": "npm:^3.4.0"
     "@metamask/storage-service": "npm:^1.0.0"
+    "@metamask/superstruct": "npm:^3.2.1"
     "@metamask/swappable-obj-proxy": "npm:^2.1.0"
     "@metamask/swaps-controller": "npm:^15.0.0"
     "@metamask/test-dapp": "npm:9.5.0"


### PR DESCRIPTION
## **Description**

- Add `@metamask/superstruct` (^3.2.1) as a direct dependency. This package provides runtime type validation utilities used across the MetaMask ecosystem.
- Remove `@metamask/abi-utils` from `devDependencies` — it was duplicated, already present in `dependencies`.
- Use `superstruct` for parsing Predict `feeCollection` feature flag

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: superstruct dependency

  Scenario: app builds with new dependency
    Given the dependency is added to package.json

    When the app is built
    Then it should build successfully without errors
```

## **Screenshots/Recordings**

N/A — dependency-only change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency and validation change; main behavioral impact is that invalid `predictFeeCollection` remote flag payloads now reliably fall back to `DEFAULT_FEE_COLLECTION_FLAG` instead of being used unchecked.
> 
> **Overview**
> Adds `@metamask/superstruct` as a direct dependency (and removes duplicate `@metamask/abi-utils` from `devDependencies`).
> 
> Introduces a small `Predict` schema layer (`parse` helper, `HexSchema`, and `PredictFeeCollectionSchema` with defaults) and updates `PredictController.resolveFeatureFlags()` to validate/normalize the `feeCollection` remote feature flag, falling back to `DEFAULT_FEE_COLLECTION_FLAG` on invalid input. Includes unit tests covering schema validation, defaulting, and `parse` fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b94d17c05ec427f5c46f8b569907f65d1ac72d20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->