### PR TITLE
feat: Extend notification account toggles to all wallet keyrings

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -97,6 +97,7 @@ const arrangeMockUseAccounts = () => {
       type: AccountGroupType.SingleAccount,
       metadata: {
         hidden: false,
+        lastSelected: 0,
         name: id,
         pinned: false,
       },

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -36,6 +36,35 @@ jest.mock(
 
 const MOCK_KEYRING_TYPE = 'HD Key Tree' as KeyringTypes;
 
+const createNotificationAccountsMap = () =>
+  ({
+    'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29': {
+      id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
+      address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
+      type: 'eip155:eoa',
+    } as InternalAccount,
+    'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC': {
+      id: 'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC',
+      address: '0x700CcD8172BC3807D893883a730A1E0E6630F8EC',
+      type: 'eip155:eoa',
+    } as InternalAccount,
+    'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20': {
+      id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20',
+      address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20',
+      type: 'eip155:eoa',
+    } as InternalAccount,
+    'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0': {
+      id: 'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0',
+      address: '0x700CcD8172BC3807D893883a730A1E0E6630F8E0',
+      type: 'eip155:eoa',
+    } as InternalAccount,
+    'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY': {
+      id: 'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
+      address: '63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
+      type: 'solana:data-account',
+    } as InternalAccount,
+  }) satisfies Record<string, InternalAccount>;
+
 const arrangeMockUseAccounts = () => {
   const createMockMultichainAccountGroup = (
     idx: number,
@@ -321,33 +350,9 @@ describe('useNotificationAccountListProps', () => {
 describe('useNotificationWalletAccountGroups', () => {
   const arrangeMocks = () => {
     const mocks = arrangeMockUseAccounts();
-    jest.mocked(selectInternalAccountsById).mockReturnValue({
-      'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29': {
-        id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
-        address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
-        type: 'eip155:eoa',
-      } as InternalAccount,
-      'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC': {
-        id: 'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC',
-        address: '0x700CcD8172BC3807D893883a730A1E0E6630F8EC',
-        type: 'eip155:eoa',
-      } as InternalAccount,
-      'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20': {
-        id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20',
-        address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20',
-        type: 'eip155:eoa',
-      } as InternalAccount,
-      'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0': {
-        id: 'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0',
-        address: '0x700CcD8172BC3807D893883a730A1E0E6630F8E0',
-        type: 'eip155:eoa',
-      } as InternalAccount,
-      'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY': {
-        id: 'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
-        address: '63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
-        type: 'solana:data-account',
-      } as InternalAccount,
-    });
+    jest
+      .mocked(selectInternalAccountsById)
+      .mockReturnValue(createNotificationAccountsMap());
 
     return mocks;
   };
@@ -387,13 +392,9 @@ describe('useAccountProps', () => {
         avatarAccountType: AvatarAccountType.Maskicon,
       },
     });
-    jest.mocked(selectInternalAccountsById).mockReturnValue({
-      'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29': {
-        id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
-        address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
-        type: 'eip155:eoa',
-      } as InternalAccount,
-    });
+    jest
+      .mocked(selectInternalAccountsById)
+      .mockReturnValue(createNotificationAccountsMap());
 
     return {
       ...arrangeMockUseAccounts(),
@@ -408,16 +409,24 @@ describe('useAccountProps', () => {
     });
 
     expect(result.current.accountAvatarType).toBe(AvatarAccountType.Maskicon);
-    expect(result.current.accountWalletGroups).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          title: 'Wallet 1',
-          wallet: expect.objectContaining({
-            id: 'entropy:wallet-1',
-            type: AccountWalletType.Entropy,
-          }),
+    expect(result.current.accountWalletGroups).toHaveLength(2);
+    expect(result.current.accountWalletGroups[0]).toStrictEqual(
+      expect.objectContaining({
+        title: 'Wallet 1',
+        wallet: expect.objectContaining({
+          id: 'entropy:wallet-1',
+          type: AccountWalletType.Entropy,
         }),
-      ]),
+      }),
+    );
+    expect(result.current.accountWalletGroups[1]).toStrictEqual(
+      expect.objectContaining({
+        title: 'Wallet 2',
+        wallet: expect.objectContaining({
+          id: 'keyring:wallet-2',
+          type: AccountWalletType.Keyring,
+        }),
+      }),
     );
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -9,6 +9,7 @@ import { getValidNotificationAccounts } from '../../../../selectors/notification
 import {
   useAccountProps,
   useNotificationAccountListProps,
+  useNotificationWalletAccountGroups,
 } from './AccountsList.hooks';
 import { selectInternalAccountsById } from '../../../../selectors/accountsController';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -95,7 +96,7 @@ const arrangeMockUseAccounts = () => {
         title: 'Wallet 2',
         wallet: {
           id: 'entropy:wallet-2',
-          type: AccountWalletType.Entropy,
+          type: AccountWalletType.Keyring,
           metadata: {
             entropy: {
               id: '',
@@ -297,12 +298,81 @@ describe('useNotificationAccountListProps', () => {
   });
 });
 
+describe('useNotificationWalletAccountGroups', () => {
+  const arrangeMocks = () => {
+    const mocks = arrangeMockUseAccounts();
+    jest.mocked(selectInternalAccountsById).mockReturnValue({
+      'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29': {
+        id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
+        address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
+        type: 'eip155:eoa',
+      } as InternalAccount,
+      'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC': {
+        id: 'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC',
+        address: '0x700CcD8172BC3807D893883a730A1E0E6630F8EC',
+        type: 'eip155:eoa',
+      } as InternalAccount,
+      'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20': {
+        id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20',
+        address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20',
+        type: 'eip155:eoa',
+      } as InternalAccount,
+      'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0': {
+        id: 'MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0',
+        address: '0x700CcD8172BC3807D893883a730A1E0E6630F8E0',
+        type: 'eip155:eoa',
+      } as InternalAccount,
+      'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY': {
+        id: 'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
+        address: '63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
+        type: 'solana:data-account',
+      } as InternalAccount,
+    });
+
+    return mocks;
+  };
+
+  it('returns wallet groups for all wallets with EVM accounts', () => {
+    arrangeMocks();
+    const { result } = renderHookWithProvider(() =>
+      useNotificationWalletAccountGroups(),
+    );
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0]).toStrictEqual(
+      expect.objectContaining({
+        title: 'Wallet 1',
+        wallet: expect.objectContaining({
+          id: 'entropy:wallet-1',
+          type: AccountWalletType.Entropy,
+        }),
+      }),
+    );
+    expect(result.current[1]).toStrictEqual(
+      expect.objectContaining({
+        title: 'Wallet 2',
+        wallet: expect.objectContaining({
+          id: 'entropy:wallet-2',
+          type: AccountWalletType.Keyring,
+        }),
+      }),
+    );
+  });
+});
+
 describe('useAccountProps', () => {
   const arrangeMocks = () => {
     const mockStore = jest.fn().mockReturnValue({
       settings: {
         avatarAccountType: AvatarAccountType.Maskicon,
       },
+    });
+    jest.mocked(selectInternalAccountsById).mockReturnValue({
+      'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29': {
+        id: 'MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
+        address: '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
+        type: 'eip155:eoa',
+      } as InternalAccount,
     });
 
     return {
@@ -318,14 +388,16 @@ describe('useAccountProps', () => {
     });
 
     expect(result.current.accountAvatarType).toBe(AvatarAccountType.Maskicon);
-    expect(result.current.firstHDWalletGroups).toStrictEqual(
-      expect.objectContaining({
-        title: 'Wallet 1',
-        wallet: expect.objectContaining({
-          id: 'entropy:wallet-1',
-          type: AccountWalletType.Entropy,
+    expect(result.current.accountWalletGroups).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Wallet 1',
+          wallet: expect.objectContaining({
+            id: 'entropy:wallet-1',
+            type: AccountWalletType.Entropy,
+          }),
         }),
-      }),
+      ]),
     );
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -15,6 +15,7 @@ import { selectInternalAccountsById } from '../../../../selectors/accountsContro
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { selectAccountGroupsByWallet } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
 
 jest.mock('../../../../selectors/notifications', () => ({
   getValidNotificationAccounts: jest.fn(),
@@ -33,8 +34,10 @@ jest.mock(
   }),
 );
 
+const MOCK_KEYRING_TYPE = 'HD Key Tree' as KeyringTypes;
+
 const arrangeMockUseAccounts = () => {
-  const createMockAccountGroup = (
+  const createMockMultichainAccountGroup = (
     idx: number,
     accounts: [string, ...string[]],
   ) =>
@@ -53,22 +56,39 @@ const arrangeMockUseAccounts = () => {
       },
     }) as const;
 
-  const group1 = createMockAccountGroup(0, [
+  const createMockSingleAccountGroup = <
+    T extends `keyring:${string}/${string}`,
+  >(
+    id: T,
+    account: string,
+  ) =>
+    ({
+      accounts: [account] as [string],
+      id,
+      type: AccountGroupType.SingleAccount,
+      metadata: {
+        hidden: false,
+        name: id,
+        pinned: false,
+      },
+    }) as const;
+
+  const group1 = createMockMultichainAccountGroup(0, [
     `MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29`,
     'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
   ]);
-  const group2 = createMockAccountGroup(1, [
+  const group2 = createMockMultichainAccountGroup(1, [
     `MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8EC`,
     'MOCK-ID-FOR-Agsjd8HjGH5DxiXLMWc8fR4jjgHhvJG3TXcCpc1ieD9B',
   ]);
-  const group3 = createMockAccountGroup(0, [
+  const group3 = createMockSingleAccountGroup(
+    'keyring:wallet-2/0',
     `MOCK-ID-FOR-0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a20`,
-    'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGR0',
-  ]);
-  const group4 = createMockAccountGroup(1, [
+  );
+  const group4 = createMockSingleAccountGroup(
+    'keyring:wallet-2/1',
     `MOCK-ID-FOR-0x700CcD8172BC3807D893883a730A1E0E6630F8E0`,
-    'MOCK-ID-FOR-Agsjd8HjGH5DxiXLMWc8fR4jjgHhvJG3TXcCpc1ieD90',
-  ]);
+  );
 
   const mockSelectoWallets = jest
     .mocked(selectAccountGroupsByWallet)
@@ -95,13 +115,13 @@ const arrangeMockUseAccounts = () => {
       {
         title: 'Wallet 2',
         wallet: {
-          id: 'entropy:wallet-2',
+          id: 'keyring:wallet-2',
           type: AccountWalletType.Keyring,
           metadata: {
-            entropy: {
-              id: '',
-            },
             name: 'Wallet 2',
+            keyring: {
+              type: MOCK_KEYRING_TYPE,
+            },
           },
           status: 'ready',
           groups: {
@@ -352,7 +372,7 @@ describe('useNotificationWalletAccountGroups', () => {
       expect.objectContaining({
         title: 'Wallet 2',
         wallet: expect.objectContaining({
-          id: 'entropy:wallet-2',
+          id: 'keyring:wallet-2',
           type: AccountWalletType.Keyring,
         }),
       }),

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
@@ -1,11 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useFetchAccountNotifications } from '../../../../util/notifications/hooks/useSwitchNotifications';
 import { getValidNotificationAccounts } from '../../../../selectors/notifications';
 import { toFormattedAddress } from '../../../../util/address';
 import { selectAvatarAccountType } from '../../../../selectors/settings';
 import { selectAccountGroupsByWallet } from '../../../../selectors/multichainAccounts/accountTreeController';
-import { AccountWalletType } from '@metamask/account-api';
 import { selectInternalAccountsById } from '../../../../selectors/accountsController';
 import { isEvmAccountType } from '@metamask/keyring-api';
 
@@ -83,20 +82,34 @@ export function useNotificationAccountListProps() {
   };
 }
 
-export function useFirstHDWalletAccounts() {
+export function useNotificationWalletAccountGroups() {
   const accountGroupsByWallet = useSelector(selectAccountGroupsByWallet);
-  const firstHDWalletGroup = accountGroupsByWallet.find(
-    (w) => w.wallet.type === AccountWalletType.Entropy,
+  const accountsMap = useSelector(selectInternalAccountsById);
+
+  return useMemo(
+    () =>
+      accountGroupsByWallet
+        .map((walletGroup) => ({
+          ...walletGroup,
+          data: walletGroup.data.filter((accountGroup) =>
+            accountGroup.accounts.some(
+              (accountId) =>
+                Boolean(accountsMap?.[accountId]?.address) &&
+                isEvmAccountType(accountsMap[accountId].type),
+            ),
+          ),
+        }))
+        .filter((walletGroup) => walletGroup.data.length > 0),
+    [accountGroupsByWallet, accountsMap],
   );
-  return firstHDWalletGroup;
 }
 
 export function useAccountProps() {
-  const firstHDWalletGroups = useFirstHDWalletAccounts();
+  const accountWalletGroups = useNotificationWalletAccountGroups();
   const accountAvatarType = useSelector(selectAvatarAccountType);
 
   return {
-    firstHDWalletGroups,
+    accountWalletGroups,
     accountAvatarType,
   };
 }

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
@@ -86,21 +86,28 @@ export function useNotificationWalletAccountGroups() {
   const accountGroupsByWallet = useSelector(selectAccountGroupsByWallet);
   const accountsMap = useSelector(selectInternalAccountsById);
 
+  const isEvmAccountId = useCallback(
+    (accountId: string) =>
+      Boolean(accountsMap?.[accountId]?.address) &&
+      isEvmAccountType(accountsMap[accountId].type),
+    [accountsMap],
+  );
+
+  const hasNotificationEligibleAccount = useCallback(
+    (accountGroup: { accounts: string[] }) =>
+      accountGroup.accounts.some(isEvmAccountId),
+    [isEvmAccountId],
+  );
+
   return useMemo(
     () =>
       accountGroupsByWallet
         .map((walletGroup) => ({
           ...walletGroup,
-          data: walletGroup.data.filter((accountGroup) =>
-            accountGroup.accounts.some(
-              (accountId) =>
-                Boolean(accountsMap?.[accountId]?.address) &&
-                isEvmAccountType(accountsMap[accountId].type),
-            ),
-          ),
+          data: walletGroup.data.filter(hasNotificationEligibleAccount),
         }))
         .filter((walletGroup) => walletGroup.data.length > 0),
-    [accountGroupsByWallet, accountsMap],
+    [accountGroupsByWallet, hasNotificationEligibleAccount],
   );
 }
 

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -300,4 +300,34 @@ describe('AccountList', () => {
       expect(mocks.mockRefetchAccountSettings).toHaveBeenCalled();
     });
   });
+
+  it('renders nothing when there are no notification wallet groups', () => {
+    const mocks = arrangeMocks();
+    mocks.mockUseAccountProps.mockReturnValue({
+      accountAvatarType: AvatarAccountType.JazzIcon,
+      accountWalletGroups: [],
+    });
+
+    const { queryByTestId } = renderWithProvider(<AccountsList />, {
+      state: initialRootState,
+    });
+
+    expect(queryByTestId(ACCOUNT_1_TEST_ID.item)).not.toBeOnTheScreen();
+  });
+
+  it('skips account groups without an EVM address', () => {
+    const mocks = arrangeMocks();
+    mocks.mockUseNotificationAccountListProps.mockReturnValue({
+      ...mocks.createUseNotificationAccountListProps(),
+      getEvmAddress: jest.fn().mockReturnValue(undefined),
+    });
+
+    const { queryByTestId } = renderWithProvider(<AccountsList />, {
+      state: initialRootState,
+    });
+
+    expect(queryByTestId(ACCOUNT_1_TEST_ID.item)).not.toBeOnTheScreen();
+    expect(queryByTestId(ACCOUNT_2_TEST_ID.item)).not.toBeOnTheScreen();
+    expect(queryByTestId(ACCOUNT_3_TEST_ID.item)).not.toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -33,10 +33,12 @@ jest.mock('@react-navigation/native', () => {
 
 const ADDRESS_1 = '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29'.toLowerCase();
 const ADDRESS_2 = '0x700CcD8172BC3807D893883a730A1E0E6630F8EC'.toLowerCase();
+const ADDRESS_3 = '0x111CcD8172BC3807D893883a730A1E0E6630F8AA'.toLowerCase();
 
 // The component uses toFormattedAddress for testIDs, so we need the checksummed versions
 const CHECKSUMMED_ADDRESS_1 = toFormattedAddress(ADDRESS_1);
 const CHECKSUMMED_ADDRESS_2 = toFormattedAddress(ADDRESS_2);
+const CHECKSUMMED_ADDRESS_3 = toFormattedAddress(ADDRESS_3);
 
 const ACCOUNT_1_TEST_ID = {
   item: NOTIFICATION_OPTIONS_TOGGLE_CONTAINER_TEST_ID(
@@ -66,6 +68,16 @@ const ACCOUNT_2_TEST_ID = {
   ),
   itemSwitch: NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
     CHECKSUMMED_ADDRESS_2,
+  ),
+};
+const ACCOUNT_3_TEST_ID = {
+  item: NOTIFICATION_OPTIONS_TOGGLE_CONTAINER_TEST_ID(
+    NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
+      CHECKSUMMED_ADDRESS_3,
+    ),
+  ),
+  itemSwitch: NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
+    CHECKSUMMED_ADDRESS_3,
   ),
 };
 
@@ -112,30 +124,50 @@ describe('AccountList', () => {
       `MOCK-ID-FOR-${CHECKSUMMED_ADDRESS_2}`,
       'MOCK-ID-FOR-Agsjd8HjGH5DxiXLMWc8fR4jjgHhvJG3TXcCpc1ieD9B',
     ]);
+    const importedGroup = createMockAccountGroup(2, [
+      `MOCK-ID-FOR-${CHECKSUMMED_ADDRESS_3}`,
+    ]);
 
     const mockUseAccountProps = jest
       .spyOn(AccountListHooksModule, 'useAccountProps')
       .mockReturnValue({
         accountAvatarType: AvatarAccountType.JazzIcon,
-        firstHDWalletGroups: {
-          title: 'Wallet 1',
-          wallet: {
-            id: 'entropy:wallet-1',
-            type: AccountWalletType.Entropy,
-            metadata: {
-              entropy: {
-                id: '',
+        accountWalletGroups: [
+          {
+            title: 'Wallet 1',
+            wallet: {
+              id: 'entropy:wallet-1',
+              type: AccountWalletType.Entropy,
+              metadata: {
+                entropy: {
+                  id: '',
+                },
+                name: 'Wallet 1',
               },
-              name: 'Wallet 1',
+              status: 'ready',
+              groups: {
+                [group1.id]: group1,
+                [group2.id]: group2,
+              },
             },
-            status: 'ready',
-            groups: {
-              [group1.id]: group1,
-              [group2.id]: group2,
-            },
+            data: [group1, group2],
           },
-          data: [group1, group2],
-        },
+          {
+            title: 'Imported wallet',
+            wallet: {
+              id: 'keyring:wallet-2',
+              type: AccountWalletType.Keyring,
+              metadata: {
+                name: 'Imported wallet',
+              },
+              status: 'ready',
+              groups: {
+                [importedGroup.id]: importedGroup,
+              },
+            },
+            data: [importedGroup],
+          },
+        ],
       });
 
     const mockRefetchAccountSettings = jest.fn();
@@ -192,6 +224,7 @@ describe('AccountList', () => {
     // Assert - Items exist
     expect(getByTestId(ACCOUNT_1_TEST_ID.item)).toBeTruthy();
     expect(getByTestId(ACCOUNT_2_TEST_ID.item)).toBeTruthy();
+    expect(getByTestId(ACCOUNT_3_TEST_ID.item)).toBeTruthy();
 
     // Assert - Item Loading
     expect(getByTestId(ACCOUNT_1_TEST_ID.itemLoading)).toBeTruthy();
@@ -218,6 +251,7 @@ describe('AccountList', () => {
     // Assert switches are disabled during initial loading
     expect(getByTestId(ACCOUNT_1_TEST_ID.itemSwitch).props.disabled).toBe(true);
     expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch).props.disabled).toBe(true);
+    expect(getByTestId(ACCOUNT_3_TEST_ID.itemSwitch).props.disabled).toBe(true);
   });
 
   it('invokes switch toggle logic when clicked', async () => {

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -13,6 +13,7 @@ import {
 import { NotificationSettingsViewSelectorsIDs } from './NotificationSettingsView.testIds';
 import { toFormattedAddress } from '../../../../util/address';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 // eslint-disable-next-line import-x/no-namespace
 import * as AccountSelectorsModule from '../../../../selectors/multichainAccounts/accounts';
@@ -20,6 +21,8 @@ import initialRootState from '../../../../util/test/initial-root-state';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockVar = any;
+
+const MOCK_KEYRING_TYPE = 'HD Key Tree' as KeyringTypes;
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -97,7 +100,7 @@ describe('AccountList', () => {
         name: `My Account ${idx}`,
       }));
 
-    const createMockAccountGroup = (
+    const createMockMultichainAccountGroup = (
       idx: number,
       accounts: [string, ...string[]],
     ) =>
@@ -116,17 +119,35 @@ describe('AccountList', () => {
         },
       }) as const;
 
-    const group1 = createMockAccountGroup(0, [
+    const createMockSingleAccountGroup = <
+      T extends `keyring:${string}/${string}`,
+    >(
+      id: T,
+      account: string,
+    ) =>
+      ({
+        accounts: [account] as [string],
+        id,
+        type: AccountGroupType.SingleAccount,
+        metadata: {
+          hidden: false,
+          name: id,
+          pinned: false,
+        },
+      }) as const;
+
+    const group1 = createMockMultichainAccountGroup(0, [
       `MOCK-ID-FOR-${CHECKSUMMED_ADDRESS_1}`,
       'MOCK-ID-FOR-63jw5Q7pJXeHgHSvfTmKytUQ19hQgiAJQ5LZykmSMGRY',
     ]);
-    const group2 = createMockAccountGroup(1, [
+    const group2 = createMockMultichainAccountGroup(1, [
       `MOCK-ID-FOR-${CHECKSUMMED_ADDRESS_2}`,
       'MOCK-ID-FOR-Agsjd8HjGH5DxiXLMWc8fR4jjgHhvJG3TXcCpc1ieD9B',
     ]);
-    const importedGroup = createMockAccountGroup(2, [
+    const importedGroup = createMockSingleAccountGroup(
+      'keyring:wallet-2/0',
       `MOCK-ID-FOR-${CHECKSUMMED_ADDRESS_3}`,
-    ]);
+    );
 
     const mockUseAccountProps = jest
       .spyOn(AccountListHooksModule, 'useAccountProps')
@@ -159,6 +180,9 @@ describe('AccountList', () => {
               type: AccountWalletType.Keyring,
               metadata: {
                 name: 'Imported wallet',
+                keyring: {
+                  type: MOCK_KEYRING_TYPE,
+                },
               },
               status: 'ready',
               groups: {

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -131,6 +131,7 @@ describe('AccountList', () => {
         type: AccountGroupType.SingleAccount,
         metadata: {
           hidden: false,
+          lastSelected: 0,
           name: id,
           pinned: false,
         },

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -246,9 +246,9 @@ describe('AccountList', () => {
     );
 
     // Assert - Items exist
-    expect(getByTestId(ACCOUNT_1_TEST_ID.item)).toBeTruthy();
-    expect(getByTestId(ACCOUNT_2_TEST_ID.item)).toBeTruthy();
-    expect(getByTestId(ACCOUNT_3_TEST_ID.item)).toBeTruthy();
+    expect(getByTestId(ACCOUNT_1_TEST_ID.item)).toBeOnTheScreen();
+    expect(getByTestId(ACCOUNT_2_TEST_ID.item)).toBeOnTheScreen();
+    expect(getByTestId(ACCOUNT_3_TEST_ID.item)).toBeOnTheScreen();
 
     // Assert - Item Loading
     expect(getByTestId(ACCOUNT_1_TEST_ID.itemLoading)).toBeTruthy();

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatList, View } from 'react-native';
+import { View } from 'react-native';
 import {
   useAccountProps,
   useNotificationAccountListProps,
@@ -15,7 +15,7 @@ export const AccountsList = () => {
   const theme = useTheme();
   const { styles } = useStyles(styleSheet, { theme });
 
-  const { accountAvatarType, firstHDWalletGroups } = useAccountProps();
+  const { accountAvatarType, accountWalletGroups } = useAccountProps();
   const {
     shouldDisableSwitches,
     isAccountLoading,
@@ -24,35 +24,42 @@ export const AccountsList = () => {
     getEvmAddress,
   } = useNotificationAccountListProps();
 
-  if (!firstHDWalletGroups) {
+  if (accountWalletGroups.length === 0) {
     return null;
   }
 
   return (
     <View>
-      <AccountListHeader
-        title={firstHDWalletGroups.title}
-        containerStyle={styles.accountHeader}
-      />
-      <FlatList
-        data={firstHDWalletGroups.data}
-        keyExtractor={(item) => `address-${item.id}`}
-        renderItem={({ item }) => (
-          <NotificationOptionToggle
-            key={item.id}
-            item={item}
-            evmAddress={getEvmAddress(item.accounts)}
-            icon={accountAvatarType}
-            disabledSwitch={shouldDisableSwitches}
-            isLoading={isAccountLoading(item.accounts)}
-            isEnabled={isAccountEnabled(item.accounts)}
-            refetchNotificationAccounts={refetchAccountSettings}
-            testID={NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
-              getEvmAddress(item.accounts) ?? '',
-            )}
+      {accountWalletGroups.map((walletGroup) => (
+        <View key={walletGroup.wallet.id}>
+          <AccountListHeader
+            title={walletGroup.title}
+            containerStyle={styles.accountHeader}
           />
-        )}
-      />
+          {walletGroup.data.map((item) => {
+            const evmAddress = getEvmAddress(item.accounts);
+            if (!evmAddress) {
+              return null;
+            }
+
+            return (
+              <NotificationOptionToggle
+                key={item.id}
+                item={item}
+                evmAddress={evmAddress}
+                icon={accountAvatarType}
+                disabledSwitch={shouldDisableSwitches}
+                isLoading={isAccountLoading(item.accounts)}
+                isEnabled={isAccountEnabled(item.accounts)}
+                refetchNotificationAccounts={refetchAccountSettings}
+                testID={NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
+                  evmAddress,
+                )}
+              />
+            );
+          })}
+        </View>
+      ))}
     </View>
   );
 };

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { useMemo } from 'react';
+import { SectionList, View } from 'react-native';
 import {
   useAccountProps,
   useNotificationAccountListProps,
@@ -24,42 +24,55 @@ export const AccountsList = () => {
     getEvmAddress,
   } = useNotificationAccountListProps();
 
+  const sections = useMemo(
+    () =>
+      accountWalletGroups.map((walletGroup) => ({
+        key: walletGroup.wallet.id,
+        title: walletGroup.title,
+        data: walletGroup.data,
+      })),
+    [accountWalletGroups],
+  );
+
   if (accountWalletGroups.length === 0) {
     return null;
   }
 
   return (
     <View>
-      {accountWalletGroups.map((walletGroup) => (
-        <View key={walletGroup.wallet.id}>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.id}
+        stickySectionHeadersEnabled={false}
+        renderSectionHeader={({ section }) => (
           <AccountListHeader
-            title={walletGroup.title}
+            title={section.title}
             containerStyle={styles.accountHeader}
           />
-          {walletGroup.data.map((item) => {
-            const evmAddress = getEvmAddress(item.accounts);
-            if (!evmAddress) {
-              return null;
-            }
+        )}
+        renderItem={({ item }) => {
+          const evmAddress = getEvmAddress(item.accounts);
+          if (!evmAddress) {
+            return null;
+          }
 
-            return (
-              <NotificationOptionToggle
-                key={item.id}
-                item={item}
-                evmAddress={evmAddress}
-                icon={accountAvatarType}
-                disabledSwitch={shouldDisableSwitches}
-                isLoading={isAccountLoading(item.accounts)}
-                isEnabled={isAccountEnabled(item.accounts)}
-                refetchNotificationAccounts={refetchAccountSettings}
-                testID={NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
-                  evmAddress,
-                )}
-              />
-            );
-          })}
-        </View>
-      ))}
+          return (
+            <NotificationOptionToggle
+              key={item.id}
+              item={item}
+              evmAddress={evmAddress}
+              icon={accountAvatarType}
+              disabledSwitch={shouldDisableSwitches}
+              isLoading={isAccountLoading(item.accounts)}
+              isEnabled={isAccountEnabled(item.accounts)}
+              refetchNotificationAccounts={refetchAccountSettings}
+              testID={NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
+                evmAddress,
+              )}
+            />
+          );
+        }}
+      />
     </View>
   );
 };

--- a/app/components/Views/Settings/NotificationsSettings/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.test.tsx
@@ -40,6 +40,8 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../UI/Notification/SwitchLoadingModal', () => () => null);
+
 const setOptions = jest.fn();
 
 describe('NotificationsSettings', () => {

--- a/app/components/Views/Settings/NotificationsSettings/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.test.tsx
@@ -15,9 +15,6 @@ const mockInitialState = {
   settings: {
     avatarAccountType: AvatarAccountType.Maskicon,
   },
-  notificationsSettings: {
-    isEnabled: true,
-  },
   engine: {
     backgroundState: {
       ...backgroundState,

--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -30,7 +30,7 @@ import styleSheet, {
 } from './NotificationsSettings.styles';
 import SessionHeader from './sectionHeader';
 import { PushNotificationToggle } from './PushNotificationToggle';
-import { useFirstHDWalletAccounts } from './AccountsList.hooks';
+import { useNotificationWalletAccountGroups } from './AccountsList.hooks';
 import { NotificationSettingsViewSelectorsIDs } from './NotificationSettingsView.testIds';
 
 const NotificationsSettings = ({ navigation, route }: Props) => {
@@ -39,10 +39,8 @@ const NotificationsSettings = ({ navigation, route }: Props) => {
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
-  const firstHDWallet = useFirstHDWalletAccounts();
-  const hasFirstHDWallet = Boolean(
-    firstHDWallet?.data && firstHDWallet?.data.length > 0,
-  );
+  const notificationWalletAccountGroups = useNotificationWalletAccountGroups();
+  const hasNotificationAccounts = notificationWalletAccountGroups.length > 0;
 
   const loadingText = useSwitchNotificationLoadingText();
 
@@ -99,7 +97,7 @@ const NotificationsSettings = ({ navigation, route }: Props) => {
           />
 
           {/* Account Notification Toggles */}
-          {hasFirstHDWallet && (
+          {hasNotificationAccounts && (
             <>
               <SessionHeader
                 title={strings(

--- a/app/core/Engine/messengers/notifications/notification-services-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/notifications/notification-services-controller-messenger.test.ts
@@ -28,8 +28,10 @@ describe('getNotificationServicesControllerMessenger', () => {
         'AuthenticationController:isSignedIn',
         'AuthenticationController:performSignIn',
         // Push Actions
+        'NotificationServicesPushController:addPushNotificationLinks',
         'NotificationServicesPushController:enablePushNotifications',
         'NotificationServicesPushController:disablePushNotifications',
+        'NotificationServicesPushController:deletePushNotificationLinks',
         'NotificationServicesPushController:subscribeToPushNotifications',
       ],
       events: [

--- a/app/core/Engine/messengers/notifications/notification-services-controller-messenger.ts
+++ b/app/core/Engine/messengers/notifications/notification-services-controller-messenger.ts
@@ -27,8 +27,10 @@ export function getNotificationServicesControllerMessenger(
       'AuthenticationController:isSignedIn',
       'AuthenticationController:performSignIn',
       // Push Actions
+      'NotificationServicesPushController:addPushNotificationLinks',
       'NotificationServicesPushController:enablePushNotifications',
       'NotificationServicesPushController:disablePushNotifications',
+      'NotificationServicesPushController:deletePushNotificationLinks',
       'NotificationServicesPushController:subscribeToPushNotifications',
     ],
     events: [

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "@metamask/native-utils": "^0.8.0",
     "@metamask/network-controller": "^30.0.0",
     "@metamask/network-enablement-controller": "^4.2.0",
-    "@metamask/notification-services-controller": "^22.0.0",
+    "@metamask/notification-services-controller": "^23.1.0",
     "@metamask/permission-controller": "^12.2.1",
     "@metamask/phishing-controller": "^17.1.1",
     "@metamask/post-message-stream": "^10.0.0",

--- a/tests/smoke/notifications/utils/mocks.ts
+++ b/tests/smoke/notifications/utils/mocks.ts
@@ -23,6 +23,7 @@ import {
   getMockUpdatePushNotificationLinksResponse,
   getMockCreateFCMRegistrationTokenResponse,
   getMockDeleteFCMRegistrationTokenResponse,
+  getMockDeletePushNotificationLinksResponse,
 } from '@metamask/notification-services-controller/push-services/mocks';
 import { getDecodedProxiedURL } from './helpers';
 import { MockttpNotificationTriggerServer } from './mock-notification-trigger-server';
@@ -104,6 +105,7 @@ export async function mockNotificationServices(server: Mockttp) {
 
   // Push Notifications
   await mockAPICall(server, getMockUpdatePushNotificationLinksResponse());
+  await mockAPICall(server, getMockDeletePushNotificationLinksResponse());
   await mockAPICall(server, getMockCreateFCMRegistrationTokenResponse());
   await mockAPICall(server, getMockDeleteFCMRegistrationTokenResponse());
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9470,23 +9470,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/notification-services-controller@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "@metamask/notification-services-controller@npm:22.0.0"
+"@metamask/notification-services-controller@npm:^23.1.0":
+  version: 23.1.0
+  resolution: "@metamask/notification-services-controller@npm:23.1.0"
   dependencies:
     "@contentful/rich-text-html-renderer": "npm:^16.5.2"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
-    "@metamask/keyring-controller": "npm:^25.1.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/profile-sync-controller": "npm:^27.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/keyring-controller": "npm:^25.2.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     firebase: "npm:^11.2.0"
+    lodash: "npm:^4.17.21"
     loglevel: "npm:^1.8.1"
     semver: "npm:^7.6.3"
     uuid: "npm:^8.3.2"
-  checksum: 10/edeaae4a61ce1ecce5ee5a2bbe30649f70ec0b7a68071e05d1cbc0ab99d62bd094640ca9f40b294052c5175084b7e1fd44c30ff43a20eb57a6ef7562134311ad
+  checksum: 10/a6381830bd121a5d89478df0f09aa08ad6952d78b76e2ce733ebea39b5c1c0744e347a0f41030fa41cfacf6911bc83c76c458dc3a71a320b486a733cee594f3a
   languageName: node
   linkType: hard
 
@@ -35937,7 +35938,7 @@ __metadata:
     "@metamask/native-utils": "npm:^0.8.0"
     "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/network-enablement-controller": "npm:^4.2.0"
-    "@metamask/notification-services-controller": "npm:^22.0.0"
+    "@metamask/notification-services-controller": "npm:^23.1.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^12.2.1"
     "@metamask/phishing-controller": "npm:^17.1.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Update **Notifications settings** so the **Account activity** section lists notification-eligible accounts from all wallet keyrings, not just the first HD wallet. This is tied to the relevant PRs in MM-core:
- https://github.com/MetaMask/core/pull/8108
- https://github.com/MetaMask/core/pull/8449

Keep the existing per-account toggle behavior unchanged, so imported accounts use the same enable/disable notification flow as HD accounts.

Add focused test coverage for multi-wallet rendering and update the settings snapshot accordingly.
 
<img width="328" height="722" alt="image" src="https://github.com/user-attachments/assets/b2c296a2-2cb7-4087-b33f-84741a90c3fb" />


## **Changelog**


<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Extend notification account toggles to all wallet keyrings

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the account-listing/filtering logic in notification settings and upgrades the notification services controller, which could affect which accounts appear and push-link behavior if filtering/messenger wiring is incorrect.
> 
> **Overview**
> Extends **Notification Settings → Account activity** to list notification-eligible (EVM) accounts across *all* wallets/keyrings, instead of only the first HD/entropy wallet.
> 
> Introduces `useNotificationWalletAccountGroups()` to filter wallet/account groups down to those containing EVM accounts, updates `AccountsList` to render per-wallet sections via `SectionList` (skipping non-EVM groups), and adjusts the settings screen to show/hide the section based on these filtered groups. Updates and expands unit/UI tests to cover multi-wallet rendering and empty/no-EVM scenarios, and refreshes smoke-test notification mocks.
> 
> Also updates the notifications controller messenger delegation to include push link add/delete actions, and bumps `@metamask/notification-services-controller` to `^23.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9844b6eceb16643a739bad19b404f511495f54f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->