### PR TITLE
fix: update fixture validation to include new ignored key for fiatOrders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,10 +552,9 @@ jobs:
     secrets: inherit
 
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
-  # TODO: Remove continue-on-error once fixture validation is stable
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
     permissions:
       contents: read
       id-token: write

--- a/tests/framework/fixtures/fixture-validation.ts
+++ b/tests/framework/fixtures/fixture-validation.ts
@@ -314,6 +314,7 @@ export function getMobileFixtureIgnoredKeys(): string[] {
     // ── Runtime-detected values (non-deterministic between environments) ──
     'card.geoLocation',
     'fiatOrders.detectedGeolocation',
+    'fiatOrders.rampRoutingDecision',
 
     // ── Networks present in app defaults but not in fixture (added by controller at runtime) ──
     'engine.backgroundState.NetworkController.networkConfigurationsByChainId.0x2105', // Base


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

  ## Summary

  - Adds `fiatOrders.rampRoutingDecision` to the fixture validation ignored
    keys — it's a non-deterministic runtime value (set by ramps routing
    detection) that was causing a false positive on main
  - Restricts the `validate-e2e-fixtures` CI job to only run on PRs, not
    on pushes to `main`, scheduled runs, or merge queue

  ## Problem

  The fixture validation job was failing on `main` with a cyclic false
  positive:

  1. **Run 1** — fixture has `null`, live app produces `"AGGREGATOR"` (ramps
     routing detection ran). Type mismatch detected → test writes updated
     fixture to disk with `"AGGREGATOR"` before throwing.
  2. **Run 2 (retry)** — reads the just-updated fixture (`"AGGREGATOR"`),
     but live app returns `null` this time. New type mismatch: `expected
     "string", received "null"`. Fails again.

  `rampRoutingDecision` is non-deterministic between runs (same category as
  `fiatOrders.detectedGeolocation`, which was already ignored).

  Running the job on `main` pushes also has no useful effect — there's no
  PR to comment on and no one to action the result.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI execution conditions (fixture validation no longer runs on non-PR events) and expands the ignored schema keys, which could hide genuine fixture drift for that field.
> 
> **Overview**
> **Stabilizes E2E fixture validation** by adding `fiatOrders.rampRoutingDecision` to the fixture-validation ignore list to avoid non-deterministic runtime mismatches.
> 
> **Adjusts CI behavior** so the `validate-e2e-fixtures` job only runs on `pull_request` events (still skipping forks), rather than running on other event types like `push`/scheduled runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 866b310f06c1e95dfb131097b25339d3f2e5484b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->