### PR TITLE
test: color-no-hex confirmations batch

### DIFF
--- a/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
+++ b/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
@@ -6,6 +6,7 @@ import { useTheme } from '../../../../../../util/theme';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './bottom-modal.styles';
 
+// eslint-disable-next-line @metamask/design-tokens/color-no-hex
 const OPAQUE_GRAY = '#414141';
 interface BottomModalProps {
   avoidKeyboard?: boolean;

--- a/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
+++ b/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
@@ -2,12 +2,13 @@ import React, { ReactChild } from 'react';
 import Modal from 'react-native-modal';
 import { View } from 'react-native';
 
+import { brandColor } from '@metamask/design-tokens';
+
 import { useTheme } from '../../../../../../util/theme';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './bottom-modal.styles';
 
-// eslint-disable-next-line @metamask/design-tokens/color-no-hex
-const OPAQUE_GRAY = '#414141';
+const OPAQUE_GRAY = brandColor.grey600;
 interface BottomModalProps {
   avoidKeyboard?: boolean;
   children: ReactChild;

--- a/app/components/Views/confirmations/components/UI/info-row/divider/divider.test.tsx
+++ b/app/components/Views/confirmations/components/UI/info-row/divider/divider.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { InfoRowDivider } from './divider';
 import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
-import { lightTheme } from '@metamask/design-tokens';
+import { mockTheme } from '../../../../../../../util/theme';
 describe('InfoRowDivider', () => {
   it('should use correct styles from useStyles hook', () => {
     const wrapper = renderWithProvider(<InfoRowDivider />);
 
     expect(wrapper.root.props.style).toEqual({
       height: 1,
-      backgroundColor: lightTheme.colors.border.muted,
+      backgroundColor: mockTheme.colors.border.muted,
       marginHorizontal: -8,
     });
   });

--- a/app/components/Views/confirmations/components/UI/nft/nft.test.tsx
+++ b/app/components/Views/confirmations/components/UI/nft/nft.test.tsx
@@ -29,6 +29,7 @@ describe('Nft', () => {
     const mockNft = createMockNft({
       standard: 'ERC721',
       collectionName: 'Bored Apes',
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
       name: 'Ape #456',
       tokenId: '456',
       balance: '0',
@@ -39,6 +40,7 @@ describe('Nft', () => {
     );
 
     expect(getByText('Bored Apes')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#456')).toBeOnTheScreen();
   });
 
@@ -55,6 +57,7 @@ describe('Nft', () => {
     );
 
     expect(getByText('CryptoPunks')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#789')).toBeOnTheScreen();
   });
 
@@ -104,6 +107,7 @@ describe('Nft', () => {
     );
 
     expect(getByText('Zero Balance')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#303')).toBeOnTheScreen();
     expect(queryByText('(0)')).not.toBeOnTheScreen();
   });
@@ -121,6 +125,7 @@ describe('Nft', () => {
     );
 
     expect(getByText('No Balance')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#404')).toBeOnTheScreen();
     expect(queryByText(/^\(/)).not.toBeOnTheScreen();
   });
@@ -150,6 +155,7 @@ describe('Nft', () => {
     );
 
     expect(getByText('Simple Collection')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#123')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
+++ b/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
@@ -66,6 +66,7 @@ describe('HeroNft', () => {
       }),
     });
 
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(queryAllByText('#12345')).toHaveLength(2);
     expect(getByTestId('hero-nft-placeholder')).toBeOnTheScreen();
 
@@ -108,6 +109,7 @@ describe('HeroNft', () => {
     expect(getByTestId('nft-image')).toBeDefined();
     expect(getByTestId('network-avatar-image')).toBeDefined();
     expect(getByText('Test Dapp NFTs')).toBeDefined();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#12345')).toBeDefined();
 
     fireEvent.press(getByTestId('nft-image'));
@@ -143,6 +145,7 @@ describe('HeroNft', () => {
     expect(getByTestId('nft-image')).toBeDefined();
     expect(getByTestId('network-avatar-image')).toBeDefined();
     expect(getByText('Test Dapp NFTs')).toBeDefined();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#12345')).toBeDefined();
 
     fireEvent.press(getByTestId('nft-image'));

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-decoded/typed-sign-decoded.test.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-decoded/typed-sign-decoded.test.tsx
@@ -198,6 +198,7 @@ describe('DecodedSimulation', () => {
     expect(await findByText('Estimated changes')).toBeOnTheScreen();
     expect(await findByText('Listing price')).toBeOnTheScreen();
     expect(await findByText('You list')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(await findByText('#22222')).toBeOnTheScreen();
   });
 
@@ -209,6 +210,7 @@ describe('DecodedSimulation', () => {
     expect(await findByText('Estimated changes')).toBeOnTheScreen();
     expect(await findByText('You receive')).toBeOnTheScreen();
     expect(await findByText('You list')).toBeOnTheScreen();
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(await findByText('#77789')).toBeOnTheScreen();
   });
 

--- a/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.test.tsx
@@ -10,23 +10,20 @@ jest.mock('../../../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('../../../../../../component-library/hooks', () => ({
-  useStyles: jest.fn(() => ({
-    styles: {
-      container: {},
-      title: {},
-      description: {},
-      balanceInfo: {},
-      buttonsContainer: {},
-      button: {},
-    },
-    theme: {
-      colors: {
-        text: {
-          alternative: '#6a737d',
-        },
+  useStyles: jest.fn(() => {
+    const { mockTheme } = jest.requireActual('../../../../../../util/theme');
+    return {
+      styles: {
+        container: {},
+        title: {},
+        description: {},
+        balanceInfo: {},
+        buttonsContainer: {},
+        button: {},
       },
-    },
-  })),
+      theme: mockTheme,
+    };
+  }),
 }));
 
 jest.mock('../../../utils/validations/approve', () => ({

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { merge } from 'lodash';
-
 import { mockTheme } from '../../../../../../../util/theme';
 import renderWithProvider, {
   ProviderValues,

--- a/app/components/Views/confirmations/hooks/nft/useNft.test.ts
+++ b/app/components/Views/confirmations/hooks/nft/useNft.test.ts
@@ -31,6 +31,7 @@ describe('useNft', () => {
     expect(result.current.name).toBe('Test Dapp NFTs');
     expect(result.current.nft).toBeDefined();
     expect(result.current.nft?.tokenId).toBe('12345');
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(result.current.nft?.name).toBe('Test Dapp NFTs #12345');
     expect(result.current.tokenId?.toString()).toBe('12345');
   });
@@ -105,6 +106,7 @@ describe('useNft', () => {
     expect(result.current.name).toBe('Test Dapp NFTs');
     expect(result.current.nft).toBeDefined();
     expect(result.current.nft?.tokenId).toBe('12345');
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(result.current.nft?.name).toBe('Test Dapp NFTs #12345');
     expect(result.current.tokenId?.toString()).toBe('12345');
   });

--- a/app/components/Views/confirmations/hooks/send/useTokenSearch.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useTokenSearch.test.ts
@@ -44,6 +44,7 @@ const mockNfts: Nft[] = [
   {
     address: '0x2222222222222222222222222222222222222222',
     standard: 'ERC721',
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     name: 'CryptoPunk #1000',
     collectionName: 'CryptoPunks',
     chainId: '0x1',
@@ -65,6 +66,7 @@ const mockNfts: Nft[] = [
   {
     address: '0x4444444444444444444444444444444444444444',
     standard: 'ERC721',
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     name: 'Ape Avatar #200',
     collectionName: 'Ape Avatars',
     chainId: '0x89',
@@ -265,6 +267,7 @@ describe('useTokenSearch', () => {
       expect(result.current.filteredNfts).toHaveLength(2);
       expect(result.current.filteredNfts.map((nft) => nft.name)).toEqual([
         'Bored Ape #1',
+        // eslint-disable-next-line @metamask/design-tokens/color-no-hex
         'Ape Avatar #200',
       ]);
     });
@@ -281,6 +284,7 @@ describe('useTokenSearch', () => {
         result.current.filteredNfts.every((nft) => nft.chainId === '0x89'),
       ).toBe(true);
       expect(result.current.filteredNfts.map((nft) => nft.name)).toEqual([
+        // eslint-disable-next-line @metamask/design-tokens/color-no-hex
         'Ape Avatar #200',
       ]);
     });

--- a/app/components/Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations.test.tsx
+++ b/app/components/Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations.test.tsx
@@ -20,6 +20,7 @@ jest.mock('../../components/UI/navbar/navbar');
 
 describe('useEmptyNavHeaderForConfirmations', () => {
   const mockGetEmptyNavHeader = jest.mocked(getEmptyNavHeader);
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
 
   const mockNavbarOptions = {
     headerTitle: () => <></>,
@@ -27,8 +28,7 @@ describe('useEmptyNavHeaderForConfirmations', () => {
     headerRight: () => <></>,
     headerTitleAlign: 'center' as const,
     headerStyle: {
-      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-      backgroundColor: '#ffffff',
+      backgroundColor: mockTheme.colors.background.default,
       shadowColor: 'transparent',
       elevation: 0,
     },

--- a/app/components/Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations.test.tsx
+++ b/app/components/Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations.test.tsx
@@ -4,15 +4,18 @@ import { Theme } from '../../../../../util/theme/models';
 import { getEmptyNavHeader } from '../../components/UI/navbar/navbar';
 import { useEmptyNavHeaderForConfirmations } from './useEmptyNavHeaderForConfirmations';
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn().mockReturnValue({
-    colors: { background: { alternative: '#ffffff' } },
-    typography: {},
-    shadows: {},
-    brandColors: {},
-    themeAppearance: 'light' as const,
-  } as Theme),
-}));
+jest.mock('../../../../../util/theme', () => {
+  const { mockTheme } = jest.requireActual('../../../../../util/theme');
+  return {
+    useTheme: jest.fn().mockReturnValue({
+      colors: mockTheme.colors,
+      typography: {},
+      shadows: {},
+      brandColors: mockTheme.brandColors,
+      themeAppearance: 'light' as const,
+    } as Theme),
+  };
+});
 jest.mock('../../components/UI/navbar/navbar');
 
 describe('useEmptyNavHeaderForConfirmations', () => {
@@ -24,6 +27,7 @@ describe('useEmptyNavHeaderForConfirmations', () => {
     headerRight: () => <></>,
     headerTitleAlign: 'center' as const,
     headerStyle: {
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
       backgroundColor: '#ffffff',
       shadowColor: 'transparent',
       elevation: 0,


### PR DESCRIPTION
## **Description**

Split from #26651 to reduce CODEOWNERS fanout.

Batch: confirmations
Source branch: \`origin/remove-static-hex-from-tests\`

When \`@metamask/design-tokens\` upgrades change color values, tests that hardcode hex literals (e.g. \`'#ffffff'\`) break because the component renders the new token value while the test still asserts the old one — even though nothing is actually wrong. This PR fixes that brittleness across the confirmations scope.

**Two strategies are applied:**

1. **Replace hardcoded hex with token references** — test mocks and assertions use \`mockTheme.colors.*\` (or \`brandColor.*\` for production code) so the test always agrees with whatever the current token value is. Package upgrades no longer cause spurious failures.

2. **Add targeted \`eslint-disable\` comments** — strings like \`'#12345'\` or \`'#456'\` are NFT token IDs that happen to look like hex colors. The \`color-no-hex\` rule can't distinguish them from CSS colors, so suppress comments are added inline to keep the rule enforced everywhere else without false positives.

Together these changes make the \`@metamask/design-tokens/color-no-hex\` lint rule enforceable across this scope, so future hex literals won't accidentally creep in.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

\`\`\`gherkin
Feature: color-no-hex lint compliance (confirmations batch)

  Scenario: user runs lint
    Given the confirmations test files have been updated
    When user runs the lint checks
    Then no color-no-hex violations are reported
\`\`\`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.