### PR TITLE
test: Sentry build type added

### DIFF
--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -40,6 +40,11 @@ on:
         type: string
         default: test
         description: 'Sentry DSN target: test or real'
+      build_variant:
+        required: false
+        type: string
+        default: rc
+        description: 'Build variant for app artifacts (rc or exp)'
     secrets:
       BROWSERSTACK_USERNAME:
         required: true
@@ -163,6 +168,12 @@ jobs:
           SENTRY_REAL_DSN="${{ secrets.MM_SENTRY_DSN }}"
           SELECTED_SENTRY_DSN=""
           SENTRY_ENVIRONMENT="github-actions-performance-e2e"
+          BUILD_VARIANT="${{ inputs.build_variant }}"
+
+          if [[ "$BUILD_VARIANT" != "rc" && "$BUILD_VARIANT" != "exp" ]]; then
+            echo "❌ Invalid build_variant '$BUILD_VARIANT'. Expected 'rc' or 'exp'."
+            exit 1
+          fi
 
           # Validate that we have a BrowserStack URL
           if [ -z "${{ inputs.browserstack_app_url }}" ]; then
@@ -210,6 +221,7 @@ jobs:
             echo "E2E_PERFORMANCE_SENTRY_DSN=$SELECTED_SENTRY_DSN"
             echo "E2E_PERFORMANCE_SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT"
             echo "E2E_PERFORMANCE_SENTRY_RELEASE=${{ github.sha }}"
+            echo "E2E_PERFORMANCE_BUILD_VARIANT=$BUILD_VARIANT"
             echo "DISABLE_VIDEO_DOWNLOAD=true"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -235,6 +235,7 @@ jobs:
       platform: android
       build_type: onboarding
       sentry_target: ${{ inputs.sentry_target || 'test' }}
+      build_variant: ${{ inputs.build_variant || 'rc' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.android_matrix }}
       browserstack_app_url: ${{ needs.trigger-android-dual-versions.outputs.without-srp-browserstack-url || inputs.browserstack_app_url_android_onboarding }}
       app_version: ${{ needs.trigger-android-dual-versions.outputs.without-srp-version || 'Manual-Input' }}
@@ -257,6 +258,7 @@ jobs:
       platform: ios
       build_type: onboarding
       sentry_target: ${{ inputs.sentry_target || 'test' }}
+      build_variant: ${{ inputs.build_variant || 'rc' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.ios_matrix }}
       browserstack_app_url: ${{ needs.trigger-ios-dual-versions.outputs.without-srp-browserstack-url || inputs.browserstack_app_url_ios_onboarding }}
       app_version: ${{ needs.trigger-ios-dual-versions.outputs.without-srp-version || 'Manual-Input' }}
@@ -295,6 +297,7 @@ jobs:
       platform: android
       build_type: imported-wallet
       sentry_target: ${{ inputs.sentry_target || 'test' }}
+      build_variant: ${{ inputs.build_variant || 'rc' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.android_matrix }}
       browserstack_app_url: ${{ needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url || inputs.browserstack_app_url_android_imported_wallet }}
       app_version: ${{ needs.trigger-android-dual-versions.outputs.with-srp-version || 'Manual-Input' }}
@@ -318,6 +321,7 @@ jobs:
       platform: ios
       build_type: imported-wallet
       sentry_target: ${{ inputs.sentry_target || 'test' }}
+      build_variant: ${{ inputs.build_variant || 'rc' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.ios_matrix }}
       browserstack_app_url: ${{ needs.trigger-ios-dual-versions.outputs.with-srp-browserstack-url || inputs.browserstack_app_url_ios_imported_wallet }}
       app_version: ${{ needs.trigger-ios-dual-versions.outputs.with-srp-version || 'Manual-Input' }}
@@ -377,6 +381,7 @@ jobs:
       platform: android
       build_type: mm-connect
       sentry_target: ${{ inputs.sentry_target || 'test' }}
