### PR TITLE
Fix quote destination token match comparison

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -131,7 +131,9 @@ export const useBridgeQuoteData = ({
       // (e.g., "solana:.../token:EPj...").
       // Use destAsset.assetId (CAIP format) for comparison.
       // For EVM chains, use the original address comparison.
-      const quoteDestAddress = isNonEvmChainId(destToken.chainId)
+      // We use destAsset.chainId from the quote to determine the format, not destToken.chainId,
+      // because the quote's destAsset structure depends on the actual destination chain in the quote.
+      const quoteDestAddress = isNonEvmChainId(destAsset.chainId)
         ? (destAsset.assetId ?? destAsset.address)
         : destAsset.address;
 


### PR DESCRIPTION
Fixes #27043. The isQuoteDestTokenMatchForQuote function was using destToken.chainId to determine whether to use assetId or address for comparison, but it should use the quote's destAsset.chainId since the quote's destAsset structure depends on the actual destination chain in the quote. This fixes the issue where the destination amount shows 0 even when a quote is available when entering swaps from popular networks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how bridge quotes are filtered/matched to the selected destination token, which can affect quote selection and displayed destination amounts across chains. Scope is small but touches core swap/bridge UI logic, so regressions could hide valid quotes or accept mismatched ones.
> 
> **Overview**
> Fixes destination-token matching for bridge quotes by determining non-EVM vs EVM address/`assetId` comparison using the quote’s `destAsset.chainId` (instead of the selected `destToken.chainId`). This prevents valid quotes—especially to non-EVM destinations like Solana—from being incorrectly rejected and showing a `0`/missing destination amount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 002346a2563cb39a6b9b03c5692d32d010bf206f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->