### PR TITLE
fix: Polish token selector for Buy, Swap and Send

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.styles.ts
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.styles.ts
@@ -15,12 +15,6 @@ export const createStyles = (params: { theme: Theme }) => {
       paddingBottom: 16,
       flexGrow: 1,
     },
-    buttonContainer: {
-      paddingHorizontal: 8,
-    },
-    searchInput: {
-      marginVertical: 12,
-    },
     tokenItem: {
       paddingVertical: 8,
     },

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -525,7 +525,7 @@ export const BridgeTokenSelector: React.FC = () => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
-      <Box style={styles.buttonContainer}>
+      <Box twClassName="pt-2 pb-4 pl-4">
         <NetworkPills
           selectedChainId={selectedChainId}
           onChainSelect={handleChainSelect}
@@ -535,13 +535,14 @@ export const BridgeTokenSelector: React.FC = () => {
             })
           }
         />
+      </Box>
 
+      <Box twClassName="px-4 pb-3">
         <TextFieldSearch
           value={searchString}
           onChangeText={handleSearchTextChange}
           placeholder={strings('swaps.search_token')}
           testID="bridge-token-search-input"
-          style={styles.searchInput}
           autoComplete="off"
           autoCorrect={false}
           autoCapitalize="none"

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -59,13 +59,13 @@ const createStyles = ({
       flex: 1,
       flexShrink: 1,
       minWidth: 0,
-      marginLeft: 8,
+      marginLeft: 12,
     },
     container: {
       backgroundColor: vars.isSelected
         ? theme.colors.primary.muted
         : theme.colors.background.default,
-      paddingVertical: 4,
+      minHeight: 72,
       paddingLeft: 16,
       paddingRight: 10,
     },
@@ -81,7 +81,7 @@ const createStyles = ({
     itemWrapper: {
       flex: 1,
       flexDirection: 'row',
-      paddingVertical: 10,
+      paddingVertical: 12,
       alignItems: 'flex-start',
     },
     tokenMainInfo: {
@@ -158,7 +158,7 @@ const FiatBalanceView = ({
 
   return (
     <Text
-      variant={TextVariant.BodyMD}
+      variant={TextVariant.BodySM}
       color={TextColor.Alternative}
       numberOfLines={1}
     >
@@ -250,7 +250,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             <AvatarToken
               name={token.symbol}
               imageSource={getTokenImageSource(token.symbol, token.image)}
-              size={AvatarSize.Md}
+              size={AvatarSize.Lg}
               testID={
                 isNative
                   ? `network-logo-${token.symbol}`
@@ -314,7 +314,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
               justifyContent={JustifyContent.spaceBetween}
             >
               <Text
-                variant={TextVariant.BodyMD}
+                variant={TextVariant.BodySM}
                 color={TextColor.Alternative}
                 numberOfLines={1}
                 ellipsizeMode="tail"

--- a/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
+++ b/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
@@ -638,7 +638,7 @@ const AssetSelectionBottomSheet: React.FC = () => {
                   twClassName="flex-1"
                 >
                   <AvatarToken
-                    size={AvatarSize.Md}
+                    size={AvatarSize.Lg}
                     // eslint-disable-next-line @typescript-eslint/no-require-imports
                     imageSource={require('../../../../../images/solana-logo.png')}
                   />
@@ -716,7 +716,7 @@ const AssetSelectionBottomSheet: React.FC = () => {
                       }
                     >
                       <AvatarToken
-                        size={AvatarSize.Md}
+                        size={AvatarSize.Lg}
                         imageSource={{
                           uri: buildTokenIconUrl(
                             item.caipChainId,

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -3219,10 +3219,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3348,7 +3348,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3362,9 +3362,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3448,10 +3448,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3577,7 +3577,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3591,9 +3591,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3662,10 +3662,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3791,7 +3791,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3805,9 +3805,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3876,10 +3876,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4005,7 +4005,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4019,9 +4019,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4090,10 +4090,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4219,7 +4219,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4233,9 +4233,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
@@ -384,14 +384,14 @@ function TokenSelection() {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
-        <Box twClassName="py-2">
+        <Box twClassName="pt-2 pb-4">
           <TokenNetworkFilterBar
             networks={uniqueNetworks}
             networkFilter={networkFilter}
             setNetworkFilter={handleNetworkFilterChange}
           />
         </Box>
-        <Box twClassName="px-4 py-3">
+        <Box twClassName="px-4 pb-3">
           <TextFieldSearch
             testID={selectTokenSelectors.TOKEN_SELECT_MODAL_SEARCH_INPUT}
             value={searchString}

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -353,7 +353,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                               [
                                 {
                                   "display": "flex",
-                                  "paddingBottom": 8,
+                                  "paddingBottom": 16,
                                   "paddingTop": 8,
                                 },
                                 undefined,
@@ -391,7 +391,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                       "backgroundColor": "#131416",
                                       "borderRadius": 12,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -403,7 +403,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                     style={
                                       {
                                         "color": "#ffffff",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -429,7 +429,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -468,7 +468,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -494,7 +494,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -533,7 +533,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -559,7 +559,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -598,7 +598,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -619,7 +619,6 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                   "paddingBottom": 12,
                                   "paddingLeft": 16,
                                   "paddingRight": 16,
-                                  "paddingTop": 12,
                                 },
                                 undefined,
                               ]
@@ -1213,7 +1212,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                               [
                                 {
                                   "display": "flex",
-                                  "paddingBottom": 8,
+                                  "paddingBottom": 16,
                                   "paddingTop": 8,
                                 },
                                 undefined,
@@ -1251,7 +1250,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                       "backgroundColor": "#131416",
                                       "borderRadius": 12,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -1263,7 +1262,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     style={
                                       {
                                         "color": "#ffffff",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -1289,7 +1288,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -1328,7 +1327,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -1354,7 +1353,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -1393,7 +1392,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -1419,7 +1418,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -1458,7 +1457,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -1479,7 +1478,6 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                   "paddingBottom": 12,
                                   "paddingLeft": 16,
                                   "paddingRight": 16,
-                                  "paddingTop": 12,
                                 },
                                 undefined,
                               ]
@@ -1721,10 +1719,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -1850,7 +1848,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -1864,9 +1862,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2021,10 +2019,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -2150,7 +2148,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -2164,9 +2162,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2321,10 +2319,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -2450,7 +2448,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -2464,9 +2462,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2621,10 +2619,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -2750,7 +2748,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -2764,9 +2762,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2921,10 +2919,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3050,7 +3048,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3064,9 +3062,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3533,7 +3531,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                               [
                                 {
                                   "display": "flex",
-                                  "paddingBottom": 8,
+                                  "paddingBottom": 16,
                                   "paddingTop": 8,
                                 },
                                 undefined,
@@ -3571,7 +3569,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                       "backgroundColor": "#131416",
                                       "borderRadius": 12,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -3583,7 +3581,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     style={
                                       {
                                         "color": "#ffffff",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -3609,7 +3607,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -3648,7 +3646,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -3674,7 +3672,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -3713,7 +3711,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -3739,7 +3737,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                       "borderRadius": 12,
                                       "borderWidth": 1,
                                       "flexDirection": "row",
-                                      "height": 32,
+                                      "height": 40,
                                       "justifyContent": "center",
                                       "overflow": "hidden",
                                       "paddingHorizontal": 16,
@@ -3778,7 +3776,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     style={
                                       {
                                         "color": "#131416",
-                                        "fontFamily": "Geist-Regular",
+                                        "fontFamily": "Geist-Medium",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -3799,7 +3797,6 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                   "paddingBottom": 12,
                                   "paddingLeft": 16,
                                   "paddingRight": 16,
-                                  "paddingTop": 12,
                                 },
                                 undefined,
                               ]
@@ -4041,10 +4038,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4170,7 +4167,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4184,9 +4181,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4341,10 +4338,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4470,7 +4467,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4484,9 +4481,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4641,10 +4638,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4770,7 +4767,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4784,9 +4781,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4941,10 +4938,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -5070,7 +5067,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -5084,9 +5081,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -5241,10 +5238,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -5370,7 +5367,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -5384,9 +5381,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >

--- a/app/components/UI/Ramp/components/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Ramp/components/TokenListItem/TokenListItem.tsx
@@ -68,13 +68,13 @@ function TokenListItem({
           <AvatarToken
             name={token.name}
             imageSource={{ uri: token.iconUrl }}
-            size={AvatarSize.Md}
+            size={AvatarSize.Lg}
           />
         </BadgeWrapper>
       </ListItemColumn>
       <ListItemColumn widthType={WidthType.Fill}>
-        <Text variant={TextVariant.BodyLGMedium}>{token.name}</Text>
-        <Text variant={TextVariant.BodyMD} color={textColor}>
+        <Text variant={TextVariant.BodyMDMedium}>{token.name}</Text>
+        <Text variant={TextVariant.BodySM} color={textColor}>
           {token.symbol}
         </Text>
       </ListItemColumn>

--- a/app/components/UI/Ramp/components/TokenListItem/__snapshots__/TokenListItem.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenListItem/__snapshots__/TokenListItem.test.tsx.snap
@@ -54,10 +54,10 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
               style={
                 {
                   "backgroundColor": "#ffffff",
-                  "borderRadius": 16,
-                  "height": 32,
+                  "borderRadius": 20,
+                  "height": 40,
                   "overflow": "hidden",
-                  "width": 32,
+                  "width": 40,
                 }
               }
             >
@@ -187,7 +187,7 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
             {
               "color": "#131416",
               "fontFamily": "Geist-Medium",
-              "fontSize": 20,
+              "fontSize": 16,
               "letterSpacing": 0,
               "lineHeight": 24,
             }
@@ -201,9 +201,9 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
             {
               "color": "#66676a",
               "fontFamily": "Geist-Regular",
-              "fontSize": 16,
+              "fontSize": 14,
               "letterSpacing": 0,
-              "lineHeight": 24,
+              "lineHeight": 22,
             }
           }
         >
@@ -269,10 +269,10 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
               style={
                 {
                   "backgroundColor": "#ffffff",
-                  "borderRadius": 16,
-                  "height": 32,
+                  "borderRadius": 20,
+                  "height": 40,
                   "overflow": "hidden",
-                  "width": 32,
+                  "width": 40,
                 }
               }
             >
@@ -402,7 +402,7 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
             {
               "color": "#131416",
               "fontFamily": "Geist-Medium",
-              "fontSize": 20,
+              "fontSize": 16,
               "letterSpacing": 0,
               "lineHeight": 24,
             }
@@ -416,9 +416,9 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
             {
               "color": "#66676a",
               "fontFamily": "Geist-Regular",
-              "fontSize": 16,
+              "fontSize": 14,
               "letterSpacing": 0,
-              "lineHeight": 24,
+              "lineHeight": 22,
             }
           }
         >

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.tsx
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.tsx
@@ -60,11 +60,11 @@ function TokenNetworkFilterBar({
         variant={
           isAllSelected ? ButtonVariants.Primary : ButtonVariants.Secondary
         }
-        size={ButtonSize.Sm}
+        size={ButtonSize.Md}
         label={
           <Text
             color={isAllSelected ? TextColor.Inverse : TextColor.Default}
-            variant={TextVariant.BodyMD}
+            variant={TextVariant.BodyMDMedium}
           >
             {strings('unified_ramp.networks_filter_bar.all_networks')}
           </Text>
@@ -83,7 +83,7 @@ function TokenNetworkFilterBar({
             variant={
               isSelected ? ButtonVariants.Primary : ButtonVariants.Secondary
             }
-            size={ButtonSize.Sm}
+            size={ButtonSize.Md}
             label={
               <>
                 <AvatarNetwork
@@ -95,7 +95,7 @@ function TokenNetworkFilterBar({
 
                 <Text
                   color={isSelected ? TextColor.Inverse : TextColor.Default}
-                  variant={TextVariant.BodyMD}
+                  variant={TextVariant.BodyMDMedium}
                 >
                   {displayName}
                 </Text>

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
           "backgroundColor": "#131416",
           "borderRadius": 12,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -44,7 +44,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={
           {
             "color": "#ffffff",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -70,7 +70,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -109,7 +109,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -135,7 +135,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -174,7 +174,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -200,7 +200,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -239,7 +239,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -285,7 +285,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
           "backgroundColor": "#131416",
           "borderRadius": 12,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -297,7 +297,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={
           {
             "color": "#ffffff",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -323,7 +323,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -362,7 +362,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -388,7 +388,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -427,7 +427,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -453,7 +453,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -492,7 +492,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -540,7 +540,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -552,7 +552,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -576,7 +576,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
           "backgroundColor": "#131416",
           "borderRadius": 12,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -615,7 +615,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={
           {
             "color": "#ffffff",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -641,7 +641,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -680,7 +680,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -706,7 +706,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
           "borderRadius": 12,
           "borderWidth": 1,
           "flexDirection": "row",
-          "height": 32,
+          "height": 40,
           "justifyContent": "center",
           "overflow": "hidden",
           "paddingHorizontal": 16,
@@ -745,7 +745,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
+            "fontFamily": "Geist-Medium",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,

--- a/app/components/Views/confirmations/components/UI/nft/nft.tsx
+++ b/app/components/Views/confirmations/components/UI/nft/nft.tsx
@@ -57,7 +57,7 @@ export function Nft({ asset, onPress }: NftProps) {
             <AvatarToken
               name={asset.name || asset.collectionName || 'NFT'}
               src={asset.image ? { uri: asset.image } : undefined}
-              style={tw.style('w-10 h-10')}
+              style={tw.style('w-10 h-10 rounded-xl')}
             />
           </BadgeWrapper>
         </Box>

--- a/app/components/Views/confirmations/components/network-filter/network-filter.tsx
+++ b/app/components/Views/confirmations/components/network-filter/network-filter.tsx
@@ -1,11 +1,14 @@
 import React, { useRef, useCallback, useEffect } from 'react';
 import {
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
   FontWeight,
   Text,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { Pressable, ImageSourcePropType } from 'react-native';
+import { ImageSourcePropType } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 import { strings } from '../../../../../../locales/i18n';
@@ -13,6 +16,8 @@ import Avatar, {
   AvatarSize,
   AvatarVariant,
 } from '../../../../../component-library/components/Avatars/Avatar';
+import ButtonToggle from '../../../../../component-library/components-temp/Buttons/ButtonToggle';
+import { ButtonSize } from '../../../../../component-library/components/Buttons/Button';
 import { AssetType } from '../../types/token';
 import { useNetworks } from '../../hooks/send/useNetworks';
 import {
@@ -38,33 +43,37 @@ const NetworkFilterTab: React.FC<NetworkFilterTabProps> = ({
 }) => {
   const tw = useTailwind();
 
-  return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) =>
-        tw.style(
-          'flex-row items-center px-3 py-2 mr-2 rounded-lg min-h-8 border border-border-muted',
-          isSelected ? 'bg-background-pressed' : 'bg-transparent',
-          pressed && 'opacity-70',
-        )
-      }
-      hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-    >
-      {showIcon && imageSource && (
-        <Box twClassName="mr-2">
-          <Avatar
-            variant={AvatarVariant.Network}
-            size={AvatarSize.Xs}
-            imageSource={imageSource}
-            name={label}
-          />
-        </Box>
-      )}
+  const labelContent =
+    showIcon && imageSource ? (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={2}
+      >
+        <Avatar
+          variant={AvatarVariant.Network}
+          size={AvatarSize.Xs}
+          imageSource={imageSource}
+          name={label}
+        />
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={isSelected ? TextColor.PrimaryInverse : TextColor.TextDefault}
+        >
+          {label}
+        </Text>
+      </Box>
+    ) : null;
 
-      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-        {label}
-      </Text>
-    </Pressable>
+  return (
+    <ButtonToggle
+      label={showIcon && imageSource ? labelContent : label}
+      isActive={isSelected}
+      onPress={onPress}
+      size={ButtonSize.Md}
+      style={tw.style('rounded-xl py-2 px-3 mr-2')}
+    />
   );
 };
 

--- a/app/components/Views/confirmations/components/send/asset/asset.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.tsx
@@ -205,6 +205,15 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
           ))}
         </Box>
       )}
+      {!hideNetworkFilter && (
+        <NetworkFilter
+          tokens={tokens}
+          onFilteredTokensChange={handleFilteredTokensChange}
+          onNetworkFilterStateChange={handleNetworkFilterStateChange}
+          onExposeFilterControls={handleExposeFilterControls}
+          onNetworkFilterChange={handleNetworkFilterChange}
+        />
+      )}
       <Box twClassName="w-full px-4 py-2">
         <TextFieldSearch
           value={searchQuery}
@@ -217,15 +226,6 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
           onPressClearButton={clearSearch}
         />
       </Box>
-      {!hideNetworkFilter && (
-        <NetworkFilter
-          tokens={tokens}
-          onFilteredTokensChange={handleFilteredTokensChange}
-          onNetworkFilterStateChange={handleNetworkFilterStateChange}
-          onExposeFilterControls={handleExposeFilterControls}
-          onNetworkFilterChange={handleNetworkFilterChange}
-        />
-      )}
       <ScrollView
         testID={TransactionPayComponentIDs.PAY_WITH_TOKEN_LIST}
         contentContainerStyle={{


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### What is the reason for the change?

- **Inconsistent filter pill styling:** Send screen network filter pills used different styling (8px radius, transparent + border) than the Bridge token selector (12px radius, solid selected/unselected pills), which made the product feel inconsistent.
- **Layout:** On Send, the search bar was above the network pills; aligning with Bridge and putting filters first improves scan order when choosing a network.
- **Typography:** Ramp token list subtitles (e.g. MUSD, ETH, BTC) used Body MD instead of the smaller Body SM used elsewhere for symbols/secondary labels.

### What is the improvement/solution?

- **Unified filter pill UI:** Send network filter pills now use the same component and styling as the Bridge token selector: `ButtonToggle` with 12px corner radius (`rounded-xl`), solid background when selected (primary) and when unselected (secondary), and no border. This matches the Bridge “Select token” filter chips.
- **Reordered Send layout:** Network filter pills are rendered above the search bar on the Send asset screen so network selection is the first step, consistent with Bridge.
- **Ramp token list typography:** Ramp `TokenListItem` subtitles (symbols) now use `TextVariant.BodySM` instead of `TextVariant.BodyMD` for consistent secondary label sizing.
- **Tests:** Snapshots were updated for the affected components (e.g. network filter, asset view, Ramp token list, Bridge token selector, NFT confirmations) to reflect the UI changes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: Polish token selector for Buy, Swap and Send

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Send and token selector UI alignment

  Scenario: user uses network filters and sees consistent token list styling
    Given the user is on the Send screen or Ramp/Bridge token selection

    When the user views network filter pills and token list items
    Then network pills are above search on Send, use 12px radius and solid pill styling
    And Ramp token list subtitles (MUSD, ETH, BTC) use Body SM
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1093" height="822" alt="Screenshot 2026-03-11 at 1 48 33 AM" src="https://github.com/user-attachments/assets/3fde6c8b-ad4e-4794-8480-ef3f1c2d389a" />


### **After**
<img width="1076" height="829" alt="Screenshot 2026-03-11 at 1 48 44 AM" src="https://github.com/user-attachments/assets/0d4ef3ff-236b-4e97-bead-40bfb86e3bad" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly visual/UI changes, but swapping Send’s network filter from `Pressable` to `ButtonToggle` and reordering filter/search could subtly affect interaction/accessibility and should be smoke-tested on-device.
> 
> **Overview**
> Unifies token selection UI styling across Bridge, Ramp, Card, and Send by updating spacing/layout, increasing token/network avatar sizes, and standardizing secondary text sizing.
> 
> Send’s network filter chips are refactored to use `ButtonToggle` (solid pill styling) and the Send asset selector now renders the network filter above the search field; Bridge/Ramp token selectors get matching padding tweaks and updated token row layout (e.g., `TokenSelectorItem` min height/typography). Snapshot tests are updated to reflect the visual changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 021620fe7d9cf369345d6a583a0c1c457f60e1b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->