### PR TITLE
fix(card): Card Onboarding name fixes

### DIFF
--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
@@ -257,6 +257,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'card.onboarding.personal_details.continue': 'Continue',
       'card.onboarding.personal_details.ssn_error': 'Invalid SSN',
       'card.onboarding.personal_details.age_error': 'Must be 18 or older',
+      'card.card_onboarding.personal_details.name_mismatch_error':
+        'First and last name must match your verified identity',
     };
     return mockStrings[key] || key;
   }),
@@ -1126,6 +1128,195 @@ describe('PersonalDetails Component', () => {
       fireEvent.changeText(lastNameInput, 'Doe');
 
       expect(queryByTestId('personal-details-ssn-input')).toBeNull();
+    });
+  });
+
+  describe('Error Reset on Name Change', () => {
+    it('clears registration error when first name is edited', () => {
+      const mockReset2 = jest.fn();
+      (useRegisterPersonalDetails as jest.Mock).mockReturnValue({
+        registerPersonalDetails: mockRegisterPersonalDetails,
+        isLoading: false,
+        isError: true,
+        error: 'Registration failed',
+        reset: mockReset2,
+      });
+
+      const { getByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'Jane',
+      );
+
+      expect(mockReset2).toHaveBeenCalled();
+    });
+
+    it('clears registration error when last name is edited', () => {
+      const mockReset2 = jest.fn();
+      (useRegisterPersonalDetails as jest.Mock).mockReturnValue({
+        registerPersonalDetails: mockRegisterPersonalDetails,
+        isLoading: false,
+        isError: true,
+        error: 'Registration failed',
+        reset: mockReset2,
+      });
+
+      const { getByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-last-name-input'),
+        'Smith',
+      );
+
+      expect(mockReset2).toHaveBeenCalled();
+    });
+  });
+
+  describe('Name Validation', () => {
+    const setupWithUserData = (userData: Record<string, unknown> | null) => {
+      (useCardSDK as jest.Mock).mockReturnValue({
+        user: userData,
+        setUser: mockSetUser,
+        fetchUserData: mockFetchUserData,
+        logoutFromProvider: jest.fn(),
+      });
+    };
+
+    it('does not show name error when pre-filled names match Veriff data', () => {
+      setupWithUserData({
+        firstName: 'John',
+        lastName: 'Doe',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+        countryOfNationality: 'US',
+        ssn: '123456789',
+      });
+
+      const { queryByTestId } = render(<PersonalDetails />);
+
+      expect(queryByTestId('personal-details-name-error')).toBeNull();
+    });
+
+    it('does not show name error when no userData is provided', () => {
+      setupWithUserData(null);
+
+      const { getByTestId, queryByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'John',
+      );
+      fireEvent.changeText(
+        getByTestId('personal-details-last-name-input'),
+        'Doe',
+      );
+
+      expect(queryByTestId('personal-details-name-error')).toBeNull();
+    });
+
+    it('shows name error when firstName is edited to drop middle name', () => {
+      setupWithUserData({
+        firstName: 'Maria Elena',
+        lastName: 'Garcia',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+        countryOfNationality: 'US',
+        ssn: '123456789',
+      });
+
+      const { getByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'Maria',
+      );
+
+      expect(getByTestId('personal-details-name-error')).toBeTruthy();
+    });
+
+    it('shows name error when lastName is edited to drop second surname', () => {
+      setupWithUserData({
+        firstName: 'John',
+        lastName: 'Garcia Lopez',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+        countryOfNationality: 'US',
+        ssn: '123456789',
+      });
+
+      const { getByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-last-name-input'),
+        'Garcia',
+      );
+
+      expect(getByTestId('personal-details-name-error')).toBeTruthy();
+    });
+
+    it('clears name error when names are corrected back to match', () => {
+      setupWithUserData({
+        firstName: 'Maria Elena',
+        lastName: 'Garcia',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+        countryOfNationality: 'US',
+        ssn: '123456789',
+      });
+
+      const { getByTestId, queryByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'Maria',
+      );
+      expect(getByTestId('personal-details-name-error')).toBeTruthy();
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'Maria Elena',
+      );
+      expect(queryByTestId('personal-details-name-error')).toBeNull();
+    });
+
+    it('allows different name splits as long as full name matches', () => {
+      setupWithUserData({
+        firstName: 'Maria Elena',
+        lastName: 'Garcia',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+        countryOfNationality: 'US',
+        ssn: '123456789',
+      });
+
+      const { getByTestId, queryByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'Maria',
+      );
+      fireEvent.changeText(
+        getByTestId('personal-details-last-name-input'),
+        'Elena Garcia',
+      );
+
+      expect(queryByTestId('personal-details-name-error')).toBeNull();
+    });
+
+    it('disables continue button when name mismatch exists', () => {
+      setupWithUserData({
+        firstName: 'Maria Elena',
+        lastName: 'Garcia Lopez',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+        countryOfNationality: 'US',
+        ssn: '123456789',
+      });
+
+      const { getByTestId } = render(<PersonalDetails />);
+
+      fireEvent.changeText(
+        getByTestId('personal-details-first-name-input'),
+        'Maria',
+      );
+
+      const continueButton = getByTestId('personal-details-continue-button');
+      expect(continueButton.props.disabled).toBe(true);
     });
   });
 });

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
@@ -1133,13 +1133,13 @@ describe('PersonalDetails Component', () => {
 
   describe('Error Reset on Name Change', () => {
     it('clears registration error when first name is edited', () => {
-      const mockReset2 = jest.fn();
+      const mockResetRegister = jest.fn();
       (useRegisterPersonalDetails as jest.Mock).mockReturnValue({
         registerPersonalDetails: mockRegisterPersonalDetails,
         isLoading: false,
         isError: true,
         error: 'Registration failed',
-        reset: mockReset2,
+        reset: mockResetRegister,
       });
 
       const { getByTestId } = render(<PersonalDetails />);
@@ -1149,17 +1149,17 @@ describe('PersonalDetails Component', () => {
         'Jane',
       );
 
-      expect(mockReset2).toHaveBeenCalled();
+      expect(mockResetRegister).toHaveBeenCalled();
     });
 
     it('clears registration error when last name is edited', () => {
-      const mockReset2 = jest.fn();
+      const mockResetRegister = jest.fn();
       (useRegisterPersonalDetails as jest.Mock).mockReturnValue({
         registerPersonalDetails: mockRegisterPersonalDetails,
         isLoading: false,
         isError: true,
         error: 'Registration failed',
-        reset: mockReset2,
+        reset: mockResetRegister,
       });
 
       const { getByTestId } = render(<PersonalDetails />);
@@ -1169,7 +1169,7 @@ describe('PersonalDetails Component', () => {
         'Smith',
       );
 
-      expect(mockReset2).toHaveBeenCalled();
+      expect(mockResetRegister).toHaveBeenCalled();
     });
   });
 
@@ -1194,7 +1194,9 @@ describe('PersonalDetails Component', () => {
 
       const { queryByTestId } = render(<PersonalDetails />);
 
-      expect(queryByTestId('personal-details-name-error')).toBeNull();
+      expect(
+        queryByTestId('personal-details-name-error'),
+      ).not.toBeOnTheScreen();
     });
 
     it('does not show name error when no userData is provided', () => {
@@ -1211,7 +1213,9 @@ describe('PersonalDetails Component', () => {
         'Doe',
       );
 
-      expect(queryByTestId('personal-details-name-error')).toBeNull();
+      expect(
+        queryByTestId('personal-details-name-error'),
+      ).not.toBeOnTheScreen();
     });
 
     it('shows name error when firstName is edited to drop middle name', () => {
@@ -1273,7 +1277,9 @@ describe('PersonalDetails Component', () => {
         getByTestId('personal-details-first-name-input'),
         'Maria Elena',
       );
-      expect(queryByTestId('personal-details-name-error')).toBeNull();
+      expect(
+        queryByTestId('personal-details-name-error'),
+      ).not.toBeOnTheScreen();
     });
 
     it('allows different name splits as long as full name matches', () => {
@@ -1296,7 +1302,9 @@ describe('PersonalDetails Component', () => {
         'Elena Garcia',
       );
 
-      expect(queryByTestId('personal-details-name-error')).toBeNull();
+      expect(
+        queryByTestId('personal-details-name-error'),
+      ).not.toBeOnTheScreen();
     });
 
     it('disables continue button when name mismatch exists', () => {

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
@@ -1230,7 +1230,7 @@ describe('PersonalDetails Component', () => {
         'Maria',
       );
 
-      expect(getByTestId('personal-details-name-error')).toBeTruthy();
+      expect(getByTestId('personal-details-name-error')).toBeOnTheScreen();
     });
 
     it('shows name error when lastName is edited to drop second surname', () => {
@@ -1249,7 +1249,7 @@ describe('PersonalDetails Component', () => {
         'Garcia',
       );
 
-      expect(getByTestId('personal-details-name-error')).toBeTruthy();
+      expect(getByTestId('personal-details-name-error')).toBeOnTheScreen();
     });
 
     it('clears name error when names are corrected back to match', () => {
@@ -1267,7 +1267,7 @@ describe('PersonalDetails Component', () => {
         getByTestId('personal-details-first-name-input'),
         'Maria',
       );
-      expect(getByTestId('personal-details-name-error')).toBeTruthy();
+      expect(getByTestId('personal-details-name-error')).toBeOnTheScreen();
 
       fireEvent.changeText(
         getByTestId('personal-details-first-name-input'),

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -50,6 +50,7 @@ const PersonalDetails = () => {
   const [lastName, setLastName] = useState('');
   const [dateOfBirth, setDateOfBirth] = useState('');
   const [dateError, setDateError] = useState('');
+  const [veriffFullName, setVeriffFullName] = useState('');
   const [nationalityKey, setNationalityKey] = useState(''); // ISO 3166-1 alpha-2 country code
   const [SSN, setSSN] = useState('');
   const [isSSNError, setIsSSNError] = useState(false);
@@ -67,6 +68,12 @@ const PersonalDetails = () => {
     if (userData) {
       setFirstName(userData.firstName || '');
       setLastName(userData.lastName || '');
+
+      const fullName = [userData.firstName, userData.lastName]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+      setVeriffFullName(fullName);
       // userData.dateOfBirth is in ISO 8601 format, parse it to local timezone
       if (userData.dateOfBirth && typeof userData.dateOfBirth === 'string') {
         // Parse the date components: YYYY-MM-DD
@@ -135,6 +142,22 @@ const PersonalDetails = () => {
     reset: resetRegisterPersonalDetails,
   } = useRegisterPersonalDetails();
 
+  const handleFirstNameChange = useCallback(
+    (text: string) => {
+      resetRegisterPersonalDetails();
+      setFirstName(text);
+    },
+    [resetRegisterPersonalDetails],
+  );
+
+  const handleLastNameChange = useCallback(
+    (text: string) => {
+      resetRegisterPersonalDetails();
+      setLastName(text);
+    },
+    [resetRegisterPersonalDetails],
+  );
+
   const handleNationalitySelect = useCallback(() => {
     resetRegisterPersonalDetails();
     setOnValueChange((region) => {
@@ -196,6 +219,24 @@ const PersonalDetails = () => {
       );
     } else setDateError('');
   }, [dateOfBirth]);
+
+  const nameError = useMemo(() => {
+    if (!veriffFullName) return '';
+    if (!firstName.trim() && !lastName.trim()) return '';
+
+    const currentFullName = [firstName.trim(), lastName.trim()]
+      .filter(Boolean)
+      .join(' ')
+      .replace(/\s+/g, ' ');
+    const expectedFullName = veriffFullName.replace(/\s+/g, ' ');
+
+    if (currentFullName !== expectedFullName) {
+      return strings(
+        'card.card_onboarding.personal_details.name_mismatch_error',
+      );
+    }
+    return '';
+  }, [firstName, lastName, veriffFullName]);
 
   useEffect(() => () => clearOnValueChange(), []);
 
@@ -284,6 +325,7 @@ const PersonalDetails = () => {
       (!SSN && selectedCountry?.key === 'US') ||
       !isSSNValid ||
       !!dateError ||
+      !!nameError ||
       !onboardingId
     );
   }, [
@@ -296,6 +338,7 @@ const PersonalDetails = () => {
     SSN,
     selectedCountry,
     dateError,
+    nameError,
     onboardingId,
   ]);
 
@@ -308,12 +351,13 @@ const PersonalDetails = () => {
         </Label>
         <TextField
           autoCapitalize={'none'}
-          onChangeText={setFirstName}
+          onChangeText={handleFirstNameChange}
           numberOfLines={1}
           autoComplete="one-time-code"
           value={firstName}
           keyboardType="default"
           maxLength={255}
+          isError={!!nameError}
           accessibilityLabel={strings(
             'card.card_onboarding.personal_details.first_name_label',
           )}
@@ -328,17 +372,27 @@ const PersonalDetails = () => {
         </Label>
         <TextField
           autoCapitalize={'none'}
-          onChangeText={setLastName}
+          onChangeText={handleLastNameChange}
           numberOfLines={1}
           autoComplete="one-time-code"
           value={lastName}
           keyboardType="default"
           maxLength={255}
+          isError={!!nameError}
           accessibilityLabel={strings(
             'card.card_onboarding.personal_details.last_name_label',
           )}
           testID="personal-details-last-name-input"
         />
+        {!!nameError && (
+          <Text
+            variant={TextVariant.BodySm}
+            testID="personal-details-name-error"
+            twClassName="text-error-default"
+          >
+            {nameError}
+          </Text>
+        )}
       </Box>
 
       {/* Date of Birth */}

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -227,8 +227,9 @@ const PersonalDetails = () => {
     const currentFullName = [firstName.trim(), lastName.trim()]
       .filter(Boolean)
       .join(' ')
-      .replace(/\s+/g, ' ');
-    const expectedFullName = veriffFullName.replace(/\s+/g, ' ');
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+    const expectedFullName = veriffFullName.replace(/\s+/g, ' ').toLowerCase();
 
     if (currentFullName !== expectedFullName) {
       return strings(
@@ -247,6 +248,7 @@ const PersonalDetails = () => {
       !lastName ||
       !dateOfBirth ||
       !nationalityKey ||
+      nameError ||
       (!SSN && selectedCountry?.key === 'US')
     ) {
       return;

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -228,8 +228,12 @@ const PersonalDetails = () => {
       .filter(Boolean)
       .join(' ')
       .replace(/\s+/g, ' ')
+      .normalize('NFC')
       .toLowerCase();
-    const expectedFullName = veriffFullName.replace(/\s+/g, ' ').toLowerCase();
+    const expectedFullName = veriffFullName
+      .replace(/\s+/g, ' ')
+      .normalize('NFC')
+      .toLowerCase();
 
     if (currentFullName !== expectedFullName) {
       return strings(

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
@@ -1838,4 +1838,90 @@ describe('PhysicalAddress Component', () => {
       expect(buttonText.props.children).toBe('Continue');
     });
   });
+
+  describe('Error Reset on Field Change', () => {
+    it('clears consent error when address field is edited', () => {
+      const mockResetConsent = jest.fn();
+      mockUseRegisterUserConsent.mockReturnValue({
+        createOnboardingConsent: jest.fn(),
+        linkUserToConsent: jest.fn(),
+        getOnboardingConsentSetByOnboardingId: jest
+          .fn()
+          .mockResolvedValue(null),
+        isLoading: false,
+        isSuccess: false,
+        isError: true,
+        error: 'Consent failed',
+        consentSetId: null,
+        clearError: jest.fn(),
+        reset: mockResetConsent,
+      });
+
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <PhysicalAddress />
+        </Provider>,
+      );
+
+      fireEvent.changeText(getByTestId('address-line-1-input'), '456 Oak Ave');
+
+      expect(mockResetConsent).toHaveBeenCalled();
+    });
+
+    it('clears consent error when city field is edited', () => {
+      const mockResetConsent = jest.fn();
+      mockUseRegisterUserConsent.mockReturnValue({
+        createOnboardingConsent: jest.fn(),
+        linkUserToConsent: jest.fn(),
+        getOnboardingConsentSetByOnboardingId: jest
+          .fn()
+          .mockResolvedValue(null),
+        isLoading: false,
+        isSuccess: false,
+        isError: true,
+        error: 'Consent failed',
+        consentSetId: null,
+        clearError: jest.fn(),
+        reset: mockResetConsent,
+      });
+
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <PhysicalAddress />
+        </Provider>,
+      );
+
+      fireEvent.changeText(getByTestId('city-input'), 'San Francisco');
+
+      expect(mockResetConsent).toHaveBeenCalled();
+    });
+
+    it('clears consent error when zip code field is edited', () => {
+      const mockResetConsent = jest.fn();
+      mockUseRegisterUserConsent.mockReturnValue({
+        createOnboardingConsent: jest.fn(),
+        linkUserToConsent: jest.fn(),
+        getOnboardingConsentSetByOnboardingId: jest
+          .fn()
+          .mockResolvedValue(null),
+        isLoading: false,
+        isSuccess: false,
+        isError: true,
+        error: 'Consent failed',
+        consentSetId: null,
+        clearError: jest.fn(),
+        reset: mockResetConsent,
+      });
+
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <PhysicalAddress />
+        </Provider>,
+      );
+
+      fireEvent.changeText(getByTestId('zip-code-input'), '94102');
+
+      expect(mockResetConsent).toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -368,41 +368,46 @@ const PhysicalAddress = () => {
   const handleAddressLine1Change = useCallback(
     (text: string) => {
       resetRegisterAddress();
+      resetConsent();
       setAddressLine1(text);
     },
-    [resetRegisterAddress],
+    [resetRegisterAddress, resetConsent],
   );
 
   const handleAddressLine2Change = useCallback(
     (text: string) => {
       resetRegisterAddress();
+      resetConsent();
       setAddressLine2(text);
     },
-    [resetRegisterAddress],
+    [resetRegisterAddress, resetConsent],
   );
 
   const handleCityChange = useCallback(
     (text: string) => {
       resetRegisterAddress();
+      resetConsent();
       setCity(text);
     },
-    [resetRegisterAddress],
+    [resetRegisterAddress, resetConsent],
   );
 
   const handleStateChange = useCallback(
     (text: string) => {
       resetRegisterAddress();
+      resetConsent();
       setState(text);
     },
-    [resetRegisterAddress],
+    [resetRegisterAddress, resetConsent],
   );
 
   const handleZipCodeChange = useCallback(
     (text: string) => {
       resetRegisterAddress();
+      resetConsent();
       setZipCode(text);
     },
-    [resetRegisterAddress],
+    [resetRegisterAddress, resetConsent],
   );
 
   const handleElectronicConsentToggle = useCallback(() => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7090,7 +7090,8 @@
         "ssn_label": "Social Security Number",
         "ssn_description": "Required by the card issuer. No credit check will be run.",
         "invalid_ssn": "Invalid SSN",
-        "invalid_date_of_birth": "Invalid date of birth. You must be at least 18 years old"
+        "invalid_date_of_birth": "Invalid date of birth. You must be at least 18 years old",
+        "name_mismatch_error": "First and last name must match your verified identity"
       },
       "physical_address": {
         "title": "Add your address",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes two bugs in the Card onboarding flow that caused the "Continue" button to become permanently disabled or unresponsive after a failed submission, and adds client-side name validation to prevent KYC mismatches.

**Why**: Users reported being stuck on the Personal Details and Physical Address onboarding screens — the "Next"/"Continue" button would stop working after a failed API call. Separately, the onboarding flow was allowing users to edit their first/last name fields to values that no longer matched their Veriff-verified identity, leading to KYC/compliance risk.

**What changed**:

- **`PersonalDetails.tsx`**: Wrapped `setFirstName` and `setLastName` in new `handleFirstNameChange` / `handleLastNameChange` callbacks that call `resetRegisterPersonalDetails()` on every keystroke, clearing stale `isError` state from previous failed submissions. Added `veriffFullName` state that captures the full name from the Veriff KYC response (`userData`). Added a `nameError` memo that validates the combined first + last name matches the Veriff full name, with an inline error message and `isDisabled` integration.

- **`PhysicalAddress.tsx`**: Added `resetConsent()` calls to all address field change handlers (`handleAddressLine1Change`, `handleAddressLine2Change`, `handleCityChange`, `handleStateChange`, `handleZipCodeChange`). Previously, these handlers only called `resetRegisterAddress()`, so a stuck `consentIsError` from a failed consent operation would keep the button disabled even after the user corrected their input.

- **`en.json`**: Added `name_mismatch_error` localization string: "First and last name must match your verified identity".

- **Tests**: Added 12 new unit tests — 9 for PersonalDetails (2 for error reset on name change, 7 for name validation scenarios including middle names, second surnames, and different splits) and 3 for PhysicalAddress (consent error reset on address/city/zip edit).

## **Changelog**

CHANGELOG entry: Fixed Card Onboarding name issues

### Added
- Added client-side name validation on Personal Details screen to prevent first/last name edits that don't match the Veriff-verified identity

## **Related issues**

Refs: Card onboarding — stuck "Continue" button and name field validation

## **Manual testing steps**

```gherkin
Feature: Card Onboarding - Personal Details error reset

  Scenario: Continue button re-enables after editing first name following a failed submission
    Given the user is on the Card onboarding Personal Details screen
    And the user has filled in all required fields
    When the user taps "Continue" and the API call fails
    Then an error message is displayed and the button is disabled
    When the user edits the "First Name" field
    Then the error is cleared and the "Continue" button is re-enabled

  Scenario: Continue button re-enables after editing last name following a failed submission
    Given the user is on the Card onboarding Personal Details screen
    And the user has filled in all required fields
    When the user taps "Continue" and the API call fails
    Then an error message is displayed and the button is disabled
    When the user edits the "Last Name" field
    Then the error is cleared and the "Continue" button is re-enabled

Feature: Card Onboarding - Name validation against Veriff identity

  Scenario: Name mismatch error shown when user edits name to not match Veriff
    Given the user completed Veriff KYC with full name "Maria Elena Garcia"
    And the Personal Details screen pre-fills firstName="Maria Elena" lastName="Garcia"
    When the user changes firstName to "Maria"
    Then an error "First and last name must match your verified identity" is shown
    And the "Continue" button is disabled

  Scenario: Name mismatch error clears when names are corrected
    Given a name mismatch error is displayed
    When the user corrects the first name back to "Maria Elena"
    Then the error message disappears
    And the "Continue" button is re-enabled

  Scenario: Different name splits are accepted if full name matches
    Given the user completed Veriff KYC with full name "Maria Elena Garcia"
    When the user sets firstName="Maria" and lastName="Elena Garcia"
    Then no name mismatch error is shown
    And the "Continue" button is enabled

Feature: Card Onboarding - Physical Address error reset

  Scenario: Continue button re-enables after editing address fields following a failed consent
    Given the user is on the Card onboarding Physical Address screen
    And the user has filled in all required fields and consents
    When the user taps "Continue" and the consent API call fails
    Then an error message is displayed and the button is disabled
    When the user edits any address field (address line 1, city, or zip code)
    Then the consent error is cleared and the "Continue" button is re-enabled
```

## **Screenshots/Recordings**

No visual design changes — the error message uses the existing `text-error-default` styling consistent with other inline errors in the onboarding flow. The name mismatch error appears below the "Last Name" field with both name fields highlighted in error state.

### **Before**

- Editing first or last name after a failed submission did not clear the `registerIsError` state, leaving the "Continue" button permanently disabled until the user interacted with the Nationality dropdown.
- Editing address fields after a failed consent operation did not clear the `consentIsError` state, leaving the "Continue" button permanently disabled.
- Users could freely edit their first/last name to values that no longer matched their Veriff-verified identity, risking KYC rejection downstream.

### **After**

- Editing any name field immediately clears stale submission errors, re-enabling the button.
- Editing any address field clears both address and consent errors, re-enabling the button.
- A name mismatch error is shown inline if the combined first + last name no longer matches the Veriff full name, and the "Continue" button is disabled until corrected.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding gating/disable logic and adds new client-side KYC-related validation, which could block legitimate users if matching rules are too strict; changes are localized and covered by tests.
> 
> **Overview**
> Fixes Card onboarding screens getting stuck after failed submissions by **resetting relevant error state on input changes** (Personal Details resets registration errors when first/last name is edited; Physical Address resets consent errors when any address field changes).
> 
> Adds client-side **name mismatch validation** on Personal Details by comparing the current first+last name against the Veriff-provided full name, showing an inline error, marking both fields as errored, and blocking Continue until corrected. Updates `en.json` with the new `name_mismatch_error` string and expands unit tests to cover error-reset behavior and name-validation scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67df80ca55c9b3a215b4a0075ba491284c555874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->