### PR TITLE
feat: Add `useMMPayFiatConfig` hook and feature flag selector

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useMMPayFiatConfig.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useMMPayFiatConfig.test.ts
@@ -1,0 +1,18 @@
+import { cloneDeep } from 'lodash';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { mockedEmptyFlagsState } from '../../../../../selectors/featureFlagController/mocks';
+
+describe('useMMPayFiatConfig', () => {
+  it('returns selector value from store', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay_fiat: { enabled: true },
+      };
+
+    const { result } = renderHookWithProvider(useMMPayFiatConfig, { state });
+
+    expect(result.current).toEqual({ enabled: true });
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useMMPayFiatConfig.ts
+++ b/app/components/Views/confirmations/hooks/pay/useMMPayFiatConfig.ts
@@ -1,0 +1,9 @@
+import { useSelector } from 'react-redux';
+import {
+  MetaMaskPayFiatFlags,
+  selectMetaMaskPayFiatFlags,
+} from '../../../../../selectors/featureFlagController/confirmations';
+
+export function useMMPayFiatConfig(): MetaMaskPayFiatFlags {
+  return useSelector(selectMetaMaskPayFiatFlags);
+}

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -11,6 +11,8 @@ import {
   selectGasFeeTokenFlags,
   GasFeeTokenFlags,
   selectPayQuoteConfig,
+  selectMetaMaskPayFiatFlags,
+  PAY_FIAT_ENABLED_DEFAULT,
   PreferredToken,
   getPreferredTokensForTransactionType,
 } from '.';
@@ -443,5 +445,23 @@ describe('getPreferredTokensForTransactionType', () => {
     expect(getPreferredTokensForTransactionType(config, undefined)).toEqual(
       defaultTokens,
     );
+  });
+});
+
+describe('selectMetaMaskPayFiatFlags', () => {
+  it('returns default when flag is absent', () => {
+    expect(selectMetaMaskPayFiatFlags(mockedEmptyFlagsState)).toEqual({
+      enabled: PAY_FIAT_ENABLED_DEFAULT,
+    });
+  });
+
+  it('returns enabled from flag value', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay_fiat: { enabled: true },
+      };
+
+    expect(selectMetaMaskPayFiatFlags(state)).toEqual({ enabled: true });
   });
 });

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -8,6 +8,7 @@ export const BUFFER_INITIAL_DEFAULT = 0.025;
 export const BUFFER_STEP_DEFAULT = 0.025;
 export const BUFFER_SUBSEQUENT_DEFAULT = 0.05;
 export const SLIPPAGE_DEFAULT = 0.005;
+export const PAY_FIAT_ENABLED_DEFAULT = false;
 
 export interface PreferredToken {
   address: string;
@@ -53,6 +54,10 @@ export interface GasFeeTokenFlags {
       }[];
     };
   };
+}
+
+export interface MetaMaskPayFiatFlags {
+  enabled: boolean;
 }
 
 export const selectMetaMaskPayFlags = createSelector(
@@ -196,6 +201,19 @@ export const selectGasFeeTokenFlags = createSelector(
 
     return {
       gasFeeTokens,
+    };
+  },
+);
+
+export const selectMetaMaskPayFiatFlags = createSelector(
+  selectRemoteFeatureFlags,
+  (featureFlags): MetaMaskPayFiatFlags => {
+    const raw = featureFlags?.confirmations_pay_fiat as
+      | Record<string, Json>
+      | undefined;
+
+    return {
+      enabled: (raw?.enabled as boolean) ?? PAY_FIAT_ENABLED_DEFAULT,
     };
   },
 );

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -7,8 +7,8 @@ export const ATTEMPTS_MAX_DEFAULT = 2;
 export const BUFFER_INITIAL_DEFAULT = 0.025;
 export const BUFFER_STEP_DEFAULT = 0.025;
 export const BUFFER_SUBSEQUENT_DEFAULT = 0.05;
-export const SLIPPAGE_DEFAULT = 0.005;
 export const PAY_FIAT_ENABLED_DEFAULT = false;
+export const SLIPPAGE_DEFAULT = 0.005;
 
 export interface PreferredToken {
   address: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Add `selectMetaMaskPayFiatFlags` selector to read the `confirmations_pay_fiat` LaunchDarkly flag, gating the upcoming fiat payment option in transaction confirmations
- Add `useMMPayFiatConfig` hook for React components to consume the flag
- Flag defaults to disabled - no UI or behavioral changes until downstream tasks wire it in

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27110

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new feature-flag selector/hook with a disabled-by-default fallback and unit tests, without changing existing app behavior.
> 
> **Overview**
> Adds support for gating upcoming fiat payments in confirmations by introducing a new `confirmations_pay_fiat` remote flag.
> 
> This PR adds `selectMetaMaskPayFiatFlags` (with `PAY_FIAT_ENABLED_DEFAULT = false`) plus a small `useMMPayFiatConfig` React hook to consume it, and includes unit tests covering default/flagged behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 419f4f68abf2672a19bb4115d197a359ba64f52e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->