### PR TITLE
feat: update dependencies and add token usage reporting for AI providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -503,7 +503,7 @@
     "vm-browserify": "1.1.2"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.71.0",
+    "@anthropic-ai/sdk": "^0.78.0",
     "@babel/core": "^7.25.2",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/preset-env": "^7.25.3",
@@ -620,7 +620,7 @@
     "metro-react-native-babel-preset": "~0.76.9",
     "metro-react-native-babel-transformer": "~0.76.9",
     "nyc": "^15.1.0",
-    "openai": "^4.77.0",
+    "openai": "^6.25.0",
     "patch-package": "^6.2.2",
     "prettier": "^3.6.2",
     "prettier-2": "npm:prettier@^2.8.8",

--- a/tests/tools/e2e-ai-analyzer/analysis/analyzer.ts
+++ b/tests/tools/e2e-ai-analyzer/analysis/analyzer.ts
@@ -13,7 +13,7 @@ import {
   AnalysisContext,
   type ModeConfig,
 } from '../types';
-import { LLM_CONFIG } from '../config';
+import { LLM_CONFIG, MODEL_PRICING } from '../config';
 import { getToolDefinitions } from '../ai-tools/tool-registry';
 import { executeTool, ToolContext } from '../ai-tools/tool-executor';
 import {
@@ -118,6 +118,40 @@ export async function analyzeWithAgent<M extends ModeKey>(
   let currentMessage: LLMContentBlock[] | string = taskPrompt;
   const conversationHistory: LLMMessage[] = [];
 
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let usedModel = provider.getDefaultModel();
+
+  function printTokenReport() {
+    if (totalInputTokens === 0 && totalOutputTokens === 0) return;
+    const pricing = MODEL_PRICING[usedModel];
+    const inputCost = pricing
+      ? (totalInputTokens / 1_000_000) * pricing.inputPerM
+      : null;
+    const outputCost = pricing
+      ? (totalOutputTokens / 1_000_000) * pricing.outputPerM
+      : null;
+    const totalCost =
+      inputCost !== null && outputCost !== null ? inputCost + outputCost : null;
+
+    console.log('\n💰 Token Usage Report');
+    console.log('─────────────────────────────────────');
+    console.log(`   Model:          ${usedModel}`);
+    console.log(
+      `   Input tokens:   ${totalInputTokens.toLocaleString()}${pricing ? `  ($${inputCost?.toFixed(4)})` : ''}`,
+    );
+    console.log(
+      `   Output tokens:  ${totalOutputTokens.toLocaleString()}${pricing ? `  ($${outputCost?.toFixed(4)})` : ''}`,
+    );
+    if (totalCost !== null) {
+      console.log(`   Total cost:     $${totalCost.toFixed(4)}`);
+    }
+    if (!pricing) {
+      console.log(`   ⚠️  No pricing data for model "${usedModel}"`);
+    }
+    console.log('─────────────────────────────────────');
+  }
+
   console.log(`🤖 Using provider: ${provider.displayName}`);
 
   for (let iteration = 0; iteration < LLM_CONFIG.maxIterations; iteration++) {
@@ -134,6 +168,12 @@ export async function analyzeWithAgent<M extends ModeKey>(
         { role: 'user', content: currentMessage },
       ],
     });
+
+    if (response.usage) {
+      totalInputTokens += response.usage.inputTokens;
+      totalOutputTokens += response.usage.outputTokens;
+      usedModel = response.model;
+    }
 
     // Handle tool uses
     const toolUseBlocks = response.content.filter(
@@ -182,10 +222,12 @@ export async function analyzeWithAgent<M extends ModeKey>(
 
             if (analysis) {
               console.log(`✅ Analysis complete!`);
+              printTokenReport();
               return analysis as ModeAnalysisResult<M>;
             }
 
             console.log('⚠️ Failed to parse finalize_tag_selection');
+            printTokenReport();
             return modeConfig.createConservativeResult() as ModeAnalysisResult<M>;
           }
 
@@ -221,6 +263,7 @@ export async function analyzeWithAgent<M extends ModeKey>(
       );
       if (analysis) {
         console.log(`✅ Analysis complete!`);
+        printTokenReport();
         return analysis as ModeAnalysisResult<M>;
       }
     }
@@ -229,5 +272,6 @@ export async function analyzeWithAgent<M extends ModeKey>(
   }
 
   console.log('⚠️ Using fallback analysis');
+  printTokenReport();
   return modeConfig.createConservativeResult() as ModeAnalysisResult<M>;
 }

