### PR TITLE
feat: import alias

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -28,6 +28,7 @@ module.exports = {
       {
         alias: {
           '@metamask/perps-controller': './app/controllers/perps',
+          '~/app': './app',
         },
       },
     ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -60,6 +60,7 @@ const config = {
   coverageDirectory: '<rootDir>/tests/coverage',
   maxWorkers: process.env.NODE_ENV === 'production' ? '50%' : '20%',
   moduleNameMapper: {
+    '^~/app/(.*)$': '<rootDir>/app/$1',
     '\\.(svg)$': '<rootDir>/app/__mocks__/svgMock.js',
     '\\.(png)$': '<rootDir>/app/__mocks__/pngMock.js',
     '\\webview/index.html': '<rootDir>/app/__mocks__/htmlMock.ts',

--- a/metro.config.js
+++ b/metro.config.js
@@ -91,6 +91,7 @@ module.exports = function (baseConfig) {
             __dirname,
             'app/controllers/perps',
           ),
+          '~/app': path.resolve(__dirname, 'app'),
           'base64-js': 'react-native-quick-base64',
           base64: 'react-native-quick-base64',
           'js-base64': 'react-native-quick-base64',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,8 @@
       // TODO: Remove this once we use `Node16` module resolution.
       "@metamask/json-rpc-engine/v2": [
         "node_modules/@metamask/json-rpc-engine/dist/v2/index.d.cts"
-      ]
+      ],
+      "~/app/*": ["./app/*"]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
## **Description**

Introduces import aliases to replace deep relative paths like ../../../some-directory/....

Why
- Readability: import origin is obvious at a glance
- Refactor-safe: moving files doesn't break imports
- No breaking changes: old relative imports continue to work, adoption is gradual

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it affects module resolution in Babel/Metro/Jest/TypeScript and could break builds/tests if the alias conflicts or is mis-resolved in some environments.
> 
> **Overview**
> Adds a new `~/app` path alias that resolves to the project `app` directory across **Babel**, **Metro**, **Jest**, and **TypeScript** configs, enabling gradual replacement of deep relative imports with `~/app/...`.
> 
> This updates module resolution mappings consistently (`module-resolver`, Metro `extraNodeModules`, Jest `moduleNameMapper`, and `tsconfig` `paths`) without changing runtime or app logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296e67e3655eb4a10c235f5286815ef522f2c217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->