### PR TITLE
fix: hide account balances in account list when privacy mode is enabled

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
@@ -14,6 +14,7 @@ import { Maskicon } from '@metamask/design-system-react-native';
 import JazzIcon from 'react-native-jazzicon';
 import { Image as RNImage } from 'react-native';
 import { AccountCellIds } from './AccountCell.testIds';
+import { backgroundState } from '../../../../util/test/initial-root-state';
 
 // Configurable mock balance for selector
 const mockBalance: { value: number; currency: string } = {
@@ -68,15 +69,17 @@ const renderAccountCell = (
     hideMenu?: boolean;
     avatarAccountType?: AvatarAccountType;
     onSelectAccount?: () => void;
+    privacyMode?: boolean;
   } = {},
 ) => {
+  const { privacyMode = false, ...componentProps } = props;
   const defaultProps = {
     accountGroup: mockAccountGroup,
     avatarAccountType: AvatarAccountType.Maskicon,
     isSelected: false,
     hideMenu: false,
     onSelectAccount: jest.fn(),
-    ...props,
+    ...componentProps,
   };
 
   const groups = [defaultProps.accountGroup];
@@ -86,6 +89,16 @@ const renderAccountCell = (
   return renderWithProvider(<AccountCell {...defaultProps} />, {
     state: {
       ...baseState,
+      engine: {
+        ...baseState.engine,
+        backgroundState: {
+          ...baseState.engine.backgroundState,
+          PreferencesController: {
+            ...backgroundState.PreferencesController,
+            privacyMode,
+          },
+        },
+      },
       settings: {
         avatarAccountType: AvatarAccountType.Maskicon,
       },
@@ -233,6 +246,27 @@ describe('AccountCell', () => {
     // When rendered
     // Then the avatar should be visible without selection indicator
     expect(getByTestId(AccountCellIds.AVATAR)).toBeTruthy();
+  });
+
+  it('hides balance when privacyMode is true', () => {
+    mockBalance.value = 100;
+    mockBalance.currency = 'usd';
+    const { getByTestId, queryByText } = renderAccountCell({
+      privacyMode: true,
+    });
+
+    // The balance element should be present but showing masked characters
+    expect(getByTestId(AccountCellIds.BALANCE)).toBeTruthy();
+    // The actual balance text should not be visible
+    expect(queryByText('$100.00')).toBeNull();
+  });
+
+  it('shows balance when privacyMode is false', () => {
+    mockBalance.value = 100;
+    mockBalance.currency = 'usd';
+    const { getByText } = renderAccountCell({ privacyMode: false });
+
+    expect(getByText('$100.00')).toBeTruthy();
   });
 
   it('displays correct test IDs for all elements', () => {

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
@@ -256,7 +256,7 @@ describe('AccountCell', () => {
     });
 
     // The balance element should be present but showing masked characters
-    expect(getByTestId(AccountCellIds.BALANCE)).toBeTruthy();
+    expect(getByTestId(AccountCellIds.BALANCE)).toBeOnTheScreen();
     // The actual balance text should not be visible
     expect(queryByText('$100.00')).toBeNull();
   });
@@ -266,7 +266,16 @@ describe('AccountCell', () => {
     mockBalance.currency = 'usd';
     const { getByText } = renderAccountCell({ privacyMode: false });
 
-    expect(getByText('$100.00')).toBeTruthy();
+    expect(getByText('$100.00')).toBeOnTheScreen();
+  });
+
+  it('shows nothing when privacyMode is true and there is no balance', () => {
+    mockBalance.value = undefined as unknown as number;
+    mockBalance.currency = 'usd';
+    const { queryByText } = renderAccountCell({ privacyMode: true });
+
+    // No masked dots when there is no balance to hide
+    expect(queryByText('••••••••••••')).toBeNull();
   });
 
   it('displays correct test IDs for all elements', () => {

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -92,7 +92,7 @@ const BalanceEndContainer = ({
             variant={TextVariant.BodyMDMedium}
             color={TextColor.Default}
             length={SensitiveTextLength.Long}
-            isHidden={privacyMode}
+            isHidden={privacyMode && !!displayBalance}
             testID={AccountCellIds.BALANCE}
           >
             {totalBalance ? displayBalance : null}

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -6,6 +6,9 @@ import { useNavigation } from '@react-navigation/native';
 import { useStyles } from '../../../hooks';
 import styleSheet from './AccountCell.styles';
 import Text, { TextColor, TextVariant } from '../../../components/Texts/Text';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../components/Texts/SensitiveText';
 import { Box } from '../../../../components/UI/Box/Box';
 import {
   AlignItems,
@@ -26,6 +29,7 @@ import {
   selectIconSeedAddressByAccountGroupId,
   selectInternalAccountByAccountGroupAndScope,
 } from '../../../../selectors/multichainAccounts/accounts';
+import { selectPrivacyMode } from '../../../../selectors/preferencesController';
 import { createAccountGroupDetailsNavigationDetails } from '../../../../components/Views/MultichainAccounts/sheets/MultichainAccountActions/MultichainAccountActions';
 import { getNetworkImageSource } from '../../../../util/networks';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
@@ -68,6 +72,7 @@ const BalanceEndContainer = ({
   const groupBalance = useSelector(selectBalanceForGroup);
   const totalBalance = groupBalance?.totalBalanceInUserCurrency;
   const userCurrency = groupBalance?.userCurrency;
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const displayBalance = useMemo(() => {
     if (totalBalance == null || !userCurrency) {
@@ -83,13 +88,15 @@ const BalanceEndContainer = ({
     <>
       <TouchableOpacity onPress={onSelectAccount}>
         <View style={styles.balanceContainer}>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodyMDMedium}
             color={TextColor.Default}
+            length={SensitiveTextLength.Long}
+            isHidden={privacyMode}
             testID={AccountCellIds.BALANCE}
           >
             {totalBalance ? displayBalance : null}
-          </Text>
+          </SensitiveText>
           {networkImageSource && (
             <Avatar
               variant={AvatarVariant.Network}

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -92,7 +92,9 @@ const BalanceEndContainer = ({
             variant={TextVariant.BodyMDMedium}
             color={TextColor.Default}
             length={SensitiveTextLength.Long}
-            isHidden={privacyMode && !!displayBalance}
+            isHidden={
+              privacyMode && Boolean(displayBalance) && Boolean(totalBalance)
+            }
             testID={AccountCellIds.BALANCE}
           >
             {totalBalance ? displayBalance : null}

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
@@ -106,6 +106,9 @@ jest.mock('../../../../util/test/initial-root-state', () => ({
         wallets: {},
       },
     },
+    PreferencesController: {
+      privacyMode: false,
+    },
     RemoteFeatureFlagController: {
       remoteFeatureFlags: {
         enableMultichainAccounts: {


### PR DESCRIPTION
## **Description**

Account balances displayed in the account list were not respecting the hide balances (privacy mode) setting toggled from the main wallet view. This aligns mobile behaviour with extension.

The fix replaces the plain `Text` component in `AccountCell`'s `BalanceEndContainer` with `SensitiveText`, reading `privacyMode` from `selectPrivacyMode` via Redux.

## **Changelog**

CHANGELOG entry: Fixed a bug where hiding balances on the wallet home screen was not reflected in the account list

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-375

## **Manual testing steps**

```gherkin
Feature: Hide balances in account list

  Scenario: user hides balances then opens account list
    Given the user is on the wallet home screen

    When user taps the eye icon to hide balances
    And user taps the account selector to open the account list
    Then balances should be masked in the account list

  Scenario: user shows balances then opens account list
    Given the user has previously hidden balances

    When user taps the eye icon to show balances
    And user taps the account selector to open the account list
    Then balances should be visible in the account list
```

## **Screenshots/Recordings**

`~`

### **Before**

https://github.com/user-attachments/assets/eb0dcaba-b58e-41d2-a793-e4545177526b

### **After**

https://github.com/user-attachments/assets/f4bf96ae-2f66-467a-9ff8-26b8f3472a26

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that masks displayed balances based on the existing `privacyMode` preference; low risk aside from potential regressions in balance rendering/masking conditions.
> 
> **Overview**
> Account list balance rendering now respects the global *privacy mode* setting by swapping the `AccountCell` balance label from `Text` to `SensitiveText` and driving masking via `selectPrivacyMode`.
> 
> Tests are updated to seed `PreferencesController.privacyMode` in mocked Redux state and add coverage for masked/unmasked balance display, including the no-balance case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3b78b952d6c5d29338aa964f26aa21d4e040189. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->