### PR TITLE
fix: migration 121 remove exception missing nativeAssetIdentifiers

### DIFF
--- a/app/store/migrations/121.test.ts
+++ b/app/store/migrations/121.test.ts
@@ -10,7 +10,7 @@ describe(`migration #${migrationVersion}`, () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it('DOES NOT modify the controller + exception if NetworkEnablementController is missing', () => {
+  it('DOES NOT modify the controller (with no exception thrown) if NetworkEnablementController is missing', () => {
     const oldStorage = {
       engine: {
         backgroundState: {
@@ -26,11 +26,7 @@ describe(`migration #${migrationVersion}`, () => {
     expect(newStorage.engine.backgroundState).toStrictEqual({
       OtherRandomController: {},
     });
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${migrationVersion}: NetworkEnablementController not found.`,
-      ),
-    );
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
   it('DOES NOT modify the controller + exception if NetworkEnablementController has changed type', () => {
@@ -64,7 +60,7 @@ describe(`migration #${migrationVersion}`, () => {
     );
   });
 
-  it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers is missing', () => {
+  it('DOES NOT modify the controller (with no exception thrown) if NetworkEnablementController.nativeAssetIdentifiers is missing', () => {
     const oldStorage = {
       engine: {
         backgroundState: {
@@ -84,11 +80,7 @@ describe(`migration #${migrationVersion}`, () => {
         anotherFieldThatIsNotNativeAssetIdentifiers: {},
       },
     });
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${migrationVersion}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
-      ),
-    );
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
   it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers has changed type', () => {

--- a/app/store/migrations/121_utils.ts
+++ b/app/store/migrations/121_utils.ts
@@ -30,9 +30,6 @@ export const checkNetworkEnablementState = (
   if (
     !hasProperty(state.engine.backgroundState, 'NetworkEnablementController')
   ) {
-    captureException(
-      new Error(`Migration ${version}: NetworkEnablementController not found.`),
-    );
     return false;
   }
 
@@ -49,11 +46,6 @@ export const checkNetworkEnablementState = (
   }
 
   if (!hasProperty(networkEnablementState, 'nativeAssetIdentifiers')) {
-    captureException(
-      new Error(
-        `Migration ${version}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
-      ),
-    );
     return false;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The PR fixes two cases that we treated as exception (expected to never happen) but are not: 
- Absence of the `nativeAssetIdentifiers` : This field was created recently (1-2 months ago) but I thought it would be initialized to an empty object for new users, but I didn't realize migrations actually run before controller init.
- Absence of the `NetworkEnablementController`  : That one confused me even more because I thought that a controller should always be assumed to be present. The NetworkEnablementController (as opposed to NetworkController) is fairly recent (7 months) and my understanding is that the message is triggered by old users.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove thrown exceptions in migration 121 when `NetworkEnablementController` is absent or `NetworkEnablementController.nativeAssetIdentifiers` is missing.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27325

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

(if we want to test it since it is a log message thing)
- Reset data.
- Find a version of the app prior the creation of `NetworkEnablementController` and install it.
- Update to latest.
- The error message will appear in the logs. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limits Sentry reporting in migration `121` by no longer emitting exceptions for expected/benign missing-state cases; migration behavior/data transforms are otherwise unchanged.
> 
> **Overview**
> Migration `121` no longer calls `captureException` when `NetworkEnablementController` is absent or when `NetworkEnablementController.nativeAssetIdentifiers` is missing; these cases now silently short-circuit.
> 
> Tests for migration `121` are updated to assert **no** Sentry exception is captured for those missing-field scenarios, while retaining exception expectations for type-mismatch cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b65b69f7ae597394e5f1cb02f88f52a1ef89116. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->