### PR TITLE
feat: migrate Skeleton component (perps scope)

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -34,7 +34,7 @@ import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import Text, {
   TextColor,
   TextVariant,

--- a/app/components/UI/Perps/Views/PerpsMarketListView/components/PerpsMarketRowSkeleton/PerpsMarketRowSkeleton.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/components/PerpsMarketRowSkeleton/PerpsMarketRowSkeleton.test.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import PerpsMarketRowSkeleton from './PerpsMarketRowSkeleton';
 
-jest.mock('../../../../../../../component-library/components/Skeleton', () => {
-  const { View } = jest.requireActual('react-native');
-  return {
-    Skeleton: ({
-      testID,
-      ...props
-    }: {
-      testID?: string;
-      width?: number;
-      height?: number;
-      style?: object;
-    }) => <View testID={testID} {...props} />,
-  };
-});
+jest.mock(
+  '../../../../../../../component-library/components-temp/Skeleton',
+  () => {
+    const { View } = jest.requireActual('react-native');
+    return {
+      Skeleton: ({
+        testID,
+        ...props
+      }: {
+        testID?: string;
+        width?: number;
+        height?: number;
+        style?: object;
+      }) => <View testID={testID} {...props} />,
+    };
+  },
+);
 
 describe('PerpsMarketRowSkeleton', () => {
   it('renders without crashing with testID', () => {

--- a/app/components/UI/Perps/Views/PerpsMarketListView/components/PerpsMarketRowSkeleton/PerpsMarketRowSkeleton.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/components/PerpsMarketRowSkeleton/PerpsMarketRowSkeleton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
+import { Skeleton } from '../../../../../../../component-library/components-temp/Skeleton';
 import { useStyles } from '../../../../../../../component-library/hooks';
 import type { PerpsMarketRowSkeletonProps } from './PerpsMarketRowSkeleton.types';
 import styleSheet from './PerpsMarketRowSkeleton.styles';

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -40,7 +40,7 @@ import ListItem from '../../../../../component-library/components/List/ListItem'
 import ListItemColumn, {
   WidthType,
 } from '../../../../../component-library/components/List/ListItemColumn';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import Text, {
   TextColor,
   TextVariant,

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -45,7 +45,7 @@ import styleSheet from './PerpsTabView.styles';
 import PerpsRowSkeleton from '../../components/PerpsRowSkeleton';
 import PerpsMarketRowItem from '../../components/PerpsMarketRowItem';
 
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import ConditionalScrollView from '../../../../../component-library/components-temp/ConditionalScrollView';
 
 const PerpsTabView = () => {

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -259,7 +259,7 @@ jest.mock('../../../../../component-library/components/Badges/Badge', () => {
   };
 });
 
-jest.mock('../../../../../component-library/components/Skeleton', () => {
+jest.mock('../../../../../component-library/components-temp/Skeleton', () => {
   const { View } = jest.requireActual('react-native');
   return {
     Skeleton: jest.fn(({ testID, width, height }) => (

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -35,7 +35,7 @@ import {
 import { usePerpsDepositProgress } from '../../hooks/usePerpsDepositProgress';
 import { usePerpsTransactionState } from '../../hooks/usePerpsTransactionState';
 import { convertPerpsAmountToUSD } from '../../utils/amountConversion';
-import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import PerpsEmptyBalance from '../PerpsEmptyBalance';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsProgressBar } from '../PerpsProgressBar';

--- a/app/components/UI/Perps/components/PerpsRowSkeleton/PerpsRowSkeleton.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRowSkeleton/PerpsRowSkeleton.test.tsx
@@ -4,22 +4,19 @@ import PerpsRowSkeleton from './PerpsRowSkeleton';
 import { HOME_SCREEN_CONFIG } from '../../constants/perpsConfig';
 
 // Mock Skeleton component
-jest.mock(
-  '../../../../../component-library/components/Skeleton/Skeleton',
-  () => {
-    const ReactNative = jest.requireActual('react-native');
-    return {
-      __esModule: true,
-      default: jest.fn(({ height, width, style, testID }) => (
-        <ReactNative.View
-          testID={testID || 'skeleton'}
-          style={[{ height, width }, style]}
-          accessibilityLabel={`skeleton-${height}x${width}`}
-        />
-      )),
-    };
-  },
-);
+jest.mock('../../../../../component-library/components-temp/Skeleton', () => {
+  const ReactNative = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    Skeleton: jest.fn(({ height, width, style, testID }) => (
+      <ReactNative.View
+        testID={testID || 'skeleton'}
+        style={[{ height, width }, style]}
+        accessibilityLabel={`skeleton-${height}x${width}`}
+      />
+    )),
+  };
+});
 
 describe('PerpsRowSkeleton', () => {
   describe('rendering', () => {

--- a/app/components/UI/Perps/components/PerpsRowSkeleton/PerpsRowSkeleton.tsx
+++ b/app/components/UI/Perps/components/PerpsRowSkeleton/PerpsRowSkeleton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, type ViewStyle } from 'react-native';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { HOME_SCREEN_CONFIG } from '../../constants/perpsConfig';
 
 export interface PerpsRowSkeletonProps {

--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.test.tsx
@@ -22,19 +22,17 @@ jest.mock('../../../../../component-library/hooks', () => ({
 }));
 
 // Mock the Skeleton component
-jest.mock(
-  '../../../../../component-library/components/Skeleton/Skeleton',
-  () =>
-    function MockSkeleton({
-      testID,
-      ...props
-    }: {
-      testID?: string;
-      [key: string]: unknown;
-    }) {
-      return <div data-testid={testID} {...props} />;
-    },
-);
+jest.mock('../../../../../component-library/components-temp/Skeleton', () => ({
+  Skeleton: function MockSkeleton({
+    testID,
+    ...props
+  }: {
+    testID?: string;
+    [key: string]: unknown;
+  }) {
+    return <div data-testid={testID} {...props} />;
+  },
+}));
 
 describe('PerpsTransactionsSkeleton', () => {
   it('renders loading skeleton with correct structure', () => {

--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './PerpsTransactionsSkeleton.styles';
 

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { WebView, WebViewMessageEvent } from '@metamask/react-native-webview';
 import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useStyles } from '../../../../../component-library/hooks';
 import { styleSheet } from './TradingViewChart.styles';
 import { type CandleData } from '@metamask/perps-controller';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated Skeleton to DSRN usage.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-274

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/b9a5e1ba-8e1e-4ce3-a15a-ee320c3d3f59



### **After**

https://github.com/user-attachments/assets/6dc17b3b-b9a6-4b11-9cb9-f766b1157f64

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk import/mocking change that swaps the Perps UI from the legacy `Skeleton` component to the `components-temp/Skeleton` export; primary risk is minor rendering or test breakage if the new Skeleton API/styles differ.
> 
> **Overview**
> Updates Perps screens/components to use the new design-system `Skeleton` implementation by switching imports from the legacy `component-library/components/Skeleton` paths to `component-library/components-temp/Skeleton`.
> 
> Adjusts related unit tests to mock the new named `Skeleton` export (instead of the previous default export), keeping existing skeleton-based loading UI and assertions working.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e4db5b9a6249b41198b7e691a8ba050dca2e68a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->