### PR TITLE
feat(ramps):  Add error_code in RAMPS_TRANSACTION_FAILED and RAMPS_ORDER_FAILED analysis

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
@@ -915,11 +915,65 @@ describe('BuildQuote Component', () => {
           currency_destination_symbol: MOCK_USDC_TOKEN.symbol,
           currency_destination_network: 'Ethereum',
           currency_source: MOCK_US_REGION.currency,
-          error_message: 'BuildQuote - Error handling authentication',
+          error_message: 'Routing failed',
+          error_code: undefined,
           is_authenticated: true,
         });
       });
     });
+
+    it('tracks RAMPS_ORDER_FAILED with error_code when routeAfterAuthentication throws Axios error', async () => {
+      const mockQuote = {
+        quoteId: 'test-quote',
+        fiatAmount: 100,
+        cryptoAmount: 0.05,
+        paymentMethod: 'credit_debit_card',
+        fiatCurrency: 'USD',
+      } as BuyQuote;
+
+      mockUseDepositSDK.mockReturnValue(
+        createMockSDKReturn({ isAuthenticated: true }),
+      );
+      mockGetQuote.mockResolvedValue(mockQuote);
+
+      const axiosError = {
+        response: {
+          data: {
+            error: {
+              errorCode: 4002,
+              message: 'KYC required',
+            },
+          },
+        },
+      };
+      mockRouteAfterAuthentication.mockRejectedValue(axiosError);
+
+      render(BuildQuote);
+
+      const continueButton = screen.getByText('Continue');
+      await act(async () => {
+        fireEvent.press(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_ORDER_FAILED', {
+          ramp_type: 'DEPOSIT',
+          amount_source: 100,
+          amount_destination: 0.05,
+          payment_method_id: MOCK_CREDIT_DEBIT_CARD.id,
+          region: MOCK_US_REGION.isoCode,
+          chain_id: MOCK_USDC_TOKEN.chainId,
+          currency_destination: MOCK_USDC_TOKEN.assetId,
+          currency_destination_symbol: MOCK_USDC_TOKEN.symbol,
+          currency_destination_network: 'Ethereum',
+          currency_source: MOCK_US_REGION.currency,
+          error_message: 'KYC required',
+          error_code: '4002',
+          is_authenticated: true,
+        });
+      });
+    });
+
     it('calls handleOnPressContinue when shouldRouteImmediately is true', async () => {
       const mockQuote = { quoteId: 'test-quote' } as BuyQuote;
 

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -358,6 +358,13 @@ const BuildQuote = () => {
         'Deposit::BuildQuote - Error handling authentication',
       );
 
+      const axiosError = routeError as {
+        response?: {
+          data?: { error?: { errorCode?: number; message?: string } };
+        };
+      };
+      const errorCode = axiosError?.response?.data?.error?.errorCode;
+
       trackEvent('RAMPS_ORDER_FAILED', {
         ramp_type: 'DEPOSIT',
         amount_source: quote?.fiatAmount || amountAsNumber,
@@ -371,7 +378,12 @@ const BuildQuote = () => {
           selectedCryptoCurrency?.chainId,
         ),
         currency_source: selectedRegion?.currency || '',
-        error_message: 'BuildQuote - Error handling authentication',
+        error_message:
+          axiosError?.response?.data?.error?.message ||
+          (routeError instanceof Error
+            ? routeError.message
+            : 'BuildQuote - Error handling authentication'),
+        error_code: errorCode != null ? String(errorCode) : undefined,
         is_authenticated: isAuthenticated,
       });
 

--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts
@@ -492,11 +492,7 @@ export const useDepositRouting = (config?: UseDepositRoutingConfig) => {
               }
               return true;
             } catch (error) {
-              throw new Error(
-                error instanceof Error && error.message
-                  ? error.message
-                  : 'Failed to process KYC flow',
-              );
+              throw error;
             }
           }
 

--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -215,6 +215,7 @@ interface RampsTransactionFailed {
   currency_destination_network?: string;
   currency_source: string;
   error_message: string;
+  error_code?: string;
   provider_onramp: string;
 }
 

--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -104,6 +104,7 @@ interface RampsOrderFailed {
   currency_destination_network?: string;
   currency_source: string;
   error_message: string;
+  error_code?: string;
   is_authenticated: boolean;
 }
 

