### PR TITLE
feat: fix button label for action button clicked event cp-7.69.0

### DIFF
--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -140,6 +140,7 @@ export const useSwapBridgeNavigation = ({
       bridgeViewMode: BridgeViewMode,
       sourceTokenOverride?: BridgeToken,
       destTokenOverride?: BridgeToken,
+      buttonLabel?: string,
     ) => {
       // Use tokenOverride if provided, otherwise fall back to tokenBase
       const effectiveSourceTokenBase = sourceTokenOverride ?? sourceTokenBase;
@@ -283,7 +284,7 @@ export const useSwapBridgeNavigation = ({
         ...(isFromNavbar
           ? {}
           : { action_position: ActionPosition.SECOND_POSITION }),
-        button_label: strings('asset_overview.swap'),
+        button_label: buttonLabel ?? strings('asset_overview.swap'),
         location: isFromNavbar
           ? ActionLocation.NAVBAR
           : ActionLocation.ASSET_DETAILS,
@@ -328,11 +329,16 @@ export const useSwapBridgeNavigation = ({
   const { networkModal } = useAddNetwork();
 
   const goToSwaps = useCallback(
-    (tokenOverride?: BridgeToken, destTokenOverride?: BridgeToken) => {
+    (
+      tokenOverride?: BridgeToken,
+      destTokenOverride?: BridgeToken,
+      buttonLabel?: string,
+    ) => {
       goToNativeBridge(
         BridgeViewMode.Unified,
         tokenOverride,
         destTokenOverride,
+        buttonLabel,
       );
     },
     [goToNativeBridge],

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
@@ -655,6 +655,7 @@ describe('useTokenActions', () => {
           chainId: defaultToken.chainId,
           symbol: defaultToken.symbol,
         }),
+        'Buy',
       );
       expect(mockGoToBuy).not.toHaveBeenCalled();
     });
@@ -692,6 +693,7 @@ describe('useTokenActions', () => {
         expect.objectContaining({
           address: defaultToken.address,
         }),
+        'Buy',
       );
     });
 
@@ -743,6 +745,7 @@ describe('useTokenActions', () => {
           chainId: '0x1',
           symbol: 'ETH',
         }),
+        'Buy',
       );
       expect(mockGoToBuy).not.toHaveBeenCalled();
     });
@@ -767,6 +770,7 @@ describe('useTokenActions', () => {
           symbol: defaultToken.symbol,
         }),
         undefined,
+        'Sell',
       );
     });
   });

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.ts
@@ -437,7 +437,11 @@ export const useTokenActions = ({
     }
 
     if (!goToSwaps) return;
-    goToSwaps(buySourceToken, currentTokenAsBridgeToken);
+    goToSwaps(
+      buySourceToken,
+      currentTokenAsBridgeToken,
+      strings('asset_overview.buy_button'),
+    );
   }, [
     goToSwaps,
     goToBuy,
@@ -450,7 +454,11 @@ export const useTokenActions = ({
   // Sell: current token as source, let swap UI compute default dest
   const handleSellPress = useCallback(() => {
     if (!goToSwaps) return;
-    goToSwaps(currentTokenAsBridgeToken, undefined);
+    goToSwaps(
+      currentTokenAsBridgeToken,
+      undefined,
+      strings('asset_overview.sell_button'),
+    );
   }, [goToSwaps, currentTokenAsBridgeToken]);
 
   return {


### PR DESCRIPTION

## **Description**

The sticky Buy and Sell buttons on the token details page were both firing ACTION_BUTTON_CLICKED with button_label: "Swap", making it impossible to distinguish between the two actions in Mixpanel.
Changes:
* Added an optional buttonLabel param to goToSwaps / goToNativeBridge in useSwapBridgeNavigation,  falls back to "Swap" so all existing callers are unaffected
* `handleBuyPress` now passes `button_label: "Buy"` and `handleSellPress` passes `button_label: "Sell"`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated event property for ACTION_BUTTON_CLICKED

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only analytics event properties by threading an optional `buttonLabel` through navigation helpers; swap/bridge navigation behavior is unchanged due to a default fallback.
> 
> **Overview**
> Fixes token details *Buy*/*Sell* sticky buttons reporting `ACTION_BUTTON_CLICKED` with `button_label: "Swap"`.
> 
> `useSwapBridgeNavigation` now accepts an optional `buttonLabel` in `goToNativeBridge`/`goToSwaps` and uses it for `trackActionButtonClick` (defaulting to the existing Swap label), and `useTokenActions` passes the correct localized Buy/Sell labels; tests were updated to assert the new arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c1b45dd1f29beda009a7bf62ada36ba056dc547. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->