### PR TITLE
fix(predict): fix query invalidation logic in usePredictToastRegistrations

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -159,12 +159,19 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
         });
 
         queryClient.invalidateQueries({
-          queryKey: predictQueries.activity.keys.all(),
-        });
-
-        queryClient.invalidateQueries({
           queryKey: predictQueries.unrealizedPnL.keys.all(),
         });
+
+        // Deposit/Withdraw should not invalidate positions/activity
+        if (type === 'claim') {
+          queryClient.invalidateQueries({
+            queryKey: predictQueries.positions.keys.all(),
+          });
+
+          queryClient.invalidateQueries({
+            queryKey: predictQueries.activity.keys.all(),
+          });
+        }
       }
 
       if (type === 'deposit') {
@@ -250,10 +257,6 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
         }
 
         if (status === 'confirmed') {
-          queryClient.invalidateQueries({
-            queryKey: predictQueries.positions.keys.all(),
-          });
-
           showSuccessToast({
             showToast,
             title: strings('predict.deposit.account_ready'),


### PR DESCRIPTION
## **Description**

Deposit and withdraw toast handlers were incorrectly invalidating positions and activity queries, causing unnecessary refetches. This change scopes those invalidations to only the `claim` type, where they are actually relevant. Balance and unrealized PnL queries remain invalidated for all types.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict query invalidations

  Scenario: Deposit completes without refetching positions/activity
    Given the user has a pending deposit transaction

    When the deposit transaction is confirmed
    Then balance and unrealized PnL queries are invalidated
    And positions and activity queries are NOT invalidated

  Scenario: Claim completes and refetches all relevant data
    Given the user has a pending claim transaction

    When the claim transaction is confirmed
    Then balance, unrealized PnL, positions, and activity queries are all invalidated
```

## **Screenshots/Recordings**

<!-- Not applicable — logic-only change -->

### **Before**

<!-- N/A -->

### **After**

<!-- N/A -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change limited to React Query cache invalidation; it only reduces unnecessary refetches after deposit/withdraw confirmations and should not affect transaction execution.
> 
> **Overview**
> Fixes `usePredictToastRegistrations` query invalidation so **on `confirmed` transactions** it always invalidates `balance` and `unrealizedPnL`, but only invalidates `positions` and `activity` when the transaction `type` is `claim`.
> 
> This prevents deposit/withdraw toast flows from triggering unnecessary `positions`/`activity` refetches while keeping claim-related data refresh behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e157a2edcf2c6826cc09a382e548998e45795d76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->