### PR TITLE
refactor: remove remaining occurrences of BIP44 flag

### DIFF
--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
@@ -90,12 +90,6 @@ jest.mock('../../../util/hideKeyFromUrl', () =>
   jest.fn((url: string) => url.replace(/\/[a-zA-Z0-9]{32,}$/, '')),
 );
 
-jest.mock('../../../multichain-accounts/remote-feature-flag', () => ({
-  isMultichainAccountsRemoteFeatureEnabled: jest.fn(),
-  MULTI_CHAIN_ACCOUNTS_FEATURE_VERSION_1: 'v1',
-  MULTI_CHAIN_ACCOUNTS_FEATURE_VERSION_2: 'v2',
-}));
-
 jest.mock('@metamask/utils', () => ({
   KnownCaipNamespace: { Eip155: 'eip155' },
   parseCaipChainId: jest.fn(),

--- a/app/components/hooks/useCurrentNetworkInfo.test.ts
+++ b/app/components/hooks/useCurrentNetworkInfo.test.ts
@@ -34,7 +34,6 @@ describe('useCurrentNetworkInfo', () => {
           },
         };
       }
-      // Second call: selectMultichainAccountsState2Enabled
       return false;
     });
   });

--- a/app/components/hooks/useNetworkEnablement/useNetworkEnablement.test.ts
+++ b/app/components/hooks/useNetworkEnablement/useNetworkEnablement.test.ts
@@ -72,7 +72,6 @@ import {
   selectChainId,
   selectNetworkConfigurations,
 } from '../../../selectors/networkController';
-import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts';
 
 const mockNetworkEnablementController = {
   enableNetwork: jest.fn(),
@@ -115,9 +114,6 @@ describe('useNetworkEnablement', () => {
       }
       if (selector === selectNetworkConfigurations) {
         return {};
-      }
-      if (selector === selectMultichainAccountsState2Enabled) {
-        return false;
       }
       return undefined;
     });
@@ -208,7 +204,6 @@ describe('useNetworkEnablement', () => {
     it('returns false when no networks are enabled', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectNetworkConfigurations) return {};
-        if (selector === selectMultichainAccountsState2Enabled) return false;
         const selectorStr = selector?.toString() ?? '';
         if (selectorStr.includes('selectEnabledNetworksByNamespace')) {
           return {
@@ -235,7 +230,6 @@ describe('useNetworkEnablement', () => {
     it('returns false when multiple networks are enabled', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectNetworkConfigurations) return {};
-        if (selector === selectMultichainAccountsState2Enabled) return false;
         const selectorStr = selector?.toString() ?? '';
         if (selectorStr.includes('selectEnabledNetworksByNamespace')) {
           return {
@@ -263,7 +257,6 @@ describe('useNetworkEnablement', () => {
     it('returns false when enabled networks object is empty', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectNetworkConfigurations) return {};
-        if (selector === selectMultichainAccountsState2Enabled) return false;
         const selectorStr = selector?.toString() ?? '';
         if (selectorStr.includes('selectEnabledNetworksByNamespace')) {
           return {

--- a/app/multichain-accounts/remote-feature-flag.ts
+++ b/app/multichain-accounts/remote-feature-flag.ts
@@ -107,22 +107,6 @@ function getRemoteFeatureFlags(): FeatureFlags {
 }
 
 /**
- * Checks if multichain accounts state 1 is enabled.
- * Returns true if the feature is enabled for state 1 or state 2.
- */
-export const isMultichainAccountsState1Enabled = () =>
-  isMultichainAccountsRemoteFeatureEnabled(getRemoteFeatureFlags(), [
-    {
-      version: MULTICHAIN_ACCOUNTS_FEATURE_VERSION_1,
-      featureKey: STATE_1_FLAG,
-    },
-    {
-      version: MULTICHAIN_ACCOUNTS_FEATURE_VERSION_2,
-      featureKey: STATE_2_FLAG,
-    },
-  ]);
-
-/**
  * Checks if multichain accounts state 2 is enabled.
  * @returns Boolean indicating if multichain accounts state 2 is enabled.
  */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Remove remaining occurrences of the BIP-44 flag and `isMultichainAccountsState1Enabled`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: null

## **Manual testing steps**

Not applicable

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor removing dead feature-flag code and related test scaffolding; minimal runtime impact limited to callers that might have relied on the deleted export.
> 
> **Overview**
> Removes the deprecated multichain accounts *state 1* flag path by deleting `isMultichainAccountsState1Enabled` and stopping any implicit “state1-or-state2” enablement checks.
> 
> Updates unit tests to drop mocks/selectors related to the removed flag (`remote-feature-flag` mocking and `selectMultichainAccountsState2Enabled` wiring), keeping tests focused on the remaining state-2-only behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9770d794e5715b7171004598e6231f16a55d854e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->