### PR TITLE
refactor: remove selectMultichainAccountsState1Enabled selector

### DIFF
--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.styles.ts
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.styles.ts
@@ -2,29 +2,6 @@ import { StyleSheet } from 'react-native';
 
 const styleSheet = () =>
   StyleSheet.create({
-    wrapper: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingHorizontal: 16,
-      paddingVertical: 4,
-      width: '100%',
-    },
-    left_section: {
-      flexDirection: 'row',
-    },
-    name_section: {
-      flexDirection: 'column',
-      marginLeft: 16,
-    },
-    network_name: {
-      width: 170,
-    },
-    button_section: {
-      flexDirection: 'row',
-      justifyContent: 'flex-end',
-      width: 100,
-    },
     multichain_accounts_row_wrapper: {
       width: '100%',
       marginBottom: 8,

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.test.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.test.tsx
@@ -39,15 +39,6 @@ jest.mock('../../../../hooks/7702/useEIP7702Accounts', () => ({
   }),
 }));
 
-const mockMultichainAccountsState1Enabled = jest.fn().mockReturnValue(false);
-jest.mock(
-  '../../../../../../../selectors/featureFlagController/multichainAccounts',
-  () => ({
-    selectMultichainAccountsState1Enabled: () =>
-      mockMultichainAccountsState1Enabled(),
-  }),
-);
-
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -80,18 +71,36 @@ describe('Account Network Row', () => {
     });
   });
 
-  it('renders correctly for smart account', () => {
+  it('renders network name correctly', () => {
     const { getByText } = renderWithProvider(
       <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
       { state: MOCK_STATE },
     );
 
-    expect(getByText('Smart account')).toBeTruthy();
-    expect(getByText('Switch back')).toBeTruthy();
+    expect(getByText(MOCK_NETWORK.name)).toBeTruthy();
   });
 
-  it('renders correctly for standard account', () => {
-    const { getByText } = renderWithProvider(
+  it('renders switch component with correct testID', () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+      { state: MOCK_STATE },
+    );
+
+    expect(getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH)).toBeTruthy();
+  });
+
+  it('renders switch in correct state for smart account (supported network)', () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+      { state: MOCK_STATE },
+    );
+
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    expect(switchComponent.props.value).toBe(true);
+  });
+
+  it('renders switch in correct state for standard account (unsupported network)', () => {
+    const { getByTestId } = renderWithProvider(
       <AccountNetworkRow
         address={MOCK_ADDRESS}
         network={{ ...MOCK_NETWORK, isSupported: false }}
@@ -99,203 +108,119 @@ describe('Account Network Row', () => {
       { state: MOCK_STATE },
     );
 
-    expect(getByText('Standard account')).toBeTruthy();
-    expect(getByText('Switch')).toBeTruthy();
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    expect(switchComponent.props.value).toBe(false);
   });
 
-  describe('Multichain Accounts Design', () => {
-    it('renders network name correctly', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByText } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
+  it('calls downgrade function when switch is toggled from smart to standard account', () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+      { state: MOCK_STATE },
+    );
 
-      expect(getByText(MOCK_NETWORK.name)).toBeTruthy();
-    });
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    fireEvent(switchComponent, 'onValueChange', false);
 
-    it('renders switch component with correct testID', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
-
-      expect(getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH)).toBeTruthy();
-    });
-
-    it('renders switch in correct state for smart account (supported network)', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
-
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      expect(switchComponent.props.value).toBe(true);
-    });
-
-    it('renders switch in correct state for standard account (unsupported network)', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow
-          address={MOCK_ADDRESS}
-          network={{ ...MOCK_NETWORK, isSupported: false }}
-        />,
-        { state: MOCK_STATE },
-      );
-
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      expect(switchComponent.props.value).toBe(false);
-    });
-
-    it('calls downgrade function when switch is toggled from smart to standard account', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
-
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      fireEvent(switchComponent, 'onValueChange', false);
-
-      expect(mockDowngradeAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
-      expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls upgrade function when switch is toggled from standard to smart account', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow
-          address={MOCK_ADDRESS}
-          network={{ ...MOCK_NETWORK, isSupported: false }}
-        />,
-        { state: MOCK_STATE },
-      );
-
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      fireEvent(switchComponent, 'onValueChange', true);
-
-      expect(mockUpgradeAccount).toHaveBeenCalledWith(
-        MOCK_ADDRESS,
-        MOCK_NETWORK.upgradeContractAddress,
-      );
-      expect(mockUpgradeAccount).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not call upgrade when upgradeContractAddress is missing', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const networkWithoutUpgradeContract = {
-        ...MOCK_NETWORK,
-        isSupported: false,
-        upgradeContractAddress: undefined,
-      };
-
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow
-          address={MOCK_ADDRESS}
-          network={networkWithoutUpgradeContract}
-        />,
-        { state: MOCK_STATE },
-      );
-
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      fireEvent(switchComponent, 'onValueChange', true);
-
-      expect(mockUpgradeAccount).not.toHaveBeenCalled();
-      expect(mockDowngradeAccount).not.toHaveBeenCalled();
-    });
-
-    it('disables switch when there are pending requests', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      mockUseBatchAuthorizationRequests.mockReturnValueOnce({
-        hasPendingRequests: true,
-      });
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      expect(switchComponent.props.disabled).toBe(true);
-    });
-
-    it('disables switch for standard account when upgradeContractAddress is missing', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const networkWithoutUpgradeContract = {
-        ...MOCK_NETWORK,
-        isSupported: false,
-        upgradeContractAddress: undefined,
-      };
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow
-          address={MOCK_ADDRESS}
-          network={networkWithoutUpgradeContract}
-        />,
-        { state: MOCK_STATE },
-      );
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-      expect(switchComponent.props.disabled).toBe(true);
-    });
+    expect(mockDowngradeAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
+    expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
   });
 