--- a/tests/tools/e2e-ai-analyzer/analysis/analyzer.ts
+++ b/tests/tools/e2e-ai-analyzer/analysis/analyzer.ts
@@ -120,11 +120,12 @@ export async function analyzeWithAgent<M extends ModeKey>(
 
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
-  let usedModel = provider.getDefaultModel();
+  const requestedModel = provider.getDefaultModel();
+  let resolvedModel: string | undefined;
 
   function printTokenReport() {
     if (totalInputTokens === 0 && totalOutputTokens === 0) return;
-    const pricing = MODEL_PRICING[usedModel];
+    const pricing = MODEL_PRICING[requestedModel];
     const inputCost = pricing
       ? (totalInputTokens / 1_000_000) * pricing.inputPerM
       : null;
@@ -136,7 +137,9 @@ export async function analyzeWithAgent<M extends ModeKey>(
 
     console.log('\n💰 Token Usage Report');
     console.log('─────────────────────────────────────');
-    console.log(`   Model:          ${usedModel}`);
+    console.log(
+      `   Model:          ${requestedModel}${resolvedModel && resolvedModel !== requestedModel ? ` (${resolvedModel})` : ''}`,
+    );
     console.log(
       `   Input tokens:   ${totalInputTokens.toLocaleString()}${pricing ? `  ($${inputCost?.toFixed(4)})` : ''}`,
     );
@@ -147,7 +150,7 @@ export async function analyzeWithAgent<M extends ModeKey>(
       console.log(`   Total cost:     $${totalCost.toFixed(4)}`);
     }
     if (!pricing) {
-      console.log(`   ⚠️  No pricing data for model "${usedModel}"`);
+      console.log(`   ⚠️  No pricing data for model "${requestedModel}"`);
     }
     console.log('─────────────────────────────────────');
   }
@@ -172,7 +175,7 @@ export async function analyzeWithAgent<M extends ModeKey>(
     if (response.usage) {
       totalInputTokens += response.usage.inputTokens;
       totalOutputTokens += response.usage.outputTokens;
-      usedModel = response.model;
+      resolvedModel = response.model;
     }
 
     // Handle tool uses

--- a/tests/tools/e2e-ai-analyzer/config.ts
+++ b/tests/tools/e2e-ai-analyzer/config.ts
@@ -7,6 +7,19 @@
 import { ProviderType, ProviderConfig } from './providers/types';
 
 /**
+ * Pricing per million tokens (USD) for each model.
+ * Update when pricing changes: https://openai.com/api/pricing / https://anthropic.com/pricing
+ */
+export const MODEL_PRICING: Record<
+  string,
+  { inputPerM: number; outputPerM: number }
+> = {
+  'gpt-5.2-chat-latest': { inputPerM: 1.75, outputPerM: 14.0 },
+  'claude-sonnet-4-6': { inputPerM: 3.0, outputPerM: 15.0 },
+  'gemini-2.0-flash': { inputPerM: 0.1, outputPerM: 0.4 },
+};
+
+/**
  * Multi-Provider LLM Configuration
  *
  * Supports automatic fallback between providers when one is unavailable.
@@ -16,18 +29,18 @@ export const LLM_CONFIG = {
    * Provider priority order for automatic fallback
    * The first available provider in this list will be used
    */
-  providerPriority: ['anthropic', 'openai', 'google'] as ProviderType[],
+  providerPriority: ['openai', 'anthropic', 'google'] as ProviderType[],
 
   /**
    * Per-provider configuration
    */
   providers: {
     anthropic: {
-      model: 'claude-opus-4-5-20251101',
+      model: 'claude-sonnet-4-6',
       envKey: 'E2E_CLAUDE_API_KEY',
     } as ProviderConfig,
     openai: {
-      model: 'gpt-5',
+      model: 'gpt-5.2-chat-latest',
       envKey: 'E2E_OPENAI_API_KEY',
     } as ProviderConfig,
     google: {

--- a/tests/tools/e2e-ai-analyzer/index.ts
+++ b/tests/tools/e2e-ai-analyzer/index.ts
@@ -304,7 +304,12 @@ async function main() {
       console.log(`   ✅ ${provider.displayName} is available`);
       availableProviders.push({ type: providerType, provider });
     } else {
-      console.log(`   ❌ ${provider.displayName} is not available`);
+      const envKey = LLM_CONFIG.providers[providerType].envKey;
+      const hasKey = !!process.env[envKey];
+      const reason = hasKey
+        ? 'API call failed (see warning above)'
+        : `missing ${envKey}`;
+      console.log(`   ❌ ${provider.displayName} is not available — ${reason}`);
     }
   }
 

--- a/tests/tools/e2e-ai-analyzer/providers/anthropic-provider.ts
+++ b/tests/tools/e2e-ai-analyzer/providers/anthropic-provider.ts
@@ -134,6 +134,10 @@ export class AnthropicProvider implements ILLMProvider {
       content: fromAnthropicContent(response.content),
       model: response.model,
       stopReason: response.stop_reason || 'end_turn',
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
     };
   }
 
@@ -150,7 +154,9 @@ export class AnthropicProvider implements ILLMProvider {
         messages: [{ role: 'user', content: 'hi' }],
       });
       return true;
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`   ⚠️  Anthropic API error: ${message}`);
       return false;
     }
   }

