### PR TITLE
chore: ban new snapshot assertions in lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,4 @@
 /* eslint-disable import/no-commonjs */
-const snapshotMatcherRestrictions = [
-  {
-    selector: "CallExpression[callee.property.name='toMatchSnapshot']",
-    message:
-      'Snapshot tests are banned. Use explicit behavioral assertions instead.',
-  },
-  {
-    selector: "CallExpression[callee.property.name='toMatchInlineSnapshot']",
-    message:
-      'Inline snapshot tests are banned. Use explicit behavioral assertions instead.',
-  },
-  {
-    selector:
-      "CallExpression[callee.property.name='toThrowErrorMatchingSnapshot']",
-    message:
-      'Snapshot-based error assertions are banned. Assert on the error explicitly instead.',
-  },
-  {
-    selector:
-      "CallExpression[callee.property.name='toThrowErrorMatchingInlineSnapshot']",
-    message:
-      'Inline snapshot-based error assertions are banned. Assert on the error explicitly instead.',
-  },
-];
-
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -142,12 +117,6 @@ module.exports = {
       },
     },
     {
-      files: ['**/*.test.{js,jsx,ts,tsx}'],
-      rules: {
-        'no-restricted-syntax': ['error', ...snapshotMatcherRestrictions],
-      },
-    },
-    {
       files: [
         'app/components/UI/Card/**/*.{js,jsx,ts,tsx}',
         'app/components/Snaps/**/*.{js,jsx,ts,tsx}',
@@ -174,7 +143,6 @@ module.exports = {
       rules: {
         'no-restricted-syntax': [
           'error',
-          ...snapshotMatcherRestrictions,
           {
             selector: `ImportSpecifier[imported.name=/${[
               'selectChainId',
@@ -224,7 +192,6 @@ module.exports = {
       rules: {
         'no-restricted-syntax': [
           'error',
-          ...snapshotMatcherRestrictions,
           {
             selector:
               "CallExpression[callee.object.name='jest'][callee.property.name='mock'][arguments.0.type='Literal'][arguments.0.value!='../../../core/Engine'][arguments.0.value!='../../../core/Engine/Engine'][arguments.0.value!='react-native-device-info']",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,29 @@
 /* eslint-disable import/no-commonjs */
+const snapshotMatcherRestrictions = [
+  {
+    selector: "CallExpression[callee.property.name='toMatchSnapshot']",
+    message:
+      'Snapshot tests are banned. Use explicit behavioral assertions instead.',
+  },
+  {
+    selector: "CallExpression[callee.property.name='toMatchInlineSnapshot']",
+    message:
+      'Inline snapshot tests are banned. Use explicit behavioral assertions instead.',
+  },
+  {
+    selector:
+      "CallExpression[callee.property.name='toThrowErrorMatchingSnapshot']",
+    message:
+      'Snapshot-based error assertions are banned. Assert on the error explicitly instead.',
+  },
+  {
+    selector:
+      "CallExpression[callee.property.name='toThrowErrorMatchingInlineSnapshot']",
+    message:
+      'Inline snapshot-based error assertions are banned. Assert on the error explicitly instead.',
+  },
+];
+
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -117,6 +142,12 @@ module.exports = {
       },
     },
     {
+      files: ['**/*.test.{js,jsx,ts,tsx}'],
+      rules: {
+        'no-restricted-syntax': ['error', ...snapshotMatcherRestrictions],
+      },
+    },
+    {
       files: [
         'app/components/UI/Card/**/*.{js,jsx,ts,tsx}',
         'app/components/Snaps/**/*.{js,jsx,ts,tsx}',
@@ -143,6 +174,7 @@ module.exports = {
       rules: {
         'no-restricted-syntax': [
           'error',
+          ...snapshotMatcherRestrictions,
           {
             selector: `ImportSpecifier[imported.name=/${[
               'selectChainId',
@@ -192,6 +224,7 @@ module.exports = {
       rules: {
         'no-restricted-syntax': [
           'error',
+          ...snapshotMatcherRestrictions,
           {
             selector:
               "CallExpression[callee.object.name='jest'][callee.property.name='mock'][arguments.0.type='Literal'][arguments.0.value!='../../../core/Engine'][arguments.0.value!='../../../core/Engine/Engine'][arguments.0.value!='react-native-device-info']",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,21 @@ jobs:
             echo "No changes detected"
           fi
 
+  new-snapshot-assertions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+      - name: Fetch PR base branch
+        if: ${{ github.event_name == 'pull_request' && github.base_ref != '' }}
+        run: git fetch origin ${{ github.base_ref }} --depth=1
+      - run: yarn lint:snapshots:new
+
   js-bundle-size-check:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean:android": "rm -rf android/app/build",
     "clean": "yarn clean:ios && yarn clean:android && yarn install --immutable",
     "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint '**/*.{js,ts,tsx}' --cache",
+    "lint:snapshots:new": "node scripts/check-new-snapshot-assertions.js",
     "lint:fix": "NODE_OPTIONS='--max-old-space-size=8192' eslint '**/*.{js,ts,tsx}' --fix --cache",
     "lint:clean": "rm -f .eslintcache",
     "lint:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc --project ./tsconfig.json",

--- a/scripts/check-new-snapshot-assertions.js
+++ b/scripts/check-new-snapshot-assertions.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-commonjs */
+
+const { execFileSync } = require('node:child_process');
+
+const SNAPSHOT_MATCHER_REGEX =
+  /\.([Tt]oMatchSnapshot|toMatchInlineSnapshot|toThrowErrorMatchingSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(/g;
+const TEST_FILE_REGEX = /\.test\.(js|jsx|ts|tsx)$/u;
+
+function runGit(args, options = {}) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim();
+}
+
+function fileExistsAtRevision(revision, filePath) {
+  try {
+    runGit(['cat-file', '-e', `${revision}:${filePath}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readFileAtRevision(revision, filePath) {
+  if (!fileExistsAtRevision(revision, filePath)) {
+    return '';
+  }
+
+  return runGit(['show', `${revision}:${filePath}`]);
+}
+
+function countSnapshotMatchers(fileContents) {
+  return [...fileContents.matchAll(SNAPSHOT_MATCHER_REGEX)].length;
+}
+
+function resolveBaseRevision() {
+  const explicitBaseRef = process.env.SNAPSHOT_BASE_REF;
+  if (explicitBaseRef) {
+    return runGit(['merge-base', explicitBaseRef, 'HEAD']);
+  }
+
+  const githubBaseRef = process.env.GITHUB_BASE_REF;
+  if (githubBaseRef) {
+    const remoteBaseRef = `origin/${githubBaseRef}`;
+    return runGit(['merge-base', remoteBaseRef, 'HEAD']);
+  }
+
+  try {
+    return runGit(['merge-base', 'origin/main', 'HEAD']);
+  } catch {
+    return runGit(['rev-parse', 'HEAD^']);
+  }
+}
+
+function getChangedTestFiles(baseRevision) {
+  const changedFiles = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMR',
+    `${baseRevision}...HEAD`,
+  ]);
+
+  return changedFiles
+    .split('\n')
+    .map((filePath) => filePath.trim())
+    .filter(Boolean)
+    .filter((filePath) => TEST_FILE_REGEX.test(filePath));
+}
+
+function main() {
+  const baseRevision = resolveBaseRevision();
+  const changedTestFiles = getChangedTestFiles(baseRevision);
+  const violations = [];
+
+  for (const filePath of changedTestFiles) {
+    const baseCount = countSnapshotMatchers(
+      readFileAtRevision(baseRevision, filePath),
+    );
+    const headCount = countSnapshotMatchers(readFileAtRevision('HEAD', filePath));
+
+    if (headCount > baseCount) {
+      violations.push({
+        addedCount: headCount - baseCount,
+        baseCount,
+        filePath,
+        headCount,
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log('No new snapshot assertions detected in changed test files.');
+    return;
+  }
+
+  console.error('New snapshot assertions detected in changed test files:');
+
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.filePath}: ${violation.baseCount} -> ${violation.headCount} (${violation.addedCount} new)`,
+    );
+  }
+
+  console.error(
+    '\nUse explicit behavioral assertions instead of adding new snapshot matchers.',
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## **Description**

This PR adds an ESLint guard that rejects new snapshot assertions in `*.test.*` files.

The motivation is that mobile currently relies heavily on snapshot testing, and in many cases snapshots appear to be used for coverage rather than to validate the specific behavior described in the test. That creates a lot of churn for broad UI or token updates and makes it harder to review what actually changed.

A good example is the recent grey palette update:

- Mobile: https://github.com/MetaMask/metamask-mobile/pull/26639 (`+9,103 -9,103`)
- Extension: https://github.com/MetaMask/metamask-extension/pull/40466 (`+37 -37`)

That delta reflects a real difference in test strategy. Extension does not rely on UI snapshots nearly as much, while mobile absorbs large snapshot diffs for changes that are often unrelated to the behavior the test claims to cover.

Representative examples from mobile:

- Ramps: ["filters regions when search text is entered"](https://github.com/MetaMask/metamask-mobile/blob/chore/color-no-hex-perps-batch-3/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx#L203) should assert that the filtered regions match the search input, instead of snapshotting the rendered output.
- Card: ["renders with only swap option when deposit is disabled"](https://github.com/MetaMask/metamask-mobile/blob/chore/color-no-hex-perps-batch-3/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx#L175) should assert that swap is present and deposit is absent, instead of relying on a snapshot.

This PR is intentionally small. It does not remove, deprecate, or migrate the repository's existing snapshot tests. It only prevents new snapshot-based assertions from being added, so we can stop growing the problem while any broader migration is discussed separately.

Scope of enforcement:

- Bans new uses of `toMatchSnapshot`
- Bans new uses of `toMatchInlineSnapshot`
- Bans new uses of `toThrowErrorMatchingSnapshot`
- Bans new uses of `toThrowErrorMatchingInlineSnapshot`

The lint rule is also applied in overlapping ESLint overrides, including confirmation tests and view tests, so it is not silently dropped in those paths.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: lint enforcement for snapshot assertions

  Scenario: developer adds a snapshot matcher to a test
    Given a test file contains expect(...).toMatchSnapshot()

    When eslint runs on that file
    Then lint fails with a message telling the author to use explicit behavioral assertions instead
```

Verified with:

```shell
./node_modules/.bin/eslint app/component-library/components/Badges/Badge/Badge.test.tsx --format unix
./node_modules/.bin/eslint app/components/Views/confirmations/__snapshot-ban-proof__.test.tsx --format unix
./node_modules/.bin/eslint app/util/test/__snapshot-ban-proof__.view.test.tsx --format unix
```

The two `__snapshot-ban-proof__` files were temporary local proof files used to verify the overlapping override paths, and were removed afterward.

## **Screenshots/Recordings**

### **Before**

Not applicable.

### **After**

Not applicable.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code risk (dev-only tooling), but it changes CI enforcement and can block merges if the base ref detection or snapshot matcher detection behaves unexpectedly.
> 
> **Overview**
> Adds a new CI job, `new-snapshot-assertions`, that runs `yarn lint:snapshots:new` on PRs to prevent introducing additional snapshot-based assertions.
> 
> Introduces `scripts/check-new-snapshot-assertions.js` and the `lint:snapshots:new` package script, which compares changed test files against the PR base revision and fails the build if new snapshot matcher calls (e.g., `toMatchSnapshot`, inline snapshot, and snapshot-throw variants) are added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee0435658f8c96f93f94f8335592647d8a1ddfe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->