### PR TITLE
feat: modify OTA workflow

### DIFF
--- a/.github/scripts/validate-pr-commit.sh
+++ b/.github/scripts/validate-pr-commit.sh
@@ -3,27 +3,25 @@
 #
 # validate-pr-commit.sh
 #
-# Validates that a given commit hash is the HEAD (last commit) of a specified PR.
+# Resolves the HEAD (last) commit of a PR and outputs it for the workflow.
+# Caller only needs to provide the PR number; no commit hash input required.
 #
 # Environment Variables (required):
-#   COMMIT_HASH      - The commit SHA to validate
-#   PR_NUMBER      - The PR number to check against
-#   BASE_BRANCH    - The base branch of the PR (for validation)
-#   GITHUB_TOKEN   - GitHub API token for authentication
+#   PR_NUMBER       - The PR number to resolve
+#   GITHUB_TOKEN    - GitHub API token for authentication
 #   GITHUB_REPOSITORY - Repository in format "owner/repo"
 #
-# Outputs:
-#   Sets GITHUB_OUTPUT pr_number if validation succeeds
-#   Exits with code 0 on success, 1 on failure
+# Outputs (to GITHUB_OUTPUT):
+#   pr_number   - The PR number (for downstream steps)
+#   commit_sha  - The HEAD commit SHA of the PR branch
 #
+# Exits with code 0 on success, 1 on failure
 #
 
 set -euo pipefail
 
 # Ensure required environment variables are set
-COMMIT_HASH="${COMMIT_HASH:?COMMIT_HASH environment variable must be set}"
 PR_NUMBER="${PR_NUMBER:?PR_NUMBER environment variable must be set}"
-BASE_BRANCH="${BASE_BRANCH:?BASE_BRANCH environment variable must be set}"
 GITHUB_TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN environment variable must be set}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY environment variable must be set}"
 
@@ -32,7 +30,7 @@ REPO="${GITHUB_REPOSITORY#*/}"
 
 API_BASE="https://api.github.com/repos/${OWNER}/${REPO}"
 
