### PR TITLE
fix(perps): resolve connection/close failures (RC1-4)

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -6,6 +6,7 @@ import {
   type Position,
   type TrackingData,
 } from '@metamask/perps-controller';
+import { captureException } from '@sentry/react-native';
 import { handlePerpsError } from '../utils/translatePerpsError';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsTrading } from './usePerpsTrading';
@@ -202,6 +203,17 @@ export const usePerpsClosePosition = (
           'usePerpsClosePosition: Error closing position',
           closeError,
         );
+        captureException(closeError, {
+          tags: {
+            component: 'usePerpsClosePosition',
+            action: 'close_position',
+          },
+          extra: {
+            symbol: params.position?.symbol,
+            size: params.size,
+            orderType: params.orderType,
+          },
+        });
         setError(closeError);
 
         // Call error callback

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -1627,6 +1627,46 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
     });
 
+    it('serves stale cached market data to subscribers when a re-fetch fails', async () => {
+      // Arrange — first subscription populates cache
+      const callback = jest.fn();
+      const unsubscribe = testStreamManager.marketData.subscribe({
+        callback,
+        throttleMs: 0,
+      });
+
+      await waitFor(() => {
+        expect(callback).toHaveBeenCalledWith(mockMarketData);
+      });
+
+      callback.mockClear();
+
+      // Make cache stale by advancing past CACHE_DURATION (5 minutes)
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+      // Next fetch will fail
+      mockGetMarketDataWithPrices.mockRejectedValue(new Error('Network error'));
+
+      // Act — second subscription triggers a background re-fetch with stale cache
+      const callback2 = jest.fn();
+      const unsubscribe2 = testStreamManager.marketData.subscribe({
+        callback: callback2,
+        throttleMs: 0,
+      });
+
+      await waitFor(() => {
+        expect(mockGetMarketDataWithPrices).toHaveBeenCalledTimes(2);
+      });
+
+      // Assert — stale cached data is served to subscribers (line 1467: notifySubscribers(existing))
+      await waitFor(() => {
+        expect(callback2).toHaveBeenCalledWith(mockMarketData);
+      });
+
+      unsubscribe();
+      unsubscribe2();
+    });
+
     it('prewarms market data cache', async () => {
       // Call prewarm
       const cleanup = testStreamManager.marketData.prewarm();

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -1449,30 +1449,36 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
         const cacheStalenessMs = this.lastFetchTime
           ? Date.now() - this.lastFetchTime
           : null;
-        Logger.error(ensureError(error, 'PerpsStreamManager.fetchMarketData'), {
-          tags: {
-            feature: PERPS_CONSTANTS.FeatureName,
-          },
-          context: {
-            name: 'PerpsStreamManager',
-            data: {
-              method: 'fetchMarketData',
-              fetchTimeMs: fetchTime,
-              hadCachedData: !!existing,
-              cachedMarketCount: existing?.length ?? 0,
-              cacheStalenessMs,
-            },
-          },
-        });
-        // Keep existing cache if fetch fails
+        const diagnosticData = {
+          method: 'fetchMarketData',
+          fetchTimeMs: fetchTime,
+          hadCachedData: !!existing,
+          cachedMarketCount: existing?.length ?? 0,
+          cacheStalenessMs,
+        };
+
         if (existing) {
+          // Transient failure with cached fallback — debug-log only, not Sentry.
+          // These are expected during network transitions and app backgrounding.
           DevLogger.log(
             'PerpsStreamManager: Using stale cache after fetch failure',
-            {
-              marketCount: existing.length,
-            },
+            diagnosticData,
           );
           this.notifySubscribers(existing);
+        } else {
+          // No cached data — genuine first-load failure, report to Sentry
+          Logger.error(
+            ensureError(error, 'PerpsStreamManager.fetchMarketData'),
+            {
+              tags: {
+                feature: PERPS_CONSTANTS.FeatureName,
+              },
+              context: {
+                name: 'PerpsStreamManager',
+                data: diagnosticData,
+              },
+            },
+          );
         }
       } finally {
         this.fetchPromise = null;

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -3626,6 +3626,51 @@ describe('HyperLiquidProvider', () => {
         expect(result[0]).toHaveProperty('price');
         expect(result[0]).toHaveProperty('fundingRate');
       });
+
+      it('retries and returns market data when first attempt yields empty universe', async () => {
+        // Arrange — first metaAndAssetCtxs returns null meta (empty), retry returns valid data
+        jest.useFakeTimers();
+
+        const assetCtx = {
+          funding: '0.0001',
+          openInterest: '1000',
+          prevDayPx: '49000',
+          dayNtlVlm: '1000000',
+          markPx: '50000',
+          midPx: '50000',
+          oraclePx: '50000',
+        };
+
+        const mockMetaAndCtxs = jest
+          .fn()
+          .mockResolvedValueOnce([null, []])
+          .mockResolvedValue([
+            { universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }] },
+            [assetCtx],
+          ]);
+
+        mockClientService.getInfoClient = jest.fn().mockReturnValue(
+          createMockInfoClient({
+            metaAndAssetCtxs: mockMetaAndCtxs,
+            allMids: jest.fn().mockResolvedValue({ BTC: '50000' }),
+          }),
+        );
+
+        const freshProvider = createTestProvider();
+
+        // Act — start fetch, then advance past the 2s retry delay
+        const fetchPromise = freshProvider.getMarketDataWithPrices();
+        await jest.runAllTimersAsync();
+        const result = await fetchPromise;
+
+        // Assert — retry succeeded, market data is returned
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].symbol).toBe('BTC');
+        expect(mockMetaAndCtxs).toHaveBeenCalledTimes(2);
+
+        jest.useRealTimers();
+      });
     });
 
     describe('withdrawal edge cases', () => {

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -416,6 +416,8 @@ describe('HyperLiquidProvider', () => {
       getCachedOrders: jest.fn().mockReturnValue([]),
       // Atomic getter - returns null when cache not initialized (prevents race condition)
       getOrdersCacheIfInitialized: jest.fn().mockReturnValue(null),
+      // WS allMids snapshot for REST fallback
+      getLastAllMidsSnapshot: jest.fn().mockReturnValue(null),
     } as Partial<HyperLiquidSubscriptionService> as jest.Mocked<HyperLiquidSubscriptionService>;
 
     // Mock constructors
@@ -3670,6 +3672,223 @@ describe('HyperLiquidProvider', () => {
         expect(mockMetaAndCtxs).toHaveBeenCalledTimes(2);
 
         jest.useRealTimers();
+      });
+
+      it('uses WS allMids snapshot as primary source (skips REST)', async () => {
+        const assetCtx = {
+          funding: '0.0001',
+          openInterest: '1000',
+          prevDayPx: '49000',
+          dayNtlVlm: '1000000',
+          markPx: '50000',
+          midPx: '50000',
+          oraclePx: '50000',
+        };
+
+        const mockAllMids = jest.fn().mockResolvedValue({ BTC: '50000' });
+        mockClientService.getInfoClient = jest.fn().mockReturnValue(
+          createMockInfoClient({
+            metaAndAssetCtxs: jest
+              .fn()
+              .mockResolvedValue([
+                { universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }] },
+                [assetCtx],
+              ]),
+            allMids: mockAllMids,
+          }),
+        );
+
+        // WS snapshot available — REST should not be called
+        mockSubscriptionService.getLastAllMidsSnapshot.mockReturnValue({
+          BTC: '50100',
+        });
+
+        const freshProvider = createTestProvider();
+        const result = await freshProvider.getMarketDataWithPrices();
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].symbol).toBe('BTC');
+        expect(mockAllMids).not.toHaveBeenCalled();
+      });
+
+      it('falls back to REST allMids on cold start (no WS snapshot)', async () => {
+        const assetCtx = {
+          funding: '0.0001',
+          openInterest: '1000',
+          prevDayPx: '49000',
+          dayNtlVlm: '1000000',
+          markPx: '50000',
+          midPx: '50000',
+          oraclePx: '50000',
+        };
+
+        const mockAllMids = jest.fn().mockResolvedValue({ BTC: '50000' });
+        mockClientService.getInfoClient = jest.fn().mockReturnValue(
+          createMockInfoClient({
+            metaAndAssetCtxs: jest
+              .fn()
+              .mockResolvedValue([
+                { universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }] },
+                [assetCtx],
+              ]),
+            allMids: mockAllMids,
+          }),
+        );
+
+        // No WS snapshot yet — cold start
+        mockSubscriptionService.getLastAllMidsSnapshot.mockReturnValue(null);
+
+        const freshProvider = createTestProvider();
+        const result = await freshProvider.getMarketDataWithPrices();
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].symbol).toBe('BTC');
+        expect(mockAllMids).toHaveBeenCalled();
+      });
+
+      it('uses per-DEX WS allMids snapshot for HIP-3 DEX (skips REST)', async () => {
+        const assetCtx = {
+          funding: '0.0001',
+          openInterest: '1000',
+          prevDayPx: '49000',
+          dayNtlVlm: '1000000',
+          markPx: '50000',
+          midPx: '50000',
+          oraclePx: '50000',
+        };
+
+        const mockAllMids = jest
+          .fn()
+          .mockResolvedValue({ 'xyz:STOCK1': '100' });
+        mockClientService.getInfoClient = jest.fn().mockReturnValue(
+          createMockInfoClient({
+            perpDexs: jest.fn().mockResolvedValue([null, { name: 'xyz' }]),
+            metaAndAssetCtxs: jest
+              .fn()
+              .mockImplementation((params?: { dex?: string }) => {
+                if (params?.dex === 'xyz') {
+                  return Promise.resolve([
+                    {
+                      universe: [
+                        {
+                          name: 'xyz:STOCK1',
+                          szDecimals: 2,
+                          maxLeverage: 20,
+                        },
+                      ],
+                    },
+                    [assetCtx],
+                  ]);
+                }
+                return Promise.resolve([
+                  {
+                    universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+                  },
+                  [assetCtx],
+                ]);
+              }),
+            allMids: mockAllMids,
+          }),
+        );
+
+        // Per-DEX WS snapshots available for both main and xyz
+        mockSubscriptionService.getLastAllMidsSnapshot.mockImplementation(
+          (dex?: string): Record<string, string> | null => {
+            if (dex === 'xyz') {
+              return { 'xyz:STOCK1': '101' };
+            }
+            if (!dex || dex === '') {
+              return { BTC: '50100' };
+            }
+            return null;
+          },
+        );
+
+        const hip3Provider = createTestProvider({
+          hip3Enabled: true,
+          allowlistMarkets: ['xyz:*'],
+        });
+        const result = await hip3Provider.getMarketDataWithPrices();
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+        expect(mockAllMids).not.toHaveBeenCalled();
+      });
+
+      it('falls back to REST for HIP-3 DEX without WS allMids snapshot', async () => {
+        const assetCtx = {
+          funding: '0.0001',
+          openInterest: '1000',
+          prevDayPx: '49000',
+          dayNtlVlm: '1000000',
+          markPx: '50000',
+          midPx: '50000',
+          oraclePx: '50000',
+        };
+
+        const mockAllMids = jest
+          .fn()
+          .mockImplementation((params?: { dex?: string }) => {
+            if (params?.dex === 'xyz') {
+              return Promise.resolve({ 'xyz:STOCK1': '100' });
+            }
+            return Promise.resolve({ BTC: '50000' });
+          });
+        mockClientService.getInfoClient = jest.fn().mockReturnValue(
+          createMockInfoClient({
+            perpDexs: jest.fn().mockResolvedValue([null, { name: 'xyz' }]),
+            metaAndAssetCtxs: jest
+              .fn()
+              .mockImplementation((params?: { dex?: string }) => {
+                if (params?.dex === 'xyz') {
+                  return Promise.resolve([
+                    {
+                      universe: [
+                        {
+                          name: 'xyz:STOCK1',
+                          szDecimals: 2,
+                          maxLeverage: 20,
+                        },
+                      ],
+                    },
+                    [assetCtx],
+                  ]);
+                }
+                return Promise.resolve([
+                  {
+                    universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+                  },
+                  [assetCtx],
+                ]);
+              }),
+            allMids: mockAllMids,
+          }),
+        );
+
+        // Main DEX has WS snapshot, but xyz does NOT
+        mockSubscriptionService.getLastAllMidsSnapshot.mockImplementation(
+          (dex?: string): Record<string, string> | null => {
+            if (!dex || dex === '') {
+              return { BTC: '50100' };
+            }
+            return null;
+          },
+        );
+
+        const hip3Provider = createTestProvider({
+          hip3Enabled: true,
+          allowlistMarkets: ['xyz:*'],
+        });
+        const result = await hip3Provider.getMarketDataWithPrices();
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+        // REST should be called for the xyz DEX (no WS snapshot)
+        expect(mockAllMids).toHaveBeenCalledWith({ dex: 'xyz' });
+        // REST should NOT be called for main DEX (has WS snapshot)
+        expect(mockAllMids).not.toHaveBeenCalledWith(undefined);
       });
     });
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -5748,6 +5748,36 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Get allMids for a DEX — uses WS snapshot as primary source, REST as fallback.
+   *
+   * @param infoClient - The HyperLiquid info client (used only on cold start).
+   * @param dexParam - Optional DEX parameter (empty string for main DEX).
+   * @returns allMids record.
+   */
+  async #getAllMids(
+    infoClient: ReturnType<
+      typeof HyperLiquidClientService.prototype.getInfoClient
+    >,
+    dexParam?: string,
+  ): Promise<Record<string, string>> {
+    const wsSnapshot =
+      this.#subscriptionService.getLastAllMidsSnapshot(dexParam);
+    if (wsSnapshot) {
+      return wsSnapshot;
+    }
+
+    // Cold start — fall back to REST
+    this.#deps.debugLogger.log(
+      '[getMarketDataWithPrices] No WS allMids snapshot, falling back to REST',
+      { dexParam: dexParam ?? 'main' },
+    );
+    const mids = await infoClient.allMids(
+      dexParam ? { dex: dexParam } : undefined,
+    );
+    return mids ?? {};
+  }
+
+  /**
    * Fetch fresh meta, assetCtxs, and allMids for a single DEX — no cache check.
    * Populates meta/assetCtxs caches after a successful fetch so subsequent calls
    * can benefit from the cache without re-fetching.
@@ -5769,15 +5799,16 @@ export class HyperLiquidProvider implements PerpsProvider {
       );
       const meta = metaAndCtxs?.[0] ?? null;
       const assetCtxs = metaAndCtxs?.[1] ?? [];
-      const dexAllMids = await infoClient.allMids(
-        dexParam ? { dex: dexParam } : undefined,
+      const dexAllMids = await this.#getAllMids(
+        infoClient,
+        dexParam || undefined,
       );
       if (meta?.universe) {
         this.#cachedMetaByDex.set(dexParam, meta);
         this.#subscriptionService.setDexMetaCache(dexParam, meta);
         this.#subscriptionService.setDexAssetCtxsCache(dexParam, assetCtxs);
       }
-      return { dex, meta, assetCtxs, allMids: dexAllMids ?? {}, success: true };
+      return { dex, meta, assetCtxs, allMids: dexAllMids, success: true };
     } catch {
       return { dex, meta: null, assetCtxs: [], allMids: {}, success: false };
     }
@@ -5876,15 +5907,16 @@ export class HyperLiquidProvider implements PerpsProvider {
               assetCtxs = freshResult?.[1] ?? [];
               this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
             }
-            // Always fetch fresh allMids for current prices
-            const dexAllMids = await infoClient.allMids(
-              dexParam ? { dex: dexParam } : undefined,
+            // Use WS allMids snapshot when available, REST as fallback
+            const dexAllMids = await this.#getAllMids(
+              infoClient,
+              dexParam || undefined,
             );
             return {
               dex,
               meta: cachedMeta,
               assetCtxs,
-              allMids: dexAllMids ?? {},
+              allMids: dexAllMids,
               success: true,
             };
           } catch (error) {

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -168,6 +168,15 @@ type GetAssetInfoParams = {
   dexName: string | null;
 };
 
+/** Per-DEX fetch result used internally by getMarketDataWithPrices */
+type DexFetchResult = {
+  dex: string | null;
+  meta: MetaResponse | null;
+  assetCtxs: PerpsAssetCtx[];
+  allMids: Record<string, string>;
+  success: boolean;
+};
+
 type GetAssetInfoResult = {
   assetInfo: {
     name: string;
@@ -5739,13 +5748,87 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Fetch fresh meta, assetCtxs, and allMids for a single DEX — no cache check.
+   * Populates meta/assetCtxs caches after a successful fetch so subsequent calls
+   * can benefit from the cache without re-fetching.
+   *
+   * @param infoClient - The HyperLiquid info client to use for API calls.
+   * @param dex - The DEX identifier (null for the main DEX).
+   * @returns A promise that resolves to the fetch result for the DEX.
+   */
+  async #fetchSingleDexFresh(
+    infoClient: ReturnType<
+      typeof HyperLiquidClientService.prototype.getInfoClient
+    >,
+    dex: string | null,
+  ): Promise<DexFetchResult> {
+    const dexParam = dex ?? '';
+    try {
+      const metaAndCtxs = await infoClient.metaAndAssetCtxs(
+        dexParam ? { dex: dexParam } : undefined,
+      );
+      const meta = metaAndCtxs?.[0] ?? null;
+      const assetCtxs = metaAndCtxs?.[1] ?? [];
+      const dexAllMids = await infoClient.allMids(
+        dexParam ? { dex: dexParam } : undefined,
+      );
+      if (meta?.universe) {
+        this.#cachedMetaByDex.set(dexParam, meta);
+        this.#subscriptionService.setDexMetaCache(dexParam, meta);
+        this.#subscriptionService.setDexAssetCtxsCache(dexParam, assetCtxs);
+      }
+      return { dex, meta, assetCtxs, allMids: dexAllMids ?? {}, success: true };
+    } catch {
+      return { dex, meta: null, assetCtxs: [], allMids: {}, success: false };
+    }
+  }
+
+  /**
+   * Filter and merge an array of per-DEX fetch results into the provided combined arrays.
+   * Applies shouldIncludeMarket filtering for HIP-3 DEXs; the main DEX passes through
+   * all markets unfiltered.
+   *
+   * @param results - The per-DEX fetch results to merge.
+   * @param combinedUniverse - Target array to push filtered market entries into.
+   * @param combinedAssetCtxs - Target array to push asset context entries into.
+   * @param combinedAllMids - Target object to merge mid prices into.
+   */
+  #mergeDexResultsInto(
+    results: DexFetchResult[],
+    combinedUniverse: MetaResponse['universe'],
+    combinedAssetCtxs: PerpsAssetCtx[],
+    combinedAllMids: Record<string, string>,
+  ): void {
+    results.forEach((result) => {
+      if (result.success && result.meta?.universe) {
+        const marketsFromDex = result.meta.universe;
+        const filteredMarkets =
+          result.dex === null
+            ? marketsFromDex
+            : marketsFromDex.filter((asset) =>
+                shouldIncludeMarket(
+                  asset.name,
+                  result.dex,
+                  this.#hip3Enabled,
+                  this.#compiledAllowlistPatterns,
+                  this.#compiledBlocklistPatterns,
+                ),
+              );
+        combinedUniverse.push(...filteredMarkets);
+        combinedAssetCtxs.push(...result.assetCtxs);
+        Object.assign(combinedAllMids, result.allMids);
+      }
+    });
+  }
+
+  /**
    * Get market data with prices, volumes, and 24h changes
    * Aggregates data from all enabled DEXs (main + HIP-3) when equity is enabled
    *
    * Note: This is called once during initialization and cached by PerpsStreamManager.
    * Real-time price updates come from WebSocket subscriptions, not this method.
    *
-   * @returns A promise that resolves to the result.
+   * @returns A promise that resolves to the combined market data from all enabled DEXs.
    */
   async getMarketDataWithPrices(): Promise<PerpsMarketData[]> {
     this.#deps.debugLogger.log(
@@ -5765,95 +5848,69 @@ export class HyperLiquidProvider implements PerpsProvider {
     // Get enabled DEXs respecting feature flags (uses cached perpDexs)
     const enabledDexs = await this.#getValidatedDexs();
 
-    // Fetch meta, assetCtxs, and allMids for each enabled DEX in parallel
-    // Optimization: Check cache first to avoid redundant API calls when buildAssetMapping
-    // has already fetched, or populate cache for buildAssetMapping to reuse
+    // Fetch meta, assetCtxs, and allMids for each enabled DEX in parallel.
+    // Check the meta cache first to avoid redundant API calls when buildAssetMapping
+    // has already populated it; on cache miss delegate to #fetchSingleDexFresh which
+    // also populates the cache for future callers.
     const dexDataResults = await Promise.all(
       enabledDexs.map(async (dex) => {
         const dexKey = dex ?? '';
         const dexParam = dex ?? '';
-        try {
-          let meta: MetaResponse | null = null;
-          let assetCtxs: PerpsAssetCtx[] = [];
-
-          // Check if meta is already cached (e.g., from previous fetch or buildAssetMapping)
-          const cachedMeta = this.#cachedMetaByDex.get(dexKey);
-          if (cachedMeta) {
-            this.#deps.debugLogger.log(
-              `[getMarketDataWithPrices] Using cached meta for ${dex ?? 'main'}`,
-              { universeSize: cachedMeta.universe.length },
-            );
-            meta = cachedMeta;
-            // Try to get cached assetCtxs from subscription service
+        const cachedMeta = this.#cachedMetaByDex.get(dexKey);
+        if (cachedMeta) {
+          this.#deps.debugLogger.log(
+            `[getMarketDataWithPrices] Using cached meta for ${dex ?? 'main'}`,
+            { universeSize: cachedMeta.universe.length },
+          );
+          try {
+            // Try to get cached assetCtxs; fetch fresh if not cached
             const cachedCtxs =
               this.#subscriptionService.getDexAssetCtxsCache(dexKey);
+            let assetCtxs: PerpsAssetCtx[];
             if (cachedCtxs) {
               assetCtxs = cachedCtxs;
             } else {
-              // Need fresh assetCtxs, fetch via metaAndAssetCtxs (meta will be same)
-              const metaAndCtxs = await infoClient.metaAndAssetCtxs(
+              const freshResult = await infoClient.metaAndAssetCtxs(
                 dexParam ? { dex: dexParam } : undefined,
               );
-              assetCtxs = metaAndCtxs?.[1] || [];
-              // Cache assetCtxs for future calls
+              assetCtxs = freshResult?.[1] ?? [];
               this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
             }
-          } else {
-            // Cache miss - fetch and populate cache for buildAssetMapping to reuse
-            this.#deps.debugLogger.log(
-              `[getMarketDataWithPrices] Cache miss for ${dex ?? 'main'}, fetching`,
-            );
-            const metaAndCtxs = await infoClient.metaAndAssetCtxs(
+            // Always fetch fresh allMids for current prices
+            const dexAllMids = await infoClient.allMids(
               dexParam ? { dex: dexParam } : undefined,
             );
-            meta = metaAndCtxs?.[0] || null;
-            assetCtxs = metaAndCtxs?.[1] || [];
-
-            // IMPORTANT: Populate cache for buildAssetMapping and other methods to reuse
-            if (meta?.universe) {
-              this.#cachedMetaByDex.set(dexKey, meta);
-              this.#subscriptionService.setDexMetaCache(dexKey, meta);
-              // Also cache assetCtxs for consistency with buildAssetMapping
-              this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
-              this.#deps.debugLogger.log(
-                `[getMarketDataWithPrices] Cached meta for ${dex ?? 'main'}`,
-                { universeSize: meta.universe.length },
-              );
-            }
+            return {
+              dex,
+              meta: cachedMeta,
+              assetCtxs,
+              allMids: dexAllMids ?? {},
+              success: true,
+            };
+          } catch (error) {
+            this.#deps.debugLogger.log(
+              `[getMarketDataWithPrices] DEX fetch failed for ${dex ?? 'main'}`,
+              {
+                error: ensureError(
+                  error,
+                  'HyperLiquidProvider.getMarketDataWithPrices',
+                ).message,
+              },
+            );
+            return {
+              dex,
+              meta: null,
+              assetCtxs: [],
+              allMids: {},
+              success: false,
+            };
           }
-
-          // Always fetch fresh allMids for current prices
-          const dexAllMids = await infoClient.allMids(
-            dexParam ? { dex: dexParam } : undefined,
-          );
-
-          return {
-            dex,
-            meta,
-            assetCtxs,
-            allMids: dexAllMids || {},
-            success: true,
-          };
-        } catch (error) {
-          // Log per-DEX failures locally only — the aggregate error at the end
-          // of this method reports to Sentry, avoiding duplicate events.
-          this.#deps.debugLogger.log(
-            `[getMarketDataWithPrices] DEX fetch failed for ${dex ?? 'main'}`,
-            {
-              error: ensureError(
-                error,
-                'HyperLiquidProvider.getMarketDataWithPrices',
-              ).message,
-            },
-          );
-          return {
-            dex,
-            meta: null,
-            assetCtxs: [],
-            allMids: {},
-            success: false,
-          };
         }
+        // Cache miss — fetch fresh and populate caches
+        this.#deps.debugLogger.log(
+          `[getMarketDataWithPrices] Cache miss for ${dex ?? 'main'}, fetching`,
+        );
+        return this.#fetchSingleDexFresh(infoClient, dex);
       }),
     );
 
