### PR TITLE
fix: bluetooth permissions check & disconnect on close

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
@@ -34,6 +34,7 @@ const mockAdapterInstance = {
   destroy: jest.fn(),
   startDeviceDiscovery: jest.fn(),
   stopDeviceDiscovery: jest.fn(),
+  ensurePermissions: jest.fn().mockResolvedValue(true),
   isTransportAvailable: jest.fn().mockReturnValue(true),
   onTransportStateChange: jest
     .fn()

--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -122,9 +122,11 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
 
   const handleAwaitingConfirmationCancel = useCallback(() => {
     DevLogger.log('[HardwareWallet] handleAwaitingConfirmationCancel');
+    // eslint-disable-next-line no-empty-function
+    refs.adapterRef.current?.disconnect().catch(() => {});
     awaitingConfirmationRejectRef.current?.();
     hideAwaitingConfirmation();
-  }, [hideAwaitingConfirmation]);
+  }, [hideAwaitingConfirmation, refs.adapterRef]);
 
   const contextValue = useMemo(
     () => ({

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -35,6 +35,7 @@ jest.mock('@ledgerhq/react-native-hw-transport-ble', () => ({
   __esModule: true,
   default: {
     open: jest.fn(),
+    disconnectDevice: jest.fn().mockResolvedValue(undefined),
     observeState: jest.fn((observer) => {
       capturedBleStateObserver = observer;
       // Immediately trigger with PoweredOn state for most tests
@@ -66,6 +67,31 @@ jest.mock('../../Ledger/Ledger', () => ({
   closeRunningAppOnLedger: jest.fn(),
 }));
 
+const mockRequestMultiple = jest.fn();
+const mockRequest = jest.fn();
+jest.mock('react-native-permissions', () => ({
+  requestMultiple: (...args: unknown[]) => mockRequestMultiple(...args),
+  request: (...args: unknown[]) => mockRequest(...args),
+  PERMISSIONS: {
+    ANDROID: {
+      BLUETOOTH_CONNECT: 'android.permission.BLUETOOTH_CONNECT',
+      BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
+      ACCESS_FINE_LOCATION: 'android.permission.ACCESS_FINE_LOCATION',
+    },
+  },
+  RESULTS: {
+    GRANTED: 'granted',
+    DENIED: 'denied',
+    BLOCKED: 'blocked',
+  },
+}));
+
+const mockGetSystemVersion = jest.fn().mockReturnValue('13');
+jest.mock('react-native-device-info', () => ({
+  getSystemVersion: () => mockGetSystemVersion(),
+}));
+
+import { Linking, Platform } from 'react-native';
 import { LedgerBluetoothAdapter } from './LedgerBluetoothAdapter';
 import { HardwareWalletType, DeviceEvent } from '@metamask/hw-wallet-sdk';
 import { HardwareWalletAdapterOptions } from '../types';
@@ -157,8 +183,7 @@ describe('LedgerBluetoothAdapter', () => {
       await adapter.connect('device-123');
       await adapter.connect('device-456');
 
-      // Should close first connection and open new one
-      expect(mockTransportInstance.close).toHaveBeenCalled();
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalled();
       expect(mockedTransportBLE.open).toHaveBeenCalledTimes(2);
     });
 
@@ -248,7 +273,7 @@ describe('LedgerBluetoothAdapter', () => {
       await adapter.connect('device-123');
       await adapter.disconnect();
 
-      expect(mockTransportInstance.close).toHaveBeenCalled();
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalled();
       expect(adapter.isConnected()).toBe(false);
       expect(adapter.getConnectedDeviceId()).toBeNull();
     });
@@ -842,12 +867,80 @@ describe('LedgerBluetoothAdapter', () => {
     });
   });
 
+  describe('ensurePermissions', () => {
+    const originalOS = Platform.OS;
+
+    afterEach(() => {
+      Platform.OS = originalOS;
+    });
+
+    it('returns true on iOS without requesting permissions', async () => {
+      Platform.OS = 'ios';
+
+      const result = await adapter.ensurePermissions();
+
+      expect(result).toBe(true);
+      expect(mockRequestMultiple).not.toHaveBeenCalled();
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it('returns true on Android 12+ when BLE permissions are granted', async () => {
+      Platform.OS = 'android';
+      mockGetSystemVersion.mockReturnValue('12');
+      mockRequestMultiple.mockResolvedValue({
+        'android.permission.BLUETOOTH_CONNECT': 'granted',
+        'android.permission.BLUETOOTH_SCAN': 'granted',
+      });
+
+      const result = await adapter.ensurePermissions();
+
+      expect(result).toBe(true);
+    });
+
+    it('opens settings on Android 12+ when BLE permissions are denied', async () => {
+      Platform.OS = 'android';
+      mockGetSystemVersion.mockReturnValue('13');
+      mockRequestMultiple.mockResolvedValue({
+        'android.permission.BLUETOOTH_CONNECT': 'denied',
+        'android.permission.BLUETOOTH_SCAN': 'granted',
+      });
+      jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined);
+
+      const result = await adapter.ensurePermissions();
+
+      expect(result).toBe(false);
+      expect(Linking.openSettings).toHaveBeenCalled();
+    });
+
+    it('returns true on older Android when location permission is granted', async () => {
+      Platform.OS = 'android';
+      mockGetSystemVersion.mockReturnValue('11');
+      mockRequest.mockResolvedValue('granted');
+
+      const result = await adapter.ensurePermissions();
+
+      expect(result).toBe(true);
+    });
+
+    it('opens settings on older Android when location permission is denied', async () => {
+      Platform.OS = 'android';
+      mockGetSystemVersion.mockReturnValue('10');
+      mockRequest.mockResolvedValue('blocked');
+      jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined);
+
+      const result = await adapter.ensurePermissions();
+
+      expect(result).toBe(false);
+      expect(Linking.openSettings).toHaveBeenCalled();
+    });
+  });
+
   describe('destroy', () => {
     it('closes transport and marks as destroyed', async () => {
       await adapter.connect('device-123');
       adapter.destroy();
 
-      expect(mockTransportInstance.close).toHaveBeenCalled();
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalled();
     });
 
     it('prevents further operations', async () => {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -183,7 +183,9 @@ describe('LedgerBluetoothAdapter', () => {
       await adapter.connect('device-123');
       await adapter.connect('device-456');
 
-      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalled();
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
       expect(mockedTransportBLE.open).toHaveBeenCalledTimes(2);
     });
 
@@ -273,7 +275,9 @@ describe('LedgerBluetoothAdapter', () => {
       await adapter.connect('device-123');
       await adapter.disconnect();
 
-      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalled();
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
       expect(adapter.isConnected()).toBe(false);
       expect(adapter.getConnectedDeviceId()).toBeNull();
     });
@@ -940,7 +944,9 @@ describe('LedgerBluetoothAdapter', () => {
       await adapter.connect('device-123');
       adapter.destroy();
 
-      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalled();
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
     });
 
     it('prevents further operations', async () => {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -563,15 +563,20 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
 
   async #closeTransport(): Promise<void> {
     const transport = this.#transport;
+    const deviceId = this.#deviceId;
     if (transport) {
       this.#transport = null;
       try {
-        // TransportBLE.close() queues a delayed disconnect (5s timeout).
-        // Force an immediate BLE disconnection so in-flight signing is
-        // aborted without delay.
-        await TransportBLE.disconnectDevice(transport.id);
+        if (deviceId) {
+          // TransportBLE.close() queues a delayed disconnect (5s timeout).
+          // Force an immediate BLE disconnection so in-flight signing is
+          // aborted without delay.
+          await TransportBLE.disconnectDevice(deviceId);
+        } else {
+          await transport.close();
+        }
       } catch {
-        // Ignore close errors
+        // Ignore close errors — device may already be disconnected
       }
     }
   }

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -1,5 +1,6 @@
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble';
 import { State as BleState } from 'react-native-ble-plx';
+import { Linking, Platform } from 'react-native';
 import { Observable, Subscription } from 'rxjs';
 import Eth from '@ledgerhq/hw-app-eth';
 import {
@@ -8,6 +9,13 @@ import {
   DeviceEventPayload,
   ErrorCode,
 } from '@metamask/hw-wallet-sdk';
+import {
+  PERMISSIONS,
+  RESULTS,
+  requestMultiple,
+  request,
+} from 'react-native-permissions';
+import { getSystemVersion } from 'react-native-device-info';
 import {
   DiscoveredDevice,
   HardwareWalletAdapter,
@@ -276,6 +284,37 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     }
   }
 
+  async ensurePermissions(): Promise<boolean> {
+    if (Platform.OS !== 'android') {
+      return true;
+    }
+
+    const version = Number(getSystemVersion()) || 0;
+
+    if (version >= 12) {
+      const result = await requestMultiple([
+        PERMISSIONS.ANDROID.BLUETOOTH_CONNECT,
+        PERMISSIONS.ANDROID.BLUETOOTH_SCAN,
+      ]);
+      const allGranted =
+        result[PERMISSIONS.ANDROID.BLUETOOTH_CONNECT] === RESULTS.GRANTED &&
+        result[PERMISSIONS.ANDROID.BLUETOOTH_SCAN] === RESULTS.GRANTED;
+
+      if (!allGranted) {
+        await Linking.openSettings();
+        return false;
+      }
+    } else {
+      const result = await request(PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION);
+      if (result !== RESULTS.GRANTED) {
+        await Linking.openSettings();
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   async isTransportAvailable(): Promise<boolean> {
     // Wait for initial BLE state if not yet received
     if (!this.#hasReceivedInitialBleState) {
@@ -527,7 +566,10 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     if (transport) {
       this.#transport = null;
       try {
-        await transport.close();
+        // TransportBLE.close() queues a delayed disconnect (5s timeout).
+        // Force an immediate BLE disconnection so in-flight signing is
+        // aborted without delay.
+        await TransportBLE.disconnectDevice(transport.id);
       } catch {
         // Ignore close errors
       }

--- a/app/core/HardwareWallet/adapters/NonHardwareAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/NonHardwareAdapter.test.ts
@@ -139,6 +139,13 @@ describe('NonHardwareAdapter', () => {
     });
   });
 
+  describe('ensurePermissions', () => {
+    it('returns true', async () => {
+      const result = await adapter.ensurePermissions();
+      expect(result).toBe(true);
+    });
+  });
+
   describe('isTransportAvailable', () => {
     it('returns true', async () => {
       const result = await adapter.isTransportAvailable();

--- a/app/core/HardwareWallet/adapters/NonHardwareAdapter.ts
+++ b/app/core/HardwareWallet/adapters/NonHardwareAdapter.ts
@@ -60,6 +60,10 @@ export class NonHardwareAdapter implements HardwareWalletAdapter {
 
   stopDeviceDiscovery(): void {}
 
+  async ensurePermissions(): Promise<boolean> {
+    return true;
+  }
+
   async isTransportAvailable(): Promise<boolean> {
     return true;
   }

--- a/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceConnectionFlow.ts
@@ -261,6 +261,10 @@ export const useDeviceConnectionFlow = ({
       adapter.resetFlowState();
     }
 
+    if (adapter && !(await adapter.ensurePermissions())) {
+      return;
+    }
+
     if (adapter && (await checkTransportEnabledOrShowError(adapter))) {
       return;
     }

--- a/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
+++ b/app/core/HardwareWallet/hooks/useDeviceEventHandlers.test.ts
@@ -40,6 +40,7 @@ describe('useDeviceEventHandlers', () => {
       resetFlowState: jest.fn(),
       startDeviceDiscovery: jest.fn().mockReturnValue(jest.fn()),
       stopDeviceDiscovery: jest.fn(),
+      ensurePermissions: jest.fn(() => Promise.resolve(true)),
       isTransportAvailable: jest.fn(() => Promise.resolve(true)),
       getRequiredAppName: jest.fn().mockReturnValue('Ethereum'),
       getTransportDisabledErrorCode: jest

--- a/app/core/HardwareWallet/types.ts
+++ b/app/core/HardwareWallet/types.ts
@@ -106,6 +106,15 @@ export interface HardwareWalletAdapter {
   stopDeviceDiscovery(): void;
 
   /**
+   * Ensure required OS permissions are granted for this adapter.
+   * Requests permissions if needed; opens OS Settings when permanently denied.
+   *
+   * @returns `true` if permissions are granted, `false` if the user was
+   * redirected to Settings (caller should abort and wait for retry).
+   */
+  ensurePermissions(): Promise<boolean>;
+
+  /**
    * Check if the underlying transport mechanism is available.
    * For Ledger: Bluetooth is enabled
    * For QR: Camera permission granted

--- a/app/core/HardwareWallet/types.ts
+++ b/app/core/HardwareWallet/types.ts
@@ -110,7 +110,7 @@ export interface HardwareWalletAdapter {
    * Requests permissions if needed; opens OS Settings when permanently denied.
    *
    * @returns `true` if permissions are granted, `false` if the user was
-   * redirected to Settings (caller should abort and wait for retry).
+   * redirected to Settings.
    */
   ensurePermissions(): Promise<boolean>;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Introduced changes:

- Permissions: New adapter method `ensurePermissions()` is called before transport checks in `retryEnsureDeviceReady`. And adds Android permission handling (Bluetooth on Android 12+, location on older Android).
- Disconnect: Ledger BLE teardown uses `TransportBLE.disconnectDevice(deviceId)` instead of `transport.close()` for immediate disconnect. Cancelling “awaiting confirmation” also triggers a best-effort adapter disconnect.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1580

## **Manual testing steps**

no manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect BLE connection lifecycle and Android permission prompting, which can alter user flow and connection stability; coverage is included but behavior depends on platform permission APIs and device/OS quirks.
> 
> **Overview**
> Improves the hardware-wallet connection retry path by introducing a new `HardwareWalletAdapter.ensurePermissions()` contract and calling it before transport checks in `retryEnsureDeviceReady`, aborting the retry if the user must be redirected to OS Settings.
> 
> For Ledger BLE, adds Android permission prompting (Android 12+ Bluetooth permissions, older Android location permission) and updates transport teardown to prefer `TransportBLE.disconnectDevice(deviceId)` over `transport.close()` to force immediate disconnects; the awaiting-confirmation cancel path now also triggers a best-effort adapter disconnect. Tests/mocks are updated accordingly (Ledger adapter, provider, non-hardware adapter).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a94bd7f2d544e4365152ea12935c14a6e0d9884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->