--- a/app/components/UI/Ramp/Deposit/utils/getDepositAnalyticsPayload.test.ts
+++ b/app/components/UI/Ramp/Deposit/utils/getDepositAnalyticsPayload.test.ts
@@ -79,8 +79,34 @@ describe('getDepositAnalyticsPayload', () => {
       currency_destination_network: 'Ethereum',
       currency_source: 'USD',
       error_message: 'Payment failed',
+      error_code: undefined,
       provider_onramp: 'TRANSAK',
     });
+  });
+
+  it('returns correct parameters for failed deposit order with error code', () => {
+    const failedOrder = {
+      ...mockDepositOrder,
+      state: FIAT_ORDER_STATES.FAILED,
+      data: {
+        ...mockDepositOrder.data,
+        statusDescription: 'Order already exists',
+        errorCode: '4005',
+      },
+    };
+
+    const [eventName, params] = getDepositAnalyticsPayload(
+      failedOrder as unknown as FiatOrder,
+      MOCK_ROOT_STATE,
+    );
+
+    expect(eventName).toBe('RAMPS_TRANSACTION_FAILED');
+    expect(params).toEqual(
+      expect.objectContaining({
+        error_message: 'Order already exists',
+        error_code: '4005',
+      }),
+    );
   });
 
   it('returns correct parameters for failed deposit order with default error message', () => {
@@ -111,6 +137,7 @@ describe('getDepositAnalyticsPayload', () => {
       currency_destination_network: 'Ethereum',
       currency_source: 'USD',
       error_message: 'transaction_failed',
+      error_code: undefined,
       provider_onramp: 'TRANSAK',
     });
   });

--- a/app/components/UI/Ramp/Deposit/utils/getDepositAnalyticsPayload.ts
+++ b/app/components/UI/Ramp/Deposit/utils/getDepositAnalyticsPayload.ts
@@ -85,6 +85,9 @@ function getDepositAnalyticsPayload(
         processing_fee: order.partnerFees ? Number(order.partnerFees) : 0,
         total_fee: Number(order.totalFeesFiat),
         error_message: order.statusDescription || 'transaction_failed',
+        error_code: (order as Record<string, unknown>).errorCode as
+          | string
+          | undefined,
       },
     ];
   }


### PR DESCRIPTION
## **Description**

Adds `error_code` support to the `RAMPS_ORDER_FAILED` and `RAMPS_TRANSACTION_FAILED` analytics events, enabling Transak error codes to flow through to Segment for root-cause analysis of failed deposit orders.

**Why:** Currently, failed deposit orders only log a generic `error_message` like "Something went wrong." By capturing the structured `errorCode` from Transak API error responses (e.g., `4002` for KYC incomplete, `4005` for duplicate order), the ramps team can distinguish specific failure reasons and measure their frequency.

**What changed:**

- Added `error_code?: string` to `RampsOrderFailed` analytics type
- Updated `BuildQuote.tsx` to extract `errorCode` from Axios error responses and include it as `error_code` in the `RAMPS_ORDER_FAILED` event
- Updated `BuildQuote.tsx` to use the actual error message from the API response instead of a generic fallback
- Changed `useDepositRouting.ts` to re-throw the original error (instead of wrapping in `new Error()`) so Axios error structure (including `errorCode`) is preserved for the caller
- Added `error_code` to `RAMPS_TRANSACTION_FAILED` payload in `getDepositAnalyticsPayload.ts`
- Added/updated unit tests for all changes

**Companion PR:** `@metamask/ramps-controller` adds `errorCode?: string` to `TransakDepositOrder` type so `getOrder()` passes it through for polling-based failures.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [TRAM-3267](https://consensyssoftware.atlassian.net/browse/TRAM-3267)

## **Manual testing steps**

This is an analytics-only change with no UI impact. Verified via unit tests:

```bash
npx jest --no-coverage app/components/UI/Ramp/Deposit/utils/getDepositAnalyticsPayload.test.ts
npx jest --no-coverage app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
npx jest --no-coverage app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
```

**Test coverage:**
- `getDepositAnalyticsPayload.test.ts`: Verifies `error_code` is included in `RAMPS_TRANSACTION_FAILED` payload (with and without `errorCode` on order data)
- `BuildQuote.test.tsx`: Verifies `RAMPS_ORDER_FAILED` event includes `error_code` extracted from Axios error response, and `error_message` uses API error message instead of generic fallback
- `useDepositRouting.test.ts`: Verifies original error is re-thrown (preserving Axios error structure with `errorCode`)

## **Screenshots/Recordings**

N/A — analytics-only change, no UI impact.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.