### PR TITLE
ci: add automatic feature flag registry check for PRs

### DIFF
--- a/.github/scripts/check-feature-flag-registry.test.ts
+++ b/.github/scripts/check-feature-flag-registry.test.ts
@@ -1,0 +1,173 @@
+jest.mock('./known-feature-flag-constants', () => ({
+  buildKnownFlagConstants: () => ({
+    'FeatureFlagNames.MyFlag': 'myResolvedFlag',
+    MY_CONSTANT: 'myConstantFlag',
+  }),
+  resolveConstantFromSourceFile: jest.fn(() => undefined),
+}));
+
+jest.mock('@actions/github', () => ({
+  context: { payload: {}, repo: { owner: 'test', repo: 'test' } },
+  getOctokit: jest.fn(),
+}));
+
+import {
+  parseDiff,
+  extractFlagReferences,
+  extractMultiLineDestructuring,
+  extractDestructuredIdentifiers,
+} from './check-feature-flag-registry';
+
+describe('extractDestructuredIdentifiers', () => {
+  it.each([
+    ['simple identifiers', 'flagA, flagB', ['flagA', 'flagB']],
+    ['renaming (before colon)', 'flagA: renamed', ['flagA']],
+    ['rest elements skipped', 'flagA, ...rest', ['flagA']],
+    ['empty parts skipped', 'flagA, , flagB', ['flagA', 'flagB']],
+    ['whitespace handled', '  flagA ,  flagB  ', ['flagA', 'flagB']],
+  ])('extracts %s', (_label, input, expected) => {
+    expect(extractDestructuredIdentifiers(input as string)).toEqual(expected);
+  });
+});
+
+describe('parseDiff', () => {
+  it('parses added lines grouped into contiguous chunks', () => {
+    const diff = [
+      'diff --git a/app/test.ts b/app/test.ts',
+      '--- a/app/test.ts', '+++ b/app/test.ts',
+      '@@ -1,3 +1,4 @@',
+      ' const a = 1;', '+const b = 2;', '+const c = 3;', ' const d = 4;',
+    ].join('\n');
+
+    const chunks = parseDiff(diff).added.get('app/test.ts');
+    expect(chunks).toHaveLength(1);
+    expect(chunks![0]).toEqual(['const b = 2;', 'const c = 3;']);
+  });
+
+  it('parses removed lines', () => {
+    const diff = ['--- a/app/test.ts', '+++ b/app/test.ts', '@@ -1,3 +1,2 @@', '-const old = true;', ' const keep = true;'].join('\n');
+    expect(parseDiff(diff).removed.get('app/test.ts')).toEqual(['const old = true;']);
+  });
+
+  it('splits non-contiguous added lines into separate chunks', () => {
+    const diff = ['--- a/app/test.ts', '+++ b/app/test.ts', '@@ -1,5 +1,7 @@', '+const first = 1;', ' const middle = 2;', '+const second = 3;'].join('\n');
+    const chunks = parseDiff(diff).added.get('app/test.ts');
+    expect(chunks).toHaveLength(2);
+    expect(chunks![0]).toEqual(['const first = 1;']);
+    expect(chunks![1]).toEqual(['const second = 3;']);
+  });
+
+  it('handles multiple files in one diff', () => {
+    const diff = ['--- a/app/a.ts', '+++ b/app/a.ts', '@@ -1 +1,2 @@', '+line in a', '--- a/app/b.ts', '+++ b/app/b.ts', '@@ -1 +1,2 @@', '+line in b'].join('\n');
+    const result = parseDiff(diff);
+    expect(result.added.get('app/a.ts')![0]).toEqual(['line in a']);
+    expect(result.added.get('app/b.ts')![0]).toEqual(['line in b']);
+  });
+
+  it('handles deleted files (+++ /dev/null)', () => {
+    const diff = ['--- a/app/old.ts', '+++ /dev/null', '@@ -1,2 +0,0 @@', '-const removed = true;'].join('\n');
+    expect(parseDiff(diff).removed.get('app/old.ts')).toEqual(['const removed = true;']);
+  });
+
+  it('returns empty maps for empty diff', () => {
+    const result = parseDiff('');
+    expect(result.added.size).toBe(0);
+    expect(result.removed.size).toBe(0);
+  });
+});
+
+describe('extractFlagReferences', () => {
+  const file = 'app/test.ts';
+  const ref = (flagName: string) => [{ flagName, filePath: file }];
+
+  describe('dot access patterns', () => {
+    it.each([
+      ['remoteFeatureFlags.myFlag', 'const v = remoteFeatureFlags.myFlag;'],
+      ['remoteFeatureFlags?.myFlag', 'const v = remoteFeatureFlags?.myFlag;'],
+      ['selectRemoteFeatureFlags(state).myFlag', 'const v = selectRemoteFeatureFlags(state).myFlag;'],
+      ['selectRemoteFeatureFlags(state)?.myFlag', 'const v = selectRemoteFeatureFlags(state)?.myFlag;'],
+    ])('detects %s', (_label, line) => {
+      expect(extractFlagReferences(line, file)).toEqual(ref('myFlag'));
+    });
+  });
+
+  describe('bracket access', () => {
+    it.each([
+      ['double quotes', 'remoteFeatureFlags["myBracketFlag"]', 'myBracketFlag'],
+      ['single quotes', "remoteFeatureFlags['myBracketFlag']", 'myBracketFlag'],
+      ['hyphenated name', 'remoteFeatureFlags["my-hyphenated-flag"]', 'my-hyphenated-flag'],
+    ])('detects string literal with %s', (_label, line, expected) => {
+      expect(extractFlagReferences(line, file)).toEqual(ref(expected));
+    });
+
+    it('resolves FeatureFlagNames.MyFlag constant', () => {
+      expect(extractFlagReferences('remoteFeatureFlags[FeatureFlagNames.MyFlag]', file)).toEqual(ref('myResolvedFlag'));
+    });
+
+    it('resolves standalone MY_CONSTANT', () => {
+      expect(extractFlagReferences('remoteFeatureFlags[MY_CONSTANT]', file)).toEqual(ref('myConstantFlag'));
+    });
+  });
+
+  it('detects hasProperty(remoteFeatureFlags, "flagName")', () => {
+    expect(extractFlagReferences('hasProperty(remoteFeatureFlags, "propFlag")', file)).toEqual(ref('propFlag'));
+  });
+
+  describe('destructuring patterns', () => {
+    it('detects destructuring from selectRemoteFeatureFlags', () => {
+      const names = extractFlagReferences('const { flagA, flagB } = selectRemoteFeatureFlags(state);', file).map((r) => r.flagName);
+      expect(names).toContain('flagA');
+      expect(names).toContain('flagB');
+    });
+
+    it('detects destructuring with useSelector', () => {
+      expect(extractFlagReferences('const { flagC } = useSelector(selectRemoteFeatureFlags);', file)).toEqual(ref('flagC'));
+    });
+
+    it('skips destructuring when skipDestructuring is true', () => {
+      const names = extractFlagReferences('const { flagSkipped } = selectRemoteFeatureFlags(state);', file, true).map((r) => r.flagName);
+      expect(names).not.toContain('flagSkipped');
+    });
+  });
+
+  describe('ignores non-code references', () => {
+    it.each([
+      ['line comments', '// remoteFeatureFlags.myFlag'],
+      ['inline comments', 'const x = 1; // remoteFeatureFlags.myFlag'],
+      ['string literals', "const msg = 'remoteFeatureFlags.fakeFlag';"],
+    ])('ignores %s', (_label, line) => {
+      expect(extractFlagReferences(line, file)).toEqual([]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it.each([
+      ['no flag references', 'const x = 1 + 2;'],
+      ['empty line', ''],
+      ['non-flag name (constructor)', 'remoteFeatureFlags.constructor'],
+    ])('returns empty for %s', (_label, line) => {
+      expect(extractFlagReferences(line, file)).toEqual([]);
+    });
+  });
+});
+
+describe('extractMultiLineDestructuring', () => {
+  it('detects destructuring split across multiple lines', () => {
+    const chunk = ['const {', '  flagMulti,', '  flagMultiB,', '} = selectRemoteFeatureFlags(state);'];
+    const names = extractMultiLineDestructuring(chunk, 'app/test.ts').map((r) => r.flagName);
+    expect(names).toContain('flagMulti');
+    expect(names).toContain('flagMultiB');
+  });
+
+  it('returns empty when no destructuring is present', () => {
+    expect(extractMultiLineDestructuring(['const x = 1;', 'const y = 2;'], 'app/test.ts')).toEqual([]);
+  });
+
+  it('looks backward up to 10 lines for the opening brace', () => {
+    const chunk = ['const {', '  flagDeep1,', '  flagDeep2,', '  flagDeep3,', '  flagDeep4,',
+      '  flagDeep5,', '  flagDeep6,', '  flagDeep7,', '  flagDeep8,', '} = selectRemoteFeatureFlags(state);'];
+    const names = extractMultiLineDestructuring(chunk, 'app/test.ts').map((r) => r.flagName);
+    expect(names).toContain('flagDeep1');
+    expect(names).toContain('flagDeep8');
+  });
+});

--- a/.github/scripts/check-feature-flag-registry.test.ts
+++ b/.github/scripts/check-feature-flag-registry.test.ts
@@ -9,7 +9,7 @@ jest.mock('./known-feature-flag-constants', () => ({
 jest.mock('@actions/github', () => ({
   context: { payload: {}, repo: { owner: 'test', repo: 'test' } },
   getOctokit: jest.fn(),
-}));
+}), { virtual: true });
 
 import {
   parseDiff,

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -110,7 +110,9 @@ async function main(): Promise<void> {
           const endIdx = line.indexOf('*/');
           if (endIdx === -1) continue;
           inBlock = false;
-          allReferences.push(...extractFlagReferences(line.slice(endIdx + 2), filePath));
+          const afterBlock = line.slice(endIdx + 2);
+          allReferences.push(...extractFlagReferences(afterBlock, filePath));
+          if (opensBlockComment(afterBlock)) inBlock = true;
           continue;
         }
         allReferences.push(...extractFlagReferences(line, filePath));

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -52,7 +52,7 @@ const NON_FLAG_NAMES = new Set([
 
 const PR_COMMENT_MARKER = '<!-- check-feature-flag-registry -->';
 
-type FlagReference = { flagName: string; filePath: string };
+export type FlagReference = { flagName: string; filePath: string };
 
 function getRegisteredFlagNames(): string[] {
   const registryPath = path.resolve(REPO_ROOT, REGISTRY_FILE);
@@ -280,7 +280,7 @@ function findOrphanedFlags(flagNames: string[]): string[] {
   return orphaned.sort();
 }
 
-function parseDiff(diff: string): DiffResult {
+export function parseDiff(diff: string): DiffResult {
   const added = new Map<string, string[][]>();
   const removed = new Map<string, string[]>();
   let currentFile = '', pendingFile = '', lastWasAdded = false;
@@ -306,7 +306,7 @@ function parseDiff(diff: string): DiffResult {
   return { added, removed };
 }
 
-function extractFlagReferences(
+export function extractFlagReferences(
   line: string,
   filePath: string,
   skipDestructuring = false,
@@ -369,7 +369,7 @@ function extractFlagReferences(
   return refs;
 }
 
-function extractMultiLineDestructuring(chunk: string[], filePath: string): FlagReference[] {
+export function extractMultiLineDestructuring(chunk: string[], filePath: string): FlagReference[] {
   const refs: FlagReference[] = [];
   for (let i = 0; i < chunk.length; i++) {
     if (!chunk[i].includes('selectRemoteFeatureFlags')) continue;
@@ -393,7 +393,7 @@ function extractMultiLineDestructuring(chunk: string[], filePath: string): FlagR
   return refs;
 }
 
-function extractDestructuredIdentifiers(content: string): string[] {
+export function extractDestructuredIdentifiers(content: string): string[] {
   const ids: string[] = [];
   for (const part of content.split(/[,;]/)) {
     const t = part.trim();
@@ -641,7 +641,9 @@ async function findMarkerComment(
   return undefined;
 }
 
-main().catch((error) => {
-  console.error('Feature flag registry check failed:', error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Feature flag registry check failed:', error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -1,0 +1,616 @@
+// Feature Flag Registry Check — scans PR diffs for feature-flag references
+// and verifies they exist in the registry. Fails if unregistered flags found.
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { context, getOctokit } from '@actions/github';
+import { buildKnownFlagConstants, resolveConstantFromSourceFile } from './known-feature-flag-constants';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const REGISTRY_DIR = 'tests/feature-flags/';
+const REGISTRY_FILE = 'tests/feature-flags/feature-flag-registry.ts';
+const SCANNABLE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const SCAN_DIRECTORIES = ['app/', 'shared/', 'tests/'];
+const ARGS = '[^)]*(?:\\([^)]*\\)[^)]*)*';
+const QUOTE_FLAG = `(?:'(\\w+)'|"(\\w+)"|` + '`(\\w+)`' + `)`;
+
+const BRACKET_STRING_PATTERNS: RegExp[] = [
+  new RegExp(`remoteFeatureFlags(?:\\?\\.)?\\[\\s*${QUOTE_FLAG}\\s*\\]`, 'g'),
+  new RegExp(`selectRemoteFeatureFlags\\(${ARGS}\\)(?:\\?\\.)?\\[\\s*${QUOTE_FLAG}\\s*\\]`, 'g'),
+];
+
+const FLAG_ACCESS_PATTERNS: RegExp[] = [
+  /remoteFeatureFlags\??\.(\w+)/g,
+  new RegExp(`selectRemoteFeatureFlags\\(${ARGS}\\)\\??\\.(\\w+)`, 'g'),
+  /state\.engine\.backgroundState\.RemoteFeatureFlagController\.remoteFeatureFlags\??\.(\w+)/g,
+];
+
+const DESTRUCTURING_PATTERNS: RegExp[] = [
+  /\{\s*([^}]+)\}\s*(?::[^=]+)?\s*=\s*selectRemoteFeatureFlags/g,
+  /\{\s*([^}]+)\}\s*(?::[^=]+)?\s*=\s*useSelector\s*\(\s*selectRemoteFeatureFlags/g,
+  /useSelector\s*\(\s*selectRemoteFeatureFlags\s*\)\s*as\s*\{\s*([^}]+)\}/g,
+  /remoteFeatureFlags:\s*\{\s*([^}]+)\}/g,
+];
+
+const CONSTANT_BRACKET_PATTERNS: RegExp[] = [
+  /remoteFeatureFlags(?:\?\.)?\[([A-Za-z_]\w*(?:\.\w+)?)\]/g,
+  new RegExp(`selectRemoteFeatureFlags\\(${ARGS}\\)(?:\\?\\.)?\\[([A-Za-z_]\\w*(?:\\.\\w+)?)\\]`, 'g'),
+];
+
+const KNOWN_FLAG_CONSTANTS = buildKnownFlagConstants();
+
+const NON_FLAG_NAMES = new Set([
+  'constructor', 'prototype', 'hasOwnProperty', 'toString', 'valueOf', 'toJSON',
+  'keys', 'values', 'entries', 'length', 'name', 'type', 'status', 'default',
+  'then', 'catch', 'finally', 'map', 'filter', 'reduce', 'forEach', 'find',
+  'some', 'every', 'includes', 'undefined', 'bind', 'call', 'apply',
+  'localOverrides', 'remoteFeatureFlags', 'rawRemoteFeatureFlags',
+  'cacheTimestamp', 'thresholdCache',
+]);
+
+const PR_COMMENT_MARKER = '<!-- check-feature-flag-registry -->';
+
+type FlagReference = { flagName: string; filePath: string };
+
+function getRegisteredFlagNames(): string[] {
+  const registryPath = path.resolve(REPO_ROOT, REGISTRY_FILE);
+  const content = fs.readFileSync(registryPath, 'utf-8');
+  const names: string[] = [];
+  const nameRe = /name:\s*'([\w.-]+)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = nameRe.exec(content)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+async function main(): Promise<void> {
+  const baseBranch =
+    process.env.GITHUB_BASE_REF || process.argv[2] || 'main';
+
+  if (!/^[\w./-]+$/.test(baseBranch)) {
+    console.error(`Invalid base branch name: "${baseBranch}"`);
+    process.exit(1);
+  }
+
+  console.log(
+    `\nChecking feature flag references against registry (base: ${baseBranch})...\n`,
+  );
+
+  const registeredFlags = new Set(getRegisteredFlagNames());
+  console.log(`Registry contains ${registeredFlags.size} flags`);
+
+  const diff = getDiff(baseBranch);
+  if (!diff.trim()) {
+    console.log('No relevant diff found. Nothing to check.');
+    process.exit(0);
+  }
+
+  const { added: fileChanges, removed: fileRemovals } = parseDiff(diff);
+  const fileCount = [...fileChanges.values()].filter(
+    (c) => c.length > 0,
+  ).length;
+  console.log(`Found changes in ${fileCount} file(s)\n`);
+
+  logRegistryChanges(baseBranch);
+
+  // --- Collect flag references from added lines ---
+  const allReferences: FlagReference[] = [];
+
+  for (const [filePath, chunks] of fileChanges) {
+    if (!isScannableFile(filePath)) {
+      continue;
+    }
+    for (const chunk of chunks) {
+      for (const line of chunk) {
+        allReferences.push(...extractFlagReferences(line, filePath));
+      }
+      for (let i = 0; i < chunk.length - 1; i++) {
+        const j2 = `${stripInlineComments(chunk[i]).trimEnd()}${stripInlineComments(chunk[i + 1]).trimStart()}`;
+        allReferences.push(
+          ...extractFlagReferences(j2, filePath, true),
+        );
+        if (i < chunk.length - 2) {
+          const j3 = `${stripInlineComments(chunk[i]).trimEnd()}${stripInlineComments(chunk[i + 1]).trim()}${stripInlineComments(chunk[i + 2]).trimStart()}`;
+          allReferences.push(
+            ...extractFlagReferences(j3, filePath, true),
+          );
+        }
+      }
+      allReferences.push(
+        ...extractMultiLineDestructuring(chunk, filePath),
+      );
+    }
+  }
+
+  // --- Collect flag references from removed lines ---
+  const removedReferences: FlagReference[] = [];
+  for (const [filePath, lines] of fileRemovals) {
+    if (!isScannableFile(filePath)) {
+      continue;
+    }
+    for (const line of lines) {
+      removedReferences.push(...extractFlagReferences(line, filePath));
+    }
+  }
+
+  // --- De-duplicate added flags: flag -> set of files ---
+  const flagToFiles = new Map<string, Set<string>>();
+  for (const { flagName, filePath } of allReferences) {
+    if (!flagToFiles.has(flagName)) {
+      flagToFiles.set(flagName, new Set());
+    }
+    flagToFiles.get(flagName)?.add(filePath);
+  }
+
+  // --- Partition into registered / unregistered ---
+  const unregisteredFlags: Array<{ flag: string; files: string[] }> = [];
+  let registeredCount = 0;
+
+  for (const [flag, files] of flagToFiles) {
+    if (registeredFlags.has(flag)) {
+      registeredCount += 1;
+    } else {
+      unregisteredFlags.push({ flag, files: [...files].sort() });
+    }
+  }
+
+  // --- Detect removed flags with no remaining codebase references ---
+  const addedFlagNames = new Set(flagToFiles.keys());
+  const removedOnlyFlags = new Set<string>();
+  for (const { flagName } of removedReferences) {
+    if (!addedFlagNames.has(flagName) && registeredFlags.has(flagName)) {
+      removedOnlyFlags.add(flagName);
+    }
+  }
+  const orphanedFlags = findOrphanedFlags([...removedOnlyFlags]);
+
+  // --- Report ---
+  console.log(
+    `\nResults: ${flagToFiles.size} unique flag(s) referenced in changed files`,
+  );
+  console.log(`  ${registeredCount} flag(s) are registered`);
+  console.log(`  ${unregisteredFlags.length} flag(s) are NOT registered`);
+  if (orphanedFlags.length > 0) {
+    console.log(
+      `  ${orphanedFlags.length} flag(s) may need removal from the registry`,
+    );
+  }
+  console.log('');
+
+  const hasIssues = unregisteredFlags.length > 0 || orphanedFlags.length > 0;
+
+  if (!hasIssues) {
+    console.log('All detected feature flags are registered.');
+    await deletePrComment();
+    process.exit(0);
+  }
+
+  const sortedUnregistered = unregisteredFlags.sort((a, b) =>
+    a.flag.localeCompare(b.flag),
+  );
+
+  if (sortedUnregistered.length > 0) {
+    console.error('Unregistered feature flags detected!\n');
+    for (const { flag, files } of sortedUnregistered) {
+      console.error(`  - ${flag}`);
+      for (const file of files) {
+        console.error(`      ${file}`);
+      }
+    }
+  }
+
+  if (orphanedFlags.length > 0) {
+    console.warn('\nFlags with no remaining codebase references:\n');
+    for (const flag of orphanedFlags) {
+      console.warn(`  - ${flag}`);
+    }
+    console.warn(
+      '\nConsider removing these from the registry or marking them as deprecated.\n',
+    );
+  }
+
+  await postPrComment(sortedUnregistered, orphanedFlags);
+
+  // Fail only for unregistered flags; orphaned flags are warnings
+  if (sortedUnregistered.length > 0) {
+    process.exit(1);
+  }
+}
+
+function getDiff(baseBranch: string): string {
+  const candidates: string[][] = [
+    ['git', 'diff', `origin/${baseBranch}...HEAD`, '--', ...SCAN_DIRECTORIES],
+    ['git', 'diff', `origin/${baseBranch}..HEAD`, '--', ...SCAN_DIRECTORIES],
+    ['git', 'diff', `${baseBranch}...HEAD`, '--', ...SCAN_DIRECTORIES],
+    ['git', 'diff', `${baseBranch}..HEAD`, '--', ...SCAN_DIRECTORIES],
+  ];
+  let lastError: unknown;
+  for (const [cmd, ...args] of candidates) {
+    try {
+      return execFileSync(cmd, args, { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024, cwd: REPO_ROOT });
+    } catch (error) { lastError = error; }
+  }
+  console.error(`Could not compute diff against base branch "${baseBranch}".`);
+  console.error('Ensure the base branch is fetched (e.g. git fetch origin <base> --depth=1).');
+  console.error('Last error:', lastError);
+  process.exit(1);
+}
+
+type DiffResult = { added: Map<string, string[][]>; removed: Map<string, string[]> };
+
+function isScannableFile(filePath: string): boolean {
+  if (filePath.startsWith(REGISTRY_DIR)) return false;
+  if (!SCANNABLE_EXTENSIONS.has(path.extname(filePath))) return false;
+  return SCAN_DIRECTORIES.some((dir) => filePath.startsWith(dir));
+}
+
+function findOrphanedFlags(flagNames: string[]): string[] {
+  const orphaned: string[] = [];
+  for (const flag of flagNames) {
+    if (!/^[\w.-]+$/.test(flag)) continue;
+    try {
+      const result = execFileSync(
+        'git', ['grep', '-lFw', flag, '--', ...SCAN_DIRECTORIES],
+        { encoding: 'utf-8', stdio: 'pipe', cwd: REPO_ROOT },
+      ).trim();
+      const files = result.split('\n').filter((f) => f && !f.startsWith(REGISTRY_DIR));
+      if (files.length === 0) orphaned.push(flag);
+    } catch (err: unknown) {
+      const exitCode = (err as { status?: number }).status;
+      if (exitCode === 1) {
+        orphaned.push(flag);
+      } else {
+        console.warn(`  git grep failed for flag "${flag}" (exit ${exitCode}), skipping orphan check`);
+      }
+    }
+  }
+  return orphaned.sort();
+}
+
+function parseDiff(diff: string): DiffResult {
+  const added = new Map<string, string[][]>();
+  const removed = new Map<string, string[]>();
+  let currentFile = '', pendingFile = '', lastWasAdded = false;
+  const ensureMaps = (f: string) => {
+    if (!added.has(f)) added.set(f, []);
+    if (!removed.has(f)) removed.set(f, []);
+  };
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('--- a/')) { pendingFile = line.slice(6); }
+    if (line.startsWith('+++ b/')) {
+      currentFile = line.slice(6); ensureMaps(currentFile); lastWasAdded = false;
+    } else if (line.startsWith('+++ /dev/null') && pendingFile) {
+      currentFile = pendingFile; ensureMaps(currentFile); lastWasAdded = false;
+    } else if (line.startsWith('+') && !line.startsWith('+++ ') && currentFile) {
+      const chunks = added.get(currentFile)!;
+      if (!lastWasAdded || chunks.length === 0) chunks.push([]);
+      chunks[chunks.length - 1].push(line.slice(1));
+      lastWasAdded = true;
+    } else if (line.startsWith('-') && !line.startsWith('--- ') && currentFile) {
+      removed.get(currentFile)?.push(line.slice(1)); lastWasAdded = false;
+    } else { lastWasAdded = false; }
+  }
+  return { added, removed };
+}
+
+function extractFlagReferences(
+  line: string,
+  filePath: string,
+  skipDestructuring = false,
+): FlagReference[] {
+  const refs: FlagReference[] = [];
+  const trimmed = line.trim();
+
+  if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+    return refs;
+  }
+
+  const commentStripped = stripInlineComments(line);
+  const masked = maskStringLiterals(commentStripped);
+  const sanitized = stripStringLiterals(commentStripped);
+
+  for (const pattern of BRACKET_STRING_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(commentStripped)) !== null) {
+      if (masked.charAt(match.index) === ' ' && commentStripped.charAt(match.index) !== ' ') continue;
+      const flagName = match[1] || match[2] || match[3];
+      if (flagName && isLikelyFlagName(flagName)) refs.push({ flagName, filePath });
+    }
+  }
+
+  for (const pattern of FLAG_ACCESS_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(sanitized)) !== null) {
+      if (isLikelyFlagName(match[1])) refs.push({ flagName: match[1], filePath });
+    }
+  }
+
+  for (const pattern of CONSTANT_BRACKET_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(sanitized)) !== null) {
+      const constantExpr = match[1];
+      const resolved = KNOWN_FLAG_CONSTANTS[constantExpr];
+      if (resolved) {
+        refs.push({ flagName: resolved, filePath });
+      } else if (isStaticConstant(constantExpr)) {
+        const fileResolved = resolveConstantFromSourceFile(constantExpr, filePath);
+        if (fileResolved) refs.push({ flagName: fileResolved, filePath });
+        else console.warn(`  Skipping unresolved constant: ${constantExpr} in ${filePath}`);
+      }
+    }
+  }
+
+  if (skipDestructuring) return refs;
+  for (const pattern of DESTRUCTURING_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(sanitized)) !== null) {
+      for (const id of extractDestructuredIdentifiers(match[1])) {
+        if (isLikelyFlagName(id)) refs.push({ flagName: id, filePath });
+      }
+    }
+  }
+  return refs;
+}
+
+function extractMultiLineDestructuring(chunk: string[], filePath: string): FlagReference[] {
+  const refs: FlagReference[] = [];
+  for (let i = 0; i < chunk.length; i++) {
+    if (!chunk[i].includes('selectRemoteFeatureFlags')) continue;
+    let combined = '';
+    for (let j = i; j >= 0 && j >= i - 10; j--) {
+      const stripped = stripInlineComments(chunk[j]);
+      combined = `${stripped} ${combined}`;
+      if (stripped.includes('{')) break;
+    }
+    const sanitized = stripStringLiterals(combined);
+    for (const pattern of DESTRUCTURING_PATTERNS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(sanitized)) !== null) {
+        for (const id of extractDestructuredIdentifiers(match[1])) {
+          if (isLikelyFlagName(id)) refs.push({ flagName: id, filePath });
+        }
+      }
+    }
+  }
+  return refs;
+}
+
+function extractDestructuredIdentifiers(content: string): string[] {
+  const ids: string[] = [];
+  for (const part of content.split(/[,;]/)) {
+    const t = part.trim();
+    if (!t || t.startsWith('...')) continue;
+    const colonIdx = t.indexOf(':');
+    const raw = colonIdx > 0 ? t.slice(0, colonIdx).trim() : t;
+    const m = raw.match(/^(\w+)/);
+    if (m) ids.push(m[1]);
+  }
+  return ids;
+}
+
+function isStaticConstant(expr: string): boolean {
+  return expr.includes('.') ? /^[A-Z]\w*\.[A-Z]\w*$/.test(expr) : /^[A-Z]/.test(expr);
+}
+
+function isLikelyFlagName(name: string): boolean {
+  return !NON_FLAG_NAMES.has(name) && name.length >= 3 && /^[a-z]/.test(name);
+}
+
+function stripInlineComments(line: string): string {
+  let result = '', inSingle = false, inDouble = false, inTemplate = false, escaped = false, inBlock = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (escaped) { escaped = false; result += ch; continue; }
+    if (inBlock) { if (ch === '*' && line[i + 1] === '/') { inBlock = false; i += 1; } continue; }
+    if (ch === '\\' && (inSingle || inDouble || inTemplate)) { escaped = true; result += ch; continue; }
+    if (ch === "'" && !inDouble && !inTemplate) { inSingle = !inSingle; }
+    else if (ch === '"' && !inSingle && !inTemplate) { inDouble = !inDouble; }
+    else if (ch === '`' && !inSingle && !inDouble) { inTemplate = !inTemplate; }
+    else if (!inSingle && !inDouble && !inTemplate && ch === '/') {
+      if (line[i + 1] === '/') return result;
+      if (line[i + 1] === '*') { inBlock = true; i += 1; continue; }
+      const prevNonWs = result.trimEnd().slice(-1);
+      if (i === 0 || /[=([!&|,;:?]/.test(prevNonWs)) {
+        const closeIdx = findRegexClose(line, i + 1);
+        if (closeIdx > i) { result += line.slice(i, closeIdx + 1); i = closeIdx; continue; }
+      }
+    }
+    result += ch;
+  }
+  return result;
+}
+
+function findRegexClose(line: string, start: number): number {
+  let inCharClass = false;
+  for (let k = start; k < line.length; k++) {
+    let bs = 0;
+    while (k - 1 - bs >= start && line[k - 1 - bs] === '\\') bs++;
+    if (bs % 2 === 1) continue;
+    const c = line[k];
+    if (c === '[') inCharClass = true;
+    else if (c === ']' && inCharClass) inCharClass = false;
+    else if (c === '/' && !inCharClass) return k;
+  }
+  return -1;
+}
+
+function processStrings(line: string, mode: 'strip' | 'mask'): string {
+  let result = '', i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch !== "'" && ch !== '"' && ch !== '`') { result += ch; i++; continue; }
+    if (ch === '`') {
+      let j = i + 1, hasExpr = false;
+      while (j < line.length) {
+        if (line[j] === '\\') { j += 2; continue; }
+        if (line[j] === '$' && line[j + 1] === '{') { hasExpr = true; break; }
+        if (line[j] === '`') break;
+        j++;
+      }
+      if (hasExpr) {
+        let depth = 1, k = j + 2, foundClose = false;
+        result += ch; if (mode === 'mask') result += ' '.repeat(j - i - 1); result += '${';
+        while (k < line.length) {
+          if (line[k] === '\\') { if (depth > 0) result += line[k] + (line[k+1]||' '); else if (mode === 'mask') result += '  '; k += 2; continue; }
+          if (depth === 0) {
+            if (line[k] === '`') { foundClose = true; result += '`'; break; }
+            if (line[k] === '$' && line[k + 1] === '{') { depth = 1; result += '${'; k += 2; continue; }
+            if (mode === 'mask') result += ' ';
+          } else {
+            if (line[k] === '$' && line[k + 1] === '{') { result += '${'; depth++; k++; }
+            else if (line[k] === '{') { result += '{'; depth++; }
+            else if (line[k] === '}') { result += '}'; depth--; }
+            else if (line[k] === '`' && depth === 1) { result += '`'; depth++; }
+            else if (line[k] === '`' && depth > 1) { result += '`'; depth--; }
+            else result += line[k];
+          }
+          k++;
+        }
+        if (!foundClose) result += line.slice(k);
+        i = foundClose ? k + 1 : line.length; continue;
+      }
+      // No interpolation — fall through to the generic handler below, but
+      // `j` already points at the closing backtick so reuse it directly.
+      if (j >= line.length) { result += ch; i++; continue; }
+      const tLen = j - i - 1;
+      result += mode === 'mask' ? ch + ' '.repeat(tLen) + ch : ch + ch;
+      i = j + 1; continue;
+    }
+    let j = i + 1;
+    while (j < line.length) { if (line[j] === '\\') { j += 2; continue; } if (line[j] === ch) break; j++; }
+    if (j >= line.length) { result += ch; i++; continue; }
+    const len = j - i - 1;
+    result += mode === 'mask' ? ch + ' '.repeat(len) + ch : ch + ch;
+    i = j + 1;
+  }
+  return result;
+}
+function stripStringLiterals(line: string): string { return processStrings(line, 'strip'); }
+function maskStringLiterals(line: string): string { return processStrings(line, 'mask'); }
+
+function logRegistryChanges(baseBranch: string): void {
+  const candidates: string[][] = [
+    ['git', 'diff', `origin/${baseBranch}...HEAD`, '--', REGISTRY_FILE],
+    ['git', 'diff', `origin/${baseBranch}..HEAD`, '--', REGISTRY_FILE],
+    ['git', 'diff', `${baseBranch}...HEAD`, '--', REGISTRY_FILE],
+    ['git', 'diff', `${baseBranch}..HEAD`, '--', REGISTRY_FILE],
+  ];
+  let registryDiff = '';
+  for (const [cmd, ...args] of candidates) {
+    try {
+      registryDiff = execFileSync(cmd, args, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, cwd: REPO_ROOT });
+      break;
+    } catch { /* try next */ }
+  }
+  if (!registryDiff.trim()) return;
+  const added: string[] = [], removed: string[] = [], nameRe = /name:\s*'([\w.-]+)'/;
+  for (const line of registryDiff.split('\n')) {
+    const m = nameRe.exec(line);
+    if (!m) continue;
+    if (line.startsWith('+') && !line.startsWith('+++')) added.push(m[1]);
+    else if (line.startsWith('-') && !line.startsWith('---')) removed.push(m[1]);
+  }
+  if (added.length > 0 || removed.length > 0) {
+    console.log('Registry file was modified in this PR:');
+    if (added.length > 0) console.log(`  Added:   ${added.join(', ')}`);
+    if (removed.length > 0) console.log(`  Removed: ${removed.join(', ')}`);
+    console.log('');
+  }
+}
+
+function buildCommentBody(
+  unregistered: Array<{ flag: string; files: string[] }>, orphaned: string[],
+): string {
+  const lines: string[] = [PR_COMMENT_MARKER, '## Feature Flag Registry Check', ''];
+  if (unregistered.length > 0) {
+    lines.push(
+      'This PR introduces feature flag references that are **not yet registered** in the',
+      '[feature flag registry](https://github.com/MetaMask/metamask-mobile/blob/main/tests/feature-flags/feature-flag-registry.ts).',
+      '', '### Unregistered flags', '',
+      '| Flag | Referenced in |', '| ---- | ------------ |',
+    );
+    for (const { flag, files } of unregistered) {
+      lines.push(`| \`${flag}\` | ${files.map((f) => `\`${f}\``).join(', ')} |`);
+    }
+    lines.push('', '<details>', '<summary>How to fix</summary>', '',
+      'Add an entry for each flag in `tests/feature-flags/feature-flag-registry.ts`:', '',
+      '```ts', 'myNewFlag: {', "  name: 'myNewFlag',", '  type: FeatureFlagType.Remote,',
+      '  inProd: false,', '  productionDefault: false,', '  status: FeatureFlagStatus.Active,',
+      '},', '```', '',
+      'Set `inProd` and `productionDefault` to match the current production values from the',
+      '[client-config API](https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=prod).', '',
+      'If you access the flag via a **constant** (e.g. `remoteFeatureFlags[MY_CONSTANT]`), also add the constant to',
+      '[`.github/scripts/known-feature-flag-constants.ts`](https://github.com/MetaMask/metamask-mobile/blob/main/.github/scripts/known-feature-flag-constants.ts)',
+      'so the CI check can resolve it.', '', '</details>',
+    );
+  }
+  if (orphaned.length > 0) {
+    if (unregistered.length > 0) lines.push('', '---', '');
+    lines.push('### Possibly unused flags', '',
+      'This PR removes the last codebase references to the following registered flags.',
+      'Consider removing them from the registry or marking them as `deprecated`.', '',
+      ...orphaned.map((f) => `- \`${f}\``),
+    );
+  }
+  return lines.join('\n');
+}
+
+async function postPrComment(
+  unregistered: Array<{ flag: string; files: string[] }>, orphaned: string[] = [],
+): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  const prNumber = context.payload.pull_request?.number;
+  if (!token || !prNumber) { console.log('Not in a GitHub Actions PR context — skipping PR comment.'); return; }
+  const octokit = getOctokit(token);
+  const { owner, repo } = context.repo;
+  const body = buildCommentBody(unregistered, orphaned);
+  try {
+    const existing = await findMarkerComment(octokit, owner, repo, prNumber);
+    if (existing) {
+      await octokit.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+      console.log(`Updated existing PR comment (id: ${existing.id}).`);
+    } else {
+      await octokit.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+      console.log('Posted new PR comment.');
+    }
+  } catch (error) { console.warn('Failed to post PR comment:', error); }
+}
+
+async function deletePrComment(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  const prNumber = context.payload.pull_request?.number;
+  if (!token || !prNumber) return;
+  const octokit = getOctokit(token);
+  const { owner, repo } = context.repo;
+  try {
+    const existing = await findMarkerComment(octokit, owner, repo, prNumber);
+    if (existing) {
+      await octokit.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+      console.log('Deleted stale PR comment.');
+    }
+  } catch { /* best-effort */ }
+}
+
+async function findMarkerComment(
+  octokit: ReturnType<typeof getOctokit>, owner: string, repo: string, prNumber: number,
+): Promise<{ id: number } | undefined> {
+  const iterator = octokit.paginate.iterator(
+    octokit.rest.issues.listComments, { owner, repo, issue_number: prNumber, per_page: 100 },
+  );
+  for await (const { data: comments } of iterator) {
+    const found = comments.find((c) => c.body?.includes(PR_COMMENT_MARKER));
+    if (found) return found;
+  }
+  return undefined;
+}
+
+main().catch((error) => {
+  console.error('Feature flag registry check failed:', error);
+  process.exit(1);
+});

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -112,8 +112,7 @@ async function main(): Promise<void> {
           continue;
         }
         allReferences.push(...extractFlagReferences(line, filePath));
