### PR TITLE
fix(homepage): move section title arrow to immediate right of text

### DIFF
--- a/app/components/Views/Homepage/components/SectionTitle/SectionTitle.tsx
+++ b/app/components/Views/Homepage/components/SectionTitle/SectionTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import {
   Box,
   Text,
@@ -9,7 +9,6 @@ import {
   TextVariant,
   BoxFlexDirection,
   BoxAlignItems,
-  BoxJustifyContent,
   TextColor,
 } from '@metamask/design-system-react-native';
 import SectionRow from '../SectionRow';
@@ -23,13 +22,9 @@ interface SectionTitleProps {
    * Optional callback when the title or arrow is pressed
    */
   onPress?: () => void;
-  /**
-   * Optional accessory element to display next to the title (e.g., info button)
-   */
-  endAccessory?: React.ReactNode;
 }
 
-const SectionTitle = ({ title, onPress, endAccessory }: SectionTitleProps) => (
+const SectionTitle = ({ title, onPress }: SectionTitleProps) => (
   <SectionRow>
     <TouchableOpacity
       onPress={onPress}
@@ -40,32 +35,17 @@ const SectionTitle = ({ title, onPress, endAccessory }: SectionTitleProps) => (
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Between}
+        gap={1}
       >
-        {/* Left side: Title + optional endAccessory */}
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          gap={1}
-        >
-          {typeof title === 'string' ? (
-            <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
-              {title}
-            </Text>
-          ) : (
-            title
-          )}
-          {endAccessory}
-        </Box>
-
-        {/* Right side: Arrow icon (visual indicator, passes touch to parent) */}
+        {typeof title === 'string' ? (
+          <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
+            {title}
+          </Text>
+        ) : (
+          title
+        )}
         {onPress && (
-          <View pointerEvents="none">
-            <ButtonIcon
-              iconName={IconName.ArrowRight}
-              size={ButtonIconSize.Sm}
-            />
-          </View>
+          <ButtonIcon iconName={IconName.ArrowRight} size={ButtonIconSize.Sm} />
         )}
       </Box>
     </TouchableOpacity>


### PR DESCRIPTION
## **Description**

Move the ">" arrow icon in `SectionTitle` to sit immediately right of the title text instead of being pushed to the far right edge of the row. This aligns the homepage section titles with the Perps and Explore sections' pattern.

Changes:
- Remove `justifyContent={Between}` from the outer `Box` so the arrow is no longer pushed to the far right
- Remove the inner `Box` wrapper that grouped title + endAccessory
- Remove the unused `endAccessory` prop (no callers use it)
- Remove the `View pointerEvents="none"` wrapper around `ButtonIcon`
- Clean up unused imports (`View`, `BoxJustifyContent`)

The entire row remains pressable via `TouchableOpacity`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [TMCU-551](https://consensyssoftware.atlassian.net/browse/TMCU-551)

## **Manual testing steps**

```gherkin
Feature: Section title arrow alignment

  Scenario: user views homepage section titles
    Given the user is on the Homepage

    When user views any section title (Tokens, NFTs, DeFi, Predictions, Perpetuals)
    Then the ">" arrow icon sits immediately right of the title text
    And the arrow is not pushed to the far right edge

  Scenario: user taps a section title row
    Given the user is on the Homepage

    When user taps anywhere on a section title row
    Then the app navigates to the corresponding full view
```

## **Screenshots/Recordings**

### **Before**

<img width="300" src="https://github.com/user-attachments/assets/3a15f527-57d3-41b1-b4a6-26ca5f4bda4c" />

### **After**

<!-- [screenshots/recordings] -->

<img width="300"  src="https://github.com/user-attachments/assets/de9b5a16-34dc-46c0-9e19-848dd2ddcf55" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.