### PR TITLE
refactor(ramp): migrate Base/Text to MMDS Text in Aggregator components

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -2998,41 +2998,18 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -3588,41 +3565,18 @@ exports[`BuildQuote View Crypto Currency Data renders a special error page if cr
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -4247,41 +4201,18 @@ exports[`BuildQuote View Crypto Currency Data renders an error page when there i
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -7194,41 +7125,18 @@ exports[`BuildQuote View Fiat Currency Data renders an error page when there is 
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -10121,41 +10029,18 @@ exports[`BuildQuote View Payment Method Data renders an error page when there is
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -15571,41 +15456,18 @@ exports[`BuildQuote View Regions data renders an error page when there is a regi
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -23304,41 +23166,18 @@ exports[`BuildQuote View renders correctly when sdkError is present 1`] = `
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -23894,41 +23733,18 @@ exports[`BuildQuote View renders correctly when sdkError is present 2`] = `
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }

--- a/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
@@ -1174,41 +1174,18 @@ exports[`Checkout displays and tracks error if no url or errors 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -1868,41 +1845,18 @@ exports[`Checkout displays sdkError when present 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -3148,41 +3102,18 @@ exports[`Checkout handles get order error gracefully 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -3886,41 +3817,18 @@ exports[`Checkout handles undefined order gracefully 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -5166,41 +5074,18 @@ exports[`Checkout sets and displays error on http error in WebView 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -5904,41 +5789,18 @@ exports[`Checkout sets and displays error on http error in WebView for callback 
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -6642,41 +6504,18 @@ exports[`Checkout sets error when handling url navigation state change and selec
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/__snapshots__/OrderDetails.test.tsx.snap
@@ -629,42 +629,19 @@ exports[`OrderDetails renders a cancelled order 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -2065,42 +2042,19 @@ exports[`OrderDetails renders a completed order 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -3516,42 +3470,19 @@ exports[`OrderDetails renders a created order 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -4897,42 +4828,19 @@ exports[`OrderDetails renders a failed order 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -6348,42 +6256,19 @@ exports[`OrderDetails renders a pending order 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -7969,41 +7854,18 @@ exports[`OrderDetails renders an error screen if a CREATED order cannot be polle
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -8763,42 +8625,19 @@ exports[`OrderDetails renders non-transacted orders 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -10239,42 +10078,19 @@ exports[`OrderDetails renders the support links if the provider has them 1`] = `
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -11709,42 +11525,19 @@ exports[`OrderDetails renders transacted orders that do not have timeDescription
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,
@@ -13138,42 +12931,19 @@ exports[`OrderDetails renders transacted orders that have timeDescriptionPending
                                               </View>
                                             </View>
                                             <Text
+                                              accessibilityRole="text"
                                               numberOfLines={1}
                                               style={
                                                 [
                                                   {
                                                     "color": "#131416",
                                                     "fontFamily": "Geist-Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  {
+                                                    "fontSize": 16,
+                                                    "fontWeight": 400,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
                                                     "textAlign": "center",
                                                   },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#131416",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
                                                   {
                                                     "flexShrink": 1,
                                                     "marginHorizontal": 5,

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx
@@ -21,7 +21,7 @@ import { PaymentCustomAction, Provider } from '@consensys/on-ramp-sdk/dist/API';
 import styleSheet from './Quotes.styles';
 import LoadingQuotes from './LoadingQuotes';
 import Timer from './Timer';
-import TextLegacy from '../../../../../Base/Text';
+import { Text, TextColor } from '@metamask/design-system-react-native';
 import ScreenLayout from '../../components/ScreenLayout';
 import ErrorViewWithReporting from '../../components/ErrorViewWithReporting';
 import ErrorView from '../../components/ErrorView';
@@ -1095,9 +1095,9 @@ function Quotes() {
           )}
 
           <ScreenLayout.Content style={styles.withoutVerticalPadding}>
-            <TextLegacy centered grey>
+            <Text color={TextColor.TextAlternative} twClassName="text-center">
               {strings('fiat_on_ramp_aggregator.compare_rates')}
-            </TextLegacy>
+            </Text>
           </ScreenLayout.Content>
         </ScreenLayout.Header>
         <InfoAlert

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Timer.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Timer.tsx
@@ -3,7 +3,11 @@ import { ActivityIndicator, View } from 'react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { useRampSDK } from '../../sdk';
 
-import Text from '../../../../../Base/Text';
+import {
+  Text,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import styleSheet from './Quotes.styles';
 
 import { strings } from '../../../../../../../locales/i18n';
@@ -28,13 +32,13 @@ const Timer = ({
           <Text> {strings('fiat_on_ramp_aggregator.fetching_new_quotes')}</Text>
         </>
       ) : (
-        <Text primary centered>
+        <Text color={TextColor.TextDefault} twClassName="text-center">
           {pollingCyclesLeft > 0
             ? strings('fiat_on_ramp_aggregator.new_quotes_in')
             : strings('fiat_on_ramp_aggregator.quotes_expire_in')}{' '}
           <Text
-            bold
-            primary
+            fontWeight={FontWeight.Bold}
+            color={TextColor.TextDefault}
             style={[
               styles.timer,
               remainingTime <= appConfig.POLLING_INTERVAL_HIGHLIGHT &&

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1157,41 +1157,18 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                             }
                           >
                             <Text
+                              accessibilityRole="text"
                               style={
                                 [
                                   {
                                     "color": "#131416",
                                     "fontFamily": "Geist-Regular",
-                                    "fontSize": 30,
-                                    "marginVertical": 2,
-                                  },
-                                  {
+                                    "fontSize": 16,
+                                    "fontWeight": 400,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
                                     "textAlign": "center",
                                   },
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  {
-                                    "color": "#131416",
-                                  },
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
                                   undefined,
                                 ]
                               }
@@ -1199,41 +1176,17 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                               New quotes in
                                
                               <Text
+                                accessibilityRole="text"
                                 style={
                                   [
                                     {
                                       "color": "#131416",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 30,
-                                      "marginVertical": 2,
-                                    },
-                                    undefined,
-                                    undefined,
-                                    {
                                       "fontFamily": "Geist-Bold",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
                                     },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    {
-                                      "color": "#131416",
-                                    },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     [
                                       {
                                         "fontVariant": [
@@ -3212,41 +3165,18 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
                                       [
                                         {
                                           "color": "#131416",
                                           "fontFamily": "Geist-Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
                                           "textAlign": "center",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#131416",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
                                         undefined,
                                       ]
                                     }
@@ -3254,41 +3184,17 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                     New quotes in
                                      
                                     <Text
+                                      accessibilityRole="text"
                                       style={
                                         [
                                           {
                                             "color": "#131416",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 30,
-                                            "marginVertical": 2,
-                                          },
-                                          undefined,
-                                          undefined,
-                                          {
                                             "fontFamily": "Geist-Bold",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
                                           },
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          {
-                                            "color": "#131416",
-                                          },
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          undefined,
                                           [
                                             {
                                               "fontVariant": [
@@ -3319,41 +3225,18 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                   }
                                 >
                                   <Text
+                                    accessibilityRole="text"
                                     style={
                                       [
                                         {
-                                          "color": "#131416",
+                                          "color": "#66676a",
                                           "fontFamily": "Geist-Regular",
-                                          "fontSize": 30,
-                                          "marginVertical": 2,
-                                        },
-                                        {
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
                                           "textAlign": "center",
                                         },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        {
-                                          "color": "#66676a",
-                                        },
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        undefined,
                                         undefined,
                                       ]
                                     }
@@ -4952,41 +4835,18 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                             }
                           >
                             <Text
+                              accessibilityRole="text"
                               style={
                                 [
                                   {
                                     "color": "#131416",
                                     "fontFamily": "Geist-Regular",
-                                    "fontSize": 30,
-                                    "marginVertical": 2,
-                                  },
-                                  {
+                                    "fontSize": 16,
+                                    "fontWeight": 400,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
                                     "textAlign": "center",
                                   },
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  {
-                                    "color": "#131416",
-                                  },
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
-                                  undefined,
                                   undefined,
                                 ]
                               }
@@ -4994,41 +4854,17 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                               New quotes in
                                
                               <Text
+                                accessibilityRole="text"
                                 style={
                                   [
                                     {
                                       "color": "#131416",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 30,
-                                      "marginVertical": 2,
-                                    },
-                                    undefined,
-                                    undefined,
-                                    {
                                       "fontFamily": "Geist-Bold",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
                                     },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    {
-                                      "color": "#131416",
-                                    },
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                    undefined,
                                     [
                                       {
                                         "fontVariant": [
@@ -6034,41 +5870,18 @@ exports[`Quotes renders correctly after animation without quotes 1`] = `
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -6705,41 +6518,18 @@ exports[`Quotes renders correctly when fetching quotes errors 1`] = `
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -7376,41 +7166,18 @@ exports[`Quotes renders correctly with sdkError 1`] = `
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -8047,41 +7814,18 @@ exports[`Quotes renders quotes expired screen 1`] = `
                                 }
                               >
                                 <Text
+                                  accessibilityRole="text"
                                   style={
                                     [
                                       {
-                                        "color": "#131416",
+                                        "color": "#66676a",
                                         "fontFamily": "Geist-Regular",
-                                        "fontSize": 30,
-                                        "marginVertical": 2,
-                                      },
-                                      {
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
                                         "textAlign": "center",
                                       },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      {
-                                        "color": "#66676a",
-                                      },
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      undefined,
                                       undefined,
                                     ]
                                   }
@@ -8166,41 +7910,18 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
   }
 >
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
-        },
-        {
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
           "textAlign": "center",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          "color": "#131416",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8208,41 +7929,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     Quotes expire in
      
     <Text
+      accessibilityRole="text"
       style={
         [
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 30,
-            "marginVertical": 2,
-          },
-          undefined,
-          undefined,
-          {
             "fontFamily": "Geist-Bold",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          {
-            "color": "#131416",
-          },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           [
             {
               "fontVariant": [
@@ -8276,41 +7973,18 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
   }
 >
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
-        },
-        {
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
           "textAlign": "center",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          "color": "#131416",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8318,41 +7992,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     Quotes expire in
      
     <Text
+      accessibilityRole="text"
       style={
         [
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 30,
-            "marginVertical": 2,
-          },
-          undefined,
-          undefined,
-          {
             "fontFamily": "Geist-Bold",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          {
-            "color": "#131416",
-          },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           [
             {
               "fontVariant": [
@@ -8386,41 +8036,18 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
   }
 >
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
-        },
-        {
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
           "textAlign": "center",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          "color": "#131416",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8428,41 +8055,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     Quotes expire in
      
     <Text
+      accessibilityRole="text"
       style={
         [
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 30,
-            "marginVertical": 2,
-          },
-          undefined,
-          undefined,
-          {
             "fontFamily": "Geist-Bold",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          {
-            "color": "#131416",
-          },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           [
             {
               "fontVariant": [
@@ -8496,41 +8099,18 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
   }
 >
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
-        },
-        {
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
           "textAlign": "center",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          "color": "#131416",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8538,41 +8118,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     New quotes in
      
     <Text
+      accessibilityRole="text"
       style={
         [
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 30,
-            "marginVertical": 2,
-          },
-          undefined,
-          undefined,
-          {
             "fontFamily": "Geist-Bold",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          {
-            "color": "#131416",
-          },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           [
             {
               "fontVariant": [
@@ -8606,41 +8162,18 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
   }
 >
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
-        },
-        {
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
           "textAlign": "center",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          "color": "#131416",
-        },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8648,41 +8181,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=false, pollingC
     New quotes in
      
     <Text
+      accessibilityRole="text"
       style={
         [
           {
             "color": "#131416",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 30,
-            "marginVertical": 2,
-          },
-          undefined,
-          undefined,
-          {
             "fontFamily": "Geist-Bold",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 24,
           },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          {
-            "color": "#131416",
-          },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           [
             {
               "fontVariant": [
@@ -8719,37 +8228,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     size="small"
   />
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8779,37 +8268,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     size="small"
   />
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8839,37 +8308,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     size="small"
   />
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }
@@ -8899,37 +8348,17 @@ exports[`Timer component renders correctly with isFetchingQuotes=true, pollingCy
     size="small"
   />
   <Text
+    accessibilityRole="text"
     style={
       [
         {
           "color": "#131416",
           "fontFamily": "Geist-Regular",
-          "fontSize": 30,
-          "marginVertical": 2,
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
         undefined,
       ]
     }

--- a/app/components/UI/Ramp/Aggregator/components/Account.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Account.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import EthereumAddress from '../../../EthereumAddress';
 import JSIdenticon from '../../../Identicon';
-import Text from '../../../../Base/Text';
+import { Text } from '@metamask/design-system-react-native';
 import { View, StyleSheet } from 'react-native';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
@@ -73,7 +73,11 @@ const Account = ({
       style={[styles.container, transparent && styles.transparentContainer]}
     >
       <Identicon diameter={15} address={address || selectedAddress} />
-      <Text style={styles.accountText} primary centered numberOfLines={1}>
+      <Text
+        style={styles.accountText}
+        twClassName="text-center"
+        numberOfLines={1}
+      >
         {accountName} (
         <EthereumAddress address={address || selectedAddress} type={'short'} />)
       </Text>

--- a/app/components/UI/Ramp/Aggregator/components/ApplePayButton.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ApplePayButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Image, StyleSheet } from 'react-native';
 import { colors as importedColors } from '../../../../../styles/common';
 import { useAssetFromTheme } from '../../../../../util/theme';
-import Text from '../../../../Base/Text';
+import { Text, FontWeight } from '@metamask/design-system-react-native';
 import StyledButton from '../../../StyledButton';
 
 /* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
@@ -66,7 +66,11 @@ const ApplePayButton = ({
       onPress={onPress}
       containerStyle={[styles.applePayButton, appleButtonColors.applePayButton]}
     >
-      <Text centered bold style={[appleButtonColors.applePayButtonText]}>
+      <Text
+        fontWeight={FontWeight.Bold}
+        style={appleButtonColors.applePayButtonText}
+        twClassName="text-center"
+      >
         {label}
       </Text>{' '}
       <ApplePay />

--- a/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useTheme } from '../../../../../util/theme';
 import Title from '../../../../Base/Title';
-import Text from '../../../../Base/Text';
+import { Text, TextColor } from '@metamask/design-system-react-native';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -155,7 +155,7 @@ function ErrorView({
         </View>
 
         <View style={styles.row}>
-          <Text centered grey>
+          <Text color={TextColor.TextAlternative} twClassName="text-center">
             {description}
           </Text>
         </View>

--- a/app/components/UI/Ramp/Aggregator/components/InfoAlert.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/InfoAlert.tsx
@@ -5,7 +5,13 @@ import { QuoteResponse } from '@consensys/on-ramp-sdk';
 import IonicIcon from 'react-native-vector-icons/Ionicons';
 
 import Box from './Box';
-import Text from '../../../../Base/Text';
+import {
+  Text,
+  TextButton,
+  TextButtonSize,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import Title from '../../../../Base/Title';
 import RemoteImage from '../../../../Base/RemoteImage';
 import { useTheme } from '../../../../../util/theme';
@@ -155,59 +161,61 @@ const InfoAlert: React.FC<Props> = ({
           )}
           {Boolean(subtitle) && (
             <View style={styles.row}>
-              <Text small grey centered>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+                twClassName="text-center"
+              >
                 {subtitle}
               </Text>
             </View>
           )}
           <View style={styles.row}>{Boolean(body) && <Text>{body}</Text>}</View>
           {Boolean(providerWebsite) && (
-            <TouchableOpacity
+            <TextButton
+              size={TextButtonSize.BodySm}
               onPress={() =>
                 handleProviderHomepageLinkPress(providerWebsite as string)
               }
+              twClassName="text-center"
             >
-              <Text small link underline centered>
-                {providerWebsite}
-              </Text>
-            </TouchableOpacity>
+              {providerWebsite as string}
+            </TextButton>
           )}
           {Boolean(providerPrivacyPolicy) && (
-            <TouchableOpacity
+            <TextButton
+              size={TextButtonSize.BodySm}
               onPress={() =>
                 handleProviderPrivacyPolicyLinkPress(
                   providerPrivacyPolicy as string,
                 )
               }
+              twClassName="text-center"
             >
-              <Text small link underline centered>
-                {strings('app_information.privacy_policy')}
-              </Text>
-            </TouchableOpacity>
+              {strings('app_information.privacy_policy')}
+            </TextButton>
           )}
           {Boolean(providerTermsOfService) && (
-            <TouchableOpacity
+            <TextButton
+              size={TextButtonSize.BodySm}
               onPress={() =>
                 handleTermsOfServiceLinkPress(providerTermsOfService as string)
               }
+              twClassName="text-center"
             >
-              <Text small link underline centered>
-                {strings('fiat_on_ramp_aggregator.terms_of_service')}
-              </Text>
-            </TouchableOpacity>
+              {strings('fiat_on_ramp_aggregator.terms_of_service')}
+            </TextButton>
           )}
           {Boolean(providerSupport) && (
-            <TouchableOpacity
+            <TextButton
+              size={TextButtonSize.BodySm}
               onPress={() =>
                 handleProviderSupportLinkPress(providerSupport as string)
               }
+              twClassName="text-center"
             >
-              <Text small link underline centered>
-                {providerName +
-                  ' ' +
-                  strings('fiat_on_ramp_aggregator.order_details.support')}
-              </Text>
-            </TouchableOpacity>
+              {`${providerName} ${strings('fiat_on_ramp_aggregator.order_details.support')}`}
+            </TextButton>
           )}
         </View>
       </Box>

--- a/app/components/UI/Ramp/Aggregator/components/RegionAlert.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/RegionAlert.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback } from 'react';
 import { Linking, StyleSheet, TouchableOpacity, View } from 'react-native';
 import Modal from 'react-native-modal';
-import Text from '../../../../Base/Text';
+import {
+  Text,
+  TextButton,
+  TextButtonSize,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import EvilIcons from 'react-native-vector-icons/EvilIcons';
 import Box from './Box';
 import { useTheme } from '../../../../../util/theme';
@@ -77,18 +83,20 @@ const RegionAlert: React.FC<Props> = ({
           <EvilIcons name="close" size={17} color={colors.icon.default} />
         </TouchableOpacity>
         <View style={styles.row}>
-          <Text bold primary bigger>
+          <Text fontWeight={FontWeight.Bold} variant={TextVariant.BodyLg}>
             {title}
           </Text>
-          <Text black>{subtitle}</Text>
+          <Text variant={TextVariant.BodyMd}>{subtitle}</Text>
           <View style={styles.row}>
-            <Text small>{body}</Text>
+            <Text variant={TextVariant.BodySm}>{body}</Text>
           </View>
-          <TouchableOpacity onPress={handleSupportLinkPress}>
-            <Text blue underline small style={styles.link}>
-              {link}
-            </Text>
-          </TouchableOpacity>
+          <TextButton
+            size={TextButtonSize.BodySm}
+            onPress={handleSupportLinkPress}
+            style={styles.link}
+          >
+            {link as string}
+          </TextButton>
         </View>
       </Box>
     </Modal>

--- a/app/components/UI/Ramp/Aggregator/components/ScreenLayout.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ScreenLayout.tsx
@@ -10,7 +10,12 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
-import Text from '../../../../Base/Text';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react-native';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -94,12 +99,24 @@ const Header = ({
   return (
     <View style={[styles.header, style]} {...props}>
       {title && (
-        <Text style={titleStyle} big black centered bold={bold}>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextDefault}
+          fontWeight={bold ? FontWeight.Bold : undefined}
+          twClassName="text-center"
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          style={titleStyle as any}
+        >
           {typeof title === 'function' ? title() : title}
         </Text>
       )}
       {description && (
-        <Text style={[styles.description, descriptionStyle]} centered grey>
+        <Text
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          style={[styles.description, descriptionStyle as any]}
+        >
           {description}
         </Text>
       )}

--- a/app/components/UI/Ramp/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Checkout/__snapshots__/Checkout.test.tsx.snap
@@ -632,41 +632,18 @@ exports[`Checkout renders error view when no URL is provided 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }
@@ -1326,41 +1303,18 @@ exports[`Checkout sets and displays error on http error for callback URL 1`] = `
                                       }
                                     >
                                       <Text
+                                        accessibilityRole="text"
                                         style={
                                           [
                                             {
-                                              "color": "#131416",
+                                              "color": "#66676a",
                                               "fontFamily": "Geist-Regular",
-                                              "fontSize": 30,
-                                              "marginVertical": 2,
-                                            },
-                                            {
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
                                               "textAlign": "center",
                                             },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            {
-                                              "color": "#66676a",
-                                            },
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            undefined,
                                             undefined,
                                           ]
                                         }


### PR DESCRIPTION
## **Description**

Migrates 8 files in the Ramp Aggregator from the deprecated `app/components/Base/Text` (boolean-prop API) to `Text` from `@metamask/design-system-react-native`.

Part of the broader MMDS Text migration tracked in #6887. This is **PR 1 of 4** for the Ramps team, covering the oldest legacy component (boolean props).

**Files migrated:**
- `app/components/UI/Ramp/Aggregator/components/Account.tsx`
- `app/components/UI/Ramp/Aggregator/components/ApplePayButton.tsx`
- `app/components/UI/Ramp/Aggregator/components/ErrorView.tsx`
- `app/components/UI/Ramp/Aggregator/components/InfoAlert.tsx`
- `app/components/UI/Ramp/Aggregator/components/RegionAlert.tsx`
- `app/components/UI/Ramp/Aggregator/components/ScreenLayout.tsx`
- `app/components/UI/Ramp/Aggregator/Views/Quotes/Timer.tsx`
- `app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx`

**Migration approach:**
- Boolean props (`bold`, `small`, `big`, `bigger`, `grey`, `primary`, `black`, `blue`, `link`, `underline`) → MMDS `variant` / `color` / `fontWeight` props
- Text alignment and decoration (`centered`, `underline`) → `twClassName="text-center"` / `twClassName="underline"` per design system guidelines
- `ScreenLayout.Header` exposes `bold?: boolean` in its public interface — this is preserved as-is; the migration translates it internally to `fontWeight={bold ? FontWeight.Bold : undefined}`

**Known TypeScript note:**
`ScreenLayout.Header` accepts `titleStyle?` and `descriptionStyle?` props typed as `TextStyle` from `@types/react-native`. MMDS Text's `style` prop uses `RNTextProps` from `react-native/index.js`, which has a structurally incompatible `fontWeight` type (numeric vs string-only). These props have no callers in the codebase, so the `as any` casts added are inert at runtime. This is a project-level dual type-definition issue, not a bug.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of: https://github.com/MetaMask/metamask-mobile/issues/6887

## **Manual testing steps**

```gherkin
Feature: Ramp Aggregator text rendering

  Scenario: user views the quotes screen
    Given the app is open and the user has navigated to the Ramp buy flow
    When user reaches the Quotes screen
    Then all text renders at the correct size, weight, color, and alignment

  Scenario: user views the error state
    Given the Ramp SDK returns an error
    When the ErrorView is displayed
    Then the error description text is muted/grey and centered

  Scenario: user views provider info alert
    Given the user taps the info icon on a quote
    When the InfoAlert modal appears
    Then provider links render as small primary-colored underlined text

  Scenario: user views the region unsupported alert
    Given the user's region is not supported
    When the RegionAlert modal appears
    Then the title renders bold/large, body renders default, and the support link renders small/blue/underlined
```

## **Screenshots/Recordings**

N/A — styling parity, no visual change intended. This migration preserves all existing text appearance by mapping each boolean prop to the equivalent MMDS `variant`/`color`/`fontWeight`/`twClassName`.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to UI text components and styling/props; main risk is small visual/regression differences in text weight/color/alignment and updated snapshots masking unintended UI changes.
> 
> **Overview**
> Migrates Ramp Aggregator UI from deprecated `Base/Text` boolean-prop usage to `@metamask/design-system-react-native` `Text` (and `TextButton` for links), mapping legacy props to MMDS `variant`/`color`/`fontWeight` and `twClassName` alignment.
> 
> Updates `ScreenLayout.Header`, `Timer`, `Quotes`, and several Aggregator components (`Account`, `ApplePayButton`, `ErrorView`, `InfoAlert`, `RegionAlert`) accordingly, and refreshes related snapshots (including new `accessibilityRole`/style output) to match the new render tree.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e88289ffef67032429484ada5439e39e2a53d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->