### PR TITLE
feat: adds skeleton loader for quote fetching

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -3,6 +3,7 @@ import '../../_mocks_/initialState';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import QuoteDetailsCard from './QuoteDetailsCard';
+import QuoteDetailsCardSkeleton from './QuoteDetailsCardSkeleton';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 import mockQuotes from '../../_mocks_/mock-quotes-sol-sol.json';
@@ -11,6 +12,7 @@ import { createBridgeTestState } from '../../testUtils';
 import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
 import { PriceImpactModalType } from '../PriceImpactModal/constants';
+import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
 
 jest.mock(
   '../../../../../animations/rewards_icon_animations.riv',
@@ -271,9 +273,26 @@ const QuoteDetailsCardTestScreen = () => (
   />
 );
 
+const QuoteDetailsCardSkeletonTestScreen = () => <QuoteDetailsCardSkeleton />;
+
 describe('QuoteDetailsCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('renders a four-row loading skeleton', () => {
+    const { getByTestId, getAllByTestId } = renderScreen(
+      QuoteDetailsCardSkeletonTestScreen,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: testState },
+    );
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.QUOTE_DETAILS_SKELETON),
+    ).toBeDefined();
+    expect(getAllByTestId('quote-details-card-loading-row')).toHaveLength(4);
   });
 
   it('renders initial state', () => {

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCardSkeleton.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCardSkeleton.tsx
@@ -23,6 +23,7 @@ const QuoteDetailsCardSkeleton = () => (
     {ROWS.map(([left, right], i) => (
       <Box
         key={i}
+        testID="quote-details-card-loading-row"
         flexDirection={BoxFlexDirection.Row}
         justifyContent={BoxJustifyContent.Between}
         alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/index.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/index.ts
@@ -1,1 +1,2 @@
 export { default } from './QuoteDetailsCard';
+export { default as QuoteDetailsCardSkeleton } from './QuoteDetailsCardSkeleton';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a skeleton loader during quote fetching in the swaps experience.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: improves quote loading UI

## **Related issues**

Fixes: null

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/test-only change that adds deterministic `testID`s and a small unit test for the quote details loading skeleton; no business logic or data flow changes.
> 
> **Overview**
> Adds a dedicated `QuoteDetailsCardSkeleton` loading state with per-row `testID`s and re-exports it from `QuoteDetailsCard/index.ts`.
> 
> Updates `QuoteDetailsCard.test.tsx` to cover the skeleton, asserting the `QUOTE_DETAILS_SKELETON` container renders and contains **four** loading rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 430944512f45468ea5c202f7ecee7439fd8a5df3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->