### PR TITLE
fix: max button 7702 re-enable cp-7.69.0

### DIFF
--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
@@ -1,40 +1,17 @@
-import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
-import { RootState } from '../../../../../reducers';
+import { selectGasIncludedQuoteParams } from '../../../../../selectors/bridge';
 import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
-import {
-  formatChainIdToHex,
-  isNativeAddress,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
+import { isNativeAddress } from '@metamask/bridge-controller';
 import { BigNumber } from 'bignumber.js';
-import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
 export const useShouldRenderMaxOption = (
   token?: BridgeToken,
   displayBalance?: string,
-  isQuoteSponsored = false,
+  _isQuoteSponsored = false,
 ) => {
-  const evmChainId = useMemo(() => {
-    if (!token?.chainId || isNonEvmChainId(token.chainId)) {
-      return undefined;
-    }
-    return formatChainIdToHex(token.chainId);
-  }, [token?.chainId]);
-  const isSendBundleSupported = useIsSendBundleSupported(evmChainId);
-  const isGaslessSwapEnabled = useMemo(
-    () => Boolean(isSendBundleSupported),
-    [isSendBundleSupported],
-  );
-  const stxEnabled = useSelector((state: RootState) =>
-    token?.chainId && !isNonEvmChainId(token.chainId)
-      ? selectShouldUseSmartTransaction(
-          state,
-          formatChainIdToHex(token.chainId),
-        )
-      : false,
+  const { gasIncluded, gasIncluded7702 } = useSelector(
+    selectGasIncludedQuoteParams,
   );
   const tokenAddress = useTokenAddress(token);
   const isNativeAsset = isNativeAddress(tokenAddress);
@@ -50,10 +27,6 @@ export const useShouldRenderMaxOption = (
     return true;
   }
 
-  // Show for EVM native tokens if gasless swap is enabled OR quote is sponsored
-  // while smart transactions is enabled.
-  // For non-EVM native tokens stxEnabled will be false evaluating the whole
-  // expression to false. We do not know the fees beforehand so we cannot
-  // max out the input amount.
-  return (isGaslessSwapEnabled || isQuoteSponsored) && stxEnabled;
+  // Keep extension parity: native max is enabled only for gas-included paths.
+  return gasIncluded || gasIncluded7702;
 };

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
@@ -1,31 +1,17 @@
 import { useSelector } from 'react-redux';
 import { selectGasIncludedQuoteParams } from '../../../../../selectors/bridge';
-import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
-import { RootState } from '../../../../../reducers';
 import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
-import {
-  formatChainIdToHex,
-  isNativeAddress,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
+import { isNativeAddress } from '@metamask/bridge-controller';
 import { BigNumber } from 'bignumber.js';
 
 export const useShouldRenderMaxOption = (
   token?: BridgeToken,
   displayBalance?: string,
-  isQuoteSponsored = false,
+  _isQuoteSponsored = false,
 ) => {
   const { gasIncluded, gasIncluded7702 } = useSelector(
     selectGasIncludedQuoteParams,
-  );
-  const stxEnabled = useSelector((state: RootState) =>
-    token?.chainId && !isNonEvmChainId(token.chainId)
-      ? selectShouldUseSmartTransaction(
-          state,
-          formatChainIdToHex(token.chainId),
-        )
-      : false,
   );
   const tokenAddress = useTokenAddress(token);
   const isNativeAsset = isNativeAddress(tokenAddress);
@@ -41,5 +27,5 @@ export const useShouldRenderMaxOption = (
     return true;
   }
 
-  return gasIncluded || gasIncluded7702 || (isQuoteSponsored && stxEnabled);
+  return gasIncluded || gasIncluded7702;
 };

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
@@ -27,6 +27,5 @@ export const useShouldRenderMaxOption = (
     return true;
   }
 
-  // Keep extension parity: native max is enabled only for gas-included paths.
   return gasIncluded || gasIncluded7702;
 };

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
@@ -1,17 +1,31 @@
 import { useSelector } from 'react-redux';
 import { selectGasIncludedQuoteParams } from '../../../../../selectors/bridge';
+import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
+import { RootState } from '../../../../../reducers';
 import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
-import { isNativeAddress } from '@metamask/bridge-controller';
+import {
+  formatChainIdToHex,
+  isNativeAddress,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
 import { BigNumber } from 'bignumber.js';
 
 export const useShouldRenderMaxOption = (
   token?: BridgeToken,
   displayBalance?: string,
-  _isQuoteSponsored = false,
+  isQuoteSponsored = false,
 ) => {
   const { gasIncluded, gasIncluded7702 } = useSelector(
     selectGasIncludedQuoteParams,
+  );
+  const stxEnabled = useSelector((state: RootState) =>
+    token?.chainId && !isNonEvmChainId(token.chainId)
+      ? selectShouldUseSmartTransaction(
+          state,
+          formatChainIdToHex(token.chainId),
+        )
+      : false,
   );
   const tokenAddress = useTokenAddress(token);
   const isNativeAsset = isNativeAddress(tokenAddress);
@@ -27,5 +41,5 @@ export const useShouldRenderMaxOption = (
     return true;
   }
 
-  return gasIncluded || gasIncluded7702;
+  return gasIncluded || gasIncluded7702 || (isQuoteSponsored && stxEnabled);
 };

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
@@ -47,11 +47,19 @@ const nativeToken: BridgeToken = {
 const setSelectorValues = ({
   gasIncluded = false,
   gasIncluded7702 = false,
+  stxEnabled = true,
 }: {
   gasIncluded?: boolean;
   gasIncluded7702?: boolean;
+  stxEnabled?: boolean;
 } = {}) => {
-  mockUseSelector.mockImplementation(() => ({ gasIncluded, gasIncluded7702 }));
+  let selectorCallCount = 0;
+  mockUseSelector.mockImplementation(() => {
+    selectorCallCount += 1;
+    return selectorCallCount % 2 === 1
+      ? { gasIncluded, gasIncluded7702 }
+      : stxEnabled;
+  });
 };
 
 describe('useShouldRenderMaxOption', () => {
@@ -90,7 +98,7 @@ describe('useShouldRenderMaxOption', () => {
   });
 
   it('returns true for native token when gasIncluded is enabled', () => {
-    setSelectorValues({ gasIncluded: true });
+    setSelectorValues({ gasIncluded: true, stxEnabled: true });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
 
@@ -105,6 +113,7 @@ describe('useShouldRenderMaxOption', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: true,
+      stxEnabled: false,
     });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
@@ -120,6 +129,7 @@ describe('useShouldRenderMaxOption', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: false,
+      stxEnabled: true,
     });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
@@ -131,25 +141,11 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(false);
   });
 
-  it('returns false for sponsored native quote when gasIncluded paths are disabled', () => {
+  it('returns true for sponsored native quote when stx is enabled', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: false,
-    });
-    mockUseTokenAddress.mockReturnValue(nativeToken.address);
-    mockIsNativeAddress.mockReturnValue(true);
-
-    const { result } = renderHook(() =>
-      useShouldRenderMaxOption(nativeToken, '1.25', true),
-    );
-
-    expect(result.current).toBe(false);
-  });
-
-  it('returns true for sponsored native quote when 7702 path is enabled', () => {
-    setSelectorValues({
-      gasIncluded: false,
-      gasIncluded7702: true,
+      stxEnabled: true,
     });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
@@ -161,6 +157,22 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(true);
   });
 
+  it('returns false for sponsored native quote when stx is disabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: false,
+      stxEnabled: false,
+    });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25', true),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
   it('returns false for non-EVM native token when no gas-included path is enabled', () => {
     const solanaToken: BridgeToken = {
       ...nativeToken,
@@ -170,6 +182,7 @@ describe('useShouldRenderMaxOption', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: false,
+      stxEnabled: false,
     });
     mockUseTokenAddress.mockReturnValue(solanaToken.address);
     mockIsNativeAddress.mockReturnValue(true);

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
@@ -47,19 +47,11 @@ const nativeToken: BridgeToken = {
 const setSelectorValues = ({
   gasIncluded = false,
   gasIncluded7702 = false,
-  stxEnabled = true,
 }: {
   gasIncluded?: boolean;
   gasIncluded7702?: boolean;
-  stxEnabled?: boolean;
 } = {}) => {
-  let selectorCallCount = 0;
-  mockUseSelector.mockImplementation(() => {
-    selectorCallCount += 1;
-    return selectorCallCount % 2 === 1
-      ? { gasIncluded, gasIncluded7702 }
-      : stxEnabled;
-  });
+  mockUseSelector.mockImplementation(() => ({ gasIncluded, gasIncluded7702 }));
 };
 
 describe('useShouldRenderMaxOption', () => {
@@ -98,7 +90,7 @@ describe('useShouldRenderMaxOption', () => {
   });
 
   it('returns true for native token when gasIncluded is enabled', () => {
-    setSelectorValues({ gasIncluded: true, stxEnabled: true });
+    setSelectorValues({ gasIncluded: true });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
 
@@ -113,7 +105,6 @@ describe('useShouldRenderMaxOption', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: true,
-      stxEnabled: false,
     });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
@@ -129,7 +120,6 @@ describe('useShouldRenderMaxOption', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: false,
-      stxEnabled: true,
     });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
@@ -141,27 +131,10 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(false);
   });
 
-  it('returns true for sponsored native quote when stx is enabled', () => {
+  it('returns false for sponsored native quote when gasIncluded paths are disabled', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: false,
-      stxEnabled: true,
-    });
-    mockUseTokenAddress.mockReturnValue(nativeToken.address);
-    mockIsNativeAddress.mockReturnValue(true);
-
-    const { result } = renderHook(() =>
-      useShouldRenderMaxOption(nativeToken, '1.25', true),
-    );
-
-    expect(result.current).toBe(true);
-  });
-
-  it('returns false for sponsored native quote when stx is disabled', () => {
-    setSelectorValues({
-      gasIncluded: false,
-      gasIncluded7702: false,
-      stxEnabled: false,
     });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
@@ -173,6 +146,21 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(false);
   });
 
+  it('returns true for sponsored native quote when 7702 path is enabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: true,
+    });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25', true),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
   it('returns false for non-EVM native token when no gas-included path is enabled', () => {
     const solanaToken: BridgeToken = {
       ...nativeToken,
@@ -182,7 +170,6 @@ describe('useShouldRenderMaxOption', () => {
     setSelectorValues({
       gasIncluded: false,
       gasIncluded7702: false,
-      stxEnabled: false,
     });
     mockUseTokenAddress.mockReturnValue(solanaToken.address);
     mockIsNativeAddress.mockReturnValue(true);

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
@@ -1,15 +1,10 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import {
-  formatChainIdToHex,
-  isNativeAddress,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
+import { isNativeAddress } from '@metamask/bridge-controller';
 import { useSelector } from 'react-redux';
 import { useShouldRenderMaxOption } from '.';
 import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
-import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -19,17 +14,11 @@ jest.mock('../useTokenAddress', () => ({
   useTokenAddress: jest.fn(),
 }));
 
-jest.mock('../useIsSendBundleSupported', () => ({
-  useIsSendBundleSupported: jest.fn(),
-}));
-
 jest.mock('@metamask/bridge-controller', () => {
   const actual = jest.requireActual('@metamask/bridge-controller');
   return {
     ...actual,
-    formatChainIdToHex: jest.fn(),
     isNativeAddress: jest.fn(),
-    isNonEvmChainId: jest.fn(),
   };
 });
 
@@ -37,18 +26,8 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseTokenAddress = useTokenAddress as jest.MockedFunction<
   typeof useTokenAddress
 >;
-const mockUseIsSendBundleSupported =
-  useIsSendBundleSupported as jest.MockedFunction<
-    typeof useIsSendBundleSupported
-  >;
-const mockFormatChainIdToHex = formatChainIdToHex as jest.MockedFunction<
-  typeof formatChainIdToHex
->;
 const mockIsNativeAddress = isNativeAddress as jest.MockedFunction<
   typeof isNativeAddress
->;
-const mockIsNonEvmChainId = isNonEvmChainId as jest.MockedFunction<
-  typeof isNonEvmChainId
 >;
 
 const mockToken: BridgeToken = {
@@ -65,22 +44,23 @@ const nativeToken: BridgeToken = {
   chainId: CHAIN_IDS.MAINNET,
 };
 
-const setSelectorValues = ({ stxEnabled = true }: { stxEnabled?: boolean }) => {
-  mockUseSelector.mockImplementation(() => stxEnabled);
+const setSelectorValues = ({
+  gasIncluded = false,
+  gasIncluded7702 = false,
+}: {
+  gasIncluded?: boolean;
+  gasIncluded7702?: boolean;
+} = {}) => {
+  mockUseSelector.mockImplementation(() => ({ gasIncluded, gasIncluded7702 }));
 };
 
 describe('useShouldRenderMaxOption', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    setSelectorValues({ stxEnabled: true });
+    setSelectorValues();
     mockUseTokenAddress.mockReturnValue(mockToken.address);
-    mockUseIsSendBundleSupported.mockReturnValue(false);
-    mockFormatChainIdToHex.mockImplementation(
-      (chainId) => chainId as `0x${string}`,
-    );
     mockIsNativeAddress.mockReturnValue(false);
-    mockIsNonEvmChainId.mockReturnValue(false);
   });
 
   it('returns false when token is undefined', () => {
@@ -109,11 +89,10 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(true);
   });
 
-  it('returns true for native token when stx and sendBundle are enabled', () => {
-    setSelectorValues({ stxEnabled: true });
+  it('returns true for native token when gasIncluded is enabled', () => {
+    setSelectorValues({ gasIncluded: true });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
-    mockUseIsSendBundleSupported.mockReturnValue(true);
 
     const { result } = renderHook(() =>
       useShouldRenderMaxOption(nativeToken, '1.25'),
@@ -122,47 +101,41 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(true);
   });
 
-  it('returns false for native token when sendBundle is disabled', () => {
-    setSelectorValues({ stxEnabled: true });
+  it('returns true for native token when 7702 is enabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: true,
+    });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
-    mockUseIsSendBundleSupported.mockReturnValue(false);
 
     const { result } = renderHook(() =>
       useShouldRenderMaxOption(nativeToken, '1.25'),
-    );
-
-    expect(result.current).toBe(false);
-  });
-
-  it('returns false for native token when stx is disabled even if sendBundle is enabled', () => {
-    setSelectorValues({ stxEnabled: false });
-    mockUseTokenAddress.mockReturnValue(nativeToken.address);
-    mockIsNativeAddress.mockReturnValue(true);
-    mockUseIsSendBundleSupported.mockReturnValue(true);
-
-    const { result } = renderHook(() =>
-      useShouldRenderMaxOption(nativeToken, '1.25'),
-    );
-
-    expect(result.current).toBe(false);
-  });
-
-  it('returns true for sponsored native quote when stx is enabled', () => {
-    setSelectorValues({ stxEnabled: true });
-    mockUseTokenAddress.mockReturnValue(nativeToken.address);
-    mockIsNativeAddress.mockReturnValue(true);
-    mockUseIsSendBundleSupported.mockReturnValue(false);
-
-    const { result } = renderHook(() =>
-      useShouldRenderMaxOption(nativeToken, '1.25', true),
     );
 
     expect(result.current).toBe(true);
   });
 
-  it('returns false for sponsored native quote when stx is disabled', () => {
-    setSelectorValues({ stxEnabled: false });
+  it('returns false for native token when gasIncluded and 7702 are both disabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: false,
+    });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
+    mockIsNativeAddress.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25'),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false for sponsored native quote when gasIncluded paths are disabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: false,
+    });
     mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
 
@@ -173,35 +146,38 @@ describe('useShouldRenderMaxOption', () => {
     expect(result.current).toBe(false);
   });
 
-  it('passes formatted EVM chain id to sendBundle hook', () => {
-    const chainId = '0xa' as `0x${string}`;
-    const formattedChainId = '0xa' as `0x${string}`;
-    const token = { ...nativeToken, chainId };
-    mockUseTokenAddress.mockReturnValue(token.address);
+  it('returns true for sponsored native quote when 7702 path is enabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: true,
+    });
+    mockUseTokenAddress.mockReturnValue(nativeToken.address);
     mockIsNativeAddress.mockReturnValue(true);
-    mockFormatChainIdToHex.mockReturnValue(formattedChainId);
 
-    renderHook(() => useShouldRenderMaxOption(token, '1.25'));
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(nativeToken, '1.25', true),
+    );
 
-    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(formattedChainId);
+    expect(result.current).toBe(true);
   });
 
-  it('passes undefined chain id to sendBundle hook for non-EVM token', () => {
+  it('returns false for non-EVM native token when no gas-included path is enabled', () => {
     const solanaToken: BridgeToken = {
       ...nativeToken,
       chainId:
         'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as `${string}:${string}`,
     };
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: false,
+    });
     mockUseTokenAddress.mockReturnValue(solanaToken.address);
     mockIsNativeAddress.mockReturnValue(true);
-    mockIsNonEvmChainId.mockReturnValue(true);
-    setSelectorValues({ stxEnabled: false });
 
     const { result } = renderHook(() =>
       useShouldRenderMaxOption(solanaToken, '3'),
     );
 
-    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(undefined);
     expect(result.current).toBe(false);
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a bug where the max button was no longer showing on select networks.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27381

## **Manual testing steps**

```gherkin
Feature: swap max button

  Scenario: user is using the swaps experience
    Given the chain they are on supports gasless 

    When user selects tokens
    Then the max button should be visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gating logic for showing the Bridge/Swap “Max” option for native assets, so regressions could hide/show the button on certain networks depending on `gasIncluded`/`gasIncluded7702` selector outputs.
> 
> **Overview**
> Updates `useShouldRenderMaxOption` to **stop depending on Smart Transactions/send-bundle support and quote sponsorship** and instead show the Max option for native assets when `selectGasIncludedQuoteParams` indicates `gasIncluded` or `gasIncluded7702`.
> 
> Refactors the corresponding hook tests to mock the new selector shape and to cover gas-included vs 7702-enabled vs disabled scenarios (including non‑EVM native tokens), removing the old STX/send-bundle assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2b4a061da5ee1bd1e5a900f04fa151052fdf7b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->