### PR TITLE
feat: Updating mUSD conversion copy to reflect annualized bonus and claim timeline cp-7.69.0

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -57,7 +57,9 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
       ),
     ).toBeOnTheScreen();
     expect(
-      getByText(/Convert your stablecoins to mUSD.*receive up to a \d+% bonus/),
+      getByText(
+        /Convert your stablecoins to mUSD.*earn up to a \d+% annualized bonus/,
+      ),
     ).toBeOnTheScreen();
     expect(
       getByText(strings('earn.musd_conversion.education.primary_button')),
@@ -389,7 +391,7 @@ describeForPlatforms('EarnMusdConversionEducationView', () => {
 
     // Assert
     const description = getByText(
-      /Convert your stablecoins to mUSD.*receive up to a \d+% bonus/,
+      /Convert your stablecoins to mUSD.*earn up to a \d+% annualized bonus/,
     );
     expect(description).toBeOnTheScreen();
     expect(description.props.children[0]).toContain(`${MUSD_CONVERSION_APY}%`);

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.test.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.test.tsx
@@ -311,7 +311,7 @@ describe('MusdQuickConvertView', () => {
       expect(
         getByText(
           strings('earn.musd_conversion.quick_convert.title', {
-            apy: MUSD_CONVERSION_APY,
+            percentage: MUSD_CONVERSION_APY,
           }),
         ),
       ).toBeOnTheScreen();

--- a/app/components/UI/Earn/Views/MusdQuickConvertView/index.tsx
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/index.tsx
@@ -258,12 +258,12 @@ const MusdQuickConvertView = () => {
         <View style={styles.headerTextContainer}>
           <Text variant={TextVariant.HeadingLG}>
             {strings('earn.musd_conversion.quick_convert.title', {
-              apy: MUSD_CONVERSION_APY,
+              percentage: MUSD_CONVERSION_APY,
             })}
           </Text>
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
             {strings('earn.musd_conversion.quick_convert.subtitle', {
-              apy: MUSD_CONVERSION_APY,
+              percentage: MUSD_CONVERSION_APY,
             })}{' '}
             <Text
               variant={TextVariant.BodySM}

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.test.tsx
@@ -131,7 +131,7 @@ describe('MusdConversionAssetOverviewCta', () => {
       ).toBeOnTheScreen();
       expect(
         getByText(
-          `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
+          `Convert your stablecoins to mUSD and get a ${MUSD_CONVERSION_APY}% annualized bonus.`,
         ),
       ).toBeOnTheScreen();
     });

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -103,7 +103,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     ).toBeOnTheScreen();
     expect(
       getByText(
-        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
+        `Convert your stablecoins to mUSD and get a ${MUSD_CONVERSION_APY}% annualized bonus.`,
       ),
     ).toBeOnTheScreen();
   });
@@ -537,7 +537,7 @@ describeForPlatforms('MusdConversionAssetOverviewCta', () => {
     // Assert
     expect(
       getByText(
-        `Convert your stablecoins to mUSD and receive up to a ${MUSD_CONVERSION_APY}% bonus.`,
+        `Convert your stablecoins to mUSD and get a ${MUSD_CONVERSION_APY}% annualized bonus.`,
       ),
     ).toBeOnTheScreen();
   });

--- a/app/components/UI/Earn/hooks/useEarnToasts.test.tsx
+++ b/app/components/UI/Earn/hooks/useEarnToasts.test.tsx
@@ -200,7 +200,7 @@ describe('useEarnToasts', () => {
 
       expect(successToast.labelOptions).toBeDefined();
       expect(Array.isArray(successToast.labelOptions)).toBe(true);
-      expect(successToast.labelOptions).toHaveLength(1);
+      expect(successToast.labelOptions).toHaveLength(3);
     });
 
     it('includes labelOptions in failed toast', () => {

--- a/app/components/UI/Earn/hooks/useEarnToasts.tsx
+++ b/app/components/UI/Earn/hooks/useEarnToasts.tsx
@@ -14,7 +14,12 @@ import {
 } from '../../../../component-library/components/Toast/Toast.types';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
-import { IconSize as ReactNativeDsIconSize } from '@metamask/design-system-react-native';
+import {
+  IconSize as ReactNativeDsIconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 
 export type EarnToastOptions = Omit<
   Extract<ToastOptions, { variant: ToastVariants.Icon }>,
@@ -185,6 +190,14 @@ const useEarnToasts = (): {
           ...earnBaseToastOptions.success,
           labelOptions: getEarnToastLabels({
             primary: strings('earn.musd_conversion.toasts.delivered'),
+            secondary: (
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {strings('earn.musd_conversion.toasts.delivered_description')}
+              </Text>
+            ),
           }),
           closeButtonOptions,
         },

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
@@ -4,11 +4,8 @@ import { PercentageRow } from './percentage-row';
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
 import { strings } from '../../../../../../../locales/i18n';
 import { MUSD_CONVERSION_APY } from '../../../../../UI/Earn/constants/musd';
-import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { TransactionType } from '@metamask/transaction-controller';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
-jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 
 function render() {
   return renderWithProvider(<PercentageRow />);
@@ -18,17 +15,11 @@ describe('PercentageRow', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
-  const useTransactionMetadataRequestMock = jest.mocked(
-    useTransactionMetadataRequest,
-  );
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.musdConversion,
-    } as never);
   });
 
   it('renders label, tooltip and APY when not loading', () => {
@@ -37,28 +28,6 @@ describe('PercentageRow', () => {
     expect(getByText(strings('earn.claimable_bonus'))).toBeOnTheScreen();
     expect(getByTestId('info-row-tooltip-open-btn')).toBeOnTheScreen();
     expect(getByText(`${MUSD_CONVERSION_APY}%`)).toBeOnTheScreen();
-  });
-
-  it('renders nothing when tx type is not supported', () => {
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.contractInteraction,
-    } as never);
-
-    const { queryByText, queryByTestId } = render();
-
-    expect(queryByTestId('percentage-row-skeleton')).toBeNull();
-    expect(queryByText(strings('earn.claimable_bonus'))).toBeNull();
-    expect(queryByText(`${MUSD_CONVERSION_APY}%`)).toBeNull();
-  });
-
-  it('renders nothing when transaction metadata is undefined', () => {
-    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
-
-    const { queryByText, queryByTestId } = render();
-
-    expect(queryByTestId('percentage-row-skeleton')).toBeNull();
-    expect(queryByText(strings('earn.claimable_bonus'))).toBeNull();
-    expect(queryByText(`${MUSD_CONVERSION_APY}%`)).toBeNull();
   });
 
   it('renders skeleton when transaction pay is loading', () => {

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.test.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { PercentageRow } from './percentage-row';
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { strings } from '../../../../../../../locales/i18n';
 import { MUSD_CONVERSION_APY } from '../../../../../UI/Earn/constants/musd';
+import { TransactionType } from '@metamask/transaction-controller';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 
 function render() {
   return renderWithProvider(<PercentageRow />);
@@ -15,11 +18,17 @@ describe('PercentageRow', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.musdConversion,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
   });
 
   it('renders label, tooltip and APY when not loading', () => {
@@ -36,5 +45,15 @@ describe('PercentageRow', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('percentage-row-skeleton')).toBeOnTheScreen();
+  });
+
+  it('renders nothing for non-musdConversion transactions', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.simpleSend,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    const { toJSON } = render();
+
+    expect(toJSON()).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet, Linking } from 'react-native';
 import InfoRow from '../../UI/info-row';
 import { MUSD_CONVERSION_APY } from '../../../../../UI/Earn/constants/musd';
 import Text, {
@@ -8,45 +9,36 @@ import Text, {
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
 import { InfoRowSkeleton } from '../../UI/info-row/info-row';
 import { strings } from '../../../../../../../locales/i18n';
-import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { TransactionType } from '@metamask/transaction-controller';
 import { IconColor } from '../../../../../../component-library/components/Icons/Icon';
+import AppConstants from '../../../../../../core/AppConstants';
 
-function getTxTypeRowConfig(
-  transactionType?: TransactionType,
-): { label: string; tooltip: string } | undefined {
-  if (transactionType === TransactionType.musdConversion) {
-    return {
-      label: strings('earn.claimable_bonus'),
-      tooltip: strings('earn.claimable_bonus_tooltip'),
-    };
-  }
-
-  return undefined;
-}
+const styles = StyleSheet.create({
+  termsText: {
+    textDecorationLine: 'underline',
+  },
+});
 
 export function PercentageRow() {
-  const transactionMetadata = useTransactionMetadataRequest();
-
   const isLoading = useIsTransactionPayLoading();
 
-  const transactionType = transactionMetadata?.type;
-  const rowConfig = getTxTypeRowConfig(transactionType);
-
-  if (!rowConfig) {
-    return null;
-  }
+  const redirectToBonusFaq = () =>
+    Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);
 
   if (isLoading) {
     return <InfoRowSkeleton testId="percentage-row-skeleton" />;
   }
 
-  const { label, tooltip } = rowConfig;
-
   return (
     <InfoRow
-      label={label}
-      tooltip={tooltip}
+      label={strings('earn.claimable_bonus')}
+      tooltip={
+        <Text>
+          {strings('earn.claimable_bonus_tooltip')}{' '}
+          <Text style={styles.termsText} onPress={redirectToBonusFaq}>
+            {strings('earn.musd_conversion.education.terms_apply')}
+          </Text>
+        </Text>
+      }
       tooltipColor={IconColor.Alternative}
     >
       <Text variant={TextVariant.BodyMD} color={TextColor.Success}>

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
@@ -11,6 +11,9 @@ import { InfoRowSkeleton } from '../../UI/info-row/info-row';
 import { strings } from '../../../../../../../locales/i18n';
 import { IconColor } from '../../../../../../component-library/components/Icons/Icon';
 import AppConstants from '../../../../../../core/AppConstants';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../../utils/transaction';
 
 const styles = StyleSheet.create({
   termsText: {
@@ -20,6 +23,14 @@ const styles = StyleSheet.create({
 
 export function PercentageRow() {
   const isLoading = useIsTransactionPayLoading();
+
+  const transactionMetadata = useTransactionMetadataRequest();
+
+  if (
+    !hasTransactionType(transactionMetadata, [TransactionType.musdConversion])
+  ) {
+    return null;
+  }
 
   const redirectToBonusFaq = () =>
     Linking.openURL(AppConstants.URLS.MUSD_CONVERSION_BONUS_TERMS_OF_USE);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5915,7 +5915,7 @@
     "error_description": "Installation of {{snap}} failed."
   },
   "earn": {
-    "claimable_bonus_tooltip": "An annual bonus claimable daily from your wallet.",
+    "claimable_bonus_tooltip": "The annualized bonus you’ve earned for holding mUSD. Your bonus is claimable daily on Linea.",
     "earn_a_percentage_bonus": "Earn a {{percentage}}% bonus",
     "claimable_bonus": "Claimable bonus",
     "claim_bonus": "Claim bonus",
@@ -6023,12 +6023,13 @@
       "toasts": {
         "converting": "Converting {{token}} → mUSD",
         "eta": "~{{time}}",
-        "delivered": "Your mUSD is here!",
+        "delivered": "mUSD conversion successful",
+        "delivered_description": "Bonus will be claimable within a day.",
         "failed": "mUSD conversion failed"
       },
       "education": {
         "heading": "GET {{percentage}}% ON\nSTABLECOINS",
-        "description": "Convert your stablecoins to mUSD, MetaMask’s US dollar-backed stablecoin, and receive up to a {{percentage}}% bonus.",
+        "description": "Convert your stablecoins to mUSD and earn up to a {{percentage}}% annualized bonus that you can claim daily.",
         "terms_apply": "Terms apply.",
         "primary_button": "Get Started",
         "secondary_button": "Not now"
@@ -6036,7 +6037,7 @@
       "buy_musd": "Buy mUSD",
       "get_musd": "Get mUSD",
       "bonus_title": "Get {{percentage}}% on your stablecoins",
-      "bonus_description": "Convert your stablecoins to mUSD and receive up to a {{percentage}}% bonus.",
+      "bonus_description": "Convert your stablecoins to mUSD and get a {{percentage}}% annualized bonus.",
       "powered_by_relay": "Powered by Relay",
       "max": "Max",
       "quick_convert_button": "Convert",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6041,13 +6041,12 @@
       "powered_by_relay": "Powered by Relay",
       "max": "Max",
       "quick_convert_button": "Convert",
-      "cta_body_earn_apy": "Earn {{apy}} yield automatically for holding mUSD.",
       "learn_more": "Learn more",
       "tooltip_title": "Earn yield with mUSD",
       "tooltip_content": "Convert your USDC, USDT, or DAI for mUSD, MetaMask's dollar-backed stablecoin. Earn {{apy}} yield on every dollar you hold.",
       "quick_convert": {
-        "title": "Convert and get {{apy}}%",
-        "subtitle": "Convert your stablecoins to mUSD and receive up to a {{apy}}% bonus.",
+        "title": "Convert and get {{percentage}}%",
+        "subtitle": "Convert your stablecoins to mUSD and receive up to a {{percentage}}% annualized bonus that you can claim daily.",
         "inline_failed_message": "Conversion failed. Try again.",
         "confirmation": {
           "title": "Convert max"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates mUSD conversion copy to reflect annualized bonus and claim timeline.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated mUSD conversion copy to reflect annualized bonus and claim timeline

## **Related issues**

Fixes:
- [MUSD-392: Annual bonus copy](https://consensyssoftware.atlassian.net/browse/MUSD-392)
- [MUSD-393: Communicate the timeframe of the bonus](https://consensyssoftware.atlassian.net/browse/MUSD-393)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
### Education screen
<img width="489" height="1022" alt="image" src="https://github.com/user-attachments/assets/e4435213-193b-4fc8-9212-4c797a5a3fc1" />

### Custom convert navbar tooltip
<img width="489" height="1022" alt="image" src="https://github.com/user-attachments/assets/b26a4251-4c2e-4aa0-b044-279894e609ce" />

### Claimable bonus tooltip

Custom convert
<img width="489" height="1022" alt="image" src="https://github.com/user-attachments/assets/8e706082-165b-455e-835b-f17c555fd313" />

Quick conver
<img width="489" height="1022" alt="image" src="https://github.com/user-attachments/assets/842dfe5f-fb8c-40dd-ba71-6609b2fbfb2f" />

### Asset details CTA
<img width="489" height="1022" alt="image" src="https://github.com/user-attachments/assets/10d66946-64e2-4bb4-8d9a-915f64cef29a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily copy/translation key updates plus minor UI tooltip/toast rendering changes (adds a terms link and an extra success-toast description) with no changes to conversion logic or data handling.
> 
> **Overview**
> Updates mUSD conversion user-facing messaging to consistently describe the incentive as an *annualized bonus* and to communicate that the bonus becomes claimable within about a day.
> 
> This refreshes strings across the education screen, quick convert header, asset overview CTA, claimable bonus tooltip, and conversion success toast (now includes a secondary description line), and adjusts the confirmation `PercentageRow` tooltip to include a tappable “Terms apply” link to the bonus terms URL. Tests are updated to match the new copy and label formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 388fcc0f47f2a53338b180ca20da458bc770d7eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->