+      build_variant: ${{ inputs.build_variant || 'rc' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.android_matrix }}
       browserstack_app_url: ${{ needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url || inputs.browserstack_app_url_android_imported_wallet }}
       app_version: ${{ needs.trigger-android-dual-versions.outputs.with-srp-version || 'Manual-Input' }}

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
@@ -65,12 +65,14 @@ describe('PerformanceSentryPublisher', () => {
   const originalSentrySampleRate =
     process.env.E2E_PERFORMANCE_SENTRY_SAMPLE_RATE;
   const originalSentryEnabled = process.env.E2E_PERFORMANCE_SENTRY_ENABLED;
+  const originalBuildVariant = process.env.E2E_PERFORMANCE_BUILD_VARIANT;
 
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.E2E_PERFORMANCE_SENTRY_DSN;
     delete process.env.E2E_PERFORMANCE_SENTRY_SAMPLE_RATE;
     delete process.env.E2E_PERFORMANCE_SENTRY_ENABLED;
+    delete process.env.E2E_PERFORMANCE_BUILD_VARIANT;
     fetchMock = jest.spyOn(global, 'fetch');
   });
 
@@ -91,6 +93,12 @@ describe('PerformanceSentryPublisher', () => {
       delete process.env.E2E_PERFORMANCE_SENTRY_ENABLED;
     } else {
       process.env.E2E_PERFORMANCE_SENTRY_ENABLED = originalSentryEnabled;
+    }
+
+    if (originalBuildVariant === undefined) {
+      delete process.env.E2E_PERFORMANCE_BUILD_VARIANT;
+    } else {
+      process.env.E2E_PERFORMANCE_BUILD_VARIANT = originalBuildVariant;
     }
 
     fetchMock.mockRestore();
@@ -115,6 +123,7 @@ describe('PerformanceSentryPublisher', () => {
   it('sends performance timers as sentry measurements', async () => {
     process.env.E2E_PERFORMANCE_SENTRY_DSN =
       'https://publicKey@o123.ingest.sentry.io/4567';
+    process.env.E2E_PERFORMANCE_BUILD_VARIANT = 'exp';
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
@@ -158,6 +167,7 @@ describe('PerformanceSentryPublisher', () => {
     expect(payload.measurements.step_1_load_2.value).toBe(700);
     expect(payload.measurements.scenario_total_time_ms.value).toBe(1300);
     expect(payload.tags.project_name).toBe('browserstack-android');
+    expect(payload.tags.build_variant).toBe('exp');
     expect(payload.extra.timer_steps).toHaveLength(2);
   });
 

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
@@ -12,6 +12,7 @@ const ENV_SENTRY_ENABLED = 'E2E_PERFORMANCE_SENTRY_ENABLED';
 const ENV_SENTRY_SAMPLE_RATE = 'E2E_PERFORMANCE_SENTRY_SAMPLE_RATE';
 const ENV_SENTRY_ENVIRONMENT = 'E2E_PERFORMANCE_SENTRY_ENVIRONMENT';
 const ENV_SENTRY_RELEASE = 'E2E_PERFORMANCE_SENTRY_RELEASE';
+const ENV_SENTRY_BUILD_VARIANT = 'E2E_PERFORMANCE_BUILD_VARIANT';
 const MAX_MEASUREMENT_KEY_LENGTH = 64;
 const RESERVED_MEASUREMENT_KEYS = [
   'scenario_total_time_ms',
@@ -73,6 +74,14 @@ function normalizeSpanStatus(status?: string): string {
     default:
       return 'unknown_error';
   }
+}
+
+function normalizeBuildVariant(variant?: string): 'rc' | 'exp' | 'unknown' {
+  if (variant === 'rc' || variant === 'exp') {
+    return variant;
+  }
+
+  return 'unknown';
 }
 
 function sanitizeMeasurementKey(name: string): string {
@@ -308,6 +317,9 @@ export async function publishPerformanceScenarioToSentry(
       test_status: options.status || 'unknown',
       retry: String(options.retry ?? 0),
       worker_index: String(options.workerIndex ?? 0),
+      build_variant: normalizeBuildVariant(
+        getEnvValue(ENV_SENTRY_BUILD_VARIANT),
+      ),
     },
     measurements,
     spans,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `build_variant` tag to Sentry performance events to distinguish between experimental and RC builds.

<div><a href="https://cursor.com/agents/bc-337614a8-9173-4060-9737-eaa2b165e4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-337614a8-9173-4060-9737-eaa2b165e4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->