### PR TITLE
feat: migrate Label (card scope)

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -4,6 +4,7 @@ import { Platform, TouchableOpacity, TextInputProps } from 'react-native';
 import {
   Box,
   FontWeight,
+  Label,
   Text,
   TextVariant,
   Icon,
@@ -11,7 +12,6 @@ import {
   IconSize,
 } from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
-import Label from '../../../../../component-library/components/Form/Label';
 
 import Button, {
   ButtonSize,

--- a/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
@@ -628,15 +628,18 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                 <Text
                                   accessibilityRole="text"
                                   style={
-                                    {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "fontFamily": "Geist-Regular",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      },
+                                      undefined,
+                                    ]
                                   }
-                                  testID="label"
                                 >
                                   Email
                                 </Text>
@@ -740,15 +743,18 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                 <Text
                                   accessibilityRole="text"
                                   style={
-                                    {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "fontFamily": "Geist-Regular",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      },
+                                      undefined,
+                                    ]
                                   }
-                                  testID="label"
                                 >
                                   Password
                                 </Text>

--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
@@ -15,9 +15,9 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Label,
 } from '@metamask/design-system-react-native';
 import { createStyles } from './AddFundsBottomSheet.styles';
-import Label from '../../../../../component-library/components/Form/Label';
 import { useTheme } from '../../../../../util/theme';
 import { View } from 'react-native';
 import { CardTokenAllowance } from '../../types';

--- a/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
@@ -647,15 +647,18 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                         <Text
                                           accessibilityRole="text"
                                           style={
-                                            {
-                                              "color": "#131416",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
-                                            }
+                                            [
+                                              {
+                                                "color": "#131416",
+                                                "fontFamily": "Geist-Regular",
+                                                "fontSize": 16,
+                                                "fontWeight": 400,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              },
+                                              undefined,
+                                            ]
                                           }
-                                          testID="label"
                                         >
                                           Fund with cash
                                         </Text>
@@ -760,15 +763,18 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                         <Text
                                           accessibilityRole="text"
                                           style={
-                                            {
-                                              "color": "#131416",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
-                                            }
+                                            [
+                                              {
+                                                "color": "#131416",
+                                                "fontFamily": "Geist-Regular",
+                                                "fontSize": 16,
+                                                "fontWeight": 400,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              },
+                                              undefined,
+                                            ]
                                           }
-                                          testID="label"
                                         >
                                           Fund with crypto
                                         </Text>
@@ -2047,15 +2053,18 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                                         <Text
                                           accessibilityRole="text"
                                           style={
-                                            {
-                                              "color": "#131416",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
-                                            }
+                                            [
+                                              {
+                                                "color": "#131416",
+                                                "fontFamily": "Geist-Regular",
+                                                "fontSize": 16,
+                                                "fontWeight": 400,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              },
+                                              undefined,
+                                            ]
                                           }
-                                          testID="label"
                                         >
                                           Fund with cash
                                         </Text>
@@ -2752,15 +2761,18 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                                         <Text
                                           accessibilityRole="text"
                                           style={
-                                            {
-                                              "color": "#131416",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
-                                              "letterSpacing": 0,
-                                              "lineHeight": 24,
-                                            }
+                                            [
+                                              {
+                                                "color": "#131416",
+                                                "fontFamily": "Geist-Regular",
+                                                "fontSize": 16,
+                                                "fontWeight": 400,
+                                                "letterSpacing": 0,
+                                                "lineHeight": 24,
+                                              },
+                                              undefined,
+                                            ]
                                           }
-                                          testID="label"
                                         >
                                           Fund with crypto
                                         </Text>

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
@@ -75,6 +75,14 @@ jest.mock('@metamask/design-system-react-native', () => {
     }) => React.createElement(Text, { testID, ...props }, children),
     Icon: ({ name, size, ...props }: { name: string; size: string }) =>
       React.createElement(View, { testID: 'icon', ...props }),
+    Label: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children: React.ReactNode;
+      testID?: string;
+    }) => React.createElement(Text, { testID, ...props }, children),
     TextVariant,
     IconName,
     IconSize,
@@ -180,19 +188,6 @@ jest.mock('../../../../../component-library/components/Buttons/Button', () => {
     ButtonVariants,
     ButtonWidthTypes,
   };
-});
-
-jest.mock('../../../../../component-library/components/Form/Label', () => {
-  const React = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-
-  return ({
-    children,
-    testID,
-  }: {
-    children: React.ReactNode;
-    testID?: string;
-  }) => React.createElement(Text, { testID }, children);
 });
 
 jest.mock('../../../Ramp/Deposit/components/DepositDateField', () => {

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -1,13 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Label,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import Button, {
   ButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import TextField from '../../../../../component-library/components/Form/TextField';
-import Label from '../../../../../component-library/components/Form/Label';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStep from './OnboardingStep';

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
@@ -147,8 +147,15 @@ jest.mock('@metamask/design-system-react-native', () => {
   const Icon = ({ name, size, ...props }: { name: string; size: string }) =>
     React.createElement(View, { testID: 'icon', ...props });
 
+  const Label = ({
+    children,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement(RNText, props, children);
+
   return {
     Box,
+    Label,
     Text,
     Icon,
     TextVariant: {
@@ -205,19 +212,6 @@ jest.mock('../../../../../component-library/components/Form/TextField', () => {
     __esModule: true,
     default: MockTextField,
   };
-});
-
-// Mock Label
-jest.mock('../../../../../component-library/components/Form/Label', () => {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  const React = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-
-  return ({
-    children,
-    ...props
-  }: React.PropsWithChildren<Record<string, unknown>>) =>
-    React.createElement(Text, props, children);
 });
 
 // Mock Button

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -6,14 +6,18 @@ import React, {
   useState,
 } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Label,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import Button, {
   ButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import TextField from '../../../../../component-library/components/Form/TextField';
-import Label from '../../../../../component-library/components/Form/Label';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStep from './OnboardingStep';

--- a/app/components/UI/Card/components/Onboarding/SetPhoneNumber.tsx
+++ b/app/components/UI/Card/components/Onboarding/SetPhoneNumber.tsx
@@ -1,13 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Label,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import Button, {
   ButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import TextField from '../../../../../component-library/components/Form/TextField';
-import Label from '../../../../../component-library/components/Form/Label';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStep from './OnboardingStep';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrate `Label` component (card scope).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-280

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/6ceb7e27-f2bd-49b2-9b15-ece4843f6572" />

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/38d76c8f-40b6-464e-9d88-c5ce5885a6c5" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the `Label` implementation in card screens; main risk is minor styling/test snapshot churn or subtle accessibility differences.
> 
> **Overview**
> Migrates card-related screens/components to use `Label` from `@metamask/design-system-react-native` instead of the local `component-library` `Form/Label` (e.g., `CardAuthentication`, `AddFundsBottomSheet`, and onboarding steps).
> 
> Updates associated Jest mocks and snapshots to reflect the new `Label` rendering/styling (notably style arrays/fontWeight and removal of the previous `testID="label"` output).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65f2d044b68208ae23ed6481a1e26dd65f2eefb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->