-  describe('Switch Button', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
+  it('calls upgrade function when switch is toggled from standard to smart account', () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow
+        address={MOCK_ADDRESS}
+        network={{ ...MOCK_NETWORK, isSupported: false }}
+      />,
+      { state: MOCK_STATE },
+    );
+
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    fireEvent(switchComponent, 'onValueChange', true);
+
+    expect(mockUpgradeAccount).toHaveBeenCalledWith(
+      MOCK_ADDRESS,
+      MOCK_NETWORK.upgradeContractAddress,
+    );
+    expect(mockUpgradeAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call upgrade when upgradeContractAddress is missing', () => {
+    const networkWithoutUpgradeContract = {
+      ...MOCK_NETWORK,
+      isSupported: false,
+      upgradeContractAddress: undefined,
+    };
+
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow
+        address={MOCK_ADDRESS}
+        network={networkWithoutUpgradeContract}
+      />,
+      { state: MOCK_STATE },
+    );
+
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    fireEvent(switchComponent, 'onValueChange', true);
+
+    expect(mockUpgradeAccount).not.toHaveBeenCalled();
+    expect(mockDowngradeAccount).not.toHaveBeenCalled();
+  });
+
+  it('disables switch when there are pending requests', () => {
+    mockUseBatchAuthorizationRequests.mockReturnValueOnce({
+      hasPendingRequests: true,
     });
-    it('when clicked call upgrade function if not already upgraded', () => {
-      const { getByText } = renderWithProvider(
-        <AccountNetworkRow
-          address={MOCK_ADDRESS}
-          network={{ ...MOCK_NETWORK, isSupported: false }}
-        />,
-        { state: MOCK_STATE },
-      );
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+      { state: MOCK_STATE },
+    );
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    expect(switchComponent.props.disabled).toBe(true);
+  });
 
-      fireEvent.press(getByText('Switch'));
+  it('disables switch for standard account when upgradeContractAddress is missing', () => {
+    const networkWithoutUpgradeContract = {
+      ...MOCK_NETWORK,
+      isSupported: false,
+      upgradeContractAddress: undefined,
+    };
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow
+        address={MOCK_ADDRESS}
+        network={networkWithoutUpgradeContract}
+      />,
+      { state: MOCK_STATE },
+    );
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+    expect(switchComponent.props.disabled).toBe(true);
+  });
 
-      expect(mockUpgradeAccount).toHaveBeenCalledTimes(1);
-    });
+  it('does not navigate to wallet view when switch is pressed', () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+      { state: MOCK_STATE },
+    );
 
-    it('when clicked call downgrade function if already upgraded', () => {
-      const { getByText } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
+    fireEvent.press(getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH));
 
-      fireEvent.press(getByText('Switch back'));
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.WALLET_VIEW);
+  });
 
