### PR TITLE
chore: Polish MainActionButton to match designs

### DIFF
--- a/app/component-library/components-temp/MainActionButton/MainActionButton.styles.ts
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.styles.ts
@@ -34,7 +34,7 @@ const styleSheet = (params: {
         backgroundColor,
         borderRadius: 12,
         paddingHorizontal: 4,
-        paddingVertical: 16,
+        paddingVertical: 12,
         justifyContent: 'center',
         alignItems: 'center',
         opacity: isDisabled ? 0.5 : 1,

--- a/app/component-library/components-temp/MainActionButton/__snapshots__/MainActionButton.test.tsx.snap
+++ b/app/component-library/components-temp/MainActionButton/__snapshots__/MainActionButton.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`MainActionButton should render correctly 1`] = `
           "justifyContent": "center",
           "opacity": 1,
           "paddingHorizontal": 4,
-          "paddingVertical": 16,
+          "paddingVertical": 12,
         },
         false,
       ]

--- a/app/components/Views/AccountsMenu/__snapshots__/AccountsMenu.test.tsx.snap
+++ b/app/components/Views/AccountsMenu/__snapshots__/AccountsMenu.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`AccountsMenu Snapshots match snapshot when MetaMask Card is hidden 1`] 
                     "justifyContent": "center",
                     "opacity": 1,
                     "paddingHorizontal": 4,
-                    "paddingVertical": 16,
+                    "paddingVertical": 12,
                   },
                   false,
                 ]
@@ -1578,7 +1578,7 @@ exports[`AccountsMenu Snapshots match snapshot when MetaMask Card is visible 1`]
                     "justifyContent": "center",
                     "opacity": 1,
                     "paddingHorizontal": 4,
-                    "paddingVertical": 16,
+                    "paddingVertical": 12,
                   },
                   false,
                 ]

--- a/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
               "justifyContent": "center",
               "opacity": 1,
               "paddingHorizontal": 4,
-              "paddingVertical": 16,
+              "paddingVertical": 12,
             },
             false,
           ]
@@ -183,7 +183,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
               "justifyContent": "center",
               "opacity": 0.5,
               "paddingHorizontal": 4,
-              "paddingVertical": 16,
+              "paddingVertical": 12,
             },
             false,
           ]
@@ -296,7 +296,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
               "justifyContent": "center",
               "opacity": 0.5,
               "paddingHorizontal": 4,
-              "paddingVertical": 16,
+              "paddingVertical": 12,
             },
             false,
           ]
@@ -409,7 +409,7 @@ exports[`AssetDetailsActions should render correctly 1`] = `
               "justifyContent": "center",
               "opacity": 1,
               "paddingHorizontal": 4,
-              "paddingVertical": 16,
+              "paddingVertical": 12,
             },
             false,
           ]


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refines the main action buttons to match the design specs. Update the vertical padding from `16px` > `12px`  to improve the spacing.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

<img width="1442" height="562" alt="Screenshot 2026-03-11 at 7 43 58 PM" src="https://github.com/user-attachments/assets/9adf2473-7c9d-4d2d-acca-b65df3284398" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only spacing change that updates styles and corresponding Jest snapshots without altering behavior or data flow.
> 
> **Overview**
> Polishes `MainActionButton` spacing by reducing `paddingVertical` from `16` to `12` in `MainActionButton.styles.ts` to better match design specs.
> 
> Updates Jest snapshots for `MainActionButton` and screens that render it (e.g., `AccountsMenu` scan button and `AssetDetailsActions` buttons) to reflect the new padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0950cef5c3fa368da62bdf496dbb4e7eda30970b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->