### PR TITLE
fix: adjust bridge token selector ticker font

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -272,7 +272,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             >
               <Box style={styles.tokenMainInfo} gap={4}>
                 <Text
-                  variant={TextVariant.BodyMD}
+                  variant={TextVariant.BodyMDMedium}
                   numberOfLines={1}
                   ellipsizeMode="tail"
                 >
@@ -297,7 +297,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                   <View style={styles.skeleton} />
                 ) : (
                   <Text
-                    variant={TextVariant.BodyMD}
+                    variant={TextVariant.BodyMDMedium}
                     color={TextColor.Default}
                     numberOfLines={1}
                     style={styles.rightValue}


### PR DESCRIPTION
## **Description**

This PR updates typography in the Bridge token selector item so ticker text weight matches the Send flow token item and Trending token row.

- Updated bridge token symbol text from `TextVariant.BodyMD` to `TextVariant.BodyMDMedium`
- Updated bridge right-side secondary balance text from `TextVariant.BodyMD` to `TextVariant.BodyMDMedium`

## **Changelog**

CHANGELOG entry: Fixed a visual inconsistency where bridge token selector ticker text appeared thinner than other token lists.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Bridge token selector typography

  Scenario: user views token rows in Bridge token selector
    Given the wallet is unlocked
    And the user is on the Bridge flow

    When user opens the token selector
    Then token ticker text is rendered with medium body typography
    And right-side token amount text is rendered with medium body typography
    And typography matches the visual weight used in send flow and trending token rows
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only typography change limited to the bridge token selector item; no logic, data flow, or side effects are modified.
> 
> **Overview**
> Updates `TokenSelectorItem` in the bridge UI so the token ticker (`token.symbol`) and the right-side secondary balance text both use `TextVariant.BodyMDMedium` instead of `BodyMD`, aligning typography with other token lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2769bb2dfb3d32c56a8975f6ea6a6486900b539c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
