### PR TITLE
fix: swap activity fee label paid by metamask

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -42,6 +42,9 @@ import { getMultichainTxFees } from '../../../../hooks/useMultichainTransactionD
 import { useMultichainBlockExplorerTxUrl } from '../../hooks/useMultichainBlockExplorerTxUrl';
 import { StatusResponse } from '@metamask/bridge-status-controller';
 import { toDateFormat } from '../../../../../util/date';
+import TagColored, {
+  TagColor,
+} from '../../../../../component-library/components-temp/TagColored';
 // import { renderShortAddress } from '../../../../../util/address';
 
 const styles = StyleSheet.create({
@@ -98,6 +101,24 @@ interface BridgeTransactionDetailsProps {
     };
   };
 }
+
+const PaidByMetaMask = () => (
+  <TagColored
+    color={TagColor.Success}
+    labelProps={{
+      variant: TextVariant.BodySM,
+      style: {
+        textTransform: 'none',
+        textAlign: 'center',
+        bottom: 1,
+        fontWeight: 'normal',
+      },
+      testID: 'paid-by-metamask',
+    }}
+  >
+    {strings('transactions.paid_by_metamask')}
+  </TagColored>
+);
 
 const BridgeStatusToColorMap: Record<StatusTypes, TextColor> = {
   [StatusTypes.PENDING]: TextColor.Warning,
@@ -371,18 +392,24 @@ export const BridgeTransactionDetails = (
           <Text variant={TextVariant.BodyMDMedium}>
             {strings('bridge_transaction_details.total_gas_fee')}
           </Text>
-          {/* TODO get solana gas fee from multiChainTx */}
-          {evmTotalGasFee && (
-            <Text>
-              {evmTotalGasFee}{' '}
-              {getNativeAssetForChainId(quote.srcChainId).symbol}
-            </Text>
-          )}
-          {multiChainTotalGasFee && (
-            <Text>
-              {multiChainTotalGasFee}{' '}
-              {getNativeAssetForChainId(quote.srcChainId).symbol}
-            </Text>
+          {evmTxMeta?.isGasFeeSponsored ? (
+            <PaidByMetaMask />
+          ) : (
+            <>
+              {/* TODO get solana gas fee from multiChainTx */}
+              {evmTotalGasFee && (
+                <Text>
+                  {evmTotalGasFee}{' '}
+                  {getNativeAssetForChainId(quote.srcChainId).symbol}
+                </Text>
+              )}
+              {multiChainTotalGasFee && (
+                <Text>
+                  {multiChainTotalGasFee}{' '}
+                  {getNativeAssetForChainId(quote.srcChainId).symbol}
+                </Text>
+              )}
+            </>
           )}
         </Box>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: adds "Paid by MetaMask" on Activity "Total gas fee" row when the tx was a gas-sponsored swap.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27246

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

1. Select Monad or SEI network (or any gas-sponsored network).
2. Select the in-app Swap feature (or "buy/sell") selecting tokens from the same network.
3. Perform the swap - "Paid by MetaMask".
4. Once completed, click on the transaction item in the Activity tab.
5. Observe content of the Transaction Detail view.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Showing a `MON` gas fee amount (zero).
<img width="200" alt="image" src="https://github.com/user-attachments/assets/291bf9da-82a9-4569-be0b-69722bc46dec" />


### **After**

<!-- [screenshots/recordings] -->

Showing the "Paid by MetaMask" label.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/566855ab-a0de-4c68-86cd-2a865a9b520a" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change gated by existing `isGasFeeSponsored` flag; low risk aside from potential styling/layout regressions in the transaction details view.
> 
> **Overview**
> Updates the Bridge/Swap transaction details screen to display a green `Paid by MetaMask` tag in the *Total gas fee* row when `evmTxMeta.isGasFeeSponsored` is true, instead of showing a (typically zero) native gas amount.
> 
> Introduces a small reusable `PaidByMetaMask` component using `TagColored` (with `testID: paid-by-metamask`) and keeps the prior fee amount rendering for non-sponsored transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12125cdb4aad815940a0884bea0be2cedf3071ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->