### PR TITLE
feat: migrate Label (core ux scope)

### DIFF
--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -126,16 +126,20 @@ exports[`ChoosePassword render matches snapshot 1`] = `
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#131416",
-                  "fontFamily": "Geist-Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                  "marginBottom": -4,
-                }
+                [
+                  {
+                    "color": "#131416",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  {
+                    "marginBottom": -4,
+                  },
+                ]
               }
-              testID="label"
             >
               Create password
             </Text>
@@ -279,16 +283,20 @@ exports[`ChoosePassword render matches snapshot 1`] = `
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#131416",
-                  "fontFamily": "Geist-Medium",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                  "marginBottom": -4,
-                }
+                [
+                  {
+                    "color": "#131416",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  {
+                    "marginBottom": -4,
+                  },
+                ]
               }
-              testID="label"
             >
               Confirm password
             </Text>

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -69,7 +69,11 @@ import Button, {
   ButtonSize,
 } from '../../../component-library/components/Buttons/Button';
 import TextField from '../../../component-library/components/Form/TextField/TextField';
-import Label from '../../../component-library/components/Form/Label';
+import {
+  Label,
+  FontWeight,
+  TextColor as DSTextColor,
+} from '@metamask/design-system-react-native';
 import Routes from '../../../constants/navigation/Routes';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import FoxRiveLoaderAnimation from './FoxRiveLoaderAnimation/FoxRiveLoaderAnimation';
@@ -661,8 +665,8 @@ const ChoosePassword = () => {
 
                 <View style={styles.field}>
                   <Label
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Default}
+                    fontWeight={FontWeight.Medium}
+                    color={DSTextColor.TextDefault}
                     style={styles.label}
                   >
                     {strings('choose_password.password')}
@@ -712,8 +716,8 @@ const ChoosePassword = () => {
 
                 <View style={styles.field}>
                   <Label
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Default}
+                    fontWeight={FontWeight.Medium}
+                    color={DSTextColor.TextDefault}
                     style={styles.label}
                   >
                     {strings('choose_password.confirm_password')}

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -50,7 +50,10 @@ import Button, {
   ButtonWidthTypes,
   ButtonSize,
 } from '../../../component-library/components/Buttons/Button';
-import Label from '../../../component-library/components/Form/Label';
+import {
+  Label,
+  TextColor as DSTextColor,
+} from '@metamask/design-system-react-native';
 import TextField from '../../../component-library/components/Form/TextField/TextField';
 import { saveOnboardingEvent as saveEvent } from '../../../actions/onboarding';
 import { AppThemeKey } from '../../../util/theme/models';
@@ -334,7 +337,7 @@ const ManualBackupStep1 = () => {
         <View style={styles.confirmPasswordWrapper}>
           <View style={[styles.content, styles.passwordRequiredContent]}>
             <View style={styles.text}>
-              <Label variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Label color={DSTextColor.TextDefault}>
                 {strings('manual_backup_step_1.before_continiuing')}
               </Label>
             </View>

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -81,7 +81,11 @@ import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBui
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import FOX_LOGO from '../../../images/branding/fox.png';
 import METAMASK_NAME from '../../../images/branding/metamask-name.png';
-import Label from '../../../component-library/components/Form/Label';
+import {
+  Label,
+  FontWeight,
+  TextColor as DSTextColor,
+} from '@metamask/design-system-react-native';
 import TextField from '../../../component-library/components/Form/TextField';
 import HelpText, {
   HelpTextSeverity,
@@ -703,8 +707,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
               <View style={styles.field}>
                 <Label
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Default}
+                  fontWeight={FontWeight.Medium}
+                  color={DSTextColor.TextDefault}
                   style={styles.label}
                 >
                   {strings('login.password')}

--- a/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
@@ -261,16 +261,20 @@ exports[`ResetPassword render matches snapshot 1`] = `
                 <Text
                   accessibilityRole="text"
                   style={
-                    {
-                      "color": "#131416",
-                      "fontFamily": "Geist-Medium",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                      "marginBottom": 4,
-                    }
+                    [
+                      {
+                        "color": "#131416",
+                        "fontFamily": "Geist-Medium",
+                        "fontSize": 16,
+                        "fontWeight": 400,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                      },
+                      {
+                        "marginBottom": 4,
+                      },
+                    ]
                   }
-                  testID="label"
                 >
                   Enter your current password
                 </Text>

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -52,7 +52,11 @@ import Button, {
   ButtonSize,
   ButtonWidthTypes,
 } from '../../../component-library/components/Buttons/Button';
-import Label from '../../../component-library/components/Form/Label';
+import {
+  Label,
+  FontWeight,
+  TextColor as DSTextColor,
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
   IconSize,
@@ -775,8 +779,8 @@ class ResetPassword extends PureComponent {
           <View style={styles.confirmPasswordWrapper}>
             <View style={[styles.content, styles.passwordRequiredContent]}>
               <Label
-                variant={TextVariant.BodyMDMedium}
-                color={TextColor.Default}
+                fontWeight={FontWeight.Medium}
+                color={DSTextColor.TextDefault}
                 style={styles.confirm_label}
               >
                 {strings('manual_backup_step_1.enter_current_password')}
@@ -907,8 +911,8 @@ class ResetPassword extends PureComponent {
 
                 <View style={styles.field}>
                   <Label
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Default}
+                    fontWeight={FontWeight.Medium}
+                    color={DSTextColor.TextDefault}
                     style={styles.passwordLabel}
                   >
                     {strings('reset_password.password')}
@@ -950,8 +954,8 @@ class ResetPassword extends PureComponent {
 
                 <View style={styles.field}>
                   <Label
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Default}
+                    fontWeight={FontWeight.Medium}
+                    color={DSTextColor.TextDefault}
                     style={styles.passwordLabel}
                   >
                     {strings('reset_password.confirm_password')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrated `Label` component (core UX scope).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-276

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/50065c3f-8fe8-4ad6-908a-08e4a0ae7d2d" />

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/4fbe9805-1ecf-418f-9ecd-555a266b042e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps `Label` implementations and updates props/snapshots; no business logic or data/auth flows are modified.
> 
> **Overview**
> Migrates `Label` usage in `ChoosePassword`, `ManualBackupStep1`, `OAuthRehydration`, and `ResetPassword` from the local component-library to `@metamask/design-system-react-native`.
> 
> Updates `Label` props to the design-system API (e.g., `fontWeight` and `DSTextColor.TextDefault`) and refreshes Jest snapshots to reflect the resulting style output changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa7ff7cdd0ca057f6abe39bd81463b5c7d4520b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->