### PR TITLE
ci: add automation tests stats

### DIFF
--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -143,29 +143,34 @@ async function downloadArtifact(artifactName) {
  * @returns {string}
  */
 function getFeatureFolder(testFilePath) {
+  const normalize = (s) => s.toLowerCase().replace(/-/g, '_');
   // app/components/UI/<Feature>/  → <Feature>
   const uiMatch = testFilePath.match(/app\/components\/UI\/([^/]+)/);
-  if (uiMatch) return uiMatch[1].toLowerCase();
+  if (uiMatch) return normalize(uiMatch[1]);
   // app/components/Views/<Feature>/ → <Feature>
   const viewsMatch = testFilePath.match(/app\/components\/Views\/([^/]+)/);
-  if (viewsMatch) return viewsMatch[1].toLowerCase();
+  if (viewsMatch) return normalize(viewsMatch[1]);
   // app/components/<other>/ → components_<other> (e.g. components_snaps, components_hooks)
   const componentsMatch = testFilePath.match(/app\/components\/([^/]+)/);
-  if (componentsMatch) return `components_${componentsMatch[1].toLowerCase()}`;
-  // app/<folder>/ → <folder> (e.g. core, util, store, selectors)
+  if (componentsMatch) return `components_${normalize(componentsMatch[1])}`;
+  // app/<folder>/ → <folder> (e.g. core, util, store, selectors, component_library)
   const appMatch = testFilePath.match(/app\/([^/]+)/);
-  return appMatch ? appMatch[1].toLowerCase() : 'other';
+  return appMatch ? normalize(appMatch[1]) : 'other';
 }
 
 /**
  * Downloads all shard artifacts matching artifactPattern, reads the
  * jest-results.json from each, and returns test counts grouped by feature folder.
  *
+ * Folders whose total count is below minFolderCount are merged into `other`
+ * to reduce noise (useful for unit tests which have hundreds of component-level folders).
+ *
  * @param {RegExp} artifactPattern
  * @param {string} label — used in log messages
+ * @param {number} [minFolderCount=0] — folders with fewer tests are bucketed into `other`
  * @returns {Promise<Record<string, number>>}
  */
-async function collectShardCounts(artifactPattern, label) {
+async function collectShardCounts(artifactPattern, label, minFolderCount = 0) {
   const artifacts = await getArtifactList();
   const shardArtifacts = artifacts.filter((a) => artifactPattern.test(a.name));
   console.log(`[${label}] found ${shardArtifacts.length} shard artifact(s)`);
@@ -179,10 +184,14 @@ async function collectShardCounts(artifactPattern, label) {
     const destDir = await downloadArtifact(artifact.name);
     const raw = await readFile(join(destDir, 'jest-results.json'), 'utf8');
     const { testResults } = JSON.parse(raw);
-    for (const { testFilePath, numPassingTests, numFailingTests } of testResults) {
-      const count = numPassingTests + numFailingTests;
+    // Jest --json CLI output uses `name` for the file path and `assertionResults`
+    // for per-test outcomes (not numPassingTests/numFailingTests which are top-level aggregates).
+    for (const { name, assertionResults } of testResults) {
+      const passed = assertionResults.filter((r) => r.status === 'passed').length;
+      const failed = assertionResults.filter((r) => r.status === 'failed').length;
+      const count = passed + failed;
       total += count;
-      const folder = getFeatureFolder(testFilePath);
+      const folder = getFeatureFolder(name);
       folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
     }
   }
@@ -190,7 +199,11 @@ async function collectShardCounts(artifactPattern, label) {
   console.log(`[${label}] total: ${total}`);
   const result = { tests_count: total };
   for (const [folder, count] of Object.entries(folderCounts)) {
-    result[`${folder}_tests_count`] = count;
+    if (minFolderCount > 0 && count < minFolderCount) {
+      result.other_tests_count = (result.other_tests_count ?? 0) + count;
+    } else {
+      result[`${folder}_tests_count`] = count;
+    }
   }
   return result;
 }
@@ -202,7 +215,9 @@ async function collectComponentViewTestCount() {
 
 async function collectUnitTestCount() {
   console.log('[unit] collecting per-suite counts from shard artifacts...');
-  return collectShardCounts(/^coverage-unit-\d+$/, 'unit');
+  // minFolderCount=200: buckets individual component-level folders into `other`,
+  // keeping only meaningful team-level categories (bridge, perps, confirmations, etc.)
+  return collectShardCounts(/^coverage-unit-\d+$/, 'unit', 200);
 }
 
 /**
@@ -211,7 +226,7 @@ async function collectUnitTestCount() {
  * Returns null for non-E2E artifacts.
  *
  * @param {string} artifactName
- * @returns {{ channel: 'main'|'flask', suiteTag: string|null } | null}
+ * @returns {{ channel: 'main'|'flask', platform: 'android'|'ios', suiteTag: string|null } | null}
  */
 function getE2EArtifactDimensions(artifactName) {
   const match = artifactName.match(/^test-e2e-(.+)-junit-results$/);
@@ -223,15 +238,17 @@ function getE2EArtifactDimensions(artifactName) {
     jobName = jobName.slice('main-'.length);
   }
 
-  if (/^flask-(?:android|ios)-smoke-\d+$/.test(jobName)) {
-    return { channel: 'flask', suiteTag: null };
+  const flaskMatch = jobName.match(/^flask-(android|ios)-smoke-\d+$/);
+  if (flaskMatch) {
+    return { channel: 'flask', platform: flaskMatch[1], suiteTag: null };
   }
 
-  const mainMatch = jobName.match(/^(.+)-(?:android|ios)-smoke-\d+$/);
+  const mainMatch = jobName.match(/^(.+)-(android|ios)-smoke-\d+$/);
   if (!mainMatch) return null;
 
   return {
     channel: 'main',
+    platform: mainMatch[2],
     suiteTag: mainMatch[1].replace(/-/g, '_'),
   };
 }
@@ -254,8 +271,12 @@ function countExecutedTestsFromJUnitXml(rawXml) {
 async function collectE2ECounts() {
   const artifacts = await getArtifactList();
 
-  let mainCount = 0;
-  let flaskCount = 0;
+  // Per-platform counts for health signalling
+  const platformCounts = {
+    main: { android: 0, ios: 0 },
+    flask: { android: 0, ios: 0 },
+  };
+  // Per-suite counts from Android only (canonical unique count)
   const suiteCounts = {};
 
   const e2eArtifacts = artifacts.filter((a) => getE2EArtifactDimensions(a.name));
@@ -267,26 +288,41 @@ async function collectE2ECounts() {
   }
 
   for (const artifact of e2eArtifacts) {
-    const dimensions = getE2EArtifactDimensions(artifact.name);
+    const { channel, platform, suiteTag } = getE2EArtifactDimensions(artifact.name);
 
     const destDir = await downloadArtifact(artifact.name);
     const junitXml = await readFile(join(destDir, 'junit.xml'), 'utf8');
     const count = countExecutedTestsFromJUnitXml(junitXml);
     console.log(`[e2e] ${artifact.name}: ${count} test(s)`);
 
-    if (dimensions.channel === 'main') {
-      mainCount += count;
-      suiteCounts[dimensions.suiteTag] = (suiteCounts[dimensions.suiteTag] ?? 0) + count;
-    } else if (dimensions.channel === 'flask') {
-      flaskCount += count;
+    platformCounts[channel][platform] += count;
+
+    // Per-suite breakdown uses Android only to represent unique test count
+    if (channel === 'main' && platform === 'android' && suiteTag) {
+      suiteCounts[suiteTag] = (suiteCounts[suiteTag] ?? 0) + count;
     }
   }
 
-  const result = {
-    main_tests_count: mainCount,
-    flask_tests_count: flaskCount,
-    tests_count: mainCount + flaskCount,
-  };
+  const androidMain = platformCounts.main.android;
+  const iosMain = platformCounts.main.ios;
+  const androidFlask = platformCounts.flask.android;
+  const iosFlask = platformCounts.flask.ios;
+
+  const result = {};
+
+  // Canonical unique counts (Android as source of truth — same tests run on iOS)
+  // A missing key means that channel did not run; present-but-zero means it ran and found nothing.
+  if (androidMain > 0 || iosMain > 0) {
+    result.main_tests_count = androidMain; // unique count
+    result.main_android_tests_count = androidMain; // platform health signal
+    result.main_ios_tests_count = iosMain; // drops to 0 if iOS infrastructure is broken
+  }
+  if (androidFlask > 0 || iosFlask > 0) {
+    result.flask_tests_count = androidFlask; // unique count
+    result.flask_android_tests_count = androidFlask;
+    result.flask_ios_tests_count = iosFlask;
+  }
+  result.tests_count = androidMain + androidFlask;
 
   for (const [tag, count] of Object.entries(suiteCounts)) {
     result[`${tag}_tests_count`] = count;
@@ -354,7 +390,7 @@ async function main() {
     { namespace: 'performance', collect: collectPerformanceTestCounts },
   ];
 
-  for (const { namespace, collect, scalar } of collectors) {
+  for (const { namespace, collect } of collectors) {
     try {
       const nested = await collect();
       if (Object.keys(nested).length === 0) continue;

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -1,25 +1,32 @@
 #!/usr/bin/env node
 /**
  *
- * Downloads pre-aggregated QA stats artifacts from the triggering CI run via the
- * GitHub API and writes a qa-stats.json file for consumption by downstream workflows.
+ * Collects QA metrics from a CI run and writes qa-stats.json, key: value format.
+ * Metrics that could not be collected (missing artifacts, tests did not run)
+ * are omitted from the output — they will never appear as zero.
  *
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
- *   WORKFLOW_RUN_ID   — ID of the CI run that produced the artifacts
- *
- * Example of output format of qa-stats.json:
- *   {
- *     "component_view_tests_count": 34,
- *     "unit_test_count": 679,
- *   }
- *
+ *   WORKFLOW_RUN_ID   — ID of the main CI run that produced tests artifacts
+ * 
  * How to add a new metric:
- *   1. Add a collector function below (see existing example)
- *   2. Call it in main() and assign the result to stats
+ *   1. Add a collector function that returns a plain object
+ *   2. Register it in the collectors array in main()
+ * 
+ * The only rule: never rename existing keys. The DB key is (project, run_id, namespace, metric_key). 
+ * Renaming a key in the JSON creates a new series in the DB while the old name stops getting new data, 
+ * which breaks the Grafana time series continuity. Adding and removing keys is fine.
+ * 
+ * Example output:
+ *   {
+ *     "component_view": { "tests_count": 94 },
+ *     "unit":           { "tests_count": 41957 },
+ *     "e2e":            { "tests_count": 420, "main_tests_count": 276, "confirmations_tests_count": 62, "flask_tests_count": 144 },
+ *     "performance":    { "tests_count": 21, "login_tests_count": 11, "onboarding_tests_count": 4, "mm_connect_tests_count": 6 }
+ *   }
  */
 
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
@@ -37,7 +44,7 @@ if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 let _artifactList = null;
 
 /**
- * Fetches (and caches) the list of artifacts for the triggering CI run.
+ * Fetches (and caches) the list of artifact names for the triggering CI run.
  * First call fetches and stores, every subsequent call returns the cached value.
  * 
  * @returns {Promise<Array>}
@@ -124,18 +131,213 @@ async function downloadArtifact(artifactName) {
 // Collectors — one async function per metric source
 // ---------------------------------------------------------------------------
 
+/**
+ * Extracts a feature folder name from a Jest test file path.
+ *
+ * Priority:
+ *   app/components/UI/<Feature>/  → <Feature> (e.g. Bridge, Perps, Earn)
+ *   app/components/Views/<Feature>/ → <Feature> (e.g. Wallet, AssetDetails)
+ *   app/<folder>/                 → <folder>  (e.g. util, core, hooks)
+ *
+ * @param {string} testFilePath
+ * @returns {string}
+ */
+function getFeatureFolder(testFilePath) {
+  // app/components/UI/<Feature>/  → <Feature>
+  const uiMatch = testFilePath.match(/app\/components\/UI\/([^/]+)/);
+  if (uiMatch) return uiMatch[1].toLowerCase();
+  // app/components/Views/<Feature>/ → <Feature>
+  const viewsMatch = testFilePath.match(/app\/components\/Views\/([^/]+)/);
+  if (viewsMatch) return viewsMatch[1].toLowerCase();
+  // app/components/<other>/ → components_<other> (e.g. components_snaps, components_hooks)
+  const componentsMatch = testFilePath.match(/app\/components\/([^/]+)/);
+  if (componentsMatch) return `components_${componentsMatch[1].toLowerCase()}`;
+  // app/<folder>/ → <folder> (e.g. core, util, store, selectors)
+  const appMatch = testFilePath.match(/app\/([^/]+)/);
+  return appMatch ? appMatch[1].toLowerCase() : 'other';
+}
+
+/**
+ * Downloads all shard artifacts matching artifactPattern, reads the
+ * jest-results.json from each, and returns test counts grouped by feature folder.
+ *
+ * @param {RegExp} artifactPattern
+ * @param {string} label — used in log messages
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectShardCounts(artifactPattern, label) {
+  const artifacts = await getArtifactList();
+  const shardArtifacts = artifacts.filter((a) => artifactPattern.test(a.name));
+  console.log(`[${label}] found ${shardArtifacts.length} shard artifact(s)`);
+
+  if (shardArtifacts.length === 0) return {};
+
+  const folderCounts = {};
+  let total = 0;
+
+  for (const artifact of shardArtifacts) {
+    const destDir = await downloadArtifact(artifact.name);
+    const raw = await readFile(join(destDir, 'jest-results.json'), 'utf8');
+    const { testResults } = JSON.parse(raw);
+    for (const { testFilePath, numPassingTests, numFailingTests } of testResults) {
+      const count = numPassingTests + numFailingTests;
+      total += count;
+      const folder = getFeatureFolder(testFilePath);
+      folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
+    }
+  }
+
+  console.log(`[${label}] total: ${total}`);
+  const result = { tests_count: total };
+  for (const [folder, count] of Object.entries(folderCounts)) {
+    result[`${folder}_tests_count`] = count;
+  }
+  return result;
+}
+
 async function collectComponentViewTestCount() {
-  const destDir = await downloadArtifact('cv-test-stats');
-  const raw = await readFile(join(destDir, 'cv-test-stats.json'), 'utf8');
-  const data = JSON.parse(raw);
-  return data.component_view_test_number;
+  console.log('[component-view] collecting per-suite counts from shard artifacts...');
+  return collectShardCounts(/^coverage-cv-\d+$/, 'component-view');
 }
 
 async function collectUnitTestCount() {
-  const destDir = await downloadArtifact('unit-test-stats');
-  const raw = await readFile(join(destDir, 'unit-test-stats.json'), 'utf8');
-  const data = JSON.parse(raw);
-  return data.unit_test_number;
+  console.log('[unit] collecting per-suite counts from shard artifacts...');
+  return collectShardCounts(/^coverage-unit-\d+$/, 'unit');
+}
+
+/**
+ * Parses a JUnit artifact name into canonical E2E dimensions.
+ *
+ * Returns null for non-E2E artifacts.
+ *
+ * @param {string} artifactName
+ * @returns {{ channel: 'main'|'flask', suiteTag: string|null } | null}
+ */
+function getE2EArtifactDimensions(artifactName) {
+  const match = artifactName.match(/^test-e2e-(.+)-junit-results$/);
+  if (!match) return null;
+
+  let jobName = match[1];
+  // Strip the default 'main-' prefix applied by run-e2e-workflow.yml
+  if (jobName.startsWith('main-')) {
+    jobName = jobName.slice('main-'.length);
+  }
+
+  if (/^flask-(?:android|ios)-smoke-\d+$/.test(jobName)) {
+    return { channel: 'flask', suiteTag: null };
+  }
+
+  const mainMatch = jobName.match(/^(.+)-(?:android|ios)-smoke-\d+$/);
+  if (!mainMatch) return null;
+
+  return {
+    channel: 'main',
+    suiteTag: mainMatch[1].replace(/-/g, '_'),
+  };
+}
+
+function getNumericAttribute(tag, name) {
+  const match = tag.match(new RegExp(`${name}="(\\d+)"`));
+  return match ? Number(match[1]) : 0;
+}
+
+function countExecutedTestsFromJUnitXml(rawXml) {
+  const suiteTags = rawXml.match(/<testsuite\b[^>]*>/g) ?? [];
+  return suiteTags.reduce((total, suiteTag) => {
+    const tests = getNumericAttribute(suiteTag, 'tests');
+    const skipped = getNumericAttribute(suiteTag, 'skipped');
+    return total + Math.max(0, tests - skipped);
+  }, 0);
+}
+
+// Collects all E2E test counts from JUnit artifacts.
+async function collectE2ECounts() {
+  const artifacts = await getArtifactList();
+
+  let mainCount = 0;
+  let flaskCount = 0;
+  const suiteCounts = {};
+
+  const e2eArtifacts = artifacts.filter((a) => getE2EArtifactDimensions(a.name));
+  console.log(`[e2e] found ${e2eArtifacts.length} JUnit artifact(s)`);
+
+  if (e2eArtifacts.length === 0) {
+    console.log('[e2e] no JUnit artifacts found — E2E tests did not run, skipping e2e metrics');
+    return {};
+  }
+
+  for (const artifact of e2eArtifacts) {
+    const dimensions = getE2EArtifactDimensions(artifact.name);
+
+    const destDir = await downloadArtifact(artifact.name);
+    const junitXml = await readFile(join(destDir, 'junit.xml'), 'utf8');
+    const count = countExecutedTestsFromJUnitXml(junitXml);
+    console.log(`[e2e] ${artifact.name}: ${count} test(s)`);
+
+    if (dimensions.channel === 'main') {
+      mainCount += count;
+      suiteCounts[dimensions.suiteTag] = (suiteCounts[dimensions.suiteTag] ?? 0) + count;
+    } else if (dimensions.channel === 'flask') {
+      flaskCount += count;
+    }
+  }
+
+  const result = {
+    main_tests_count: mainCount,
+    flask_tests_count: flaskCount,
+    tests_count: mainCount + flaskCount,
+  };
+
+  for (const [tag, count] of Object.entries(suiteCounts)) {
+    result[`${tag}_tests_count`] = count;
+  }
+
+  return result;
+}
+
+/**
+ * Counts executed performance scenarios by scanning *.spec.js files
+ * under tests/performance/ and counting non-skipped test() calls.
+ *
+ * The top-level subdirectory (login, onboarding, mm-connect) determines the
+ * category for per-category metrics.
+ */
+async function collectPerformanceTestCounts() {
+  console.log('[performance] scanning tests/performance/ for scenarios...');
+
+  const categoryCounts = {};
+
+  async function scanDir(dir, category) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Top-level subdirectory determines the category
+        await scanDir(fullPath, category ?? entry.name);
+      } else if (entry.isFile() && entry.name.endsWith('.spec.js')) {
+        const source = await readFile(fullPath, 'utf8');
+        // Count test() calls, excluding test.skip()
+        const matches = source.match(/^\s*test\s*\(/gm) ?? [];
+        const count = matches.length;
+        if (count > 0 && category) {
+          const key = category.replace(/-/g, '_');
+          categoryCounts[key] = (categoryCounts[key] ?? 0) + count;
+        }
+      }
+    }
+  }
+
+  await scanDir('tests/performance', null);
+
+  const total = Object.values(categoryCounts).reduce((s, n) => s + n, 0);
+
+  const result = { tests_count: total };
+  for (const [cat, count] of Object.entries(categoryCounts)) {
+    result[`${cat}_tests_count`] = count;
+    console.log(`[performance] ${cat}: ${count}`);
+  }
+  console.log(`[performance] total: ${total}`);
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,22 +348,20 @@ async function main() {
   const stats = {};
 
   const collectors = [
-    {
-      key: 'component_view_tests_count',
-      collect: collectComponentViewTestCount,
-    },
-    {
-      key: 'unit_tests_count',
-      collect: collectUnitTestCount,
-    },
+    { namespace: 'component_view', collect: collectComponentViewTestCount },
+    { namespace: 'unit', collect: collectUnitTestCount },
+    { namespace: 'e2e', collect: collectE2ECounts },
+    { namespace: 'performance', collect: collectPerformanceTestCounts },
   ];
 
-  for (const { key, collect } of collectors) {
+  for (const { namespace, collect, scalar } of collectors) {
     try {
-      stats[key] = await collect();
+      const nested = await collect();
+      if (Object.keys(nested).length === 0) continue;
+      stats[namespace] = nested;
     } catch (err) {
-      // stat will not be present in the output file if the collector fails
-      console.error(`[${key}] collector failed, skipping stat:`, err.message);
+      // namespace will not be present in the output if the collector fails
+      console.error(`[${namespace}] collector failed, skipping:`, err.message);
     }
   }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
         shell: bash
         run: |
           mv ./tests/coverage/coverage-final.json ./tests/coverage/coverage-unit-${{ matrix.shard }}.json
+          cp tests/results/unit-test-results-${{ matrix.shard }}.json ./tests/coverage/jest-results.json
           count=$(jq '(.numPassedTests // 0) + (.numFailedTests // 0)' tests/results/unit-test-results-${{ matrix.shard }}.json)
           echo "{\"count\": $count}" > ./tests/coverage/count.json
       - uses: actions/upload-artifact@v4
@@ -388,6 +389,7 @@ jobs:
         shell: bash
         run: |
           mv ./tests/coverage/coverage-final.json ./tests/coverage/coverage-cv-${{ matrix.shard }}.json
+          cp tests/results/cv-test-results-${{ matrix.shard }}.json ./tests/coverage/jest-results.json
           count=$(jq '(.numPassedTests // 0) + (.numFailedTests // 0)' tests/results/cv-test-results-${{ matrix.shard }}.json)
           echo "{\"count\": $count}" > ./tests/coverage/count.json
       - uses: actions/upload-artifact@v4
@@ -585,7 +587,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: test-e2e-validate-e2e-fixtures-junit-results
+          name: test-e2e-main-validate-e2e-fixtures-junit-results
           path: fixture-results/
 
       - name: Report results

--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -165,6 +165,7 @@ jobs:
       total_splits: 3
       changed_files: ${{ inputs.changed_files }}
       build_type: 'flask'
+      artifact_name_prefix: ''
     secrets: inherit
 
   report-android-smoke-tests:
@@ -187,7 +188,7 @@ jobs:
         continue-on-error: true
         with:
           path: all-test-artifacts/
-          pattern: 'test-e2e-*-android-*'
+          pattern: 'test-e2e-flask-android-smoke-*'
 
       - name: Post Test Report
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -242,7 +242,7 @@ jobs:
         continue-on-error: true
         with:
           path: all-test-artifacts/
-          pattern: 'test-e2e-*-android-*'
+          pattern: 'test-e2e-main-*-android-*'
 
       - name: Post Test Report
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -141,6 +141,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'flask'
       metamask_environment: 'e2e'
+      artifact_name_prefix: ''
     secrets: inherit
 
   report-ios-smoke-tests:
@@ -163,7 +164,7 @@ jobs:
         continue-on-error: true
         with:
           path: all-test-artifacts/
-          pattern: 'test-e2e-*-ios-*'
+          pattern: 'test-e2e-flask-ios-smoke-*'
 
       - name: Post Test Report
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -266,7 +266,7 @@ jobs:
         continue-on-error: true
         with:
           path: all-test-artifacts/
-          pattern: 'test-e2e-*-ios-*'
+          pattern: 'test-e2e-main-*-ios-*'
 
       - name: Post Test Report
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: string
         default: ''
+      artifact_name_prefix:
+        description: 'Optional prefix added to uploaded test artifacts'
+        required: false
+        type: string
+        default: 'main-'
 
 jobs:
   test-e2e-mobile:
@@ -190,7 +195,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: test-e2e-${{ inputs.test-suite-name }}-junit-results
+          name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-junit-results
           path: ./previous-test-results/
 
       - name: Debug - List downloaded test results (on re-run)
@@ -265,11 +270,28 @@ jobs:
           # Clean up temporary node_modules
           rm -rf node_modules temp-deps
 
+      - name: Rebuild merged JUnit after previous-results merge (on re-run)
+        if: ${{ !cancelled() && github.run_attempt > 1 && steps.download-previous-results.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          echo "📊 Rebuilding merged junit.xml after previous-results merge..."
+
+          mkdir -p temp-deps && cd temp-deps
+          npm init -y > /dev/null 2>&1
+          npm install xml2js@0.6.2 --no-audit --no-fund --silent
+
+          cp -r node_modules ${{ github.workspace }}/
+          cd ${{ github.workspace }}
+
+          node .github/scripts/e2e-merge-detox-junit-reports.mjs
+
+          rm -rf node_modules temp-deps
+
       - name: Upload JUnit XML results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-e2e-${{ inputs.test-suite-name }}-junit-results
+          name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-junit-results
           path: tests/reports/
           retention-days: 7
 
@@ -277,6 +299,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-e2e-${{ inputs.test-suite-name }}-screenshots
+          name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-screenshots
           path: tests/artifacts/
           retention-days: 7

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -250,6 +250,7 @@ jobs:
       # Without this, tests that passed in attempt N but were skipped in attempt N+1 would have no
       # results in the artifact, causing them to be re-run in attempt N+2.
       - name: Merge previous test results (on re-run)
+        id: merge-previous-results
         if: ${{ !cancelled() && github.run_attempt > 1 && steps.download-previous-results.outcome == 'success' }}
         continue-on-error: true
         run: |
@@ -271,7 +272,7 @@ jobs:
           rm -rf node_modules temp-deps
 
       - name: Rebuild merged JUnit after previous-results merge (on re-run)
-        if: ${{ !cancelled() && github.run_attempt > 1 && steps.download-previous-results.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.merge-previous-results.outcome == 'success' }}
         continue-on-error: true
         run: |
           echo "📊 Rebuilding merged junit.xml after previous-results merge..."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Added new automated tests metrics to follow trends:
- qa metrics script extended
- artifact names changed

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

- revisit jobs and artefacts manually ✅
- check new metrics output  ✅

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple GitHub Actions workflows and artifact naming/patterns; misalignment could break test report downloads, rerun merging, or metrics generation even though it doesn’t affect production code.
> 
> **Overview**
> Updates QA stats collection to emit **namespaced** metrics (`component_view`, `unit`, `e2e`, `performance`) and to derive counts directly from CI artifacts: per-feature Jest counts from shard `coverage-*` artifacts, executed E2E counts parsed from JUnit XML (with main vs flask + platform health signals), and performance scenario counts by scanning `tests/performance` specs. Metrics are now omitted when artifacts/tests are missing rather than defaulting to zero.
> 
> Adjusts CI workflows to support this data: unit/CV shards now include `jest-results.json` inside `coverage-*` artifacts, and E2E workflows standardize artifact naming via a new `artifact_name_prefix` input (default `main-`, blank for flask), update download patterns accordingly, rename the fixture-validation artifact, and rebuild merged JUnit XML after re-run result merging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beebe269af3c873a1576ccf263db02fb7fc6863a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->