### PR TITLE
fix: duplicate wallet started events for social login

### DIFF
--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -416,16 +416,6 @@ const Onboarding = () => {
         const accountType = getSocialAccountType(provider, result.existingUser);
         dispatch(setAccountType(accountType));
 
-        if (result.existingUser) {
-          track(MetaMetricsEvents.WALLET_IMPORT_STARTED, {
-            account_type: accountType,
-          });
-        } else {
-          track(MetaMetricsEvents.WALLET_SETUP_STARTED, {
-            account_type: accountType,
-          });
-        }
-
         track(MetaMetricsEvents.SOCIAL_LOGIN_COMPLETED, {
           account_type: accountType,
         });
@@ -700,13 +690,14 @@ const Onboarding = () => {
         tags: getTraceTags(store.getState()),
       });
 
+      const accountType = getSocialAccountType(provider, !createWallet);
       if (createWallet) {
         track(MetaMetricsEvents.WALLET_SETUP_STARTED, {
-          account_type: `${AccountType.Metamask}_${provider}`,
+          account_type: accountType,
         });
       } else {
         track(MetaMetricsEvents.WALLET_IMPORT_STARTED, {
-          account_type: `${AccountType.Imported}_${provider}`,
+          account_type: accountType,
         });
       }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

* `WALLET_SETUP_STARTED` and `WALLET_IMPORT_STARTED` events were firing twice during social login. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: `WALLET_SETUP_STARTED` and `WALLET_IMPORT_STARTED` events were firing twice during social login. 

## **Manual testing steps**

```gherkin
Feature: Social login wallet setup analytics

  Scenario: user starts wallet setup via Google login
    Given user is on the onboarding screen
    When user taps "Continue with Google"
    Then WALLET_SETUP_STARTED event fires once with account_type "metamask_google"
  Scenario: user starts wallet import via Apple login
    Given user is on the onboarding screen with import flow
    When user taps "Continue with Apple"
    Then WALLET_IMPORT_STARTED event fires once with account_type "imported_apple"

```

## **Screenshots/Recordings**
N/A — analytics-only change, no UI impact.
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that moves `WALLET_SETUP_STARTED`/`WALLET_IMPORT_STARTED` tracking to a single call site; main risk is incorrect `account_type` attribution if the new `getSocialAccountType` inputs are wrong.
> 
> **Overview**
> Prevents duplicate `WALLET_SETUP_STARTED` and `WALLET_IMPORT_STARTED` metrics from firing during social login by removing the post-login tracking in `handlePostSocialLogin` and emitting the start event once when the social login flow begins.
> 
> Standardizes the `account_type` property for these start events by deriving it via `getSocialAccountType(provider, !createWallet)` instead of manual string formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43388b05dfeb285b74d421f956b539ee3d1880c8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->