### PR TITLE
feat: update nft position section

### DIFF
--- a/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.test.ts
+++ b/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.test.ts
@@ -6,6 +6,13 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
+jest.mock(
+  '../../../../../hooks/useNetworkEnablement/useNetworkEnablement',
+  () => ({
+    useNetworkEnablement: () => ({ popularNetworks: [] }),
+  }),
+);
+
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 const createMockNft = (
@@ -20,13 +27,33 @@ const createMockNft = (
   image: `https://example.com/nft-${tokenId}.png`,
 });
 
+/**
+ * Hook calls useSelector 3 times: selectedAccountGroupInternalAccounts,
+ * selectHomepageSectionsV1Enabled, then multichainCollectiblesByEnabledNetworksSelector result.
+ */
+const mockSelectors = (
+  nftsByChain: Record<string, unknown[]>,
+  overrides?: {
+    selectedGroupAccounts?: { address: string }[];
+    isHomepageSectionsV1Enabled?: boolean;
+  },
+) => {
+  let callCount = 0;
+  mockUseSelector.mockImplementation(() => {
+    callCount += 1;
+    if (callCount === 1) return overrides?.selectedGroupAccounts ?? [];
+    if (callCount === 2) return overrides?.isHomepageSectionsV1Enabled ?? false;
+    return nftsByChain;
+  });
+};
+
 describe('useOwnedNfts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns empty array when no NFTs exist', () => {
-    mockUseSelector.mockReturnValue({});
+    mockSelectors({});
 
     const { result } = renderHook(() => useOwnedNfts());
 
@@ -35,9 +62,7 @@ describe('useOwnedNfts', () => {
 
   it('returns owned NFTs from a single chain', () => {
     const ownedNft = createMockNft('0x123', '1', true);
-    mockUseSelector.mockReturnValue({
-      '0x1': [ownedNft],
-    });
+    mockSelectors({ '0x1': [ownedNft] });
 
     const { result } = renderHook(() => useOwnedNfts());
 
@@ -47,7 +72,7 @@ describe('useOwnedNfts', () => {
   it('returns owned NFTs from multiple chains', () => {
     const nft1 = createMockNft('0x123', '1', true);
     const nft2 = createMockNft('0x456', '2', true);
-    mockUseSelector.mockReturnValue({
+    mockSelectors({
       '0x1': [nft1],
       '0x89': [nft2],
     });
@@ -62,7 +87,7 @@ describe('useOwnedNfts', () => {
   it('filters out NFTs that are not currently owned', () => {
     const ownedNft = createMockNft('0x123', '1', true);
     const notOwnedNft = createMockNft('0x456', '2', false);
-    mockUseSelector.mockReturnValue({
+    mockSelectors({
       '0x1': [ownedNft, notOwnedNft],
     });
 
@@ -75,7 +100,7 @@ describe('useOwnedNfts', () => {
   it('returns empty array when all NFTs are not currently owned', () => {
     const notOwned1 = createMockNft('0x123', '1', false);
     const notOwned2 = createMockNft('0x456', '2', false);
-    mockUseSelector.mockReturnValue({
+    mockSelectors({
       '0x1': [notOwned1, notOwned2],
     });
 
@@ -93,7 +118,7 @@ describe('useOwnedNfts', () => {
       createMockNft('0x333', '3', true),
       createMockNft('0x444', '4', false), // Not owned, should be filtered
     ];
-    mockUseSelector.mockReturnValue({
+    mockSelectors({
       '0x1': chain1Nfts,
       '0x89': chain2Nfts,
     });
@@ -104,5 +129,40 @@ describe('useOwnedNfts', () => {
     expect(result.current).toContainEqual(chain1Nfts[0]);
     expect(result.current).toContainEqual(chain1Nfts[1]);
     expect(result.current).toContainEqual(chain2Nfts[0]);
+  });
+
+  it('returns owned NFTs when homepage sections V1 is enabled', () => {
+    const ownedNft = createMockNft('0x123', '1', true);
+    mockSelectors({ '0x1': [ownedNft] }, { isHomepageSectionsV1Enabled: true });
+
+    const { result } = renderHook(() => useOwnedNfts());
+
+    expect(result.current).toEqual([ownedNft]);
+  });
+
+  it('returns owned NFTs when homepage sections V1 is disabled', () => {
+    const ownedNft = createMockNft('0x123', '1', true);
+    mockSelectors(
+      { '0x1': [ownedNft] },
+      { isHomepageSectionsV1Enabled: false },
+    );
+
+    const { result } = renderHook(() => useOwnedNfts());
+
+    expect(result.current).toEqual([ownedNft]);
+  });
+
+  it('uses selected group accounts when provided for addressesOverride', () => {
+    const ownedNft = createMockNft('0x123', '1', true);
+    mockSelectors(
+      { '0x1': [ownedNft] },
+      {
+        selectedGroupAccounts: [{ address: '0xaaa' }, { address: '0xbbb' }],
+      },
+    );
+
+    const { result } = renderHook(() => useOwnedNfts());
+
+    expect(result.current).toEqual([ownedNft]);
   });
 });

--- a/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.ts
+++ b/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.ts
@@ -1,24 +1,59 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Nft } from '@metamask/assets-controllers';
+import { RootState } from '../../../../../../reducers';
 import { multichainCollectiblesByEnabledNetworksSelector } from '../../../../../../reducers/collectibles';
+import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectHomepageSectionsV1Enabled } from '../../../../../../selectors/featureFlagController/homepage';
 
 /**
- * Hook to get all owned NFTs for the currently selected account
- * across enabled networks.
- *
+ * Hook to get all owned NFTs for the currently selected account.
+ * When homepage sections V1 is enabled, uses popular networks (from useNetworkEnablement);
+ * otherwise uses enabled networks from state.
+ * Aggregates from all addresses in the selected account group so NFTs show when
+ * e.g. Solana is selected (NFTs are keyed by EVM address in controller).
  * Only returns NFTs that are currently owned (isCurrentlyOwned === true),
  * matching the same logic used by NftGrid.
  *
  * @returns Array of owned NFTs
  */
 const useOwnedNfts = (): Nft[] => {
-  const nftsByChain = useSelector(
-    multichainCollectiblesByEnabledNetworksSelector,
+  const { popularNetworks } = useNetworkEnablement();
+  const selectedGroupAccounts = useSelector(
+    selectSelectedAccountGroupInternalAccounts,
+  );
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
+
+  const addressesOverride = useMemo(
+    () =>
+      selectedGroupAccounts?.length > 0
+        ? selectedGroupAccounts.map((a) => a.address)
+        : undefined,
+    [selectedGroupAccounts],
+  );
+  const popularChainIds = useMemo(
+    () =>
+      isHomepageSectionsV1Enabled && popularNetworks?.length > 0
+        ? popularNetworks
+        : undefined,
+    [isHomepageSectionsV1Enabled, popularNetworks],
+  );
+
+  const nftsByChain = useSelector((state: RootState) =>
+    (
+      multichainCollectiblesByEnabledNetworksSelector as (
+        s: RootState,
+        preferredChainIds?: string[],
+        addressesOverride?: string[],
+      ) => Record<string, Nft[]>
+    )(state, popularChainIds, addressesOverride),
   ) as Record<string, Nft[]>;
 
   return useMemo(() => {
-    const allNfts = Object.values(nftsByChain).flat();
+    const allNfts = Object.values(nftsByChain ?? {}).flat();
     return allNfts.filter((nft) => nft.isCurrentlyOwned);
   }, [nftsByChain]);
 };

--- a/app/reducers/collectibles/index.js
+++ b/app/reducers/collectibles/index.js
@@ -1,5 +1,5 @@
+import { toHex } from '@metamask/controller-utils';
 import { createSelector } from 'reselect';
-import { KnownCaipNamespace } from '@metamask/utils';
 import { selectChainId } from '../../selectors/networkController';
 import {
   selectAllNftContracts,
@@ -9,6 +9,23 @@ import { selectSelectedInternalAccountAddress } from '../../selectors/accountsCo
 import { compareTokenIds } from '../../util/tokens';
 import { createDeepEqualSelector } from '../../selectors/util';
 import { selectEnabledNetworksByNamespace } from '../../selectors/networkEnablementController';
+
+/**
+ * Builds a set of chain IDs for filtering. When chainIds include CAIP-2 (e.g. from listPopularNetworks),
+ * adds Hex form for eip155:* so we match NFT keys which are Hex.
+ * @param {string[]} chainIds - CAIP-2 or Hex chain IDs
+ * @returns {Set<string>}
+ */
+function buildAllowedChainIdSet(chainIds) {
+  const set = new Set(chainIds);
+  for (const id of chainIds) {
+    if (id.startsWith('eip155:')) {
+      const reference = id.slice(7);
+      if (reference) set.add(toHex(reference));
+    }
+  }
+  return set;
+}
 
 const favoritesSelector = (state) => state.collectibles.favorites;
 
@@ -33,44 +50,78 @@ export const collectiblesSelector = createDeepEqualSelector(
   (address, chainId, allNfts) => allNfts[address]?.[chainId] || [],
 );
 
+/**
+ * Multichain collectibles filtered by chain IDs. When addressesOverride is passed (e.g. all
+ * addresses in the selected account group), aggregates NFTs from those addresses so that when
+ * Solana is selected we still include NFTs keyed by EVM address. When preferredChainIds is
+ * passed (e.g. from listPopularNetworks()), uses that list; otherwise falls back to
+ * selectEnabledNetworksByNamespace.
+ * @param {object} state - Redux state
+ * @param {string[]} [preferredChainIds] - Optional chain IDs (CAIP-2 or Hex) to filter by; when omitted, uses enabled networks
+ * @param {string[]} [addressesOverride] - Optional list of addresses to aggregate NFTs from; when omitted, uses selected account address only
+ */
 export const multichainCollectiblesByEnabledNetworksSelector =
   createDeepEqualSelector(
-    selectSelectedInternalAccountAddress,
-    selectAllNfts,
-    selectEnabledNetworksByNamespace,
-    (address, allNfts, enabledNetworks) => {
-      const addressNfts = allNfts[address];
+    [
+      selectSelectedInternalAccountAddress,
+      selectAllNfts,
+      selectEnabledNetworksByNamespace,
+      (state, preferredChainIds) => preferredChainIds,
+      (state, _preferredChainIds, addressesOverride) => addressesOverride,
+    ],
+    (
+      selectedAddress,
+      allNfts,
+      enabledNetworks,
+      preferredChainIds,
+      addressesOverride,
+    ) => {
+      const addresses =
+        addressesOverride != null &&
+        Array.isArray(addressesOverride) &&
+        addressesOverride.length > 0
+          ? addressesOverride
+          : selectedAddress
+            ? [selectedAddress]
+            : [];
 
-      if (!addressNfts || Object.keys(addressNfts).length === 0) {
-        return {};
-      }
-
-      const enabledNetworksForEip155 =
-        enabledNetworks?.[KnownCaipNamespace.Eip155] || {};
+      let allowedChainIdsSet;
 
       if (
-        !enabledNetworksForEip155 ||
-        Object.keys(enabledNetworksForEip155).length === 0
+        preferredChainIds != null &&
+        Array.isArray(preferredChainIds) &&
+        preferredChainIds.length > 0
       ) {
-        return {};
+        allowedChainIdsSet = buildAllowedChainIdSet(preferredChainIds);
+      } else {
+        const enabledChainIds = [];
+        for (const namespace of Object.keys(enabledNetworks || {})) {
+          const networkMap = enabledNetworks[namespace] || {};
+          for (const chainId of Object.keys(networkMap)) {
+            if (networkMap[chainId]) enabledChainIds.push(chainId);
+          }
+        }
+
+        if (enabledChainIds.length === 0) {
+          return {};
+        }
+
+        allowedChainIdsSet = new Set(enabledChainIds);
       }
 
-      const enabledChainIds = Object.keys(enabledNetworksForEip155).filter(
-        (chainId) => enabledNetworksForEip155[chainId],
-      );
-
-      if (enabledChainIds.length === 0) {
-        return {};
+      const result = {};
+      for (const address of addresses) {
+        const addressNfts = allNfts?.[address];
+        if (!addressNfts) continue;
+        for (const chainId of Object.keys(addressNfts)) {
+          if (!allowedChainIdsSet.has(chainId)) continue;
+          const nfts = addressNfts[chainId];
+          if (!Array.isArray(nfts)) continue;
+          result[chainId] = (result[chainId] || []).concat(nfts);
+        }
       }
 
-      const enabledChainIdsSet = new Set(enabledChainIds);
-
-      return Object.keys(addressNfts)
-        .filter((chainId) => enabledChainIdsSet.has(chainId))
-        .reduce((acc, chainId) => {
-          acc[chainId] = addressNfts[chainId];
-          return acc;
-        }, {});
+      return result;
     },
   );
 

--- a/app/reducers/collectibles/index.test.ts
+++ b/app/reducers/collectibles/index.test.ts
@@ -178,6 +178,21 @@ describe('collectibles reducer', () => {
   });
 });
 
+type MultichainCollectiblesSelector = (
+  state: RootState,
+  preferredChainIds?: string[],
+  addressesOverride?: string[],
+) => Record<string, unknown[]>;
+
+const callSelector = (
+  state: RootState,
+  preferredChainIds?: string[],
+  addressesOverride?: string[],
+) =>
+  (
+    multichainCollectiblesByEnabledNetworksSelector as MultichainCollectiblesSelector
+  )(state, preferredChainIds, addressesOverride);
+
 describe('collectibles selectors', () => {
   const mockAddress = '0x1234567890123456789012345678901234567890';
   const mockAddress2 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
@@ -256,7 +271,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
 
       expect(result).toEqual({
         '0x1': mockNfts,
@@ -278,7 +293,7 @@ describe('collectibles selectors', () => {
         },
       );
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
       expect(result).toEqual({});
     });
 
@@ -297,7 +312,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
       expect(result).toEqual({});
     });
 
@@ -320,7 +335,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
 
       expect(result).toEqual({
         '0x1': mockNfts,
@@ -347,7 +362,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
       expect(result).toEqual(allNfts[mockAddress]);
     });
 
@@ -366,7 +381,7 @@ describe('collectibles selectors', () => {
       });
 
       // The selector should return empty object when EIP155 namespace is missing
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
       expect(result).toEqual({});
     });
 
@@ -381,7 +396,7 @@ describe('collectibles selectors', () => {
         [KnownCaipNamespace.Eip155]: {},
       });
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
       expect(result).toEqual({});
     });
 
@@ -401,7 +416,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result1 = multichainCollectiblesByEnabledNetworksSelector(state1);
+      const result1 = callSelector(state1, undefined, undefined);
       expect(result1).toEqual({
         '0x1': mockNfts,
       });
@@ -412,7 +427,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result2 = multichainCollectiblesByEnabledNetworksSelector(state2);
+      const result2 = callSelector(state2, undefined, undefined);
       expect(result2).toEqual({
         '0x1': [{ ...mockNfts[0], tokenId: '100', name: 'Different NFT' }],
       });
@@ -436,7 +451,7 @@ describe('collectibles selectors', () => {
         },
       });
 
-      const result = multichainCollectiblesByEnabledNetworksSelector(state);
+      const result = callSelector(state, undefined, undefined);
 
       expect(result).toEqual({
         '0x1': mockNfts,
@@ -444,6 +459,46 @@ describe('collectibles selectors', () => {
       });
       expect((result as Record<string, unknown>)['0xa86a']).toBeUndefined();
       expect((result as Record<string, unknown>)['0x38']).toBeUndefined();
+    });
+
+    it('filters by preferredChainIds when passed (e.g. listPopularNetworks), fallback to enabled when not', () => {
+      const allNfts = {
+        [mockAddress]: {
+          '0x1': mockNfts,
+          '0x89': [{ ...mockNfts[0], tokenId: '3' }],
+          '0xa86a': [{ ...mockNfts[0], tokenId: '4' }],
+        },
+      };
+
+      const state = createMockState({}, allNfts, mockAddress, {
+        [KnownCaipNamespace.Eip155]: {
+          '0x1': true,
+          '0x89': false,
+          '0xa86a': true,
+        },
+      });
+
+      const withPreferred = callSelector(
+        state,
+        ['eip155:1', '0x89'],
+        undefined,
+      );
+      expect(withPreferred).toEqual({
+        '0x1': mockNfts,
+        '0x89': [{ ...mockNfts[0], tokenId: '3' }],
+      });
+      expect(
+        (withPreferred as Record<string, unknown>)['0xa86a'],
+      ).toBeUndefined();
+
+      const withoutPreferred = callSelector(state, undefined, undefined);
+      expect(withoutPreferred).toEqual({
+        '0x1': mockNfts,
+        '0xa86a': [{ ...mockNfts[0], tokenId: '4' }],
+      });
+      expect(
+        (withoutPreferred as Record<string, unknown>)['0x89'],
+      ).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

update the new home page nft section redesign to always show popular networks

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update the new home page nft section redesign to always show popular networks

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/137702a5-b7df-4cb6-a75d-040a4b7495bd



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates NFT selection logic used by homepage to pass dynamic chain/address filters into a shared selector, which could change which NFTs appear across networks/accounts. No auth/security impact, but affects core asset display behavior.
> 
> **Overview**
> Updates the homepage `useOwnedNfts` hook to **optionally filter by “popular” networks** (when the homepage sections V1 flag is enabled) and to **aggregate NFTs across all addresses in the selected account group**, rather than only the currently selected address.
> 
> Extends `multichainCollectiblesByEnabledNetworksSelector` to accept optional `preferredChainIds` (including CAIP-2 `eip155:*`, normalized to hex) and `addressesOverride`, while preserving the previous enabled-network fallback; corresponding unit tests are updated/added for the new selector and hook behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6da55a6c39625b50049bf0a844fa0571bfdb10f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->