### PR TITLE
fix: increase touchable area of select quotes entry

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -602,6 +602,45 @@ describe('QuoteDetailsCard', () => {
     });
   });
 
+  it('does not navigate when price impact is below warning threshold', () => {
+    // priceImpact 0.04 < warning threshold 0.05 → priceImpactIsSafe = true → no navigation
+    const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
+    mockModule.useBridgeQuoteData.mockImplementationOnce(() => ({
+      quoteFetchError: null,
+      activeQuote: {
+        ...mockQuotes[0],
+        quote: {
+          ...mockQuotes[0].quote,
+          priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '0.04' },
+          gasIncluded: false,
+          gasIncluded7702: false,
+        },
+      },
+      destTokenAmount: '24.44',
+      isLoading: false,
+      formattedQuoteData: {
+        networkFee: '0.01',
+        estimatedTime: '1 min',
+        rate: '1 ETH = 24.4 USDC',
+        priceImpact: '0.04%',
+        slippage: '0.5%',
+      },
+    }));
+
+    const { getByTestId } = renderScreen(
+      QuoteDetailsCardTestScreen,
+      { name: Routes.BRIDGE.ROOT },
+      { state: testState },
+    );
+
+    fireEvent.press(getByTestId('price-impact-info-button'));
+
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.PRICE_IMPACT_MODAL,
+      params: expect.anything(),
+    });
+  });
+
   it('opens rate tooltip modal when rate info icon is pressed', () => {
     const { getByLabelText } = renderScreen(
       QuoteDetailsCardTestScreen,

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -95,7 +95,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
 
   const priceImpactIsSafe =
     !activeQuote?.quote.priceData?.priceImpact ||
-    activeQuote.quote.priceData.priceImpact <=
+    Number(activeQuote.quote.priceData.priceImpact) <=
       // @ts-expect-error TODO: remove comment after changes to core are published.
       (bridgeFeatureFlags?.priceImpactThreshold?.warning ??
         AppConstants.BRIDGE.PRICE_IMPACT_WARNING_THRESHOLD);

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { TouchableOpacity, Platform, UIManager, Pressable } from 'react-native';
+import { TouchableOpacity, Platform, UIManager } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
@@ -26,6 +26,7 @@ import {
   selectSourceAmount,
   selectDestToken,
   selectSourceToken,
+  selectBridgeFeatureFlags,
 } from '../../../../../core/redux/slices/bridge';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { formatMinimumReceived } from '../../utils/currencyUtils';
@@ -53,6 +54,7 @@ import { PriceImpactModalType } from '../PriceImpactModal/constants';
 import { formatPriceImpact } from '../../utils/formatPriceImpact';
 import KeyValueRowLabel from '../../../../../component-library/components-temp/KeyValueRow/KeyValueLabel/KeyValueLabel';
 import { usePriceImpactViewData } from '../../hooks/usePriceImpactViewData';
+import AppConstants from '../../../../../core/AppConstants';
 
 if (
   Platform.OS === 'android' &&
@@ -65,6 +67,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
   hasInsufficientBalance,
   location,
 }) => {
+  const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const tw = useTailwind();
   const theme = useTheme();
   const navigation = useNavigation();
@@ -89,6 +92,13 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
     activeQuote,
     isQuoteLoading,
   });
+
+  const priceImpactIsSafe =
+    !activeQuote?.quote.priceData?.priceImpact ||
+    activeQuote.quote.priceData.priceImpact <=
+      // @ts-expect-error TODO: remove comment after changes to core are published.
+      (bridgeFeatureFlags?.priceImpactThreshold?.warning ??
+        AppConstants.BRIDGE.PRICE_IMPACT_WARNING_THRESHOLD);
 
   const nativeTokenName = useMemo(() => {
     const chainId = sourceToken?.chainId;
@@ -117,6 +127,10 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
   };
 
   const handlePriceImpactPress = () => {
+    if (priceImpactIsSafe) {
+      return;
+    }
+
     navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
       screen: Routes.BRIDGE.MODALS.PRICE_IMPACT_MODAL,
       params: {
@@ -133,7 +147,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
     activeQuote?.minToTokenAmount?.amount || '0',
   );
 
-  const priceImactViewData = usePriceImpactViewData(
+  const priceImpactViewData = usePriceImpactViewData(
     activeQuote?.quote.priceData?.priceImpact,
   );
 
@@ -178,28 +192,33 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
               iconName: IconNameLegacy.Info,
             }}
           />
-          <Box twClassName="flex-1 min-w-0">
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-              style={tw`text-right`}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {formattedQuoteData?.rate}
-            </Text>
-          </Box>
-          <Pressable
-            style={tw`shrink-0`}
+          <TouchableOpacity
+            style={tw`flex-1 items-end`}
             onPress={handleRatePress}
             testID="rate-arrow-button"
+            activeOpacity={0.6}
           >
-            <Icon
-              name={IconName.ArrowRight}
-              size={IconSize.Sm}
-              color={IconColor.IconAlternative}
-            />
-          </Pressable>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={1}
+            >
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+                style={tw`text-right`}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {formattedQuoteData?.rate}
+              </Text>
+              <Icon
+                name={IconName.ArrowRight}
+                size={IconSize.Sm}
+                color={IconColor.IconAlternative}
+              />
+            </Box>
+          </TouchableOpacity>
         </Box>
         {shouldShowGasSponsored ? (
           <KeyValueRow
@@ -372,32 +391,32 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
           }}
           value={{
             label: (
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                gap={1}
+              <TouchableOpacity
+                testID="price-impact-info-button"
+                onPress={handlePriceImpactPress}
+                activeOpacity={priceImpactIsSafe ? 1 : 0.6}
               >
-                <TouchableOpacity
-                  testID="price-impact-info-button"
-                  onPress={handlePriceImpactPress}
-                  activeOpacity={0.6}
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  gap={1}
                 >
-                  {priceImactViewData.icon && (
+                  {priceImpactViewData.icon && (
                     <Icon
-                      name={priceImactViewData.icon.name}
+                      name={priceImpactViewData.icon.name}
                       size={IconSize.Sm}
-                      color={priceImactViewData.icon.color}
+                      color={priceImpactViewData.icon.color}
                       twClassName="mt-[2px]"
                     />
                   )}
-                </TouchableOpacity>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={priceImactViewData.textColor}
-                >
-                  {formatPriceImpact(formattedQuoteData.priceImpact)}
-                </Text>
-              </Box>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={priceImpactViewData.textColor}
+                  >
+                    {formatPriceImpact(formattedQuoteData.priceImpact)}
+                  </Text>
+                </Box>
+              </TouchableOpacity>
             ),
           }}
         />

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -454,95 +454,70 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                               />
                             </TouchableOpacity>
                           </View>
-                          <View
-                            style={
-                              [
-                                {
-                                  "display": "flex",
-                                  "flexBasis": "0%",
-                                  "flexGrow": 1,
-                                  "flexShrink": 1,
-                                  "minWidth": 0,
-                                },
-                                undefined,
-                              ]
-                            }
-                          >
-                            <Text
-                              accessibilityRole="text"
-                              ellipsizeMode="tail"
-                              numberOfLines={1}
-                              style={
-                                [
-                                  {
-                                    "color": "#66676a",
-                                    "fontFamily": "Geist-Regular",
-                                    "fontSize": 16,
-                                    "fontWeight": 400,
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  },
-                                  {
-                                    "textAlign": "right",
-                                  },
-                                ]
-                              }
-                            >
-                              1 ETH = 24.4 USDC
-                            </Text>
-                          </View>
-                          <View
-                            accessibilityState={
-                              {
-                                "busy": undefined,
-                                "checked": undefined,
-                                "disabled": undefined,
-                                "expanded": undefined,
-                                "selected": undefined,
-                              }
-                            }
-                            accessibilityValue={
-                              {
-                                "max": undefined,
-                                "min": undefined,
-                                "now": undefined,
-                                "text": undefined,
-                              }
-                            }
-                            accessible={true}
-                            collapsable={false}
-                            focusable={true}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onResponderGrant={[Function]}
-                            onResponderMove={[Function]}
-                            onResponderRelease={[Function]}
-                            onResponderTerminate={[Function]}
-                            onResponderTerminationRequest={[Function]}
-                            onStartShouldSetResponder={[Function]}
+                          <TouchableOpacity
+                            activeOpacity={0.6}
+                            onPress={[Function]}
                             style={
                               {
-                                "flexShrink": 0,
+                                "alignItems": "flex-end",
+                                "flexBasis": "0%",
+                                "flexGrow": 1,
+                                "flexShrink": 1,
                               }
                             }
                             testID="rate-arrow-button"
                           >
-                            <SvgMock
-                              fill="currentColor"
-                              name="ArrowRight"
+                            <View
                               style={
                                 [
                                   {
-                                    "color": "#66676a",
-                                    "height": 16,
-                                    "width": 16,
+                                    "alignItems": "center",
+                                    "display": "flex",
+                                    "flexDirection": "row",
+                                    "gap": 4,
                                   },
                                   undefined,
                                 ]
                               }
-                            />
-                          </View>
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                ellipsizeMode="tail"
+                                numberOfLines={1}
+                                style={
+                                  [
+                                    {
+                                      "color": "#66676a",
+                                      "fontFamily": "Geist-Regular",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    },
+                                    {
+                                      "textAlign": "right",
+                                    },
+                                  ]
+                                }
+                              >
+                                1 ETH = 24.4 USDC
+                              </Text>
+                              <SvgMock
+                                fill="currentColor"
+                                name="ArrowRight"
+                                style={
+                                  [
+                                    {
+                                      "color": "#66676a",
+                                      "height": 16,
+                                      "width": 16,
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              />
+                            </View>
+                          </TouchableOpacity>
                         </View>
                         <View
                           style={
@@ -963,43 +938,44 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   }
                                 }
                               >
-                                <View
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "display": "flex",
-                                        "flexDirection": "row",
-                                        "gap": 4,
-                                      },
-                                      undefined,
-                                    ]
-                                  }
+                                <TouchableOpacity
+                                  activeOpacity={1}
+                                  onPress={[Function]}
+                                  testID="price-impact-info-button"
                                 >
-                                  <TouchableOpacity
-                                    activeOpacity={0.6}
-                                    onPress={[Function]}
-                                    testID="price-impact-info-button"
-                                  />
-                                  <Text
-                                    accessibilityRole="text"
+                                  <View
                                     style={
                                       [
                                         {
-                                          "color": "#66676a",
-                                          "fontFamily": "Geist-Regular",
-                                          "fontSize": 16,
-                                          "fontWeight": 400,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
+                                          "alignItems": "center",
+                                          "display": "flex",
+                                          "flexDirection": "row",
+                                          "gap": 4,
                                         },
                                         undefined,
                                       ]
                                     }
                                   >
-                                    0%
-                                  </Text>
-                                </View>
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#66676a",
+                                            "fontFamily": "Geist-Regular",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0%
+                                    </Text>
+                                  </View>
+                                </TouchableOpacity>
                               </View>
                             </View>
                           </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

increase touchable area of select quotes entry

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  increase touchable area of select quotes entry

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4246

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change confined to the Bridge quote details card; main risk is unintentionally preventing users from opening the price impact modal if thresholds/feature flags are misconfigured.
> 
> **Overview**
> Improves the Bridge `QuoteDetailsCard` interaction by making the *entire rate value + arrow* area tappable (larger touch target) to open the quote selector.
> 
> Adds a `priceImpactIsSafe` check (using `selectBridgeFeatureFlags.priceImpactThreshold.warning` with a fallback to `AppConstants`) so pressing the price impact value only navigates to the price impact modal when impact is at/above the warning threshold; tests and snapshots are updated and a new test asserts no navigation below the threshold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7666e16e05d8abcf6398dd39f756ed54cc923a0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->