### PR TITLE
test: adds diagnosis for when Detox's internal port is already in use

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -461,11 +461,62 @@ export default class TestHelpers {
   }
 
   static async removeAndroidReversePort(port) {
-    const command = `adb ${this.getAdbDeviceFlag()} reverse --remove tcp:${port}`;
-    await execAsync(command);
-    logger.warn(
-      `[launch recovery] Removed conflicting adb reverse tcp:${port}. Retrying app launch once.`,
-    );
+    try {
+      const command = `adb ${this.getAdbDeviceFlag()} reverse --remove tcp:${port}`;
+      await execAsync(command);
+      logger.warn(
+        `[launch recovery] Removed conflicting adb reverse tcp:${port}. Retrying app launch once.`,
+      );
+    } catch (removeError) {
+      const msg =
+        removeError instanceof Error
+          ? removeError.message
+          : String(removeError);
+      if (msg.includes('not found')) {
+        logger.warn(
+          `[launch recovery] Port tcp:${port} not in adb reverse table (likely TIME_WAIT or OS-level bind). Will still retry.`,
+        );
+      } else {
+        logger.error(
+          `[launch recovery] Unexpected error removing tcp:${port}: ${msg}`,
+        );
+      }
+    }
+  }
+
+  static async diagnoseEmulatorPort(port) {
+    const deviceFlag = this.getAdbDeviceFlag();
+    try {
+      // Dump socket state inside the emulator to identify what holds the port
+      const hexPort = parseInt(port, 10)
+        .toString(16)
+        .toUpperCase()
+        .padStart(4, '0');
+      const { stdout: tcpState } = await execAsync(
+        `adb ${deviceFlag} shell cat /proc/net/tcp6 2>/dev/null || adb ${deviceFlag} shell cat /proc/net/tcp 2>/dev/null`,
+      );
+      // Filter for the specific port (column 2 = local_address, port is after the colon in hex)
+      const relevantLines = tcpState
+        .split('\n')
+        .filter((line) => line.includes(`:${hexPort}`));
+      if (relevantLines.length > 0) {
+        logger.warn(
+          `[launch diagnostics] Emulator socket state for port ${port} (hex ${hexPort}):\n${relevantLines.join('\n')}`,
+        );
+        // TCP states: 01=ESTABLISHED, 02=SYN_SENT, 06=TIME_WAIT, 0A=LISTEN
+        logger.warn(
+          `[launch diagnostics] TCP state reference: 01=ESTABLISHED, 06=TIME_WAIT, 0A=LISTEN`,
+        );
+      } else {
+        logger.warn(
+          `[launch diagnostics] No socket entries found for port ${port} inside emulator`,
+        );
+      }
+    } catch (diagError) {
+      logger.debug(
+        `[launch diagnostics] Could not read emulator socket state: ${diagError.message}`,
+      );
+    }
   }
 
   static async launchAppWithRecovery(launchOptions) {
@@ -489,6 +540,7 @@ export default class TestHelpers {
       await this.logAndroidReversePorts(
         'launch failure before reverse cleanup',
       );
+      await this.diagnoseEmulatorPort(conflictingPort);
       await this.removeAndroidReversePort(conflictingPort);
       await this.logAndroidReversePorts('after reverse cleanup before retry');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Fixes unhandled crash in `launchAppWithRecovery` when `adb reverse --remove` fails with "listener not found"
- Adds diagnostic instrumentation to identify the root cause of intermittent port collisions on CI

### Problem

On CI, `device.launchApp()` occasionally fails when Detox tries to set up its internal adb reverse:

```
adb -s emulator-16526 reverse tcp:37351 tcp:37351
adb: error: cannot bind listener: Address already in use
```

The recovery code then attempts `adb reverse --remove tcp:37351`, which also fails ("listener not found") — and this **unhandled error crashes the test**.

The port is occupied at the OS socket level inside the emulator but is NOT tracked in adb's reverse table. This happens on a fresh emulator (`-wipe-data`), first test in the shard, single worker — ruling out stale state from previous tests or parallel interference.

**Leading hypothesis:** TIME_WAIT from Detox's own device initialization. During the ~83s boot phase, Detox may set up and tear down an initial adb reverse for its server port. The adb entry is removed, but the socket inside the Android VM enters TIME_WAIT (~60s). When `device.launchApp()` tries to re-bind the same port, `bind()` fails.

### Changes

1. **`removeAndroidReversePort`** — wraps `adb reverse --remove` in try-catch so "not found" errors no longer crash the test, allowing the retry to proceed

2. **`diagnoseEmulatorPort`** (new) — on port collision, reads `/proc/net/tcp6` inside the emulator and logs the socket state (`06`=TIME_WAIT, `0A`=LISTEN, `01`=ESTABLISHED). The next CI failure will confirm what's holding the port.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk; changes are confined to Detox test helpers and add logging/defensive error handling around `adb reverse --remove`, which could slightly mask unexpected failures but only impacts test runs.
> 
> **Overview**
> Improves Detox Android app-launch recovery when `adb reverse` fails due to an “Address already in use” collision.
> 
> `removeAndroidReversePort` now catches `adb reverse --remove` failures (including “listener not found”) so tests still proceed to the single retry, and a new `diagnoseEmulatorPort` hook logs the emulator’s `/proc/net/tcp{,6}` socket state for the conflicting port to help root-cause intermittent CI port binds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd2ca96010f381f61ed26b32dce5a824707e9a74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->