### PR TITLE
feat(perps): add remote feature flag for default pay token when no balance

### DIFF
--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.test.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.test.ts
@@ -2,6 +2,10 @@ import { renderHookWithProvider } from '../../../../util/test/renderWithProvider
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from './useDefaultPayWithTokenWhenNoPerpsBalance';
 import type { PerpsToken } from '@metamask/perps-controller';
 
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('7.70.0'),
+}));
+
 jest.mock('./usePerpsPaymentTokens', () => ({
   usePerpsPaymentTokens: jest.fn(() => []),
 }));
@@ -18,6 +22,7 @@ function getState(
     allowlistAssets?: string[];
     isTestnet?: boolean;
     activeProvider?: 'hyperliquid' | 'myx' | 'aggregated';
+    defaultPayTokenWhenNoBalanceEnabled?: boolean;
   } = {},
 ) {
   const {
@@ -25,6 +30,7 @@ function getState(
     allowlistAssets = [],
     isTestnet = false,
     activeProvider,
+    defaultPayTokenWhenNoBalanceEnabled = true,
   } = overrides;
   return {
     engine: {
@@ -37,6 +43,10 @@ function getState(
         RemoteFeatureFlagController: {
           remoteFeatureFlags: {
             perpsPayWithAnyTokenAllowlistAssets: allowlistAssets,
+            perpsDefaultPayTokenWhenNoBalanceEnabled:
+              defaultPayTokenWhenNoBalanceEnabled
+                ? { enabled: true, minimumVersion: '0.0.0' }
+                : { enabled: false, minimumVersion: '0.0.0' },
           },
         },
       },
@@ -74,6 +84,27 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       getState({
         perpsAccount: { availableBalance: '100' },
         allowlistAssets: ['0xa4b1.0xusdc'],
+      }),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when feature flag is disabled', () => {
+    mockUsePerpsPaymentTokens.mockReturnValue([
+      {
+        address: '0xusdc',
+        chainId: '0xa4b1',
+        symbol: 'USDC',
+        balanceFiat: 'US$500',
+        decimals: 6,
+      },
+    ] as PerpsToken[]);
+
+    const { result } = runHook(
+      getState({
+        allowlistAssets: ['0xa4b1.0xusdc'],
+        defaultPayTokenWhenNoBalanceEnabled: false,
       }),
     );
 

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
@@ -7,7 +7,10 @@ import {
   PERPS_MIN_BALANCE_THRESHOLD,
   PROVIDER_CONFIG,
 } from '../constants/perpsConfig';
-import { selectPerpsPayWithAnyTokenAllowlistAssets } from '../selectors/featureFlags';
+import {
+  selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag,
+  selectPerpsPayWithAnyTokenAllowlistAssets,
+} from '../selectors/featureFlags';
 import {
   selectPerpsAccountState,
   selectPerpsProvider,
@@ -21,6 +24,9 @@ import { usePerpsPaymentTokens } from './usePerpsPaymentTokens';
  * Otherwise returns null (caller should default to "Perps balance").
  */
 export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPaymentToken | null {
+  const featureEnabled = useSelector(
+    selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag,
+  );
   const perpsAccount = useSelector(selectPerpsAccountState);
   const allowlistAssets = useSelector(
     selectPerpsPayWithAnyTokenAllowlistAssets,
@@ -30,6 +36,9 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
   const paymentTokens = usePerpsPaymentTokens();
 
   return useMemo(() => {
+    if (!featureEnabled) {
+      return null;
+    }
     const availableBalance = Number.parseFloat(
       perpsAccount?.availableBalance?.toString() ?? '0',
     );
@@ -82,6 +91,7 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
       description: top.symbol,
     };
   }, [
+    featureEnabled,
     perpsAccount?.availableBalance,
     allowlistAssets,
     activeProvider,

--- a/app/components/UI/Perps/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Perps/mocks/remoteFeatureFlagMocks.ts
@@ -14,4 +14,5 @@ export const mockedPerpsFeatureFlagsEnabledState: Record<
   perpsOrderBookEnabled: mockEnabledPerpsLDFlag,
   perpsFeedbackEnabled: mockEnabledPerpsLDFlag,
   perpsMyxProviderEnabled: mockEnabledPerpsLDFlag,
+  perpsDefaultPayTokenWhenNoBalanceEnabled: mockEnabledPerpsLDFlag,
 };

--- a/app/components/UI/Perps/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.test.ts
@@ -5,6 +5,7 @@ import {
   selectPerpsOrderBookEnabledFlag,
   selectPerpsButtonColorTestVariant,
   selectHip3ConfigVersion,
+  selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag,
   selectPerpsFeedbackEnabledFlag,
   selectPerpsTradeWithAnyTokenEnabledFlag,
   selectPerpsPayWithAnyTokenAllowlistAssets,
@@ -891,6 +892,99 @@ describe('Perps Feature Flag Selectors', () => {
         );
         expect(result).toBe(false);
       });
+    });
+  });
+
+  describe('selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag', () => {
+    const createEmptyFlagsState = () => ({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {},
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    });
+
+    it('returns true when remote flag is not set (default)', () => {
+      const result = selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag(
+        createEmptyFlagsState(),
+      );
+      expect(result).toBe(true);
+    });
+
+    it('uses remote flag when valid and enabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+
+      const stateWithEnabledRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsDefaultPayTokenWhenNoBalanceEnabled: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag(
+        stateWithEnabledRemoteFlag,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('uses remote flag when valid but disabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+
+      const stateWithDisabledRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsDefaultPayTokenWhenNoBalanceEnabled: {
+                  enabled: false,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag(
+        stateWithDisabledRemoteFlag,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns true when remote flag is invalid (default fallback)', () => {
+      const stateWithInvalidRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsDefaultPayTokenWhenNoBalanceEnabled: {
+                  enabled: 'invalid',
+                  minimumVersion: 123,
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag(
+        stateWithInvalidRemoteFlag,
+      );
+      expect(result).toBe(true);
     });
   });
 

--- a/app/components/UI/Perps/selectors/featureFlags/index.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.ts
@@ -278,3 +278,20 @@ export const selectPerpsMYXProviderEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => resolvePerpsMyxProviderEnabled(remoteFeatureFlags),
 );
+
+/**
+ * Selector for default pay token when no perps balance feature flag.
+ * When enabled: preselect allowlist token with highest balance in Pay row when user has no perps balance,
+ * and show "Add funds" CTA on market details when no token can be preselected.
+ * When disabled: no default token preselection and no Add funds CTA (legacy behavior).
+ * Controlled only by remote flag; when remote is missing or invalid, defaults to true.
+ *
+ * @returns boolean - true if feature is enabled, false otherwise
+ */
+export const selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag =
+  createSelector(selectRemoteFeatureFlags, (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.perpsDefaultPayTokenWhenNoBalanceEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? true;
+  });

--- a/docs/perps/perps-feature-flags.md
+++ b/docs/perps/perps-feature-flags.md
@@ -159,13 +159,14 @@ Follow existing test patterns covering:
 
 ### Version-Gated Boolean Flags
 
-| Redux Property                                     | LaunchDarkly Key                                         | Env Variable                                   | Default | Purpose                   |
-| -------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------- | ------- | ------------------------- |
-| `perpsPerpTradingEnabled`                          | `perps-perp-trading-enabled`                             | `MM_PERPS_ENABLED`                             | false   | Main Perps feature toggle |
-| `perpsPerpTradingServiceInterruptionBannerEnabled` | `perps-perp-trading-service-interruption-banner-enabled` | `MM_PERPS_SERVICE_INTERRUPTION_BANNER_ENABLED` | false   | Service disruption banner |
-| `perpsPerpGtmOnboardingModalEnabled`               | `perps-perp-gtm-onboarding-modal-enabled`                | `MM_PERPS_GTM_MODAL_ENABLED`                   | false   | GTM onboarding modal      |
-| `perpsOrderBookEnabled`                            | `perps-order-book-enabled`                               | `MM_PERPS_ORDER_BOOK_ENABLED`                  | false   | Order Book feature        |
-| `perpsFeedbackEnabled`                             | `perps-feedback-enabled`                                 | `MM_PERPS_FEEDBACK_ENABLED`                    | false   | Feedback button on home   |
+| Redux Property                                     | LaunchDarkly Key                                         | Env Variable                                   | Default | Purpose                                                                                 |
+| -------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------- | ------- | --------------------------------------------------------------------------------------- |
+| `perpsPerpTradingEnabled`                          | `perps-perp-trading-enabled`                             | `MM_PERPS_ENABLED`                             | false   | Main Perps feature toggle                                                               |
+| `perpsPerpTradingServiceInterruptionBannerEnabled` | `perps-perp-trading-service-interruption-banner-enabled` | `MM_PERPS_SERVICE_INTERRUPTION_BANNER_ENABLED` | false   | Service disruption banner                                                               |
+| `perpsPerpGtmOnboardingModalEnabled`               | `perps-perp-gtm-onboarding-modal-enabled`                | `MM_PERPS_GTM_MODAL_ENABLED`                   | false   | GTM onboarding modal                                                                    |
+| `perpsOrderBookEnabled`                            | `perps-order-book-enabled`                               | `MM_PERPS_ORDER_BOOK_ENABLED`                  | false   | Order Book feature                                                                      |
+| `perpsFeedbackEnabled`                             | `perps-feedback-enabled`                                 | `MM_PERPS_FEEDBACK_ENABLED`                    | false   | Feedback button on home                                                                 |
+| `perpsDefaultPayTokenWhenNoBalanceEnabled`         | `perps-default-pay-token-when-no-balance-enabled`        | —                                              | true    | Default pay token when no perps balance + Add funds CTA on market details (remote only) |
 
 ### A/B Test Flags
 


### PR DESCRIPTION
## **Description**

This PR adds a remote feature flag to control the "default pay token when no Perps balance" behavior introduced previously.

- Added `selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag` in Perps feature flag selectors.
- Gated `useDefaultPayWithTokenWhenNoPerpsBalance` behind that selector.
- Kept this control as **remote-only**.
- Updated Perps feature flag docs and mocks.
- Added/updated unit tests for selector behavior and hook behavior when flag is disabled.

## **Changelog**

CHANGELOG entry: Added a remote feature flag to control default pay token preselection when users have no Perps balance.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Perps default pay token flag

  Scenario: remote flag enabled
    Given a user has no Perps balance and has allowlisted pay tokens with balance
    When user opens the Perps order pay row
    Then the highest-balance allowlisted token is preselected

  Scenario: remote flag disabled
    Given a user has no Perps balance and has allowlisted pay tokens with balance
    When user opens the Perps order pay row
    Then no default pay token is preselected by this logic
```

## **Screenshots/Recordings**

### **Before**

N/A (logic/flagging change)

### **After**

N/A (logic/flagging change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes default payment-token preselection logic in Perps (user-facing trading/deposit flow), though behavior is fully gated by a new remote flag and covered by unit tests.
> 
> **Overview**
> Adds a new **remote-only** version-gated flag, `perpsDefaultPayTokenWhenNoBalanceEnabled`, with a selector `selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag` that defaults to *true* when missing/invalid.
> 
> Updates `useDefaultPayWithTokenWhenNoPerpsBalance` to short-circuit to `null` when this flag is disabled, and extends mocks, docs, and unit tests to cover the new flag behavior and the hook’s disabled-flag path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fedf46cae4d40b8e361500e8f76b83ce8f4c8dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->