### PR TITLE
fix: show build type and branch name on About MetaMask for non-production builds

### DIFF
--- a/app/components/Views/Settings/AppInformation/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/AppInformation/__snapshots__/index.test.tsx.snap
@@ -424,7 +424,7 @@ exports[`AppInformation renders correctly with snapshot 1`] = `
                                 }
                               }
                             >
-                              Branch: undefined
+                               | Branch: undefined
                             </Text>
                           </View>
                           <Text

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -32,7 +32,7 @@ import AppConstants from '../../../../core/AppConstants';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import { AboutMetaMaskSelectorsIDs } from './AboutMetaMask.testIds';
-import { isQa } from '../../../../util/test/utils';
+import { isProduction } from '../../../../util/environment';
 import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
@@ -227,7 +227,7 @@ class AppInformation extends PureComponent {
               />
             </TouchableOpacity>
             <Text style={styles.versionInfo}>{this.getVersionDisplay()}</Text>
-            {isQa ? (
+            {!isProduction() ? (
               <Text style={styles.branchInfo}>
                 {`Branch: ${process.env['GIT_BRANCH']}`}
               </Text>

--- a/app/components/Views/Settings/AppInformation/index.js
+++ b/app/components/Views/Settings/AppInformation/index.js
@@ -229,7 +229,7 @@ class AppInformation extends PureComponent {
             <Text style={styles.versionInfo}>{this.getVersionDisplay()}</Text>
             {!isProduction() ? (
               <Text style={styles.branchInfo}>
-                {`Branch: ${process.env['GIT_BRANCH']}`}
+                {`${(process.env.METAMASK_ENVIRONMENT || '').toUpperCase()} | Branch: ${process.env['GIT_BRANCH']}`}
               </Text>
             ) : null}
 

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -21,10 +21,10 @@ jest.mock('react-native-device-info', () => ({
   getBuildNumber: () => mockGetBuildNumber(),
 }));
 
-// Mock isQa utility
-const mockIsQa = jest.fn();
-jest.mock('../../../../util/test/utils', () => ({
-  isQa: () => mockIsQa(),
+// Mock isProduction utility
+const mockIsProduction = jest.fn();
+jest.mock('../../../../util/environment', () => ({
+  isProduction: () => mockIsProduction(),
 }));
 
 // Mock getFeatureFlagAppEnvironment and getFeatureFlagAppDistribution
@@ -70,7 +70,7 @@ describe('AppInformation', () => {
     mockGetApplicationName.mockResolvedValue('MetaMask');
     mockGetVersion.mockResolvedValue('7.0.0');
     mockGetBuildNumber.mockResolvedValue('1000');
-    mockIsQa.mockReturnValue(false);
+    mockIsProduction.mockReturnValue(false);
     mockGetFeatureFlagAppEnvironment.mockReturnValue('Development');
     mockGetFeatureFlagAppDistribution.mockReturnValue('main');
   });
@@ -324,10 +324,10 @@ describe('AppInformation', () => {
       });
     });
 
-    it('displays branch information when isQa is true', async () => {
-      // Given isQa returns true
+    it('displays branch information for non-production builds', async () => {
+      // Given isProduction returns false
       process.env.GIT_BRANCH = 'feature/test-branch';
-      mockIsQa.mockReturnValue(true);
+      mockIsProduction.mockReturnValue(false);
 
       const { getByText } = renderScreen(
         AppInformation,
@@ -336,9 +336,27 @@ describe('AppInformation', () => {
       );
 
       // When the component renders
-      // Then it should display the branch information (this is always visible for QA)
+      // Then it should display the branch information
       await waitFor(() => {
         expect(getByText(/Branch:/)).toBeTruthy();
+      });
+    });
+
+    it('does not display branch information for production builds', async () => {
+      // Given isProduction returns true
+      process.env.GIT_BRANCH = 'release/7.69.0';
+      mockIsProduction.mockReturnValue(true);
+
+      const { queryByText } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      // When the component renders
+      // Then it should not display the branch information
+      await waitFor(() => {
+        expect(queryByText(/Branch:/)).toBeNull();
       });
     });
   });

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -324,9 +324,9 @@ describe('AppInformation', () => {
       });
     });
 
-    it('displays branch information for non-production builds', async () => {
+    it('displays build type and branch for non-production builds', async () => {
       // Given isProduction returns false
-      process.env.GIT_BRANCH = 'feature/test-branch';
+      process.env.GIT_BRANCH = 'release/7.69.0';
       mockIsProduction.mockReturnValue(false);
 
       const { getByText } = renderScreen(
@@ -336,15 +336,18 @@ describe('AppInformation', () => {
       );
 
       // When the component renders
-      // Then it should display the branch information
+      // Then it should display build type and branch
+      // Note: env values are inlined by babel's transform-inline-environment-variables,
+      // so we assert on the structural pattern rather than exact env values
       await waitFor(() => {
-        expect(getByText(/Branch:/)).toBeTruthy();
+        expect(getByText(/\| Branch:/)).toBeTruthy();
       });
     });
 
-    it('does not display branch information for production builds', async () => {
+    it('does not display build type or branch for production builds', async () => {
       // Given isProduction returns true
       process.env.GIT_BRANCH = 'release/7.69.0';
+      process.env.METAMASK_ENVIRONMENT = 'production';
       mockIsProduction.mockReturnValue(true);
 
       const { queryByText } = renderScreen(
@@ -354,7 +357,7 @@ describe('AppInformation', () => {
       );
 
       // When the component renders
-      // Then it should not display the branch information
+      // Then it should not display the build type or branch information
       await waitFor(() => {
         expect(queryByText(/Branch:/)).toBeNull();
       });


### PR DESCRIPTION
## **Description**

The branch name on the About MetaMask screen was only visible for QA builds (`isQa` check). This meant RC, beta, dev, and other non-production builds did not indicate which branch they were built from, making it easy to confuse a CI build from `main` with an official release candidate.

During 7.69.0 release testing, a team member installed a TestFlight build (3926) from `main` and thought it was the RC (3910) because the About screen showed `7.69.0` with no branch indicator.

## **Changes**

- Replaced `isQa` condition with `!isProduction()` so the build info is visible on all non-production builds (rc, beta, qa, dev, e2e, exp) and hidden only for production releases
- Added the `METAMASK_ENVIRONMENT` (uppercased) as a build type label alongside the branch name (e.g. `RC | Branch: release/7.69.0`)
- Updated tests to mock `isProduction` instead of `isQa`
- Added test case confirming build type and branch are hidden on production builds

## **Changelog**

CHANGELOG entry: Added build type and branch name display on About MetaMask screen for all non-production builds to help identify build source

## **Related issues**

[MMQA-1559](https://consensyssoftware.atlassian.net/browse/MMQA-1559)

## **Manual testing steps**

```gherkin
Feature: Build type and branch name visibility on About MetaMask screen

  Scenario: Build type and branch name are visible on RC builds
    Given the user has installed an RC build from the release/7.69.0 branch

    When the user navigates to Settings > About MetaMask
    Then "RC | Branch: release/7.69.0" is displayed below the version number

  Scenario: Build type and branch name are visible on QA builds
    Given the user has installed a QA build from a feature branch

    When the user navigates to Settings > About MetaMask
    Then "QA | Branch: <branch-name>" is displayed below the version number

  Scenario: Build type and branch name are hidden on production builds
    Given the user has installed a production release build

    When the user navigates to Settings > About MetaMask
    Then only the version number and build number are shown
    And no build type or branch name is displayed
```

## **Screenshots/Recordings**

### **Before**

On non-production builds (RC, beta, dev), the About MetaMask screen only shows:

```
MetaMask v7.69.0 (3910)
```

The branch name is only visible on QA builds, making it impossible to distinguish an RC build from a CI build off `main`.

### **After**

On all non-production builds (RC, beta, QA, dev, e2e, exp), the About MetaMask screen now shows:

```
MetaMask v7.69.0 (3910)
RC | Branch: release/7.69.0
```

Production builds remain unchanged — no build type or branch label is shown.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Coding Standards](https://github.com/user-attachments/files/18498227/MetaMask.Coding.Standards.1.0.1.pdf)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR
- [x] I've properly set the PR status:
  - [x] In case the PR is not ready to be reviewed, I've set it as "Draft"
  - [x] In case the PR is ready to be reviewed, I've changed it from "Draft" to "Ready for review"

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket and includes the necessary testing evidence such as recordings and or screenshots


[MMQA-1559]: https://consensyssoftware.atlassian.net/browse/MMQA-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