--- a/tests/tools/e2e-ai-analyzer/providers/google-provider.ts
+++ b/tests/tools/e2e-ai-analyzer/providers/google-provider.ts
@@ -296,10 +296,17 @@ export class GoogleProvider implements ILLMProvider {
     const contents = toGoogleContents(request.messages);
     const result = await model.generateContent({ contents });
 
+    const meta = result.response.usageMetadata;
     return {
       content: fromGoogleResponse(result),
       model: request.model,
       stopReason: mapFinishReason(result),
+      usage: meta
+        ? {
+            inputTokens: meta.promptTokenCount ?? 0,
+            outputTokens: meta.candidatesTokenCount ?? 0,
+          }
+        : undefined,
     };
   }
 
@@ -319,7 +326,9 @@ export class GoogleProvider implements ILLMProvider {
         contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
       });
       return true;
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`   ⚠️  Google API error: ${message}`);
       return false;
     }
   }

--- a/tests/tools/e2e-ai-analyzer/providers/openai-provider.ts
+++ b/tests/tools/e2e-ai-analyzer/providers/openai-provider.ts
@@ -141,12 +141,14 @@ function fromOpenAIResponse(
   // Add tool calls if present
   if (message.tool_calls) {
     for (const toolCall of message.tool_calls) {
-      content.push({
-        type: 'tool_use',
-        id: toolCall.id,
-        name: toolCall.function.name,
-        input: JSON.parse(toolCall.function.arguments || '{}'),
-      });
+      if (toolCall.type === 'function') {
+        content.push({
+          type: 'tool_use',
+          id: toolCall.id,
+          name: toolCall.function.name,
+          input: JSON.parse(toolCall.function.arguments || '{}'),
+        });
+      }
     }
   }
 
@@ -231,6 +233,12 @@ export class OpenAIProvider implements ILLMProvider {
       content: fromOpenAIResponse(choice),
       model: response.model,
       stopReason: mapFinishReason(choice.finish_reason),
+      usage: response.usage
+        ? {
+            inputTokens: response.usage.prompt_tokens,
+            outputTokens: response.usage.completion_tokens,
+          }
+        : undefined,
     };
   }
 
