### PR TITLE
feat: Add fiat payment state selectors and data hooks for MMPay

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionPayTotals,
   TransactionPayRequiredToken,
   TransactionPaySourceAmount,
+  TransactionFiatPayment,
 } from '@metamask/transaction-pay-controller';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import {
@@ -15,6 +16,7 @@ import {
   useTransactionPayTotals,
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
+  useTransactionPayFiatPayment,
 } from './useTransactionPayData';
 import { cloneDeep, merge } from 'lodash';
 import {
@@ -44,6 +46,11 @@ const TOTALS_MOCK = {
   total: { usd: '1000', fiat: '1234' },
 } as TransactionPayTotals;
 
+const FIAT_PAYMENT_MOCK: TransactionFiatPayment = {
+  selectedPaymentMethodId: 'pm-123',
+  amountFiat: '50.00',
+};
+
 const state = merge(
   {},
   simpleSendTransactionControllerMock,
@@ -61,6 +68,7 @@ const state = merge(
               sourceAmounts: [SOURCE_AMOUNT_MOCK],
               tokens: [REQUIRED_TOKEN_MOCK],
               totals: TOTALS_MOCK,
+              fiatPayment: FIAT_PAYMENT_MOCK,
             },
           },
         },
@@ -179,6 +187,13 @@ describe('useTransactionPayData', () => {
         state: updatedState,
       }).result.current,
     ).toBe(false);
+  });
+
+  it('returns fiatPayment', () => {
+    expect(
+      renderHookWithProvider(useTransactionPayFiatPayment, { state }).result
+        .current,
+    ).toStrictEqual(FIAT_PAYMENT_MOCK);
   });
 
   it('returns false for isPostQuote when no transaction data', () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import {
   selectIsTransactionPayLoadingByTransactionId,
+  selectTransactionPayFiatPaymentByTransactionId,
   selectTransactionPayIsMaxAmountByTransactionId,
   selectTransactionPayIsPostQuoteByTransactionId,
   selectTransactionPayQuotesByTransactionId,
@@ -46,6 +47,10 @@ export function useTransactionPayIsMaxAmount() {
 
 export function useTransactionPayIsPostQuote() {
   return useTransactionPayData(selectTransactionPayIsPostQuoteByTransactionId);
+}
+
+export function useTransactionPayFiatPayment() {
+  return useTransactionPayData(selectTransactionPayFiatPaymentByTransactionId);
 }
 
 function useTransactionPayData<T>(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPaySelectedFiatPaymentMethod.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPaySelectedFiatPaymentMethod.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { type PaymentMethod } from '@metamask/ramps-controller';
+import { useTransactionPaySelectedFiatPaymentMethod } from './useTransactionPaySelectedFiatPaymentMethod';
+import { useTransactionPayFiatPayment } from './useTransactionPayData';
+import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+
+jest.mock('./useTransactionPayData');
+jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+
+const PAYMENT_METHOD_MOCK = {
+  id: 'pm-123',
+  name: 'Credit Card',
+} as PaymentMethod;
+
+describe('useTransactionPaySelectedFiatPaymentMethod', () => {
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
+  const useRampsPaymentMethodsMock = jest.mocked(useRampsPaymentMethods);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+    useRampsPaymentMethodsMock.mockReturnValue({
+      paymentMethods: [PAYMENT_METHOD_MOCK],
+    } as ReturnType<typeof useRampsPaymentMethods>);
+  });
+
+  it('returns undefined when no fiat payment is selected', () => {
+    const { result } = renderHook(() =>
+      useTransactionPaySelectedFiatPaymentMethod(),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the matching payment method when selected', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-123',
+    });
+
+    const { result } = renderHook(() =>
+      useTransactionPaySelectedFiatPaymentMethod(),
+    );
+
+    expect(result.current).toStrictEqual(PAYMENT_METHOD_MOCK);
+  });
+
+  it('returns undefined when selected ID does not match any payment method', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-nonexistent',
+    });
+
+    const { result } = renderHook(() =>
+      useTransactionPaySelectedFiatPaymentMethod(),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPaySelectedFiatPaymentMethod.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPaySelectedFiatPaymentMethod.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { type PaymentMethod } from '@metamask/ramps-controller';
+import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useTransactionPayFiatPayment } from './useTransactionPayData';
+
+export function useTransactionPaySelectedFiatPaymentMethod():
+  | PaymentMethod
+  | undefined {
+  const fiatPayment = useTransactionPayFiatPayment();
+  const { paymentMethods } = useRampsPaymentMethods();
+
+  return useMemo(
+    () =>
+      fiatPayment?.selectedPaymentMethodId
+        ? paymentMethods.find(
+            (pm) => pm.id === fiatPayment.selectedPaymentMethodId,
+          )
+        : undefined,
+    [fiatPayment?.selectedPaymentMethodId, paymentMethods],
+  );
+}

--- a/app/selectors/transactionPayController.ts
+++ b/app/selectors/transactionPayController.ts
@@ -53,6 +53,11 @@ export const selectTransactionPayIsPostQuoteByTransactionId = createSelector(
   (transactionData) => transactionData?.isPostQuote ?? false,
 );
 
+export const selectTransactionPayFiatPaymentByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.fiatPayment,
+);
+
 export const selectTransactionPayTransactionData = createSelector(
   selectTransactionPayControllerState,
   (state) => state.transactionData,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Add `selectTransactionPayFiatPaymentByTransactionId` selector to read `fiatPayment` from `TransactionPayController` state per transaction
- Add `useTransactionPayFiatPayment()` data hook following the existing `useTransactionPayData` pattern
- Add `useTransactionPaySelectedFiatPaymentMethod()` hook that resolves the selected fiat payment method ID to the full `PaymentMethod` object from `RampsController`, returning `undefined` when nothing is selected

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27111

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds read-only selectors/hooks and unit tests without changing transaction execution or payment logic.
> 
> **Overview**
> Adds a new `selectTransactionPayFiatPaymentByTransactionId` selector plus a `useTransactionPayFiatPayment()` hook to expose `fiatPayment` from `TransactionPayController` state for the active confirmation transaction.
> 
> Introduces `useTransactionPaySelectedFiatPaymentMethod()` to map `fiatPayment.selectedPaymentMethodId` to the corresponding `PaymentMethod` from `useRampsPaymentMethods`, returning `undefined` when unset or unmatched, and adds unit coverage for the new selector/hook behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 151d4a598bc2b05d4ad244769ba6ec48b56d6b9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->