### PR TITLE
fix(seedless-onboarding): handle both vault formats in encryptorAdapter cp-7.69.0

### DIFF
--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
@@ -68,11 +68,15 @@ const getAuthTokenHandlerMocks = () => {
 jest.mock('../../../Encryptor', () => {
   const mockEncryptWithKeyFn = jest.fn();
   const mockDecryptWithKeyFn = jest.fn();
+  const mockDecryptFn = jest.fn();
+  const mockDecryptWithDetailFn = jest.fn();
 
   return {
     Encryptor: jest.fn().mockImplementation(() => ({
       encryptWithKey: mockEncryptWithKeyFn,
       decryptWithKey: mockDecryptWithKeyFn,
+      decrypt: mockDecryptFn,
+      decryptWithDetail: mockDecryptWithDetailFn,
     })),
     LEGACY_DERIVATION_OPTIONS: {
       algorithm: 'PBKDF2',
@@ -80,6 +84,8 @@ jest.mock('../../../Encryptor', () => {
     },
     __mockEncryptWithKey: mockEncryptWithKeyFn,
     __mockDecryptWithKey: mockDecryptWithKeyFn,
+    __mockDecrypt: mockDecryptFn,
+    __mockDecryptWithDetail: mockDecryptWithDetailFn,
   };
 });
 
@@ -88,10 +94,14 @@ const getEncryptorMocks = () => {
   const mocks = jest.requireMock('../../../Encryptor') as {
     __mockEncryptWithKey: jest.Mock;
     __mockDecryptWithKey: jest.Mock;
+    __mockDecrypt: jest.Mock;
+    __mockDecryptWithDetail: jest.Mock;
   };
   return {
     mockEncryptWithKey: mocks.__mockEncryptWithKey,
     mockDecryptWithKey: mocks.__mockDecryptWithKey,
+    mockDecrypt: mocks.__mockDecrypt,
+    mockDecryptWithDetail: mocks.__mockDecryptWithDetail,
   };
 };
 
@@ -116,9 +126,20 @@ describe('seedless onboarding controller init', () => {
     // Reset web3AuthNetwork to valid value before each test
     mockWeb3AuthNetwork.value = 'sapphire_devnet';
 
-    const { mockEncryptWithKey, mockDecryptWithKey } = getEncryptorMocks();
+    const {
+      mockEncryptWithKey,
+      mockDecryptWithKey,
+      mockDecrypt,
+      mockDecryptWithDetail,
+    } = getEncryptorMocks();
     mockEncryptWithKey.mockResolvedValue(mockEncryptResult);
     mockDecryptWithKey.mockResolvedValue({ test: 'decrypted-data' });
+    mockDecrypt.mockResolvedValue({ test: 'decrypted-data' });
+    mockDecryptWithDetail.mockResolvedValue({
+      vault: { test: 'decrypted-data' },
+      exportedKeyString: 'mock-key-string',
+      salt: 'mock-salt',
+    });
 
     const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
       namespace: MOCK_ANY_NAMESPACE,
@@ -229,6 +250,245 @@ describe('seedless onboarding controller init', () => {
         keyMetadata: encryptedObject.keyMetadata,
       });
       expect(decrypted).toEqual({ test: 'decrypted-data' });
+    });
+
+    it('decryptWithKey falls back to cipher field for pre-adapter vaults', async () => {
+      const { mockDecryptWithKey } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const mockKey = { key: 'test-key', lib: 'test-lib', exportable: true };
+      // Legacy vault format: uses 'cipher' instead of 'data'
+      const legacyEncryptedObject = {
+        cipher: 'legacy-cipher-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      };
+
+      // Cast as never: the package type expects `data` (DefaultEncryptionResult), but we
+      // intentionally pass a legacy vault with `cipher` only to test the fallback path.
+      await encryptorAdapter.decryptWithKey(
+        mockKey,
+        legacyEncryptedObject as never,
+      );
+
+      expect(mockDecryptWithKey).toHaveBeenCalledWith(mockKey, {
+        cipher: 'legacy-cipher-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+        lib: undefined,
+        keyMetadata: undefined,
+      });
+    });
+
+    it('decryptWithKey throws when both data and cipher are absent', async () => {
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const mockKey = { key: 'test-key', lib: 'test-lib', exportable: true };
+      const malformedObject = { iv: 'test-iv', salt: 'test-salt' };
+
+      // Cast as never: the package type expects `data` (DefaultEncryptionResult), but we
+      // intentionally pass a malformed vault (missing both fields) to test the error path.
+      await expect(
+        encryptorAdapter.decryptWithKey(mockKey, malformedObject as never),
+      ).rejects.toThrow(
+        'SeedlessOnboardingController encryptorAdapter: vault is missing both "data" and "cipher" fields',
+      );
+    });
+
+    it('decrypt normalizes data-format vault before decryption', async () => {
+      const { mockDecrypt } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const dataFormatVault = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decrypt('password', dataFormatVault);
+
+      // Should normalize 'data' → 'cipher' before passing to underlying encryptor
+      const expectedNormalized = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+        cipher: 'encrypted-data',
+      });
+      expect(mockDecrypt).toHaveBeenCalledWith('password', expectedNormalized);
+    });
+
+    it('decrypt passes cipher-format vault through unchanged', async () => {
+      const { mockDecrypt } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const cipherFormatVault = JSON.stringify({
+        cipher: 'encrypted-cipher',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decrypt('password', cipherFormatVault);
+
+      expect(mockDecrypt).toHaveBeenCalledWith('password', cipherFormatVault);
+    });
+
+    it('decryptWithDetail normalizes data-format vault before decryption', async () => {
+      const { mockDecryptWithDetail } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const dataFormatVault = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decryptWithDetail('password', dataFormatVault);
+
+      const expectedNormalized = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+        cipher: 'encrypted-data',
+      });
+      expect(mockDecryptWithDetail).toHaveBeenCalledWith(
+        'password',
+        expectedNormalized,
+      );
+    });
+
+    it('decryptWithDetail passes cipher-format vault through unchanged', async () => {
+      const { mockDecryptWithDetail } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const cipherFormatVault = JSON.stringify({
+        cipher: 'encrypted-cipher',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decryptWithDetail('password', cipherFormatVault);
+
+      expect(mockDecryptWithDetail).toHaveBeenCalledWith(
+        'password',
+        cipherFormatVault,
+      );
+    });
+
+    /**
+     * End-to-end bug reproduction scenario:
+     *
+     * Bug (pre-fix): While the wallet is unlocked, a background JWT token
+     * refresh triggers SeedlessOnboardingController#updateVault, which calls
+     * encryptWithKey via the adapter. The adapter returns { data, iv, salt }
+     * (browser-passworder format). This vault string (with `data`, no `cipher`)
+     * is persisted to state.
+     *
+     * On next unlock, the controller reads the persisted vault and calls
+     * decrypt / decryptWithDetail. The underlying mobile Encryptor reads
+     * `cipher` from the parsed vault — finds undefined — and crashes with
+     * "TypeError: The first argument must be one of type string, Buffer..."
+     *
+     * Fix: normalizeVaultFormat detects a vault that has `data` but no
+     * `cipher` and injects cipher = data before handing it to the Encryptor.
+     */
+    describe('end-to-end: background token refresh followed by unlock', () => {
+      it('decrypt can read a vault written by encryptWithKey (data-format vault)', async () => {
+        const { mockDecrypt } = getEncryptorMocks();
+        seedlessOnboardingControllerInit(initRequestMock);
+
+        const encryptorAdapter =
+          seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+        const mockKey = {
+          key: 'test-key',
+          lib: 'test-lib',
+          exportable: true,
+          keyMetadata: { algorithm: 'PBKDF2', params: { iterations: 600000 } },
+        };
+
+        // Step 1: background token refresh writes vault via encryptWithKey
+        // → adapter converts cipher → data, returning browser-passworder format
+        const encryptedVault = await encryptorAdapter.encryptWithKey(mockKey, {
+          secret: 'seed-phrase',
+        });
+        expect(encryptedVault).toHaveProperty('data'); // data, not cipher
+        expect(encryptedVault).not.toHaveProperty('cipher');
+
+        // Step 2: controller serializes and persists the vault
+        const persistedVaultString = JSON.stringify(encryptedVault);
+
+        // Step 3: wallet locks, vaultEncryptionKey is cleared (persist: false).
+        // On next unlock the controller calls decrypt with the persisted string.
+        // Without the fix this would crash because the Encryptor reads `cipher`
+        // (undefined here) and passes it to QuickCryptoLib.decrypt.
+        await encryptorAdapter.decrypt('user-password', persistedVaultString);
+
+        // The underlying Encryptor must receive the vault with `cipher` injected
+        const expectedNormalized = JSON.stringify({
+          ...encryptedVault,
+          cipher: encryptedVault.data,
+        });
+        expect(mockDecrypt).toHaveBeenCalledWith(
+          'user-password',
+          expectedNormalized,
+        );
+      });
+
+      it('decryptWithDetail can read a vault written by encryptWithKey (data-format vault)', async () => {
+        const { mockDecryptWithDetail } = getEncryptorMocks();
+        seedlessOnboardingControllerInit(initRequestMock);
+
+        const encryptorAdapter =
+          seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+        const mockKey = {
+          key: 'test-key',
+          lib: 'test-lib',
+          exportable: true,
+          keyMetadata: { algorithm: 'PBKDF2', params: { iterations: 600000 } },
+        };
+
+        // Step 1: background token refresh writes vault via encryptWithKey
+        const encryptedVault = await encryptorAdapter.encryptWithKey(mockKey, {
+          secret: 'seed-phrase',
+        });
+
+        // Step 2: persist
+        const persistedVaultString = JSON.stringify(encryptedVault);
+
+        // Step 3: unlock via decryptWithDetail (used when vaultEncryptionKey is absent)
+        await encryptorAdapter.decryptWithDetail(
+          'user-password',
+          persistedVaultString,
+        );
+
+        const expectedNormalized = JSON.stringify({
+          ...encryptedVault,
+          cipher: encryptedVault.data,
+        });
+        expect(mockDecryptWithDetail).toHaveBeenCalledWith(
+          'user-password',
+          expectedNormalized,
+        );
+      });
     });
   });
 

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
@@ -32,6 +32,25 @@ interface ControllerEncryptionResult {
 }
 
 /**
+ * Normalizes a serialized vault so the mobile Encryptor can decrypt it
+ * regardless of whether the vault was written by the adapter (using 'data')
+ * or by the original mobile Encryptor (using 'cipher').
+ *
+ * Background: the SeedlessOnboardingController stores vaults via
+ * encryptWithKey (adapter, 'data' field) and via encryptWithDetail (mobile
+ * Encryptor, 'cipher' field).  The mobile Encryptor's decrypt / decryptWithDetail
+ * always reads 'cipher', so vaults produced by the adapter must be normalized
+ * before being handed to those methods.
+ */
+function normalizeVaultFormat(text: string): string {
+  const payload: Record<string, unknown> = JSON.parse(text);
+  if (payload.data !== undefined && payload.cipher === undefined) {
+    return JSON.stringify({ ...payload, cipher: payload.data });
+  }
+  return text;
+}
+
+/**
  * Adapter that wraps the mobile Encryptor to be compatible with
  * SeedlessOnboardingController's VaultEncryptor interface.
  * Maps 'cipher' <-> 'data' between mobile and controller formats.
@@ -53,15 +72,33 @@ const encryptorAdapter = {
   },
   decryptWithKey: async (
     key: EncryptionKey,
-    encryptedObject: ControllerEncryptionResult,
-  ): Promise<unknown> =>
-    encryptor.decryptWithKey(key, {
-      cipher: encryptedObject.data,
+    // Accept both adapter format ('data') and legacy mobile format ('cipher').
+    // 'data' is intentionally optional here: pre-adapter vaults only carry
+    // 'cipher', so making 'data' required would be a lie about the runtime
+    // shape and would allow the fallback to be silently removed.
+    encryptedObject: Omit<ControllerEncryptionResult, 'data'> & {
+      data?: string;
+      cipher?: string;
+    },
+  ): Promise<unknown> => {
+    const cipher = encryptedObject.data ?? encryptedObject.cipher;
+    if (!cipher) {
+      throw new Error(
+        'SeedlessOnboardingController encryptorAdapter: vault is missing both "data" and "cipher" fields',
+      );
+    }
+    return encryptor.decryptWithKey(key, {
+      cipher,
       iv: encryptedObject.iv,
       salt: encryptedObject.salt,
       lib: encryptedObject.lib,
       keyMetadata: encryptedObject.keyMetadata,
-    }),
+    });
+  },
+  decrypt: async (password: string, text: string): Promise<unknown> =>
+    encryptor.decrypt(password, normalizeVaultFormat(text)),
+  decryptWithDetail: async (password: string, text: string) =>
+    encryptor.decryptWithDetail(password, normalizeVaultFormat(text)),
 };
 
 /**


### PR DESCRIPTION
## Explanation

Fixes a critical regression introduced by PR #26258 (`encryptorAdapter` for SeedlessOnboardingController) that permanently locks affected users out of their wallets.

### Root cause

The `encryptorAdapter` overrides `encryptWithKey` to write vaults using a `data` field (browser-passworder standard), and overrides `decryptWithKey` to read from `data`. However, `decrypt` and `decryptWithDetail` were left as spreads from `...encryptor` — the mobile Encryptor — which internally reads `cipher`.

The only passwordless `#updateVault` call (in `#doRefreshAuthTokens`, line 2193 in the controller) fires automatically in the background whenever the wallet is unlocked and a JWT token refresh succeeds. After this runs:

1. Vault is written to AsyncStorage in **`data` format** (adapter's `encryptWithKey`)
2. Wallet locks (auto-lock or restart)
3. `vaultEncryptionKey` is cleared (not persisted)
4. User tries to unlock → `decryptWithDetail` (mobile Encryptor) reads `JSON.parse(vault).cipher` → **`undefined`**
5. `Buffer.from(undefined, 'base64')` → **crash** → user is permanently locked out

Every subsequent unlock attempt fails the same way — there is no recovery path without a fix.

### Fix

Three changes to `encryptorAdapter`:

1. **`decrypt`** — overridden to call `normalizeVaultFormat` before delegating to `encryptor.decrypt`, mapping `data` → `cipher` for vaults written by the adapter.
2. **`decryptWithDetail`** — same normalization before delegating to `encryptor.decryptWithDetail`.
3. **`decryptWithKey`** — falls back to `encryptedObject.cipher` when `encryptedObject.data` is absent, so pre-adapter vaults (stored with `cipher`) remain readable.

The `normalizeVaultFormat` helper adds a `cipher` field equal to `data` when a vault has `data` but not `cipher`. Vaults already in `cipher` format pass through unchanged.

### Impact

- Only **seedless onboarding users** are affected
- Triggered automatically after any background JWT token refresh while the wallet is unlocked

## References

- Sentry issue: METAMASK-MOBILE-5K9N
- Regression introduced by: https://github.com/MetaMask/metamask-mobile/commit/0134ffd0ce4c29706e7b88ba1d848535b8c5884f

## Changelog

CHANGELOG entry: Fixed a bug that permanently locked some seedless onboarding users out of their wallets after a background token refresh

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've manually tested the PR (required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches seedless onboarding vault encryption/decryption paths; mistakes here can break unlock/decrypt behavior and potentially lock users out. Although scoped and well-tested, it modifies security- and data-critical logic.
> 
> **Overview**
> Fixes `seedlessOnboardingController`’s `encryptorAdapter` to correctly handle both vault serialization formats (`data` vs `cipher`). It adds `normalizeVaultFormat()` and overrides `decrypt`/`decryptWithDetail` to map `data`→`cipher` before delegating to the mobile `Encryptor`, and updates `decryptWithKey` to accept legacy `cipher` objects (and throw a clear error if neither field exists).
> 
> Expands `index.test.ts` to mock the new decrypt methods and cover normalization, legacy fallback behavior, and the new error case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e270d211f6564f85b5fedebcdaf60d2b9e97f59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->