### PR TITLE
feat(card): enable Monad delegation

### DIFF
--- a/app/components/UI/Card/constants.ts
+++ b/app/components/UI/Card/constants.ts
@@ -8,6 +8,7 @@ const infuraProjectId = InfuraKey === 'null' ? '' : InfuraKey;
 
 export const LINEA_MAINNET_RPC_URL = `https://linea-mainnet.infura.io/v3/${infuraProjectId}`;
 export const BASE_MAINNET_RPC_URL = `https://base-mainnet.infura.io/v3/${infuraProjectId}`;
+export const MONAD_MAINNET_RPC_URL = `https://monad-mainnet.infura.io/v3/${infuraProjectId}`;
 export const BALANCE_SCANNER_ABI =
   balanceScannerAbi as ethers.ContractInterface;
 export const ARBITRARY_ALLOWANCE = 100000000000;
@@ -19,6 +20,7 @@ export const SUPPORTED_ASSET_NETWORKS: CardNetwork[] = [
   'linea',
   'solana',
   'base',
+  'monad',
 ];
 export const CARD_SUPPORT_EMAIL = 'metamask@cl-cards.com';
 export const NON_PRODUCTION_ENVIRONMENTS = [
@@ -39,6 +41,10 @@ export const cardNetworkInfos: Record<CardNetwork, CardNetworkInfo> = {
     caipChainId: 'eip155:8453',
     rpcUrl: BASE_MAINNET_RPC_URL,
   },
+  monad: {
+    caipChainId: 'eip155:143',
+    rpcUrl: MONAD_MAINNET_RPC_URL,
+  },
   solana: {
     caipChainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
   },
@@ -47,6 +53,7 @@ export const cardNetworkInfos: Record<CardNetwork, CardNetworkInfo> = {
 export const caipChainIdToNetwork: Record<CaipChainId, CardNetwork> = {
   'eip155:59144': 'linea',
   'eip155:8453': 'base',
+  'eip155:143': 'monad',
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'solana',
 };
 

--- a/app/components/UI/Card/types.ts
+++ b/app/components/UI/Card/types.ts
@@ -94,7 +94,7 @@ export interface CardLoginInitiateResponse {
 
 export type CardLocation = 'us' | 'international';
 
-export type CardNetwork = 'linea' | 'solana' | 'base';
+export type CardNetwork = 'linea' | 'solana' | 'base' | 'monad';
 
 export interface CardNetworkInfo {
   caipChainId: CaipChainId;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds Monad mainnet as a supported network for Card asset delegation, enabling users to delegate their Card balances to the Monad network (chain ID 143).

**Why**: Users need the ability to delegate Card assets to Monad network for spending and withdrawal, similar to existing support for Linea, Base, and Solana.

**What changed**:

- **`constants.ts`**: Added `MONAD_MAINNET_RPC_URL` using Infura's Monad mainnet endpoint. Added `'monad'` to `SUPPORTED_ASSET_NETWORKS`. Added `monad` entry to `cardNetworkInfos` with caipChainId `eip155:143` and RPC URL. Added `eip155:143` → `monad` mapping to `caipChainIdToNetwork`.

- **`types.ts`**: Extended `CardNetwork` type to include `'monad'`.

## **Changelog**

CHANGELOG entry: Add Monad integration on Card delegation

## **Related issues**

Refs: Card Monad network integration

## **Manual testing steps**

```gherkin
Feature: Card - Monad network delegation

  Scenario: Monad network appears in supported asset networks
    Given the user has a Card with balance
    When the user opens the asset selection or delegation flow
    Then Monad network should appear as an available option alongside Linea, Base, and Solana

  Scenario: User can delegate Card assets to Monad network
    Given the user has a Card with balance
    When the user selects Monad as the delegation network
    And completes the delegation flow
    Then the delegation should succeed and assets should be available on Monad
```

## **Screenshots/Recordings**

No visual design changes — Monad network is added to the existing network selection UI and follows the same patterns as Linea and Base.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new supported chain (`monad`, `eip155:143`) and RPC endpoint, which can affect network filtering and delegation flows if the chain metadata or RPC URL is incorrect.
> 
> **Overview**
> Adds Monad mainnet support to Card asset delegation by introducing `MONAD_MAINNET_RPC_URL`, including `monad` in `SUPPORTED_ASSET_NETWORKS`, and wiring `eip155:143` into `cardNetworkInfos` and `caipChainIdToNetwork`.
> 
> Extends the `CardNetwork` union type to include `monad`, enabling downstream UI/SDK code to treat Monad as a first-class supported network.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e11f8f4b38c95f94db37aace71486456d2ff5ee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->