### PR TITLE
feat: migrate Label (core scope)

### DIFF
--- a/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.tsx
+++ b/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.tsx
@@ -12,7 +12,7 @@ import { Box } from '../../UI/Box/Box';
 import Text, {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import Label from '../../../component-library/components/Form/Label';
+import { Label, FontWeight } from '@metamask/design-system-react-native';
 import TextField from '../../../component-library/components/Form/TextField';
 import HelpText, {
   HelpTextSeverity,
@@ -82,7 +82,7 @@ const MatchedAccountInfo = ({
   });
   return (
     <Box flexDirection={FlexDirection.Column}>
-      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      {label && <Label fontWeight={FontWeight.Medium}>{label}</Label>}
       <Box
         backgroundColor={colors.background.default}
         alignItems={AlignItems.center}
@@ -228,7 +228,7 @@ export const SnapUIAddressInput = ({
 
   return (
     <Box style={style}>
-      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      {label && <Label fontWeight={FontWeight.Medium}>{label}</Label>}
       <TextField
         {...props}
         ref={inputRef}

--- a/app/components/Snaps/SnapUICheckbox/SnapUICheckbox.tsx
+++ b/app/components/Snaps/SnapUICheckbox/SnapUICheckbox.tsx
@@ -4,9 +4,8 @@ import { FlexDirection } from '../../UI/Box/box.types';
 import Checkbox from '../../../component-library/components/Checkbox/Checkbox';
 import { HelpTextSeverity } from '../../../component-library/components/Form/HelpText/HelpText.types';
 import HelpText from '../../../component-library/components/Form/HelpText';
-import Label from '../../../component-library/components/Form/Label';
+import { Label, FontWeight } from '@metamask/design-system-react-native';
 import { Box } from '../../UI/Box/Box';
-import { TextVariant } from '../../../component-library/components/Texts/Text';
 import { ViewStyle } from 'react-native';
 
 export interface SnapUICheckboxProps {
@@ -51,9 +50,7 @@ export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
 
   return (
     <Box style={style} flexDirection={FlexDirection.Column}>
-      {fieldLabel && (
-        <Label variant={TextVariant.BodyMDMedium}>{fieldLabel}</Label>
-      )}
+      {fieldLabel && <Label fontWeight={FontWeight.Medium}>{fieldLabel}</Label>}
       <Checkbox
         {...props}
         onPress={handleChange}

--- a/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
+++ b/app/components/Snaps/SnapUIDateTimePicker/SnapUIDateTimePicker.tsx
@@ -1,12 +1,10 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
 import { DateTime } from 'luxon';
-import { Box } from '@metamask/design-system-react-native';
-import Label from '../../../component-library/components/Form/Label';
+import { Box, Label, FontWeight } from '@metamask/design-system-react-native';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
-import { TextVariant } from '../../../component-library/components/Texts/Text';
 import DateTimePicker, {
   DateTimePickerEvent,
 } from '@react-native-community/datetimepicker';
@@ -293,7 +291,7 @@ export const SnapUIDateTimePicker: FunctionComponent<
 
   return (
     <Box testID={'snap-ui-renderer__date-time-picker'}>
-      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      {label && <Label fontWeight={FontWeight.Medium}>{label}</Label>}
       <TextField
         testID={`snap-ui-renderer__date-time-picker--${type}`}
         placeholder={placeholder}

--- a/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
+++ b/app/components/Snaps/SnapUIInput/SnapUIInput.tsx
@@ -5,9 +5,8 @@ import TextField from '../../../component-library/components/Form/TextField';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
-import Label from '../../../component-library/components/Form/Label';
+import { Label, FontWeight } from '@metamask/design-system-react-native';
 import { Box } from '../../UI/Box/Box';
-import { TextVariant } from '../../../component-library/components/Texts/Text';
 
 export interface SnapUIInputProps {
   name: string;
@@ -77,7 +76,7 @@ export const SnapUIInput = ({
 
   return (
     <Box style={style}>
-      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      {label && <Label fontWeight={FontWeight.Medium}>{label}</Label>}
       <TextField
         {...props}
         isDisabled={disabled}

--- a/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
+++ b/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
@@ -1,8 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { ViewStyle } from 'react-native';
 import { Box } from '../../UI/Box/Box';
-import Label from '../../../component-library/components/Form/Label';
-import { TextVariant } from '../../../component-library/components/Texts/Text';
+import { Label, FontWeight } from '@metamask/design-system-react-native';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
@@ -51,7 +50,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
 
   return (
     <Box style={style} testID="snap-ui-renderer__radio">
-      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      {label && <Label fontWeight={FontWeight.Medium}>{label}</Label>}
       {options.map((option) => (
         <RadioButton
           key={option.value}

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -1783,15 +1783,18 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      undefined,
+                    ]
                   }
-                  testID="label"
                 >
                   My Input
                 </Text>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/account-selector.test.ts.snap
@@ -189,15 +189,18 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
               <Text
                 accessibilityRole="text"
                 style={
-                  {
-                    "color": "#131416",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#131416",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
-                testID="label"
               >
                 Account Selector
               </Text>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/date-time-picker.test.tsx.snap
@@ -67,15 +67,18 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
               <Text
                 accessibilityRole="text"
                 style={
-                  {
-                    "color": "#131416",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#131416",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
-                testID="label"
               >
                 Select date and time
               </Text>
@@ -749,15 +752,18 @@ exports[`SnapUIDateTimePicker renders inside a field 1`] = `
               <Text
                 accessibilityRole="text"
                 style={
-                  {
-                    "color": "#131416",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#131416",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
-                testID="label"
               >
                 Select date and time
               </Text>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -282,15 +282,18 @@ exports[`SnapUIForm will render with fields 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      undefined,
+                    ]
                   }
-                  testID="label"
                 >
                   My Input
                 </Text>
@@ -398,15 +401,18 @@ exports[`SnapUIForm will render with fields 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      undefined,
+                    ]
                   }
-                  testID="label"
                 >
                   My Checkbox
                 </Text>
@@ -490,15 +496,18 @@ exports[`SnapUIForm will render with fields 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      undefined,
+                    ]
                   }
-                  testID="label"
                 >
                   My Radio Group
                 </Text>
@@ -631,15 +640,18 @@ exports[`SnapUIForm will render with fields 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      undefined,
+                    ]
                   }
-                  testID="label"
                 >
                   My Dropdown
                 </Text>
@@ -1331,15 +1343,18 @@ exports[`SnapUIForm will render with fields 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      undefined,
+                    ]
                   }
-                  testID="label"
                 >
                   My Selector
                 </Text>

--- a/app/components/Snaps/SnapUISelector/SnapUISelector.tsx
+++ b/app/components/Snaps/SnapUISelector/SnapUISelector.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
-import Label from '../../../component-library/components/Form/Label';
+import { Label, FontWeight } from '@metamask/design-system-react-native';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
@@ -14,7 +14,6 @@ import stylesheet from './SnapUISelector.styles';
 import { View, ScrollView, ViewStyle } from 'react-native';
 import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import ApprovalModal from '../../Approvals/ApprovalModal';
-import { TextVariant } from '../../../component-library/components/Texts/Text';
 import { State } from '@metamask/snaps-sdk';
 import { isObject } from '@metamask/utils';
 
@@ -139,7 +138,7 @@ export const SnapUISelector: React.FunctionComponent<SnapUISelectorProps> = ({
   return (
     <>
       <Box style={style} flexDirection={FlexDirection.Column}>
-        {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+        {label && <Label fontWeight={FontWeight.Medium}>{label}</Label>}
         <ButtonBase
           width={ButtonWidthTypes.Full}
           label={inlineButtonLabel}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated `Label` component (core scope).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-276

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fda35f8c-90b1-41d2-9f34-17551d0e9a2e" />

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c88a9c4f-5b0a-49ba-9dfb-b2a2f4b95640" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a UI-only component swap affecting label rendering; main risk is minor visual/regression differences in Snap UI screens and snapshot brittleness.
> 
> **Overview**
> Migrates Snap UI form components (`SnapUIInput`, `SnapUIAddressInput`, `SnapUICheckbox`, `SnapUIRadioGroup`, `SnapUIDateTimePicker`, `SnapUISelector`) to use the design-system `Label` (`@metamask/design-system-react-native`) instead of the component-library label.
> 
> Updates label usage from `variant={TextVariant.BodyMDMedium}` to `fontWeight={FontWeight.Medium}`, and refreshes Jest snapshots to reflect the new rendered text styles/props (e.g., style arrays and `fontWeight` output).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9415f789065ff31a278053c28f11b8b79b50b1a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->