### PR TITLE
fix(homepage): restructure perps market tile card header layout

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
@@ -21,20 +21,6 @@ const styleSheet = (params: {
       flex: 1,
       padding: 16,
     },
-    topRow: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'flex-start',
-    },
-    symbolSection: {
-      flexDirection: 'column',
-      flex: 1,
-    },
-    symbolRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 6,
-    },
     tokenLogoWrapper: {
       position: 'relative' as const,
     },

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Animated, TouchableOpacity, View } from 'react-native';
 import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
   Text,
   TextColor,
   TextVariant,
@@ -101,28 +104,38 @@ const PerpsMarketTileCard: React.FC<PerpsMarketTileCardProps> = ({
       testID={testID}
     >
       <View style={styles.content}>
-        <View style={styles.topRow}>
-          <View style={styles.symbolSection}>
-            <View style={styles.symbolRow}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Start}
+          gap={2}
+        >
+          <Box twClassName="flex-1 min-w-0">
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+              numberOfLines={1}
+            >
+              {getPerpsDisplaySymbol(market.symbol)}
+            </Text>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={1}
+            >
               <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
+                variant={TextVariant.BodySm}
+                color={
+                  isPositive ? TextColor.SuccessDefault : TextColor.ErrorDefault
+                }
+                numberOfLines={1}
+                twClassName="shrink"
               >
-                {getPerpsDisplaySymbol(market.symbol)}
+                {changePercent}
               </Text>
               <PerpsLeverage maxLeverage={market.maxLeverage} />
-            </View>
-
-            <Text
-              variant={TextVariant.BodySm}
-              color={
-                isPositive ? TextColor.SuccessDefault : TextColor.ErrorDefault
-              }
-            >
-              {changePercent}
-            </Text>
-          </View>
+            </Box>
+          </Box>
 
           <View style={styles.tokenLogoWrapper}>
             <PerpsTokenLogo
@@ -143,7 +156,7 @@ const PerpsMarketTileCard: React.FC<PerpsMarketTileCardProps> = ({
               </View>
             )}
           </View>
-        </View>
+        </Box>
       </View>
 
       <View style={styles.sparklineContainer}>


### PR DESCRIPTION
## **Description**

Restructure the `PerpsMarketTileCard` header layout so the ticker symbol sits on its own row with ellipsis overflow, and the percentage variation + leverage badge share a second row where the percentage can grow and ellipsis when too wide.

Changes:
- Replace `View`-based layout styles (`topRow`, `symbolSection`, `symbolRow`) with `Box` components using typed props (`flexDirection`, `alignItems`, `gap`) and `twClassName`
- Move `PerpsLeverage` badge from the ticker row to the percentage row
- Add `numberOfLines={1}` to ticker and percentage `Text` for truncation
- Use `flex-1` + `min-w-0` on the left column to enable ellipsis inside flex children
- Use `shrink` on the percentage text so it truncates before pushing the leverage badge off-screen

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: Perps market tile card header

  Scenario: user views a market card with a short ticker
    Given the Perps section carousel is visible on the homepage

    When user views a market card (e.g. BTC, ETH)
    Then the ticker is on the first row
    And the percentage and leverage badge are on the second row

  Scenario: user views a market card with a long ticker or large percentage
    Given the Perps section carousel is visible on the homepage

    When user views a market card with a long ticker symbol
    Then the ticker text truncates with ellipsis
    And the percentage text truncates with ellipsis if too wide
    And the leverage badge remains visible
```

## **Screenshots/Recordings**

### **Before**

<img width="300" src="https://github.com/user-attachments/assets/e14aa77c-e3bd-4a48-9ccb-15209f5c1dee" />

### **After**

<!-- [screenshots/recordings] -->
<img width="300" src="https://github.com/user-attachments/assets/e06096c2-3213-4f74-80df-4d498a685941" />

#### Video showing ellipsis truncation


https://github.com/user-attachments/assets/b8e4ad3f-8682-4e3e-9bfa-22ddd4c7620a



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout refactor in the perps market tile header; main risk is minor visual regression in text wrapping/spacing across devices.
> 
> **Overview**
> Refactors `PerpsMarketTileCard` header layout to place the market symbol on its own single-line row (ellipsis via `numberOfLines` + `min-w-0`) and move the 24h percent change + `PerpsLeverage` onto a second row.
> 
> Replaces several custom `View` style blocks (`topRow`/`symbolSection`/`symbolRow`) with design-system `Box` layout props and tailwind classes (e.g., `shrink`) to ensure long percent values truncate without pushing the leverage badge off-screen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42970d15b84127963e3e8e3d6361be857f1ff90d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->