-        const openIdx = line.lastIndexOf('/*');
-        if (openIdx !== -1 && line.indexOf('*/', openIdx + 2) === -1) inBlock = true;
+        if (opensBlockComment(line)) inBlock = true;
       }
       for (let i = 0; i < chunk.length - 1; i++) {
         const j2 = `${stripInlineComments(chunk[i]).trimEnd()}${stripInlineComments(chunk[i + 1]).trimStart()}`;
@@ -403,6 +402,25 @@ function extractDestructuredIdentifiers(content: string): string[] {
     if (m) ids.push(m[1]);
   }
   return ids;
+}
+
+function opensBlockComment(line: string): boolean {
+  let inSingle = false, inDouble = false, inTemplate = false, escaped = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\' && (inSingle || inDouble || inTemplate)) { escaped = true; continue; }
+    if (ch === "'" && !inDouble && !inTemplate) { inSingle = !inSingle; continue; }
+    if (ch === '"' && !inSingle && !inTemplate) { inDouble = !inDouble; continue; }
+    if (ch === '`' && !inSingle && !inDouble) { inTemplate = !inTemplate; continue; }
+    if (!inSingle && !inDouble && !inTemplate && ch === '/' && line[i + 1] === '/') return false;
+    if (!inSingle && !inDouble && !inTemplate && ch === '/' && line[i + 1] === '*') {
+      const closeIdx = line.indexOf('*/', i + 2);
+      if (closeIdx === -1) return true;
+      i = closeIdx + 1;
+    }
+  }
+  return false;
 }
 
 function isStaticConstant(expr: string): boolean {

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -17,6 +17,7 @@ const QUOTE_FLAG = `(?:'([\\w.-]+)'|"([\\w.-]+)"|` + '`([\\w.-]+)`' + `)`;
 const BRACKET_STRING_PATTERNS: RegExp[] = [
   new RegExp(`remoteFeatureFlags(?:\\?\\.)?\\[\\s*${QUOTE_FLAG}\\s*\\]`, 'g'),
   new RegExp(`selectRemoteFeatureFlags\\(${ARGS}\\)(?:\\?\\.)?\\[\\s*${QUOTE_FLAG}\\s*\\]`, 'g'),
+  new RegExp(`hasProperty\\(\\s*remoteFeatureFlags\\s*,\\s*${QUOTE_FLAG}\\s*\\)`, 'g'),
 ];
 
 const FLAG_ACCESS_PATTERNS: RegExp[] = [
@@ -35,6 +36,7 @@ const DESTRUCTURING_PATTERNS: RegExp[] = [
 const CONSTANT_BRACKET_PATTERNS: RegExp[] = [
   /remoteFeatureFlags(?:\?\.)?\[([A-Za-z_]\w*(?:\.\w+)?)\]/g,
   new RegExp(`selectRemoteFeatureFlags\\(${ARGS}\\)(?:\\?\\.)?\\[([A-Za-z_]\\w*(?:\\.\\w+)?)\\]`, 'g'),
+  /hasProperty\(\s*remoteFeatureFlags\s*,\s*([A-Za-z_]\w*(?:\.\w+)?)\s*\)/g,
 ];
 
 const KNOWN_FLAG_CONSTANTS = buildKnownFlagConstants();

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -12,7 +12,7 @@ const REGISTRY_FILE = 'tests/feature-flags/feature-flag-registry.ts';
 const SCANNABLE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 const SCAN_DIRECTORIES = ['app/', 'shared/', 'tests/'];
 const ARGS = '[^)]*(?:\\([^)]*\\)[^)]*)*';
-const QUOTE_FLAG = `(?:'(\\w+)'|"(\\w+)"|` + '`(\\w+)`' + `)`;
+const QUOTE_FLAG = `(?:'([\\w.-]+)'|"([\\w.-]+)"|` + '`([\\w.-]+)`' + `)`;
 
 const BRACKET_STRING_PATTERNS: RegExp[] = [
   new RegExp(`remoteFeatureFlags(?:\\?\\.)?\\[\\s*${QUOTE_FLAG}\\s*\\]`, 'g'),

--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -102,8 +102,18 @@ async function main(): Promise<void> {
       continue;
     }
     for (const chunk of chunks) {
+      let inBlock = false;
       for (const line of chunk) {
+        if (inBlock) {
+          const endIdx = line.indexOf('*/');
+          if (endIdx === -1) continue;
+          inBlock = false;
+          allReferences.push(...extractFlagReferences(line.slice(endIdx + 2), filePath));
+          continue;
+        }
         allReferences.push(...extractFlagReferences(line, filePath));
+        const openIdx = line.lastIndexOf('/*');
+        if (openIdx !== -1 && line.indexOf('*/', openIdx + 2) === -1) inBlock = true;
       }
       for (let i = 0; i < chunk.length - 1; i++) {
         const j2 = `${stripInlineComments(chunk[i]).trimEnd()}${stripInlineComments(chunk[i + 1]).trimStart()}`;
@@ -249,9 +259,10 @@ function findOrphanedFlags(flagNames: string[]): string[] {
   const orphaned: string[] = [];
   for (const flag of flagNames) {
     if (!/^[\w.-]+$/.test(flag)) continue;
+    const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     try {
       const result = execFileSync(
-        'git', ['grep', '-lFw', flag, '--', ...SCAN_DIRECTORIES],
+        'git', ['grep', '-Pl', `\\b${escaped}\\b`, '--', ...SCAN_DIRECTORIES],
         { encoding: 'utf-8', stdio: 'pipe', cwd: REPO_ROOT },
       ).trim();
       const files = result.split('\n').filter((f) => f && !f.startsWith(REGISTRY_DIR));

--- a/.github/scripts/known-feature-flag-constants.ts
+++ b/.github/scripts/known-feature-flag-constants.ts
@@ -1,0 +1,65 @@
+// Maps constant names to resolved flag strings for bracket-access like
+// `remoteFeatureFlags[CONSTANT]`. Add new constants here when the CI job
+// reports an "unresolved constant" error.
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const REWARDS_FILE = 'app/selectors/featureFlagController/rewards/rewardsEnabled.ts';
+const sel = (sub: string) => `app/selectors/featureFlagController/${sub}/index.ts`;
+
+const FILE_SOURCES: Array<{ key: string; file: string; exportName: string }> = [
+  { key: 'BITCOIN_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'BITCOIN_REWARDS_FLAG_NAME' },
+  { key: 'TRON_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'TRON_REWARDS_FLAG_NAME' },
+  { key: 'SNAPSHOTS_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'SNAPSHOTS_REWARDS_FLAG_NAME' },
+  { key: 'MISSING_ENROLLED_ACCOUNTS_FLAG_NAME', file: REWARDS_FILE, exportName: 'MISSING_ENROLLED_ACCOUNTS_FLAG_NAME' },
+  { key: 'CAMPAIGNS_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'CAMPAIGNS_REWARDS_FLAG_NAME' },
+  { key: 'ACCOUNT_MENU_FLAG_KEY', file: sel('accountMenu'), exportName: 'ACCOUNT_MENU_FLAG_KEY' },
+  { key: 'NETWORK_MANAGEMENT_FLAG_KEY', file: sel('networkManagement'), exportName: 'NETWORK_MANAGEMENT_FLAG_KEY' },
+  // FEATURE_FLAG_NAME is omitted (non-unique across rwa / gasFeesSponsored); per-file fallback handles it.
+  { key: 'OTA_UPDATES_FLAG_NAME', file: sel('otaUpdates'), exportName: 'OTA_UPDATES_FLAG_NAME' },
+  { key: 'FULL_PAGE_ACCOUNT_LIST_FLAG_NAME', file: sel('fullPageAccountList'), exportName: 'FULL_PAGE_ACCOUNT_LIST_FLAG_NAME' },
+  { key: 'IMPORT_SRP_WORD_SUGGESTION_FLAG_NAME', file: sel('importSrpWordSuggestion'), exportName: 'IMPORT_SRP_WORD_SUGGESTION_FLAG_NAME' },
+  { key: 'ASSETS_UNIFY_STATE_FLAG', file: sel('assetsUnifyState'), exportName: 'ASSETS_UNIFY_STATE_FLAG' },
+];
+
+function resolveConstantFromFile(filePath: string, constantName: string): string | undefined {
+  try {
+    const content = fs.readFileSync(path.resolve(REPO_ROOT, filePath), 'utf-8');
+    const escaped = constantName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(
+      `(?:export\\s+)?const\\s+${escaped}(?:\\s*:[^=]+)?\\s*=\\s*(?:'([^']+)'|"([^"]+)"|` + '`([^`]+)`)',
+    );
+    const match = re.exec(content);
+    return match?.[1] ?? match?.[2] ?? match?.[3];
+  } catch { return undefined; }
+}
+
+function resolveFeatureFlagNamesEnum(): Record<string, string> {
+  const result: Record<string, string> = {};
+  try {
+    const content = fs.readFileSync(path.resolve(REPO_ROOT, 'app/constants/featureFlags.ts'), 'utf-8');
+    const enumMatch = content.match(/enum\s+FeatureFlagNames\s*\{([^}]+)\}/);
+    if (!enumMatch) return result;
+    const entryRe = /(\w+)\s*=\s*(?:'([^']+)'|"([^"]+)"|`([^`]+)`)/g;
+    let m: RegExpExecArray | null;
+    while ((m = entryRe.exec(enumMatch[1])) !== null) {
+      const value = m[2] ?? m[3] ?? m[4];
+      if (m[1] && value) result[`FeatureFlagNames.${m[1]}`] = value;
+    }
+  } catch { /* non-fatal */ }
+  return result;
+}
+
+export function resolveConstantFromSourceFile(constantName: string, sourceFilePath: string): string | undefined {
+  return resolveConstantFromFile(sourceFilePath, constantName);
+}
+
+export function buildKnownFlagConstants(): Record<string, string> {
+  const constants: Record<string, string> = { ...resolveFeatureFlagNamesEnum() };
+  for (const { key, file, exportName } of FILE_SOURCES) {
+    const resolved = resolveConstantFromFile(file, exportName);
+    if (resolved) constants[key] = resolved;
+  }
+  return constants;
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -10,7 +10,8 @@
     "create-bug-report-issue": "ts-node ./create-bug-report-issue.ts",
     "run-bitrise-e2e-check": "ts-node ./bitrise/run-bitrise-e2e-check.ts",
     "bitrise-results-check": "ts-node ./bitrise/bitrise-results-check.ts",
-    "gen:commits": "node generate-rc-commits.mjs"
+    "gen:commits": "node generate-rc-commits.mjs",
+    "check-feature-flag-registry": "ts-node ./check-feature-flag-registry.ts"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/.github/workflows/check-feature-flag-registry.yml
+++ b/.github/workflows/check-feature-flag-registry.yml
@@ -1,0 +1,55 @@
+name: Check Feature Flag Registry
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-feature-flags:
+    name: Verify feature flags are registered
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install CI script dependencies
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd .github/scripts && yarn --immutable
+
+      - name: Fetch base branch for diff
+        run: git fetch origin "$BASE_REF"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+
+      - name: Check feature flag registry
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn run check-feature-flag-registry
+        working-directory: '.github/scripts'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a CI job that automatically detects feature flag references in PR diffs and verifies they exist in the feature flag registry introduced in #26913.

- If a PR introduces a new feature flag that isn't registered, the job fails and posts a comment on the PR explaining which flags are missing and how to add them.
- If a PR removes the last reference to a registered flag, the job warns in the PR comment, suggesting the flag be removed from the registry or marked as deprecated.

This ensures every feature flag has a production default value in the registry from the start, keeping E2E test mocks accurate, and helps identify stale flags that can be cleaned up.

1. Scans changed files in `app/,` `shared/`, and `tests/` for feature flag access patterns
2. Compares detected flags against the feature flag registry
3. Fails the job and comments on the PR if unregistered flags are found, with a table of missing flags and instructions for adding them
4. Warns in the PR comment if a flag's last codebase reference is being removed, suggesting a registry cleanup

**Example PR comments**

**When a PR introduces an unregistered flag**:
> ## Feature Flag Registry Check
>
> This PR introduces feature flag references that are not yet registered in the
> feature flag registry.
>
> ### Unregistered flags
>
> | Flag | Referenced in |
> | ---- | ------------ |
> | myNewFeatureFlag | app/selectors/featureFlagController/index.ts |
>
> <details>
> <summary>How to fix</summary>
>
> Add an entry for each flag in tests/feature-flags/feature-flag-registry.ts:
>
>
> myNewFlag: {
>   name: 'myNewFlag',
>   type: FeatureFlagType.Remote,
>   inProd: false,
>   productionDefault: false,
>   status: FeatureFlagStatus.Active,
> },
>
>
> </details>

**When a PR removes the last reference to a registered flag**:
> ## Feature Flag Registry Check
>
> ### Possibly unused flags
>
> This PR removes the last codebase references to the following registered flags.
> Consider removing them from the registry or marking them as deprecated.
>
> - oldDeprecatedFlag

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1145](https://consensyssoftware.atlassian.net/browse/MMQA-1145?atlOrigin=eyJpIjoiYTEyZWVlNDk4MzM1NGQxOWI5ZTg0M2IyZjU3YzkzYzgiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Run locally: `cd .github/scripts && yarn run check-feature-flag-registry main`
2. Verify it reports 0 unregistered flags on a clean branch
3. Add a line like `remoteFeatureFlags?.myTestFlag` to any source file in `app/` and commit it
4. Re-run the script and verify it detects `myTestFlag` as unregistered and exits with code 1

**Example of posted comment when the job fails: https://github.com/Unik0rnMaggie/metamask-mobile/pull/1#issuecomment-4038680108** 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new PR-blocking GitHub Actions workflow and a custom diff-scanning script that can fail builds or post/update PR comments; main risk is false positives/negatives in regex-based detection and Git diff/grep behavior in CI.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`check-feature-flag-registry.yml`) that runs on PRs to `main` and executes a new `.github/scripts/check-feature-flag-registry.ts` validator.
> 
> The validator parses the PR diff for feature-flag access patterns (dot access, bracket access, `hasProperty`, and destructuring from `selectRemoteFeatureFlags`), resolves bracketed constants via a new `known-feature-flag-constants.ts`, and compares detected flags against `tests/feature-flags/feature-flag-registry.ts`. It fails the job and posts/updates a PR comment when unregistered flags are introduced, and warns (without failing) when removed references appear to orphan registered flags.
> 
> Adds Jest coverage for diff parsing and reference extraction, and wires the script into `.github/scripts/package.json` as `yarn run check-feature-flag-registry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 004dff6c9975ecacc0cf8a0cd62544f5824c5795. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->