### PR TITLE
refactor: replace custom prediction hooks with team React Query hooks

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -106,6 +106,27 @@ jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
   selectPredictEnabledFlag: jest.fn(() => true),
 }));
 
+jest.mock('../../UI/Predict/hooks/usePredictPositions', () => ({
+  usePredictPositions: () => ({
+    data: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../../UI/Predict/hooks/usePredictMarketData', () => ({
+  usePredictMarketData: () => ({
+    marketData: [],
+    isFetching: false,
+    isFetchingMore: false,
+    error: null,
+    hasMore: false,
+    refetch: jest.fn().mockResolvedValue(undefined),
+    fetchMore: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 jest.mock(
   '../../../selectors/featureFlagController/assetsDefiPositions',
   () => ({

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -50,13 +50,13 @@ jest.mock('./hooks', () => ({
     markets: [],
     isLoading: false,
     error: null,
-    refresh: jest.fn(),
+    refetch: jest.fn(),
   })),
   usePredictPositionsForHomepage: jest.fn(() => ({
     positions: [],
     isLoading: false,
     error: null,
-    refresh: jest.fn(),
+    refetch: jest.fn(),
   })),
 }));
 
@@ -163,7 +163,7 @@ describe('PredictionsSection', () => {
       ],
       isLoading: false,
       error: null,
-      refresh: jest.fn(),
+      refetch: jest.fn(),
     });
 
     mockUsePredictPositionsForHomepage.mockImplementation(
@@ -172,7 +172,7 @@ describe('PredictionsSection', () => {
         isLoading: false,
         error: null,
         totalClaimableValue: 0,
-        refresh: jest.fn(),
+        refetch: jest.fn(),
       }),
     );
   });
@@ -219,7 +219,7 @@ describe('PredictionsSection', () => {
           isLoading: false,
           error: null,
           totalClaimableValue: 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
     });
@@ -244,7 +244,7 @@ describe('PredictionsSection', () => {
           isLoading: !claimable, // only active positions loading
           error: null,
           totalClaimableValue: 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
 
@@ -284,7 +284,7 @@ describe('PredictionsSection', () => {
         markets: mockMarkets,
         isLoading: false,
         error: null,
-        refresh: jest.fn(),
+        refetch: jest.fn(),
       });
 
       renderWithProvider(
@@ -301,7 +301,7 @@ describe('PredictionsSection', () => {
         markets: [],
         isLoading: true,
         error: null,
-        refresh: jest.fn(),
+        refetch: jest.fn(),
       });
 
       renderWithProvider(
@@ -317,7 +317,7 @@ describe('PredictionsSection', () => {
         markets: [],
         isLoading: false,
         error: null,
-        refresh: jest.fn(),
+        refetch: jest.fn(),
       });
 
       const { toJSON } = renderWithProvider(
@@ -334,7 +334,7 @@ describe('PredictionsSection', () => {
         markets: [],
         isLoading: false,
         error: 'Network error',
-        refresh: jest.fn(),
+        refetch: jest.fn(),
       });
 
       renderWithProvider(
@@ -350,7 +350,7 @@ describe('PredictionsSection', () => {
         markets: [],
         isLoading: true,
         error: null,
-        refresh: jest.fn(),
+        refetch: jest.fn(),
       });
 
       renderWithProvider(
@@ -374,7 +374,7 @@ describe('PredictionsSection', () => {
           isLoading: false,
           error: null,
           totalClaimableValue: 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
     });
@@ -396,7 +396,7 @@ describe('PredictionsSection', () => {
           isLoading: false,
           error: null,
           totalClaimableValue: claimable ? 200 : 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
 
@@ -418,7 +418,7 @@ describe('PredictionsSection', () => {
           isLoading: claimable, // claimable fetch still loading
           error: null,
           totalClaimableValue: 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
 
@@ -438,7 +438,7 @@ describe('PredictionsSection', () => {
           isLoading: !claimable, // active fetch still loading
           error: null,
           totalClaimableValue: 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
 
@@ -458,7 +458,7 @@ describe('PredictionsSection', () => {
           isLoading: false,
           error: null,
           totalClaimableValue: claimable ? 200 : 0,
-          refresh: jest.fn(),
+          refetch: jest.fn(),
         }),
       );
 
@@ -479,26 +479,24 @@ describe('PredictionsSection', () => {
   });
 
   describe('refresh functionality', () => {
-    it('refreshes only markets when user has no positions', async () => {
-      const mockRefreshActivePositions = jest.fn().mockResolvedValue(undefined);
-      const mockRefreshMarkets = jest.fn().mockResolvedValue(undefined);
+    it('refreshes both positions and markets on pull-to-refresh', async () => {
+      const mockRefetchPositions = jest.fn().mockResolvedValue(undefined);
+      const mockRefetchMarkets = jest.fn().mockResolvedValue(undefined);
 
       mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
+        (_options: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: [],
           isLoading: false,
           error: null,
           totalClaimableValue: 0,
-          refresh: claimable ? jest.fn() : mockRefreshActivePositions,
+          refetch: mockRefetchPositions,
         }),
       );
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: false,
         error: null,
-        refresh: mockRefreshMarkets,
+        refetch: mockRefetchMarkets,
       });
 
       const ref = React.createRef<{ refresh: () => Promise<void> }>();
@@ -512,45 +510,8 @@ describe('PredictionsSection', () => {
 
       await ref.current?.refresh();
 
-      expect(mockRefreshActivePositions).not.toHaveBeenCalled();
-      expect(mockRefreshMarkets).toHaveBeenCalled();
-    });
-
-    it('refreshes positions and markets when user has positions', async () => {
-      const mockRefreshActivePositions = jest.fn().mockResolvedValue(undefined);
-      const mockRefreshMarkets = jest.fn().mockResolvedValue(undefined);
-
-      mockUsePredictPositionsForHomepage.mockImplementation(
-        ({
-          claimable = false,
-        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
-          positions: claimable ? [] : mockActivePositions,
-          isLoading: false,
-          error: null,
-          totalClaimableValue: 0,
-          refresh: claimable ? jest.fn() : mockRefreshActivePositions,
-        }),
-      );
-      mockUsePredictMarketsForHomepage.mockReturnValue({
-        markets: [],
-        isLoading: false,
-        error: null,
-        refresh: mockRefreshMarkets,
-      });
-
-      const ref = React.createRef<{ refresh: () => Promise<void> }>();
-      renderWithProvider(
-        <PredictionsSection
-          sectionIndex={0}
-          totalSectionsLoaded={1}
-          ref={ref}
-        />,
-      );
-
-      await ref.current?.refresh();
-
-      expect(mockRefreshActivePositions).toHaveBeenCalled();
-      expect(mockRefreshMarkets).toHaveBeenCalled();
+      expect(mockRefetchPositions).toHaveBeenCalled();
+      expect(mockRefetchMarkets).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -6,7 +6,6 @@ import Routes from '../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
 const mockClaim = jest.fn();
-const mockRefreshClaimable = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -140,7 +139,6 @@ describe('PredictionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockClaim.mockResolvedValue(undefined);
-    mockRefreshClaimable.mockResolvedValue(undefined);
 
     // Reset mock return value to default (true) to ensure test isolation
     jest
@@ -168,13 +166,13 @@ describe('PredictionsSection', () => {
       refresh: jest.fn(),
     });
 
-    // Differentiate active vs claimable positions calls by second arg
     mockUsePredictPositionsForHomepage.mockImplementation(
-      (_maxPositions?: number, claimable = false) => ({
+      (_options: { maxPositions?: number; claimable?: boolean } = {}) => ({
         positions: [],
         isLoading: false,
         error: null,
-        refresh: claimable ? mockRefreshClaimable : jest.fn(),
+        totalClaimableValue: 0,
+        refresh: jest.fn(),
       }),
     );
   });
@@ -214,11 +212,14 @@ describe('PredictionsSection', () => {
   describe('when user has positions', () => {
     beforeEach(() => {
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: claimable ? [] : mockActivePositions,
           isLoading: false,
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: 0,
+          refresh: jest.fn(),
         }),
       );
     });
@@ -236,11 +237,14 @@ describe('PredictionsSection', () => {
 
     it('shows position skeletons when loading positions', () => {
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: [],
           isLoading: !claimable, // only active positions loading
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: 0,
+          refresh: jest.fn(),
         }),
       );
 
@@ -363,11 +367,14 @@ describe('PredictionsSection', () => {
     beforeEach(() => {
       // Show positions so the positions branch renders
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: claimable ? [] : mockActivePositions,
           isLoading: false,
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: 0,
+          refresh: jest.fn(),
         }),
       );
     });
@@ -381,13 +388,15 @@ describe('PredictionsSection', () => {
     });
 
     it('shows claim button with total amount when claimable positions exist', async () => {
-      // totalClaimable = 75 + 125 = 200
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: claimable ? mockClaimablePositions : mockActivePositions,
           isLoading: false,
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: claimable ? 200 : 0,
+          refresh: jest.fn(),
         }),
       );
 
@@ -402,11 +411,14 @@ describe('PredictionsSection', () => {
 
     it('does not show claim button while claimable positions are loading', () => {
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: [],
           isLoading: claimable, // claimable fetch still loading
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: 0,
+          refresh: jest.fn(),
         }),
       );
 
@@ -419,11 +431,14 @@ describe('PredictionsSection', () => {
 
     it('does not show claim button while active positions are loading', () => {
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: [],
           isLoading: !claimable, // active fetch still loading
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: 0,
+          refresh: jest.fn(),
         }),
       );
 
@@ -434,13 +449,16 @@ describe('PredictionsSection', () => {
       expect(screen.queryByText(/Claim \$/)).not.toBeOnTheScreen();
     });
 
-    it('calls claim and then refreshes claimable positions on press', async () => {
+    it('calls claim on press without manual refresh', async () => {
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: claimable ? mockClaimablePositions : mockActivePositions,
           isLoading: false,
           error: null,
-          refresh: claimable ? mockRefreshClaimable : jest.fn(),
+          totalClaimableValue: claimable ? 200 : 0,
+          refresh: jest.fn(),
         }),
       );
 
@@ -456,24 +474,24 @@ describe('PredictionsSection', () => {
 
       await waitFor(() => {
         expect(mockClaim).toHaveBeenCalledTimes(1);
-        expect(mockRefreshClaimable).toHaveBeenCalledTimes(1);
       });
     });
   });
 
   describe('refresh functionality', () => {
-    it('refreshes markets and claimable when user has no positions', async () => {
+    it('refreshes only markets when user has no positions', async () => {
       const mockRefreshActivePositions = jest.fn().mockResolvedValue(undefined);
       const mockRefreshMarkets = jest.fn().mockResolvedValue(undefined);
 
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: [],
           isLoading: false,
           error: null,
-          refresh: claimable
-            ? mockRefreshClaimable
-            : mockRefreshActivePositions,
+          totalClaimableValue: 0,
+          refresh: claimable ? jest.fn() : mockRefreshActivePositions,
         }),
       );
       mockUsePredictMarketsForHomepage.mockReturnValue({
@@ -496,21 +514,21 @@ describe('PredictionsSection', () => {
 
       expect(mockRefreshActivePositions).not.toHaveBeenCalled();
       expect(mockRefreshMarkets).toHaveBeenCalled();
-      expect(mockRefreshClaimable).toHaveBeenCalled();
     });
 
-    it('refreshes positions, markets, and claimable when user has positions', async () => {
+    it('refreshes positions and markets when user has positions', async () => {
       const mockRefreshActivePositions = jest.fn().mockResolvedValue(undefined);
       const mockRefreshMarkets = jest.fn().mockResolvedValue(undefined);
 
       mockUsePredictPositionsForHomepage.mockImplementation(
-        (_maxPositions?: number, claimable = false) => ({
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
           positions: claimable ? [] : mockActivePositions,
           isLoading: false,
           error: null,
-          refresh: claimable
-            ? mockRefreshClaimable
-            : mockRefreshActivePositions,
+          totalClaimableValue: 0,
+          refresh: claimable ? jest.fn() : mockRefreshActivePositions,
         }),
       );
       mockUsePredictMarketsForHomepage.mockReturnValue({
@@ -533,7 +551,6 @@ describe('PredictionsSection', () => {
 
       expect(mockRefreshActivePositions).toHaveBeenCalled();
       expect(mockRefreshMarkets).toHaveBeenCalled();
-      expect(mockRefreshClaimable).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -97,21 +97,12 @@ const PredictionsSection = forwardRef<
     refresh: refreshMarkets,
   } = usePredictMarketsForHomepage(MAX_MARKETS_DISPLAYED);
 
-  const {
-    positions: claimablePositions,
-    isLoading: isLoadingClaimable,
-    refresh: refreshClaimable,
-  } = usePredictPositionsForHomepage(undefined, true);
+  const { totalClaimableValue, isLoading: isLoadingClaimable } =
+    usePredictPositionsForHomepage({ claimable: true });
 
   const handleClaim = useCallback(async () => {
     await claim();
-    await refreshClaimable();
-  }, [claim, refreshClaimable]);
-
-  const totalClaimable = claimablePositions.reduce(
-    (sum, p) => sum + (p.currentValue ?? 0),
-    0,
-  );
+  }, [claim]);
 
   // Determine if user has positions
   const hasPositions = positions.length > 0;
@@ -152,18 +143,13 @@ const PredictionsSection = forwardRef<
     itemCount,
   });
 
-  // Refresh: only refresh positions if user has them, always refresh markets + claimable
   const refresh = useCallback(async () => {
     if (hasPositionsRef.current) {
-      await Promise.all([
-        refreshPositions(),
-        refreshMarkets(),
-        refreshClaimable(),
-      ]);
+      await Promise.all([refreshPositions(), refreshMarkets()]);
     } else {
-      await Promise.all([refreshMarkets(), refreshClaimable()]);
+      await refreshMarkets();
     }
-  }, [refreshPositions, refreshMarkets, refreshClaimable]);
+  }, [refreshPositions, refreshMarkets]);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
@@ -231,10 +217,10 @@ const PredictionsSection = forwardRef<
             )}
             {!isLoadingPositions &&
               !isLoadingClaimable &&
-              totalClaimable > 0 && (
+              totalClaimableValue > 0 && (
                 <Box paddingHorizontal={4} paddingTop={1} paddingBottom={3}>
                   <PredictClaimButton
-                    amount={totalClaimable}
+                    amount={totalClaimableValue}
                     onPress={handleClaim}
                   />
                 </Box>

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -87,14 +87,14 @@ const PredictionsSection = forwardRef<
     positions,
     isLoading: isLoadingPositions,
     error: positionsError,
-    refresh: refreshPositions,
+    refetch: refetchPositions,
   } = usePredictPositionsForHomepage();
 
   const {
     markets,
     isLoading: isLoadingMarkets,
     error: marketsError,
-    refresh: refreshMarkets,
+    refetch: refetchMarkets,
   } = usePredictMarketsForHomepage(MAX_MARKETS_DISPLAYED);
 
   const { totalClaimableValue, isLoading: isLoadingClaimable } =
@@ -106,10 +106,6 @@ const PredictionsSection = forwardRef<
 
   // Determine if user has positions
   const hasPositions = positions.length > 0;
-
-  // Use ref so refresh always reads the latest value without stale closures
-  const hasPositionsRef = useRef(hasPositions);
-  hasPositionsRef.current = hasPositions;
 
   const isLoading = isLoadingPositions || isLoadingMarkets;
 
@@ -144,12 +140,8 @@ const PredictionsSection = forwardRef<
   });
 
   const refresh = useCallback(async () => {
-    if (hasPositionsRef.current) {
-      await Promise.all([refreshPositions(), refreshMarkets()]);
-    } else {
-      await refreshMarkets();
-    }
-  }, [refreshPositions, refreshMarkets]);
+    await Promise.all([refetchPositions(), refetchMarkets()]);
+  }, [refetchPositions, refetchMarkets]);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.test.ts
@@ -2,25 +2,6 @@ import { renderHook } from '@testing-library/react-native';
 import { usePredictMarketsForHomepage } from './usePredictMarketsForHomepage';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
 
-let mockIsPredictEnabled = true;
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (selector: (...args: unknown[]) => unknown) => {
-    if (
-      selector ===
-      jest.requireMock('../../../../../UI/Predict').selectPredictEnabledFlag
-    ) {
-      return mockIsPredictEnabled;
-    }
-    return undefined;
-  },
-}));
-
-jest.mock('../../../../../UI/Predict', () => ({
-  selectPredictEnabledFlag: jest.fn(),
-}));
-
 const mockRefetch = jest.fn().mockResolvedValue(undefined);
 let mockUsePredictMarketDataReturn: {
   marketData: PredictMarket[];
@@ -61,7 +42,6 @@ const createMockMarket = (id: string): PredictMarket =>
 describe('usePredictMarketsForHomepage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsPredictEnabled = true;
     mockUsePredictMarketDataReturn = {
       marketData: [
         createMockMarket('1'),
@@ -83,30 +63,6 @@ describe('usePredictMarketsForHomepage', () => {
     expect(result.current.markets).toHaveLength(3);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
-  });
-
-  it('returns empty markets when predict is disabled', () => {
-    mockIsPredictEnabled = false;
-
-    const { result } = renderHook(() => usePredictMarketsForHomepage(5));
-
-    expect(result.current.markets).toHaveLength(0);
-  });
-
-  it('slices markets to the specified limit', () => {
-    mockUsePredictMarketDataReturn.marketData = [
-      createMockMarket('1'),
-      createMockMarket('2'),
-      createMockMarket('3'),
-      createMockMarket('4'),
-      createMockMarket('5'),
-    ];
-
-    const { result } = renderHook(() => usePredictMarketsForHomepage(3));
-
-    expect(result.current.markets).toHaveLength(3);
-    expect(result.current.markets[0].id).toBe('1');
-    expect(result.current.markets[2].id).toBe('3');
   });
 
   it('forwards isFetching as isLoading', () => {
@@ -131,27 +87,11 @@ describe('usePredictMarketsForHomepage', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('calls refetch when refresh is invoked', async () => {
+  it('exposes refetch from usePredictMarketData', async () => {
     const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
-    await result.current.refresh();
+    await result.current.refetch();
 
     expect(mockRefetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('defaults limit to 5', () => {
-    mockUsePredictMarketDataReturn.marketData = [
-      createMockMarket('1'),
-      createMockMarket('2'),
-      createMockMarket('3'),
-      createMockMarket('4'),
-      createMockMarket('5'),
-      createMockMarket('6'),
-      createMockMarket('7'),
-    ];
-
-    const { result } = renderHook(() => usePredictMarketsForHomepage());
-
-    expect(result.current.markets).toHaveLength(5);
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.test.ts
@@ -1,19 +1,6 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import {
-  usePredictMarketsForHomepage,
-  _clearMarketsCache,
-} from './usePredictMarketsForHomepage';
+import { renderHook } from '@testing-library/react-native';
+import { usePredictMarketsForHomepage } from './usePredictMarketsForHomepage';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
-
-const mockGetMarkets = jest.fn();
-
-jest.mock('../../../../../../core/Engine', () => ({
-  context: {
-    PredictController: {
-      getMarkets: (...args: unknown[]) => mockGetMarkets(...args),
-    },
-  },
-}));
 
 let mockIsPredictEnabled = true;
 
@@ -34,6 +21,29 @@ jest.mock('../../../../../UI/Predict', () => ({
   selectPredictEnabledFlag: jest.fn(),
 }));
 
+const mockRefetch = jest.fn().mockResolvedValue(undefined);
+let mockUsePredictMarketDataReturn: {
+  marketData: PredictMarket[];
+  isFetching: boolean;
+  isFetchingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  refetch: jest.Mock;
+  fetchMore: jest.Mock;
+} = {
+  marketData: [],
+  isFetching: false,
+  isFetchingMore: false,
+  error: null,
+  hasMore: false,
+  refetch: mockRefetch,
+  fetchMore: jest.fn(),
+};
+
+jest.mock('../../../../../UI/Predict/hooks/usePredictMarketData', () => ({
+  usePredictMarketData: () => mockUsePredictMarketDataReturn,
+}));
+
 const createMockMarket = (id: string): PredictMarket =>
   ({
     id,
@@ -51,30 +61,28 @@ const createMockMarket = (id: string): PredictMarket =>
 describe('usePredictMarketsForHomepage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    _clearMarketsCache();
     mockIsPredictEnabled = true;
-
-    mockGetMarkets.mockResolvedValue([
-      createMockMarket('1'),
-      createMockMarket('2'),
-      createMockMarket('3'),
-    ]);
+    mockUsePredictMarketDataReturn = {
+      marketData: [
+        createMockMarket('1'),
+        createMockMarket('2'),
+        createMockMarket('3'),
+      ],
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: mockRefetch,
+      fetchMore: jest.fn(),
+    };
   });
 
-  it('fetches markets on mount when predict is enabled', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
+  it('returns markets from usePredictMarketData', () => {
+    const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
     expect(result.current.markets).toHaveLength(3);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(mockGetMarkets).toHaveBeenCalledWith({
-      category: 'trending',
-      limit: 5,
-    });
   });
 
   it('returns empty markets when predict is disabled', () => {
@@ -83,134 +91,67 @@ describe('usePredictMarketsForHomepage', () => {
     const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
     expect(result.current.markets).toHaveLength(0);
-    expect(result.current.isLoading).toBe(false);
-    expect(mockGetMarkets).not.toHaveBeenCalled();
   });
 
-  it('limits markets to the specified limit', async () => {
-    mockGetMarkets.mockResolvedValue([
+  it('slices markets to the specified limit', () => {
+    mockUsePredictMarketDataReturn.marketData = [
       createMockMarket('1'),
       createMockMarket('2'),
       createMockMarket('3'),
       createMockMarket('4'),
       createMockMarket('5'),
-    ]);
+    ];
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketsForHomepage(3),
-    );
-
-    await waitForNextUpdate();
+    const { result } = renderHook(() => usePredictMarketsForHomepage(3));
 
     expect(result.current.markets).toHaveLength(3);
+    expect(result.current.markets[0].id).toBe('1');
+    expect(result.current.markets[2].id).toBe('3');
   });
 
-  it('sets error state when fetch fails', async () => {
-    mockGetMarkets.mockRejectedValue(new Error('Network error'));
+  it('forwards isFetching as isLoading', () => {
+    mockUsePredictMarketDataReturn.isFetching = true;
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
+    const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
-    await waitForNextUpdate();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('forwards error from usePredictMarketData', () => {
+    mockUsePredictMarketDataReturn.error = 'Network error';
+
+    const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
     expect(result.current.error).toBe('Network error');
-    expect(result.current.markets).toHaveLength(0);
-    expect(result.current.isLoading).toBe(false);
   });
 
-  it('sets fallback error for non-Error throws', async () => {
-    mockGetMarkets.mockRejectedValue('string error');
+  it('returns null error when no error', () => {
+    const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
-
-    expect(result.current.error).toBe('Failed to fetch prediction markets');
-  });
-
-  it('handles null response from getMarkets', async () => {
-    mockGetMarkets.mockResolvedValue(null);
-
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
-
-    expect(result.current.markets).toHaveLength(0);
     expect(result.current.error).toBeNull();
   });
 
-  it('uses cached data on subsequent renders within TTL', async () => {
-    const { waitForNextUpdate, unmount } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
-
-    expect(mockGetMarkets).toHaveBeenCalledTimes(1);
-    unmount();
-
-    const { result: result2 } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
-
-    expect(result2.current.markets).toHaveLength(3);
-    expect(result2.current.isLoading).toBe(false);
-    expect(mockGetMarkets).toHaveBeenCalledTimes(1);
-  });
-
-  it('clears cache and refetches on refresh', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictMarketsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
-
-    expect(mockGetMarkets).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    expect(mockGetMarkets).toHaveBeenCalledTimes(2);
-  });
-
-  it('returns error when Engine context is null', async () => {
-    const engineMock = jest.requireMock('../../../../../../core/Engine');
-    const savedContext = engineMock.context;
-    engineMock.context = null;
-
+  it('calls refetch when refresh is invoked', async () => {
     const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
-    // Allow the async fetchMarkets to settle
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await result.current.refresh();
 
-    expect(result.current.error).toBe('Engine not initialized');
-    expect(result.current.isLoading).toBe(false);
-
-    engineMock.context = savedContext;
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
-  it('returns error when PredictController is null', async () => {
-    const engineMock = jest.requireMock('../../../../../../core/Engine');
-    const savedController = engineMock.context.PredictController;
-    engineMock.context.PredictController = null;
+  it('defaults limit to 5', () => {
+    mockUsePredictMarketDataReturn.marketData = [
+      createMockMarket('1'),
+      createMockMarket('2'),
+      createMockMarket('3'),
+      createMockMarket('4'),
+      createMockMarket('5'),
+      createMockMarket('6'),
+      createMockMarket('7'),
+    ];
 
-    const { result } = renderHook(() => usePredictMarketsForHomepage(5));
+    const { result } = renderHook(() => usePredictMarketsForHomepage());
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    expect(result.current.error).toBe('Predict controller not available');
-    expect(result.current.isLoading).toBe(false);
-
-    engineMock.context.PredictController = savedController;
+    expect(result.current.markets).toHaveLength(5);
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.ts
@@ -1,7 +1,4 @@
-import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import { usePredictMarketData } from '../../../../../UI/Predict/hooks/usePredictMarketData';
-import { selectPredictEnabledFlag } from '../../../../../UI/Predict';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
 
 /**
@@ -14,43 +11,34 @@ export interface UsePredictMarketsForHomepageResult {
   isLoading: boolean;
   /** Error message if fetch failed */
   error: string | null;
-  /** Refresh function to manually refetch data */
-  refresh: () => Promise<void>;
+  /** Refetch function to manually refetch data */
+  refetch: () => Promise<unknown>;
 }
 
 /**
  * Lightweight wrapper around the Predict team's usePredictMarketData hook,
  * adapted for homepage display with trending markets.
  *
- * Delegates all caching, retry logic, and error handling to the underlying hook.
+ * The feature flag check is handled at the UI level (Homepage conditionally
+ * renders the Predictions section), so this hook assumes it is only called
+ * when predictions are enabled.
  *
  * @param limit - Maximum number of markets to return (default: 5)
- * @returns Object with markets, isLoading, error, refresh
+ * @returns Object with markets, isLoading, error, refetch
  */
 export const usePredictMarketsForHomepage = (
   limit = 5,
 ): UsePredictMarketsForHomepageResult => {
-  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
-
   const { marketData, isFetching, error, refetch } = usePredictMarketData({
     category: 'trending',
     pageSize: limit,
   });
 
-  const markets = useMemo(
-    () => (isPredictEnabled ? marketData.slice(0, limit) : []),
-    [isPredictEnabled, marketData, limit],
-  );
-
-  const refresh = useCallback(async () => {
-    await refetch();
-  }, [refetch]);
-
   return {
-    markets,
+    markets: marketData,
     isLoading: isFetching,
     error,
-    refresh,
+    refetch,
   };
 };
 

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import Engine from '../../../../../../core/Engine';
+import { usePredictMarketData } from '../../../../../UI/Predict/hooks/usePredictMarketData';
 import { selectPredictEnabledFlag } from '../../../../../UI/Predict';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
 
@@ -18,209 +18,38 @@ export interface UsePredictMarketsForHomepageResult {
   refresh: () => Promise<void>;
 }
 
-// Module-level cache for markets
-// Persists across component mounts/unmounts for efficient re-use
-interface CacheEntry {
-  markets: PredictMarket[];
-  timestamp: number;
-  limit: number;
-}
-
-let marketsCache: CacheEntry | null = null;
-
-// Cache TTL: 5 minutes
-const CACHE_TTL_MS = 5 * 60 * 1000;
-
 /**
- * Clear the cache - exported for testing purposes only
- * @internal
- */
-export const _clearMarketsCache = (): void => {
-  marketsCache = null;
-};
-
-/**
- * usePredictMarketsForHomepage Hook
+ * Lightweight wrapper around the Predict team's usePredictMarketData hook,
+ * adapted for homepage display with trending markets.
  *
- * Fetches trending prediction markets for homepage display.
- * Designed for homepage/discovery use cases with module-level caching.
- *
- * Key Features:
- * - Module-level caching (5 min TTL) to avoid repeated API calls
- * - Uses PredictController.getMarkets() with category: 'trending'
- * - Returns limited results for carousel display
+ * Delegates all caching, retry logic, and error handling to the underlying hook.
  *
  * @param limit - Maximum number of markets to return (default: 5)
  * @returns Object with markets, isLoading, error, refresh
- *
- * @example
- * ```tsx
- * const { markets, isLoading, error, refresh } = usePredictMarketsForHomepage(5);
- * ```
  */
 export const usePredictMarketsForHomepage = (
   limit = 5,
 ): UsePredictMarketsForHomepageResult => {
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
 
-  // Track if component is still mounted
-  const isMountedRef = useRef(true);
-
-  // Track current request to prevent stale responses
-  const requestIdRef = useRef(0);
-
-  // Use ref for limit to keep fetchMarkets callback stable
-  const limitRef = useRef(limit);
-  limitRef.current = limit;
-
-  const [state, setState] = useState<{
-    markets: PredictMarket[];
-    isLoading: boolean;
-    error: string | null;
-  }>(() => {
-    // Initialize from cache if available and limit is satisfied
-    if (
-      marketsCache &&
-      Date.now() - marketsCache.timestamp < CACHE_TTL_MS &&
-      marketsCache.limit >= limit
-    ) {
-      return {
-        markets: marketsCache.markets.slice(0, limit),
-        isLoading: false,
-        error: null,
-      };
-    }
-
-    return {
-      markets: [],
-      isLoading: isPredictEnabled,
-      error: null,
-    };
+  const { marketData, isFetching, error, refetch } = usePredictMarketData({
+    category: 'trending',
+    pageSize: limit,
   });
 
-  const fetchMarkets = useCallback(async () => {
-    const currentLimit = limitRef.current;
+  const markets = useMemo(
+    () => (isPredictEnabled ? marketData.slice(0, limit) : []),
+    [isPredictEnabled, marketData, limit],
+  );
 
-    if (!isPredictEnabled) {
-      setState({
-        markets: [],
-        isLoading: false,
-        error: null,
-      });
-      return;
-    }
-
-    // Capture current request ID to detect stale responses
-    const currentRequestId = ++requestIdRef.current;
-
-    // Check cache first (only valid if limit is satisfied)
-    if (
-      marketsCache &&
-      Date.now() - marketsCache.timestamp < CACHE_TTL_MS &&
-      marketsCache.limit >= currentLimit
-    ) {
-      if (isMountedRef.current) {
-        setState({
-          markets: marketsCache.markets.slice(0, currentLimit),
-          isLoading: false,
-          error: null,
-        });
-      }
-      return;
-    }
-
-    try {
-      setState((prev) => ({ ...prev, isLoading: true, error: null }));
-
-      if (!Engine || !Engine.context) {
-        throw new Error('Engine not initialized');
-      }
-
-      const controller = Engine.context.PredictController;
-      if (!controller) {
-        throw new Error('Predict controller not available');
-      }
-
-      const markets = await controller.getMarkets({
-        category: 'trending',
-        limit: currentLimit,
-      });
-
-      // Verify this response matches current request
-      if (requestIdRef.current !== currentRequestId || !isMountedRef.current) {
-        return;
-      }
-
-      if (!markets || !Array.isArray(markets)) {
-        setState({
-          markets: [],
-          isLoading: false,
-          error: null,
-        });
-        return;
-      }
-
-      // Cache the result with the limit used for the API call
-      marketsCache = {
-        markets,
-        timestamp: Date.now(),
-        limit: currentLimit,
-      };
-
-      setState({
-        markets: markets.slice(0, currentLimit),
-        isLoading: false,
-        error: null,
-      });
-    } catch (err) {
-      // Verify this error is for current request
-      if (requestIdRef.current !== currentRequestId || !isMountedRef.current) {
-        return;
-      }
-
-      setState({
-        markets: [],
-        isLoading: false,
-        error:
-          err instanceof Error
-            ? err.message
-            : 'Failed to fetch prediction markets',
-      });
-    }
-  }, [isPredictEnabled]);
-
-  // Refresh function that bypasses cache
   const refresh = useCallback(async () => {
-    marketsCache = null; // Clear cache to force refetch
-    await fetchMarkets();
-  }, [fetchMarkets]);
-
-  // Effect to fetch markets on mount
-  useEffect(() => {
-    isMountedRef.current = true;
-
-    if (!isPredictEnabled) {
-      setState({
-        markets: [],
-        isLoading: false,
-        error: null,
-      });
-      return () => {
-        isMountedRef.current = false;
-      };
-    }
-
-    fetchMarkets();
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, [isPredictEnabled, fetchMarkets]);
+    await refetch();
+  }, [refetch]);
 
   return {
-    markets: state.markets,
-    isLoading: state.isLoading,
-    error: state.error,
+    markets,
+    isLoading: isFetching,
+    error,
     refresh,
   };
 };

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
@@ -2,25 +2,6 @@ import { renderHook } from '@testing-library/react-native';
 import { usePredictPositionsForHomepage } from './usePredictPositionsForHomepage';
 import type { PredictPosition } from '../../../../../UI/Predict/types';
 
-let mockIsPredictEnabled = true;
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (selector: (...args: unknown[]) => unknown) => {
-    if (
-      selector ===
-      jest.requireMock('../../../../../UI/Predict').selectPredictEnabledFlag
-    ) {
-      return mockIsPredictEnabled;
-    }
-    return undefined;
-  },
-}));
-
-jest.mock('../../../../../UI/Predict', () => ({
-  selectPredictEnabledFlag: jest.fn(),
-}));
-
 const mockRefetch = jest.fn().mockResolvedValue(undefined);
 let mockUsePredictPositionsReturn: {
   data: PredictPosition[] | undefined;
@@ -55,7 +36,6 @@ const createMockPosition = (id: string, currentValue = 12): PredictPosition =>
 describe('usePredictPositionsForHomepage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsPredictEnabled = true;
     mockUsePredictPositionsReturn = {
       data: [
         createMockPosition('1'),
@@ -138,10 +118,10 @@ describe('usePredictPositionsForHomepage', () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  it('calls refetch when refresh is invoked', async () => {
+  it('exposes refetch from usePredictPositions', async () => {
     const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-    await result.current.refresh();
+    await result.current.refetch();
 
     expect(mockRefetch).toHaveBeenCalledTimes(1);
   });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.test.ts
@@ -1,22 +1,8 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import {
-  usePredictPositionsForHomepage,
-  _clearPositionsCache,
-} from './usePredictPositionsForHomepage';
+import { renderHook } from '@testing-library/react-native';
+import { usePredictPositionsForHomepage } from './usePredictPositionsForHomepage';
 import type { PredictPosition } from '../../../../../UI/Predict/types';
 
-const mockGetPositions = jest.fn();
-
-jest.mock('../../../../../../core/Engine', () => ({
-  context: {
-    PredictController: {
-      getPositions: (...args: unknown[]) => mockGetPositions(...args),
-    },
-  },
-}));
-
 let mockIsPredictEnabled = true;
-let mockUserAddress: string | null = '0xuser123';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -27,13 +13,6 @@ jest.mock('react-redux', () => ({
     ) {
       return mockIsPredictEnabled;
     }
-    if (
-      selector ===
-      jest.requireMock('../../../../../../selectors/accountsController')
-        .selectSelectedInternalAccountFormattedAddress
-    ) {
-      return mockUserAddress;
-    }
     return undefined;
   },
 }));
@@ -42,11 +21,24 @@ jest.mock('../../../../../UI/Predict', () => ({
   selectPredictEnabledFlag: jest.fn(),
 }));
 
-jest.mock('../../../../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccountFormattedAddress: jest.fn(),
+const mockRefetch = jest.fn().mockResolvedValue(undefined);
+let mockUsePredictPositionsReturn: {
+  data: PredictPosition[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: jest.Mock;
+} = {
+  data: undefined,
+  isLoading: false,
+  error: null,
+  refetch: mockRefetch,
+};
+
+jest.mock('../../../../../UI/Predict/hooks/usePredictPositions', () => ({
+  usePredictPositions: () => mockUsePredictPositionsReturn,
 }));
 
-const createMockPosition = (id: string): PredictPosition =>
+const createMockPosition = (id: string, currentValue = 12): PredictPosition =>
   ({
     outcomeId: `outcome-${id}`,
     outcomeIndex: 0,
@@ -55,7 +47,7 @@ const createMockPosition = (id: string): PredictPosition =>
     outcome: 'Yes',
     icon: `https://example.com/icon-${id}.png`,
     initialValue: 10,
-    currentValue: 12,
+    currentValue,
     size: 15,
     percentPnl: 20,
   }) as unknown as PredictPosition;
@@ -63,222 +55,141 @@ const createMockPosition = (id: string): PredictPosition =>
 describe('usePredictPositionsForHomepage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    _clearPositionsCache();
     mockIsPredictEnabled = true;
-    mockUserAddress = '0xuser123';
-
-    mockGetPositions.mockResolvedValue([
-      createMockPosition('1'),
-      createMockPosition('2'),
-      createMockPosition('3'),
-    ]);
+    mockUsePredictPositionsReturn = {
+      data: [
+        createMockPosition('1'),
+        createMockPosition('2'),
+        createMockPosition('3'),
+      ],
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    };
   });
 
-  it('fetches positions on mount when predict is enabled', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
+  it('returns positions from usePredictPositions', () => {
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
     expect(result.current.positions).toHaveLength(3);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(mockGetPositions).toHaveBeenCalledWith({
-      address: '0xuser123',
-      claimable: false,
-    });
   });
 
-  it('returns empty positions when predict is disabled', () => {
-    mockIsPredictEnabled = false;
+  it('returns empty positions when data is undefined', () => {
+    mockUsePredictPositionsReturn.data = undefined;
 
-    const { result } = renderHook(() => usePredictPositionsForHomepage(5));
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
     expect(result.current.positions).toHaveLength(0);
-    expect(result.current.isLoading).toBe(false);
-    expect(mockGetPositions).not.toHaveBeenCalled();
   });
 
-  it('returns empty positions when user address is null', () => {
-    mockUserAddress = null;
-
-    const { result } = renderHook(() => usePredictPositionsForHomepage(5));
-
-    expect(result.current.positions).toHaveLength(0);
-    expect(result.current.isLoading).toBe(false);
-    expect(mockGetPositions).not.toHaveBeenCalled();
-  });
-
-  it('limits positions to maxPositions parameter', async () => {
-    mockGetPositions.mockResolvedValue([
+  it('slices positions to maxPositions', () => {
+    mockUsePredictPositionsReturn.data = [
       createMockPosition('1'),
       createMockPosition('2'),
       createMockPosition('3'),
       createMockPosition('4'),
       createMockPosition('5'),
-    ]);
+    ];
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictPositionsForHomepage(2),
+    const { result } = renderHook(() =>
+      usePredictPositionsForHomepage({ maxPositions: 2 }),
     );
-
-    await waitForNextUpdate();
 
     expect(result.current.positions).toHaveLength(2);
+    expect(result.current.positions[0].outcomeId).toBe('outcome-1');
+    expect(result.current.positions[1].outcomeId).toBe('outcome-2');
   });
 
-  it('sets error state when fetch fails', async () => {
-    mockGetPositions.mockRejectedValue(new Error('API error'));
+  it('returns all positions when maxPositions is omitted', () => {
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
+    expect(result.current.positions).toHaveLength(3);
+  });
 
-    await waitForNextUpdate();
+  it('maps Error to error string', () => {
+    mockUsePredictPositionsReturn.error = new Error('API error');
+
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
     expect(result.current.error).toBe('API error');
-    expect(result.current.positions).toHaveLength(0);
-    expect(result.current.isLoading).toBe(false);
   });
 
-  it('sets fallback error for non-Error throws', async () => {
-    mockGetPositions.mockRejectedValue('string error');
+  it('maps non-Error to error string', () => {
+    mockUsePredictPositionsReturn.error = 'string error' as unknown as Error;
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-    await waitForNextUpdate();
-
-    expect(result.current.error).toBe('Failed to fetch positions');
+    expect(result.current.error).toBe('string error');
   });
 
-  it('handles null response from getPositions', async () => {
-    mockGetPositions.mockResolvedValue(null);
+  it('returns null error when no error', () => {
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
-
-    await waitForNextUpdate();
-
-    expect(result.current.positions).toHaveLength(0);
     expect(result.current.error).toBeNull();
   });
 
-  it('uses cached data on subsequent renders within TTL', async () => {
-    const { waitForNextUpdate, unmount } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
+  it('forwards isLoading from usePredictPositions', () => {
+    mockUsePredictPositionsReturn.isLoading = true;
 
-    await waitForNextUpdate();
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-    expect(mockGetPositions).toHaveBeenCalledTimes(1);
-    unmount();
-
-    const { result: result2 } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
-
-    expect(result2.current.positions).toHaveLength(3);
-    expect(result2.current.isLoading).toBe(false);
-    expect(mockGetPositions).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(true);
   });
 
-  it('clears cache and refetches on refresh', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      usePredictPositionsForHomepage(5),
-    );
+  it('calls refetch when refresh is invoked', async () => {
+    const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-    await waitForNextUpdate();
+    await result.current.refresh();
 
-    expect(mockGetPositions).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    expect(mockGetPositions).toHaveBeenCalledTimes(2);
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
-  describe('claimable parameter', () => {
-    it('passes claimable: false to getPositions by default', async () => {
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictPositionsForHomepage(5),
-      );
+  describe('claimable option', () => {
+    it('defaults claimable to false', () => {
+      const { result } = renderHook(() => usePredictPositionsForHomepage());
 
-      await waitForNextUpdate();
-
-      expect(mockGetPositions).toHaveBeenCalledWith({
-        address: '0xuser123',
-        claimable: false,
-      });
+      expect(result.current.totalClaimableValue).toBe(0);
     });
 
-    it('passes claimable: true to getPositions when specified', async () => {
-      const { waitForNextUpdate } = renderHook(() =>
-        usePredictPositionsForHomepage(undefined, true),
-      );
-
-      await waitForNextUpdate();
-
-      expect(mockGetPositions).toHaveBeenCalledWith({
-        address: '0xuser123',
-        claimable: true,
-      });
-    });
-
-    it('uses separate cache keys for claimable and non-claimable fetches', async () => {
-      // Fetch non-claimable
-      const { waitForNextUpdate: wait1, unmount: unmount1 } = renderHook(() =>
-        usePredictPositionsForHomepage(5, false),
-      );
-      await wait1();
-      unmount1();
-
-      expect(mockGetPositions).toHaveBeenCalledTimes(1);
-
-      // Fetch claimable — must hit the API again (different cache key)
-      const { waitForNextUpdate: wait2 } = renderHook(() =>
-        usePredictPositionsForHomepage(5, true),
-      );
-      await wait2();
-
-      expect(mockGetPositions).toHaveBeenCalledTimes(2);
-    });
-
-    it('serves claimable positions from cache independently of non-claimable', async () => {
-      const claimablePositions = [createMockPosition('c1')];
-      const nonClaimablePositions = [
-        createMockPosition('1'),
-        createMockPosition('2'),
+    it('computes totalClaimableValue as sum of currentValue when claimable is true', () => {
+      mockUsePredictPositionsReturn.data = [
+        createMockPosition('c1', 5),
+        createMockPosition('c2', 10),
+        createMockPosition('c3', 3),
       ];
 
-      mockGetPositions
-        .mockResolvedValueOnce(nonClaimablePositions)
-        .mockResolvedValueOnce(claimablePositions);
+      const { result } = renderHook(() =>
+        usePredictPositionsForHomepage({ claimable: true }),
+      );
 
-      // Populate both caches
-      const {
-        result: r1,
-        waitForNextUpdate: w1,
-        unmount: u1,
-      } = renderHook(() => usePredictPositionsForHomepage(undefined, false));
-      await w1();
-      u1();
+      expect(result.current.totalClaimableValue).toBe(18);
+    });
 
-      const {
-        result: r2,
-        waitForNextUpdate: w2,
-        unmount: u2,
-      } = renderHook(() => usePredictPositionsForHomepage(undefined, true));
-      await w2();
-      u2();
+    it('returns totalClaimableValue 0 when claimable is false', () => {
+      mockUsePredictPositionsReturn.data = [createMockPosition('1', 100)];
 
-      // Each set has its own cached value
-      expect(r1.current.positions).toHaveLength(2);
-      expect(r2.current.positions).toHaveLength(1);
+      const { result } = renderHook(() =>
+        usePredictPositionsForHomepage({ claimable: false }),
+      );
+
+      expect(result.current.totalClaimableValue).toBe(0);
+    });
+
+    it('treats undefined currentValue as 0 in totalClaimableValue sum', () => {
+      mockUsePredictPositionsReturn.data = [
+        {
+          ...createMockPosition('c1', 5),
+          currentValue: undefined,
+        } as unknown as PredictPosition,
+      ];
+
+      const { result } = renderHook(() =>
+        usePredictPositionsForHomepage({ claimable: true }),
+      );
+
+      expect(result.current.totalClaimableValue).toBe(0);
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
@@ -1,197 +1,72 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import Engine from '../../../../../../core/Engine';
-import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
+import { usePredictPositions } from '../../../../../UI/Predict/hooks/usePredictPositions';
 import { selectPredictEnabledFlag } from '../../../../../UI/Predict';
 import type { PredictPosition } from '../../../../../UI/Predict/types';
 
 export interface UsePredictPositionsForHomepageResult {
   positions: PredictPosition[];
+  /** Sum of currentValue across all claimable positions (only meaningful when claimable: true) */
+  totalClaimableValue: number;
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
 }
 
-interface CacheEntry {
-  positions: PredictPosition[];
-  timestamp: number;
+interface UsePredictPositionsForHomepageOptions {
+  maxPositions?: number;
+  claimable?: boolean;
 }
 
-// Module-level cache for positions data
-const positionsCache = new Map<string, CacheEntry>();
-const CACHE_TTL_MS = 60 * 1000; // 1 minute TTL for positions (shorter than markets)
-
 /**
- * Clean expired entries from cache
- */
-const cleanExpiredCache = () => {
-  const now = Date.now();
-  for (const [key, value] of positionsCache.entries()) {
-    if (now - value.timestamp > CACHE_TTL_MS) {
-      positionsCache.delete(key);
-    }
-  }
-};
-
-/**
- * Clear the positions cache (useful for testing or forced refresh)
- */
-export const _clearPositionsCache = (): void => {
-  positionsCache.clear();
-};
-
-/**
- * Lightweight hook for fetching user prediction positions for the homepage.
+ * Lightweight wrapper around the Predict team's usePredictPositions hook,
+ * adapted for homepage display with optional slicing and claimable value sum.
  *
- * Uses module-level caching to avoid redundant API calls.
- *
- * @param maxPositions - Maximum number of positions to return (all if omitted)
- * @param claimable - When true, returns only claimable positions; when false (default), returns only active positions
- * @returns Positions data, loading state, and refresh function
+ * Delegates all caching, deduplication, and error handling to the underlying
+ * React Query-backed hook.
  */
 export const usePredictPositionsForHomepage = (
-  maxPositions?: number,
-  claimable = false,
+  options: UsePredictPositionsForHomepageOptions = {},
 ): UsePredictPositionsForHomepageResult => {
+  const { maxPositions, claimable = false } = options;
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
-  const userAddress = useSelector(
-    selectSelectedInternalAccountFormattedAddress,
-  );
 
-  const isMountedRef = useRef(true);
-  const requestIdRef = useRef(0);
-
-  // Use ref for maxPositions to keep fetchPositions callback stable
-  const maxPositionsRef = useRef(maxPositions);
-  maxPositionsRef.current = maxPositions;
-
-  const cacheKey = userAddress
-    ? `predict_positions_${userAddress}_${claimable}`
-    : null;
-
-  const [state, setState] = useState<{
-    positions: PredictPosition[];
-    isLoading: boolean;
-    error: string | null;
-  }>(() => {
-    // Check cache on initial render
-    if (!cacheKey || !isPredictEnabled) {
-      return { positions: [], isLoading: false, error: null };
-    }
-
-    const cached = positionsCache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-      return {
-        positions: maxPositions
-          ? cached.positions.slice(0, maxPositions)
-          : cached.positions,
-        isLoading: false,
-        error: null,
-      };
-    }
-
-    return { positions: [], isLoading: true, error: null };
+  const { data, isLoading, error, refetch } = usePredictPositions({
+    enabled: isPredictEnabled,
+    claimable,
   });
 
-  const fetchPositions = useCallback(async () => {
-    const currentMaxPositions = maxPositionsRef.current;
+  const allPositions = useMemo(() => data ?? [], [data]);
 
-    if (!isPredictEnabled || !cacheKey || !userAddress) {
-      setState({ positions: [], isLoading: false, error: null });
-      return;
-    }
+  const positions = useMemo(
+    () =>
+      maxPositions !== undefined
+        ? allPositions.slice(0, maxPositions)
+        : allPositions,
+    [allPositions, maxPositions],
+  );
 
-    const currentRequestId = ++requestIdRef.current;
-
-    // Check cache first
-    const cached = positionsCache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-      if (isMountedRef.current) {
-        setState({
-          positions: currentMaxPositions
-            ? cached.positions.slice(0, currentMaxPositions)
-            : cached.positions,
-          isLoading: false,
-          error: null,
-        });
-      }
-      return;
-    }
-
-    try {
-      setState((prev) => ({ ...prev, isLoading: true, error: null }));
-
-      const controller = Engine.context.PredictController;
-      const positionsData = await controller.getPositions({
-        address: userAddress,
-        claimable,
-      });
-
-      // Check if this request is still valid
-      if (requestIdRef.current !== currentRequestId || !isMountedRef.current) {
-        return;
-      }
-
-      const validPositions = Array.isArray(positionsData) ? positionsData : [];
-
-      // Update cache
-      positionsCache.set(cacheKey, {
-        positions: validPositions,
-        timestamp: Date.now(),
-      });
-
-      cleanExpiredCache();
-
-      setState({
-        positions: currentMaxPositions
-          ? validPositions.slice(0, currentMaxPositions)
-          : validPositions,
-        isLoading: false,
-        error: null,
-      });
-    } catch (err) {
-      if (requestIdRef.current !== currentRequestId || !isMountedRef.current) {
-        return;
-      }
-
-      setState({
-        positions: [],
-        isLoading: false,
-        error: err instanceof Error ? err.message : 'Failed to fetch positions',
-      });
-    }
-  }, [isPredictEnabled, cacheKey, userAddress, claimable]);
+  const totalClaimableValue = useMemo(
+    () =>
+      claimable
+        ? allPositions.reduce((sum, p) => sum + (p.currentValue ?? 0), 0)
+        : 0,
+    [claimable, allPositions],
+  );
 
   const refresh = useCallback(async () => {
-    // Clear cache and refetch
-    if (cacheKey) {
-      positionsCache.delete(cacheKey);
-    }
-    await fetchPositions();
-  }, [cacheKey, fetchPositions]);
-
-  // Initial fetch
-  useEffect(() => {
-    isMountedRef.current = true;
-
-    if (!isPredictEnabled || !userAddress) {
-      setState({ positions: [], isLoading: false, error: null });
-      return () => {
-        isMountedRef.current = false;
-      };
-    }
-
-    fetchPositions();
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, [isPredictEnabled, userAddress, fetchPositions]);
+    await refetch();
+  }, [refetch]);
 
   return {
-    positions: state.positions,
-    isLoading: state.isLoading,
-    error: state.error,
+    positions,
+    totalClaimableValue,
+    isLoading,
+    error: error
+      ? error instanceof Error
+        ? error.message
+        : String(error)
+      : null,
     refresh,
   };
 };

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictPositionsForHomepage.ts
@@ -1,7 +1,5 @@
-import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
 import { usePredictPositions } from '../../../../../UI/Predict/hooks/usePredictPositions';
-import { selectPredictEnabledFlag } from '../../../../../UI/Predict';
 import type { PredictPosition } from '../../../../../UI/Predict/types';
 
 export interface UsePredictPositionsForHomepageResult {
@@ -10,7 +8,7 @@ export interface UsePredictPositionsForHomepageResult {
   totalClaimableValue: number;
   isLoading: boolean;
   error: string | null;
-  refresh: () => Promise<void>;
+  refetch: () => Promise<unknown>;
 }
 
 interface UsePredictPositionsForHomepageOptions {
@@ -22,17 +20,16 @@ interface UsePredictPositionsForHomepageOptions {
  * Lightweight wrapper around the Predict team's usePredictPositions hook,
  * adapted for homepage display with optional slicing and claimable value sum.
  *
- * Delegates all caching, deduplication, and error handling to the underlying
- * React Query-backed hook.
+ * The feature flag check is handled at the UI level (Homepage conditionally
+ * renders the Predictions section), so this hook assumes it is only called
+ * when predictions are enabled.
  */
 export const usePredictPositionsForHomepage = (
   options: UsePredictPositionsForHomepageOptions = {},
 ): UsePredictPositionsForHomepageResult => {
   const { maxPositions, claimable = false } = options;
-  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
 
   const { data, isLoading, error, refetch } = usePredictPositions({
-    enabled: isPredictEnabled,
     claimable,
   });
 
@@ -54,10 +51,6 @@ export const usePredictPositionsForHomepage = (
     [claimable, allPositions],
   );
 
-  const refresh = useCallback(async () => {
-    await refetch();
-  }, [refetch]);
-
   return {
     positions,
     totalClaimableValue,
@@ -67,7 +60,7 @@ export const usePredictPositionsForHomepage = (
         ? error.message
         : String(error)
       : null,
-    refresh,
+    refetch,
   };
 };
 


### PR DESCRIPTION
## **Description**

Replaces the custom controller-level implementations in `usePredictPositionsForHomepage` and `usePredictMarketsForHomepage` with thin wrappers around the Predict team's existing React Query-backed hooks (`usePredictPositions`, `usePredictMarketData`). This removes ~300 lines of manual caching (Map + TTL), staleness guards (`requestIdRef`), unmount protection (`isMountedRef`), and request deduplication that React Query handles automatically.

Key changes:
- `usePredictPositionsForHomepage` now delegates to `usePredictPositions`, accepts an options object `{ maxPositions?, claimable? }`, and returns `totalClaimableValue`
- `usePredictMarketsForHomepage` now delegates to `usePredictMarketData`
- `PredictionsSection` no longer manually computes `totalClaimable` or calls `refreshClaimable` after claiming (React Query handles cache invalidation)
- All tests updated to mock team hooks instead of `Engine.context.PredictController`

<details>
<summary>Implementation Plan</summary>

# Refactor Predictions Homepage Hooks to Use Team Hooks

## Problem

`usePredictPositionsForHomepage` directly calls `Engine.context.PredictController.getPositions()` and implements its own module-level caching (Map + TTL), staleness guards (`requestIdRef`), and unmount protection (`isMountedRef`). The Predict team already has `usePredictPositions` which wraps the same controller call with React Query, providing automatic caching (5s stale time), deduplication, error handling, and optimistic polling -- all for free.

The same applies to `usePredictMarketsForHomepage` which directly calls `PredictController.getMarkets()` with its own cache, while the team has `usePredictMarketData` with pagination support.

## Current vs Team Hook Comparison

### Positions

| Aspect | `usePredictPositionsForHomepage` (current) | `usePredictPositions` (team) |
|--------|-------------------------------------------|------------------------------|
| Data source | `Engine.context.PredictController.getPositions()` | Same, via React Query `queryFn` |
| Caching | Manual Map + 60s TTL | React Query, 5s stale time |
| Staleness guard | `requestIdRef` counter | React Query built-in |
| Unmount safety | `isMountedRef` | React Query built-in |
| Filtering | `maxPositions` slice, `claimable` param | `claimable` select filter, `marketId` filter |
| Account tracking | `selectSelectedInternalAccountFormattedAddress` | `getEvmAccountFromSelectedAccountGroup()` |
| Return shape | `{ positions, isLoading, error, refresh }` | React Query result (`{ data, isLoading, error, refetch }`) |

### Markets

`usePredictMarketsForHomepage` directly calls `PredictController.getMarkets()` with manual caching, while `usePredictMarketData` provides the same with pagination and error handling.

## Changes

### 1. `usePredictPositionsForHomepage` -- delegate to `usePredictPositions`
- Change signature to options object `({ maxPositions?, claimable? })`
- Remove manual state, caching, refs, and `useEffect`
- Add `totalClaimableValue` to return type

### 2. `usePredictMarketsForHomepage` -- delegate to `usePredictMarketData`
- Remove module-level cache, manual state, refs
- Map `marketData` to `markets`, `isFetching` to `isLoading`

### 3. `PredictionsSection` -- update call sites
- Use options object for claimable call
- Remove local `totalClaimable` reduce
- Remove `refreshClaimable()` from `handleClaim` (React Query handles it)
- Remove `refreshClaimable` from `refresh` callback

</details>

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Feedback from Predict team (Luis) about using their existing hooks

## **Manual testing steps**

```gherkin
Feature: Predictions section uses team hooks

  Scenario: Positions load correctly
    Given user has prediction positions
    When user views the homepage Predictions section
    Then positions are displayed correctly

  Scenario: Trending markets load correctly
    Given user has no prediction positions
    When user views the homepage Predictions section
    Then trending market cards are displayed in the carousel

  Scenario: Claim button works
    Given user has claimable positions
    When user taps the Claim button
    Then the claim is processed and positions update automatically
```

## **Screenshots/Recordings**

N/A -- internal refactor with no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors data-fetching for the homepage Predictions section to rely on shared React Query hooks, which may subtly change caching/refresh behavior and when claimable amounts update. UI logic is mostly unchanged but depends on new hook return shapes (`refetch`, `totalClaimableValue`).
> 
> **Overview**
> **Refactors the homepage Predictions section to use the Predict team’s React Query hooks instead of controller calls + manual caching.** `usePredictMarketsForHomepage` now wraps `usePredictMarketData` and `usePredictPositionsForHomepage` wraps `usePredictPositions`, replacing the old `refresh` APIs with `refetch` and adding `totalClaimableValue` for claimable positions.
> 
> `PredictionsSection` is updated to use the new hook signatures, show the claim button based on `totalClaimableValue`, and simplify pull-to-refresh to always `refetch` positions + markets (no separate claimable refresh; claim no longer triggers a manual refresh).
> 
> Tests are updated accordingly, including mocking `usePredictPositions`/`usePredictMarketData` in `Homepage.test.tsx` and adjusting section/hook tests to the new `refetch`/options-object APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa612f298b42079c0ef2597bef427dd5c4e881fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->