### PR TITLE
Amount input cursor

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -774,6 +774,24 @@ describe('BuildQuote View', () => {
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
       ).toHaveTextContent(`${denomSymbol}2`);
     });
+
+    it('shows and hides the live input cursor based on focus', () => {
+      render(BuildQuote);
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
+      ).toBeNull();
+
+      fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
+      ).toBeTruthy();
+
+      fireEvent.press(getByRoleButton('Done'));
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
+      ).toBeNull();
+    });
   });
 
   describe('Amount to sell input', () => {

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds.ts
@@ -2,6 +2,7 @@ import enContent from '../../../../../../../locales/languages/en.json';
 
 export const BuildQuoteSelectors = {
   AMOUNT_INPUT: 'amount-input',
+  AMOUNT_INPUT_CURSOR: 'amount-input-cursor',
   AMOUNT_TO_BUY_LABEL: enContent.fiat_on_ramp_aggregator.amount_to_buy,
   AMOUNT_TO_SELL_LABEL: enContent.fiat_on_ramp_aggregator.amount_to_sell,
   GET_QUOTES_BUTTON: enContent.fiat_on_ramp_aggregator.get_quotes,

--- a/app/components/UI/Ramp/Aggregator/components/AmountInput.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AmountInput.test.tsx
@@ -4,6 +4,7 @@ import AmountInput from './AmountInput';
 import { TouchableOpacity } from 'react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
+import { BuildQuoteSelectors } from '../Views/BuildQuote/BuildQuote.testIds';
 
 const defaultState = {
   engine: {
@@ -78,6 +79,26 @@ describe('AmountInput', () => {
       },
     );
     expect(screen.toJSON()).toMatchSnapshot();
+  });
+
+  it('shows live cursor when input is highlighted', () => {
+    renderWithProvider(<AmountInput {...mockProps} highlighted />, {
+      state: defaultState,
+    });
+
+    expect(
+      screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
+    ).toBeTruthy();
+  });
+
+  it('does not show live cursor when input is not highlighted', () => {
+    renderWithProvider(<AmountInput {...mockProps} />, {
+      state: defaultState,
+    });
+
+    expect(
+      screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
+    ).toBeNull();
   });
 
   it('does not call onPress when loading', () => {

--- a/app/components/UI/Ramp/Aggregator/components/AmountInput.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AmountInput.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { Animated, Easing, StyleSheet, TouchableOpacity, View } from 'react-native';
 import Box from './Box';
 import SkeletonText from './SkeletonText';
 import DownChevronText from './DownChevronText';
@@ -12,11 +12,21 @@ import Text, {
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
 import { BuildQuoteSelectors } from '../Views/BuildQuote/BuildQuote.testIds';
+import { useTheme } from '../../../../../util/theme';
 
 const styles = StyleSheet.create({
   amount: {
     fontSize: 24,
     lineHeight: 32,
+  },
+  amountWithCursor: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  cursor: {
+    height: 24,
+    marginHorizontal: 5,
+    width: 1,
   },
   chevron: {
     flex: 0,
@@ -50,54 +60,118 @@ const AmountInput: React.FC<Props> = ({
   highlightedError,
   onPress,
   onCurrencyPress,
-}: Props) => (
-  <Box label={label} highlighted={highlighted} compact>
-    <ListItem>
-      <ListItemColumn widthType={WidthType.Fill}>
-        <TouchableOpacity
-          accessible
-          accessibilityRole="button"
-          onPress={onPress}
-          hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
-          testID={BuildQuoteSelectors.AMOUNT_INPUT}
-        >
-          {loading ? (
-            <SkeletonText medium />
-          ) : (
-            <Text
-              numberOfLines={1}
-              adjustsFontSizeToFit
-              style={styles.amount}
-              variant={TextVariant.BodyMDMedium}
-              color={highlightedError ? TextColor.Error : TextColor.Default}
-            >
-              {currencySymbol || ''}
-              {amount}
-            </Text>
-          )}
-        </TouchableOpacity>
-      </ListItemColumn>
+}: Props) => {
+  const { colors } = useTheme();
+  const cursorOpacity = useRef(new Animated.Value(0.6)).current;
 
-      {onCurrencyPress ? (
-        <ListItemColumn style={styles.chevron}>
-          {loading ? (
-            <SkeletonText small />
-          ) : (
-            <TouchableOpacity
-              accessible
-              accessibilityRole="button"
-              disabled={!onCurrencyPress}
-              onPress={onCurrencyPress}
-              hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
-              testID={BuildQuoteSelectors.SELECT_CURRENCY}
-            >
-              <DownChevronText text={currencyCode} />
-            </TouchableOpacity>
-          )}
+  useEffect(() => {
+    const shouldAnimateCursor =
+      highlighted && !loading && process.env.NODE_ENV !== 'test';
+
+    if (!shouldAnimateCursor) {
+      cursorOpacity.stopAnimation();
+      cursorOpacity.setValue(1);
+      return;
+    }
+
+    const blinkAnimation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(cursorOpacity, {
+          duration: 800,
+          easing: () => Easing.bounce(1),
+          toValue: 0,
+          useNativeDriver: true,
+        }),
+        Animated.timing(cursorOpacity, {
+          easing: () => Easing.bounce(1),
+          duration: 800,
+          toValue: 1,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    blinkAnimation.start();
+
+    return () => {
+      blinkAnimation.stop();
+      cursorOpacity.stopAnimation();
+      cursorOpacity.setValue(0.6);
+    };
+  }, [cursorOpacity, highlighted, loading]);
+
+  return (
+    <Box label={label} highlighted={highlighted} compact>
+      <ListItem>
+        <ListItemColumn widthType={WidthType.Fill}>
+          <TouchableOpacity
+            accessible
+            accessibilityRole="button"
+            onPress={onPress}
+            hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
+            testID={BuildQuoteSelectors.AMOUNT_INPUT}
+          >
+            {loading ? (
+              <SkeletonText medium />
+            ) : highlighted ? (
+              <View style={styles.amountWithCursor}>
+                <Text
+                  numberOfLines={1}
+                  adjustsFontSizeToFit
+                  style={styles.amount}
+                  variant={TextVariant.BodyMDMedium}
+                  color={highlightedError ? TextColor.Error : TextColor.Default}
+                >
+                  {currencySymbol || ''}
+                  {amount}
+                </Text>
+                <Animated.View
+                  style={[
+                    styles.cursor,
+                    {
+                      backgroundColor: colors.primary.default,
+                      opacity: cursorOpacity,
+                    },
+                  ]}
+                  testID={BuildQuoteSelectors.AMOUNT_INPUT_CURSOR}
+                />
+              </View>
+            ) : (
+              <Text
+                numberOfLines={1}
+                adjustsFontSizeToFit
+                style={styles.amount}
+                variant={TextVariant.BodyMDMedium}
+                color={highlightedError ? TextColor.Error : TextColor.Default}
+              >
+                {currencySymbol || ''}
+                {amount}
+              </Text>
+            )}
+          </TouchableOpacity>
         </ListItemColumn>
-      ) : null}
-    </ListItem>
-  </Box>
-);
+
+        {onCurrencyPress ? (
+          <ListItemColumn style={styles.chevron}>
+            {loading ? (
+              <SkeletonText small />
+            ) : (
+              <TouchableOpacity
+                accessible
+                accessibilityRole="button"
+                disabled={!onCurrencyPress}
+                onPress={onCurrencyPress}
+                hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
+                testID={BuildQuoteSelectors.SELECT_CURRENCY}
+              >
+                <DownChevronText text={currencyCode} />
+              </TouchableOpacity>
+            )}
+          </ListItemColumn>
+        ) : null}
+      </ListItem>
+    </Box>
+  );
+};
 
 export default AmountInput;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement a live-input cursor on the Unified Buy Phase 2 amount input screen to match the SendFlow experience.

This PR adds a blinking cursor to the `AmountInput` component, which appears when the input is highlighted (focused) and is modeled after the existing Send flow's cursor behavior for consistency.

---
[Slack Thread](https://consensys.slack.com/archives/C030G4739T3/p1772844538786079?thread_ts=1772844538.786079&cid=C030G4739T3)

<p><a href="https://cursor.com/agents/bc-a9a5bcb0-6866-593b-aaf0-a9657a526e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9a5bcb0-6866-593b-aaf0-a9657a526e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->