### PR TITLE
fix(homepage): revert perps position row to PerpsCard component

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -286,7 +286,7 @@ describe('PerpsSection', () => {
     expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
   });
 
-  it('renders live positions', () => {
+  it('renders live positions with leverage info', () => {
     usePerpsLivePositions.mockReturnValue({
       positions: [
         makePosition({ symbol: 'BTC', size: '-0.0015' }),
@@ -294,27 +294,6 @@ describe('PerpsSection', () => {
           symbol: 'ETH',
           size: '0.03',
           entryPrice: '3200',
-          leverage: { type: 'isolated', value: 40 },
-        }),
-      ],
-      isInitialLoading: false,
-    });
-
-    renderWithProvider(
-      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
-    );
-
-    expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
-    expect(screen.getByText('ETH 40X position')).toBeOnTheScreen();
-  });
-
-  it('renders position rows with leverage info', () => {
-    usePerpsLivePositions.mockReturnValue({
-      positions: [
-        makePosition({ symbol: 'BTC', size: '-1' }),
-        makePosition({
-          symbol: 'ETH',
-          size: '1',
           leverage: { type: 'isolated', value: 40 },
         }),
       ],

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { screen, fireEvent, act } from '@testing-library/react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import PerpsSection, { positionDisplayKey } from './PerpsSection';
+import PerpsSection from './PerpsSection';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
 import {
@@ -85,16 +85,26 @@ jest.mock('../../../../UI/Perps/components/PerpsCard', () => {
   return {
     __esModule: true,
     default: ({
+      position,
       order,
       testID,
     }: {
-      order: { symbol: string; side: string; orderId: string };
-      testID: string;
+      position?: { symbol: string; leverage?: { type: string; value: number } };
+      order?: { symbol: string; side: string; orderId: string };
+      testID?: string;
     }) => (
       <TouchableOpacity testID={testID}>
-        <Text>
-          {order.symbol} {order.side === 'buy' ? 'long' : 'short'} order
-        </Text>
+        {position && (
+          <Text>
+            {position.symbol}{' '}
+            {position.leverage ? `${position.leverage.value}X` : ''} position
+          </Text>
+        )}
+        {order && (
+          <Text>
+            {order.symbol} {order.side === 'buy' ? 'long' : 'short'} order
+          </Text>
+        )}
       </TouchableOpacity>
     ),
   };
@@ -246,73 +256,6 @@ jest.mock('../../hooks/useHomeViewedEvent', () => ({
   },
 }));
 
-describe('positionDisplayKey', () => {
-  it('returns stable key from position display fields', () => {
-    const position = makePosition({
-      symbol: 'BTC',
-      entryPrice: '98500',
-      size: '-0.0015',
-      unrealizedPnl: '9.4',
-      takeProfitPrice: undefined,
-      stopLossPrice: undefined,
-    }) as Parameters<typeof positionDisplayKey>[0];
-    expect(positionDisplayKey(position)).toBe('BTC:98500:-0.0015:9.4::');
-  });
-
-  it('uses empty string for undefined optional fields', () => {
-    const position = makePosition({
-      symbol: 'ETH',
-      entryPrice: undefined,
-      size: '1',
-      unrealizedPnl: undefined,
-      takeProfitPrice: undefined,
-      stopLossPrice: undefined,
-    }) as Parameters<typeof positionDisplayKey>[0];
-    expect(positionDisplayKey(position)).toBe('ETH::1:::');
-  });
-
-  it('includes takeProfitPrice and stopLossPrice when set', () => {
-    const position = makePosition({
-      symbol: 'SOL',
-      entryPrice: '180',
-      size: '10',
-      unrealizedPnl: '-5',
-      takeProfitPrice: '200',
-      stopLossPrice: '160',
-    }) as Parameters<typeof positionDisplayKey>[0];
-    expect(positionDisplayKey(position)).toBe('SOL:180:10:-5:200:160');
-  });
-
-  it('returns different keys when display-relevant fields differ', () => {
-    const base = makePosition({ symbol: 'BTC' }) as Parameters<
-      typeof positionDisplayKey
-    >[0];
-    const withPnl = makePosition({
-      symbol: 'BTC',
-      unrealizedPnl: '100',
-    }) as Parameters<typeof positionDisplayKey>[0];
-    expect(positionDisplayKey(base)).not.toBe(positionDisplayKey(withPnl));
-  });
-
-  it('returns same key when only non-display fields differ', () => {
-    const a = makePosition({
-      symbol: 'BTC',
-      entryPrice: '50000',
-      size: '1',
-      unrealizedPnl: '100',
-      positionValue: '50000',
-    }) as Parameters<typeof positionDisplayKey>[0];
-    const b = makePosition({
-      symbol: 'BTC',
-      entryPrice: '50000',
-      size: '1',
-      unrealizedPnl: '100',
-      positionValue: '99999',
-    }) as Parameters<typeof positionDisplayKey>[0];
-    expect(positionDisplayKey(a)).toBe(positionDisplayKey(b));
-  });
-});
-
 describe('PerpsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -350,8 +293,6 @@ describe('PerpsSection', () => {
           size: '0.03',
           entryPrice: '3200',
           leverage: { type: 'isolated', value: 40 },
-          takeProfitPrice: '3680',
-          stopLossPrice: '2720',
         }),
       ],
       isInitialLoading: false,
@@ -361,11 +302,11 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(screen.getByText('Short BTC')).toBeOnTheScreen();
-    expect(screen.getByText('Long ETH')).toBeOnTheScreen();
+    expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('ETH 40X position')).toBeOnTheScreen();
   });
 
-  it('shows leverage badges', () => {
+  it('renders position rows with leverage info', () => {
     usePerpsLivePositions.mockReturnValue({
       positions: [
         makePosition({ symbol: 'BTC', size: '-1' }),
@@ -382,75 +323,11 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(screen.getByText('10X short')).toBeOnTheScreen();
-    expect(screen.getByText('40X long')).toBeOnTheScreen();
+    expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('ETH 40X position')).toBeOnTheScreen();
   });
 
-  it('shows TP/SL immediately when any position has TP/SL data', () => {
-    usePerpsLivePositions.mockReturnValue({
-      positions: [
-        makePosition({ symbol: 'BTC' }),
-        makePosition({
-          symbol: 'ETH',
-          size: '0.03',
-          entryPrice: '3200',
-          takeProfitPrice: '3680',
-          stopLossPrice: '2720',
-        }),
-      ],
-      isInitialLoading: false,
-    });
-
-    renderWithProvider(
-      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
-    );
-
-    expect(screen.getByText('TP 15%, SL 15%')).toBeOnTheScreen();
-    expect(screen.getByText('No TP/SL')).toBeOnTheScreen();
-    expect(screen.queryByTestId('tp-sl-skeleton')).toBeNull();
-  });
-
-  it('shows TP/SL skeleton when no position has TP/SL data yet', () => {
-    usePerpsLivePositions.mockReturnValue({
-      positions: [makePosition({ symbol: 'BTC' })],
-      isInitialLoading: false,
-    });
-
-    renderWithProvider(
-      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
-    );
-
-    expect(screen.getByTestId('tp-sl-skeleton')).toBeOnTheScreen();
-    expect(screen.queryByText('No TP/SL')).toBeNull();
-  });
-
-  it('shows "No TP/SL" after fallback timeout settles', () => {
-    jest.useFakeTimers();
-
-    try {
-      usePerpsLivePositions.mockReturnValue({
-        positions: [makePosition({ symbol: 'BTC' })],
-        isInitialLoading: false,
-      });
-
-      renderWithProvider(
-        <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
-      );
-
-      expect(screen.getByTestId('tp-sl-skeleton')).toBeOnTheScreen();
-
-      act(() => {
-        jest.advanceTimersByTime(5500);
-      });
-
-      expect(screen.getByText('No TP/SL')).toBeOnTheScreen();
-      expect(screen.queryByTestId('tp-sl-skeleton')).toBeNull();
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('shows position value and ROE', () => {
+  it('renders multiple position rows', () => {
     usePerpsLivePositions.mockReturnValue({
       positions: [
         makePosition(),
@@ -463,8 +340,8 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    const roeElements = screen.getAllByText('+9.40%');
-    expect(roeElements.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('ETH 10X position')).toBeOnTheScreen();
   });
 
   it('navigates to perps home on title press with home_section source', () => {
@@ -584,12 +461,12 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(screen.getByText('Short BTC')).toBeOnTheScreen();
-    expect(screen.getByText('Long ETH')).toBeOnTheScreen();
-    expect(screen.getByText('Long SOL')).toBeOnTheScreen();
-    expect(screen.getByText('Short DOGE')).toBeOnTheScreen();
-    expect(screen.getByText('Long AVAX')).toBeOnTheScreen();
-    expect(screen.queryByText('Long LINK')).toBeNull();
+    expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('ETH 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('SOL 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('DOGE 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('AVAX 10X position')).toBeOnTheScreen();
+    expect(screen.queryByText('LINK 10X position')).toBeNull();
     expect(screen.queryByTestId('perps-order-row-order-1')).toBeNull();
   });
 
@@ -613,8 +490,8 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(screen.getByText('Short BTC')).toBeOnTheScreen();
-    expect(screen.getByText('Long ETH')).toBeOnTheScreen();
+    expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
+    expect(screen.getByText('ETH 10X position')).toBeOnTheScreen();
     expect(screen.getByTestId('perps-order-row-o1')).toBeOnTheScreen();
     expect(screen.getByTestId('perps-order-row-o2')).toBeOnTheScreen();
   });

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -87,13 +87,15 @@ jest.mock('../../../../UI/Perps/components/PerpsCard', () => {
     default: ({
       position,
       order,
+      onPress,
       testID,
     }: {
       position?: { symbol: string; leverage?: { type: string; value: number } };
       order?: { symbol: string; side: string; orderId: string };
+      onPress?: () => void;
       testID?: string;
     }) => (
-      <TouchableOpacity testID={testID}>
+      <TouchableOpacity testID={testID} onPress={onPress}>
         {position && (
           <Text>
             {position.symbol}{' '}

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -33,7 +33,6 @@ import { usePerpsConnection } from '../../../../UI/Perps/hooks/usePerpsConnectio
 import { filterAndSortMarkets } from '../../../../UI/Perps/utils/filterAndSortMarkets';
 import { selectPerpsWatchlistMarkets } from '../../../../UI/Perps/selectors/perpsController';
 import type { PerpsNavigationParamList } from '../../../../UI/Perps/types/navigation';
-import PerpsPositionCard from '../../../../UI/Perps/components/PerpsPositionCard/PerpsPositionCard';
 import PerpsCard from '../../../../UI/Perps/components/PerpsCard';
 import PerpsPositionSkeleton from './components/PerpsPositionSkeleton';
 import PerpsMarketTileCard from './components/PerpsMarketTileCard';
@@ -51,41 +50,6 @@ import type { PerpsSectionProps } from './PerpsSectionWithProvider';
 const MAX_ITEMS = 5;
 const MAX_TRENDING_MARKETS = 5;
 const HOMEPAGE_THROTTLE_MS = 5000;
-
-/** Key fields that affect position card display; skip re-render if unchanged. Exported for testing. */
-export function positionDisplayKey(p: Position): string {
-  return `${p.symbol}:${p.entryPrice ?? ''}:${p.size ?? ''}:${p.unrealizedPnl ?? ''}:${p.takeProfitPrice ?? ''}:${p.stopLossPrice ?? ''}`;
-}
-
-/**
- * Memoized row so only the position card whose data changed re-renders on stream updates.
- */
-const PositionCardItem = React.memo<{
-  position: Position;
-  tpSlLoading: boolean;
-  onPositionPress: (position: Position) => void;
-}>(
-  ({ position, tpSlLoading, onPositionPress }) => {
-    const handlePress = useCallback(
-      () => onPositionPress(position),
-      [onPositionPress, position],
-    );
-    return (
-      <PerpsPositionCard
-        position={position}
-        compact
-        compactVariant="position"
-        tpSlLoading={tpSlLoading}
-        onPress={handlePress}
-        testID={`perps-position-row-${position.symbol}`}
-      />
-    );
-  },
-  (prev, next) =>
-    prev.tpSlLoading === next.tpSlLoading &&
-    prev.onPositionPress === next.onPositionPress &&
-    positionDisplayKey(prev.position) === positionDisplayKey(next.position),
-);
 
 /**
  * PerpsSection — single "Perpetuals" section on the homepage.
@@ -129,36 +93,6 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     }, [hookLoading]);
 
     const showSkeleton = hookLoading || deferredLoading;
-
-    // TP/SL is extracted from orders and merged into positions by the
-    // subscription service. Due to the 5s throttle the merged update can be
-    // delayed — positions appear first without TP/SL. If any position already
-    // has TP/SL the merge is done for all of them; otherwise wait for a
-    // fallback timeout (throttle interval + margin).
-    const anyPositionHasTpSl = useMemo(
-      () =>
-        positions.some(
-          (p) => p.takeProfitPrice != null || p.stopLossPrice != null,
-        ),
-      [positions],
-    );
-
-    const [tpSlSettled, setTpSlSettled] = useState(false);
-
-    useEffect(() => {
-      if (showSkeleton) {
-        setTpSlSettled(false);
-        return undefined;
-      }
-      if (anyPositionHasTpSl) return undefined;
-      const timer = setTimeout(
-        () => setTpSlSettled(true),
-        HOMEPAGE_THROTTLE_MS + 500,
-      );
-      return () => clearTimeout(timer);
-    }, [showSkeleton, anyPositionHasTpSl]);
-
-    const tpSlReady = anyPositionHasTpSl || tpSlSettled;
 
     const { markets, isLoading: marketsLoading } = usePerpsMarkets();
     const watchlistSymbols = useSelector(selectPerpsWatchlistMarkets);
@@ -334,11 +268,11 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
             <SectionRow>
               <Box testID="homepage-perps-positions">
                 {displayPositions.map((position) => (
-                  <PositionCardItem
+                  <PerpsCard
                     key={position.symbol}
                     position={position}
-                    tpSlLoading={!tpSlReady}
-                    onPositionPress={handlePositionPress}
+                    onPress={() => handlePositionPress(position)}
+                    testID={`perps-position-row-${position.symbol}`}
                   />
                 ))}
                 {displayOrders.map((order) => (


### PR DESCRIPTION
## **Description**

Replace `PerpsPositionCard` (compact position variant with TP/SL and ROE) with the simpler `PerpsCard` component for rendering position rows in the homepage Perps section, matching the pre-homepage-sections tab UI behavior.

Changes:
- Replace `PositionCardItem` (memoized `PerpsPositionCard` wrapper) with `PerpsCard` for position rows
- Remove `positionDisplayKey` helper function (only needed for the custom memo comparator)
- Remove TP/SL loading state logic (`anyPositionHasTpSl`, `tpSlSettled`, `tpSlReady`) which was only relevant for `PerpsPositionCard`'s compact position variant
- Update `PerpsCard` mock in tests to handle both `position` and `order` props
- Remove `positionDisplayKey` unit tests and TP/SL-specific tests

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [TMCU-523](https://consensyssoftware.atlassian.net/browse/TMCU-523)

## **Manual testing steps**

```gherkin
Feature: Perps position row on homepage

  Scenario: user views open perps positions on the homepage
    Given the user has open perps positions
    And the homepage Perps section is visible

    When user views the position rows
    Then the rows display the old/simple PerpsCard format (icon, symbol/leverage + size, value + PnL)
    And the rows do not show TP/SL info or ROE

  Scenario: user taps a position row
    Given the user has open perps positions on the homepage

    When user taps a position row
    Then the app navigates to the market details for that position
```

## **Screenshots/Recordings**

### **Before**


<img width="300" alt="perps_row_before" src="https://github.com/user-attachments/assets/3538094a-8d96-4f57-ad8e-58f424b2ed7e" />


### **After**

<img width="300" alt="perps_row_after" src="https://github.com/user-attachments/assets/e4aa46d7-a6be-45e6-80ac-6204ff247246" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor in the homepage Perps section that changes which component renders position rows and removes TP/SL-related loading behavior; main risk is minor display/regression or performance differences during live updates.
> 
> **Overview**
> **Homepage Perps position rows are reverted to the simpler `PerpsCard` UI.** The section no longer uses the memoized `PerpsPositionCard` wrapper (and its `positionDisplayKey` comparator), so position rows stop showing TP/SL/ROE-specific behavior and related loading states.
> 
> Tests were updated to match the new rendering: the `PerpsCard` mock now supports both `position` and `order` rows with `onPress`, and TP/SL/key-stability assertions were removed/rewritten to validate the simpler position-row output and leverage display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 811fabeadc5af8b6c5b16dd3277caffd9c3e5501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->