### PR TITLE
fix: cp-7.69.0 default to first convertible token regardless of selected network in deeplink flow

### DIFF
--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.test.tsx
@@ -139,6 +139,21 @@ const mockConversionToken = {
   balance: '1000000',
   logo: undefined,
   isETH: false,
+  fiat: { balance: 50 },
+};
+
+const mockConversionTokenHighBalance = {
+  address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  chainId: '0x1',
+  aggregators: [],
+  decimals: 6,
+  image: '',
+  name: 'Tether USD',
+  symbol: 'USDT',
+  balance: '5000000',
+  logo: undefined,
+  isETH: false,
+  fiat: { balance: 500 },
 };
 
 describe('EarnMusdConversionEducationView', () => {
@@ -457,7 +472,7 @@ describe('EarnMusdConversionEducationView', () => {
       });
     });
 
-    it('navigates to home when has convertible tokens but no valid payment token and mUSD is not buyable', async () => {
+    it('falls back to first conversion token when getPaymentTokenForSelectedNetwork returns null', async () => {
       mockUseMusdConversionFlowData.mockReturnValue({
         isGeoEligible: true,
         hasConvertibleTokens: true,
@@ -468,7 +483,7 @@ describe('EarnMusdConversionEducationView', () => {
         isPopularNetworksFilterActive: false,
         selectedChainId: null,
         selectedChains: [],
-        conversionTokens: [mockConversionToken],
+        conversionTokens: [mockConversionTokenHighBalance, mockConversionToken],
         isMusdBuyableOnChain: {},
         isMusdBuyableOnAnyChain: false,
       });
@@ -487,6 +502,91 @@ describe('EarnMusdConversionEducationView', () => {
       });
 
       await waitFor(() => {
+        expect(mockInitiateConversion).toHaveBeenCalledWith({
+          preferredPaymentToken: {
+            address: mockConversionTokenHighBalance.address,
+            chainId: mockConversionTokenHighBalance.chainId,
+          },
+          skipEducationCheck: true,
+          navigationOverride: MUSD_CONVERSION_NAVIGATION_OVERRIDE.QUICK_CONVERT,
+        });
+      });
+    });
+
+    it('falls through to buy when first conversion token has no chainId', async () => {
+      const mockGoToBuy = jest.fn();
+      mockUseRampNavigation.mockReturnValue({
+        goToBuy: mockGoToBuy,
+        goToAggregator: mockGoToAggregator,
+        goToSell: jest.fn(),
+        goToDeposit: jest.fn(),
+      });
+
+      mockUseMusdConversionFlowData.mockReturnValue({
+        isGeoEligible: true,
+        hasConvertibleTokens: true,
+        isEmptyWallet: false,
+        getPaymentTokenForSelectedNetwork: jest.fn().mockReturnValue(null),
+        getChainIdForBuyFlow: mockGetChainIdForBuyFlow,
+        isMusdBuyable: true,
+        isPopularNetworksFilterActive: false,
+        selectedChainId: null,
+        selectedChains: [],
+        conversionTokens: [{ ...mockConversionToken, chainId: undefined }],
+        isMusdBuyableOnChain: {},
+        isMusdBuyableOnAnyChain: false,
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <EarnMusdConversionEducationView />,
+        { state: {} },
+      );
+
+      await act(async () => {
+        fireEvent.press(
+          getByTestId(
+            EARN_TEST_IDS.MUSD.CONVERSION_EDUCATION_VIEW.PRIMARY_BUTTON,
+          ),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockInitiateConversion).not.toHaveBeenCalled();
+        expect(mockGoToBuy).toHaveBeenCalled();
+      });
+    });
+
+    it('falls through to navigate_home when first token invalid and mUSD not buyable', async () => {
+      mockUseMusdConversionFlowData.mockReturnValue({
+        isGeoEligible: true,
+        hasConvertibleTokens: true,
+        isEmptyWallet: false,
+        getPaymentTokenForSelectedNetwork: jest.fn().mockReturnValue(null),
+        getChainIdForBuyFlow: mockGetChainIdForBuyFlow,
+        isMusdBuyable: false,
+        isPopularNetworksFilterActive: false,
+        selectedChainId: null,
+        selectedChains: [],
+        conversionTokens: [{ ...mockConversionToken, chainId: undefined }],
+        isMusdBuyableOnChain: {},
+        isMusdBuyableOnAnyChain: false,
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <EarnMusdConversionEducationView />,
+        { state: {} },
+      );
+
+      await act(async () => {
+        fireEvent.press(
+          getByTestId(
+            EARN_TEST_IDS.MUSD.CONVERSION_EDUCATION_VIEW.PRIMARY_BUTTON,
+          ),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockInitiateConversion).not.toHaveBeenCalled();
         expect(mockNavigation.navigate).toHaveBeenCalledWith(
           Routes.WALLET.HOME,
           {

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -41,6 +41,8 @@ import { EARN_TEST_IDS } from '../../constants/testIds';
 import AppConstants from '../../../../../core/AppConstants';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../types/musd.types';
 import { selectMusdQuickConvertEnabledFlag } from '../../selectors/featureFlags';
+import { toChecksumAddress } from '../../../../../util/address';
+import { safeFormatChainIdToHex } from '../../../Card/util/safeFormatChainIdToHex';
 interface EarnMusdConversionEducationViewRouteParams {
   /**
    * Indicates if this navigation originated from a deeplink
@@ -81,6 +83,7 @@ const EarnMusdConversionEducationView = () => {
     getPaymentTokenForSelectedNetwork,
     getChainIdForBuyFlow,
     isMusdBuyable,
+    conversionTokens,
   } = useMusdConversionFlowData();
 
   const { styles } = useStyles(styleSheet, {});
@@ -106,7 +109,18 @@ const EarnMusdConversionEducationView = () => {
 
     // Try conversion flow if user has convertible tokens
     if (hasConvertibleTokens) {
-      const paymentToken = getPaymentTokenForSelectedNetwork();
+      const fallbackToken = conversionTokens[0];
+      const fallbackChainIdHex = fallbackToken?.chainId
+        ? safeFormatChainIdToHex(fallbackToken.chainId)
+        : null;
+      const paymentToken =
+        getPaymentTokenForSelectedNetwork() ??
+        (fallbackToken?.address && fallbackChainIdHex?.startsWith('0x')
+          ? {
+              address: toChecksumAddress(fallbackToken.address) as Hex,
+              chainId: fallbackChainIdHex as Hex,
+            }
+          : null);
       if (paymentToken) {
         return {
           action: 'convert' as const,
@@ -131,6 +145,7 @@ const EarnMusdConversionEducationView = () => {
     getPaymentTokenForSelectedNetwork,
     getChainIdForBuyFlow,
     isMusdBuyable,
+    conversionTokens,
   ]);
 
   const primaryButtonText = useMemo(() => {

--- a/app/components/UI/Earn/hooks/useMusdConversionTokens.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionTokens.test.ts
@@ -191,6 +191,23 @@ describe('useMusdConversionTokens', () => {
       expect(result.current.tokens).not.toContainEqual(mockDaiMainnet);
     });
 
+    it('returns tokens sorted by fiat balance descending', () => {
+      mockUseAccountTokens.mockReturnValue([
+        mockUsdcLinea,
+        mockUsdcMainnet,
+        mockUsdtMainnet,
+      ]);
+      mockIsTokenAllowed.mockReturnValue(true);
+
+      const { result } = renderHook(() => useMusdConversionTokens());
+
+      expect(result.current.tokens).toEqual([
+        mockUsdtMainnet,
+        mockUsdcMainnet,
+        mockUsdcLinea,
+      ]);
+    });
+
     it('returns empty array when no tokens match allowlist', () => {
       mockUseAccountTokens.mockReturnValue([mockDaiMainnet]);
       mockIsTokenAllowed.mockReturnValue(false);

--- a/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
@@ -87,9 +87,12 @@ export const useMusdConversionTokens = () => {
     [filterTokensWithAllowlistAndBlocklist, filterTokensWithMinBalance],
   );
 
-  // Allowed tokens for conversion.
+  // Allowed tokens for conversion, sorted by fiat balance descending.
   const conversionTokens = useMemo(
-    () => filterAllowedTokens(allTokens),
+    () =>
+      filterAllowedTokens(allTokens).sort(
+        (a, b) => (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0),
+      ),
     [allTokens, filterAllowedTokens],
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user opens the mUSD conversion education screen via deeplink, the component calls getPaymentTokenForSelectedNetwork() to determine which token to convert. If the user hasn't selected a specific network (e.g., using the "Popular networks" filter), this function can return null — causing the flow to skip conversion entirely and fall through to the buy or navigate-home paths, even though the user has convertible tokens.

This fix adds a fallback: when getPaymentTokenForSelectedNetwork() returns null but conversionTokens is non-empty (guarded by the hasConvertibleTokens check), the component defaults to the first available conversion token. This ensures deeplink users are always routed to the conversion flow when they have eligible tokens.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: n/a

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-496

## **Manual testing steps**

```gherkin
Feature: mUSD Deeplink Conversion Fallback

  Background:
    Given the user has convertible stablecoin tokens in their wallet
    And the user goes through deeplink flow  `xcrun simctl openurl booted "metamask://earn-musd"`

  Scenario: Deeplink converts using first available token when no network-specific token exists
    Given the user has not selected a specific network filter
    And getPaymentTokenForSelectedNetwork returns null
    When the user opens the mUSD conversion deeplink
    And the education screen is displayed
    And the user presses the primary "Get Started" button
    Then the conversion flow initiates with the first convertible token
    And the education screen is marked as seen

  Scenario: Deeplink converts using network-specific token when available
    Given the user has selected a specific network
    And getPaymentTokenForSelectedNetwork returns a valid token
    When the user opens the mUSD conversion deeplink
    And the education screen is displayed
    And the user presses the primary "Get Started" button
    Then the conversion flow initiates with the network-specific token
    And the education screen is marked as seen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://consensys.slack.com/files/U06EZC2Q81X/F0AKSVBC51P/screenrecording_03-09-2026_10-22-25_1.mp4

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/4adb4590-20e1-4555-b652-201edff1d8c1

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deeplink routing to auto-select a fallback conversion token and alters conversion-token ordering, which can affect which asset is preselected/converted for users in edge cases. Scope is limited to mUSD conversion entry flow and covered by added tests, but impacts user-facing navigation/selection logic.
> 
> **Overview**
> **mUSD deeplink conversion now falls back to a wallet token instead of skipping conversion.** When `getPaymentTokenForSelectedNetwork()` returns `null`, the education deeplink flow uses the first `conversionTokens` entry (validated/normalized via `safeFormatChainIdToHex` + `toChecksumAddress`) to proceed with `convert` rather than falling through to *buy* or *home*.
> 
> **Conversion token ordering is updated.** `useMusdConversionTokens` now sorts eligible conversion tokens by descending fiat balance so the fallback token is deterministically the highest-value option.
> 
> **Tests updated/added** to cover the fallback conversion behavior and the buy/home fall-through when the fallback token is invalid (e.g., missing `chainId`), plus token sorting by fiat balance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a5c5da7d9b698341c9473e291c434df99365000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->