-echo "🔍 Validating that commit ${COMMIT_HASH} is the HEAD (last commit) of PR #${PR_NUMBER} (base: ${BASE_BRANCH})..." >&2
+echo "🔍 Resolving HEAD commit for PR #${PR_NUMBER}..." >&2
 
 # Function to make GitHub API calls
 api_call() {
@@ -49,11 +47,9 @@ pr_details=$(api_call "/pulls/${PR_NUMBER}")
 
 # Check if PR exists
 if echo "$pr_details" | jq -e '.id' > /dev/null 2>&1; then
-  pr_base_ref=$(echo "$pr_details" | jq -r '.base.ref')
   pr_head_sha=$(echo "$pr_details" | jq -r '.head.sha')
   pr_state=$(echo "$pr_details" | jq -r '.state')
-  
-  echo "  PR base branch: ${pr_base_ref}" >&2
+
   echo "  PR head SHA: ${pr_head_sha}" >&2
   echo "  PR state: ${pr_state}" >&2
 else
@@ -61,24 +57,9 @@ else
   exit 1
 fi
 
-# Validate base branch matches (security-critical)
-if [ "$pr_base_ref" != "$BASE_BRANCH" ]; then
-  echo "❌ Validation failed: PR base branch (${pr_base_ref}) does not match provided base branch (${BASE_BRANCH})" >&2
-  echo "💡 The base_branch input must exactly match the PR's actual base branch to prevent fingerprint comparison against the wrong target." >&2
-  exit 1
-fi
-
-# Validate that commit is the PR head (last commit)
-if [ "$pr_head_sha" = "$COMMIT_HASH" ]; then
-  echo "✅ Commit ${COMMIT_HASH} is the HEAD (last commit) of PR #${PR_NUMBER}" >&2
-  echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-  exit 0
-else
-  echo "❌ Validation failed: Commit ${COMMIT_HASH} is not the HEAD of PR #${PR_NUMBER}" >&2
-  echo "❌ PR HEAD commit is: ${pr_head_sha}" >&2
-  echo "❌ Target commit is:  ${COMMIT_HASH}" >&2
-  echo "" >&2
-  echo "💡 The commit hash must be the last commit in the PR branch." >&2
-  echo "💡 Please use the HEAD commit SHA of the PR branch." >&2
-  exit 1
-fi
+echo "✅ Resolved PR #${PR_NUMBER} HEAD commit: ${pr_head_sha}" >&2
+{
+  echo "pr_number=${PR_NUMBER}"
+  echo "commit_sha=${pr_head_sha}"
+} >> "$GITHUB_OUTPUT"
+exit 0

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -3,12 +3,8 @@ name: Push OTA Update
 on:
   workflow_dispatch:
     inputs:
-      commit_hash:
-        description: 'Commit hash to publish'
-        required: true
-        type: string
       pr_number:
-        description: 'PR number associated with the commit'
+        description: 'PR number to publish (uses PR branch HEAD commit)'
         required: true
         type: string
       base_branch:
@@ -43,7 +39,6 @@ permissions:
   id-token: write
 
 env:
-  TARGET_COMMIT_HASH: ${{ inputs.commit_hash }}
   TARGET_PR_NUMBER: ${{ inputs.pr_number }}
   BASE_BRANCH_REF: ${{ inputs.base_branch }}
   UPDATE_MESSAGE: ${{ inputs.message }}
@@ -51,8 +46,30 @@ env:
   OTA_PUSH_PLATFORM: ${{ inputs.platform }}
 
 jobs:
+  validate-pr:
+    name: Resolve PR HEAD commit
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve-pr.outputs.pr_number }}
+      commit_sha: ${{ steps.resolve-pr.outputs.commit_sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR HEAD commit
+        id: resolve-pr
+        env:
+          PR_NUMBER: ${{ env.TARGET_PR_NUMBER }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          .github/scripts/validate-pr-commit.sh
+
   ota-summary:
     name: OTA Update Summary
+    needs: validate-pr
     runs-on: ubuntu-latest
     steps:
       - name: Display OTA Summary
@@ -65,7 +82,7 @@ jobs:
             echo "| **Update version** | ${UPDATE_MESSAGE} |"
             echo "| **Target version** | ${BASE_BRANCH_REF} |"
             echo "| **Environment** | ${TARGET_CHANNEL} |"
-            echo "| **Target commit** | ${TARGET_COMMIT_HASH} |"
+            echo "| **Target commit** | ${{ needs.validate-pr.outputs.commit_sha }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   setup-dependencies:
@@ -74,7 +91,7 @@ jobs:
       - validate-pr
     uses: ./.github/workflows/setup-node-modules.yml
     with:
-      ref: ${{ inputs.commit_hash }}
+      ref: ${{ needs.validate-pr.outputs.commit_sha }}
       fetch-depth: 0
       upload-artifact: true
       artifact-name: node-modules-eas-update-pr
@@ -95,6 +112,7 @@ jobs:
   fingerprint-comparison:
     name: Compare Expo Fingerprints
     needs:
+      - validate-pr
       - setup-dependencies
       - setup-dependencies-base
     runs-on: ubuntu-latest
@@ -109,7 +127,7 @@ jobs:
       - name: Checkout target commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.TARGET_COMMIT_HASH }}
+          ref: ${{ needs.validate-pr.outputs.commit_sha }}
           fetch-depth: 0
 
       - name: Checkout base branch snapshot
@@ -214,7 +232,7 @@ jobs:
           BRANCH_FP: ${{ steps.branch_fingerprint.outputs.fingerprint }}
           MAIN_FP: ${{ steps.main_fingerprint.outputs.fingerprint }}
           MATCHES: ${{ steps.compare.outputs.equal }}
-          TARGET_COMMIT_HASH: ${{ env.TARGET_COMMIT_HASH }}
+          TARGET_COMMIT_HASH: ${{ needs.validate-pr.outputs.commit_sha }}
           BASE_BRANCH_REF: ${{ env.BASE_BRANCH_REF }}
         run: |
           {
@@ -224,28 +242,6 @@ jobs:
             echo "- Base branch (\`$BASE_BRANCH_REF\`) fingerprint: \`$MAIN_FP\`"
             echo "- Match: \`$MATCHES\`"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  validate-pr:
-    name: Validate PR and Commit
-    runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.validate-pr.outputs.pr_number }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Validate PR contains commit
-        id: validate-pr
-        env:
-          COMMIT_HASH: ${{ env.TARGET_COMMIT_HASH }}
-          PR_NUMBER: ${{ env.TARGET_PR_NUMBER }}
-          BASE_BRANCH: ${{ env.BASE_BRANCH_REF }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          .github/scripts/validate-pr-commit.sh
 
   approval:
     name: Require OTA Update Approval
@@ -275,6 +271,7 @@ jobs:
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
       needs.approval.result == 'success'
     env:
+      TARGET_COMMIT_HASH: ${{ needs.validate-pr.outputs.commit_sha }}
       ARTIFACT_NAME: ${{ needs.setup-dependencies.outputs.artifact-name }}
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In the current workflow, the OTA PR needs to point to a base that is the same as the branch that we are applying the OTA to. However, this does not work because when we have a release branch, since the base is always `stable` so we will need to change the base branch whenever we run OTA update. 

In this PR:
- Get rid of hash commit input. We don't really need it because we will remove the approval if a new commit is pushed and we will always use the latest commit
- We get the latest commit hash in the OTA PR and output it in the workflow
- Remove the restriction on the OTA base branch. In the OTA PR, it shouldn't matter which base branch it's pointing to. We will compare the fingerprint to the actual release tag that the OTA is applying (which is one of the inputs when triggering the workflow)

workflow run: https://github.com/MetaMask/metamask-mobile/actions/runs/23026234415

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed OTA workflow commit hash input

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the OTA release workflow’s source-of-truth for what gets built/published and removes prior base-branch/commit validation, which could result in publishing an unintended revision if PR context is wrong.
> 
> **Overview**
> Updates the OTA `push-eas-update` workflow to publish from a PR’s **current HEAD commit** rather than a user-supplied commit SHA.
> 
> Reworks `.github/scripts/validate-pr-commit.sh` to *resolve* and output `commit_sha` for a given `PR_NUMBER` (no longer validates `COMMIT_HASH` or `BASE_BRANCH`), and wires this new output through checkout, dependency setup, fingerprint comparison, and the final push step; the manual `commit_hash` input and the old “validate PR contains commit” job are removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d9dcd1ec2b8321f230c0fed3fc33ac0acb0365a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->