@@ -5865,29 +5922,12 @@ export class HyperLiquidProvider implements PerpsProvider {
     // Used by the aggregation log below to avoid referencing stale first-attempt data.
     let latestDexResults = dexDataResults;
 
-    dexDataResults.forEach((result) => {
-      if (result.success && result.meta?.universe) {
-        // Apply market filtering for HIP-3 DEXs only (main DEX returns all markets)
-        const marketsFromDex = result.meta.universe;
-        const filteredMarkets =
-          result.dex === null
-            ? marketsFromDex // Main DEX: no filtering
-            : marketsFromDex.filter((asset) =>
-                shouldIncludeMarket(
-                  asset.name,
-                  result.dex,
-                  this.#hip3Enabled,
-                  this.#compiledAllowlistPatterns,
-                  this.#compiledBlocklistPatterns,
-                ),
-              );
-
-        combinedUniverse.push(...filteredMarkets);
-        combinedAssetCtxs.push(...result.assetCtxs);
-        // Merge price data from this DEX into combined prices
-        Object.assign(combinedAllMids, result.allMids);
-      }
-    });
+    this.#mergeDexResultsInto(
+      dexDataResults,
+      combinedUniverse,
+      combinedAssetCtxs,
+      combinedAllMids,
+    );
 
     if (combinedUniverse.length === 0) {
       // All DEXs returned empty — retry once after a short delay.
@@ -5908,65 +5948,16 @@ export class HyperLiquidProvider implements PerpsProvider {
       await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 
       const retryResults = await Promise.all(
-        enabledDexs.map(async (dex) => {
-          const dexParam = dex ?? '';
-          try {
-            const metaAndCtxs = await infoClient.metaAndAssetCtxs(
-              dexParam ? { dex: dexParam } : undefined,
-            );
-            const meta = metaAndCtxs?.[0] || null;
-            const assetCtxs = metaAndCtxs?.[1] || [];
-            const dexAllMids = await infoClient.allMids(
-              dexParam ? { dex: dexParam } : undefined,
-            );
-            // Populate meta cache so the next call doesn't re-fetch unnecessarily
-            if (meta?.universe) {
-              this.#cachedMetaByDex.set(dexParam, meta);
-              this.#subscriptionService.setDexMetaCache(dexParam, meta);
-              this.#subscriptionService.setDexAssetCtxsCache(
-                dexParam,
-                assetCtxs,
-              );
-            }
-            return {
-              dex,
-              meta,
-              assetCtxs,
-              allMids: dexAllMids || {},
-              success: true,
-            };
-          } catch {
-            return {
-              dex,
-              meta: null,
-              assetCtxs: [],
-              allMids: {},
-              success: false,
-            };
-          }
-        }),
+        enabledDexs.map((dex) => this.#fetchSingleDexFresh(infoClient, dex)),
       );
 
       // Merge retry results into combined arrays
-      retryResults.forEach((result) => {
-        if (result.success && result.meta?.universe) {
-          const filteredMarkets =
-            result.dex === null
-              ? result.meta.universe
-              : result.meta.universe.filter((asset) =>
-                  shouldIncludeMarket(
-                    asset.name,
-                    result.dex,
-                    this.#hip3Enabled,
-                    this.#compiledAllowlistPatterns,
-                    this.#compiledBlocklistPatterns,
-                  ),
-                );
-          combinedUniverse.push(...filteredMarkets);
-          combinedAssetCtxs.push(...result.assetCtxs);
-          Object.assign(combinedAllMids, result.allMids);
-        }
-      });
+      this.#mergeDexResultsInto(
+        retryResults,
+        combinedUniverse,
+        combinedAssetCtxs,
+        combinedAllMids,
+      );
 
       // If still empty after retry, throw with diagnostic info
       if (combinedUniverse.length === 0) {

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -279,6 +279,9 @@ export class HyperLiquidProvider implements PerpsProvider {
   // Filtering is applied on-demand (cheap array operations) - no need for separate processed cache
   readonly #cachedMetaByDex = new Map<string, MetaResponse>();
 
+  // Last successfully transformed market data — used as stale fallback when retry fails
+  #lastGoodMarketData: PerpsMarketData[] | null = null;
+
   // Session cache for spot metadata (contains USDC/USDH token info for HIP-3 collateral checks)
   // Pre-fetched in ensureReadyForTrading() to avoid API failures during order placement
   #cachedSpotMeta: SpotMetaResponse | null = null;
@@ -1279,6 +1282,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Store raw meta response for reuse
     this.#cachedMetaByDex.set(dexKey, meta);
+    this.#backfillAssetMapForDex(dexName, meta);
 
     this.#deps.debugLogger.log(
       '[getCachedMeta] Fetched and cached meta response',
@@ -2135,6 +2139,77 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Backfill symbolToAssetId entries for a single DEX from its cached meta.
+   * Additive — does not clear existing entries.
+   *
+   * @param dexName - The DEX name (null for main DEX)
+   * @param meta - The meta response containing universe data
+   * @returns Number of entries added
+   */
+  #backfillAssetMapForDex(dexName: string | null, meta: MetaResponse): number {
+    if (!meta?.universe || !Array.isArray(meta.universe)) {
+      return 0;
+    }
+
+    const allPerpDexs = this.#cachedAllPerpDexs;
+    if (!allPerpDexs) {
+      return 0;
+    }
+
+    const perpDexIndex = allPerpDexs.findIndex((entry) => {
+      if (dexName === null) {
+        return entry === null;
+      }
+      return entry !== null && entry.name === dexName;
+    });
+
+    if (perpDexIndex === -1) {
+      return 0;
+    }
+
+    const { symbolToAssetId } = buildAssetMapping({
+      metaUniverse: meta.universe,
+      dex: dexName,
+      perpDexIndex,
+    });
+
+    let added = 0;
+    symbolToAssetId.forEach((assetId, coin) => {
+      if (!this.#symbolToAssetId.has(coin)) {
+        added += 1;
+      }
+      this.#symbolToAssetId.set(coin, assetId);
+    });
+
+    return added;
+  }
+
+  /**
+   * Resolve asset ID for a symbol, repairing the map on cache miss.
+   *
+   * @param symbol - The trading pair symbol (e.g., 'ETH' or 'xyz:TOKEN')
+   * @returns The numeric asset ID
+   */
+  async #resolveAssetId(symbol: string): Promise<number> {
+    const assetId = this.#symbolToAssetId.get(symbol);
+    if (assetId !== undefined) {
+      return assetId;
+    }
+
+    // Attempt repair: extract DEX name, fetch meta, backfill
+    const dexName = symbol.includes(':') ? symbol.split(':')[0] : null;
+    const meta = await this.#getCachedMeta({ dexName, skipCache: true });
+    this.#backfillAssetMapForDex(dexName, meta);
+
+    const retried = this.#symbolToAssetId.get(symbol);
+    if (retried !== undefined) {
+      return retried;
+    }
+
+    throw new Error(`Asset ID not found for ${symbol}`);
+  }
+
+  /**
    * Set user fee discount context for next operations
    * Used by PerpsController to apply MetaMask reward discounts
    *
@@ -2177,7 +2252,7 @@ export class HyperLiquidProvider implements PerpsProvider {
   ): Promise<{ dex: string | null; data: TResult }[]> {
     const enabledDexs = await this.#getValidatedDexs();
 
-    const results = await Promise.all(
+    const settled = await Promise.allSettled(
       enabledDexs.map(async (dex) => {
         const params = dex
           ? ({ ...baseParams, dex } as TParams & { dex: string })
@@ -2186,6 +2261,31 @@ export class HyperLiquidProvider implements PerpsProvider {
         return { dex, data };
       }),
     );
+
+    const results: { dex: string | null; data: TResult }[] = [];
+    const failures: { dex: string | null; error: Error }[] = [];
+
+    for (let i = 0; i < settled.length; i++) {
+      const entry = settled[i];
+      if (entry.status === 'fulfilled') {
+        results.push(entry.value);
+      } else {
+        failures.push({
+          dex: enabledDexs[i],
+          error: ensureError(entry.reason),
+        });
+      }
+    }
+
+    if (failures.length > 0) {
+      this.#deps.debugLogger.log('[queryUserDataAcrossDexs] Partial failures', {
+        failed: failures.map((failure) => failure.dex ?? 'main'),
+      });
+    }
+
+    if (results.length === 0) {
+      throw failures[0].error;
+    }
 
     return results;
   }
@@ -3900,11 +4000,8 @@ export class HyperLiquidProvider implements PerpsProvider {
           );
         }
 
-        // Get asset ID
-        const assetId = this.#symbolToAssetId.get(position.symbol);
-        if (assetId === undefined) {
-          throw new Error(`Asset ID not found for ${position.symbol}`);
-        }
+        // Get asset ID (with auto-repair on cache miss)
+        const assetId = await this.#resolveAssetId(position.symbol);
 
         // Calculate position details (always full close)
         const positionSize = parseFloat(position.size);
@@ -4125,10 +4222,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // Cancel existing TP/SL orders for this position
       // OPTIMIZATION: Use WebSocket cache first (0 weight), fall back to single-DEX REST (20 weight)
       // Previously: queryUserDataAcrossDexs queried ALL DEXs (20 weight × N DEXs = 40+ weight)
-      const assetId = this.#symbolToAssetId.get(symbol);
-      if (assetId === undefined) {
-        throw new Error(`Asset ID not found for ${symbol}`);
-      }
+      const assetId = await this.#resolveAssetId(symbol);
 
       let cancelRequests: { a: number; o: number }[] = [];
 
@@ -4520,11 +4614,8 @@ export class HyperLiquidProvider implements PerpsProvider {
       // Determine position direction
       const isBuy = parseFloat(position.size) > 0; // true for long, false for short
 
-      // Get asset ID for the symbol
-      const assetId = this.#symbolToAssetId.get(symbol);
-      if (assetId === undefined) {
-        throw new Error(`Asset ID not found for ${symbol}`);
-      }
+      // Get asset ID for the symbol (with auto-repair on cache miss)
+      const assetId = await this.#resolveAssetId(symbol);
 
       // Convert amount to micro-units (HyperLiquid SDK requirement)
       const amountFloat = parseFloat(amount);
@@ -5504,7 +5595,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       );
       // Re-throw the error so the controller can handle it properly
       // This allows the UI to show proper error messages instead of zeros
-      throw error;
+      throw ensureError(error, 'HyperLiquidProvider.getAccountState');
     }
   }
 
@@ -5991,8 +6082,17 @@ export class HyperLiquidProvider implements PerpsProvider {
         combinedAllMids,
       );
 
-      // If still empty after retry, throw with diagnostic info
+      // If still empty after retry, use stale cache or throw
       if (combinedUniverse.length === 0) {
+        if (this.#lastGoodMarketData) {
+          this.#deps.debugLogger.log(
+            '[getMarketDataWithPrices] Retry failed, returning stale cache',
+            { staleCount: this.#lastGoodMarketData.length },
+          );
+          return this.#lastGoodMarketData;
+        }
+
+        // Genuine first-load failure — throw with diagnostics
         const failedDexs = retryResults
           .filter((result) => !result.success)
           .map((result) => result.dex ?? 'main');
@@ -6040,7 +6140,7 @@ export class HyperLiquidProvider implements PerpsProvider {
     });
 
     // Transform to UI-friendly format using standalone utility
-    return transformMarketData(
+    const marketData = transformMarketData(
       {
         universe: combinedUniverse,
         assetCtxs: combinedAssetCtxs,
@@ -6049,6 +6149,8 @@ export class HyperLiquidProvider implements PerpsProvider {
       this.#deps.marketDataFormatters,
       HIP3_ASSET_MARKET_TYPES,
     );
+    this.#lastGoodMarketData = marketData;
+    return marketData;
   }
 
   /**
@@ -7447,6 +7549,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // to prevent repeated signing requests across reconnections
       this.#cachedMetaByDex.clear();
       this.#cachedSpotMeta = null;
+      this.#lastGoodMarketData = null;
       this.#perpDexsCache = { data: null, timestamp: 0 };
       this.#dexDiscoveryComplete = false;
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -5861,6 +5861,9 @@ export class HyperLiquidProvider implements PerpsProvider {
     const combinedUniverse: MetaResponse['universe'] = [];
     const combinedAssetCtxs: PerpsAssetCtx[] = [];
     const combinedAllMids: Record<string, string> = {};
+    // Tracks which result set was authoritative — updated to retryResults if retry runs.
+    // Used by the aggregation log below to avoid referencing stale first-attempt data.
+    let latestDexResults = dexDataResults;
 
     dexDataResults.forEach((result) => {
       if (result.success && result.meta?.universe) {
@@ -5887,16 +5890,93 @@ export class HyperLiquidProvider implements PerpsProvider {
     });
 
     if (combinedUniverse.length === 0) {
-      const failedDexs = dexDataResults
-        .filter((result) => !result.success)
-        .map((result) => result.dex ?? 'main');
-      const succeededDexs = dexDataResults
-        .filter((result) => result.success)
-        .map((result) => result.dex ?? 'main');
-      const wsState = this.#clientService.getConnectionState();
-      throw new Error(
-        `Failed to fetch market data - no markets available (enabledDexs=${enabledDexs.length}, failed=[${failedDexs.join(',')}], succeeded=[${succeededDexs.join(',')}], wsState=${wsState})`,
+      // All DEXs returned empty — retry once after a short delay.
+      // Transient failures (app resuming from background, network transition)
+      // often resolve within seconds, so a single retry eliminates most noise.
+      // Clear stale partial data before retry to prevent index misalignment
+      // (assetCtxs/allMids may have been populated even when universe is empty
+      // due to market filtering removing all entries for a "successful" DEX).
+      combinedUniverse.length = 0;
+      combinedAssetCtxs.length = 0;
+      for (const key of Object.keys(combinedAllMids)) {
+        delete combinedAllMids[key];
+      }
+      const retryDelayMs = 2000;
+      this.#deps.debugLogger.log(
+        `[getMarketDataWithPrices] All DEXs returned empty, retrying in ${retryDelayMs}ms`,
       );
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+
+      const retryResults = await Promise.all(
+        enabledDexs.map(async (dex) => {
+          const dexParam = dex ?? '';
+          try {
+            const metaAndCtxs = await infoClient.metaAndAssetCtxs(
+              dexParam ? { dex: dexParam } : undefined,
+            );
+            const meta = metaAndCtxs?.[0] || null;
+            const assetCtxs = metaAndCtxs?.[1] || [];
+            const dexAllMids = await infoClient.allMids(
+              dexParam ? { dex: dexParam } : undefined,
+            );
+            return {
+              dex,
+              meta,
+              assetCtxs,
+              allMids: dexAllMids || {},
+              success: true,
+            };
+          } catch {
+            return {
+              dex,
+              meta: null,
+              assetCtxs: [],
+              allMids: {},
+              success: false,
+            };
+          }
+        }),
+      );
+
+      // Merge retry results into combined arrays
+      retryResults.forEach((result) => {
+        if (result.success && result.meta?.universe) {
+          const filteredMarkets =
+            result.dex === null
+              ? result.meta.universe
+              : result.meta.universe.filter((asset) =>
+                  shouldIncludeMarket(
+                    asset.name,
+                    result.dex,
+                    this.#hip3Enabled,
+                    this.#compiledAllowlistPatterns,
+                    this.#compiledBlocklistPatterns,
+                  ),
+                );
+          combinedUniverse.push(...filteredMarkets);
+          combinedAssetCtxs.push(...result.assetCtxs);
+          Object.assign(combinedAllMids, result.allMids);
+        }
+      });
+
+      // If still empty after retry, throw with diagnostic info
+      if (combinedUniverse.length === 0) {
+        const failedDexs = retryResults
+          .filter((result) => !result.success)
+          .map((result) => result.dex ?? 'main');
+        const succeededDexs = retryResults
+          .filter((result) => result.success)
+          .map((result) => result.dex ?? 'main');
+        const wsState = this.#clientService.getConnectionState();
+        throw new Error(
+          `Failed to fetch market data - no markets available (enabledDexs=${enabledDexs.length}, failed=[${failedDexs.join(',')}], succeeded=[${succeededDexs.join(',')}], wsState=${wsState})`,
+        );
+      }
+
+      latestDexResults = retryResults;
+      this.#deps.debugLogger.log('[getMarketDataWithPrices] Retry succeeded', {
+        marketCount: combinedUniverse.length,
+      });
     }
 
     this.#deps.debugLogger.log(
@@ -5904,10 +5984,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       {
         dexCount: enabledDexs.length,
         totalMarkets: combinedUniverse.length,
-        mainDexMarkets: dexDataResults[0]?.meta?.universe?.length ?? 0,
+        mainDexMarkets: latestDexResults[0]?.meta?.universe?.length ?? 0,
         hip3Markets:
           combinedUniverse.length -
-          (dexDataResults[0]?.meta?.universe?.length ?? 0),
+          (latestDexResults[0]?.meta?.universe?.length ?? 0),
       },
     );
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -5919,6 +5919,15 @@ export class HyperLiquidProvider implements PerpsProvider {
             const dexAllMids = await infoClient.allMids(
               dexParam ? { dex: dexParam } : undefined,
             );
+            // Populate meta cache so the next call doesn't re-fetch unnecessarily
+            if (meta?.universe) {
+              this.#cachedMetaByDex.set(dexParam, meta);
+              this.#subscriptionService.setDexMetaCache(dexParam, meta);
+              this.#subscriptionService.setDexAssetCtxsCache(
+                dexParam,
+                assetCtxs,
+              );
+            }
             return {
               dex,
               meta,

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -167,6 +167,15 @@ export class HyperLiquidSubscriptionService {
   // Global price data cache
   #cachedPriceData: Map<string, PriceUpdate> | null = null;
 
+  // Per-DEX WS allMids snapshots — key is dex name ('' for main DEX).
+  // Used as primary source for allMids in getMarketDataWithPrices (avoids REST).
+  readonly #allMidsSnapshots = new Map<string, Record<string, string>>();
+
+  // HIP-3: per-DEX allMids WS subscriptions (key: dex name)
+  readonly #dexAllMidsSubscriptions = new Map<string, ISubscription>();
+
+  readonly #dexAllMidsSubscriptionPromises = new Map<string, Promise<void>>();
+
   // Fills cache for cache-first pattern (similar to price caching)
   #cachedFills: OrderFill[] | null = null;
 
@@ -980,6 +989,20 @@ export class HyperLiquidSubscriptionService {
             ),
             this.#getErrorContext(
               'subscribeToPrices.ensureAssetCtxsSubscription',
+              { dex: dexName },
+            ),
+          );
+        });
+
+        // HIP-3: per-DEX allMids subscription (main DEX uses global allMids)
+        this.#ensureDexAllMidsSubscription(dexName).catch((error) => {
+          this.#logErrorUnlessClearing(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.subscribeToPrices',
+            ),
+            this.#getErrorContext(
+              'subscribeToPrices.ensureDexAllMidsSubscription',
               { dex: dexName },
             ),
           );
@@ -2216,6 +2239,22 @@ export class HyperLiquidSubscriptionService {
   }
 
   /**
+   * Returns the most recent raw WS allMids snapshot for a given DEX,
+   * or null if no WS data has been received yet.
+   *
+   * @param dex - Optional DEX name (empty string or omitted for main DEX).
+   * @returns Defensive copy of the allMids snapshot, or null.
+   */
+  public getLastAllMidsSnapshot(dex?: string): Record<string, string> | null {
+    const dexKey = dex ?? '';
+    const snapshot = this.#allMidsSnapshots.get(dexKey);
+    if (!snapshot) {
+      return null;
+    }
+    return { ...snapshot };
+  }
+
+  /**
    * Get cached fills from WebSocket userFills subscription
    * OPTIMIZATION: Use this instead of REST userFills() to avoid rate limiting
    *
@@ -2355,6 +2394,9 @@ export class HyperLiquidSubscriptionService {
 
         // Initialize cache if needed
         this.#cachedPriceData ??= new Map<string, PriceUpdate>();
+
+        // Store raw snapshot for main DEX (all symbols, not just subscribed)
+        this.#allMidsSnapshots.set('', data.mids as Record<string, string>);
 
         const subscribedSymbols = new Set<string>();
 
@@ -2595,6 +2637,83 @@ export class HyperLiquidSubscriptionService {
       this.#assetCtxsSubscriptionPromises.delete(dexKey);
       throw error;
     }
+  }
+
+  /**
+   * Ensure a per-DEX allMids WS subscription exists (singleton per DEX).
+   * Mirrors the #ensureAssetCtxsSubscription pattern with promise dedup.
+   *
+   * @param dex - The HIP-3 DEX name (e.g. 'xyz', 'flx'). Skips main DEX (handled by global).
+   */
+  async #ensureDexAllMidsSubscription(dex: string): Promise<void> {
+    if (!dex) {
+      return;
+    }
+
+    if (this.#dexAllMidsSubscriptions.has(dex)) {
+      return;
+    }
+
+    if (this.#dexAllMidsSubscriptionPromises.has(dex)) {
+      await this.#dexAllMidsSubscriptionPromises.get(dex);
+      return;
+    }
+
+    const promise = this.#createDexAllMidsSubscription(dex);
+    this.#dexAllMidsSubscriptionPromises.set(dex, promise);
+
+    try {
+      await promise;
+    } catch (error) {
+      this.#dexAllMidsSubscriptionPromises.delete(dex);
+      throw error;
+    }
+  }
+
+  /**
+   * Create allMids WS subscription for a specific HIP-3 DEX.
+   *
+   * @param dex - The HIP-3 DEX name.
+   */
+  async #createDexAllMidsSubscription(dex: string): Promise<void> {
+    await this.#clientService.ensureSubscriptionClient(
+      this.#walletService.createWalletAdapter(),
+    );
+    const subscriptionClient = this.#clientService.getSubscriptionClient();
+
+    if (!subscriptionClient) {
+      throw new Error('Subscription client not initialized');
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      subscriptionClient
+        .allMids({ dex }, (data: AllMidsWsEvent) => {
+          this.#allMidsSnapshots.set(dex, data.mids as Record<string, string>);
+        })
+        .then((sub) => {
+          this.#dexAllMidsSubscriptions.set(dex, sub);
+          this.#deps.debugLogger.log(
+            `allMids subscription established for DEX: ${dex}`,
+          );
+          resolve();
+          return undefined;
+        })
+        .catch((error) => {
+          this.#logErrorUnlessClearing(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.createDexAllMidsSubscription',
+            ),
+            this.#getErrorContext('createDexAllMidsSubscription', { dex }),
+          );
+          reject(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.createDexAllMidsSubscription',
+            ),
+          );
+        });
+    });
   }
 
   /**
@@ -3179,6 +3298,8 @@ export class HyperLiquidSubscriptionService {
       // Clear existing subscriptions (they're dead after reconnection)
       this.#assetCtxsSubscriptions.clear();
       this.#assetCtxsSubscriptionPromises.clear();
+      this.#dexAllMidsSubscriptions.clear();
+      this.#dexAllMidsSubscriptionPromises.clear();
       // Clear reference counts to prevent double-counting after reconnection
       this.#dexSubscriberCounts.clear();
 
@@ -3202,13 +3323,16 @@ export class HyperLiquidSubscriptionService {
         dexsNeeded.add('');
       }
 
-      // Re-establish subscriptions
+      // Re-establish assetCtxs + per-DEX allMids subscriptions
       await Promise.all(
-        Array.from(dexsNeeded).map((dex) =>
+        Array.from(dexsNeeded).flatMap((dex) => [
           this.#ensureAssetCtxsSubscription(dex).catch(() => {
             // Ignore errors during assetCtxs subscription restoration
           }),
-        ),
+          this.#ensureDexAllMidsSubscription(dex).catch(() => {
+            // Ignore errors during per-DEX allMids subscription restoration
+          }),
+        ]),
       );
     }
   }
@@ -3241,6 +3365,7 @@ export class HyperLiquidSubscriptionService {
 
     // Clear cached data
     this.#cachedPriceData = null;
+    this.#allMidsSnapshots.clear();
     this.#cachedPositions = null;
     this.#cachedOrders = null;
     this.#cachedAccount = null;
@@ -3286,6 +3411,10 @@ export class HyperLiquidSubscriptionService {
     // HIP-3: Clear assetCtxs subscriptions (clearinghouseState no longer needed with webData3)
     this.#assetCtxsSubscriptions.clear();
     this.#assetCtxsSubscriptionPromises.clear();
+
+    // HIP-3: Clear per-DEX allMids subscriptions
+    this.#dexAllMidsSubscriptions.clear();
+    this.#dexAllMidsSubscriptionPromises.clear();
 
     // Cleanup individual subscriptions (clearinghouseState + openOrders)
     if (this.#clearinghouseStateSubscriptions.size > 0) {

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -2611,30 +2611,34 @@ export class HyperLiquidSubscriptionService {
   async #ensureAssetCtxsSubscription(dex: string): Promise<void> {
     const dexKey = dex || '';
 
-    // Increment subscriber count for this DEX
-    const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
-    this.#dexSubscriberCounts.set(dexKey, currentCount + 1);
-
-    // Return if subscription already exists
+    // Return early (with refcount increment) if subscription already exists
     if (this.#assetCtxsSubscriptions.has(dexKey)) {
+      const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
+      this.#dexSubscriberCounts.set(dexKey, currentCount + 1);
       return;
     }
 
-    // Await existing promise if subscription is being established
+    // Await existing promise (with refcount increment) if subscription is being established
     if (this.#assetCtxsSubscriptionPromises.has(dexKey)) {
+      const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
+      this.#dexSubscriberCounts.set(dexKey, currentCount + 1);
       await this.#assetCtxsSubscriptionPromises.get(dexKey);
       return;
     }
 
-    // Create new subscription promise
+    // Create new subscription promise — only increment refcount on success
     const promise = this.#createAssetCtxsSubscription(dex);
     this.#assetCtxsSubscriptionPromises.set(dexKey, promise);
 
     try {
       await promise;
+      // Increment only after successful creation
+      const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
+      this.#dexSubscriberCounts.set(dexKey, currentCount + 1);
     } catch (error) {
-      // Clear promise on error so it can be retried
+      // Clear all state on error so it can be retried cleanly
       this.#assetCtxsSubscriptionPromises.delete(dexKey);
+      this.#dexSubscriberCounts.delete(dexKey);
       throw error;
     }
   }
@@ -2876,18 +2880,19 @@ export class HyperLiquidSubscriptionService {
             this.#getErrorContext('cleanupAssetCtxsSubscription', { dex }),
           );
         });
-
-        this.#assetCtxsSubscriptions.delete(dexKey);
-        this.#dexAssetCtxsCache.delete(dexKey);
-        this.#assetCtxsSubscriptionPromises.delete(dexKey);
-        this.#dexSubscriberCounts.delete(dexKey);
-
-        this.#deps.debugLogger.log(
-          `Cleaned up assetCtxs subscription for ${
-            dex ? `DEX: ${dex}` : 'main DEX'
-          }`,
-        );
       }
+
+      // Always clear state, even if subscription object is null
+      this.#assetCtxsSubscriptions.delete(dexKey);
+      this.#dexAssetCtxsCache.delete(dexKey);
+      this.#assetCtxsSubscriptionPromises.delete(dexKey);
+      this.#dexSubscriberCounts.delete(dexKey);
+
+      this.#deps.debugLogger.log(
+        `Cleaned up assetCtxs subscription for ${
+          dex ? `DEX: ${dex}` : 'main DEX'
+        }`,
+      );
     } else {
       // Still has subscribers - just decrement count
       this.#dexSubscriberCounts.set(dexKey, currentCount - 1);
@@ -3324,16 +3329,56 @@ export class HyperLiquidSubscriptionService {
       }
 
       // Re-establish assetCtxs + per-DEX allMids subscriptions
+      const failedDexs: string[] = [];
+      const dexArray = Array.from(dexsNeeded);
+
       await Promise.all(
-        Array.from(dexsNeeded).flatMap((dex) => [
-          this.#ensureAssetCtxsSubscription(dex).catch(() => {
-            // Ignore errors during assetCtxs subscription restoration
+        dexArray.flatMap((dex) => [
+          this.#ensureAssetCtxsSubscription(dex).catch((error) => {
+            failedDexs.push(dex || 'main');
+            this.#deps.debugLogger.log(
+              `Failed to restore assetCtxs subscription for ${dex || 'main'}`,
+              { error },
+            );
           }),
-          this.#ensureDexAllMidsSubscription(dex).catch(() => {
-            // Ignore errors during per-DEX allMids subscription restoration
+          this.#ensureDexAllMidsSubscription(dex).catch((error) => {
+            this.#deps.debugLogger.log(
+              `Failed to restore allMids subscription for ${dex || 'main'}`,
+              { error },
+            );
           }),
         ]),
       );
+
+      if (failedDexs.length > 0) {
+        this.#deps.debugLogger.log(
+          `[restoreSubscriptions] ${failedDexs.length} DEX(s) failed, scheduling retry`,
+          { failedDexs },
+        );
+
+        // Single delayed retry for failed DEXs only
+        const uniqueFailedDexs = [...new Set(failedDexs)];
+        setTimeout(() => {
+          Promise.all(
+            uniqueFailedDexs.flatMap((dexLabel) => {
+              const dex = dexLabel === 'main' ? '' : dexLabel;
+              return [
+                this.#ensureAssetCtxsSubscription(dex).catch(
+                  // Silently ignore — best-effort retry
+                  (_e: unknown) => undefined,
+                ),
+                this.#ensureDexAllMidsSubscription(dex).catch(
+                  // Silently ignore — best-effort retry
+                  (_e: unknown) => undefined,
+                ),
+              ];
+            }),
+          ).catch(
+            // Silently ignore — best-effort retry
+            (_e: unknown) => undefined,
+          );
+        }, 5000);
+      }
     }
   }
 


### PR DESCRIPTION
## **Description**

Fixes 4 root causes of perps connection/close failures identified in the Codex investigation, impacting 50K+ users:

- **RC1 — Asset ID not found:** `closePositions`, `updatePositionTPSL`, and `updateMargin` threw when `symbolToAssetId` map was incomplete after partial DEX discovery. Added `#resolveAssetId()` that auto-repairs the map on cache miss via fresh meta fetch.
- **RC2 — Refcount leak on failed subscription:** `#ensureAssetCtxsSubscription` incremented the refcount before attempting creation, leaving phantom counts on failure that blocked future recovery. Moved increment to after success; cleanup now clears state unconditionally.
- **RC3 — Market data fetch throws on transient failure:** After retry exhaustion, `getMarketDataWithPrices` threw even when prior data existed. Added `#lastGoodMarketData` stale-cache fallback so the UI stays populated during transient outages.
- **RC4 — One DEX failure breaks all account state:** `queryUserDataAcrossDexs` used `Promise.all`, so a single DEX error cascaded. Switched to `Promise.allSettled` with partial-result return. Also added `captureException` to `usePerpsClosePosition` (matching existing pattern in flip/order hooks).

CHANGELOG entry: Fixed perpetuals connection and close-position failures caused by subscription refcount leaks, missing asset IDs, transient market data errors, and single-DEX failures cascading to all account state.

## **Related issues**

Fixes: Codex investigation `mobile-recipes/perps-connection-investigation/report.md`

## **Manual testing steps**

```gherkin
Feature: Perps resilience

  Scenario: Market data survives transient failure
    Given the user has the Perps tab open with markets loaded
    When a transient network error occurs during market data refresh
    Then the market list remains populated with stale data
    And no error screen is shown

  Scenario: Close position with stale asset map
    Given the user has an open HIP-3 position
    When the asset ID map is incomplete (e.g. after app resume)
    And the user taps Close Position
    Then the asset ID is auto-repaired from fresh meta
    And the position closes successfully

  Scenario: Account state with one DEX down
    Given the user has positions on main DEX and a HIP-3 DEX
    When one DEX API is unreachable
    Then account state shows data from the healthy DEX
    And positions from the failed DEX are omitted (not error screen)

  Scenario: Subscription recovery after reconnect
    Given the user backgrounds the app for 30+ seconds
    When the app resumes and WebSocket reconnects
    Then assetCtxs subscriptions are re-established
    And failed DEXs retry after 5 seconds
```

## **Screenshots/Recordings**

N/A — backend resilience, no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.