### PR TITLE
fix: pin seed phrase font size to prevent shrinking on large font devices

### DIFF
--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -417,7 +417,7 @@ const ManualBackupStep1 = () => {
                     <Text
                       variant={TextVariant.BodyMD}
                       color={TextColor.Alternative}
-                      allowFontScaling={false}
+                      maxFontSizeMultiplier={1}
                     >
                       {index + 1}.
                     </Text>
@@ -429,7 +429,7 @@ const ManualBackupStep1 = () => {
                       numberOfLines={1}
                       style={styles.word}
                       testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
-                      allowFontScaling={false}
+                      maxFontSizeMultiplier={1}
                     >
                       {item}
                     </Text>

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -417,6 +417,7 @@ const ManualBackupStep1 = () => {
                     <Text
                       variant={TextVariant.BodyMD}
                       color={TextColor.Alternative}
+                      allowFontScaling={false}
                     >
                       {index + 1}.
                     </Text>
@@ -428,10 +429,7 @@ const ManualBackupStep1 = () => {
                       numberOfLines={1}
                       style={styles.word}
                       testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
-                      adjustsFontSizeToFit
-                      allowFontScaling
-                      minimumFontScale={0.1}
-                      maxFontSizeMultiplier={0}
+                      allowFontScaling={false}
                     >
                       {item}
                     </Text>

--- a/app/components/Views/ManualBackupStep2/index.js
+++ b/app/components/Views/ManualBackupStep2/index.js
@@ -318,14 +318,14 @@ const ManualBackupStep2 = ({
   const renderGridItemText = useCallback(
     (item, index, isEmpty) => (
       <>
-        <Text style={styles.gridItemIndex} allowFontScaling={false}>
+        <Text style={styles.gridItemIndex} maxFontSizeMultiplier={1}>
           {index + 1}.
         </Text>
         <Text
           variant={TextVariant.BodySM}
           color={TextColor.Default}
           style={styles.gridItemText}
-          allowFontScaling={false}
+          maxFontSizeMultiplier={1}
         >
           {isEmpty ? item : '••••••'}
         </Text>
@@ -407,7 +407,7 @@ const ManualBackupStep2 = ({
                 variant={TextVariant.BodyMDMedium}
                 color={isUsed ? TextColor.Alternative : TextColor.Primary}
                 testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM_MISSING}-${i}`}
-                allowFontScaling={false}
+                maxFontSizeMultiplier={1}
               >
                 {word}
               </Text>

--- a/app/components/Views/ManualBackupStep2/index.js
+++ b/app/components/Views/ManualBackupStep2/index.js
@@ -318,15 +318,14 @@ const ManualBackupStep2 = ({
   const renderGridItemText = useCallback(
     (item, index, isEmpty) => (
       <>
-        <Text style={styles.gridItemIndex}>{index + 1}.</Text>
+        <Text style={styles.gridItemIndex} allowFontScaling={false}>
+          {index + 1}.
+        </Text>
         <Text
           variant={TextVariant.BodySM}
           color={TextColor.Default}
           style={styles.gridItemText}
-          adjustsFontSizeToFit
-          allowFontScaling
-          minimumFontScale={0.05}
-          maxFontSizeMultiplier={0}
+          allowFontScaling={false}
         >
           {isEmpty ? item : '••••••'}
         </Text>
@@ -408,10 +407,7 @@ const ManualBackupStep2 = ({
                 variant={TextVariant.BodyMDMedium}
                 color={isUsed ? TextColor.Alternative : TextColor.Primary}
                 testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM_MISSING}-${i}`}
-                adjustsFontSizeToFit
-                allowFontScaling
-                minimumFontScale={0.1}
-                maxFontSizeMultiplier={0}
+                allowFontScaling={false}
               >
                 {word}
               </Text>

--- a/app/components/Views/RevealPrivateCredential/components/SeedPhraseDisplay.tsx
+++ b/app/components/Views/RevealPrivateCredential/components/SeedPhraseDisplay.tsx
@@ -44,7 +44,7 @@ const SeedPhraseDisplay = ({
             <Text
               variant={TextVariant.BodyMD}
               color={TextColor.Alternative}
-              allowFontScaling={false}
+              maxFontSizeMultiplier={1}
             >
               {index + 1}.
             </Text>
@@ -54,7 +54,7 @@ const SeedPhraseDisplay = ({
               key={index}
               ellipsizeMode="tail"
               numberOfLines={1}
-              allowFontScaling={false}
+              maxFontSizeMultiplier={1}
               style={styles.word}
               testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
             >

--- a/app/components/Views/RevealPrivateCredential/components/SeedPhraseDisplay.tsx
+++ b/app/components/Views/RevealPrivateCredential/components/SeedPhraseDisplay.tsx
@@ -41,7 +41,11 @@ const SeedPhraseDisplay = ({
         keyExtractor={(_, index) => index.toString()}
         renderItem={({ item, index }) => (
           <View style={[styles.inputContainer]}>
-            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyMD}
+              color={TextColor.Alternative}
+              allowFontScaling={false}
+            >
               {index + 1}.
             </Text>
             <Text
@@ -50,12 +54,9 @@ const SeedPhraseDisplay = ({
               key={index}
               ellipsizeMode="tail"
               numberOfLines={1}
+              allowFontScaling={false}
               style={styles.word}
               testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
-              adjustsFontSizeToFit
-              allowFontScaling
-              minimumFontScale={0.1}
-              maxFontSizeMultiplier={0}
             >
               {item}
             </Text>


### PR DESCRIPTION
## **Description**

On devices with increased font sizes (~80% of max accessibility setting), the seed phrase words across multiple SRP screens would shrink to unreadable sizes. This happened because:

1. `allowFontScaling` was enabled (default), causing system font scaling to enlarge the text
2. `adjustsFontSizeToFit` would then shrink it back to fit inside the fixed-height cell
3. `minimumFontScale={0.1}` allowed shrinking down to 10%, resulting in tiny text

This fix uses `maxFontSizeMultiplier={1}` to cap the font at its base design-system size, preventing it from scaling **up** beyond the intended size on large font devices. Font scaling **down** is still allowed, so users with smaller-than-default font sizes will see proportionally smaller text — preserving accessibility in both directions.

The `adjustsFontSizeToFit`, `minimumFontScale`, and previous `allowFontScaling` / `maxFontSizeMultiplier={0}` props are removed as they are no longer needed.

This applies to the index numbers and seed phrase words across **three screens**:

- **`ManualBackupStep1`** — The "Save your Secret Recovery Phrase" screen during onboarding
- **`ManualBackupStep2`** — The "Confirm your Secret Recovery Phrase" screen during onboarding
- **`SeedPhraseDisplay`** (used by `RevealPrivateCredential`) — The "Show Secret Recovery Phrase" screen in Settings > Security & Privacy

**Note:** At maximum font size, earlier onboarding screens overflow and prevent navigation to the backup screens entirely — that is a separate issue tracked in #18590's broader scope.

## **Related issues**

Fixes: #18590
Jira: TO-578

## **Manual testing steps**

### Scenario 1: ManualBackupStep1 — Seed phrase words are readable at ~80% large font size

```
Given I have set my device font size to approximately 80% of max (iOS: Settings > Accessibility > Display & Text Size > Larger Text)
And I navigate through onboarding to the "Save your Secret Recovery Phrase" screen
When I tap "Tap to reveal your Secret Recovery Phrase"
Then all 12 seed phrase words should be displayed at a consistent, readable size
And the word index numbers (1. through 12.) should also be at a readable size
And the text should NOT scale up larger than the default BodyMD size
```

### Scenario 2: ManualBackupStep2 — Confirmation grid words are readable at ~80% large font size

```
Given I have set my device font size to approximately 80% of max
And I navigate through onboarding past the SRP reveal to the "Confirm your Secret Recovery Phrase" screen
Then the 12-word grid should display all words at a consistent, readable size
And the missing word options at the bottom should also display at a readable size
And the text should NOT scale up larger than the default size
```

### Scenario 3: RevealPrivateCredential — Settings SRP display is readable at ~80% large font size

```
Given I have set my device font size to approximately 80% of max
And I navigate to Settings > Security & Privacy > Reveal Secret Recovery Phrase
When I enter my password and reveal the SRP
Then all 12 seed phrase words should be displayed at a consistent, readable size
And the word index numbers (1. through 12.) should also be at a readable size
And the text should NOT scale up larger than the default BodyMD size
```

### Scenario 4: Seed phrase words scale down at small font sizes

```
Given I have set my device font size to the smallest setting
And I navigate to any of the three SRP screens above
Then all 12 seed phrase words should scale down proportionally with the system font
And the text should be smaller than default, matching the user's preference
```

### Scenario 5: No visual regression at default font size

```
Given I have the default device font size
And I visit each of the three SRP screens above
Then all seed phrase words should display at normal BodyMD size
And there should be no visual regression from the previous behavior
```

## **Screenshots/Recordings**

<!-- Before/after screenshots at large, default, and small font sizes -->


<img width="300" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-10 at 17 27 50" src="https://github.com/user-attachments/assets/f2dfc451-a451-4334-9337-3a34997a6b7d" />
<img width="300" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-10 at 17 30 53" src="https://github.com/user-attachments/assets/d1bb49dd-13a3-4593-bb6c-108dbbef37a0" />


<img width="300" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-10 at 17 29 28" src="https://github.com/user-attachments/assets/f37b3455-c018-44a8-8b7e-de2e438a3818" />
<img width="300" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-10 at 17 33 29" src="https://github.com/user-attachments/assets/db4aa7c5-5d60-4d81-a88f-7fafcc615fb9" />

<img width="300" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-10 at 17 26 51" src="https://github.com/user-attachments/assets/595a2d2a-e4d6-4a99-bd33-ec1ccf963ba1" />
<img width="300" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-10 at 17 31 32" src="https://github.com/user-attachments/assets/45f768a1-81fd-4986-90a1-44ac985ecd9b" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on this PR
- [x] I've manually tested this PR
- [x] I've confirmed there are no breaking changes

CHANGELOG entry: Fixed seed phrase words shrinking to unreadable sizes on devices with large accessibility font settings while preserving font scaling for smaller font preferences