@@ -248,7 +256,9 @@ export class OpenAIProvider implements ILLMProvider {
         messages: [{ role: 'user', content: 'hi' }],
       });
       return true;
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`   ⚠️  OpenAI API error: ${message}`);
       return false;
     }
   }

--- a/tests/tools/e2e-ai-analyzer/providers/types.ts
+++ b/tests/tools/e2e-ai-analyzer/providers/types.ts
@@ -71,12 +71,21 @@ export interface LLMRequest {
 }
 
 /**
+ * Token usage for a single API call
+ */
+export interface LLMUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
  * Response from creating a message/completion
  */
 export interface LLMResponse {
   content: LLMContentBlock[];
   model: string;
   stopReason: string;
+  usage?: LLMUsage;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.71.0":
-  version: 0.71.2
-  resolution: "@anthropic-ai/sdk@npm:0.71.2"
+"@anthropic-ai/sdk@npm:^0.78.0":
+  version: 0.78.0
+  resolution: "@anthropic-ai/sdk@npm:0.78.0"
   dependencies:
     json-schema-to-ts: "npm:^3.1.1"
   peerDependencies:
@@ -60,7 +60,7 @@ __metadata:
       optional: true
   bin:
     anthropic-ai-sdk: bin/cli
-  checksum: 10/a8190f9e860079dd97a544a95f36bd4b0b3a9a941610d7e067c431dc47febe03e3e761fc371166b261af9629d832533eeb3d8e72298e9f73dd52994a61881a2c
+  checksum: 10/7cb34e36d4fc766f0765b2581596825996073b03eec97a1193f07c6ca4ab48a021310dae9df630d61550ae2aa7fb3a6cf54236f7418932b25ea1a0e32624fdf1
   languageName: node
   linkType: hard
 
@@ -35396,7 +35396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "metamask@workspace:."
   dependencies:
-    "@anthropic-ai/sdk": "npm:^0.71.0"
+    "@anthropic-ai/sdk": "npm:^0.78.0"
     "@babel/core": "npm:^7.25.2"
     "@babel/eslint-parser": "npm:^7.25.1"
     "@babel/preset-env": "npm:^7.25.3"
@@ -35739,7 +35739,7 @@ __metadata:
     multihashes: "npm:0.4.14"
     number-to-bn: "npm:1.7.0"
     nyc: "npm:^15.1.0"
-    openai: "npm:^4.77.0"
+    openai: "npm:^6.25.0"
     pako: "npm:^2.1.0"
     patch-package: "npm:^6.2.2"
     path: "npm:0.12.7"
@@ -37939,7 +37939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:4.104.0, openai@npm:^4.77.0":
+"openai@npm:4.104.0":
   version: 4.104.0
   resolution: "openai@npm:4.104.0"
   dependencies:
@@ -37986,6 +37986,23 @@ __metadata:
   bin:
     openai: bin/cli
   checksum: 10/bffe52dc4cc49a4537fb88e7101ea6d043294819f1e2d540bcad1dadbff1a44d963912541fe8b212fd93b12f1fe6a082265bb5043fa9ab25896268449d4edcb6
+  languageName: node
+  linkType: hard
+
+"openai@npm:^6.25.0":
+  version: 6.25.0
+  resolution: "openai@npm:6.25.0"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: 10/c9243b5bb769463c794d7f76e4cd0deee1d3d16e752d0119aad677144f414c5d3f2aaed3f50ab8e8260f7f114140b751563aa48c6d61847c90752f7f39a0cfa2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
  Upgrades the smart E2E selector's AI provider stack and adds token usage
  and cost reporting to make it easier to monitor and compare provider costs.

  ### Provider changes
  - **Default provider switched to OpenAI** (`openai → anthropic → google` priority)
  - **OpenAI model**: `gpt-5.2-chat-latest`
  - **Anthropic model**: `claude-sonnet-4-6` (was `claude-opus-4-5-20251101`)

  ### SDK upgrades
  - `openai`: `^4.77.0` → `^6.25.0`
  - `@anthropic-ai/sdk`: `^0.71.0` → `^0.78.0`
  - Fixed breaking change from openai v6: `ChatCompletionMessageToolCall` is now
    a discriminated union — added `toolCall.type === 'function'` guard before
    accessing `.function`

  ### Error visibility
  - Provider `isAvailable()` catch blocks now log the actual API error instead
    of silently returning `false`
  - Availability check output now distinguishes between missing API key and
    failed API call

  ### Token cost tracking
  - Added `LLMUsage` type to `LLMResponse` — all three providers now return
    `inputTokens` / `outputTokens` per API call
  - `analyzeWithAgent` accumulates totals across iterations and prints a cost
    report on completion
  - `MODEL_PRICING` table added to `config.ts` (keyed to the three active models)
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

 ## **Manual testing steps**                                                                        
                                                                                                     
  ```gherkin                                                                                         
  Feature: Smart E2E provider selection and cost tracking                                            
                                                                                                  
    Scenario: user runs analyzer with valid OpenAI key
      Given E2E_OPENAI_API_KEY is set to a valid key
      When user runs node -r esbuild-register tests/tools/e2e-ai-analyzer --pr <number> -p openai
      Then the output shows "✅ OpenAI GPT is available"
      And a "💰 Token Usage Report" is printed with input tokens, output tokens, and total cost in
  USD

    Scenario: user runs analyzer with missing API key
      Given E2E_OPENAI_API_KEY is not set
      When user runs node -r esbuild-register tests/tools/e2e-ai-analyzer --pr <number>
      Then the output shows "❌ OpenAI GPT is not available — missing E2E_OPENAI_API_KEY"
      And the analyzer falls back to the next available provider

    Scenario: user runs analyzer with an invalid API key
      Given E2E_OPENAI_API_KEY is set to an invalid value
      When user runs node -r esbuild-register tests/tools/e2e-ai-analyzer --pr <number>
      Then the output shows "⚠️   OpenAI API error: <error message>"
      And the output shows "❌ OpenAI GPT is not available — API call failed (see warning above)"

    Scenario: user runs analyzer with only Anthropic key set
      Given E2E_OPENAI_API_KEY is not set and E2E_CLAUDE_API_KEY is valid
      When user runs node -r esbuild-register tests/tools/e2e-ai-analyzer --pr <number>
      Then Anthropic is used as the active provider
      And the token report shows model "claude-sonnet-4-6" with cost in USD
  ```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to major `openai` SDK upgrade and provider/model default changes that can alter analyzer behavior and costs, though the impact is confined to test tooling.
> 
> **Overview**
> Updates the `tests/tools/e2e-ai-analyzer` provider stack by upgrading `openai` to v6 and `@anthropic-ai/sdk`, switching the default provider priority to **OpenAI → Anthropic → Google**, and updating the default OpenAI/Anthropic model IDs.
> 
> Adds **token usage + estimated cost reporting**: introduces `LLMUsage` on `LLMResponse`, populates usage from all three providers, accumulates totals across agent iterations in `analyzeWithAgent`, and prints a final report using a new `MODEL_PRICING` table.
> 
> Improves provider diagnostics by logging underlying API errors during `isAvailable()` checks and making availability output distinguish between missing API keys and failed API calls; also adds an OpenAI v6 tool-call type guard (`toolCall.type === 'function'`) when decoding tool uses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8389bd8f25556b803e6df589a96ef16d3ad9c08c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->