### PR TITLE
fix: block explorer url was using global chain id and not tx chain id

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -30,9 +30,7 @@ import { withNavigation } from '@react-navigation/compat';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import decodeTransaction from '../../TransactionElement/utils';
 import {
-  selectChainId,
   selectNetworkConfigurations,
-  selectProviderConfig,
   selectTickerByChainId,
 } from '../../../../selectors/networkController';
 import {
@@ -129,10 +127,6 @@ class TransactionDetails extends PureComponent {
     */
     navigation: PropTypes.object,
     /**
-     * Chain ID string
-     */
-    chainId: PropTypes.string,
-    /**
      * Object corresponding to a transaction, containing transaction object, networkId and transaction hash string
      */
     transactionObject: PropTypes.object,
@@ -181,12 +175,11 @@ class TransactionDetails extends PureComponent {
 
   /**
    * Returns the appropriate block explorer URL for a given chain
-   * @param {string} chainId - The chain ID to get the block explorer for
    * @param {string} txChainId - The transaction chain ID
    * @param {Object} networkConfigurations - The network configurations object
    * @returns {string} The block explorer URL
    */
-  getBlockExplorerForChain = (chainId, txChainId, networkConfigurations) => {
+  getBlockExplorerForChain = (txChainId, networkConfigurations) => {
     // First check for network configuration block explorer
     let blockExplorer =
       networkConfigurations?.[txChainId]?.blockExplorerUrls[
@@ -215,8 +208,8 @@ class TransactionDetails extends PureComponent {
     }
 
     // Check for non-EVM chain block explorer
-    if (isNonEvmChainId(chainId)) {
-      blockExplorer = findBlockExplorerForNonEvmChainId(chainId);
+    if (isNonEvmChainId(txChainId)) {
+      blockExplorer = findBlockExplorerForNonEvmChainId(txChainId);
     }
 
     return blockExplorer;
@@ -282,12 +275,10 @@ class TransactionDetails extends PureComponent {
   componentDidMount = () => {
     const {
       transactionObject: { chainId: txChainId },
-      chainId,
       networkConfigurations,
     } = this.props;
 
     const blockExplorer = this.getBlockExplorerForChain(
-      chainId,
       txChainId,
       networkConfigurations,
     );
@@ -545,8 +536,6 @@ class TransactionDetails extends PureComponent {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  chainId: selectChainId(state),
-  providerConfig: selectProviderConfig(state),
   networkConfigurations: selectNetworkConfigurations(state),
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
   transactions: selectTransactions(state),

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -128,7 +128,6 @@ const renderComponent = ({
               ...(hash ? { hash } : {}),
             }}
             navigation={navigationMock}
-            chainId={networkId}
           />
         )}
       </Stack.Screen>


### PR DESCRIPTION
## **Description**

When viewing EVM transactions from the "Popular networks" activity feed while a non-EVM network was active, the "View on [Explorer]" link incorrectly resolved to the non-EVM block explorer (e.g. Mempool) instead of the correct EVM explorer (e.g. Etherscan). Switching to an EVM network and back would fix it temporarily.

The root cause was that `getBlockExplorerForChain` used `chainId` (the currently active network from Redux) rather than `txChainId` (the transaction's own chain) for the non-EVM block explorer check. The fix uses `txChainId` consistently throughout the function, and removes the now unused `chainId` prop and its associated Redux selector subscriptions.

## **Changelog**

CHANGELOG entry: Fixed a bug where switching to a non-EVM network caused EVM transaction details to display the wrong block explorer link

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-550
https://github.com/MetaMask/metamask-mobile/issues/27253

## **Manual testing steps**

```gherkin
Feature: Block explorer link in transaction details

  Scenario: user views EVM transaction while on a non-EVM network
    Given the user has a non-EVM network active (e.g. Bitcoin)
    And the activity feed is filtered by "Popular networks"

    When user taps a confirmed EVM transaction (e.g. Ethereum, Arbitrum)
    Then the correct EVM block explorer link appears (e.g. "View on Etherscan")
    And tapping it opens the correct transaction URL

  Scenario: user views a non-EVM transaction
    Given the user has transactions on a non-EVM network
    When user taps a confirmed transaction
    Then the correct non-EVM block explorer link appears (e.g. "View on Mempool")
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/2a823c20-9663-4e7b-8e17-bd223ec7f8e6

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI bug fix that only changes how the block explorer URL is selected for the transaction details link, plus a small test update to match the new props.
> 
> **Overview**
> Fixes the **"View on [Explorer]"** link in `TransactionDetails` to consistently derive the block explorer from the transaction’s `txChainId`, preventing EVM transactions from incorrectly using a non‑EVM explorer when the active network is non‑EVM.
> 
> Removes the now-unused `chainId`/`providerConfig` Redux props and updates the unit test to stop passing `chainId` explicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd46296bd689cca1d4fe1d96cf49b9f579f798b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->