### PR TITLE
feat: Integrate fiat payment methods into `PayWithModal` and row

### DIFF
--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -20,7 +20,11 @@ import {
 } from '@metamask/transaction-controller';
 import { AssetType, TokenStandard } from '../../../types/token';
 import { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
-import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import {
+  useTransactionPayFiatPayment,
+  useTransactionPayRequiredTokens,
+} from '../../../hooks/pay/useTransactionPayData';
+import { useFiatPaymentHighlightedActions } from '../../../hooks/pay/useFiatPaymentHighlightedActions';
 import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
@@ -50,6 +54,7 @@ jest.mock('../../../../../../core/Engine', () => ({
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
+jest.mock('../../../hooks/pay/useFiatPaymentHighlightedActions');
 jest.mock('../../../hooks/pay/useWithdrawTokenFilter');
 jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../utils/transaction-pay');
@@ -221,6 +226,9 @@ describe('PayWithModal', () => {
       canSelectWithdrawToken: false,
     });
 
+    jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
+    jest.mocked(useFiatPaymentHighlightedActions).mockReturnValue([]);
+
     getAvailableTokensMock.mockReturnValue(TOKENS_MOCK);
     useWithdrawTokenFilterMock.mockReturnValue(
       jest.fn((tokens: AssetType[]) => tokens),
@@ -390,6 +398,41 @@ describe('PayWithModal', () => {
 
       expect(mockAddTokens).toHaveBeenCalled();
       expect(setPayTokenMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('fiat payment', () => {
+    it('passes fiatPayment to getAvailableTokens', () => {
+      const fiatPaymentMock = { selectedPaymentMethodId: 'pm-card' };
+      jest
+        .mocked(useTransactionPayFiatPayment)
+        .mockReturnValue(fiatPaymentMock);
+
+      render();
+
+      expect(getAvailableTokensMock).toHaveBeenCalledWith(
+        expect.objectContaining({ fiatPayment: fiatPaymentMock }),
+      );
+    });
+
+    it('prepends fiat highlighted actions to token list', () => {
+      const fiatAction = {
+        position: 'outside_of_asset_list' as const,
+        icon: 'card-icon',
+        paymentType: 'debit-credit-card',
+        name: 'Credit Card',
+        name_description: '5-10 min',
+        action: jest.fn(),
+        isSelected: false,
+      };
+
+      jest
+        .mocked(useFiatPaymentHighlightedActions)
+        .mockReturnValue([fiatAction]);
+
+      const { getByText } = render();
+
+      expect(getByText('Credit Card')).toBeDefined();
     });
   });
 });

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -17,7 +17,11 @@ import {
   isHighlightedItemOutsideAssetList,
   TokenListItem,
 } from '../../../types/token';
-import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import {
+  useTransactionPayFiatPayment,
+  useTransactionPayRequiredTokens,
+} from '../../../hooks/pay/useTransactionPayData';
+import { useFiatPaymentHighlightedActions } from '../../../hooks/pay/useFiatPaymentHighlightedActions';
 import { getAvailableTokens } from '../../../utils/transaction-pay';
 import { useTransactionPayBlockedTokens } from '../../../hooks/pay/useTransactionPayBlockedTokens';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
@@ -41,6 +45,8 @@ export function PayWithModal() {
   const { payToken, setPayToken } = useTransactionPayToken();
   const { isWithdraw } = useTransactionPayWithdraw();
   const requiredTokens = useTransactionPayRequiredTokens();
+  const fiatPayment = useTransactionPayFiatPayment();
+  const fiatHighlightedActions = useFiatPaymentHighlightedActions();
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const { filterAllowedTokens: musdTokenFilter } = useMusdConversionTokens();
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
@@ -156,6 +162,7 @@ export function PayWithModal() {
         requiredTokens,
         tokens,
         blockedTokens,
+        fiatPayment,
       });
 
       let filteredTokens: TokenListItem[] = availableTokens;
@@ -172,10 +179,17 @@ export function PayWithModal() {
         filteredTokens = perpsBalanceTokenFilter(availableTokens);
       }
 
-      return wrapHighlightedItemCallbacks(filteredTokens);
+      const wrappedTokens = wrapHighlightedItemCallbacks(filteredTokens);
+      const wrappedFiatActions = wrapHighlightedItemCallbacks(
+        fiatHighlightedActions,
+      );
+
+      return [...wrappedFiatActions, ...wrappedTokens];
     },
     [
       blockedTokens,
+      fiatHighlightedActions,
+      fiatPayment,
       withdrawTokenFilter,
       musdTokenFilter,
       payToken,

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -4,6 +4,8 @@ import { TokenIconProps } from '../../token-icon';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
+import { type PaymentMethod } from '@metamask/ramps-controller';
 import { useNavigation } from '@react-navigation/native';
 import { act, fireEvent } from '@testing-library/react-native';
 import Routes from '../../../../../../constants/navigation/Routes';
@@ -21,6 +23,7 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod');
 jest.mock('../../../../../../util/address');
 jest.mock('../../../hooks/metrics/useConfirmationMetricEvents');
 
@@ -68,6 +71,10 @@ describe('PayWithRow', () => {
     });
 
     useTransactionPayRequiredTokensMock.mockReturnValue(undefined as never);
+
+    jest
+      .mocked(useTransactionPaySelectedFiatPaymentMethod)
+      .mockReturnValue(undefined);
 
     jest.mocked(useTransactionPayToken).mockReturnValue({
       payToken: {
@@ -194,6 +201,42 @@ describe('PayWithRow', () => {
 
       const { getByTestId } = render();
       expect(getByTestId('pay-with-row-skeleton')).toBeDefined();
+    });
+  });
+
+  describe('fiat payment method', () => {
+    const FIAT_PAYMENT_METHOD_MOCK = {
+      id: 'pm-card',
+      paymentType: 'debit-credit-card',
+      name: 'Credit Card',
+      score: 1,
+      icon: 'card-icon',
+    } as PaymentMethod;
+
+    it('renders fiat payment method row when selected', () => {
+      jest
+        .mocked(useTransactionPaySelectedFiatPaymentMethod)
+        .mockReturnValue(FIAT_PAYMENT_METHOD_MOCK);
+
+      const { getByText } = render();
+
+      expect(getByText('Pay with Credit Card')).toBeDefined();
+    });
+
+    it('navigates to modal when fiat payment method row is pressed', async () => {
+      jest
+        .mocked(useTransactionPaySelectedFiatPaymentMethod)
+        .mockReturnValue(FIAT_PAYMENT_METHOD_MOCK);
+
+      const { getByText } = render();
+
+      await act(() => {
+        fireEvent.press(getByText('Pay with Credit Card'));
+      });
+
+      expect(navigateMock).toHaveBeenCalledWith(
+        Routes.CONFIRMATION_PAY_WITH_MODAL,
+      );
     });
   });
 });

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
+import { PaymentType } from '@consensys/on-ramp-sdk';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { TokenIcon } from '../../token-icon';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
 import { TouchableOpacity } from 'react-native';
 import { Box } from '../../../../../UI/Box/Box';
 import {
@@ -28,17 +30,21 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
+import PaymentMethodIcon from '../../../../../UI/Ramp/Aggregator/components/PaymentMethodIcon';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import {
   ConfirmationRowComponentIDs,
   TransactionPayComponentIDs,
 } from '../../../ConfirmationView.testIds';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
+import { type PaymentMethod } from '@metamask/ramps-controller';
 export function PayWithRow() {
   const navigation = useNavigation();
   const { payToken } = useTransactionPayToken();
   const { isWithdraw } = useTransactionPayWithdraw();
   const requiredTokens = useTransactionPayRequiredTokens();
+  const selectedFiatPaymentMethod =
+    useTransactionPaySelectedFiatPaymentMethod();
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const { styles } = useStyles(styleSheet, {});
   const { setConfirmationMetric } = useConfirmationMetricEvents();
@@ -83,6 +89,18 @@ export function PayWithRow() {
     [formatFiat, payToken?.balanceUsd],
   );
 
+  if (selectedFiatPaymentMethod) {
+    return (
+      <PayWithFiatPaymentMethodRow
+        paymentMethod={selectedFiatPaymentMethod}
+        label={label}
+        canEdit={canEdit}
+        hasFrom={Boolean(from)}
+        onPress={handleClick}
+      />
+    );
+  }
+
   if (!displayToken) {
     return <PayWithRowSkeleton />;
   }
@@ -122,6 +140,57 @@ export function PayWithRow() {
           </Text>
         )}
         {canEdit && from && (
+          <Icon
+            name={IconName.ArrowDown}
+            size={IconSize.Sm}
+            color={IconColor.Alternative}
+          />
+        )}
+      </Box>
+    </TouchableOpacity>
+  );
+}
+
+function PayWithFiatPaymentMethodRow({
+  paymentMethod,
+  label,
+  canEdit,
+  hasFrom,
+  onPress,
+}: {
+  paymentMethod: PaymentMethod;
+  label: string;
+  canEdit: boolean;
+  hasFrom: boolean;
+  onPress: () => void;
+}) {
+  const { styles } = useStyles(styleSheet, {});
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={!canEdit}
+      testID={ConfirmationRowComponentIDs.PAY_WITH}
+    >
+      <Box
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        justifyContent={JustifyContent.center}
+        gap={12}
+        style={styles.container}
+      >
+        <PaymentMethodIcon
+          paymentMethodType={paymentMethod.paymentType as PaymentType}
+          size={20}
+        />
+        <Text
+          variant={TextVariant.BodyMDMedium}
+          color={TextColor.Default}
+          testID={TransactionPayComponentIDs.PAY_WITH_SYMBOL}
+        >
+          {`${label} ${paymentMethod.name}`}
+        </Text>
+        {canEdit && hasFrom && (
           <Icon
             name={IconName.ArrowDown}
             size={IconSize.Sm}

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -353,6 +353,36 @@ describe('Transaction Pay Utils', () => {
       });
     });
 
+    describe('fiatPayment', () => {
+      it('clears isSelected on all tokens when fiat payment is active', () => {
+        const result = getAvailableTokens({
+          tokens: [TOKEN_MOCK],
+          payToken: {
+            address: TOKEN_MOCK.address as Hex,
+            chainId: TOKEN_MOCK.chainId as Hex,
+          } as TransactionPaymentToken,
+          fiatPayment: { selectedPaymentMethodId: 'pm-card' },
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].isSelected).toBe(false);
+      });
+
+      it('preserves isSelected when fiat payment has no selected method', () => {
+        const result = getAvailableTokens({
+          tokens: [TOKEN_MOCK],
+          payToken: {
+            address: TOKEN_MOCK.address as Hex,
+            chainId: TOKEN_MOCK.chainId as Hex,
+          } as TransactionPaymentToken,
+          fiatPayment: {},
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].isSelected).toBe(true);
+      });
+    });
+
     describe('blockedTokens', () => {
       it('marks token as disabled when its chain is in blocklist chainIds', () => {
         const blockedTokens: BlockedTokensListConfig = {

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -8,6 +8,7 @@ import { Hex } from '@metamask/utils';
 import { PERPS_MINIMUM_DEPOSIT } from '../constants/perps';
 import { AssetType, TokenStandard } from '../types/token';
 import {
+  TransactionFiatPayment,
   TransactionPayRequiredToken,
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
@@ -92,12 +93,15 @@ export function getAvailableTokens({
   requiredTokens,
   tokens,
   blockedTokens,
+  fiatPayment,
 }: {
   payToken?: TransactionPaymentToken;
   requiredTokens?: TransactionPayRequiredToken[];
   tokens: AssetType[];
   blockedTokens?: BlockedTokensListConfig;
+  fiatPayment?: TransactionFiatPayment;
 }): AssetType[] {
+  const hasFiatPayment = Boolean(fiatPayment?.selectedPaymentMethodId);
   const supportedGasFeeTokens = getSupportedGasFeeTokens();
 
   return tokens
@@ -158,9 +162,10 @@ export function getAvailableTokens({
           ? strings('pay_with_modal.no_gas')
           : undefined;
 
-      const isSelected =
-        payToken?.address.toLowerCase() === token.address.toLowerCase() &&
-        payToken?.chainId === token.chainId;
+      const isSelected = hasFiatPayment
+        ? false
+        : payToken?.address.toLowerCase() === token.address.toLowerCase() &&
+          payToken?.chainId === token.chainId;
 
       return {
         ...token,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Fiat payment methods now appear at the top of the `PayWithModal` token list, prepended as highlighted action items via `useFiatPaymentHighlightedActions`
- When a fiat payment method is selected, the Pay-With row renders a `PayWithFiatPaymentMethodRow` showing the payment method icon and name instead of the token row
- `getAvailableTokens` accepts an optional `fiatPayment` parameter - when a fiat method is active, all token isSelected flags are cleared so fiat takes visual precedence

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27113

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation payment selection UI and token list logic to prioritize fiat methods, which could affect what users see as selected and how they choose a pay option. Scope is limited to confirmations UI/util logic and is covered by updated tests.
> 
> **Overview**
> Adds fiat payment method support to the confirmations *Pay With* UX: `PayWithModal` now prepends fiat payment actions (from `useFiatPaymentHighlightedActions`) above the token list and passes `fiatPayment` into `getAvailableTokens`.
> 
> Updates the *Pay With* row to render a dedicated fiat payment method row (icon + name) when a method is selected via `useTransactionPaySelectedFiatPaymentMethod`, and adjusts `getAvailableTokens` so token `isSelected` is cleared when a fiat method is actively selected; accompanying unit tests cover these behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82a6107356828794497b83364550862b6727ea2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->