### PR TITLE
fix(perps): use safe provider access to prevent CLIENT_NOT_INITIALIZED errors

### DIFF
--- a/app/components/UI/Perps/hooks/useDepositRequests.test.ts
+++ b/app/components/UI/Perps/hooks/useDepositRequests.test.ts
@@ -39,6 +39,7 @@ describe('useDepositRequests', () => {
 
   let mockController: {
     getActiveProvider: jest.MockedFunction<() => unknown>;
+    getActiveProviderOrNull: jest.MockedFunction<() => unknown>;
   };
   let mockProvider: {
     getUserNonFundingLedgerUpdates: jest.MockedFunction<
@@ -158,6 +159,7 @@ describe('useDepositRequests', () => {
     // Mock controller
     mockController = {
       getActiveProvider: jest.fn().mockReturnValue(mockProvider),
+      getActiveProviderOrNull: jest.fn().mockReturnValue(mockProvider),
     };
 
     // Mock Engine context
@@ -320,7 +322,7 @@ describe('useDepositRequests', () => {
     });
 
     it('handles no active provider', async () => {
-      mockController.getActiveProvider.mockReturnValue(undefined);
+      mockController.getActiveProviderOrNull.mockReturnValue(null);
 
       const { result } = renderHookWithProvider(() => useDepositRequests(), {
         state: createMockState(),
@@ -330,13 +332,14 @@ describe('useDepositRequests', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(result.current.error).toBe('No active provider available');
+      // With getActiveProviderOrNull returning null, hook bails early without error
+      expect(result.current.error).toBeNull();
       expect(result.current.depositRequests).toEqual([]);
     });
 
     it('handles provider without getUserNonFundingLedgerUpdates method', async () => {
       mockProvider = {} as unknown as typeof mockProvider;
-      mockController.getActiveProvider.mockReturnValue(mockProvider);
+      mockController.getActiveProviderOrNull.mockReturnValue(mockProvider);
 
       const { result } = renderHookWithProvider(() => useDepositRequests(), {
         state: createMockState(),

--- a/app/components/UI/Perps/hooks/useDepositRequests.ts
+++ b/app/components/UI/Perps/hooks/useDepositRequests.ts
@@ -118,9 +118,10 @@ export const useDepositRequests = (
         throw new Error('PerpsController not available');
       }
 
-      const provider = controller.getActiveProvider();
+      const provider = controller.getActiveProviderOrNull();
       if (!provider) {
-        throw new Error('No active provider available');
+        setIsLoading(false);
+        return;
       }
 
       // Check if provider has the getUserNonFundingLedgerUpdates method

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.test.ts
@@ -55,6 +55,7 @@ jest.mock('../../../../core/Engine', () => ({
   context: {
     PerpsController: {
       getActiveProvider: jest.fn(),
+      getActiveProviderOrNull: jest.fn(),
     },
   },
 }));
@@ -836,9 +837,9 @@ describe('usePerpsHomeData', () => {
 
       renderHook(() => usePerpsHomeData());
 
-      // getActiveProvider should NOT be called when not connected
+      // getActiveProviderOrNull should NOT be called when not connected
       expect(
-        Engine.context.PerpsController.getActiveProvider,
+        Engine.context.PerpsController.getActiveProviderOrNull,
       ).not.toHaveBeenCalled();
     });
 
@@ -852,7 +853,7 @@ describe('usePerpsHomeData', () => {
       ];
       const mockGetOrderFills = jest.fn().mockResolvedValue(mockFillsFromRest);
       (
-        Engine.context.PerpsController.getActiveProvider as jest.Mock
+        Engine.context.PerpsController.getActiveProviderOrNull as jest.Mock
       ).mockReturnValue({
         getOrderFills: mockGetOrderFills,
       });
@@ -872,7 +873,7 @@ describe('usePerpsHomeData', () => {
       });
 
       expect(
-        Engine.context.PerpsController.getActiveProvider,
+        Engine.context.PerpsController.getActiveProviderOrNull,
       ).toHaveBeenCalled();
       expect(mockGetOrderFills).toHaveBeenCalledWith({
         aggregateByTime: false,

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -103,7 +103,7 @@ export const usePerpsHomeData = ({
     const fetchFills = async () => {
       try {
         const controller = Engine.context.PerpsController;
-        const provider = controller?.getActiveProvider();
+        const provider = controller?.getActiveProviderOrNull();
         if (!provider) {
           return;
         }

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../../core/Engine', () => ({
   context: {
     PerpsController: {
       getActiveProvider: jest.fn(),
+      getActiveProviderOrNull: jest.fn(),
     },
   },
 }));
@@ -30,9 +31,9 @@ const mockUsePerpsLiveFills = usePerpsLiveFills as jest.MockedFunction<
   typeof usePerpsLiveFills
 >;
 
-const mockGetActiveProvider = Engine.context.PerpsController
-  .getActiveProvider as jest.MockedFunction<
-  typeof Engine.context.PerpsController.getActiveProvider
+const mockGetActiveProviderOrNull = Engine.context.PerpsController
+  .getActiveProviderOrNull as jest.MockedFunction<
+  typeof Engine.context.PerpsController.getActiveProviderOrNull
 >;
 
 // Test data
@@ -89,7 +90,7 @@ describe('usePerpsMarketFills', () => {
       getOrderFills: jest.fn().mockResolvedValue([]),
     };
 
-    mockGetActiveProvider.mockReturnValue(
+    mockGetActiveProviderOrNull.mockReturnValue(
       mockProvider as unknown as ReturnType<
         typeof Engine.context.PerpsController.getActiveProvider
       >,
@@ -411,7 +412,7 @@ describe('usePerpsMarketFills', () => {
 
     it('handles missing provider gracefully', async () => {
       // Arrange
-      mockGetActiveProvider.mockReturnValue(
+      mockGetActiveProviderOrNull.mockReturnValue(
         null as unknown as ReturnType<
           typeof Engine.context.PerpsController.getActiveProvider
         >,

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -82,7 +82,7 @@ export const usePerpsMarketFills = ({
     }
 
     try {
-      const provider = controller?.getActiveProvider();
+      const provider = controller?.getActiveProviderOrNull();
       if (!provider) {
         return;
       }

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -58,6 +58,7 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 describe('usePerpsTransactionHistory', () => {
   let mockController: {
     getActiveProvider: jest.MockedFunction<() => unknown>;
+    getActiveProviderOrNull: jest.MockedFunction<() => unknown>;
   };
   let mockProvider: {
     getOrderFills: jest.MockedFunction<
@@ -176,6 +177,7 @@ describe('usePerpsTransactionHistory', () => {
     // Mock controller
     mockController = {
       getActiveProvider: jest.fn().mockReturnValue(mockProvider),
+      getActiveProviderOrNull: jest.fn().mockReturnValue(mockProvider),
     };
 
     // Mock Engine context
@@ -647,7 +649,7 @@ describe('usePerpsTransactionHistory', () => {
     });
 
     it('handles no active provider', async () => {
-      mockController.getActiveProvider.mockReturnValue(undefined);
+      mockController.getActiveProviderOrNull.mockReturnValue(null);
       // WebSocket fills are empty for this test
       mockUsePerpsLiveFills.mockReturnValue({
         fills: [],
@@ -662,7 +664,8 @@ describe('usePerpsTransactionHistory', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(result.current.error).toBe('No active provider available');
+      // With getActiveProviderOrNull returning null, hook bails early without error
+      expect(result.current.error).toBeNull();
       // With no REST data and no WebSocket data, transactions should be empty
       expect(result.current.transactions).toEqual([]);
     });

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -97,9 +97,10 @@ export const usePerpsTransactionHistory = ({
         throw new Error('PerpsController not available');
       }
 
-      const provider = controller.getActiveProvider();
+      const provider = controller.getActiveProviderOrNull();
       if (!provider) {
-        throw new Error('No active provider available');
+        setIsLoading(false);
+        return;
       }
 
       DevLogger.log('Fetching comprehensive transaction history...');

--- a/app/components/UI/Perps/hooks/useUserHistory.test.ts
+++ b/app/components/UI/Perps/hooks/useUserHistory.test.ts
@@ -14,6 +14,7 @@ const mockDevLogger = DevLogger as jest.Mocked<typeof DevLogger>;
 describe('useUserHistory', () => {
   let mockController: {
     getActiveProvider: jest.MockedFunction<() => unknown>;
+    getActiveProviderOrNull: jest.MockedFunction<() => unknown>;
   };
   let mockProvider: {
     getUserHistory: jest.MockedFunction<
@@ -53,6 +54,7 @@ describe('useUserHistory', () => {
     // Mock controller
     mockController = {
       getActiveProvider: jest.fn().mockReturnValue(mockProvider),
+      getActiveProviderOrNull: jest.fn().mockReturnValue(mockProvider),
     };
 
     // Mock Engine context

--- a/app/components/UI/Perps/hooks/useUserHistory.ts
+++ b/app/components/UI/Perps/hooks/useUserHistory.ts
@@ -50,9 +50,13 @@ export const useUserHistory = ({
 
       DevLogger.log('Fetching user history with params:', params);
 
-      const history = await controller
-        .getActiveProvider()
-        .getUserHistory(params);
+      const provider = controller.getActiveProviderOrNull();
+      if (!provider) {
+        setIsLoading(false);
+        return [];
+      }
+
+      const history = await provider.getUserHistory(params);
 
       DevLogger.log('User history fetched successfully:', history);
       setUserHistory(history);


### PR DESCRIPTION
## **Description**

Replace `getActiveProvider()` with `getActiveProviderOrNull()` in 5 hooks that call the provider before PerpsController initialization completes.

The throwing variant causes a race condition when React hooks mount before async controller init finishes, producing ~249 CLIENT_NOT_INITIALIZED errors/day in Sentry. The null-returning variant allows hooks to bail early gracefully, matching the pattern already used by `useWithdrawalRequests`.

**Hooks updated:**
- `usePerpsMarketFills` — was reporting to Sentry via Logger.error
- `useUserHistory` — was surfacing as unnecessary error state
- `useDepositRequests` — was throwing "No active provider available"
- `usePerpsTransactionHistory` — was throwing "No active provider available"
- `usePerpsHomeData` — defense-in-depth (already had isInitialized guard)

## **Changelog**

CHANGELOG entry: Fixed a race condition causing CLIENT_NOT_INITIALIZED errors when navigating to Perps before controller initialization completes

## **Related issues**

Fixes: METAMASK-MOBILE-5E61

## **Manual testing steps**

```gherkin
Feature: Perps hooks handle uninitialized controller gracefully

  Scenario: User navigates to Perps before controller init completes
    Given the app is launched and PerpsController is still initializing

    When user navigates to PerpsMarketListView
    Then no CLIENT_NOT_INITIALIZED errors appear in Metro logs
    And the UI shows loading state until the controller finishes initializing
    And data loads normally once initialization completes
```

## **Screenshots/Recordings**

### **Before**

N/A — error suppression fix, no UI changes. Verified via Metro logs and CDP.

### **After**

N/A — error suppression fix, no UI changes. Verified via Metro logs and CDP.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change: swaps provider lookup to a null-safe variant and adjusts loading/error handling; main risk is masking real provider-availability issues by returning early without surfacing an error.
> 
> **Overview**
> Prevents Perps hooks from throwing/logging errors when the `PerpsController` provider isn’t ready by switching from `getActiveProvider()` to `getActiveProviderOrNull()` in `useDepositRequests`, `usePerpsTransactionHistory`, `useUserHistory`, `usePerpsMarketFills`, and `usePerpsHomeData`.
> 
> When the provider is `null`, these hooks now **bail out gracefully** (clearing loading state and leaving `error` as `null`) instead of throwing `No active provider available` and generating `CLIENT_NOT_INITIALIZED` noise. Tests are updated accordingly to mock `getActiveProviderOrNull` and assert the new no-error behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b85d67b90a252215e1e86dbc78c830dab33b579c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->