### PR TITLE
fix: resolve iOS bundle executable case mismatch and missing permissions in E2E CI

### DIFF
--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -155,21 +155,26 @@ jobs:
       - name: Restore iOS app matching fingerprint from branch cache
         id: cache-restore
         # This action automatically updates the cache at the end of the workflow
+        # IOS_APP_CACHE_VERSION: bump this to bust the ios-app cache and force a full rebuild
         uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        env:
+          IOS_APP_CACHE_VERSION: 2
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
-          key: ios-app-${{ github.ref_name }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
+          key: ios-app-${{ github.ref_name }}-v${{ env.IOS_APP_CACHE_VERSION }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
 
       - name: Restore iOS app matching fingerprint from main cache
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main' }}
         id: cache-restore-main
         # This will only restore the cache, not update it
         uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        env:
+          IOS_APP_CACHE_VERSION: 2
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
-          key: ios-app-main-${{ steps.generate-fingerprint.outputs.fingerprint }}
+          key: ios-app-main-v${{ env.IOS_APP_CACHE_VERSION }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
 
       # Build the iOS E2E app for simulator
       - name: Build iOS E2E App

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -251,6 +251,28 @@ jobs:
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
+      # Verify app bundle contents before upload (diagnose missing executable)
+      - name: Verify iOS App Bundle Before Upload
+        run: |
+          APP_PATH="ios/build/Build/Products/Release-iphonesimulator/MetaMask.app"
+          echo "=== Top-level contents of MetaMask.app ==="
+          ls -la "$APP_PATH/" || echo "ERROR: MetaMask.app directory not found"
+          echo ""
+          echo "=== Binary check ==="
+          if [ -f "$APP_PATH/MetaMask" ]; then
+            echo "✅ Binary exists: $(ls -lh "$APP_PATH/MetaMask")"
+            echo "   Type: $(file "$APP_PATH/MetaMask")"
+          elif [ -L "$APP_PATH/MetaMask" ]; then
+            echo "⚠️  Binary is a symlink: $(ls -la "$APP_PATH/MetaMask")"
+            echo "   Points to: $(readlink "$APP_PATH/MetaMask")"
+          else
+            echo "❌ Binary is MISSING from MetaMask.app"
+          fi
+          echo ""
+          echo "=== CFBundleExecutable in Info.plist ==="
+          /usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null || echo "Could not read CFBundleExecutable"
+        shell: bash
+
       # Upload the iOS .app file that works in simulators
       - name: Upload iOS APP Artifact (Simulator)
         id: upload-app

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -31,6 +31,9 @@ jobs:
       app-uploaded: ${{ steps.upload-app.outcome == 'success' }}
       sourcemap-uploaded: ${{ steps.upload-sourcemap.outcome == 'success' }}
     env:
+      # Bump these to bust the respective caches and force a full rebuild
+      XCODE_CACHE_VERSION: 1
+      IOS_APP_CACHE_VERSION: 2
       RCT_NO_LAUNCH_PACKAGER: 1
       XCODE_BUILD_SETTINGS: 'COMPILER_INDEX_STORE_ENABLE=NO'
       GITHUB_CI: 'true' # This ensures it's available during pod install
@@ -76,8 +79,6 @@ jobs:
         id: xcode-restore-cache
         # This action automatically updates the cache at the end of the workflow
         uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
-        env:
-          XCODE_CACHE_VERSION: 1
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
@@ -89,8 +90,6 @@ jobs:
         id: xcode-restore-cache-main
         # This will only restore the cache, not update it
         uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
-        env:
-          XCODE_CACHE_VERSION: 1
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
@@ -155,10 +154,7 @@ jobs:
       - name: Restore iOS app matching fingerprint from branch cache
         id: cache-restore
         # This action automatically updates the cache at the end of the workflow
-        # IOS_APP_CACHE_VERSION: bump this to bust the ios-app cache and force a full rebuild
         uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
-        env:
-          IOS_APP_CACHE_VERSION: 2
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -169,8 +165,6 @@ jobs:
         id: cache-restore-main
         # This will only restore the cache, not update it
         uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
-        env:
-          IOS_APP_CACHE_VERSION: 2
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -251,42 +251,31 @@ jobs:
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
-      # Fix iOS bundle executable: ensure correct case and execute permissions before upload.
-      # actions/upload-artifact strips execute permissions, so we must chmod +x before zipping.
-      # Xcode on case-insensitive APFS sometimes stores the binary with wrong case (e.g. "metamask"
-      # instead of "MetaMask"), which causes xcrun simctl install to fail on the test runner because
-      # it does a case-sensitive directory enumeration when looking for CFBundleExecutable.
+      # Xcode on case-insensitive APFS can store the bundle executable with wrong case (e.g. "metamask"
+      # vs CFBundleExecutable "MetaMask"), causing xcrun simctl install to fail with a case-sensitive
+      # directory lookup on the test runner. actions/upload-artifact also strips execute permissions.
       - name: Fix iOS bundle executable case and permissions before upload
         run: |
           APP_PATH="ios/build/Build/Products/Release-iphonesimulator/MetaMask.app"
           BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
           if [ -z "$BUNDLE_EXEC" ]; then
-            echo "❌ Could not read CFBundleExecutable from Info.plist"
+            echo "Could not read CFBundleExecutable from Info.plist"
             exit 1
           fi
-          echo "CFBundleExecutable: $BUNDLE_EXEC"
 
-          # Find the binary case-insensitively (Xcode may produce lowercase name on case-insensitive APFS)
           ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
           if [ -z "$ACTUAL_PATH" ]; then
-            echo "❌ Bundle executable not found (even case-insensitively): $BUNDLE_EXEC"
-            ls -la "$APP_PATH/"
+            echo "Bundle executable not found: $BUNDLE_EXEC"
             exit 1
           fi
-          ACTUAL_NAME=$(basename "$ACTUAL_PATH")
-          echo "Found on disk: $ACTUAL_NAME"
 
-          # Fix case mismatch with a two-step rename (direct rename fails on case-insensitive APFS)
-          if [ "$ACTUAL_NAME" != "$BUNDLE_EXEC" ]; then
-            echo "⚠️  Case mismatch detected — renaming $ACTUAL_NAME → $BUNDLE_EXEC"
+          # Two-step rename to fix case on case-insensitive APFS (direct rename is a no-op)
+          if [ "$(basename "$ACTUAL_PATH")" != "$BUNDLE_EXEC" ]; then
             mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
             mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
-            echo "✅ Renamed: $ACTUAL_NAME → $BUNDLE_EXEC"
           fi
 
-          # Restore execute permissions (actions/upload-artifact strips them from the ZIP)
           chmod +x "$APP_PATH/$BUNDLE_EXEC"
-          echo "✅ Execute permission set: $(ls -lh "$APP_PATH/$BUNDLE_EXEC")"
         shell: bash
 
       # Upload the iOS .app file that works in simulators

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -251,26 +251,42 @@ jobs:
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
-      # Verify app bundle contents before upload (diagnose missing executable)
-      - name: Verify iOS App Bundle Before Upload
+      # Fix iOS bundle executable: ensure correct case and execute permissions before upload.
+      # actions/upload-artifact strips execute permissions, so we must chmod +x before zipping.
+      # Xcode on case-insensitive APFS sometimes stores the binary with wrong case (e.g. "metamask"
+      # instead of "MetaMask"), which causes xcrun simctl install to fail on the test runner because
+      # it does a case-sensitive directory enumeration when looking for CFBundleExecutable.
+      - name: Fix iOS bundle executable case and permissions before upload
         run: |
           APP_PATH="ios/build/Build/Products/Release-iphonesimulator/MetaMask.app"
-          echo "=== Top-level contents of MetaMask.app ==="
-          ls -la "$APP_PATH/" || echo "ERROR: MetaMask.app directory not found"
-          echo ""
-          echo "=== Binary check ==="
-          if [ -f "$APP_PATH/MetaMask" ]; then
-            echo "✅ Binary exists: $(ls -lh "$APP_PATH/MetaMask")"
-            echo "   Type: $(file "$APP_PATH/MetaMask")"
-          elif [ -L "$APP_PATH/MetaMask" ]; then
-            echo "⚠️  Binary is a symlink: $(ls -la "$APP_PATH/MetaMask")"
-            echo "   Points to: $(readlink "$APP_PATH/MetaMask")"
-          else
-            echo "❌ Binary is MISSING from MetaMask.app"
+          BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
+          if [ -z "$BUNDLE_EXEC" ]; then
+            echo "❌ Could not read CFBundleExecutable from Info.plist"
+            exit 1
           fi
-          echo ""
-          echo "=== CFBundleExecutable in Info.plist ==="
-          /usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null || echo "Could not read CFBundleExecutable"
+          echo "CFBundleExecutable: $BUNDLE_EXEC"
+
+          # Find the binary case-insensitively (Xcode may produce lowercase name on case-insensitive APFS)
+          ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
+          if [ -z "$ACTUAL_PATH" ]; then
+            echo "❌ Bundle executable not found (even case-insensitively): $BUNDLE_EXEC"
+            ls -la "$APP_PATH/"
+            exit 1
+          fi
+          ACTUAL_NAME=$(basename "$ACTUAL_PATH")
+          echo "Found on disk: $ACTUAL_NAME"
+
+          # Fix case mismatch with a two-step rename (direct rename fails on case-insensitive APFS)
+          if [ "$ACTUAL_NAME" != "$BUNDLE_EXEC" ]; then
+            echo "⚠️  Case mismatch detected — renaming $ACTUAL_NAME → $BUNDLE_EXEC"
+            mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
+            mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
+            echo "✅ Renamed: $ACTUAL_NAME → $BUNDLE_EXEC"
+          fi
+
+          # Restore execute permissions (actions/upload-artifact strips them from the ZIP)
+          chmod +x "$APP_PATH/$BUNDLE_EXEC"
+          echo "✅ Execute permission set: $(ls -lh "$APP_PATH/$BUNDLE_EXEC")"
         shell: bash
 
       # Upload the iOS .app file that works in simulators

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -183,6 +183,34 @@ jobs:
         with:
           path: artifacts/
 
+      - name: Verify downloaded iOS app bundle
+        if: ${{ inputs.platform == 'ios' }}
+        env:
+          BUILD_TYPE: ${{ inputs.build_type }}
+          METAMASK_ENV: ${{ inputs.metamask_environment }}
+        run: |
+          APP_PATH="artifacts/${BUILD_TYPE}-${METAMASK_ENV}-MetaMask.app"
+          echo "=== Artifact directory structure (top level) ==="
+          ls -la "artifacts/" || echo "artifacts/ directory not found"
+          echo ""
+          echo "=== App bundle top-level contents ==="
+          ls -la "$APP_PATH/" || echo "ERROR: $APP_PATH not found"
+          echo ""
+          echo "=== Binary check ==="
+          if [ -f "$APP_PATH/MetaMask" ]; then
+            echo "✅ Binary exists: $(ls -lh "$APP_PATH/MetaMask")"
+            echo "   Type: $(file "$APP_PATH/MetaMask")"
+          elif [ -L "$APP_PATH/MetaMask" ]; then
+            echo "⚠️  Binary is a symlink: $(ls -la "$APP_PATH/MetaMask")"
+            echo "   Points to: $(readlink "$APP_PATH/MetaMask")"
+          else
+            echo "❌ Binary MISSING from $APP_PATH"
+          fi
+          echo ""
+          echo "=== CFBundleExecutable in Info.plist ==="
+          /usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null || echo "Could not read CFBundleExecutable"
+        shell: bash
+
       # On re-run (run_attempt > 1), download previous test results to identify failed tests
       - name: Download previous test results (on re-run)
         if: ${{ github.run_attempt > 1 }}

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -183,32 +183,43 @@ jobs:
         with:
           path: artifacts/
 
-      - name: Verify downloaded iOS app bundle
+      # Restore execute permissions on the iOS bundle executable.
+      # actions/upload-artifact strips execute bits when creating the artifact ZIP.
+      # Also handles any residual case mismatch as a safety net.
+      - name: Restore iOS bundle executable permissions
         if: ${{ inputs.platform == 'ios' }}
         env:
           BUILD_TYPE: ${{ inputs.build_type }}
           METAMASK_ENV: ${{ inputs.metamask_environment }}
         run: |
           APP_PATH="artifacts/${BUILD_TYPE}-${METAMASK_ENV}-MetaMask.app"
-          echo "=== Artifact directory structure (top level) ==="
-          ls -la "artifacts/" || echo "artifacts/ directory not found"
-          echo ""
-          echo "=== App bundle top-level contents ==="
-          ls -la "$APP_PATH/" || echo "ERROR: $APP_PATH not found"
-          echo ""
-          echo "=== Binary check ==="
-          if [ -f "$APP_PATH/MetaMask" ]; then
-            echo "✅ Binary exists: $(ls -lh "$APP_PATH/MetaMask")"
-            echo "   Type: $(file "$APP_PATH/MetaMask")"
-          elif [ -L "$APP_PATH/MetaMask" ]; then
-            echo "⚠️  Binary is a symlink: $(ls -la "$APP_PATH/MetaMask")"
-            echo "   Points to: $(readlink "$APP_PATH/MetaMask")"
-          else
-            echo "❌ Binary MISSING from $APP_PATH"
+          BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
+          if [ -z "$BUNDLE_EXEC" ]; then
+            echo "❌ Could not read CFBundleExecutable from Info.plist"
+            ls -la "$APP_PATH/" || echo "App path not found: $APP_PATH"
+            exit 1
           fi
-          echo ""
-          echo "=== CFBundleExecutable in Info.plist ==="
-          /usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null || echo "Could not read CFBundleExecutable"
+          echo "CFBundleExecutable: $BUNDLE_EXEC"
+
+          # Find the binary case-insensitively (safety net for any residual case mismatch)
+          ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
+          if [ -z "$ACTUAL_PATH" ]; then
+            echo "❌ Bundle executable not found: $BUNDLE_EXEC"
+            ls -la "$APP_PATH/"
+            exit 1
+          fi
+          ACTUAL_NAME=$(basename "$ACTUAL_PATH")
+
+          # Fix case if needed (two-step rename for case-insensitive APFS)
+          if [ "$ACTUAL_NAME" != "$BUNDLE_EXEC" ]; then
+            echo "⚠️  Case mismatch: $ACTUAL_NAME → $BUNDLE_EXEC, fixing..."
+            mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
+            mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
+          fi
+
+          # Restore execute permissions (stripped by actions/upload-artifact)
+          chmod +x "$APP_PATH/$BUNDLE_EXEC"
+          echo "✅ Ready: $(ls -lh "$APP_PATH/$BUNDLE_EXEC")"
         shell: bash
 
       # On re-run (run_attempt > 1), download previous test results to identify failed tests

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -183,9 +183,8 @@ jobs:
         with:
           path: artifacts/
 
-      # Restore execute permissions on the iOS bundle executable.
-      # actions/upload-artifact strips execute bits when creating the artifact ZIP.
-      # Also handles any residual case mismatch as a safety net.
+      # actions/upload-artifact strips execute permissions from the ZIP.
+      # Also fixes any residual case mismatch as a safety net.
       - name: Restore iOS bundle executable permissions
         if: ${{ inputs.platform == 'ios' }}
         env:
@@ -195,31 +194,23 @@ jobs:
           APP_PATH="artifacts/${BUILD_TYPE}-${METAMASK_ENV}-MetaMask.app"
           BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
           if [ -z "$BUNDLE_EXEC" ]; then
-            echo "❌ Could not read CFBundleExecutable from Info.plist"
-            ls -la "$APP_PATH/" || echo "App path not found: $APP_PATH"
+            echo "Could not read CFBundleExecutable from Info.plist"
             exit 1
           fi
-          echo "CFBundleExecutable: $BUNDLE_EXEC"
 
-          # Find the binary case-insensitively (safety net for any residual case mismatch)
           ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
           if [ -z "$ACTUAL_PATH" ]; then
-            echo "❌ Bundle executable not found: $BUNDLE_EXEC"
-            ls -la "$APP_PATH/"
+            echo "Bundle executable not found: $BUNDLE_EXEC"
             exit 1
           fi
-          ACTUAL_NAME=$(basename "$ACTUAL_PATH")
 
-          # Fix case if needed (two-step rename for case-insensitive APFS)
-          if [ "$ACTUAL_NAME" != "$BUNDLE_EXEC" ]; then
-            echo "⚠️  Case mismatch: $ACTUAL_NAME → $BUNDLE_EXEC, fixing..."
+          # Two-step rename to fix case on case-insensitive APFS (direct rename is a no-op)
+          if [ "$(basename "$ACTUAL_PATH")" != "$BUNDLE_EXEC" ]; then
             mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
             mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
           fi
 
-          # Restore execute permissions (stripped by actions/upload-artifact)
           chmod +x "$APP_PATH/$BUNDLE_EXEC"
-          echo "✅ Ready: $(ls -lh "$APP_PATH/$BUNDLE_EXEC")"
         shell: bash
 
       # On re-run (run_attempt > 1), download previous test results to identify failed tests

--- a/scripts/repack.js
+++ b/scripts/repack.js
@@ -223,6 +223,9 @@ async function repackIos() {
       );
     }
     logger.success(`Bundle executable verified: ${sourceAppName}`);
+    // Restore execute permissions (may have been lost if the binary came from a cached artifact)
+    fs.chmodSync(executablePath, 0o755);
+    logger.success(`Execute permissions set on: ${sourceAppName}`);
 
     // Remove old app and move repacked app to final location
     fs.rmSync(finalApp, { recursive: true, force: true });

--- a/scripts/repack.js
+++ b/scripts/repack.js
@@ -171,9 +171,13 @@ async function repackIos() {
     logger.info('🚀 Starting iOS E2E App repack process...');
     logger.info(`Source App: ${sourceApp}`);
 
-    // Verify source app exists
+    // Verify source app exists and has a bundle executable
     if (!fs.existsSync(sourceApp)) {
       throw new Error(`App not found: ${sourceApp}`);
+    }
+    const sourceInfoPlist = path.join(sourceApp, 'Info.plist');
+    if (!fs.existsSync(sourceInfoPlist)) {
+      throw new Error(`Source app is missing Info.plist: ${sourceApp}`);
     }
 
     // Generate Expo.plist if it doesn't exist (fallback for builds that don't auto-generate it)
@@ -201,10 +205,24 @@ async function repackIos() {
       env: process.env,
     });
 
-    // Verify and move repacked app
+    // Verify repacked app exists and contains a bundle executable
     if (!fs.existsSync(repackedApp)) {
       throw new Error(`Repacked app not found: ${repackedApp}`);
     }
+    // Verify the bundle executable is present.
+    // Info.plist is in binary format after repack, so we derive the executable name
+    // from the source app directory name (e.g. MetaMask.app -> MetaMask).
+    const sourceAppName = path.basename(sourceApp, '.app');
+    const executablePath = path.join(repackedApp, sourceAppName);
+    if (!fs.existsSync(executablePath)) {
+      throw new Error(
+        `Repacked app is missing its bundle executable at "${executablePath}". ` +
+        `@expo/repack-app may have dropped the binary (possible symlink handling issue). ` +
+        `Aborting to prevent uploading a broken artifact — bust IOS_APP_CACHE_VERSION ` +
+        `in build-ios-e2e.yml to force a full rebuild.`
+      );
+    }
+    logger.success(`Bundle executable verified: ${sourceAppName}`);
 
     // Remove old app and move repacked app to final location
     fs.rmSync(finalApp, { recursive: true, force: true });


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

  **Problem**                                                                                                                         
                                                                                                                                  
  All iOS E2E tests were failing with:
  main-qa-MetaMask.app is missing its bundle executable at "main-qa-MetaMask.app/MetaMask"

  Two issues in the artifact upload/download pipeline:

  1. Case mismatch — Xcode on the case-insensitive build runner stored the binary as metamask (lowercase) while CFBundleExecutable
  in Info.plist declared it as MetaMask. actions/upload-artifact packaged the file under its actual on-disk name. xcrun simctl
  install on the test runner validates the bundle with a case-sensitive directory lookup, found no entry named MetaMask, and
  reported it as missing.
  2. Permissions stripped — actions/upload-artifact does not preserve execute bits when creating the ZIP, so the binary arrived on
  the test runner as -rw-r--r-- instead of -rwxr-xr-x.

  Fix

  - Before upload (build-ios-e2e.yml): read CFBundleExecutable from Info.plist, locate the binary case-insensitively, rename to the
  correct case via a two-step move (required on case-insensitive APFS), then chmod +x
  - After download (run-e2e-workflow.yml): chmod +x as a safety net, with the same case-fix logic
  - Repack path (scripts/repack.js): chmod 755 on the repacked binary so the cache-hit code path is also covered

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iOS E2E build/test workflows and cached artifact handling; missteps could break CI pipelines or increase rebuild frequency, but changes are localized to automation scripts.
> 
> **Overview**
> Improves iOS E2E artifact reliability by **normalizing the app bundle executable name and permissions** before upload and again after download, preventing `simctl install` failures due to case-mismatched binaries and stripped execute bits.
> 
> Updates iOS build caching by introducing `IOS_APP_CACHE_VERSION` in cache keys (plus a centralized `XCODE_CACHE_VERSION` env), and hardens `scripts/repack.js` to verify the repacked `.app` contains the expected bundle executable and to restore its execute permissions, failing fast if `@expo/repack-app` drops the binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 750b4221dacd717fa18d4ef7723821a9aa400389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->