### PR TITLE
fix: navigate to token list when closing "Token not available" modal

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.test.tsx
@@ -138,13 +138,16 @@ describe('TokenNotAvailableModal', () => {
     );
   });
 
-  it('closes the modal when the close button is pressed', () => {
+  it('navigates to token selection when the close button is pressed', () => {
     const { getByTestId } = render(TokenNotAvailableModal);
     const closeButton = getByTestId('bottomsheetheader-close-button');
 
     fireEvent.press(closeButton);
 
-    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.TOKEN_SELECTION, {
+      screen: Routes.RAMP.TOKEN_SELECTION,
+    });
   });
 
   it('matches snapshot with missing provider and token names', () => {

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
@@ -83,14 +83,6 @@ function TokenNotAvailableModal() {
     createEventBuilder,
   ]);
 
-  const handleClose = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet(() => {
-      navigation.navigate(Routes.RAMP.TOKEN_SELECTION, {
-        screen: Routes.RAMP.TOKEN_SELECTION,
-      });
-    });
-  }, [navigation]);
-
   return (
     <BottomSheet
       ref={sheetRef}
@@ -99,7 +91,7 @@ function TokenNotAvailableModal() {
       testID="token-unavailable-for-provider-modal"
     >
       <BottomSheetHeader
-        onClose={handleClose}
+        onClose={handleChangeToken}
         closeButtonProps={{ testID: 'bottomsheetheader-close-button' }}
       >
         <Text variant={TextVariant.HeadingMD}>

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
@@ -84,8 +84,12 @@ function TokenNotAvailableModal() {
   ]);
 
   const handleClose = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet();
-  }, []);
+    sheetRef.current?.onCloseBottomSheet(() => {
+      navigation.navigate(Routes.RAMP.TOKEN_SELECTION, {
+        screen: Routes.RAMP.TOKEN_SELECTION,
+      });
+    });
+  }, [navigation]);
 
   return (
     <BottomSheet


### PR DESCRIPTION
## **Description**

When the user presses the "X" (close) button on the "Token not available with provider" modal, they were returned to the BuildQuote (Amount Input) screen. Since that screen re-checks token availability and re-opens the modal, the user was stuck in a loop.

This fix navigates the user back to the token selection list when closing the modal, matching the behavior of the "Change token" button.

## **Changelog**

CHANGELOG entry: Fixed the close button on the "Token not available" modal to navigate back to the token list instead of staying stuck on the amount input screen.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3329

## **Manual testing steps**

```gherkin
Feature: Token not available modal close behavior

  Scenario: user closes the "Token not available" modal via X button
    Given the user is on the Buy flow amount input screen
    And the selected token is not available with the current provider

    When the "Token not available" modal appears
    And the user taps the X (close) button
    Then the user is navigated back to the token selection list
```

## **Screenshots/Recordings**

### **Before**

<!-- Pressing X returns to amount input, modal reopens immediately -->

### **After**

<!-- Pressing X navigates to token selection list -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation change limited to the `TokenNotAvailableModal` close action; main risk is unintended navigation regression in the ramp flow.
> 
> **Overview**
> Fixes the "Token not available" ramp modal close (X) behavior to **navigate to the token selection screen** instead of simply dismissing the bottom sheet, preventing users from getting stuck reopening the modal.
> 
> Updates the modal header `onClose` to reuse `handleChangeToken`, and adjusts the corresponding test to assert bottom sheet closure plus navigation to `Routes.RAMP.TOKEN_SELECTION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c1ff66641aa4c9c73cb2f25b25b16ba9e75235b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->