### PR TITLE
feat: MUSD-497 redirect home when user max converts final eligible token

### DIFF
--- a/app/components/UI/Earn/hooks/useMusdConfirmNavigation.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdConfirmNavigation.test.ts
@@ -2,6 +2,9 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
 import { useMusdConfirmNavigation } from './useMusdConfirmNavigation';
+import { useMusdConversionTokens } from './useMusdConversionTokens';
+import { useTransactionPayIsMaxAmount } from '../../../Views/confirmations/hooks/pay/useTransactionPayData';
+import { AssetType } from '../../../Views/confirmations/types/token';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -21,11 +24,51 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock(
+  '../../../Views/confirmations/hooks/pay/useTransactionPayData',
+  () => ({
+    useTransactionPayIsMaxAmount: jest.fn(),
+  }),
+);
+
+jest.mock('./useMusdConversionTokens');
+
+const mockUseTransactionPayIsMaxAmount =
+  useTransactionPayIsMaxAmount as jest.MockedFunction<
+    typeof useTransactionPayIsMaxAmount
+  >;
+const mockUseMusdConversionTokens =
+  useMusdConversionTokens as jest.MockedFunction<
+    typeof useMusdConversionTokens
+  >;
+
+const createTokenWithBalance = (
+  overrides: Partial<AssetType> = {},
+): AssetType =>
+  ({
+    address: '0xToken1',
+    chainId: '0x1',
+    symbol: 'USDC',
+    rawBalance: '0x1000',
+    ...overrides,
+  }) as AssetType;
+
 describe('useMusdConfirmNavigation', () => {
   const useSelectorMock = useSelector as jest.Mock;
 
   beforeEach(() => {
     jest.resetAllMocks();
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
+    mockUseMusdConversionTokens.mockReturnValue({
+      tokens: [
+        createTokenWithBalance(),
+        createTokenWithBalance({ address: '0xToken2', symbol: 'USDT' }),
+      ],
+      filterAllowedTokens: jest.fn(),
+      isConversionToken: jest.fn(),
+      isMusdSupportedOnChain: jest.fn(),
+      hasConvertibleTokensByChainId: jest.fn(),
+    });
   });
 
   it('goes back when quick convert is enabled and navigation can go back', () => {
@@ -68,5 +111,64 @@ describe('useMusdConfirmNavigation', () => {
     expect(mockCanGoBack).not.toHaveBeenCalled();
     expect(mockGoBack).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
+  });
+
+  it('navigates to wallet view when max converting the last token', () => {
+    useSelectorMock.mockReturnValue(true);
+    mockCanGoBack.mockReturnValue(true);
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(true);
+    mockUseMusdConversionTokens.mockReturnValue({
+      tokens: [createTokenWithBalance()],
+      filterAllowedTokens: jest.fn(),
+      isConversionToken: jest.fn(),
+      isMusdSupportedOnChain: jest.fn(),
+      hasConvertibleTokensByChainId: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useMusdConfirmNavigation());
+
+    act(() => {
+      result.current.navigateOnConfirm();
+    });
+
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
+  });
+
+  it('goes back when max converting with multiple tokens remaining', () => {
+    useSelectorMock.mockReturnValue(true);
+    mockCanGoBack.mockReturnValue(true);
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(true);
+
+    const { result } = renderHook(() => useMusdConfirmNavigation());
+
+    act(() => {
+      result.current.navigateOnConfirm();
+    });
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('goes back when custom converting the last token with partial amount', () => {
+    useSelectorMock.mockReturnValue(true);
+    mockCanGoBack.mockReturnValue(true);
+    mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
+    mockUseMusdConversionTokens.mockReturnValue({
+      tokens: [createTokenWithBalance()],
+      filterAllowedTokens: jest.fn(),
+      isConversionToken: jest.fn(),
+      isMusdSupportedOnChain: jest.fn(),
+      hasConvertibleTokensByChainId: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useMusdConfirmNavigation());
+
+    act(() => {
+      result.current.navigateOnConfirm();
+    });
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Earn/hooks/useMusdConfirmNavigation.ts
+++ b/app/components/UI/Earn/hooks/useMusdConfirmNavigation.ts
@@ -3,6 +3,8 @@ import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectMusdQuickConvertEnabledFlag } from '../selectors/featureFlags';
+import { useMusdConversionTokens } from './useMusdConversionTokens';
+import { useTransactionPayIsMaxAmount } from '../../../Views/confirmations/hooks/pay/useTransactionPayData';
 
 export const useMusdConfirmNavigation = () => {
   const navigation = useNavigation();
@@ -10,14 +12,32 @@ export const useMusdConfirmNavigation = () => {
     selectMusdQuickConvertEnabledFlag,
   );
 
+  const isMaxAmount = useTransactionPayIsMaxAmount();
+
+  const { tokens: conversionTokens } = useMusdConversionTokens();
+
+  const isLastConvertibleToken = conversionTokens.length <= 1;
+
   const navigateOnConfirm = useCallback(() => {
-    if (isMusdQuickConvertEnabled && navigation.canGoBack()) {
-      navigation.goBack();
-      return;
+    if (isMusdQuickConvertEnabled) {
+      if (isMaxAmount && isLastConvertibleToken) {
+        navigation.navigate(Routes.WALLET_VIEW);
+        return;
+      }
+
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+        return;
+      }
     }
 
     navigation.navigate(Routes.WALLET_VIEW);
-  }, [isMusdQuickConvertEnabled, navigation]);
+  }, [
+    isMusdQuickConvertEnabled,
+    navigation,
+    isMaxAmount,
+    isLastConvertibleToken,
+  ]);
 
   return {
     navigateOnConfirm,

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.test.ts
@@ -23,6 +23,10 @@ import {
 } from '../selectors/featureFlags';
 import { selectAccountGroupBalanceForEmptyState } from '../../../../selectors/assets/balances';
 import { selectMusdConversionAssetDetailCtasSeen } from '../../../../reducers/user/selectors';
+import {
+  selectHasInFlightMusdConversion,
+  selectHasUnapprovedMusdConversion,
+} from '../selectors/musdConversionStatus';
 import type { WildcardTokenList } from '../utils/wildcardTokenList';
 import type { TokenI } from '../../Tokens/types';
 import type { AssetType } from '../../../Views/confirmations/types/token';
@@ -163,6 +167,8 @@ describe('useMusdCtaVisibility', () => {
     userCurrency: 'USD',
   };
   let mockMusdConversionAssetDetailCtasSeen: Record<string, boolean> = {};
+  let mockHasUnapprovedMusdConversion = false;
+  let mockHasInFlightMusdConversion = false;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -170,6 +176,8 @@ describe('useMusdCtaVisibility', () => {
     mockIsMusdConversionTokenListItemCtaEnabled = false;
     mockIsMusdConversionAssetOverviewEnabled = false;
     mockMusdConversionCtaTokens = {};
+    mockHasUnapprovedMusdConversion = false;
+    mockHasInFlightMusdConversion = false;
     // Default to non-empty wallet
     mockAccountBalance = {
       walletId: 'test-wallet',
@@ -198,6 +206,12 @@ describe('useMusdCtaVisibility', () => {
       }
       if (selector === selectMusdConversionAssetDetailCtasSeen) {
         return mockMusdConversionAssetDetailCtasSeen;
+      }
+      if (selector === selectHasUnapprovedMusdConversion) {
+        return mockHasUnapprovedMusdConversion;
+      }
+      if (selector === selectHasInFlightMusdConversion) {
+        return mockHasInFlightMusdConversion;
       }
       return undefined;
     });
@@ -1602,6 +1616,214 @@ describe('useMusdCtaVisibility', () => {
           result.current.shouldShowAssetOverviewCta(assetOverviewToken);
 
         expect(isVisible).toBe(true);
+      });
+    });
+  });
+
+  describe('last-token in-flight conversion CTA suppression', () => {
+    const conversionToken: AssetType = createMockToken({
+      chainId: CHAIN_IDS.MAINNET,
+      name: 'USD Coin',
+      symbol: 'USDC',
+      decimals: 6,
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      balance: '1000000',
+      balanceFiat: '1.00',
+    });
+
+    const listItemToken: TokenI = {
+      ...conversionToken,
+      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    };
+
+    beforeEach(() => {
+      mockMusdConversionCtaTokens = { [CHAIN_IDS.MAINNET]: ['USDC'] };
+      mockIsMusdConversionTokenListItemCtaEnabled = true;
+      mockIsMusdConversionAssetOverviewEnabled = true;
+
+      mockUseNetworksByCustomNamespace.mockReturnValue({
+        ...defaultNetworksByNamespace,
+        areAllNetworksSelected: true,
+      });
+      mockUseCurrentNetworkInfo.mockReturnValue({
+        ...defaultNetworkInfo,
+        enabledNetworks: [
+          { chainId: CHAIN_IDS.MAINNET, enabled: true },
+          { chainId: CHAIN_IDS.LINEA_MAINNET, enabled: true },
+        ],
+      });
+      mockUseMusdBalance.mockReturnValue(
+        createMusdBalanceMockReturn({
+          hasMusdBalanceOnAnyChain: true,
+          hasMusdBalanceOnChain: jest.fn().mockReturnValue(true),
+        }),
+      );
+    });
+
+    describe('shouldShowBuyGetMusdCta', () => {
+      it('hides Get mUSD CTA when in-flight conversion and only one token remaining', () => {
+        mockHasInFlightMusdConversion = true;
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+        mockUseMusdBalance.mockReturnValue(createMusdBalanceMockReturn());
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const { shouldShowCta } = result.current.shouldShowBuyGetMusdCta();
+
+        expect(shouldShowCta).toBe(false);
+      });
+
+      it('shows Get mUSD CTA when in-flight conversion but multiple tokens remaining', () => {
+        mockHasInFlightMusdConversion = true;
+        const secondToken: AssetType = createMockToken({
+          chainId: CHAIN_IDS.MAINNET,
+          name: 'Dai',
+          symbol: 'DAI',
+          address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          balance: '1000000',
+          balanceFiat: '1.00',
+        });
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken, secondToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+        mockUseMusdBalance.mockReturnValue(createMusdBalanceMockReturn());
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const { shouldShowCta } = result.current.shouldShowBuyGetMusdCta();
+
+        expect(shouldShowCta).toBe(true);
+      });
+
+      it('hides Get mUSD CTA when unapproved conversion and only one token remaining', () => {
+        mockHasUnapprovedMusdConversion = true;
+        mockHasInFlightMusdConversion = false;
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+        mockUseMusdBalance.mockReturnValue(createMusdBalanceMockReturn());
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const { shouldShowCta } = result.current.shouldShowBuyGetMusdCta();
+
+        expect(shouldShowCta).toBe(false);
+      });
+
+      it('shows Get mUSD CTA when one token remaining but no in-flight conversion', () => {
+        mockHasInFlightMusdConversion = false;
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+        mockUseMusdBalance.mockReturnValue(createMusdBalanceMockReturn());
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+        const { shouldShowCta } = result.current.shouldShowBuyGetMusdCta();
+
+        expect(shouldShowCta).toBe(true);
+      });
+    });
+
+    describe('shouldShowTokenListItemCta', () => {
+      it('hides token list item CTA when in-flight conversion and only one token remaining', () => {
+        mockHasInFlightMusdConversion = true;
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowTokenListItemCta(listItemToken)).toBe(
+          false,
+        );
+      });
+
+      it('shows token list item CTA when in-flight conversion but multiple tokens remaining', () => {
+        mockHasInFlightMusdConversion = true;
+        const secondToken: AssetType = createMockToken({
+          chainId: CHAIN_IDS.MAINNET,
+          name: 'Dai',
+          symbol: 'DAI',
+          address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          balance: '1000000',
+          balanceFiat: '1.00',
+        });
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken, secondToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowTokenListItemCta(listItemToken)).toBe(
+          true,
+        );
+      });
+    });
+
+    describe('shouldShowAssetOverviewCta', () => {
+      it('hides asset overview CTA when in-flight conversion and only one token remaining', () => {
+        mockHasInFlightMusdConversion = true;
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowAssetOverviewCta(listItemToken)).toBe(
+          false,
+        );
+      });
+
+      it('shows asset overview CTA when in-flight conversion but multiple tokens remaining', () => {
+        mockHasInFlightMusdConversion = true;
+        const secondToken: AssetType = createMockToken({
+          chainId: CHAIN_IDS.MAINNET,
+          name: 'Dai',
+          symbol: 'DAI',
+          address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          balance: '1000000',
+          balanceFiat: '1.00',
+        });
+        mockUseMusdConversionTokens.mockReturnValue({
+          tokens: [conversionToken, secondToken],
+          filterAllowedTokens: jest.fn(),
+          isConversionToken: jest.fn(),
+          isMusdSupportedOnChain: jest.fn(),
+          hasConvertibleTokensByChainId: jest.fn().mockReturnValue(true),
+        });
+
+        const { result } = renderHook(() => useMusdCtaVisibility());
+
+        expect(result.current.shouldShowAssetOverviewCta(listItemToken)).toBe(
+          true,
+        );
       });
     });
   });

--- a/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
+++ b/app/components/UI/Earn/hooks/useMusdCtaVisibility.ts
@@ -16,6 +16,10 @@ import { useMusdConversionTokens } from './useMusdConversionTokens';
 import { isTokenInWildcardList } from '../utils/wildcardTokenList';
 import { isNonEvmChainId } from '../../../../core/Multichain/utils';
 import { useMusdConversionFlowData } from './useMusdConversionFlowData';
+import {
+  selectHasInFlightMusdConversion,
+  selectHasUnapprovedMusdConversion,
+} from '../selectors/musdConversionStatus';
 
 /**
  * Variant for the primary mUSD CTA.
@@ -90,6 +94,21 @@ export const useMusdCtaVisibility = () => {
 
   const { tokens: conversionTokens, hasConvertibleTokensByChainId } =
     useMusdConversionTokens();
+
+  const hasUnapprovedMusdConversion = useSelector(
+    selectHasUnapprovedMusdConversion,
+  );
+
+  const hasInFlightMusdConversion = useSelector(
+    selectHasInFlightMusdConversion,
+  );
+
+  // Covers the brief window where the tx is still `unapproved` before transitioning to `approved` after confirmation.
+  const hasNonTerminalMusdConversion =
+    hasUnapprovedMusdConversion || hasInFlightMusdConversion;
+
+  const isLastTokenBeingConverted =
+    hasNonTerminalMusdConversion && conversionTokens.length <= 1;
 
   const getConversionTokensWithCtas = useCallback(
     (tokens: AssetType[]) =>
@@ -206,6 +225,10 @@ export const useMusdCtaVisibility = () => {
       variant: null,
     };
 
+    if (isLastTokenBeingConverted) {
+      return hiddenResult;
+    }
+
     // If the buy/get mUSD CTA feature flag is disabled, don't show the buy/get mUSD CTA
     if (!isMusdGetBuyCtaEnabled) {
       return hiddenResult;
@@ -263,6 +286,7 @@ export const useMusdCtaVisibility = () => {
     hasMusdBalanceOnChain,
     isEmptyWallet,
     isGeoEligible,
+    isLastTokenBeingConverted,
     isMusdGetBuyCtaEnabled,
     isPopularNetworksFilterActive,
     selectedChainId,
@@ -294,6 +318,10 @@ export const useMusdCtaVisibility = () => {
 
   const shouldShowTokenListItemCta = useCallback(
     (asset?: TokenI) => {
+      if (isLastTokenBeingConverted) {
+        return false;
+      }
+
       if (!isMusdConversionTokenListItemCtaEnabled || !asset?.chainId) {
         return false;
       }
@@ -322,6 +350,7 @@ export const useMusdCtaVisibility = () => {
       hasMusdBalanceOnAnyChain,
       hasMusdBalanceOnChain,
       isGeoEligible,
+      isLastTokenBeingConverted,
       isMusdConversionTokenListItemCtaEnabled,
       isPopularNetworksFilterActive,
       isTokenWithCta,
@@ -330,6 +359,10 @@ export const useMusdCtaVisibility = () => {
 
   const shouldShowAssetOverviewCta = useCallback(
     (asset?: TokenI) => {
+      if (isLastTokenBeingConverted) {
+        return false;
+      }
+
       if (
         !isMusdConversionAssetOverviewEnabled ||
         !asset?.address ||
@@ -352,6 +385,7 @@ export const useMusdCtaVisibility = () => {
       return isTokenWithCta(asset);
     },
     [
+      isLastTokenBeingConverted,
       isMusdConversionAssetOverviewEnabled,
       isTokenWithCta,
       musdConversionAssetDetailCtasSeen,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -26,9 +26,11 @@ import { TransactionPayQuote } from '@metamask/transaction-pay-controller';
 import { Json } from '@metamask/utils';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
+import { useMusdConfirmNavigation } from '../../../../UI/Earn/hooks/useMusdConfirmNavigation';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
+const mockMusdNavigateOnConfirm = jest.fn();
 
 jest.mock('../useApprovalRequest');
 jest.mock('./useTransactionMetadataRequest');
@@ -41,6 +43,7 @@ jest.mock('../../../../../util/transactions/sentinel-api');
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../gas/useIsGaslessSupported');
 jest.mock('../gas/useGaslessSupportedSmartTransactions');
+jest.mock('../../../../UI/Earn/hooks/useMusdConfirmNavigation');
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -79,9 +82,15 @@ describe('useTransactionConfirm', () => {
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
+  const useMusdConfirmNavigationMock = jest.mocked(useMusdConfirmNavigation);
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    useMusdConfirmNavigationMock.mockReturnValue({
+      navigateOnConfirm: mockMusdNavigateOnConfirm,
+    });
+
     useIsGaslessSupportedMock.mockReturnValue({
       isSmartTransaction: true,
       isSupported: true,
@@ -281,7 +290,7 @@ describe('useTransactionConfirm', () => {
       expect(mockGoBack).not.toHaveBeenCalled();
     });
 
-    it('wallet home if musdConversion', async () => {
+    it('calls musdConversionNavigateOnConfirm if musdConversion', async () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         id: transactionIdMock,
         type: TransactionType.musdConversion,
@@ -293,7 +302,7 @@ describe('useTransactionConfirm', () => {
         await result.current.onConfirm();
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
+      expect(mockMusdNavigateOnConfirm).toHaveBeenCalled();
     });
 
     it('transactions if full screen', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates the mUSD conversion flow to redirect users to the home page if they've "Max" converted their last eligible token.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated the mUSD conversion flow to redirect users to the home page if they've "Max" converted their last eligible token.

## **Related issues**

Fixes: [MUSD-497: Redirect to home screen from Quick Convert when there are no tokens left to convert.](https://consensyssoftware.atlassian.net/browse/MUSD-497)

## **Manual testing steps**

```gherkin
Feature: Redirect to home after converting last eligible token

  Scenario: user max-converts their final eligible token
    Given user has exactly one remaining token eligible for mUSD conversion
    And user is on the mUSD conversion confirmation screen with max amount selected
    Or user is on the mUSD Max conversion bottom sheet

    When user confirms the conversion
    Then user is navigated to the wallet home screen

  Scenario: user converts a token with other eligible tokens remaining
    Given user has multiple tokens eligible for mUSD conversion

    When user confirms a conversion
    Then user is returned to the quick convert flow

  Scenario: mUSD CTAs hidden while last token conversion is in-flight
    Given user has initiated a conversion of their only remaining eligible token
    And the transaction is still unapproved or in-flight

    When user views the token list, asset overview, or wallet banner
    Then no mUSD conversion CTAs are displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
We always redirected back to the Quick Convert view.

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/408247be-b4ee-4d10-a7e0-4a45c36f7a9e

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-confirm navigation and CTA visibility logic in the mUSD conversion flow, which could affect user routing and conversion entry points if token-count/tx-status conditions are miscomputed.
> 
> **Overview**
> Updates mUSD conversion confirmation navigation to **route to `Routes.WALLET_VIEW` when the user is in Quick Convert and confirms a *Max* conversion of their last remaining convertible token**, otherwise preserving the existing back-navigation behavior.
> 
> Adds CTA suppression in `useMusdCtaVisibility` so Buy/Get mUSD, token list item, and asset overview conversion CTAs are hidden while an `unapproved` or in-flight conversion is occurring *and* there is only one convertible token remaining, with expanded unit tests covering these edge cases and `useTransactionConfirm` now delegating musd conversion navigation to `useMusdConfirmNavigation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e64af9b1757ae61fc8efe8b79d1512a5e78037e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->