### PR TITLE
feat: update defi position section

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsControlBar.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsControlBar.test.tsx
@@ -17,6 +17,10 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock('../../../selectors/featureFlagController/homepage', () => ({
+  selectHomepageSectionsV1Enabled: () => false,
+}));
+
 jest.mock('../../../selectors/networkController', () => ({
   selectIsAllNetworks: () => false,
   selectIsPopularNetwork: () => true,
@@ -158,6 +162,10 @@ describe('DeFiPositionsControlBar', () => {
   beforeEach(() => {
     store = mockStore(createMockState());
     jest.clearAllMocks();
+    const homepageModule = jest.requireMock(
+      '../../../selectors/featureFlagController/homepage',
+    );
+    homepageModule.selectHomepageSectionsV1Enabled = () => false;
   });
 
   it('should render correctly with default state', () => {
@@ -271,7 +279,7 @@ describe('DeFiPositionsControlBar', () => {
     );
   });
 
-  it('should be disabled when on testnet', () => {
+  it('should be disabled when on testnet and homepage sections V1 is disabled', () => {
     const networksModule = jest.requireMock('../../../util/networks');
     networksModule.isTestNet.mockReturnValue(true);
 
@@ -306,7 +314,47 @@ describe('DeFiPositionsControlBar', () => {
     expect(filterButton.props.disabled).toBe(true);
   });
 
-  it('should be disabled when not on popular network', () => {
+  it('is not disabled when on testnet if homepage sections V1 is enabled', () => {
+    const homepageModule = jest.requireMock(
+      '../../../selectors/featureFlagController/homepage',
+    );
+    homepageModule.selectHomepageSectionsV1Enabled = () => true;
+
+    const networksModule = jest.requireMock('../../../util/networks');
+    networksModule.isTestNet.mockReturnValue(true);
+
+    const mockState = createMockState({
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            provider: {
+              chainId: CHAIN_IDS.GOERLI,
+              type: 'goerli',
+            },
+          },
+          MultichainNetworkController: {
+            isEvmSelected: true,
+          },
+          PreferencesController: {
+            selectedAddress: '0x123',
+          },
+        },
+      },
+    });
+
+    store = mockStore(mockState);
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <DeFiPositionsControlBar />
+      </Provider>,
+    );
+
+    const filterButton = getByTestId('defi-positions-network-filter');
+    expect(filterButton.props.disabled).toBe(false);
+  });
+
+  it('should be disabled when not on popular network and homepage sections V1 is disabled', () => {
     const networkControllerModule = jest.requireMock(
       '../../../selectors/networkController',
     );
@@ -323,6 +371,30 @@ describe('DeFiPositionsControlBar', () => {
 
     const filterButton = getByTestId('defi-positions-network-filter');
     expect(filterButton.props.disabled).toBe(true);
+  });
+
+  it('is not disabled when not on popular network if homepage sections V1 is enabled', () => {
+    const homepageModule = jest.requireMock(
+      '../../../selectors/featureFlagController/homepage',
+    );
+    homepageModule.selectHomepageSectionsV1Enabled = () => true;
+
+    const networkControllerModule = jest.requireMock(
+      '../../../selectors/networkController',
+    );
+    networkControllerModule.selectIsPopularNetwork = () => false;
+
+    const mockState = createMockState();
+    store = mockStore(mockState);
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <DeFiPositionsControlBar />
+      </Provider>,
+    );
+
+    const filterButton = getByTestId('defi-positions-network-filter');
+    expect(filterButton.props.disabled).toBe(false);
   });
 
   it('should render sort button with filter icon', () => {

--- a/app/components/UI/DeFiPositions/DeFiPositionsControlBar.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsControlBar.tsx
@@ -8,13 +8,19 @@ import {
 import { isTestNet } from '../../../util/networks';
 import { WalletViewSelectorsIDs } from '../../Views/Wallet/WalletView.testIds';
 import BaseControlBar from '../shared/BaseControlBar/BaseControlBar';
+import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 
 const DeFiPositionsControlBar: React.FC = () => {
   const isPopularNetwork = useSelector(selectIsPopularNetwork);
   const currentChainId = useSelector(selectChainId) as Hex;
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
 
   // Custom disabled logic for DeFi positions
-  const isDisabled = isTestNet(currentChainId) || !isPopularNetwork;
+  const isDisabled = isHomepageSectionsV1Enabled
+    ? false
+    : isTestNet(currentChainId) || !isPopularNetwork;
 
   return (
     <BaseControlBar

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
@@ -1,15 +1,28 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useDeFiPositionsForHomepage } from './useDeFiPositionsForHomepage';
 
-const mockSelectDeFiPositionsByAddress = jest.fn();
-const mockSelectDefiPositionsByEnabledNetworks = jest.fn();
+const mockSelectDefiPositionsByChainIds = jest.fn();
 const mockSelectTokenSortConfig = jest.fn();
 
 jest.mock('../../../../../../selectors/defiPositionsController', () => ({
-  selectDeFiPositionsByAddress: () => mockSelectDeFiPositionsByAddress(),
-  selectDefiPositionsByEnabledNetworks: () =>
-    mockSelectDefiPositionsByEnabledNetworks(),
+  selectDefiPositionsByChainIds: (_state: unknown, _chainIds: unknown) =>
+    mockSelectDefiPositionsByChainIds(),
 }));
+
+jest.mock('../../../../../../selectors/networkEnablementController', () => ({
+  selectEVMEnabledNetworks: () => [],
+}));
+
+jest.mock('../../../../../../selectors/featureFlagController/homepage', () => ({
+  selectHomepageSectionsV1Enabled: () => false,
+}));
+
+jest.mock(
+  '../../../../../hooks/useNetworkEnablement/useNetworkEnablement',
+  () => ({
+    useNetworkEnablement: () => ({ popularEvmNetworks: [] }),
+  }),
+);
 
 jest.mock('../../../../../../selectors/preferencesController', () => ({
   selectTokenSortConfig: () => mockSelectTokenSortConfig(),
@@ -41,9 +54,8 @@ describe('useDeFiPositionsForHomepage', () => {
     });
   });
 
-  it('returns loading state when defiPositions is undefined', () => {
-    mockSelectDeFiPositionsByAddress.mockReturnValue(undefined);
-    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(undefined);
+  it('returns loading state when defiPositionsByChainIds is undefined', () => {
+    mockSelectDefiPositionsByChainIds.mockReturnValue(undefined);
 
     const { result } = renderHook(() => useDeFiPositionsForHomepage());
 
@@ -53,9 +65,8 @@ describe('useDeFiPositionsForHomepage', () => {
     expect(result.current.positions).toEqual([]);
   });
 
-  it('returns error state when defiPositions is null', () => {
-    mockSelectDeFiPositionsByAddress.mockReturnValue(null);
-    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(null);
+  it('returns error state when defiPositionsByChainIds is null', () => {
+    mockSelectDefiPositionsByChainIds.mockReturnValue(null);
 
     const { result } = renderHook(() => useDeFiPositionsForHomepage());
 
@@ -65,9 +76,8 @@ describe('useDeFiPositionsForHomepage', () => {
     expect(result.current.positions).toEqual([]);
   });
 
-  it('returns empty state when defiPositions is empty object', () => {
-    mockSelectDeFiPositionsByAddress.mockReturnValue({});
-    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue({});
+  it('returns empty state when defiPositionsByChainIds is empty object', () => {
+    mockSelectDefiPositionsByChainIds.mockReturnValue({});
 
     const { result } = renderHook(() => useDeFiPositionsForHomepage());
 
@@ -92,8 +102,7 @@ describe('useDeFiPositionsForHomepage', () => {
       },
     };
 
-    mockSelectDeFiPositionsByAddress.mockReturnValue(mockPositions);
-    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(mockPositions);
+    mockSelectDefiPositionsByChainIds.mockReturnValue(mockPositions);
 
     const { result } = renderHook(() => useDeFiPositionsForHomepage());
 
@@ -115,8 +124,7 @@ describe('useDeFiPositionsForHomepage', () => {
       },
     };
 
-    mockSelectDeFiPositionsByAddress.mockReturnValue(mockPositions);
-    mockSelectDefiPositionsByEnabledNetworks.mockReturnValue(mockPositions);
+    mockSelectDefiPositionsByChainIds.mockReturnValue(mockPositions);
 
     const { result } = renderHook(() => useDeFiPositionsForHomepage(2));
 

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
@@ -3,12 +3,13 @@ import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { GroupedDeFiPositions } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
-import {
-  selectDeFiPositionsByAddress,
-  selectDefiPositionsByEnabledNetworks,
-} from '../../../../../../selectors/defiPositionsController';
+import { selectDefiPositionsByChainIds } from '../../../../../../selectors/defiPositionsController';
 import { selectTokenSortConfig } from '../../../../../../selectors/preferencesController';
+import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
+import { RootState } from '../../../../../../reducers';
 import { sortAssets } from '../../../../../UI/Tokens/util';
+import { selectHomepageSectionsV1Enabled } from '../../../../../../selectors/featureFlagController/homepage';
+import { selectEVMEnabledNetworks } from '../../../../../../selectors/networkEnablementController';
 
 /**
  * Represents a single DeFi position entry for the homepage.
@@ -48,14 +49,25 @@ export const useDeFiPositionsForHomepage = (
   maxPositions: number = MAX_POSITIONS_DEFAULT,
 ): UseDeFiPositionsForHomepageResult => {
   const tokenSortConfig = useSelector(selectTokenSortConfig);
-  const defiPositions = useSelector(selectDeFiPositionsByAddress);
-  const defiPositionsByEnabledNetworks = useSelector(
-    selectDefiPositionsByEnabledNetworks,
+  const evmEnabledNetworks = useSelector(selectEVMEnabledNetworks);
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
+  const { popularEvmNetworks } = useNetworkEnablement();
+
+  const popularEvmChainIds = useMemo(
+    () =>
+      isHomepageSectionsV1Enabled ? popularEvmNetworks : evmEnabledNetworks,
+    [isHomepageSectionsV1Enabled, popularEvmNetworks, evmEnabledNetworks],
+  );
+
+  const defiPositionsByChainIds = useSelector((state: RootState) =>
+    selectDefiPositionsByChainIds(state, popularEvmChainIds),
   );
 
   const result = useMemo((): UseDeFiPositionsForHomepageResult => {
     // Loading state - data not yet available
-    if (defiPositions === undefined) {
+    if (defiPositionsByChainIds === undefined) {
       return {
         positions: [],
         isLoading: true,
@@ -65,7 +77,7 @@ export const useDeFiPositionsForHomepage = (
     }
 
     // Error state - data fetch failed
-    if (defiPositions === null) {
+    if (defiPositionsByChainIds === null) {
       return {
         positions: [],
         isLoading: false,
@@ -74,7 +86,7 @@ export const useDeFiPositionsForHomepage = (
       };
     }
 
-    const chainFilteredDeFiPositions = defiPositionsByEnabledNetworks as {
+    const chainFilteredDeFiPositions = defiPositionsByChainIds as {
       [key: Hex]: GroupedDeFiPositions;
     };
 
@@ -125,12 +137,7 @@ export const useDeFiPositionsForHomepage = (
       hasError: false,
       isEmpty: limitedPositions.length === 0,
     };
-  }, [
-    defiPositions,
-    defiPositionsByEnabledNetworks,
-    tokenSortConfig,
-    maxPositions,
-  ]);
+  }, [defiPositionsByChainIds, tokenSortConfig, maxPositions]);
 
   return result;
 };

--- a/app/selectors/defiPositionsController.test.ts
+++ b/app/selectors/defiPositionsController.test.ts
@@ -3,6 +3,7 @@ import { RootState } from '../reducers';
 import {
   selectDeFiPositionsByAddress,
   selectDefiPositionsByEnabledNetworks,
+  selectDefiPositionsByChainIds,
 } from './defiPositionsController';
 
 describe('defiPositionsController selectors', () => {
@@ -236,6 +237,95 @@ describe('defiPositionsController selectors', () => {
 
       const result = selectDefiPositionsByEnabledNetworks(state);
       expect(result).toStrictEqual({});
+    });
+  });
+
+  describe('selectDefiPositionsByChainIds', () => {
+    it('returns positions only for the given chain IDs', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/0',
+        defiPositions: {
+          [mockAddress1]: mockDefiPositions,
+        },
+      });
+
+      const result = selectDefiPositionsByChainIds(state, ['0x1', '0xa86a']);
+      expect(result).toStrictEqual({
+        '0x1': mockDefiPositions['0x1'],
+        '0xa86a': mockDefiPositions['0xa86a'],
+      });
+      expect(result?.['0x89']).toBeUndefined();
+    });
+
+    it('returns empty object when there is no evm account in the selected account group', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/btc-only',
+      });
+
+      const result = selectDefiPositionsByChainIds(state, ['0x1']);
+      expect(result).toStrictEqual({});
+    });
+
+    it('returns undefined when no positions exist for the selected address', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/0',
+      });
+
+      const result = selectDefiPositionsByChainIds(state, ['0x1']);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns null when that is the value stored for that address', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/0',
+        defiPositions: {
+          [mockAddress1]: null,
+        },
+      });
+
+      const result = selectDefiPositionsByChainIds(state, ['0x1']);
+      expect(result).toBeNull();
+    });
+
+    it('returns empty object when chainIds is undefined', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/0',
+        defiPositions: {
+          [mockAddress1]: mockDefiPositions,
+        },
+      });
+
+      const result = selectDefiPositionsByChainIds(state, undefined);
+      expect(result).toStrictEqual({});
+    });
+
+    it('returns empty object when chainIds is empty array', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/0',
+        defiPositions: {
+          [mockAddress1]: mockDefiPositions,
+        },
+      });
+
+      const result = selectDefiPositionsByChainIds(state, []);
+      expect(result).toStrictEqual({});
+    });
+
+    it('returns only requested chain IDs that exist in positions', () => {
+      const state = createMockState({
+        selectedAccountGroup: 'entropy:wallet0/0',
+        defiPositions: {
+          [mockAddress1]: mockDefiPositions,
+        },
+      });
+
+      const result = selectDefiPositionsByChainIds(state, [
+        '0x1',
+        '0x999' as `0x${string}`,
+      ]);
+      expect(result).toStrictEqual({
+        '0x1': mockDefiPositions['0x1'],
+      });
     });
   });
 });

--- a/app/selectors/defiPositionsController.ts
+++ b/app/selectors/defiPositionsController.ts
@@ -99,3 +99,58 @@ export const selectDefiPositionsByEnabledNetworks = createDeepEqualSelector(
     return filteredDefiPositionByAddress;
   },
 );
+
+/**
+ * DeFi positions for the selected EVM account, filtered by an explicit list of chain IDs.
+ * @param state - Redux state
+ * @param chainIds - Hex chain IDs to include (e.g. from listPopularEvmNetworks())
+ * @returns Positions by chain ID for the selected account, or NO_DATA if no account / no positions
+ */
+export const selectDefiPositionsByChainIds = createDeepEqualSelector(
+  [
+    selectDeFiPositionsControllerState,
+    selectSelectedInternalAccountByScope,
+    (_state: RootState, chainIds: Hex[] | undefined) => chainIds,
+  ],
+  (
+    defiPositionsControllerState: DeFiPositionsControllerState,
+    selectedInternalAccountByScope: ReturnType<
+      typeof selectSelectedInternalAccountByScope
+    >,
+    chainIds: Hex[] | undefined,
+  ): DeFiPositionsControllerState['allDeFiPositions'][Hex] | undefined => {
+    const selectedEvmAccount = selectedInternalAccountByScope(EVM_SCOPE);
+    if (!selectedEvmAccount) {
+      return NO_DATA;
+    }
+
+    const defiPositionByAddress =
+      defiPositionsControllerState?.allDeFiPositions[
+        selectedEvmAccount.address
+      ];
+
+    if (defiPositionByAddress == null) {
+      return defiPositionByAddress;
+    }
+
+    if (!chainIds || chainIds.length === 0) {
+      return NO_DATA;
+    }
+
+    const chainIdsSet = new Set(chainIds);
+    const filtered = Object.keys(defiPositionByAddress)
+      .filter((chainId) => chainIdsSet.has(chainId as Hex))
+      .reduce<DeFiPositionsControllerState['allDeFiPositions'][Hex]>(
+        (acc, chainId) => {
+          const value = defiPositionByAddress[chainId as Hex];
+          if (value != null && acc) {
+            acc[chainId as Hex] = value;
+          }
+          return acc;
+        },
+        {} as DeFiPositionsControllerState['allDeFiPositions'][Hex],
+      );
+
+    return filtered;
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

update the new home page redesign defi section to always show popular networks

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update the new home page redesign defi section to always show popular networks

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->



https://github.com/user-attachments/assets/bdff5b07-959d-43e7-8c3a-dd9098ee26bf


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DeFi positions filtering/enablement logic (including testnet and non-popular network handling) behind a feature flag, which can alter what users see and which controls are enabled. Risk is mitigated by added unit coverage and flag-gated behavior, but incorrect chain list selection could hide/show positions unexpectedly.
> 
> **Overview**
> **Homepage DeFi positions now prefer popular networks when `homepageSectionsV1` is enabled.** The homepage DeFi hook switches from “enabled networks” filtering to an explicit popular-chain list, using a new selector `selectDefiPositionsByChainIds` to fetch only those chains’ positions.
> 
> **DeFi positions control bar disabling is relaxed under the same flag.** When `homepageSectionsV1` is enabled, the network filter is no longer disabled on testnets or non-popular networks; otherwise it keeps the prior testnet/popular-network gating. Tests were updated/added to cover the new selector and flag-dependent UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf0897ed790f876140bda7fb735416661dac4df9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->