### PR TITLE
fix(perps): reduce Sentry noise from handled perpDexs() transient failures

### DIFF
--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -1049,9 +1049,14 @@ export class HyperLiquidProvider implements PerpsProvider {
     try {
       allDexs = await infoClient.perpDexs();
     } catch (error) {
-      this.#deps.logger.error(
-        ensureError(error, 'HyperLiquidProvider.fetchValidatedDexsInternal'),
-        this.#getErrorContext('getValidatedDexs.perpDexs'),
+      // debugLogger not logger.error: this is a handled transient failure — the app
+      // recovers to main DEX via return [null]. Sending to Sentry as error() is noise.
+      this.#deps.debugLogger.log(
+        '[fetchValidatedDexsInternal] perpDexs() call failed, falling back to main DEX',
+        {
+          error: String(error),
+          ...this.#getErrorContext('getValidatedDexs.perpDexs'),
+        },
       );
       // Do not cache — transient error, allow retry on next call
       return [null];


### PR DESCRIPTION
## **Description**

In `HyperLiquidProvider.fetchValidatedDexsInternal`, the catch block for a failed `perpDexs()` API call was using `logger.error()`, which routes to Sentry. The error is fully handled — the app returns `[null]`, falls back to main DEX, and retries on the next call. Using `error()` overstates severity and generates Sentry noise.

I switched to `debugLogger.log()`, consistent with the invalid-response case directly below in the same function, which uses the same pattern for the same reason.

This error became visible in Sentry after #27127 fixed the caching bug: before that fix, the same transient failure was masked by the downstream "perpDexs not cached" crash.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Sentry issue [7317078108](https://metamask.sentry.io/issues/7317078108/) — `Unknown error (no details provided) [HyperLiquidProvider.fetchValidatedDexsInternal]`

## **Manual testing steps**

```gherkin
Feature: perpDexs transient failure handling

  Scenario: perpDexs() API call fails transiently
    Given the app is running with HIP-3 enabled
    When the HyperLiquid perpDexs() API returns an error
    Then the app falls back to main DEX without crashing
    And no error is sent to Sentry
    And the next call retries the perpDexs() fetch
```

## **Screenshots/Recordings**

### **Before**

Sentry: ~11 events/day — `Unknown error (no details provided) [HyperLiquidProvider.fetchValidatedDexsInternal]` on 7.68.0

### **After**

0 Sentry events. Failure logged locally via `debugLogger.log` only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes log level/shape for a transient, already-handled error path while preserving the existing fallback to main DEX and retry behavior.
> 
> **Overview**
> Stops reporting `HyperLiquidProvider.#fetchValidatedDexsInternal` transient `perpDexs()` API failures as `logger.error()` (Sentry noise) and instead logs them via `debugLogger.log()` with a clear fallback message and context.
> 
> Behavior remains the same on failure: it returns `[null]` (main DEX only) and does not cache the result so the next call can retry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcefda06c0aecbfab8efc2719bccd9caf6d9c855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->