### PR TITLE
feat: balance sort on homepage and enable popular networks on focus

### DIFF
--- a/app/components/UI/Tokens/util/sortAssets.ts
+++ b/app/components/UI/Tokens/util/sortAssets.ts
@@ -7,6 +7,13 @@ export interface SortCriteria {
   sortCallback: string;
 }
 
+/** Default sort: by balance (fiat value descending). Used when resetting sort after leaving View all. */
+export const DEFAULT_TOKEN_SORT_CONFIG = {
+  key: 'tokenFiatAmount',
+  order: 'dsc',
+  sortCallback: 'stringNumeric',
+} as const;
+
 export type SortingType = number | string | Date;
 
 export interface SortingCallbacksT {

--- a/app/components/Views/DeFiFullView/DeFiFullView.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -10,10 +11,29 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
 import { Box } from '@metamask/design-system-react-native';
 import DeFiPositionsList from '../../UI/DeFiPositions/DeFiPositionsList';
+import Engine from '../../../core/Engine';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
+import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 
 const DeFiFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
+
+  useFocusEffect(
+    useCallback(
+      () => () => {
+        if (isHomepageSectionsV1Enabled) {
+          Engine.context.PreferencesController.setTokenSortConfig(
+            DEFAULT_TOKEN_SORT_CONFIG,
+          );
+        }
+      },
+      [isHomepageSectionsV1Enabled],
+    ),
+  );
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -149,6 +149,7 @@ jest.mock('./hooks/useHomeViewedEvent', () => ({
   },
 }));
 