-      expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
-    });
+  it('returns early when switchRequestSubmitted is true', async () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+      { state: MOCK_STATE },
+    );
 
-    it('does not close account modal when useMultichainAccountsDesign is true', () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
+    const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
 
-      fireEvent.press(getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH));
+    // First click to trigger the switch and set switchRequestSubmitted to true
+    fireEvent(switchComponent, 'onValueChange', false);
 
-      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.WALLET_VIEW);
-    });
+    // Second click while switchRequestSubmitted is true - should return early
+    fireEvent(switchComponent, 'onValueChange', true);
 
-    it('returns early when switchRequestSubmitted is true', async () => {
-      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
-      const { getByTestId } = renderWithProvider(
-        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
-        { state: MOCK_STATE },
-      );
-
-      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
-
-      // First click to trigger the switch and set switchRequestSubmitted to true
-      fireEvent(switchComponent, 'onValueChange', false);
-
-      // Second click while switchRequestSubmitted is true - should return early
-      fireEvent(switchComponent, 'onValueChange', true);
-
-      // Calls downgradeAccount once
-      expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
-    });
+    // Calls downgradeAccount once
+    expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
@@ -1,32 +1,20 @@
 import { Hex } from '@metamask/utils';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Switch, View } from 'react-native';
+import { Switch } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import { SmartAccountIds } from '../../../../../MultichainAccounts/SmartAccount.testIds';
-import { SwitchAccountModalSelectorIDs } from '../SwitchAccountModal.testIds';
-import { strings } from '../../../../../../../../locales/i18n';
-import Avatar, {
-  AvatarSize,
-  AvatarVariant,
-} from '../../../../../../../component-library/components/Avatars/Avatar';
-import Button, {
-  ButtonVariants,
-} from '../../../../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../../../component-library/components/Texts/Text';
-import { getNetworkImageSource } from '../../../../../../../util/networks';
-import Spinner, { SpinnerSize } from '../../../../../../UI/AnimatedSpinner';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import { EIP7702NetworkConfiguration } from '../../../../hooks/7702/useEIP7702Networks';
 import { useBatchAuthorizationRequests } from '../../../../hooks/7702/useBatchAuthorizationRequests';
 import { useEIP7702Accounts } from '../../../../hooks/7702/useEIP7702Accounts';
 import styleSheet from './account-network-row.styles';
