### PR TITLE
chore: Silence premature close warnings in JSON-RPC streams

### DIFF
--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -370,7 +370,7 @@ export default class SnapBridge {
     pump(caipStream, caipProviderStream, caipStream, (error: Error | null) => {
       caipEngine.destroy();
 
-      if (error) {
+      if (error && !error.message?.match(/Premature close/i)) {
         Logger.log('[SNAP BRIDGE] Error with CAIP provider stream:', error);
       }
     });

--- a/app/util/streams.js
+++ b/app/util/streams.js
@@ -34,7 +34,7 @@ function jsonStringifyStream() {
 function setupMultiplex(connectionStream) {
   const mux = new ObjectMultiplex();
   pump(connectionStream, mux, connectionStream, (err) => {
-    if (err) {
+    if (err && !err.message?.match(/Premature close/i)) {
       console.warn(err);
     }
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Silence premature close warnings in JSON-RPC streams to reduce unnecessary logging. This mirrors what is done in extension.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
