### PR TITLE
fix: Mockserver abort error

### DIFF
--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -37,9 +37,9 @@ const logger = createLogger({
  * @param request - The mockttp request object
  * @returns The body text or undefined if reading failed or was aborted
  */
-export const safeGetBodyText = async (
-  request: { body: { getText: () => Promise<string | undefined> } },
-): Promise<string | undefined> => {
+export const safeGetBodyText = async (request: {
+  body: { getText: () => Promise<string | undefined> };
+}): Promise<string | undefined> => {
   try {
     return await request.body.getText();
   } catch (error) {

--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -27,6 +27,31 @@ const logger = createLogger({
   name: 'MockServer',
   level: LogLevel.INFO,
 });
+
+/**
+ * Safely reads request body text, catching abort errors.
+ * When a client drops a connection mid-request (e.g., app navigation, AbortController),
+ * mockttp's streamToBuffer rejects with Error('Aborted'). This wrapper catches those
+ * errors and returns undefined instead of letting them bubble up as unhandled rejections.
+ *
+ * @param request - The mockttp request object
+ * @returns The body text or undefined if reading failed or was aborted
+ */
+export const safeGetBodyText = async (
+  request: { body: { getText: () => Promise<string | undefined> } },
+): Promise<string | undefined> => {
+  try {
+    return await request.body.getText();
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Aborted') {
+      logger.debug('Request body read aborted (client disconnected)');
+      return undefined;
+    }
+    logger.warn('Failed to read request body:', error);
+    return undefined;
+  }
+};
+
 interface LiveRequest {
   url: string;
   method: string;
@@ -461,11 +486,17 @@ export default class MockServerE2E implements Resource {
         }
 
         try {
+          // Read body safely before passing to handleDirectFetch to catch abort errors
+          const bodyText = await safeGetBodyText(request);
+          // If body read was aborted, return 499 (client closed request)
+          if (request.method === 'POST' && bodyText === undefined) {
+            return { statusCode: 499, body: '' };
+          }
           return await handleDirectFetch(
             translatedUrl,
             request.method,
             request.headers,
-            await request.body.getText(),
+            bodyText,
           );
         } catch (error) {
           // Client dropped the connection before we could respond (e.g. bridge

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -7,6 +7,7 @@ import {
   MockEventsObject,
 } from '../../framework';
 import { getDecodedProxiedURL } from '../../smoke/notifications/utils/helpers.ts';
+import { safeGetBodyText } from '../MockServerE2E.ts';
 
 // Creates a logger with INFO level as the mockServer produces too much noise
 // Change this to DEBUG as needed
@@ -252,30 +253,27 @@ export const setupMockPostRequest = async (
       }
 
       // If URL matches, also check if request body matches (ignoring specified fields)
-      try {
-        const requestBodyText = await request.body.getText();
-        const result = processPostRequestBody(requestBodyText, requestBody, {
-          ignoreFields,
-        });
+      // Use safeGetBodyText to handle abort errors gracefully
+      const requestBodyText = await safeGetBodyText(request);
 
-        if (!result.matches) {
-          logger.warn('❌ Request body validation failed for', decodedUrl);
-          logger.debug('Expected:', requestBody);
-          logger.debug('Received:', result.requestBodyJson);
-          logger.debug('Ignored fields:', ignoreFields);
-          logger.debug('Error:', result.error);
-        }
-
-        return result.matches;
-      } catch (error) {
-        // If we can't read the body, log the error and don't match
-        // This prevents incorrect mock selection when body processing fails
-        logger.error(
-          'Failed to read request body during mock matching:',
-          error,
-        );
+      // If body read failed/aborted, don't match this mock
+      if (requestBodyText === undefined) {
         return false;
       }
+
+      const result = processPostRequestBody(requestBodyText, requestBody, {
+        ignoreFields,
+      });
+
+      if (!result.matches) {
+        logger.warn('❌ Request body validation failed for', decodedUrl);
+        logger.debug('Expected:', requestBody);
+        logger.debug('Received:', result.requestBodyJson);
+        logger.debug('Ignored fields:', ignoreFields);
+        logger.debug('Error:', result.error);
+      }
+
+      return result.matches;
     })
     .asPriority(priority) // Adding priority to this mock request helper as we want TestSpecificMocks to always take precedence
     .thenCallback(async (request) => {
@@ -324,17 +322,35 @@ export const interceptProxyUrl = async (
         }
       }
 
-      const response = await fetch(transformedUrl, {
-        method: request.method,
-        headers,
-        body:
-          request.method === 'POST' ? await request.body.getText() : undefined,
-      });
+      // Use safeGetBodyText to handle abort errors gracefully
+      let bodyText: string | undefined;
+      if (request.method === 'POST') {
+        bodyText = await safeGetBodyText(request);
+        // If body read was aborted, return 499 (client closed request)
+        if (bodyText === undefined) {
+          return { statusCode: 499, body: '' };
+        }
+      }
 
-      return {
-        statusCode: response.status,
-        body: await response.text(),
-      };
+      try {
+        const response = await fetch(transformedUrl, {
+          method: request.method,
+          headers,
+          body: bodyText,
+        });
+
+        return {
+          statusCode: response.status,
+          body: await response.text(),
+        };
+      } catch (error) {
+        // Handle fetch errors (e.g., network issues)
+        logger.error('Error forwarding request:', error);
+        return {
+          statusCode: 502,
+          body: JSON.stringify({ error: 'Failed to forward request' }),
+        };
+      }
     });
 };
 

--- a/tests/api-mocking/mock-responses/polymarket/polymarket-mocks.ts
+++ b/tests/api-mocking/mock-responses/polymarket/polymarket-mocks.ts
@@ -4,6 +4,7 @@
 
 import { Mockttp } from 'mockttp';
 import { setupMockRequest } from '../../helpers/mockHelpers.ts';
+import { safeGetBodyText } from '../../MockServerE2E.ts';
 import {
   POLYMARKET_CURRENT_POSITIONS_RESPONSE,
   POLYMARKET_RESOLVED_LOST_POSITIONS_RESPONSE,
@@ -437,7 +438,10 @@ export const POLYMARKET_PRICES_MOCKS = async (mockServer: Mockttp) => {
     })
     .asPriority(PRIORITY.BASE)
     .thenCallback(async (request) => {
-      const bodyText = await request.body.getText();
+      const bodyText = await safeGetBodyText(request);
+      if (bodyText === undefined) {
+        return { statusCode: 499, body: '' };
+      }
       const body = bodyText ? JSON.parse(bodyText) : [];
 
       // Extract unique token IDs from the request
@@ -787,7 +791,10 @@ export const POLYMARKET_USDC_BALANCE_MOCKS = async (
     })
     .asPriority(PRIORITY.BASE)
     .thenCallback(async (request) => {
-      const bodyText = await request.body.getText();
+      const bodyText = await safeGetBodyText(request);
+      if (bodyText === undefined) {
+        return { statusCode: 499, body: '' };
+      }
       const body = bodyText ? JSON.parse(bodyText) : undefined;
 
       // Return appropriate mock response based on the call
@@ -1248,7 +1255,10 @@ export const POLYMARKET_UPDATE_USDC_BALANCE_MOCKS = async (
     })
     .asPriority(PRIORITY.BALANCE_REFRESH_PROXY) // Higher priority (1005) to catch balance refresh calls before base mocks
     .thenCallback(async (request) => {
-      const bodyText = await request.body.getText();
+      const bodyText = await safeGetBodyText(request);
+      if (bodyText === undefined) {
+        return { statusCode: 499, body: '' };
+      }
       const body = bodyText ? JSON.parse(bodyText) : undefined;
 
       // Return the current global balance (not a captured value)

--- a/tests/framework/index.ts
+++ b/tests/framework/index.ts
@@ -13,6 +13,9 @@ export { Logger, createLogger, LogLevel, logger } from './logger.ts';
 export { default as PortManager, ResourceType } from './PortManager.ts';
 export * from './types.ts';
 
+// Mock server utilities
+export { safeGetBodyText } from '../api-mocking/MockServerE2E.ts';
+
 // Dapp server exports for standalone usage (e.g., Appwright tests)
 export { default as DappServer } from './DappServer.ts';
 export { DappVariants, TestDapps } from './Constants.ts';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `IncomingMessage.failWithAbortError` in the mockserver by safely handling aborted connections when reading request bodies.

---
[Slack Thread](https://consensys.slack.com/archives/C02U025CVU4/p1773130024614199?thread_ts=1773130024.614199&cid=C02U025CVU4)

<p><a href="https://cursor.com/agents/bc-f5115996-b2ea-5922-8a19-f5fa03ed7ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5115996-b2ea-5922-8a19-f5fa03ed7ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->