### PR TITLE
chore: adjust TokenSelectorItem sizing and balance colors

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -127,7 +127,7 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(getByText('$500')).toBeTruthy();
-      expect(getByText('50 USDC')).toBeTruthy();
+      expect(getByText('50')).toBeTruthy();
     });
 
     it('hides balance when shouldShowBalance is false', () => {
@@ -225,8 +225,8 @@ describe('TokenSelectorItem', () => {
 
   describe('balance formatting', () => {
     it.each([
-      ['zero balance', '0', '0 TOKEN'],
-      ['small balance', '0.000001', '< 0.00001 TOKEN'],
+      ['zero balance', '0', '0'],
+      ['small balance', '0.000001', '< 0.00001'],
     ])('formats %s correctly', (_, balance, expected) => {
       const token = createMockTokenWithBalance({ balance, symbol: 'TOKEN' });
 
@@ -363,7 +363,7 @@ describe('TokenSelectorItem', () => {
         <TokenSelectorItem token={token} onPress={mockOnPress} />,
       );
 
-      const tokenBalanceElement = getByText('50 TOKEN');
+      const tokenBalanceElement = getByText('50');
 
       expect(tokenBalanceElement.props.numberOfLines).toBe(1);
     });

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -127,7 +127,7 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(getByText('$500')).toBeTruthy();
-      expect(getByText('50')).toBeTruthy();
+      expect(getByText('50 USDC')).toBeTruthy();
     });
 
     it('hides balance when shouldShowBalance is false', () => {
@@ -225,8 +225,8 @@ describe('TokenSelectorItem', () => {
 
   describe('balance formatting', () => {
     it.each([
-      ['zero balance', '0', '0'],
-      ['small balance', '0.000001', '< 0.00001'],
+      ['zero balance', '0', '0 TOKEN'],
+      ['small balance', '0.000001', '< 0.00001 TOKEN'],
     ])('formats %s correctly', (_, balance, expected) => {
       const token = createMockTokenWithBalance({ balance, symbol: 'TOKEN' });
 
@@ -363,7 +363,7 @@ describe('TokenSelectorItem', () => {
         <TokenSelectorItem token={token} onPress={mockOnPress} />,
       );
 
-      const tokenBalanceElement = getByText('50');
+      const tokenBalanceElement = getByText('50 TOKEN');
 
       expect(tokenBalanceElement.props.numberOfLines).toBe(1);
     });

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -198,7 +198,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   };
 
   const cryptoBalance = token.balance
-    ? formatTokenBalance(token.balance)
+    ? `${formatTokenBalance(token.balance)} ${token.symbol}`
     : undefined;
 
   const isNative = token.address === ethers.constants.AddressZero;

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -157,7 +157,11 @@ const FiatBalanceView = ({
   }
 
   return (
-    <Text variant={TextVariant.BodyLGMedium} numberOfLines={1}>
+    <Text
+      variant={TextVariant.BodyMD}
+      color={TextColor.Alternative}
+      numberOfLines={1}
+    >
       {balance}
     </Text>
   );
@@ -194,7 +198,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   };
 
   const cryptoBalance = token.balance
-    ? `${formatTokenBalance(token.balance)} ${token.symbol}`
+    ? formatTokenBalance(token.balance)
     : undefined;
 
   const isNative = token.address === ethers.constants.AddressZero;
@@ -268,7 +272,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             >
               <Box style={styles.tokenMainInfo} gap={4}>
                 <Text
-                  variant={TextVariant.BodyLGMedium}
+                  variant={TextVariant.BodyMDMedium}
                   numberOfLines={1}
                   ellipsizeMode="tail"
                 >
@@ -293,8 +297,8 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                   <View style={styles.skeleton} />
                 ) : (
                   <Text
-                    variant={TextVariant.BodyMD}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodyMDMedium}
+                    color={TextColor.Default}
                     numberOfLines={1}
                     style={styles.rightValue}
                   >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR scopes `TokenSelectorItem` updates to sizing and color hierarchy only in the Bridge asset selector.

Changes included:
- Set ticker text to `BodyMDMedium` (16sp).
- Set token balance text to `BodyMDMedium` (16sp) with default text color.
- Set fiat balance text to `BodyMD` (16sp) with alternative text color.

## **Changelog**

CHANGELOG entry: Updated Bridge token selector balance sizing and color hierarchy.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Bridge token selector balance sizing and color hierarchy

  Scenario: user views token selector rows
    Given the user opens the Bridge token selector
    When a token row is rendered with both token and fiat balances
    Then ticker text is shown in 16sp medium weight
    And token balance is shown in 16sp medium weight with default text color
    And fiat balance is shown in 16sp regular weight with alternative text color
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change adjusting text variants/colors for token and fiat balances in the Bridge token selector; no business logic, data, or security behavior changes.
> 
> **Overview**
> Updates `TokenSelectorItem` balance presentation to better reflect a primary/secondary hierarchy in the Bridge asset selector.
> 
> The token symbol and right-side token balance are now rendered with `BodyMDMedium` and default text color, while the fiat balance display is rendered with `BodyMD` and alternative text color (including its non-loading state), making fiat visually secondary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6405330919f3d8049fdfd29f0b5217c4a2b4e8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->