-import { useSelector } from 'react-redux';
 import {
   AlignItems,
   FlexDirection,
@@ -34,7 +22,6 @@ import {
 } from '../../../../../../UI/Box/box.types';
 import { Box } from '../../../../../../UI/Box/Box';
 import { useTheme } from '../../../../../../../util/theme';
-import { selectMultichainAccountsState1Enabled } from '../../../../../../../selectors/featureFlagController/multichainAccounts';
 
 const AccountNetworkRow = ({
   address,
@@ -43,9 +30,6 @@ const AccountNetworkRow = ({
   address: Hex;
   network: EIP7702NetworkConfiguration;
 }) => {
-  const useMultichainAccountsDesign = useSelector(
-    selectMultichainAccountsState1Enabled,
-  );
   const navigation = useNavigation();
   const { downgradeAccount, upgradeAccount } = useEIP7702Accounts(
     network as unknown as NetworkConfiguration,
@@ -55,7 +39,6 @@ const AccountNetworkRow = ({
   const { styles } = useStyles(styleSheet, {});
 
   const { name, chainId, isSupported, upgradeContractAddress } = network;
-  const networkImage = getNetworkImageSource({ networkType: 'evm', chainId });
   const [addressSupportSmartAccount, setAddressSupportSmartAccount] =
     useState(isSupported);
   const [switchRequestSubmitted, setSwitchRequestSubmitted] = useState(false);
@@ -73,13 +56,7 @@ const AccountNetworkRow = ({
     } else if (upgradeContractAddress) {
       await upgradeAccount(address, upgradeContractAddress);
     }
-    if (!useMultichainAccountsDesign) {
-      // This navigation below is to close account modal.
-      navigation.navigate(Routes.WALLET_VIEW);
-    }
 
-    // This navigation to confirmation modal
-    // is needed as above navigation lands on home page
     navigation.navigate(Routes.CONFIRMATION_REQUEST_MODAL);
     setSwitchRequestSubmitted(false);
   }, [
@@ -89,7 +66,6 @@ const AccountNetworkRow = ({
     navigation,
     upgradeAccount,
     upgradeContractAddress,
-    useMultichainAccountsDesign,
     switchRequestSubmitted,
   ]);
 
@@ -102,78 +78,32 @@ const AccountNetworkRow = ({
     prevHasPendingRequests.current = hasPendingRequests;
   }, [addressSupportSmartAccount, hasPendingRequests, prevHasPendingRequests]);
 
-  if (useMultichainAccountsDesign) {
-    return (
-      <Box
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-        alignItems={AlignItems.center}
-        style={styles.multichain_accounts_row_wrapper}
-      >
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Alternative}>
-          {network.name}
-        </Text>
-        <Switch
-          testID={SmartAccountIds.SMART_ACCOUNT_SWITCH}
-          value={addressSupportSmartAccount}
-          onValueChange={onSwitch}
-          trackColor={{
-            true: colors.primary.default,
-            false: colors.border.muted,
-          }}
-          thumbColor={theme.brandColors.white}
-          ios_backgroundColor={colors.border.muted}
-          disabled={
-            hasPendingRequests ||
-            (!addressSupportSmartAccount && !upgradeContractAddress)
-          }
-        />
-      </Box>
-    );
-  }
-
   return (
-    <View style={styles.wrapper}>
-      <View style={styles.left_section}>
-        <Avatar
-          variant={AvatarVariant.Network}
-          size={AvatarSize.Lg}
-          name={name}
-          imageSource={networkImage}
-        />
-        <View style={styles.name_section}>
-          <Text
-            variant={TextVariant.BodyMDBold}
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            style={styles.network_name}
-          >
-            {name}
-          </Text>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
-            {addressSupportSmartAccount
-              ? strings('confirm.7702_functionality.smartAccountLabel')
-              : strings('confirm.7702_functionality.standardAccountLabel')}
-          </Text>
-        </View>
-      </View>
-      <View style={styles.button_section}>
-        {hasPendingRequests || switchRequestSubmitted ? (
-          <Spinner size={SpinnerSize.SM} />
-        ) : (
-          <Button
-            variant={ButtonVariants.Link}
-            label={
-              addressSupportSmartAccount
-                ? strings('confirm.7702_functionality.switchBack')
-                : strings('confirm.7702_functionality.switch')
-            }
-            onPress={onSwitch}
-            testID={`${SwitchAccountModalSelectorIDs.SWITCH_ACCOUNT_BUTTON}-${name}`}
-          />
-        )}
-      </View>
-    </View>
+    <Box
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.spaceBetween}
+      alignItems={AlignItems.center}
+      style={styles.multichain_accounts_row_wrapper}
+    >
+      <Text variant={TextVariant.BodyMDMedium} color={TextColor.Alternative}>
+        {name}
+      </Text>
+      <Switch
+        testID={SmartAccountIds.SMART_ACCOUNT_SWITCH}
+        value={addressSupportSmartAccount}
+        onValueChange={onSwitch}
+        trackColor={{
+          true: colors.primary.default,
+          false: colors.border.muted,
+        }}
+        thumbColor={theme.brandColors.white}
+        ios_backgroundColor={colors.border.muted}
+        disabled={
+          hasPendingRequests ||
+          (!addressSupportSmartAccount && !upgradeContractAddress)
+        }
+      />
+    </Box>
   );
 };
 

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal.test.tsx
@@ -13,8 +13,6 @@ import * as Networks7702 from '../../../hooks/7702/useEIP7702Networks';
 import { EIP7702NetworkConfiguration } from '../../../hooks/7702/useEIP7702Networks';
 import SwitchAccountTypeModal from './switch-account-type-modal';
 
-import {} from '../../../../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
-
 jest.mock('../../../hooks/tokens/useTokenWithBalance');
 jest.mock('../../../hooks/gas/useGasFeeToken');
 
@@ -69,13 +67,6 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
-jest.mock(
-  '../../../../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts',
-  () => ({
-    selectMultichainAccountsState1Enabled: () => false,
-  }),
-);
-
 const MOCK_STATE = {
   engine: {
     backgroundState: {
@@ -124,8 +115,6 @@ describe('Switch Account Type Modal', () => {
       );
       expect(getByText('Account 1')).toBeOnTheScreen();
       expect(getByText('Sepolia')).toBeOnTheScreen();
-      expect(getByText('Smart account')).toBeOnTheScreen();
-      expect(getByText('Switch back')).toBeOnTheScreen();
     });
 
     it('renders empty state when network7702List is empty', () => {

--- a/app/selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts.test.ts
+++ b/app/selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts.test.ts
@@ -1,7 +1,4 @@
-import {
-  selectMultichainAccountsState1Enabled,
-  selectMultichainAccountsState2Enabled,
-} from './enabledMultichainAccounts';
+import { selectMultichainAccountsState2Enabled } from './enabledMultichainAccounts';
 
 jest.mock('../../../../package.json', () => ({
   version: '15.0.0',
@@ -13,12 +10,6 @@ const disabledStateMock = {
   minimumVersion: null,
 };
 
-const state1Mock = {
-  enabled: true,
-  featureVersion: '1',
-  minimumVersion: '13.0.0',
-};
-
 const state2Mock = {
   enabled: true,
   featureVersion: '2',
@@ -26,30 +17,6 @@ const state2Mock = {
 };
 
 describe('Multichain Accounts Feature Flag', () => {
-  describe('selectMultichainAccountsState1Enabled', () => {
-    it('returns true when the flag is undefined', () => {
-      const result = selectMultichainAccountsState1Enabled.resultFunc({
-        // @ts-expect-error testing undefined case
-        enableMultichainAccounts: undefined,
-      });
-      expect(result).toBe(true);
-    });
-
-    it('returns false when the feature is not enabled', () => {
-      const result = selectMultichainAccountsState1Enabled.resultFunc({
-        enableMultichainAccounts: disabledStateMock,
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns true when the feature is enabled for state 1', () => {
-      const result = selectMultichainAccountsState1Enabled.resultFunc({
-        enableMultichainAccounts: state1Mock,
-      });
-      expect(result).toBe(true);
-    });
-  });
-
   describe('selectMultichainAccountsState2Enabled', () => {
     it('returns true when the flag is undefined', () => {
       const result = selectMultichainAccountsState2Enabled.resultFunc({

--- a/app/selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts.ts
+++ b/app/selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts.ts
@@ -3,9 +3,7 @@ import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import {
   isMultichainAccountsRemoteFeatureEnabled,
-  STATE_1_FLAG,
   STATE_2_FLAG,
-  MULTICHAIN_ACCOUNTS_FEATURE_VERSION_1,
   MULTICHAIN_ACCOUNTS_FEATURE_VERSION_2,
 } from '../../../multichain-accounts/remote-feature-flag';
 
@@ -26,22 +24,6 @@ const createMultichainAccountsStateSelector = (
       featureVersionsToCheck,
     ),
   );
-
-/**
- * Selector to check if multichain accounts state 1 is enabled.
- * Returns true if the feature is enabled for state 1 or state 2.
- */
-export const selectMultichainAccountsState1Enabled =
-  createMultichainAccountsStateSelector([
-    {
-      version: MULTICHAIN_ACCOUNTS_FEATURE_VERSION_1,
-      featureKey: STATE_1_FLAG,
-    },
-    {
-      version: MULTICHAIN_ACCOUNTS_FEATURE_VERSION_2,
-      featureKey: STATE_2_FLAG,
-    },
-  ]);
 
 /**
  * Selector to check if multichain accounts state 2 is enabled.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes complete usage of the selector `selectMultichainAccountsState1Enabled`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1471

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes feature-flag gating and the legacy `AccountNetworkRow` UI/navigation path, which could change the switch-account modal behavior and navigation flow. Risk is limited to UI/UX and modal routing (no sensitive data/auth logic touched).
> 
> **Overview**
> **Removes the multichain accounts “state 1” flag path.** Deletes `selectMultichainAccountsState1Enabled` and its unit tests, leaving only the state-2 selector.
> 
> **Simplifies the switch-account-type modal row UI.** `AccountNetworkRow` now always renders the switch-based layout (dropping the legacy avatar/button variant), removes the conditional navigation to `Routes.WALLET_VIEW`, and updates tests/styles accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79499fe0ed03628869f9215bbe1271a8ee6b906e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->