### PR TITLE
fix(perps): privacy mode

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -44,6 +44,7 @@ import {
   FEEDBACK_CONFIG,
 } from '../../constants/perpsConfig';
 import { selectPerpsFeedbackEnabledFlag } from '../../selectors/featureFlags';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import PerpsMarketBalanceActions from '../../components/PerpsMarketBalanceActions';
 import PerpsCard from '../../components/PerpsCard';
 import PerpsWatchlistMarkets from '../../components/PerpsWatchlistMarkets/PerpsWatchlistMarkets';
@@ -80,6 +81,7 @@ const PerpsHomeView = () => {
 
   // Feature flag for feedback button
   const isFeedbackEnabled = useSelector(selectPerpsFeedbackEnabledFlag);
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Use centralized navigation hook
   const perpsNavigation = usePerpsNavigation();
@@ -428,9 +430,9 @@ const PerpsHomeView = () => {
         {/* Positions Section */}
         <PerpsHomeSection
           title={strings('perps.home.positions')}
-          subtitle={positionsSubtitle}
+          subtitle={privacyMode ? undefined : positionsSubtitle}
           subtitleColor={positionsSubtitleColor}
-          subtitleSuffix={positionsSubtitleSuffix}
+          subtitleSuffix={privacyMode ? undefined : positionsSubtitleSuffix}
           subtitleTestID={PerpsHomeViewSelectorsIDs.POSITIONS_PNL_VALUE}
           isLoading={isLoading.positions}
           isEmpty={positions.length === 0}

--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@testing-library/react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import PerpsPositionsView from './PerpsPositionsView';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
   usePerpsTrading,
   usePerpsTPSLUpdate,
@@ -195,7 +196,7 @@ describe('PerpsPositionsView', () => {
       isInitialLoading: false,
     });
 
-    // Default eligibility mock
+    // Default selector mocks: eligible, privacy mode off
     const { useSelector } = jest.requireMock('react-redux');
     const mockSelectPerpsEligibility = jest.requireMock(
       '../../selectors/perpsController',
@@ -203,6 +204,9 @@ describe('PerpsPositionsView', () => {
     useSelector.mockImplementation((selector: unknown) => {
       if (selector === mockSelectPerpsEligibility) {
         return true;
+      }
+      if (selector === selectPrivacyMode) {
+        return false;
       }
       return undefined;
     });
@@ -564,6 +568,86 @@ describe('PerpsPositionsView', () => {
       mockLoadPositions({ isRefresh: true });
 
       expect(mockLoadPositions).toHaveBeenCalledWith({ isRefresh: true });
+    });
+  });
+
+  describe('Privacy Mode', () => {
+    const DOTS_SHORT = '•'.repeat(6); // SensitiveTextLength.Short
+
+    const enablePrivacyMode = () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) return true;
+        if (selector === selectPrivacyMode) return true;
+        return undefined;
+      });
+    };
+
+    it('hides account balance values when privacy mode is enabled', async () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionsView />);
+
+      // Assert - actual balance numbers not shown, dots shown in their place
+      await waitFor(() => {
+        expect(screen.queryByText('$10,000')).toBeNull();
+        expect(screen.queryByText('$4,700')).toBeNull();
+        expect(screen.queryByText('$5,300')).toBeNull();
+        const hiddenValues = screen.getAllByText(DOTS_SHORT);
+        expect(hiddenValues.length).toBeGreaterThanOrEqual(3);
+      });
+    });
+
+    it('hides total unrealized PnL when privacy mode is enabled', async () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionsView />);
+
+      // Assert - PnL value hidden
+      await waitFor(() => {
+        expect(screen.queryByText(/\+\$75\.50/)).toBeNull();
+        const hiddenValues = screen.getAllByText(DOTS_SHORT);
+        expect(hiddenValues.length).toBeGreaterThanOrEqual(4);
+      });
+    });
+
+    it('keeps account summary labels visible when privacy mode is enabled', async () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionsView />);
+
+      // Assert - labels (not values) remain visible
+      await waitFor(() => {
+        expect(screen.getByText('Total balance')).toBeOnTheScreen();
+        expect(screen.getByText('Available balance')).toBeOnTheScreen();
+        expect(screen.getByText('Margin used')).toBeOnTheScreen();
+        expect(screen.getByText('Total unrealized P&L')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows account balance values when privacy mode is disabled', async () => {
+      // Arrange - privacy mode off (default from beforeEach)
+
+      // Act
+      render(<PerpsPositionsView />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText('$10,000')).toBeOnTheScreen();
+        expect(screen.getByText('$4,700')).toBeOnTheScreen();
+        expect(screen.getByText('$5,300')).toBeOnTheScreen();
+        expect(screen.getByText(/\+\$75\.50/)).toBeOnTheScreen();
+        expect(screen.queryByText(DOTS_SHORT)).toBeNull();
+      });
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -13,6 +14,10 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../component-library/components/Texts/SensitiveText';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useStyles } from '../../../../../component-library/hooks';
 import PerpsPositionCard from '../../components/PerpsPositionCard';
 import { PERPS_CONSTANTS } from '@metamask/perps-controller';
@@ -32,6 +37,7 @@ import { PerpsPositionsViewSelectorsIDs } from '../../Perps.testIds';
 const PerpsPositionsView: React.FC = () => {
   const { styles } = useStyles(createStyles, {});
   const navigation = useNavigation();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const { account } = usePerpsLiveAccount();
 
@@ -154,55 +160,76 @@ const PerpsPositionsView: React.FC = () => {
             <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
               {strings('perps.position.account.total_balance')}
             </Text>
-            <Text variant={TextVariant.BodySMMedium} color={TextColor.Default}>
+            <SensitiveText
+              variant={TextVariant.BodySMMedium}
+              color={TextColor.Default}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+            >
               {account?.totalBalance !== undefined &&
               account?.totalBalance !== null
                 ? formatPerpsFiat(account.totalBalance, {
                     ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })
                 : PERPS_CONSTANTS.FallbackDataDisplay}
-            </Text>
+            </SensitiveText>
           </View>
 
           <View style={styles.summaryRow}>
             <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
               {strings('perps.position.account.available_balance')}
             </Text>
-            <Text variant={TextVariant.BodySMMedium} color={TextColor.Default}>
+            <SensitiveText
+              variant={TextVariant.BodySMMedium}
+              color={TextColor.Default}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+            >
               {account?.availableBalance !== undefined &&
               account?.availableBalance !== null
                 ? formatPerpsFiat(account.availableBalance, {
                     ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })
                 : PERPS_CONSTANTS.FallbackDataDisplay}
-            </Text>
+            </SensitiveText>
           </View>
 
           <View style={styles.summaryRow}>
             <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
               {strings('perps.position.account.margin_used')}
             </Text>
-            <Text variant={TextVariant.BodySMMedium} color={TextColor.Default}>
+            <SensitiveText
+              variant={TextVariant.BodySMMedium}
+              color={TextColor.Default}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+            >
               {account?.marginUsed !== undefined && account?.marginUsed !== null
                 ? formatPerpsFiat(account.marginUsed, {
                     ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })
                 : PERPS_CONSTANTS.FallbackDataDisplay}
-            </Text>
+            </SensitiveText>
           </View>
 
           <View style={styles.summaryRow}>
             <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
               {strings('perps.position.account.total_unrealized_pnl')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodySMMedium}
               color={
-                totalUnrealizedPnl >= 0 ? TextColor.Success : TextColor.Error
+                privacyMode
+                  ? TextColor.Default
+                  : totalUnrealizedPnl >= 0
+                    ? TextColor.Success
+                    : TextColor.Error
               }
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
             >
               {formatPnl(totalUnrealizedPnl)}
-            </Text>
+            </SensitiveText>
           </View>
         </View>
         {renderContent()}

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -421,23 +421,24 @@ describe('PerpsCard', () => {
       );
 
       // Assert - actual values visible, no hiding dots
-      expect(getByText('+$100.50 (+5.0%)')).toBeDefined();
+      expect(getByText('+$100.50 (+5.0%)')).toBeOnTheScreen();
       expect(queryByText(DOTS_SHORT)).toBeNull();
     });
 
-    it('hides order price value when privacy mode is enabled', () => {
+    it('hides order price value but not the order type label when privacy mode is enabled', () => {
       // Arrange
       (useSelector as jest.Mock).mockReturnValue(true);
 
       // Act
-      const { queryByText, getAllByText } = render(
+      const { queryByText, getAllByText, getByText } = render(
         <PerpsCard order={mockOrder} testID="test-card" />,
       );
 
-      // Assert - order price is hidden
+      // Assert - price value is hidden, but non-financial order type label is not
       expect(queryByText('$3,000')).toBeNull();
       const hiddenElements = getAllByText(DOTS_SHORT);
       expect(hiddenElements.length).toBeGreaterThanOrEqual(1);
+      expect(getByText('perps.order.limit_price')).toBeOnTheScreen();
     });
 
     it('does not hide non-financial labels (symbol, direction) when privacy mode is enabled', () => {
@@ -450,8 +451,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert - left-side non-financial content is unaffected
-      expect(getByText('ETH 3x long')).toBeDefined();
-      expect(getByText('1.5 ETH')).toBeDefined();
+      expect(getByText('ETH 3x long')).toBeOnTheScreen();
+      expect(getByText('1.5 ETH')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import PerpsCard from './PerpsCard';
 import Routes from '../../../../../constants/navigation/Routes';
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
@@ -19,6 +20,15 @@ jest.mock('@react-navigation/native', () => {
     }),
   };
 });
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => false), // Default: privacy mode off
+}));
+
+jest.mock('../../hooks/usePerpsEventTracking', () => ({
+  usePerpsEventTracking: jest.fn(() => ({ track: jest.fn() })),
+}));
 
 jest.mock('../../../../../component-library/hooks', () => ({
   useStyles: () => ({
@@ -50,6 +60,8 @@ describe('PerpsCard', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: privacy mode off
+    (useSelector as jest.Mock).mockReturnValue(false);
     // Set up default mock return value
     mockUsePerpsMarkets.mockReturnValue({
       markets: [
@@ -366,6 +378,80 @@ describe('PerpsCard', () => {
       expect(getByText('$2,000')).toBeDefined();
       expect(getByText('perps.order.limit_price')).toBeDefined();
       expect(queryByText('perps.order.market_price')).toBeNull();
+    });
+  });
+
+  describe('Privacy Mode', () => {
+    const DOTS_SHORT = '•'.repeat(6); // SensitiveTextLength.Short
+
+    it('hides position value and PnL label when privacy mode is enabled', () => {
+      // Arrange
+      (useSelector as jest.Mock).mockReturnValue(true);
+      const positivePosition = {
+        ...mockPosition,
+        positionValue: '4350.00',
+        unrealizedPnl: '150.00',
+        returnOnEquity: '10.3',
+      };
+
+      // Act
+      const { queryByText, getAllByText } = render(
+        <PerpsCard position={positivePosition} testID="test-card" />,
+      );
+
+      // Assert - right-side financial values replaced with dots
+      expect(queryByText('$4,350')).toBeNull();
+      expect(queryByText(/\+\$150/)).toBeNull();
+      const hiddenElements = getAllByText(DOTS_SHORT);
+      expect(hiddenElements.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('shows position value and PnL label when privacy mode is disabled', () => {
+      // Arrange
+      (useSelector as jest.Mock).mockReturnValue(false);
+      const positivePosition = {
+        ...mockPosition,
+        unrealizedPnl: '100.50',
+        returnOnEquity: '0.05',
+      };
+
+      // Act
+      const { getByText, queryByText } = render(
+        <PerpsCard position={positivePosition} testID="test-card" />,
+      );
+
+      // Assert - actual values visible, no hiding dots
+      expect(getByText('+$100.50 (+5.0%)')).toBeDefined();
+      expect(queryByText(DOTS_SHORT)).toBeNull();
+    });
+
+    it('hides order price value when privacy mode is enabled', () => {
+      // Arrange
+      (useSelector as jest.Mock).mockReturnValue(true);
+
+      // Act
+      const { queryByText, getAllByText } = render(
+        <PerpsCard order={mockOrder} testID="test-card" />,
+      );
+
+      // Assert - order price is hidden
+      expect(queryByText('$3,000')).toBeNull();
+      const hiddenElements = getAllByText(DOTS_SHORT);
+      expect(hiddenElements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not hide non-financial labels (symbol, direction) when privacy mode is enabled', () => {
+      // Arrange
+      (useSelector as jest.Mock).mockReturnValue(true);
+
+      // Act
+      const { getByText } = render(
+        <PerpsCard position={mockPosition} testID="test-card" />,
+      );
+
+      // Assert - left-side non-financial content is unaffected
+      expect(getByText('ETH 3x long')).toBeDefined();
+      expect(getByText('1.5 ETH')).toBeDefined();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -208,11 +208,11 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
           <SensitiveText
             variant={TextVariant.BodySM}
             color={
-              privacyMode
+              privacyMode && !!position
                 ? TextColor.Default
                 : (displayData?.valueColor ?? TextColor.Default)
             }
-            isHidden={privacyMode}
+            isHidden={privacyMode && !!position}
             length={SensitiveTextLength.Short}
           >
             {displayData?.labelText ?? ''}

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -1,10 +1,15 @@
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../component-library/components/Texts/SensitiveText';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -99,6 +104,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
   const { styles } = useStyles(styleSheet, { iconSize });
   const navigation = useNavigation();
   const { track } = usePerpsEventTracking();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Determine which type of data we have
   const symbol = position?.symbol || order?.symbol || '';
@@ -191,15 +197,26 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
 
         {/* Right side: Value and label */}
         <View style={styles.cardRight}>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+          <SensitiveText
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Default}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
+          >
             {displayData?.valueText ?? ''}
-          </Text>
-          <Text
+          </SensitiveText>
+          <SensitiveText
             variant={TextVariant.BodySM}
-            color={displayData?.valueColor ?? TextColor.Default}
+            color={
+              privacyMode
+                ? TextColor.Default
+                : (displayData?.valueColor ?? TextColor.Default)
+            }
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
           >
             {displayData?.labelText ?? ''}
-          </Text>
+          </SensitiveText>
         </View>
       </View>
     </TouchableOpacity>

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -306,6 +306,7 @@ describe('PerpsMarketBalanceActions', () => {
     perpsControllerOverrides: Partial<
       ReturnType<typeof getDefaultPerpsControllerState>
     > = {},
+    privacyMode = false,
   ) => ({
     engine: {
       backgroundState: {
@@ -317,6 +318,9 @@ describe('PerpsMarketBalanceActions', () => {
           multichainNetworkConfigurationsByChainId: {},
           isEvmSelected: true,
           selectedMultichainNetworkChainId: undefined, // EVM selected, non-EVM chain field is undefined
+        },
+        PreferencesController: {
+          privacyMode,
         },
       },
     },
@@ -642,6 +646,76 @@ describe('PerpsMarketBalanceActions', () => {
 
       // Assert
       expect(mockStopAnimation).toHaveBeenCalled();
+    });
+  });
+
+  describe('Privacy Mode', () => {
+    const DOTS_MEDIUM = '•'.repeat(9); // SensitiveTextLength.Medium
+    const DOTS_SHORT = '•'.repeat(6); // SensitiveTextLength.Short
+
+    it('hides total balance value when privacy mode is enabled', () => {
+      // Arrange & Act
+      const { queryByText, getByText } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState({}, true) },
+        false,
+      );
+
+      // Assert - balance replaced with dots, actual value not shown
+      expect(queryByText('$10.57')).toBeNull();
+      expect(getByText(DOTS_MEDIUM)).toBeOnTheScreen();
+    });
+
+    it('shows total balance value when privacy mode is disabled', () => {
+      // Arrange & Act
+      const { getByTestId } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState() },
+        false,
+      );
+
+      // Assert
+      const balanceEl = getByTestId(
+        PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE,
+      );
+      expect(balanceEl.props.children).toBe('$10.57');
+    });
+
+    it('hides available balance amount when privacy mode is enabled', () => {
+      // Arrange & Act
+      const { getAllByText } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState({}, true) },
+        false,
+      );
+
+      // Assert - at least the available balance value is hidden
+      const hiddenValues = getAllByText(DOTS_SHORT);
+      expect(hiddenValues.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('keeps "available" label visible when privacy mode is enabled', () => {
+      // Arrange & Act
+      const { getByText } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState({}, true) },
+        false,
+      );
+
+      // Assert - label stays, only the amount is hidden
+      expect(getByText('perps.available')).toBeOnTheScreen();
+    });
+
+    it('shows available balance amount when privacy mode is disabled', () => {
+      // Arrange & Act
+      const { queryByText } = renderWithProvider(
+        <PerpsMarketBalanceActions />,
+        { state: createMockState() },
+        false,
+      );
+
+      // Assert - actual value is visible, no dots
+      expect(queryByText(DOTS_SHORT)).toBeNull();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -13,7 +13,11 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../component-library/components/Texts/SensitiveText';
 import { strings } from '../../../../../../locales/i18n';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useColorPulseAnimation, useBalanceComparison } from '../../hooks';
 import { usePerpsHomeActions } from '../../hooks/usePerpsHomeActions';
 import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
@@ -65,6 +69,7 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
 }) => {
   const tw = useTailwind();
   const { isDepositInProgress } = usePerpsDepositProgress();
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Get withdrawal requests filtered by current account using memoized selector
   const withdrawalRequests = useSelector(
@@ -212,16 +217,18 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
               </Text>
               {/* Only show dollar value when there's a single transaction in progress */}
               {shouldShowDollarAmount && (
-                <Text
+                <SensitiveText
                   variant={TextVariant.BodySMMedium}
                   color={TextColor.Default}
+                  isHidden={privacyMode}
+                  length={SensitiveTextLength.Short}
                 >
                   {isOnlyDepositInProgress && transactionAmountWei
                     ? convertPerpsAmountToUSD(transactionAmountWei)
                     : isOnlyWithdrawalInProgress && withdrawalAmount
                       ? convertPerpsAmountToUSD(withdrawalAmount)
                       : null}
-                </Text>
+                </SensitiveText>
               )}
             </Box>
           </Box>
@@ -235,28 +242,39 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
         ) : (
           <Box twClassName="px-4 pt-4 pb-4">
             <Animated.View style={[getBalanceAnimatedStyle]}>
-              <Text
+              <SensitiveText
                 variant={TextVariant.DisplayMD}
                 color={TextColor.Default}
                 testID={PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Medium}
               >
                 {formatPerpsFiat(totalBalance)}
-              </Text>
+              </SensitiveText>
             </Animated.View>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
               style={tw.style('mt-1')}
               testID={
                 PerpsMarketBalanceActionsSelectorsIDs.AVAILABLE_BALANCE_TEXT
               }
             >
-              {formatPerpsFiat(availableBalance, {
-                ranges: PRICE_RANGES_MINIMAL_VIEW,
-                stripTrailingZeros: false,
-              })}{' '}
-              {strings('perps.available')}
-            </Text>
+              <SensitiveText
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Short}
+              >
+                {formatPerpsFiat(availableBalance, {
+                  ranges: PRICE_RANGES_MINIMAL_VIEW,
+                  stripTrailingZeros: false,
+                })}
+              </SensitiveText>
+              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+                {' '}
+                {strings('perps.available')}
+              </Text>
+            </Box>
             {/* Action Buttons */}
             {showActionButtons && (
               <Box

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react-native';
 import { PerpsPositionCardSelectorsIDs } from '../../Perps.testIds';
 import { PERPS_CONSTANTS, type Position } from '@metamask/perps-controller';
 import PerpsPositionCard from './PerpsPositionCard';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
@@ -243,7 +244,7 @@ describe('PerpsPositionCard', () => {
       },
     });
 
-    // Default eligibility mock
+    // Default selector mocks: eligible, privacy mode off
     const { useSelector } = jest.requireMock('react-redux');
     const mockSelectPerpsEligibility = jest.requireMock(
       '../../selectors/perpsController',
@@ -251,6 +252,9 @@ describe('PerpsPositionCard', () => {
     useSelector.mockImplementation((selector: unknown) => {
       if (selector === mockSelectPerpsEligibility) {
         return true;
+      }
+      if (selector === selectPrivacyMode) {
+        return false;
       }
       return undefined;
     });
@@ -577,6 +581,157 @@ describe('PerpsPositionCard', () => {
         PerpsPositionCardSelectorsIDs.SHARE_BUTTON,
       );
       expect(shareButton).toBeNull();
+    });
+  });
+
+  describe('Privacy Mode', () => {
+    const DOTS_SHORT = '•'.repeat(6); // SensitiveTextLength.Short
+
+    const enablePrivacyMode = () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) return true;
+        if (selector === selectPrivacyMode) return true;
+        return undefined;
+      });
+    };
+
+    it('hides PnL value when privacy mode is enabled', () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionCard position={mockPosition} />);
+
+      // Assert - actual PnL text absent, dots present
+      expect(screen.queryByText(/\+\$250\.00/)).toBeNull();
+      expect(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.PNL_VALUE),
+      ).toHaveTextContent(DOTS_SHORT);
+    });
+
+    it('hides ROE value when privacy mode is enabled', () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionCard position={mockPosition} />);
+
+      // Assert
+      expect(screen.queryByText(/\+1250\.00%/)).toBeNull();
+      expect(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.RETURN_VALUE),
+      ).toHaveTextContent(DOTS_SHORT);
+    });
+
+    it('hides margin value when privacy mode is enabled', () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionCard position={mockPosition} />);
+
+      // Assert
+      expect(screen.queryByText(/\$500/)).toBeNull();
+      expect(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.MARGIN_VALUE),
+      ).toHaveTextContent(DOTS_SHORT);
+    });
+
+    it('hides size value when privacy mode is enabled', () => {
+      // Arrange
+      enablePrivacyMode();
+
+      // Act
+      render(<PerpsPositionCard position={mockPosition} />);
+
+      // Assert - position size in token units is hidden
+      expect(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.SIZE_VALUE),
+      ).toHaveTextContent(DOTS_SHORT);
+    });
+
+    it('shows identical PnL text for positive and negative positions when privacy mode is enabled (color does not leak direction)', () => {
+      // Arrange
+      enablePrivacyMode();
+      const positivePosition = { ...mockPosition, unrealizedPnl: '250.00' };
+      const negativePosition = {
+        ...mockPosition,
+        unrealizedPnl: '-250.00',
+        returnOnEquity: '-12.5',
+      };
+
+      // Act
+      const { unmount } = render(
+        <PerpsPositionCard position={positivePosition} />,
+      );
+      const positivePnlText = screen
+        .getByTestId(PerpsPositionCardSelectorsIDs.PNL_VALUE)
+        .props.children?.toString();
+      unmount();
+
+      render(<PerpsPositionCard position={negativePosition} />);
+      const negativePnlText = screen
+        .getByTestId(PerpsPositionCardSelectorsIDs.PNL_VALUE)
+        .props.children?.toString();
+
+      // Assert - both show the same dots regardless of profit/loss
+      expect(positivePnlText).toBe(negativePnlText);
+      expect(positivePnlText).toBe(DOTS_SHORT);
+    });
+
+    it('shows actual PnL value when privacy mode is disabled', () => {
+      // Arrange - privacy mode off (default from beforeEach)
+
+      // Act
+      render(<PerpsPositionCard position={mockPosition} />);
+
+      // Assert
+      expect(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.PNL_VALUE),
+      ).toHaveTextContent(/\+\$250\.00/);
+      expect(screen.queryByText(DOTS_SHORT)).toBeNull();
+    });
+
+    describe('Compact mode', () => {
+      it('hides position value and PnL in compact default variant', () => {
+        // Arrange
+        enablePrivacyMode();
+
+        // Act
+        render(
+          <PerpsPositionCard
+            position={mockPosition}
+            compact
+            compactVariant="default"
+          />,
+        );
+
+        // Assert - financial values replaced with dots
+        const hiddenValues = screen.getAllByText(DOTS_SHORT);
+        expect(hiddenValues.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('hides ROE in compact position variant', () => {
+        // Arrange
+        enablePrivacyMode();
+
+        // Act
+        render(
+          <PerpsPositionCard
+            position={mockPosition}
+            compact
+            compactVariant="position"
+          />,
+        );
+
+        // Assert
+        const hiddenValues = screen.getAllByText(DOTS_SHORT);
+        expect(hiddenValues.length).toBeGreaterThanOrEqual(1);
+      });
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { PerpsPositionCardSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonIcon, {
@@ -18,7 +19,11 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../component-library/components/Texts/SensitiveText';
 import { useStyles } from '../../../../../component-library/hooks';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
   PERPS_CONSTANTS,
   getPerpsDisplaySymbol,
@@ -112,6 +117,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, { iconSize });
   const [showSizeInUSD, setShowSizeInUSD] = useState(false);
+  const privacyMode = useSelector(selectPrivacyMode);
 
   // Determine if position is long or short based on size
   const isLong = parseFloat(position.size) >= 0;
@@ -231,32 +237,49 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         </Text>
       );
       secondaryValue = (
-        <Text
+        <SensitiveText
           variant={TextVariant.BodySM}
           color={
-            hasValidRoe
-              ? roeRaw >= 0
-                ? TextColor.Success
-                : TextColor.Error
-              : TextColor.Alternative
+            privacyMode
+              ? TextColor.Default
+              : hasValidRoe
+                ? roeRaw >= 0
+                  ? TextColor.Success
+                  : TextColor.Error
+                : TextColor.Alternative
           }
+          isHidden={privacyMode}
+          length={SensitiveTextLength.Short}
         >
           {roeDisplay}
-        </Text>
+        </SensitiveText>
       );
     } else {
       secondaryLabel = (
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <SensitiveText
+          variant={TextVariant.BodySM}
+          color={TextColor.Alternative}
+          isHidden={privacyMode}
+          length={SensitiveTextLength.Short}
+        >
           {formatPositionSize(absoluteSize.toString())} {displaySymbol}
-        </Text>
+        </SensitiveText>
       );
       secondaryValue = (
-        <Text
+        <SensitiveText
           variant={TextVariant.BodySM}
-          color={pnlNum >= 0 ? TextColor.Success : TextColor.Error}
+          color={
+            privacyMode
+              ? TextColor.Default
+              : pnlNum >= 0
+                ? TextColor.Success
+                : TextColor.Error
+          }
+          isHidden={privacyMode}
+          length={SensitiveTextLength.Short}
         >
           {formatPnl(pnlNum)} ({roeDisplay})
-        </Text>
+        </SensitiveText>
       );
     }
 
@@ -288,11 +311,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             </View>
           </View>
           <View style={styles.compactRight}>
-            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            <SensitiveText
+              variant={TextVariant.BodyMDMedium}
+              color={TextColor.Default}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+            >
               {formatPerpsFiat(position.positionValue, {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
               })}
-            </Text>
+            </SensitiveText>
             {secondaryValue}
           </View>
         </View>
@@ -326,13 +354,21 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
             {strings('perps.position.card.pnl_label')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMD}
-            color={pnlNum >= 0 ? TextColor.Success : TextColor.Error}
+            color={
+              privacyMode
+                ? TextColor.Default
+                : pnlNum >= 0
+                  ? TextColor.Success
+                  : TextColor.Error
+            }
             testID={PerpsPositionCardSelectorsIDs.PNL_VALUE}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
           >
             {formatPnl(pnlNum)}
-          </Text>
+          </SensitiveText>
         </View>
 
         <View
@@ -342,14 +378,22 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
             {strings('perps.position.card.return_label')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMD}
-            color={roe >= 0 ? TextColor.Success : TextColor.Error}
+            color={
+              privacyMode
+                ? TextColor.Default
+                : roe >= 0
+                  ? TextColor.Success
+                  : TextColor.Error
+            }
             testID={PerpsPositionCardSelectorsIDs.RETURN_VALUE}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
           >
             {roe >= 0 ? '+' : ''}
             {roe.toFixed(2)}%
-          </Text>
+          </SensitiveText>
         </View>
       </View>
 
@@ -364,17 +408,19 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
               {strings('perps.position.card.size_label')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodyMD}
               color={TextColor.Default}
               testID={PerpsPositionCardSelectorsIDs.SIZE_VALUE}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
             >
               {showSizeInUSD && currentPrice
                 ? formatPerpsFiat(absoluteSize * currentPrice, {
                     ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })
                 : `${formatPositionSize(absoluteSize.toString())} ${getPerpsDisplaySymbol(position.symbol)}`}
-            </Text>
+            </SensitiveText>
           </View>
           <View style={styles.iconButtonContainer}>
             <ButtonIcon
@@ -398,15 +444,17 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
               {strings('perps.position.card.margin_label')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodyMD}
               color={TextColor.Default}
               testID={PerpsPositionCardSelectorsIDs.MARGIN_VALUE}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
             >
               {formatPerpsFiat(position.marginUsed, {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
               })}
-            </Text>
+            </SensitiveText>
           </View>
           {onMarginPress && (
             <View style={styles.iconButtonContainer}>
@@ -484,9 +532,14 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
               }
 
               return (
-                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                <SensitiveText
+                  variant={TextVariant.BodyMD}
+                  color={TextColor.Default}
+                  isHidden={privacyMode}
+                  length={SensitiveTextLength.Short}
+                >
                   {parts.join(', ')}
-                </Text>
+                </SensitiveText>
               );
             }
 
@@ -554,11 +607,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           >
             {strings('perps.position.card.entry_label')}
           </Text>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <SensitiveText
+            variant={TextVariant.BodyMD}
+            color={TextColor.Default}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
+          >
             {formatPerpsFiat(position.entryPrice, {
               ranges: PRICE_RANGES_UNIVERSAL,
             })}
-          </Text>
+          </SensitiveText>
         </View>
 
         <View style={styles.detailRow}>
@@ -569,15 +627,20 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             {strings('perps.position.card.liquidation_price_label')}
           </Text>
           <View style={styles.liquidationPriceValue}>
-            <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+            <SensitiveText
+              variant={TextVariant.BodyMD}
+              color={TextColor.Default}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+            >
               {position.liquidationPrice !== undefined &&
               position.liquidationPrice !== null
                 ? formatPerpsFiat(position.liquidationPrice, {
                     ranges: PRICE_RANGES_UNIVERSAL,
                   })
                 : PERPS_CONSTANTS.FallbackPriceDisplay}
-            </Text>
-            {liquidationDistance !== null && (
+            </SensitiveText>
+            {liquidationDistance !== null && !privacyMode && (
               <>
                 <Text
                   variant={TextVariant.BodyMD}
@@ -603,9 +666,14 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           >
             {strings('perps.position.card.funding_payments_label')}
           </Text>
-          <Text variant={TextVariant.BodyMD} color={fundingColor}>
+          <SensitiveText
+            variant={TextVariant.BodyMD}
+            color={privacyMode ? TextColor.Default : fundingColor}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
+          >
             {fundingDisplay}
-          </Text>
+          </SensitiveText>
         </View>
       </View>
     </View>

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -12,6 +12,11 @@ import {
 const mockNavigate = jest.fn();
 const mockTrack = jest.fn();
 
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  ...jest.requireActual('../../../../../selectors/preferencesController'),
+  selectPrivacyMode: () => false,
+}));
+
 jest.mock('../../../../UI/Perps/hooks/usePerpsEventTracking', () => ({
   usePerpsEventTracking: jest.fn(() => ({
     track: mockTrack,


### PR DESCRIPTION
## **Description**

Perps screens had no privacy mode support — enabling the wallet privacy toggle had no effect on any financial values displayed in the perpetuals trading UI.

This PR integrates `SensitiveText` (with `selectPrivacyMode`) across all Perps components that render sensitive financial data, following the same pattern already established by the Predict feature.

**What changed:**
- **`PerpsMarketBalanceActions`** — total balance and available balance value hidden behind dots; transaction in-progress amounts (deposit/withdrawal) also hidden
- **`PerpsCard`** — position value and PnL/ROE label on the home screen cards hidden
- **`PerpsPositionCard`** — comprehensive coverage: PnL, ROE, position value, size, margin, entry price, liquidation price, TP/SL prices, and funding payments all hidden; liquidation distance % and icon suppressed
- **`PerpsPositionsView`** — all four account summary values (total balance, available balance, margin used, total unrealized PnL) hidden
- **`PerpsHomeView`** — positions section PnL subtitle hidden

**Color leaking fix:** Values with directional colors (green for profit, red for loss) are forced to `TextColor.Default` when privacy mode is on, so the color itself cannot reveal whether a position is profitable or not.

**Tests:** Privacy mode test blocks added to all four affected test files. `PerpsCard.test.tsx` also received a missing `react-redux` mock that was required after the `useSelector` call was introduced.

## **Changelog**

CHANGELOG entry: Fixed privacy mode not hiding financial values on Perps screens

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23187

## **Manual testing steps**

```gherkin
Feature: Perps privacy mode

  Scenario: user enables privacy mode and navigates to Perps home
    Given the user has a funded Perps account with open positions
    And privacy mode is disabled

    When user enables privacy mode from wallet settings
    And navigates to the Perps home screen

    Then the total balance is replaced with bullet dots
    And the available balance amount is replaced with bullet dots
    And the "available" label remains visible
    And each position card shows bullet dots instead of position value and PnL
    And the positions section PnL subtitle is hidden

  Scenario: user views position detail with privacy mode enabled
    Given privacy mode is enabled
    And the user has an open ETH position

    When user taps on a position card

    Then PnL, ROE, size, margin, entry price, liquidation price, TP/SL prices, and funding payments all show bullet dots
    And none of the hidden values are displayed in green or red (color does not reveal direction)

  Scenario: user views the Positions tab with privacy mode enabled
    Given privacy mode is enabled

    When user navigates to the Positions tab

    Then total balance, available balance, margin used, and total unrealized PnL in the account summary all show bullet dots
    And the row labels (Total balance, Available balance, etc.) remain visible

  Scenario: user disables privacy mode
    Given privacy mode was previously enabled

    When user disables privacy mode

    Then all financial values are visible again with their correct amounts and directional colors
```

## **Screenshots/Recordings**

### **Before**

| | | |
|---|---|---|
| <img width="390" alt="Before 1" src="https://github.com/user-attachments/assets/3c44a7d7-200e-4024-b175-25b431901762" /> | <img width="390" alt="Before 2" src="https://github.com/user-attachments/assets/3ff88aef-9bba-4dc4-9f35-6603d75c27ba" /> | <img width="390" alt="Before 3" src="https://github.com/user-attachments/assets/a4645a06-bc1b-4735-a1d4-14fc521c343a" /> |

### **After**

| | | |
|---|---|---|
| <img width="390" alt="After 1" src="https://github.com/user-attachments/assets/1525ccd4-8b12-44bb-8562-d2e5d10461aa" /> | <img width="390" alt="After 2" src="https://github.com/user-attachments/assets/1ec9f8c4-2411-44e0-aa7f-03933e462e15" /> | <img width="390" alt="After 3" src="https://github.com/user-attachments/assets/3cd1d2a1-1a67-45ed-a70c-1e02567ea71f" /> |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple Perps UI surfaces and display logic to conditionally hide values and neutralize PnL coloring; risk is mainly UI regressions or incorrectly hidden/shown fields, not core trading behavior.
> 
> **Overview**
> Adds Perps support for wallet *privacy mode* by wiring `selectPrivacyMode` into the home, positions list, and position-detail surfaces and replacing sensitive numeric fields with `SensitiveText` dots.
> 
> This also prevents profit/loss direction leakage by forcing neutral text colors and suppressing liquidation distance UI when privacy mode is on, and updates/extends unit tests to cover privacy-on/off rendering (including required Redux selector mocks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8523c4f75cfed51ccaeec86ba99a53b37572afc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->