### PR TITLE
feat: Add fiat payment method highlighted actions for PayWithModal

### DIFF
--- a/app/components/Views/confirmations/components/UI/highlighted-item/highlighted-item.test.tsx
+++ b/app/components/Views/confirmations/components/UI/highlighted-item/highlighted-item.test.tsx
@@ -95,4 +95,18 @@ describe('HighlightedItem', () => {
 
     expect(queryByText('Add')).not.toBeOnTheScreen();
   });
+
+  it('renders PaymentMethodIcon when paymentType is set', () => {
+    const paymentItem: HighlightedItem = {
+      ...assetItem,
+      paymentType: 'debit-credit-card',
+    };
+
+    const { getByTestId, getByText } = renderWithProvider(
+      <HighlightedItemRow item={paymentItem} />,
+    );
+
+    expect(getByTestId('icon')).toBeOnTheScreen();
+    expect(getByText('Perps Balance')).toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/confirmations/components/UI/highlighted-item/highlighted-item.tsx
+++ b/app/components/Views/confirmations/components/UI/highlighted-item/highlighted-item.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { Pressable } from 'react-native';
+import { PaymentType } from '@consensys/on-ramp-sdk';
 import {
   AvatarToken,
   Box,
@@ -18,7 +19,11 @@ import {
 import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
-import { HighlightedItem as HighlightedItemType } from '../../../types/token';
+import PaymentMethodIcon from '../../../../../UI/Ramp/Aggregator/components/PaymentMethodIcon';
+import {
+  HighlightedActionButton,
+  HighlightedItem as HighlightedItemType,
+} from '../../../types/token';
 
 interface HighlightedItemProps {
   item: HighlightedItemType;
@@ -26,10 +31,6 @@ interface HighlightedItemProps {
 
 export function HighlightedItem({ item }: HighlightedItemProps) {
   const tw = useTailwind();
-  const iconName = Object.values(IconName).includes(item.icon as IconName)
-    ? (item.icon as IconName)
-    : undefined;
-  const hasActionButtons = (item.actions?.length ?? 0) > 0;
 
   const handlePress = useCallback(() => {
     item.action();
@@ -46,27 +47,7 @@ export function HighlightedItem({ item }: HighlightedItemProps) {
       onPress={handlePress}
     >
       <Box twClassName="flex-row items-center flex-1 min-w-0">
-        {iconName ? (
-          <Box
-            style={tw.style(
-              'w-10 h-10 rounded-full bg-background-section items-center justify-center',
-            )}
-            testID="icon"
-          >
-            <Icon
-              name={iconName}
-              size={IconSize.Md}
-              color={IconColor.IconAlternative}
-            />
-          </Box>
-        ) : (
-          <AvatarToken
-            name={item.name}
-            src={item.icon ? { uri: item.icon } : undefined}
-            style={tw.style('w-10 h-10')}
-          />
-        )}
-
+        <HighlightedItemIcon item={item} />
         <Box twClassName="ml-4 flex-1 min-w-0">
           <Text
             variant={TextVariant.BodyMd}
@@ -84,45 +65,101 @@ export function HighlightedItem({ item }: HighlightedItemProps) {
           </Text>
         </Box>
       </Box>
-
-      {hasActionButtons || item.isLoading ? (
-        <Box twClassName="flex-row items-center">
-          {item.isLoading && <Spinner />}
-          {!item.isLoading &&
-            item.actions?.map((actionItem, index) => (
-              <Box
-                key={`${item.name}-${actionItem.buttonLabel}-${index}`}
-                twClassName={index > 0 ? 'ml-2' : ''}
-              >
-                <Button
-                  variant={ButtonVariant.Secondary}
-                  size={ButtonSize.Md}
-                  onPress={actionItem.onPress}
-                  isDisabled={actionItem.isDisabled}
-                >
-                  {actionItem.buttonLabel}
-                </Button>
-              </Box>
-            ))}
-        </Box>
-      ) : (
-        <Box twClassName="h-12 justify-center items-end shrink-0">
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            numberOfLines={1}
-          >
-            {item.fiat}
-          </Text>
-          <Text
-            variant={TextVariant.BodySm}
-            color={TextColor.TextAlternative}
-            numberOfLines={1}
-          >
-            {item.fiat_description}
-          </Text>
-        </Box>
-      )}
+      <HighlightedItemActions item={item} />
     </Pressable>
+  );
+}
+
+function HighlightedItemIcon({ item }: { item: HighlightedItemType }) {
+  const tw = useTailwind();
+
+  if (item.paymentType) {
+    return (
+      <Box
+        style={tw.style(
+          'w-10 h-10 rounded-full bg-background-section items-center justify-center',
+        )}
+        testID="icon"
+      >
+        <PaymentMethodIcon
+          paymentMethodType={item.paymentType as PaymentType}
+          size={20}
+        />
+      </Box>
+    );
+  }
+
+  const iconName = Object.values(IconName).includes(item.icon as IconName)
+    ? (item.icon as IconName)
+    : undefined;
+
+  if (iconName) {
+    return (
+      <Box
+        style={tw.style(
+          'w-10 h-10 rounded-full bg-background-section items-center justify-center',
+        )}
+        testID="icon"
+      >
+        <Icon
+          name={iconName}
+          size={IconSize.Md}
+          color={IconColor.IconAlternative}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <AvatarToken
+      name={item.name}
+      src={item.icon ? { uri: item.icon } : undefined}
+      style={tw.style('w-10 h-10')}
+    />
+  );
+}
+
+function HighlightedItemActions({ item }: { item: HighlightedItemType }) {
+  if (item.isLoading || (item.actions?.length ?? 0) > 0) {
+    return (
+      <Box twClassName="flex-row items-center">
+        {item.isLoading && <Spinner />}
+        {!item.isLoading &&
+          item.actions?.map((actionItem: HighlightedActionButton, index) => (
+            <Box
+              key={`${item.name}-${actionItem.buttonLabel}-${index}`}
+              twClassName={index > 0 ? 'ml-2' : ''}
+            >
+              <Button
+                variant={ButtonVariant.Secondary}
+                size={ButtonSize.Md}
+                onPress={actionItem.onPress}
+                isDisabled={actionItem.isDisabled}
+              >
+                {actionItem.buttonLabel}
+              </Button>
+            </Box>
+          ))}
+      </Box>
+    );
+  }
+
+  return (
+    <Box twClassName="h-12 justify-center items-end shrink-0">
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        numberOfLines={1}
+      >
+        {item.fiat}
+      </Text>
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        numberOfLines={1}
+      >
+        {item.fiat_description}
+      </Text>
+    </Box>
   );
 }

--- a/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.test.ts
@@ -1,0 +1,128 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { type PaymentMethod } from '@metamask/ramps-controller';
+import { useFiatPaymentHighlightedActions } from './useFiatPaymentHighlightedActions';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { useTransactionPayFiatPayment } from './useTransactionPayData';
+import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import Engine from '../../../../../core/Engine';
+
+jest.mock('./useMMPayFiatConfig');
+jest.mock('./useTransactionPayData');
+jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    TransactionPayController: {
+      updateFiatPayment: jest.fn(),
+    },
+  },
+}));
+
+const PAYMENT_METHOD_MOCK: PaymentMethod = {
+  id: 'pm-card',
+  paymentType: 'debit-credit-card',
+  name: 'Credit Card',
+  score: 1,
+  icon: 'card-icon',
+  delay: [5, 10],
+} as PaymentMethod;
+
+const TRANSACTION_ID_MOCK = 'tx-123';
+
+describe('useFiatPaymentHighlightedActions', () => {
+  const useMMPayFiatConfigMock = jest.mocked(useMMPayFiatConfig);
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
+  const useRampsPaymentMethodsMock = jest.mocked(useRampsPaymentMethods);
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+  const updateFiatPaymentMock = jest.mocked(
+    Engine.context.TransactionPayController.updateFiatPayment,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useMMPayFiatConfigMock.mockReturnValue({ enabled: true });
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+    useRampsPaymentMethodsMock.mockReturnValue({
+      paymentMethods: [PAYMENT_METHOD_MOCK],
+    } as ReturnType<typeof useRampsPaymentMethods>);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+  });
+
+  it('returns empty array when feature flag is off', () => {
+    useMMPayFiatConfigMock.mockReturnValue({ enabled: false });
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns empty array when no payment methods available', () => {
+    useRampsPaymentMethodsMock.mockReturnValue({
+      paymentMethods: [],
+    } as unknown as ReturnType<typeof useRampsPaymentMethods>);
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('maps payment methods to highlighted items', () => {
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      position: 'outside_of_asset_list',
+      icon: 'card-icon',
+      paymentType: 'debit-credit-card',
+      name: 'Credit Card',
+      isSelected: false,
+    });
+  });
+
+  it('marks item as selected when payment method ID matches', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+    });
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current[0].isSelected).toBe(true);
+  });
+
+  it('calls updateFiatPayment to select when action is fired on unselected item', () => {
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    result.current[0].action();
+
+    expect(updateFiatPaymentMock).toHaveBeenCalledWith({
+      transactionId: TRANSACTION_ID_MOCK,
+      callback: expect.any(Function),
+    });
+
+    const fiatPayment = { selectedPaymentMethodId: undefined };
+    updateFiatPaymentMock.mock.calls[0][0].callback(fiatPayment);
+    expect(fiatPayment.selectedPaymentMethodId).toBe('pm-card');
+  });
+
+  it('calls updateFiatPayment to deselect when action is fired on selected item', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+    });
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    result.current[0].action();
+
+    const fiatPayment = { selectedPaymentMethodId: 'pm-card' };
+    updateFiatPaymentMock.mock.calls[0][0].callback(fiatPayment);
+    expect(fiatPayment.selectedPaymentMethodId).toBeUndefined();
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import { type PaymentMethod } from '@metamask/ramps-controller';
+import Engine from '../../../../../core/Engine';
+import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { formatDelayFromArray } from '../../../../UI/Ramp/Aggregator/utils';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { useTransactionPayFiatPayment } from './useTransactionPayData';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { HighlightedItem } from '../../types/token';
+
+/**
+ * Converts available Ramps payment methods into {@link HighlightedItem}s for
+ * the Pay-With modal. Returns `[]` when the fiat feature flag is off or no
+ * payment methods are available. Selecting an item toggles
+ * `fiatPayment.selectedPaymentMethodId` on the current transaction.
+ */
+export function useFiatPaymentHighlightedActions(): HighlightedItem[] {
+  const { enabled } = useMMPayFiatConfig();
+  const { paymentMethods } = useRampsPaymentMethods();
+  const fiatPayment = useTransactionPayFiatPayment();
+  const transactionMeta = useTransactionMetadataRequest();
+  const transactionId = transactionMeta?.id ?? '';
+  const selectedPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
+
+  return useMemo(() => {
+    if (!enabled || paymentMethods.length === 0) {
+      return [];
+    }
+
+    return paymentMethods.map((pm) =>
+      toHighlightedItem(pm, transactionId, selectedPaymentMethodId),
+    );
+  }, [enabled, paymentMethods, transactionId, selectedPaymentMethodId]);
+}
+
+function toHighlightedItem(
+  paymentMethod: PaymentMethod,
+  transactionId: string,
+  selectedPaymentMethodId?: string,
+): HighlightedItem {
+  const isSelected = paymentMethod.id === selectedPaymentMethodId;
+
+  return {
+    position: 'outside_of_asset_list',
+    icon: paymentMethod.icon,
+    paymentType: paymentMethod.paymentType,
+    name: paymentMethod.name,
+    name_description: paymentMethod.delay
+      ? formatDelayFromArray(paymentMethod.delay)
+      : '',
+    action: () => {
+      Engine.context.TransactionPayController.updateFiatPayment({
+        transactionId,
+        callback: (fiatPayment) => {
+          fiatPayment.selectedPaymentMethodId = isSelected
+            ? undefined
+            : paymentMethod.id;
+        },
+      });
+    },
+    isSelected,
+  };
+}

--- a/app/components/Views/confirmations/types/token.ts
+++ b/app/components/Views/confirmations/types/token.ts
@@ -42,6 +42,8 @@ export interface HighlightedItem {
   position: HighlightedItemPosition;
   /** Either an IconName string or a remote icon URI. */
   icon: string;
+  /** Payment method type identifier used to render a PaymentMethodIcon. Takes precedence over `icon` when set. */
+  paymentType?: string;
   /** Primary label shown for the highlighted row. */
   name: string;
   /** Secondary label shown under the primary name. */
@@ -51,9 +53,9 @@ export interface HighlightedItem {
   /** Optional action buttons shown on the right side of the row. */
   actions?: HighlightedActionButton[];
   /** Right-side fiat value shown when no action buttons are rendered. */
-  fiat: string;
+  fiat?: string;
   /** Right-side fiat subtitle shown below the fiat value. */
-  fiat_description: string;
+  fiat_description?: string;
   /** Selected state used to apply pressed/selected background styling. */
   isSelected?: boolean;
   /** Loading state that shows a spinner and hides action buttons. */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Add `useFiatPaymentHighlightedActions` hook that converts Ramps payment methods into selectable items for the Pay-With-Modal, gated behind the `confirmations_pay_fiat` feature flag
- Extend `HighlightedItem` type with optional `paymentType` field to support rendering `PaymentMethodIcon` alongside existing icon types
- Extract `HighlightedItemIcon` and `HighlightedItemActions` local components to simplify the `HighlightedItem` rendering logic
- Make fiat and `fiat_description` optional on `HighlightedItem` since payment method rows don't display fiat values
- Selecting a payment method toggles `fiatPayment.selectedPaymentMethodId` on the current transaction via `TransactionPayController.updateFiatPayment`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27112

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new transaction-updating selection logic (`TransactionPayController.updateFiatPayment`) and changes the `HighlightedItem` rendering/type shape, which could affect Pay-With UI behavior when the fiat feature flag is enabled.
> 
> **Overview**
> Adds `useFiatPaymentHighlightedActions` to convert available Ramps payment methods into selectable `HighlightedItem`s for the Pay-With modal (gated by `confirmations_pay_fiat`), toggling `fiatPayment.selectedPaymentMethodId` via `TransactionPayController.updateFiatPayment`.
> 
> Updates the highlighted row UI/type to support payment-method icons: `HighlightedItem` now accepts optional `paymentType` (rendered with `PaymentMethodIcon`, taking precedence over `icon`) and makes `fiat`/`fiat_description` optional; `HighlightedItem` rendering is refactored into `HighlightedItemIcon` and `HighlightedItemActions`. Tests were added/updated to cover the new hook behavior and payment icon rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf19b0a3daef4a796d1c2b32e598fab07fe9a06e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->