### PR TITLE
fix: price impact modal content

### DIFF
--- a/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactDescription.test.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactDescription.test.tsx
@@ -1,64 +1,31 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { PriceImpactDescription } from './PriceImpactDescription';
-import { PriceImpactModalType } from './constants';
 import { strings } from '../../../../../../locales/i18n';
 
 describe('PriceImpactDescription', () => {
-  describe('Execution type', () => {
-    it('renders the execution description with the given priceImpact', () => {
+  describe('content rendering', () => {
+    it('renders the localized content string with the given formattedPriceImpact', () => {
       const { getByText } = render(
         <PriceImpactDescription
-          type={PriceImpactModalType.Execution}
+          content="bridge.price_impact_error_description"
           formattedPriceImpact="-30%"
         />,
       );
 
       expect(
         getByText(
-          strings('bridge.price_impact_execution_description', {
+          strings('bridge.price_impact_error_description', {
             priceImpact: '-30%',
           }),
         ),
       ).toBeTruthy();
     });
 
-    it('renders the execution description with "0" when priceImpact is undefined', () => {
+    it('renders the warning description with the given formattedPriceImpact', () => {
       const { getByText } = render(
         <PriceImpactDescription
-          type={PriceImpactModalType.Execution}
-          formattedPriceImpact={undefined}
-        />,
-      );
-
-      expect(
-        getByText(
-          strings('bridge.price_impact_execution_description', {
-            priceImpact: '0',
-          }),
-        ),
-      ).toBeTruthy();
-    });
-
-    it('does not render the info description', () => {
-      const { queryByText } = render(
-        <PriceImpactDescription
-          type={PriceImpactModalType.Execution}
-          formattedPriceImpact="-30%"
-        />,
-      );
-
-      expect(
-        queryByText(strings('bridge.price_impact_info_description')),
-      ).toBeNull();
-    });
-  });
-
-  describe('Info type — with priceImpact (warning state)', () => {
-    it('renders the warning description with the given priceImpact', () => {
-      const { getByText } = render(
-        <PriceImpactDescription
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_warning_description"
           formattedPriceImpact="-10%"
         />,
       );
@@ -72,23 +39,42 @@ describe('PriceImpactDescription', () => {
       ).toBeTruthy();
     });
 
-    it('does not render the info description when priceImpact is provided', () => {
-      const { queryByText } = render(
+    it('renders the info description (no interpolation needed)', () => {
+      const { getByText } = render(
         <PriceImpactDescription
-          type={PriceImpactModalType.Info}
-          formattedPriceImpact="-10%"
+          content="bridge.price_impact_info_description"
+          formattedPriceImpact={undefined}
         />,
       );
 
       expect(
-        queryByText(strings('bridge.price_impact_info_description')),
-      ).toBeNull();
+        getByText(strings('bridge.price_impact_info_description')),
+      ).toBeTruthy();
     });
+  });
 
-    it('treats the string "0" as a truthy priceImpact and renders the warning description', () => {
+  describe('formattedPriceImpact fallback', () => {
+    it('falls back to "0" when formattedPriceImpact is undefined', () => {
       const { getByText } = render(
         <PriceImpactDescription
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_error_description"
+          formattedPriceImpact={undefined}
+        />,
+      );
+
+      expect(
+        getByText(
+          strings('bridge.price_impact_error_description', {
+            priceImpact: '0',
+          }),
+        ),
+      ).toBeTruthy();
+    });
+
+    it('uses the provided value and does not fall back when formattedPriceImpact is "0"', () => {
+      const { getByText } = render(
+        <PriceImpactDescription
+          content="bridge.price_impact_warning_description"
           formattedPriceImpact="0"
         />,
       );
@@ -100,78 +86,6 @@ describe('PriceImpactDescription', () => {
           }),
         ),
       ).toBeTruthy();
-    });
-  });
-
-  describe('Info type — without priceImpact (info state)', () => {
-    it('renders the info description when priceImpact is undefined', () => {
-      const { getByText } = render(
-        <PriceImpactDescription
-          type={PriceImpactModalType.Info}
-          formattedPriceImpact={undefined}
-        />,
-      );
-
-      expect(
-        getByText(strings('bridge.price_impact_info_description')),
-      ).toBeTruthy();
-    });
-
-    it('renders the info description when priceImpact is an empty string', () => {
-      const { getByText } = render(
-        <PriceImpactDescription
-          type={PriceImpactModalType.Info}
-          formattedPriceImpact=""
-        />,
-      );
-
-      expect(
-        getByText(strings('bridge.price_impact_info_description')),
-      ).toBeTruthy();
-    });
-
-    it('does not render the warning description when priceImpact is absent', () => {
-      const { queryByText } = render(
-        <PriceImpactDescription
-          type={PriceImpactModalType.Info}
-          formattedPriceImpact={undefined}
-        />,
-      );
-
-      expect(
-        queryByText(
-          strings('bridge.price_impact_warning_description', {
-            priceImpact: undefined,
-          }),
-        ),
-      ).toBeNull();
-    });
-  });
-
-  describe('priority — Execution type takes precedence over warning state', () => {
-    it('renders the execution description rather than the warning description when type is Execution and priceImpact is provided', () => {
-      const { getByText, queryByText } = render(
-        <PriceImpactDescription
-          type={PriceImpactModalType.Execution}
-          formattedPriceImpact="-10%"
-        />,
-      );
-
-      expect(
-        getByText(
-          strings('bridge.price_impact_execution_description', {
-            priceImpact: '-10%',
-          }),
-        ),
-      ).toBeTruthy();
-
-      expect(
-        queryByText(
-          strings('bridge.price_impact_warning_description', {
-            priceImpact: '-10%',
-          }),
-        ),
-      ).toBeNull();
     });
   });
 });

--- a/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactDescription.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactDescription.tsx
@@ -1,36 +1,23 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { strings } from '../../../../../../locales/i18n';
 import { Box, Text, TextColor } from '@metamask/design-system-react-native';
-import { PriceImpactModalType } from './constants';
 
 interface PriceImpactDescriptionProps {
-  type: PriceImpactModalType;
+  content: string;
   formattedPriceImpact?: string;
 }
 
 export function PriceImpactDescription({
-  type,
+  content,
   formattedPriceImpact,
 }: PriceImpactDescriptionProps) {
-  const isWarning = Boolean(formattedPriceImpact);
-
-  const body = useMemo(() => {
-    if (type === PriceImpactModalType.Execution) {
-      return strings('bridge.price_impact_execution_description', {
-        priceImpact: formattedPriceImpact ?? '0',
-      });
-    }
-    if (isWarning) {
-      return strings('bridge.price_impact_warning_description', {
-        priceImpact: formattedPriceImpact ?? '0',
-      });
-    }
-    return strings('bridge.price_impact_info_description');
-  }, [type, formattedPriceImpact, isWarning]);
-
   return (
     <Box paddingHorizontal={4} paddingVertical={2}>
-      <Text color={TextColor.TextAlternative}>{body}</Text>
+      <Text color={TextColor.TextAlternative}>
+        {strings(content, {
+          priceImpact: formattedPriceImpact ?? '0',
+        })}
+      </Text>
     </Box>
   );
 }

--- a/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactHeader.test.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactHeader.test.tsx
@@ -1,25 +1,21 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import { PriceImpactHeader } from './PriceImpactHeader';
-import { PriceImpactModalType } from './constants';
 import { strings } from '../../../../../../locales/i18n';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import { IconColor, IconName } from '@metamask/design-system-react-native';
 
 // Render the warning Icon with a testID derived from the icon name so it can
 // be queried in tests without coupling to SVG internals.
-jest.mock('../../../../../component-library/components/Icons/Icon', () => {
+// Only Icon is overridden; all other design-system exports (ButtonIcon, etc.)
+// are preserved from the real module so their existing behaviour is unchanged.
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   const { View } = jest.requireActual('react-native');
   return {
-    __esModule: true,
-    default: ({ name, testID }: { name: string; testID?: string }) => (
+    ...actual,
+    Icon: ({ name, testID }: { name: string; testID?: string }) => (
       <View testID={testID ?? `icon-${name}`} />
     ),
-    IconName: jest.requireActual(
-      '../../../../../component-library/components/Icons/Icon',
-    ).IconName,
-    IconSize: jest.requireActual(
-      '../../../../../component-library/components/Icons/Icon',
-    ).IconSize,
   };
 });
 
@@ -30,27 +26,42 @@ beforeEach(() => {
 });
 
 describe('PriceImpactHeader', () => {
-  describe('title', () => {
-    it('renders "Price impact" for the Info type', () => {
+  describe('content rendering', () => {
+    it('renders the localized string for price_impact_info_title', () => {
       const { getByText } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_info_title"
           onClose={onClose}
         />,
       );
 
-      expect(getByText(strings('bridge.price_impact'))).toBeTruthy();
+      expect(getByText(strings('bridge.price_impact_info_title'))).toBeTruthy();
     });
 
-    it('renders "High price impact" for the Execution type', () => {
+    it('renders the localized string for price_impact_warning_title', () => {
       const { getByText } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Execution}
+          content="bridge.price_impact_warning_title"
           onClose={onClose}
         />,
       );
 
-      expect(getByText(strings('bridge.price_impact_high'))).toBeTruthy();
+      expect(
+        getByText(strings('bridge.price_impact_warning_title')),
+      ).toBeTruthy();
+    });
+
+    it('renders the localized string for price_impact_error_title', () => {
+      const { getByText } = render(
+        <PriceImpactHeader
+          content="bridge.price_impact_error_title"
+          onClose={onClose}
+        />,
+      );
+
+      expect(
+        getByText(strings('bridge.price_impact_error_title')),
+      ).toBeTruthy();
     });
   });
 
@@ -58,7 +69,7 @@ describe('PriceImpactHeader', () => {
     it('renders the close button', () => {
       const { getByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_info_title"
           onClose={onClose}
         />,
       );
@@ -69,7 +80,7 @@ describe('PriceImpactHeader', () => {
     it('calls onClose when the close button is pressed', () => {
       const { getByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_info_title"
           onClose={onClose}
         />,
       );
@@ -79,13 +90,13 @@ describe('PriceImpactHeader', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onClose on the Execution type as well', () => {
+    it('calls onClose when an icon is also shown', () => {
       const { getByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Execution}
+          content="bridge.price_impact_error_title"
           onClose={onClose}
-          warningIconName={IconName.Danger}
-          warningIconColor="red"
+          iconName={IconName.Danger}
+          iconColor={IconColor.ErrorDefault}
         />,
       );
 
@@ -96,37 +107,37 @@ describe('PriceImpactHeader', () => {
   });
 
   describe('warning icon', () => {
-    it('renders the warning icon when both warningIconName and warningIconColor are provided', () => {
+    it('renders the warning icon when both iconName and iconColor are provided', () => {
       const { getByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Execution}
+          content="bridge.price_impact_error_title"
           onClose={onClose}
-          warningIconName={IconName.Danger}
-          warningIconColor="red"
+          iconName={IconName.Danger}
+          iconColor={IconColor.ErrorDefault}
         />,
       );
 
       expect(getByTestId(`icon-${IconName.Danger}`)).toBeTruthy();
     });
 
-    it('does not render the warning icon when warningIconName is absent', () => {
+    it('does not render the warning icon when iconName is absent', () => {
       const { queryByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Execution}
+          content="bridge.price_impact_error_title"
           onClose={onClose}
-          warningIconColor="red"
+          iconColor={IconColor.ErrorDefault}
         />,
       );
 
       expect(queryByTestId(`icon-${IconName.Danger}`)).toBeNull();
     });
 
-    it('does not render the warning icon when warningIconColor is absent', () => {
+    it('does not render the warning icon when iconColor is absent', () => {
       const { queryByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_info_title"
           onClose={onClose}
-          warningIconName={IconName.Warning}
+          iconName={IconName.Warning}
         />,
       );
 
@@ -136,7 +147,7 @@ describe('PriceImpactHeader', () => {
     it('does not render the warning icon when neither prop is provided', () => {
       const { queryByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_info_title"
           onClose={onClose}
         />,
       );
@@ -145,13 +156,13 @@ describe('PriceImpactHeader', () => {
       expect(queryByTestId(`icon-${IconName.Warning}`)).toBeNull();
     });
 
-    it('renders a Warning icon for the Info type when both props are provided', () => {
+    it('renders a Warning icon when iconName and iconColor are both provided', () => {
       const { getByTestId } = render(
         <PriceImpactHeader
-          type={PriceImpactModalType.Info}
+          content="bridge.price_impact_warning_title"
           onClose={onClose}
-          warningIconName={IconName.Warning}
-          warningIconColor="orange"
+          iconName={IconName.Warning}
+          iconColor={IconColor.WarningDefault}
         />,
       );
 

--- a/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactHeader.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/PriceImpactHeader.tsx
@@ -1,9 +1,4 @@
 import React from 'react';
-import Icon, {
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
-import { strings } from '../../../../../../locales/i18n';
 import {
   Box,
   BoxAlignItems,
@@ -11,54 +6,42 @@ import {
   BoxJustifyContent,
   ButtonIcon,
   ButtonIconSize,
-  FontWeight,
-  IconName as DSIconName,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
   Text,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { PriceImpactModalType } from './constants';
+import { strings } from '../../../../../../locales/i18n';
 
 interface PriceImpactHeaderProps {
-  type: PriceImpactModalType;
   onClose: () => void;
-  warningIconName?: IconName;
-  warningIconColor?: string;
+  iconName?: IconName;
+  iconColor?: IconColor;
+  content: string;
 }
 
 export function PriceImpactHeader({
-  type,
   onClose,
-  warningIconName,
-  warningIconColor,
+  iconColor,
+  iconName,
+  content,
 }: PriceImpactHeaderProps) {
-  const isWarning = Boolean(warningIconName && warningIconColor);
-  const title =
-    type === PriceImpactModalType.Execution
-      ? strings('bridge.price_impact_high')
-      : strings('bridge.price_impact');
-
   return (
     <Box
       paddingHorizontal={2}
       flexDirection={BoxFlexDirection.Row}
-      alignItems={isWarning ? BoxAlignItems.Start : BoxAlignItems.Center}
-      twClassName={isWarning ? 'py-2' : 'min-h-14'}
+      alignItems={BoxAlignItems.Start}
+      twClassName={'py-2'}
     >
       <Box twClassName="flex-1" />
       <Box alignItems={BoxAlignItems.Center}>
-        {isWarning && warningIconName && warningIconColor && (
-          <Icon
-            name={warningIconName}
-            size={IconSize.Xl}
-            color={warningIconColor}
-          />
+        {iconColor && iconName && (
+          <Icon name={iconName} size={IconSize.Xl} color={iconColor} />
         )}
-        <Text
-          variant={isWarning ? TextVariant.HeadingMd : TextVariant.BodyMd}
-          fontWeight={isWarning ? undefined : FontWeight.Bold}
-          twClassName={isWarning ? 'text-center mt-2' : 'text-center'}
-        >
-          {title}
+        <Text variant={TextVariant.HeadingMd} twClassName={'text-center mt-4'}>
+          {strings(content)}
         </Text>
       </Box>
       <Box
@@ -67,7 +50,7 @@ export function PriceImpactHeader({
         justifyContent={BoxJustifyContent.End}
       >
         <ButtonIcon
-          iconName={DSIconName.Close}
+          iconName={IconName.Close}
           size={ButtonIconSize.Md}
           onPress={onClose}
         />

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.test.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.test.tsx
@@ -3,8 +3,11 @@ import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { PriceImpactModal } from './index';
 import { PriceImpactModalType } from './constants';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
-import { TextColor } from '../../../../../component-library/components/Texts/Text';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import {
+  IconColor,
+  IconName,
+  TextColor,
+} from '@metamask/design-system-react-native';
 
 // Mock BottomSheet
 jest.mock(
@@ -27,12 +30,20 @@ jest.mock(
 // Mock sub-components so we can assert on the props they receive
 jest.mock('./PriceImpactHeader', () => ({
   PriceImpactHeader: jest.fn(
-    ({ type, onClose }: { type: string; onClose: () => void }) => {
+    ({
+      onClose,
+      content,
+    }: {
+      onClose: () => void;
+      iconName?: string;
+      iconColor?: string;
+      content: string;
+    }) => {
       const { View, TouchableOpacity, Text } =
         jest.requireActual('react-native');
       return (
         <View testID="price-impact-header">
-          <Text testID="price-impact-header-type">{type}</Text>
+          <Text testID="price-impact-header-content">{content}</Text>
           <TouchableOpacity
             testID="price-impact-header-close"
             onPress={onClose}
@@ -47,13 +58,21 @@ jest.mock('./PriceImpactHeader', () => ({
 
 jest.mock('./PriceImpactDescription', () => ({
   PriceImpactDescription: jest.fn(
-    ({ type, priceImpact }: { type: string; priceImpact?: string }) => {
+    ({
+      content,
+      formattedPriceImpact,
+    }: {
+      content: string;
+      formattedPriceImpact?: string;
+    }) => {
       const { View, Text } = jest.requireActual('react-native');
       return (
         <View testID="price-impact-description">
-          <Text testID="price-impact-description-type">{type}</Text>
-          {priceImpact ? (
-            <Text testID="price-impact-description-value">{priceImpact}</Text>
+          <Text testID="price-impact-description-content">{content}</Text>
+          {formattedPriceImpact ? (
+            <Text testID="price-impact-description-value">
+              {formattedPriceImpact}
+            </Text>
           ) : null}
         </View>
       );
@@ -176,8 +195,10 @@ const defaultParams = {
 };
 
 const defaultViewData = {
-  textColor: TextColor.Alternative,
+  textColor: TextColor.TextAlternative,
   icon: undefined,
+  title: 'bridge.price_impact_info_title',
+  description: 'bridge.price_impact_info_description',
 };
 
 describe('PriceImpactModal', () => {
@@ -232,25 +253,32 @@ describe('PriceImpactModal', () => {
   });
 
   describe('props passed to sub-components', () => {
-    it('passes type to PriceImpactHeader', () => {
-      mockUseParams.mockReturnValue({
-        ...defaultParams,
-        type: PriceImpactModalType.Execution,
-      });
+    it('passes content (title key) from priceImpactViewData to PriceImpactHeader', () => {
+      mockUsePriceImpactViewData.mockReturnValue({
+        ...defaultViewData,
+        title: 'bridge.price_impact_error_title',
+      } as ReturnType<typeof usePriceImpactViewData>);
 
       render(<PriceImpactModal />);
 
       expect(mockPriceImpactHeader).toHaveBeenCalledWith(
-        expect.objectContaining({ type: PriceImpactModalType.Execution }),
+        expect.objectContaining({ content: 'bridge.price_impact_error_title' }),
         expect.anything(),
       );
     });
 
-    it('passes type to PriceImpactDescription', () => {
+    it('passes content (description key) from priceImpactViewData to PriceImpactDescription', () => {
+      mockUsePriceImpactViewData.mockReturnValue({
+        ...defaultViewData,
+        description: 'bridge.price_impact_warning_description',
+      } as ReturnType<typeof usePriceImpactViewData>);
+
       render(<PriceImpactModal />);
 
       expect(mockPriceImpactDescription).toHaveBeenCalledWith(
-        expect.objectContaining({ type: PriceImpactModalType.Info }),
+        expect.objectContaining({
+          content: 'bridge.price_impact_warning_description',
+        }),
         expect.anything(),
       );
     });
@@ -264,11 +292,7 @@ describe('PriceImpactModal', () => {
       );
     });
 
-    it('passes priceImpact to PriceImpactDescription when warningIcon is present', () => {
-      mockUsePriceImpactViewData.mockReturnValue({
-        textColor: TextColor.Error,
-        icon: { name: IconName.Danger, color: TextColor.Error },
-      } as ReturnType<typeof usePriceImpactViewData>);
+    it('passes formattedPriceImpact to PriceImpactDescription when formattedQuoteData has it', () => {
       mockUseBridgeQuoteData.mockReturnValue({
         formattedQuoteData: { priceImpact: '5%' },
       } as ReturnType<typeof useBridgeQuoteData>);
@@ -281,13 +305,9 @@ describe('PriceImpactModal', () => {
       );
     });
 
-    it('passes undefined priceImpact to PriceImpactDescription when warningIcon is absent', () => {
-      mockUsePriceImpactViewData.mockReturnValue({
-        textColor: TextColor.Alternative,
-        icon: undefined,
-      } as ReturnType<typeof usePriceImpactViewData>);
+    it('passes undefined formattedPriceImpact to PriceImpactDescription when formattedQuoteData is absent', () => {
       mockUseBridgeQuoteData.mockReturnValue({
-        formattedQuoteData: { priceImpact: '5%' },
+        formattedQuoteData: undefined,
       } as ReturnType<typeof useBridgeQuoteData>);
 
       render(<PriceImpactModal />);
@@ -298,30 +318,31 @@ describe('PriceImpactModal', () => {
       );
     });
 
-    it('passes warningIconName and warningIconColor to PriceImpactHeader from view data', () => {
+    it('passes iconName and iconColor to PriceImpactHeader from view data', () => {
       mockUsePriceImpactViewData.mockReturnValue({
-        textColor: TextColor.Warning,
-        icon: { name: IconName.Warning, color: TextColor.Warning },
+        ...defaultViewData,
+        textColor: TextColor.WarningDefault,
+        icon: { name: IconName.Warning, color: IconColor.WarningDefault },
       } as ReturnType<typeof usePriceImpactViewData>);
 
       render(<PriceImpactModal />);
 
       expect(mockPriceImpactHeader).toHaveBeenCalledWith(
         expect.objectContaining({
-          warningIconName: IconName.Warning,
-          warningIconColor: TextColor.Warning,
+          iconName: IconName.Warning,
+          iconColor: IconColor.WarningDefault,
         }),
         expect.anything(),
       );
     });
 
-    it('passes undefined warningIconName and warningIconColor when icon is absent', () => {
+    it('passes undefined iconName and iconColor when icon is absent', () => {
       render(<PriceImpactModal />);
 
       expect(mockPriceImpactHeader).toHaveBeenCalledWith(
         expect.objectContaining({
-          warningIconName: undefined,
-          warningIconColor: undefined,
+          iconName: undefined,
+          iconColor: undefined,
         }),
         expect.anything(),
       );

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
@@ -42,23 +42,19 @@ export const PriceImpactModal = () => {
     await confirmBridge();
   }, [confirmBridge]);
 
-  const warningIcon = priceImpactViewData.icon;
-
   useModalCloseOnQuoteExpiry();
 
   return (
     <BottomSheet ref={sheetRef}>
       <PriceImpactHeader
-        type={type}
         onClose={handleClose}
-        warningIconName={warningIcon?.name}
-        warningIconColor={warningIcon?.color}
+        iconName={priceImpactViewData.icon?.name}
+        iconColor={priceImpactViewData.icon?.color}
+        content={priceImpactViewData.title}
       />
       <PriceImpactDescription
-        type={type}
-        formattedPriceImpact={
-          warningIcon ? formattedQuoteData?.priceImpact : undefined
-        }
+        formattedPriceImpact={formattedQuoteData?.priceImpact}
+        content={priceImpactViewData.description}
       />
       <PriceImpactFooter
         type={type}

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -301,6 +301,8 @@ describe('QuoteDetailsCard', () => {
     expect(getByText('0.01')).toBeDefined();
     expect(getByText('Price impact')).toBeTruthy();
     expect(getByTestId('price-impact-info-button')).toBeTruthy();
+    // Default mock has priceImpact: '-0.06%'; formatPriceImpact clips negatives to '0%'
+    expect(getByText('0%')).toBeTruthy();
   });
 
   it('displays quote rate', () => {
@@ -529,7 +531,6 @@ describe('QuoteDetailsCard', () => {
     mockModule.useBridgeQuoteData.mockImplementation(originalImpl);
   });
 
-  // Minimal tests to hit missing branches for 80% coverage
   it('handles early return when formattedQuoteData is missing', () => {
     const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
     mockModule.useBridgeQuoteData.mockImplementationOnce(() => ({
@@ -540,13 +541,16 @@ describe('QuoteDetailsCard', () => {
       formattedQuoteData: null,
     }));
 
-    const { queryByTestId } = renderScreen(
+    const { queryByTestId, queryByText } = renderScreen(
       QuoteDetailsCardTestScreen,
       { name: Routes.BRIDGE.ROOT },
       { state: testState },
     );
 
-    expect(queryByTestId('quote-details-card')).toBeNull();
+    // Component returns null when formattedQuoteData is absent — no content should be rendered
+    expect(queryByTestId('price-impact-info-button')).toBeNull();
+    expect(queryByTestId('edit-slippage-button')).toBeNull();
+    expect(queryByText(strings('bridge.rate'))).toBeNull();
   });
 
   it('handles price impact info button navigation', () => {
@@ -626,7 +630,8 @@ describe('QuoteDetailsCard', () => {
     );
   });
 
-  it('renders price impact info button for low price impact values', () => {
+  it('renders price impact row in normal state when price impact is below warning threshold', () => {
+    // 0.04 (4%) < warning threshold 0.05 (5%) → normal state, no warning icon
     const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
     mockModule.useBridgeQuoteData.mockImplementationOnce(() => ({
       quoteFetchError: null,
@@ -634,7 +639,7 @@ describe('QuoteDetailsCard', () => {
         ...mockQuotes[0],
         quote: {
           ...mockQuotes[0].quote,
-          priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '0.1' },
+          priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '0.04' },
           gasIncluded: false,
           gasIncluded7702: false,
         },
@@ -645,7 +650,7 @@ describe('QuoteDetailsCard', () => {
         networkFee: '0.01',
         estimatedTime: '1 min',
         rate: '1 ETH = 24.4 USDC',
-        priceImpact: '0.1%',
+        priceImpact: '0.04%',
         slippage: '0.5%',
       },
     }));
@@ -658,9 +663,49 @@ describe('QuoteDetailsCard', () => {
 
     expect(getByText('Price impact')).toBeTruthy();
     expect(getByTestId('price-impact-info-button')).toBeTruthy();
+    // formatPriceImpact('0.04%') → '0.04%'
+    expect(getByText('0.04%')).toBeTruthy();
   });
 
-  it('renders price impact row with info button for high price impact values', () => {
+  it('renders price impact row in warning state when price impact is between thresholds', () => {
+    // 0.10 (10%) >= warning threshold 0.05 (5%) but < error threshold 0.25 (25%) → warning state
+    const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
+    mockModule.useBridgeQuoteData.mockImplementationOnce(() => ({
+      quoteFetchError: null,
+      activeQuote: {
+        ...mockQuotes[0],
+        quote: {
+          ...mockQuotes[0].quote,
+          priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '0.10' },
+          gasIncluded: false,
+          gasIncluded7702: false,
+        },
+      },
+      destTokenAmount: '24.44',
+      isLoading: false,
+      formattedQuoteData: {
+        networkFee: '0.01',
+        estimatedTime: '1 min',
+        rate: '1 ETH = 24.4 USDC',
+        priceImpact: '0.10%',
+        slippage: '0.5%',
+      },
+    }));
+
+    const { getByText, getByTestId } = renderScreen(
+      QuoteDetailsCardTestScreen,
+      { name: Routes.BRIDGE.ROOT },
+      { state: testState },
+    );
+
+    expect(getByText('Price impact')).toBeTruthy();
+    expect(getByTestId('price-impact-info-button')).toBeTruthy();
+    // formatPriceImpact('0.10%') → '0.1%'
+    expect(getByText('0.1%')).toBeTruthy();
+  });
+
+  it('renders price impact row in error state when price impact exceeds error threshold', () => {
+    // 25.0 >= error threshold 0.25 (25%) → error state
     const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
     mockModule.useBridgeQuoteData.mockImplementationOnce(() => ({
       quoteFetchError: null,
@@ -691,8 +736,9 @@ describe('QuoteDetailsCard', () => {
     );
 
     expect(getByText('Price impact')).toBeTruthy();
-    expect(getByText('25%')).toBeTruthy();
     expect(getByTestId('price-impact-info-button')).toBeTruthy();
+    // formatPriceImpact('25.0%') → '25%'
+    expect(getByText('25%')).toBeTruthy();
   });
 
   describe('minimum received row', () => {

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -345,39 +345,47 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
 
         <KeyValueRow
           field={{
+            label: {
+              text: toSentenceCase(strings('bridge.price_impact')),
+              variant: TextVariantLegacy.BodyMD,
+              color: TextColorLegacy.Alternative,
+            },
+            tooltip: {
+              title: strings('bridge.price_impact_info_title'),
+              content: strings('bridge.price_impact_info_description'),
+              size: TooltipSizes.Sm,
+              iconName: IconNameLegacy.Info,
+            },
+          }}
+          value={{
             label: (
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
                 gap={1}
               >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
-                >
-                  {toSentenceCase(strings('bridge.price_impact'))}
-                </Text>
                 <TouchableOpacity
                   testID="price-impact-info-button"
                   onPress={handlePriceImpactPress}
                   activeOpacity={0.6}
                 >
-                  <Icon
-                    name={IconName.Info}
-                    size={IconSize.Sm}
-                    color={IconColor.IconAlternative}
-                  />
+                  {priceImactViewData.icon && (
+                    <Icon
+                      name={priceImactViewData.icon.name}
+                      size={IconSize.Sm}
+                      color={priceImactViewData.icon.color}
+                      twClassName="mt-[2px]"
+                    />
+                  )}
                 </TouchableOpacity>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={priceImactViewData.textColor}
+                >
+                  {formatPriceImpact(formattedQuoteData.priceImpact)}
+                </Text>
               </Box>
             ),
-          }}
-          value={{
-            icon: priceImactViewData.icon,
-            label: {
-              text: formatPriceImpact(formattedQuoteData.priceImpact),
-              variant: TextVariantLegacy.BodyMD,
-              color: priceImactViewData.textColor,
-            },
           }}
         />
 

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -848,58 +848,55 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   }
                                 }
                               >
-                                <View
+                                <Text
+                                  accessibilityRole="text"
                                   style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "display": "flex",
-                                        "flexDirection": "row",
-                                        "gap": 4,
-                                      },
-                                      undefined,
-                                    ]
+                                    {
+                                      "color": "#66676a",
+                                      "fontFamily": "Geist-Regular",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                  testID="label"
+                                >
+                                  Price impact
+                                </Text>
+                                <TouchableOpacity
+                                  accessibilityLabel="Price impact tooltip"
+                                  accessibilityRole="button"
+                                  accessible={true}
+                                  activeOpacity={1}
+                                  disabled={false}
+                                  onPress={[Function]}
+                                  onPressIn={[Function]}
+                                  onPressOut={[Function]}
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "borderRadius": 8,
+                                      "height": 24,
+                                      "justifyContent": "center",
+                                      "opacity": 1,
+                                      "width": 24,
+                                    }
                                   }
                                 >
-                                  <Text
-                                    accessibilityRole="text"
+                                  <SvgMock
+                                    color="#66676a"
+                                    fill="currentColor"
+                                    height={16}
+                                    name="Info"
                                     style={
-                                      [
-                                        {
-                                          "color": "#66676a",
-                                          "fontFamily": "Geist-Regular",
-                                          "fontSize": 16,
-                                          "fontWeight": 400,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        },
-                                        undefined,
-                                      ]
-                                    }
-                                  >
-                                    Price impact
-                                  </Text>
-                                  <TouchableOpacity
-                                    activeOpacity={0.6}
-                                    onPress={[Function]}
-                                    testID="price-impact-info-button"
-                                  >
-                                    <SvgMock
-                                      fill="currentColor"
-                                      name="Info"
-                                      style={
-                                        [
-                                          {
-                                            "color": "#66676a",
-                                            "height": 16,
-                                            "width": 16,
-                                          },
-                                          undefined,
-                                        ]
+                                      {
+                                        "height": 16,
+                                        "width": 16,
                                       }
-                                    />
-                                  </TouchableOpacity>
-                                </View>
+                                    }
+                                    width={16}
+                                  />
+                                </TouchableOpacity>
                               </View>
                             </View>
                           </View>
@@ -928,21 +925,43 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   }
                                 }
                               >
-                                <Text
-                                  accessibilityRole="text"
+                                <View
                                   style={
-                                    {
-                                      "color": "#66676a",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "gap": 4,
+                                      },
+                                      undefined,
+                                    ]
                                   }
-                                  testID="label"
                                 >
-                                  0%
-                                </Text>
+                                  <TouchableOpacity
+                                    activeOpacity={0.6}
+                                    onPress={[Function]}
+                                    testID="price-impact-info-button"
+                                  />
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      [
+                                        {
+                                          "color": "#66676a",
+                                          "fontFamily": "Geist-Regular",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    0%
+                                  </Text>
+                                </View>
                               </View>
                             </View>
                           </View>

--- a/app/components/UI/Bridge/utils/getPriceImpactViewData.test.ts
+++ b/app/components/UI/Bridge/utils/getPriceImpactViewData.test.ts
@@ -1,22 +1,31 @@
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { TextColor } from '../../../../component-library/components/Texts/Text';
+import {
+  IconColor,
+  IconName,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { getPriceImpactViewData } from './getPriceImpactViewData';
 
 const DEFAULT_THRESHOLD = { warning: 0.05, error: 0.25 };
 
 const ALTERNATIVE = {
-  textColor: TextColor.Alternative,
+  textColor: TextColor.TextAlternative,
   icon: undefined,
+  title: 'bridge.price_impact_info_title',
+  description: 'bridge.price_impact_info_description',
 };
 
 const WARNING = {
-  textColor: TextColor.Warning,
-  icon: { name: IconName.Warning, color: TextColor.Warning },
+  textColor: TextColor.WarningDefault,
+  icon: { name: IconName.Warning, color: IconColor.WarningDefault },
+  title: 'bridge.price_impact_warning_title',
+  description: 'bridge.price_impact_warning_description',
 };
 
 const DANGER = {
-  textColor: TextColor.Error,
-  icon: { name: IconName.Danger, color: TextColor.Error },
+  textColor: TextColor.ErrorDefault,
+  icon: { name: IconName.Danger, color: IconColor.ErrorDefault },
+  title: 'bridge.price_impact_error_title',
+  description: 'bridge.price_impact_error_description',
 };
 
 describe('getPriceImpactViewData', () => {

--- a/app/components/UI/Bridge/utils/getPriceImpactViewData.ts
+++ b/app/components/UI/Bridge/utils/getPriceImpactViewData.ts
@@ -1,5 +1,8 @@
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { TextColor } from '../../../../component-library/components/Texts/Text';
+import {
+  IconColor,
+  IconName,
+  TextColor,
+} from '@metamask/design-system-react-native';
 
 interface Params {
   priceImpactValue?: string;
@@ -12,8 +15,10 @@ export const getPriceImpactViewData = ({
 }: Params) => {
   if (!priceImpactValue) {
     return {
-      textColor: TextColor.Alternative,
+      textColor: TextColor.TextAlternative,
       icon: undefined,
+      title: 'bridge.price_impact_info_title',
+      description: 'bridge.price_impact_info_description',
     };
   }
 
@@ -21,33 +26,41 @@ export const getPriceImpactViewData = ({
 
   if (!Number.isFinite(priceImpact)) {
     return {
-      textColor: TextColor.Alternative,
+      textColor: TextColor.TextAlternative,
       icon: undefined,
+      title: 'bridge.price_impact_info_title',
+      description: 'bridge.price_impact_info_description',
     };
   }
 
   if (priceImpact >= threshold.error) {
     return {
-      textColor: TextColor.Error,
+      textColor: TextColor.ErrorDefault,
       icon: {
         name: IconName.Danger,
-        color: TextColor.Error,
+        color: IconColor.ErrorDefault,
       },
+      title: 'bridge.price_impact_error_title',
+      description: 'bridge.price_impact_error_description',
     };
   }
 
   if (priceImpact >= threshold.warning) {
     return {
-      textColor: TextColor.Warning,
+      textColor: TextColor.WarningDefault,
       icon: {
         name: IconName.Warning,
-        color: TextColor.Warning,
+        color: IconColor.WarningDefault,
       },
+      title: 'bridge.price_impact_warning_title',
+      description: 'bridge.price_impact_warning_description',
     };
   }
 
   return {
-    textColor: TextColor.Alternative,
+    textColor: TextColor.TextAlternative,
     icon: undefined,
+    title: 'bridge.price_impact_info_title',
+    description: 'bridge.price_impact_info_description',
   };
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6578,9 +6578,9 @@
     "hardware_wallet_not_supported": "Hardware wallets aren't supported yet. Use a hot wallet to continue.",
     "hardware_wallet_not_supported_solana": "Hardware wallets aren't supported for Solana yet. Use a hot wallet to continue.",
     "price_impact_info_title": "Price impact",
-    "price_impact_info_description": "Price impact reflects how your swap order affects the market price of the asset. It depends on the trade size and the available liquidity in the pool. MetaMask does not influence or control price impact.",
+    "price_impact_info_description": "This is how your trade changes the market price of a token. It depends on the trade size, available liquidity, and provider fees. MetaMask doesn't control price impact.",
     "price_impact_info_gasless_description": "Price impact reflects how your swap order affects the market price of the asset. If you don't hold enough funds for gas, part of your source token is automatically allocated to cover fees, which increases price impact. MetaMask does not influence or control price impact.",
-    "price_impact_warning_description": "This trade has an estimated {{priceImpact}} price impact, which reflects how much your trade changes the market price. The quote already reflects this.",
+    "price_impact_warning_description": "Because of your trade size and available liquidity, you'll get about {{priceImpact}} less than the market price. This is already factored into your quote.",
     "price_impact_high": "High price impact",
     "price_impact_execution_description": "You'll lose approximately {{priceImpact}} of your token's value on this swap. Try lowering the amount or choosing a more liquid route.",
     "proceed": "Proceed",
@@ -6615,7 +6615,10 @@
     "select_quote_info": "Quotes are sorted by the estimated total cost, which includes the exchange rate and network fee.",
     "lowest_cost": "Lowest cost",
     "total_cost": "Total Cost",
-     "got_it": "Got it"
+    "got_it": "Got it",
+    "price_impact_warning_title": "High price impact",
+    "price_impact_error_title": "Very high price impact",
+    "price_impact_error_description": "You'll lose approximately {{priceImpact}} of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate."
   },
   "quote_expired_modal": {
     "title": "New quotes are available",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates price impact modals content

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates price impact modals content

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4239,  https://consensyssoftware.atlassian.net/browse/SWAPS-4240

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/746ae502-e694-4099-a5eb-6c192ffcd3ec



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI copy/rendering refactors and test updates; risk is limited to incorrect i18n key wiring or visual regressions in the bridge price impact surfaces.
> 
> **Overview**
> Bridge price-impact messaging is refactored so `PriceImpactHeader` and `PriceImpactDescription` render directly from passed i18n `content` keys (plus optional icon/color), instead of branching on `PriceImpactModalType`/“warning state”. The modal now always receives `formattedQuoteData.priceImpact` and uses `usePriceImpactViewData` to choose the appropriate `title`/`description` keys and icon styling.
> 
> `getPriceImpactViewData` now returns design-system colors and adds explicit `title`/`description` keys for info/warning/error states; `QuoteDetailsCard` updates its price impact row to use those colors/icons and adjusts tests/snapshots accordingly. English locale strings are updated and new `price_impact_warning_title`/`price_impact_error_title`/`price_impact_error_description` keys are added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 717dd57a3e17cd881427ae27117d10e91d6e8030. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->