### PR TITLE
fix: scanning verbiage only shows when actually scanning

### DIFF
--- a/app/components/UI/QRHardware/AnimatedQRScanner.tsx
+++ b/app/components/UI/QRHardware/AnimatedQRScanner.tsx
@@ -371,9 +371,11 @@ const AnimatedQRScannerModal = (props: AnimatedQRScannerProps) => {
               </View>
 
               <View style={styles.overlay}>
-                <Text style={styles.scanningText}>{`${strings(
-                  'qr_scanner.scanning',
-                )} ${progress ? `${progress.toString()}%` : ''}`}</Text>
+                {progress > 0 && (
+                  <Text style={styles.scanningText}>{`${strings(
+                    'qr_scanner.scanning',
+                  )} ${progress ? `${progress.toString()}%` : ''}`}</Text>
+                )}
               </View>
             </View>
             {/* Close button */}


### PR DESCRIPTION
## **Description**

Scanning verbiage only shows when actually scanning in hardware QR scanning flow

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-431

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

| Scanning | Not Scanning |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/f235d414-2c81-4ee3-b794-911eed18e97d) | ![after](https://github.com/user-attachments/assets/f0fa8f39-18e0-4457-9f1d-94758d379236) |

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only conditional rendering change; no changes to scanning/decoding logic or data handling.
> 
> **Overview**
> Updates `AnimatedQRScanner.tsx` so the "Scanning" progress text is **conditionally rendered only when `progress > 0`**, preventing the label from appearing when the scanner is idle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2241229dd8413d2a4d4437a6a7888e1b29a544f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->