### PR TITLE
fix(predict): fix fee amount calculation cp-7.69.0

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1109,15 +1109,11 @@ export async function calculateFees({
   const totalFeePercentage =
     (feeCollection.metamaskFee + feeCollection.providerFee) * 100;
 
-  let metamaskFee = userBetAmount * feeCollection.metamaskFee;
-  let providerFee = userBetAmount * feeCollection.providerFee;
+  const metamaskFee = userBetAmount * feeCollection.metamaskFee;
+  const providerFee = userBetAmount * feeCollection.providerFee;
 
-  // Round to 3 decimals
-  metamaskFee = Math.round(metamaskFee * 1000) / 1000;
-  providerFee = Math.round(providerFee * 1000) / 1000;
-
-  // Rounded to 4 decimals
-  const totalFee = metamaskFee + providerFee;
+  // Rounded to 6 decimals
+  const totalFee = Math.round((metamaskFee + providerFee) * 1000000) / 1000000;
 
   return {
     metamaskFee,
@@ -1520,7 +1516,7 @@ export const previewOrder = async (
       fees: await calculateFees({
         feeCollection,
         marketId,
-        userBetAmount: size,
+        userBetAmount: makerAmount,
       }),
     };
   }


### PR DESCRIPTION
## **Description**

Fix the Predict fee calculation to match the backend order relay calculation. Previously, individual fee components (`metamaskFee`, `providerFee`) were rounded to 3 decimal places before summing, and `previewOrder` was passing `size` instead of `makerAmount` as the fee basis. This caused rounding discrepancies that led to order failures on certain amounts (e.g., $6.12 yielding a $0.244 fee instead of $0.2448).

**Changes:**
- Remove per-component rounding of `metamaskFee` and `providerFee` — keep full precision
- Round only `totalFee` to 6 decimal places (matching backend precision)
- Use `makerAmount` instead of `size` as the `userBetAmount` in `previewOrder`, aligning with the backend order relay

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-740

## **Manual testing steps**

```gherkin
Feature: Predict fee calculation accuracy

  Scenario: user places a bet with an amount that previously caused rounding errors
    Given the user is on the Predict market detail screen

    When user enters a bet amount of $6.12
    Then the displayed fee should be $0.2448 (not $0.244)
    And the order should succeed without a fee mismatch error
```

## **Screenshots/Recordings**

<!-- Not applicable — logic-only change with no UI modifications -->

### **Before**

<!-- N/A -->

### **After**

<!-- N/A -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates fee math used for order previews/relaying; incorrect rounding or amount basis could still cause fee mismatches and failed orders, but the change is localized to fee computation.
> 
> **Overview**
> Adjusts Predict’s Polymarket fee calculation to **stop rounding `metamaskFee`/`providerFee` individually** and instead **round only `totalFee` to 6 decimals**, matching backend precision.
> 
> Updates `previewOrder` (BUY) to compute fees from the rounded `makerAmount` rather than the raw input `size`, reducing client/backend fee discrepancies that can cause order submission failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06004e3f5d793e65a92aa9c219690ae4470325d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->