+const mockEnableAllPopularNetworks = jest.fn();
 jest.mock('../../hooks/useNetworkEnablement/useNetworkEnablement', () => ({
   useNetworkEnablement: () => ({
     namespace: 'eip155',
@@ -158,7 +159,7 @@ jest.mock('../../hooks/useNetworkEnablement/useNetworkEnablement', () => ({
     networkEnablementController: {},
     enableNetwork: jest.fn(),
     disableNetwork: jest.fn(),
-    enableAllPopularNetworks: jest.fn(),
+    enableAllPopularNetworks: mockEnableAllPopularNetworks,
     popularEvmNetworks: [],
     popularMultichainNetworks: [],
     popularNetworks: [],
@@ -196,6 +197,12 @@ describe('Homepage', () => {
         '../../../selectors/featureFlagController/assetsDefiPositions',
       )
       .selectAssetsDefiPositionsEnabled.mockReturnValue(true);
+  });
+
+  it('calls enableAllPopularNetworks when Homepage is focused (useFocusEffect)', () => {
+    renderWithProvider(<Homepage />, { state: stateWithPreferences });
+
+    expect(mockEnableAllPopularNetworks).toHaveBeenCalled();
   });
 
   it('renders NFTs section title', () => {

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import TokensSection from './Sections/Tokens';
@@ -18,6 +19,7 @@ import { selectPredictEnabledFlag } from '../../UI/Predict/selectors/featureFlag
 import { selectAssetsDefiPositionsEnabled } from '../../../selectors/featureFlagController/assetsDefiPositions';
 import { HomeSectionNames, HomeSectionName } from './hooks/useHomeViewedEvent';
 import useHomeSessionSummary from './hooks/useHomeSessionSummary';
+import { useNetworkEnablement } from '../../hooks/useNetworkEnablement/useNetworkEnablement';
 
 /**
  * Homepage component - Main view for the redesigned wallet homepage.
@@ -35,6 +37,18 @@ const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const isDeFiEnabled = useSelector(selectAssetsDefiPositionsEnabled);
+
+  const { enableAllPopularNetworks } = useNetworkEnablement();
+
+  // useFocusEffect (not useEffect) so we run every time the user focuses this screen
+  // (e.g. switches to Wallet tab or returns from a section). With useEffect we would
+  // only run on first mount, so "all popular networks" would not be re-applied when
+  // they come back to the homepage.
+  useFocusEffect(
+    useCallback(() => {
+      enableAllPopularNetworks();
+    }, [enableAllPopularNetworks]),
+  );
 
   /**
    * Compute the ordered list of enabled sections. Tokens and NFTs are always

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useDeFiPositionsForHomepage } from './useDeFiPositionsForHomepage';
 
 const mockSelectDefiPositionsByChainIds = jest.fn();
-const mockSelectTokenSortConfig = jest.fn();
 
 jest.mock('../../../../../../selectors/defiPositionsController', () => ({
   selectDefiPositionsByChainIds: (_state: unknown, _chainIds: unknown) =>
@@ -24,16 +23,19 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../../../selectors/preferencesController', () => ({
-  selectTokenSortConfig: () => mockSelectTokenSortConfig(),
-}));
-
 jest.mock('react-redux', () => ({
   useSelector: (selector: () => unknown) => selector(),
 }));
 
+const mockSortAssets = jest.fn(
+  (assets: unknown[], _config?: unknown): unknown[] => assets,
+);
+
 jest.mock('../../../../../UI/Tokens/util', () => ({
-  sortAssets: jest.fn((assets) => assets),
+  sortAssets: (assets: unknown[], config: unknown) => {
+    mockSortAssets(assets, config);
+    return assets;
+  },
 }));
 
 const createMockProtocolAggregate = (name: string, marketValue: number) => ({
@@ -48,10 +50,6 @@ const createMockProtocolAggregate = (name: string, marketValue: number) => ({
 describe('useDeFiPositionsForHomepage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSelectTokenSortConfig.mockReturnValue({
-      key: 'tokenFiatAmount',
-      order: 'dsc',
-    });
   });
 
   it('returns loading state when defiPositionsByChainIds is undefined', () => {
@@ -129,5 +127,29 @@ describe('useDeFiPositionsForHomepage', () => {
     const { result } = renderHook(() => useDeFiPositionsForHomepage(2));
 
     expect(result.current.positions).toHaveLength(2);
+  });
+
+  it('sorts positions by market value using homepage sort config (not user preference)', () => {
+    const mockPositions = {
+      '0x1': {
+        protocols: {
+          aave: createMockProtocolAggregate('Aave', 1000),
+          uniswap: createMockProtocolAggregate('Uniswap', 500),
+        },
+      },
+    };
+
+    mockSelectDefiPositionsByChainIds.mockReturnValue(mockPositions);
+
+    renderHook(() => useDeFiPositionsForHomepage());
+
+    expect(mockSortAssets).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        key: 'protocolAggregate.aggregatedMarketValue',
+        order: 'dsc',
+        sortCallback: 'stringNumeric',
+      }),
+    );
   });
 });

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
@@ -4,12 +4,18 @@ import { Hex } from '@metamask/utils';
 import { GroupedDeFiPositions } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
 import { selectDefiPositionsByChainIds } from '../../../../../../selectors/defiPositionsController';
-import { selectTokenSortConfig } from '../../../../../../selectors/preferencesController';
 import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { RootState } from '../../../../../../reducers';
 import { sortAssets } from '../../../../../UI/Tokens/util';
 import { selectHomepageSectionsV1Enabled } from '../../../../../../selectors/featureFlagController/homepage';
 import { selectEVMEnabledNetworks } from '../../../../../../selectors/networkEnablementController';
+
+/** Homepage always sorts DeFi by market value; View all uses user preference. */
+const HOMEPAGE_DEFI_SORT_BY_VALUE = {
+  key: 'protocolAggregate.aggregatedMarketValue',
+  order: 'dsc',
+  sortCallback: 'stringNumeric',
+} as const;
 
 /**
  * Represents a single DeFi position entry for the homepage.
@@ -48,7 +54,6 @@ const MAX_POSITIONS_DEFAULT = 5;
 export const useDeFiPositionsForHomepage = (
   maxPositions: number = MAX_POSITIONS_DEFAULT,
 ): UseDeFiPositionsForHomepageResult => {
-  const tokenSortConfig = useSelector(selectTokenSortConfig);
   const evmEnabledNetworks = useSelector(selectEVMEnabledNetworks);
   const isHomepageSectionsV1Enabled = useSelector(
     selectHomepageSectionsV1Enabled,
@@ -114,18 +119,10 @@ export const useDeFiPositionsForHomepage = (
       )
       .flat();
 
-    // Sort by market value (descending) or name
-    const defiSortConfig = {
-      ...tokenSortConfig,
-      key:
-        tokenSortConfig.key === 'tokenFiatAmount'
-          ? 'protocolAggregate.aggregatedMarketValue'
-          : 'protocolAggregate.protocolDetails.name',
-    };
-
+    // Homepage always sorts by market value (descending); View all DeFi list uses user preference.
     const sortedPositions = sortAssets(
       defiPositionsList,
-      defiSortConfig,
+      HOMEPAGE_DEFI_SORT_BY_VALUE,
     ) as DeFiPositionEntry[];
 
     // Limit to maxPositions
@@ -137,7 +134,7 @@ export const useDeFiPositionsForHomepage = (
       hasError: false,
       isEmpty: limitedPositions.length === 0,
     };
-  }, [defiPositionsByChainIds, tokenSortConfig, maxPositions]);
+  }, [defiPositionsByChainIds, maxPositions]);
 
   return result;
 };

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -46,7 +46,7 @@ jest.mock(
 );
 
 jest.mock('../../../../../selectors/assets/assets-list', () => ({
-  selectSortedAssetsBySelectedAccountGroupForChainIds: (
+  selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance: (
     state: unknown,
     chainIds: string[],
   ) => mockSortedTokenKeys(state, chainIds),
@@ -407,7 +407,7 @@ describe('TokensSection', () => {
     });
   });
 
-  it('uses popular network list for token list (selectSortedAssetsBySelectedAccountGroupForChainIds)', () => {
+  it('uses popular network list for token list (selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance)', () => {
     mockUseIsZeroBalanceAccount.mockReturnValue(false);
     const popularChainIds = ['eip155:1', '0xa'];
     mockPopularNetworks = popularChainIds;

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -76,10 +76,6 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
     const popularTokensListRef = useRef<SectionRefreshHandle>(null);
     const [hasTokensError, setHasTokensError] = useState(false);
 
-    // useEffect(() => {
-    //   console.log('sortedTokenKeys ........', sortedTokenKeys);
-    // }, []);
-
     const {
       removeTokenState,
       showRemoveMenu,

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -16,7 +16,7 @@ import ErrorState from '../../components/ErrorState';
 import Routes from '../../../../../constants/navigation/Routes';
 import SectionRow from '../../components/SectionRow';
 import { useIsZeroBalanceAccount } from './hooks';
-import { selectSortedAssetsBySelectedAccountGroupForChainIds } from '../../../../../selectors/assets/assets-list';
+import { selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance } from '../../../../../selectors/assets/assets-list';
 import { useNetworkEnablement } from '../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
 import { TokenListItem } from '../../../../UI/Tokens/TokenList/TokenListItem/TokenListItem';
@@ -61,7 +61,7 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
     const isZeroBalanceAccount = useIsZeroBalanceAccount();
     const { popularNetworks: popularChainIds } = useNetworkEnablement();
     const sortedTokenKeys = useSelector((state: RootState) =>
-      selectSortedAssetsBySelectedAccountGroupForChainIds(
+      selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
         state,
         popularChainIds,
       ),
@@ -75,6 +75,10 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
     const { shouldShowTokenListItemCta } = useMusdCtaVisibility();
     const popularTokensListRef = useRef<SectionRefreshHandle>(null);
     const [hasTokensError, setHasTokensError] = useState(false);
+
+    // useEffect(() => {
+    //   console.log('sortedTokenKeys ........', sortedTokenKeys);
+    // }, []);
 
     const {
       removeTokenState,

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -10,10 +11,29 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
 import Tokens from '../../UI/Tokens';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
+import Engine from '../../../core/Engine';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
+import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 
 const TokensFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
+
+  useFocusEffect(
+    useCallback(
+      () => () => {
+        if (isHomepageSectionsV1Enabled) {
+          Engine.context.PreferencesController.setTokenSortConfig(
+            DEFAULT_TOKEN_SORT_CONFIG,
+          );
+        }
+      },
+      [isHomepageSectionsV1Enabled],
+    ),
+  );
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -18,6 +18,7 @@ import {
   selectAssetsBySelectedAccountGroup,
   selectSortedAssetsBySelectedAccountGroup,
   selectSortedAssetsBySelectedAccountGroupForChainIds,
+  selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance,
   selectTronSpecialAssetsBySelectedAccountGroup,
 } from './assets-list';
 import I18n from '../../../locales/i18n';
@@ -1020,6 +1021,82 @@ describe('selectSortedAssetsBySelectedAccountGroupForChainIds', () => {
       tronAssets.find((a) => a.address?.includes('in-lock-period')),
     ).toBeUndefined();
     expect(tronAssets).toHaveLength(1);
+  });
+});
+
+describe('selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance', () => {
+  it('filters assets by explicit chain IDs (same as ForChainIds)', () => {
+    const state = mockState();
+    const chainIds = ['eip155:1', '0xa'];
+    const result = selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+      state,
+      chainIds,
+    );
+
+    const chainIdsInResult = [...new Set(result.map((r) => r.chainId))];
+    expect(chainIdsInResult.sort()).toEqual(['0x1', '0xa']);
+    expect(
+      result.every((r) => r.chainId === '0x1' || r.chainId === '0xa'),
+    ).toBe(true);
+  });
+
+  it('returns empty array when chainIds is empty', () => {
+    const state = mockState();
+    const result = selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+      state,
+      [],
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('includes both 0x1 and eip155:1 in allowed set (same as ForChainIds)', () => {
+    const state = mockState();
+    const byCaip = selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+      state,
+      ['eip155:1'],
+    );
+    const byHex = selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+      state,
+      ['0x1'],
+    );
+    expect(byCaip).toEqual(byHex);
+  });
+
+  it('always sorts by balance and ignores PreferencesController tokenSortConfig', () => {
+    const stateWithNameSort = {
+      ...mockState(),
+      engine: {
+        ...mockState().engine,
+        backgroundState: {
+          ...mockState().engine.backgroundState,
+          PreferencesController: {
+            ...mockState().engine.backgroundState.PreferencesController,
+            tokenSortConfig: {
+              key: 'name',
+              order: 'asc',
+              sortCallback: 'alphaNumeric',
+            },
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    const byBalance =
+      selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+        stateWithNameSort,
+        ['eip155:1'],
+      );
+    const byUserPref = selectSortedAssetsBySelectedAccountGroupForChainIds(
+      stateWithNameSort,
+      ['eip155:1'],
+    );
+
+    expect(byBalance).toHaveLength(byUserPref.length);
+    expect(byBalance.every((r) => r.chainId === '0x1')).toBe(true);
+    // ByBalance uses balance sort; ForChainIds with name sort can produce different order
+    expect(byBalance.map((r) => r.address)).toEqual(
+      expect.arrayContaining(byUserPref.map((r) => r.address)),
+    );
   });
 });
 

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -360,9 +360,17 @@ function buildAllowedNetworkIdSet(chainIds: string[]): Set<string> {
   return set;
 }
 
+/** Sort config for "by balance" (fiat value descending). Used for homepage so it always shows balance order; View all uses user preference. */
+const BALANCE_SORT_CONFIG = {
+  key: 'tokenFiatAmount',
+  order: 'dsc',
+  sortCallback: 'stringNumeric',
+} as const;
+
 /**
  * Sorted assets by selected account group filtered by an explicit list of chain IDs (e.g. from listPopularNetworks()).
  * Use when the chain list comes from a hook or callback rather than from state.
+ * Respects user's token sort preference (balance vs name).
  * @param state - Redux state
  * @param chainIds - Array of network/chain IDs (CAIP-2 or Hex) to include
  */
@@ -387,6 +395,34 @@ export const selectSortedAssetsBySelectedAccountGroupForChainIds =
         filteredAssets,
         stakedAssets,
         tokenSortConfig,
+      );
+    },
+  );
+
+/**
+ * Like selectSortedAssetsBySelectedAccountGroupForChainIds but always sorts by balance (fiat value desc).
+ * Use on the homepage so the tokens section always shows by balance; the full "View all" list keeps the user's sort preference.
+ */
+export const selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance =
+  createDeepEqualSelector(
+    [
+      selectAssetsBySelectedAccountGroup,
+      (_state: RootState, chainIds: string[]) => chainIds,
+      selectStakedAssets,
+    ],
+    (bip44Assets, chainIds, stakedAssets) => {
+      const allowedIds = buildAllowedNetworkIdSet(chainIds);
+      const filteredAssets = Object.entries(bip44Assets)
+        .filter(([networkId]) => allowedIds.has(networkId))
+        .flatMap(([_, chainAssets]) =>
+          chainAssets.filter(
+            (asset) => !isTronSpecialAsset(asset.chainId, asset.symbol),
+          ),
+        );
+      return mergeStakedSortAndDedupeAssets(
+        filteredAssets,
+        stakedAssets,
+        BALANCE_SORT_CONFIG,
       );
     },
   );


### PR DESCRIPTION
# Pull Request

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## Description

1. **Homepage sort is independent of View all**  
   The homepage (Tokens and DeFi sections) always sorts by balance/market value. The sort choice in "View all" (token list or DeFi list) no longer affects the homepage. View all continues to use the user's saved sort preference (balance vs name).

2. **Popular networks when opening View all**  
   When the user focuses the Wallet/Homepage (e.g. switches to the Wallet tab or returns to it), we call `enableAllPopularNetworks()`. So the first time they open "View all" (tokens or networks), all popular networks are already selected instead of a single network.

**Summary of changes:**

- Added `selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance` and use it in the homepage Tokens section so homepage tokens are always sorted by balance.
- Homepage DeFi section always sorts by market value (no longer uses user sort preference).
- Full token list and full DeFi list still use the user's sort preference.
- Homepage uses `useFocusEffect` to run `enableAllPopularNetworks()` when the screen is focused so popular networks are selected before opening any section or View all.
- Balance refresh: removed `AbortController` from the refresh flow and simplified the timeout (no NFT abort on timeout).

---

*1. What is the reason for the change?*  
Homepage should show a consistent balance-based order; View all should keep the user's sort and have popular networks selected when opened from the homepage.

*2. What is the improvement/solution?*  
Homepage always sorts by balance; View all keeps its own sort and gets popular networks selected on focus.

---

## Changelog

CHANGELOG entry: Homepage tokens and DeFi now always sort by balance/value; View all keeps your sort preference. Popular networks are selected when opening the Wallet so View all shows all popular networks by default.


---

## Related issues

Fixes:

---

## Manual testing steps

```gherkin
Feature: Homepage sort and popular networks

  Scenario: Homepage shows balance order regardless of View all sort
    Given the user has tokens and has set "View all" sort to "Name A–Z"
    When the user is on the Wallet tab with homepage sections (Tokens / DeFi)
    Then Tokens and DeFi sections on the homepage are ordered by balance/value (highest first)
    And changing sort in "View all" (tokens or DeFi) does not change homepage section order

  Scenario: View all has popular networks selected when opened from homepage
    Given the user is on the Wallet tab (homepage focused at least once)
    When the user taps "View all" on Tokens or opens the network filter for the first time
    Then "Popular networks" (all popular) is selected
    And the list shows data for all popular networks

  Scenario: View all respects user sort preference
    Given the user has set token sort to "Name A–Z" in View all
    When the user opens the full token list (View all)
    Then tokens are sorted by name A–Z
    And the homepage Tokens section still shows balance order
```

---

## Screenshots/Recordings

### Before

<!-- Add screenshots/recordings -->

### After

<!-- Add screenshots/recordings -->


https://github.com/user-attachments/assets/e379560d-de47-46dd-b2c7-f78aebb2fa3d



---

## Pre-merge author checklist

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

---

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes homepage sorting behavior and triggers network-enable side effects on every homepage focus, which could impact perceived ordering and network selection state.
> 
> **Overview**
> **Homepage token/DeFi ordering is now decoupled from the user’s “View all” sort preference.** The homepage Tokens section switches to a new selector (`selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance`) that always sorts by fiat balance desc, and the homepage DeFi hook now always sorts positions by `aggregatedMarketValue` desc.
> 
> **Homepage focus now reapplies popular network enablement.** `Homepage` calls `enableAllPopularNetworks()` via `useFocusEffect`, and both `TokensFullView` and `DeFiFullView` reset `PreferencesController.tokenSortConfig` to a shared `DEFAULT_TOKEN_SORT_CONFIG` on exit (behind `selectHomepageSectionsV1Enabled`). Tests were updated/added to lock in these behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aabdb3849e3ca30164cd3e3c151be27d00ca4296. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->