### PR TITLE
fix(perps): ensure Arbitrum exists before deposit when Long/Short from Asset Details

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '@react-navigation/native';
 import PerpsOrderRedirect from './PerpsOrderRedirect';
 import { usePerpsConnection } from '../hooks/usePerpsConnection';
+import { usePerpsNetworkManagement } from '../hooks/usePerpsNetworkManagement';
 import { usePerpsTrading } from '../hooks/usePerpsTrading';
 import usePerpsToasts from '../hooks/usePerpsToasts';
 import Routes from '../../../../constants/navigation/Routes';
@@ -23,6 +24,10 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('../hooks/usePerpsConnection', () => ({
   usePerpsConnection: jest.fn(),
+}));
+
+jest.mock('../hooks/usePerpsNetworkManagement', () => ({
+  usePerpsNetworkManagement: jest.fn(),
 }));
 
 jest.mock('../hooks/usePerpsTrading', () => ({
@@ -65,12 +70,17 @@ const mockToastOptions = {
 const mockUseNavigation = jest.mocked(useNavigation);
 const mockUseRoute = jest.mocked(useRoute);
 const mockUsePerpsConnection = jest.mocked(usePerpsConnection);
+const mockUsePerpsNetworkManagement = jest.mocked(usePerpsNetworkManagement);
 const mockUsePerpsTrading = jest.mocked(usePerpsTrading);
 const mockUsePerpsToasts = jest.mocked(usePerpsToasts);
+
+const mockEnsureArbitrumNetworkExists = jest.fn();
 
 describe('PerpsOrderRedirect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockEnsureArbitrumNetworkExists.mockResolvedValue(undefined);
 
     mockUseNavigation.mockReturnValue({
       navigate: mockNavigate,
@@ -82,6 +92,10 @@ describe('PerpsOrderRedirect', () => {
       key: 'test',
       name: 'PerpsOrderRedirect',
       params: { direction: 'long', asset: 'ETH' },
+    } as never);
+
+    mockUsePerpsNetworkManagement.mockReturnValue({
+      ensureArbitrumNetworkExists: mockEnsureArbitrumNetworkExists,
     } as never);
 
     mockUsePerpsTrading.mockReturnValue({
@@ -124,6 +138,51 @@ describe('PerpsOrderRedirect', () => {
     render(<PerpsOrderRedirect />);
 
     // Assert
+    expect(mockEnsureArbitrumNetworkExists).not.toHaveBeenCalled();
+    expect(mockDepositWithOrder).not.toHaveBeenCalled();
+  });
+
+  it('calls ensureArbitrumNetworkExists then depositWithOrder when WebSocket is ready', async () => {
+    // Arrange
+    mockUsePerpsConnection.mockReturnValue({
+      isConnected: true,
+      isInitialized: true,
+    } as never);
+
+    mockDepositWithOrder.mockResolvedValue(undefined);
+    (StackActions.replace as jest.Mock).mockReturnValue({ type: 'REPLACE' });
+
+    // Act
+    render(<PerpsOrderRedirect />);
+
+    // Assert - both called (ensure Arbitrum first, then depositWithOrder via promise chain)
+    await waitFor(() => {
+      expect(mockEnsureArbitrumNetworkExists).toHaveBeenCalledTimes(1);
+      expect(mockDepositWithOrder).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows toast and goes back when ensureArbitrumNetworkExists fails', async () => {
+    // Arrange
+    mockUsePerpsConnection.mockReturnValue({
+      isConnected: true,
+      isInitialized: true,
+    } as never);
+
+    mockEnsureArbitrumNetworkExists.mockRejectedValue(
+      new Error('Failed to add network'),
+    );
+
+    // Act
+    render(<PerpsOrderRedirect />);
+
+    // Assert
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        mockToastOptions.accountManagement.oneClickTrade.txCreationFailed,
+      );
+      expect(mockGoBack).toHaveBeenCalled();
+    });
     expect(mockDepositWithOrder).not.toHaveBeenCalled();
   });
 

--- a/app/components/UI/Perps/Views/PerpsOrderRedirect.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderRedirect.tsx
@@ -12,6 +12,7 @@ import {
 } from '@metamask/design-system-react-native';
 import Routes from '../../../../constants/navigation/Routes';
 import { usePerpsConnection } from '../hooks/usePerpsConnection';
+import { usePerpsNetworkManagement } from '../hooks/usePerpsNetworkManagement';
 import { usePerpsTrading } from '../hooks/usePerpsTrading';
 import usePerpsToasts from '../hooks/usePerpsToasts';
 import PerpsLoader from '../components/PerpsLoader';
@@ -29,8 +30,9 @@ type RouteParams = RouteProp<PerpsNavigationParamList, 'PerpsOrderRedirect'>;
  * A redirect screen that handles navigation from Token Details to the Perps order confirmation.
  * This screen:
  * 1. Waits for the WebSocket connection to be established (via PerpsConnectionProvider)
- * 2. Calls depositWithOrder() to create the pending transaction
- * 3. Navigates to the confirmation screen with the transaction ready
+ * 2. Ensures Arbitrum network exists (adds it if missing, same as in-Perps deposit flow)
+ * 3. Calls depositWithOrder() to create the pending transaction
+ * 4. Navigates to the confirmation screen with the transaction ready
  *
  * This is necessary because Token Details is outside the Perps stack, so the WebSocket
  * is not initialized there. By navigating to this screen first, we ensure the WebSocket
@@ -47,6 +49,7 @@ const PerpsOrderRedirect: React.FC = () => {
   } = route.params;
 
   const { isConnected, isInitialized } = usePerpsConnection();
+  const { ensureArbitrumNetworkExists } = usePerpsNetworkManagement();
   const { depositWithOrder } = usePerpsTrading();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
 
@@ -58,12 +61,16 @@ const PerpsOrderRedirect: React.FC = () => {
     if (hasStartedRef.current) return;
     hasStartedRef.current = true;
 
-    Logger.log('[PerpsOrderRedirect] Starting depositWithOrder', {
-      direction,
-      asset,
-    });
+    Logger.log(
+      '[PerpsOrderRedirect] Ensuring Arbitrum network, then starting depositWithOrder',
+      {
+        direction,
+        asset,
+      },
+    );
 
-    depositWithOrder()
+    ensureArbitrumNetworkExists()
+      .then(() => depositWithOrder())
       .then(() => {
         Logger.log(
           '[PerpsOrderRedirect] depositWithOrder resolved, navigating to confirmation',
@@ -102,6 +109,7 @@ const PerpsOrderRedirect: React.FC = () => {
     asset,
     fromTokenDetails,
     assetsASSETS2493AbtestTokenDetailsLayout,
+    ensureArbitrumNetworkExists,
     depositWithOrder,
     navigation,
     showToast,


### PR DESCRIPTION
## Description

When users tap **Long** or **Short** from the Asset Details (Token Details) screen, the app navigates to `PerpsOrderRedirect`, which calls `depositWithOrder()` to create the deposit transaction. If the user does not have the Arbitrum network in their wallet (e.g. fresh install or certain builds), `PerpsController.depositWithConfirmation` throws because `#findNetworkClientIdForChain(assetChainId)` returns `null`, and the user sees the generic **"Transaction creation failed. Please try again."** toast.

The in-Perps flows (Add funds from Perps home, Perps balance in pay-with) already call `ensureArbitrumNetworkExists()` from `usePerpsNetworkManagement` before creating the deposit, so Arbitrum is added when missing. The one-click Long/Short path from Token Details did not, so it could fail for users without Arbitrum.

This PR adds the same **ensure Arbitrum** step in `PerpsOrderRedirect`: before calling `depositWithOrder()`, we call `ensureArbitrumNetworkExists()`. If Arbitrum is missing, it is added and enabled; then the deposit tx is created. On failure of either step, the existing toast and go-back behavior is unchanged.

**Changes:**
- `PerpsOrderRedirect`: use `usePerpsNetworkManagement`, call `ensureArbitrumNetworkExists()` then `depositWithOrder()` in the effect.
- Tests: mock `usePerpsNetworkManagement`, add tests for "ensure then deposit" and for "toast + go back when ensure fails".

---

## Changelog

CHANGELOG entry: Long/Short from Asset Details now ensures Arbitrum network exists (adds it if missing) before creating the deposit transaction, fixing "Transaction creation failed" when the user has no Arbitrum network (#26756)

---

## Related issues

Fixes: #26756 – Asset Details: Cannot Short/Long from the Asset Details page, getting "Transaction creation failed. Please try again."

---

## Manual testing steps

**Feature:** Perps one-click Long/Short from Asset Details

**Scenario:** User taps Long or Short from Token Details when Arbitrum is not in the network list
- **Given:** Perps enabled, Token Details V2 layout (treatment) so Long/Short are visible, and Arbitrum One removed from Settings → Networks (or use a profile that never had Arbitrum).
- **When:** User opens Token Details for a perps asset (e.g. ETH) and taps **Long** or **Short**.
- **Then:** App shows "Preparing order…", adds Arbitrum if missing, creates the deposit tx, and navigates to the confirmation screen (no "Transaction creation failed" toast).

**Scenario:** User taps Long or Short when Arbitrum is already present
- **Given:** Arbitrum One is in the network list.
- **When:** User opens Token Details for a perps asset and taps **Long** or **Short**.
- **Then:** Flow proceeds to confirmation as before (no regression).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the perps one-click Long/Short initiation flow to add/enable a network before creating a deposit transaction, which could affect order startup timing and error paths. Scope is limited to `PerpsOrderRedirect` and is covered by added unit tests for success and failure cases.
> 
> **Overview**
> Fixes the Token Details Long/Short redirect flow by **ensuring the Arbitrum network is present/enabled** via `ensureArbitrumNetworkExists()` before calling `depositWithOrder()` in `PerpsOrderRedirect`.
> 
> Updates tests to mock `usePerpsNetworkManagement` and to assert the new call order (ensure → deposit), plus verify toast + `goBack` behavior when the network ensure step fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5938c6f302dd79371ccac1e5c91d5f802fffb584. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->