### PR TITLE
fix: allow SRP button text to wrap on OnboardingSheet

### DIFF
--- a/app/components/Views/Onboarding/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Onboarding/__snapshots__/index.test.tsx.snap
@@ -132,13 +132,16 @@ exports[`Onboarding applies compact gap and medium button size on medium device 
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 40,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 40,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -155,7 +158,7 @@ exports[`Onboarding applies compact gap and medium button size on medium device 
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -219,13 +222,16 @@ exports[`Onboarding applies compact gap and medium button size on medium device 
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 40,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 40,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -246,7 +252,7 @@ exports[`Onboarding applies compact gap and medium button size on medium device 
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -453,13 +459,16 @@ exports[`Onboarding applies iPhoneX notification padding when on iPhoneX 1`] = `
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -476,7 +485,7 @@ exports[`Onboarding applies iPhoneX notification padding when on iPhoneX 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -540,13 +549,16 @@ exports[`Onboarding applies iPhoneX notification padding when on iPhoneX 1`] = `
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -567,7 +579,7 @@ exports[`Onboarding applies iPhoneX notification padding when on iPhoneX 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -1041,13 +1053,16 @@ exports[`Onboarding applies standard gap and large button size on non-medium dev
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -1064,7 +1079,7 @@ exports[`Onboarding applies standard gap and large button size on non-medium dev
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -1128,13 +1143,16 @@ exports[`Onboarding applies standard gap and large button size on non-medium dev
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -1155,7 +1173,7 @@ exports[`Onboarding applies standard gap and large button size on non-medium dev
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -1362,13 +1380,16 @@ exports[`Onboarding applies standard notification padding when not on iPhoneX 1`
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -1385,7 +1406,7 @@ exports[`Onboarding applies standard notification padding when not on iPhoneX 1`
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -1449,13 +1470,16 @@ exports[`Onboarding applies standard notification padding when not on iPhoneX 1`
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -1476,7 +1500,7 @@ exports[`Onboarding applies standard notification padding when not on iPhoneX 1`
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -1950,13 +1974,16 @@ exports[`Onboarding renders correctly 1`] = `
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -1973,7 +2000,7 @@ exports[`Onboarding renders correctly 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -2037,13 +2064,16 @@ exports[`Onboarding renders correctly 1`] = `
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -2064,7 +2094,7 @@ exports[`Onboarding renders correctly 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -2271,13 +2301,16 @@ exports[`Onboarding renders correctly with android 1`] = `
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 40,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 40,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -2294,7 +2327,7 @@ exports[`Onboarding renders correctly with android 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -2358,13 +2391,16 @@ exports[`Onboarding renders correctly with android 1`] = `
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 40,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 40,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -2385,7 +2421,7 @@ exports[`Onboarding renders correctly with android 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -2592,13 +2628,16 @@ exports[`Onboarding renders correctly with large device and iphoneX 1`] = `
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -2615,7 +2654,7 @@ exports[`Onboarding renders correctly with large device and iphoneX 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -2679,13 +2718,16 @@ exports[`Onboarding renders correctly with large device and iphoneX 1`] = `
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 48,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 48,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -2706,7 +2748,7 @@ exports[`Onboarding renders correctly with large device and iphoneX 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -2913,13 +2955,16 @@ exports[`Onboarding renders correctly with medium device and android 1`] = `
                     "borderRadius": 12,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 40,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 40,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -2936,7 +2981,7 @@ exports[`Onboarding renders correctly with medium device and android 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {
@@ -3000,13 +3045,16 @@ exports[`Onboarding renders correctly with medium device and android 1`] = `
                     "borderWidth": 1,
                     "columnGap": 8,
                     "flexDirection": "row",
-                    "height": 40,
+                    "height": "auto",
                     "justifyContent": "center",
+                    "minHeight": 40,
                     "minWidth": 80,
                     "opacity": 1,
                     "overflow": "hidden",
+                    "paddingBottom": 12,
                     "paddingLeft": 16,
                     "paddingRight": 16,
+                    "paddingTop": 12,
                     "width": "100%",
                   },
                   {
@@ -3027,7 +3075,7 @@ exports[`Onboarding renders correctly with medium device and android 1`] = `
               <Text
                 accessibilityRole="text"
                 ellipsizeMode="clip"
-                numberOfLines={1}
+                numberOfLines={0}
                 style={
                   [
                     {

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -821,6 +821,8 @@ const Onboarding = () => {
             testID={OnboardingSelectorIDs.NEW_WALLET_BUTTON}
             isFullWidth
             size={Device.isMediumDevice() ? ButtonSize.Md : ButtonSize.Lg}
+            twClassName={`min-h-${Device.isMediumDevice() ? '10' : '12'} h-auto py-3`}
+            textProps={{ numberOfLines: 0 }}
           >
             {strings('onboarding.start_exploring_now')}
           </Button>
@@ -831,6 +833,8 @@ const Onboarding = () => {
             testID={OnboardingSelectorIDs.EXISTING_WALLET_BUTTON}
             isFullWidth
             size={Device.isMediumDevice() ? ButtonSize.Md : ButtonSize.Lg}
+            twClassName={`min-h-${Device.isMediumDevice() ? '10' : '12'} h-auto py-3`}
+            textProps={{ numberOfLines: 0 }}
             style={tw.style({
               backgroundColor: importedColors.applePayBlack,
               borderColor: 'transparent',

--- a/app/components/Views/OnboardingSheet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/OnboardingSheet/__snapshots__/index.test.tsx.snap
@@ -481,13 +481,16 @@ exports[`OnboardingSheet Snapshots renders correctly with createWallet=false (im
                   "borderWidth": 1,
                   "columnGap": 8,
                   "flexDirection": "row",
-                  "height": 48,
+                  "height": "auto",
                   "justifyContent": "center",
+                  "minHeight": 48,
                   "minWidth": 80,
                   "opacity": 1,
                   "overflow": "hidden",
+                  "paddingBottom": 12,
                   "paddingLeft": 16,
                   "paddingRight": 16,
+                  "paddingTop": 12,
                   "width": "100%",
                 },
                 {
@@ -504,7 +507,7 @@ exports[`OnboardingSheet Snapshots renders correctly with createWallet=false (im
             <Text
               accessibilityRole="text"
               ellipsizeMode="clip"
-              numberOfLines={1}
+              numberOfLines={0}
               style={
                 [
                   {
@@ -1091,13 +1094,16 @@ exports[`OnboardingSheet Snapshots renders correctly with createWallet=true (cre
                   "borderWidth": 1,
                   "columnGap": 8,
                   "flexDirection": "row",
-                  "height": 48,
+                  "height": "auto",
                   "justifyContent": "center",
+                  "minHeight": 48,
                   "minWidth": 80,
                   "opacity": 1,
                   "overflow": "hidden",
+                  "paddingBottom": 12,
                   "paddingLeft": 16,
                   "paddingRight": 16,
+                  "paddingTop": 12,
                   "width": "100%",
                 },
                 {
@@ -1114,7 +1120,7 @@ exports[`OnboardingSheet Snapshots renders correctly with createWallet=true (cre
             <Text
               accessibilityRole="text"
               ellipsizeMode="clip"
-              numberOfLines={1}
+              numberOfLines={0}
               style={
                 [
                   {

--- a/app/components/Views/OnboardingSheet/index.tsx
+++ b/app/components/Views/OnboardingSheet/index.tsx
@@ -198,6 +198,8 @@ const OnboardingSheet = (props: OnboardingSheetProps) => {
             testID={OnboardingSheetSelectorIDs.IMPORT_SEED_BUTTON}
             isFullWidth
             size={ButtonSize.Lg}
+            twClassName="min-h-12 h-auto py-3"
+            textProps={{ numberOfLines: 0 }}
           >
             {createWallet
               ? strings('onboarding.continue_with_srp')


### PR DESCRIPTION
## **Description**

Users who set their system font size to maximum scale experience button text clipping on the Onboarding and OnboardingSheet screens. The design system `ButtonPrimary` and `ButtonSecondary` both hardcode `numberOfLines: 1` with `ellipsizeMode: 'clip'`, and `ButtonBase` uses a fixed height (`h-12` for Lg, `h-10` for Md). This means longer strings like "Import using Secret Recovery Phrase" and "I have an existing wallet" get cut off instead of wrapping.

This fix overrides the button containers to use `min-h h-auto py-3` and sets `numberOfLines: 0` so buttons expand to fit their content at any font scale.

> **Depends on** #26673 being merged first — this branch is based on `refactor/onboarding-tailwind-migration-part1`.

### Screens fixed

| Screen | Buttons |
|--------|---------|
| `Onboarding/index.tsx` | "Create a new wallet", "I have an existing wallet" |
| `OnboardingSheet/index.tsx` | "Import using Secret Recovery Phrase" / "Continue with Secret Recovery Phrase" |

### Root cause

Two constraints in `@metamask/design-system-react-native`:
1. `ButtonPrimary` and `ButtonSecondary` both pass `numberOfLines: 1, ellipsizeMode: 'clip'` to `ButtonBase` text props
2. `ButtonBase` applies a fixed height class (`h-12` for Lg, `h-10` for Md) via `TWCLASSMAP_BUTTONBASE_SIZE_DIMENSION`

Both are overridable from the consumer side via `textProps` and `twClassName`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Depends on: #26673

## **Manual testing steps**

```gherkin
Feature: Onboarding button text wrapping at max font scale

  Scenario: user views onboarding with system font set to maximum
    Given app is freshly installed
    And user's system font size is set to largest/maximum

    When user reaches the onboarding screen
    Then "Create a new wallet" and "I have an existing wallet" buttons display full text without clipping

  Scenario: user views onboarding sheet with large font
    Given user taps "Create a new wallet" or "I already have a wallet"

    When the onboarding sheet appears
    Then the "Import using Secret Recovery Phrase" button text wraps to multiple lines instead of being clipped
```

## **Screenshots/Recordings**

### **Before**

Button text is clipped to one line on devices with max font scale:

<img width="300" height="1280" alt="Screenshot_1773224200" src="https://github.com/user-attachments/assets/855a3bad-c6b7-4f1a-8341-3f513ad0ebde" />

<img width="300" alt="Screenshot_1773222833" src="https://github.com/user-attachments/assets/2dccc4cd-5a4f-4ed9-bf8b-1246b2f17136" />

### **After**

Buttons expand to fit the full text:

<img width="300" height="1280" alt="Screenshot_1773224472" src="https://github.com/user-attachments/assets/41930a9c-bfca-4b7c-a10c-bd32cc388a1c" />

<img width="300" alt="Screenshot_1773222827" src="https://github.com/user-attachments/assets/6dc37a93-4fbc-4797-ad9f-809537465e82" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.