### PR TITLE
test: add mechanism to check page object migration

### DIFF
--- a/tests/framework/PageObjectMigrationTestUtils.ts
+++ b/tests/framework/PageObjectMigrationTestUtils.ts
@@ -1,0 +1,137 @@
+import { FrameworkDetector, TestFramework } from './FrameworkDetector';
+import { EncapsulatedElement } from './EncapsulatedElement';
+import Matchers from './Matchers';
+import PlaywrightMatchers from './PlaywrightMatchers';
+
+function getEncapsulatedGetterNames(pageObject: object): string[] {
+  FrameworkDetector.reset();
+  FrameworkDetector.setFramework(TestFramework.DETOX);
+
+  const spy = jest.spyOn(EncapsulatedElement, 'create');
+  const names: string[] = [];
+
+  const proto = Object.getPrototypeOf(pageObject);
+  for (const key of Object.getOwnPropertyNames(proto)) {
+    if (key === 'constructor') continue;
+    const descriptor = Object.getOwnPropertyDescriptor(proto, key);
+    if (!descriptor?.get) continue;
+    try {
+      spy.mockClear();
+      descriptor.get.call(pageObject);
+      if (spy.mock.calls.length > 0) {
+        names.push(key);
+      }
+    } catch {
+      // getter threw — skip
+    }
+  }
+
+  spy.mockRestore();
+  FrameworkDetector.reset();
+
+  return names;
+}
+
+function noPlaywrightMatcherWasCalled(): void {
+  expect(PlaywrightMatchers.getElementById).not.toHaveBeenCalled();
+  expect(PlaywrightMatchers.getElementByText).not.toHaveBeenCalled();
+  expect(PlaywrightMatchers.getElementByAccessibilityId).not.toHaveBeenCalled();
+}
+
+function noDetoxMatcherWasCalled(): void {
+  expect(Matchers.getElementByID).not.toHaveBeenCalled();
+  expect(Matchers.getElementByText).not.toHaveBeenCalled();
+}
+
+export function describePageObjectMigration(
+  pageObjectName: string,
+  pageObject: object,
+): void {
+  const getterNames = getEncapsulatedGetterNames(pageObject);
+
+  describe(`${pageObjectName}`, () => {
+    if (getterNames.length === 0) {
+      it('has no migrated getters', () => {
+        expect(true).toBe(true);
+      });
+      return;
+    }
+
+    describe('Detox context', () => {
+      beforeEach(() => {
+        FrameworkDetector.reset();
+        FrameworkDetector.setFramework(TestFramework.DETOX);
+      });
+
+      afterEach(() => {
+        FrameworkDetector.reset();
+      });
+
+      for (const name of getterNames) {
+        it(`${name} calls the Detox locator`, async () => {
+          const descriptor = Object.getOwnPropertyDescriptor(
+            Object.getPrototypeOf(pageObject),
+            name,
+          );
+          await Promise.resolve(descriptor?.get?.call(pageObject));
+
+          noPlaywrightMatcherWasCalled();
+        });
+      }
+    });
+
+    describe('Appium context — iOS', () => {
+      beforeEach(() => {
+        FrameworkDetector.reset();
+        FrameworkDetector.setFramework(TestFramework.APPIUM);
+        (global as Record<string, unknown>).driver = {
+          capabilities: Promise.resolve({ platformName: 'iOS' }),
+        };
+      });
+
+      afterEach(() => {
+        FrameworkDetector.reset();
+        delete (global as Record<string, unknown>).driver;
+      });
+
+      for (const name of getterNames) {
+        it(`${name} calls the Appium locator`, async () => {
+          const descriptor = Object.getOwnPropertyDescriptor(
+            Object.getPrototypeOf(pageObject),
+            name,
+          );
+          await Promise.resolve(descriptor?.get?.call(pageObject));
+
+          noDetoxMatcherWasCalled();
+        });
+      }
+    });
+
+    describe('Appium context — Android', () => {
+      beforeEach(() => {
+        FrameworkDetector.reset();
+        FrameworkDetector.setFramework(TestFramework.APPIUM);
+        (global as Record<string, unknown>).driver = {
+          capabilities: Promise.resolve({ platformName: 'Android' }),
+        };
+      });
+
+      afterEach(() => {
+        FrameworkDetector.reset();
+        delete (global as Record<string, unknown>).driver;
+      });
+
+      for (const name of getterNames) {
+        it(`${name} calls the Appium locator`, async () => {
+          const descriptor = Object.getOwnPropertyDescriptor(
+            Object.getPrototypeOf(pageObject),
+            name,
+          );
+          await Promise.resolve(descriptor?.get?.call(pageObject));
+
+          noDetoxMatcherWasCalled();
+        });
+      }
+    });
+  });
+}

--- a/tests/framework/PageObjectMigrationTestUtils.ts
+++ b/tests/framework/PageObjectMigrationTestUtils.ts
@@ -3,6 +3,30 @@ import { EncapsulatedElement } from './EncapsulatedElement';
 import Matchers from './Matchers';
 import PlaywrightMatchers from './PlaywrightMatchers';
 
+function findPageObjectsWithEncapsulated(dir: string): string[] {
+  const fs = jest.requireActual<typeof import('fs')>('fs');
+  const path = jest.requireActual<typeof import('path')>('path');
+  const results: string[] = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...findPageObjectsWithEncapsulated(fullPath));
+      continue;
+    }
+
+    if (!entry.name.endsWith('.ts') || entry.name.includes('.test.')) continue;
+
+    const source = fs.readFileSync(fullPath, 'utf8');
+    if (source.includes('encapsulated(')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
 function getEncapsulatedGetterNames(pageObject: object): string[] {
   FrameworkDetector.reset();
   FrameworkDetector.setFramework(TestFramework.DETOX);
@@ -43,29 +67,19 @@ function noDetoxMatcherWasCalled(): void {
   expect(Matchers.getElementByText).not.toHaveBeenCalled();
 }
 
-export function describePageObjectMigration(
+function describeGetters(
   pageObjectName: string,
   pageObject: object,
+  getterNames: string[],
 ): void {
-  const getterNames = getEncapsulatedGetterNames(pageObject);
-
   describe(`${pageObjectName}`, () => {
-    if (getterNames.length === 0) {
-      it('has no migrated getters', () => {
-        expect(true).toBe(true);
-      });
-      return;
-    }
-
     describe('Detox context', () => {
       beforeEach(() => {
         FrameworkDetector.reset();
         FrameworkDetector.setFramework(TestFramework.DETOX);
       });
 
-      afterEach(() => {
-        FrameworkDetector.reset();
-      });
+      afterEach(() => FrameworkDetector.reset());
 
       for (const name of getterNames) {
         it(`${name} calls the Detox locator`, async () => {
@@ -134,4 +148,32 @@ export function describePageObjectMigration(
       }
     });
   });
+}
+
+export function describePageObjectMigration(
+  pageObjectName: string,
+  pageObject: object,
+): void {
+  const getterNames = getEncapsulatedGetterNames(pageObject);
+
+  if (getterNames.length === 0) return;
+
+  describeGetters(pageObjectName, pageObject, getterNames);
+}
+
+export function discoverAndDescribeMigratedPageObjects(
+  pageObjectsDir: string,
+): void {
+  const files = findPageObjectsWithEncapsulated(pageObjectsDir);
+
+  const path = jest.requireActual<typeof import('path')>('path');
+
+  for (const filePath of files) {
+    const mod = jest.requireActual<{ default?: object }>(filePath);
+    const pageObject = mod.default;
+    if (!pageObject || typeof pageObject !== 'object') continue;
+
+    const name = path.basename(filePath, '.ts');
+    describePageObjectMigration(name, pageObject);
+  }
 }

--- a/tests/framework/PageObjectMigrationTestUtils.ts
+++ b/tests/framework/PageObjectMigrationTestUtils.ts
@@ -91,6 +91,7 @@ function describeGetters(
   describe(`${pageObjectName}`, () => {
     describe('Detox context', () => {
       beforeEach(() => {
+        jest.clearAllMocks();
         FrameworkDetector.reset();
         FrameworkDetector.setFramework(TestFramework.DETOX);
       });
@@ -113,6 +114,7 @@ function describeGetters(
 
     describe('Appium context — iOS', () => {
       beforeEach(() => {
+        jest.clearAllMocks();
         FrameworkDetector.reset();
         FrameworkDetector.setFramework(TestFramework.APPIUM);
         (global as Record<string, unknown>).driver = {
@@ -141,6 +143,7 @@ function describeGetters(
 
     describe('Appium context — Android', () => {
       beforeEach(() => {
+        jest.clearAllMocks();
         FrameworkDetector.reset();
         FrameworkDetector.setFramework(TestFramework.APPIUM);
         (global as Record<string, unknown>).driver = {

--- a/tests/framework/PageObjectMigrationTestUtils.ts
+++ b/tests/framework/PageObjectMigrationTestUtils.ts
@@ -56,6 +56,22 @@ function getEncapsulatedGetterNames(pageObject: object): string[] {
   return names;
 }
 
+function atLeastOneDetoxMatcherWasCalled(): void {
+  const detoxCallCount =
+    (Matchers.getElementByID as jest.Mock).mock.calls.length +
+    (Matchers.getElementByText as jest.Mock).mock.calls.length;
+  expect(detoxCallCount).toBeGreaterThan(0);
+}
+
+function atLeastOnePlaywrightMatcherWasCalled(): void {
+  const playwrightCallCount =
+    (PlaywrightMatchers.getElementById as jest.Mock).mock.calls.length +
+    (PlaywrightMatchers.getElementByText as jest.Mock).mock.calls.length +
+    (PlaywrightMatchers.getElementByAccessibilityId as jest.Mock).mock.calls
+      .length;
+  expect(playwrightCallCount).toBeGreaterThan(0);
+}
+
 function noPlaywrightMatcherWasCalled(): void {
   expect(PlaywrightMatchers.getElementById).not.toHaveBeenCalled();
   expect(PlaywrightMatchers.getElementByText).not.toHaveBeenCalled();
@@ -89,6 +105,7 @@ function describeGetters(
           );
           await Promise.resolve(descriptor?.get?.call(pageObject));
 
+          atLeastOneDetoxMatcherWasCalled();
           noPlaywrightMatcherWasCalled();
         });
       }
@@ -116,6 +133,7 @@ function describeGetters(
           );
           await Promise.resolve(descriptor?.get?.call(pageObject));
 
+          atLeastOnePlaywrightMatcherWasCalled();
           noDetoxMatcherWasCalled();
         });
       }
@@ -143,6 +161,7 @@ function describeGetters(
           );
           await Promise.resolve(descriptor?.get?.call(pageObject));
 
+          atLeastOnePlaywrightMatcherWasCalled();
           noDetoxMatcherWasCalled();
         });
       }

--- a/tests/page-objects/migrated-page-objects.test.ts
+++ b/tests/page-objects/migrated-page-objects.test.ts
@@ -36,16 +36,12 @@ jest.mock('../framework/UnifiedGestures.ts', () => ({
   default: { waitAndTap: jest.fn(), typeText: jest.fn() },
 }));
 
-import { describePageObjectMigration } from '../framework/PageObjectMigrationTestUtils';
-import LoginView from './wallet/LoginView';
-import WalletView from './wallet/WalletView';
+import { discoverAndDescribeMigratedPageObjects } from '../framework/PageObjectMigrationTestUtils';
 
 describe('Migrated page objects', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  // Add a page object here once any of its getters are migrated to encapsulated()
-  describePageObjectMigration('LoginView', LoginView);
-  describePageObjectMigration('WalletView', WalletView);
+  discoverAndDescribeMigratedPageObjects(__dirname);
 });

--- a/tests/page-objects/migrated-page-objects.test.ts
+++ b/tests/page-objects/migrated-page-objects.test.ts
@@ -1,0 +1,51 @@
+jest.mock('../framework/logger.ts', () => ({
+  createLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+  Logger: jest.fn(),
+  LogLevel: { ERROR: 0, WARN: 1, INFO: 2, DEBUG: 3, TRACE: 4 },
+}));
+
+jest.mock('../framework/Matchers.ts', () => ({
+  __esModule: true,
+  default: {
+    getElementByID: jest.fn().mockResolvedValue({}),
+    getElementByText: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+jest.mock('../framework/PlaywrightMatchers.ts', () => ({
+  __esModule: true,
+  default: {
+    getElementById: jest.fn().mockResolvedValue({}),
+    getElementByText: jest.fn().mockResolvedValue({}),
+    getElementByAccessibilityId: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+jest.mock('../framework/Gestures.ts', () => ({
+  __esModule: true,
+  default: { waitAndTap: jest.fn(), typeText: jest.fn() },
+}));
+
+jest.mock('../framework/UnifiedGestures.ts', () => ({
+  __esModule: true,
+  default: { waitAndTap: jest.fn(), typeText: jest.fn() },
+}));
+
+import { describePageObjectMigration } from '../framework/PageObjectMigrationTestUtils';
+import LoginView from './wallet/LoginView';
+import WalletView from './wallet/WalletView';
+
+describe('Migrated page objects', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Add a page object here once any of its getters are migrated to encapsulated()
+  describePageObjectMigration('LoginView', LoginView);
+  describePageObjectMigration('WalletView', WalletView);
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> Adds PageObjectMigrationTestUtils to auto-discover .ts page objects containing encapsulated(, introspect which getters build EncapsulatedElements, and generate assertions that in Detox context no Playwright/Appium matchers are invoked, and in Appium (iOS/Android) context no Detox matchers are invoked.

> Introduces migrated-page-objects.test.ts that wires this up under Jest with mocks for logging, matchers, and gestures, then runs the discovery against the tests/page-objects directory.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1571

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Jest-only utilities and tests without changing production runtime behavior. Main risk is potential test flakiness/over-discovery due to filesystem scanning and dynamic `requireActual` of page objects.
> 
> **Overview**
> Adds `PageObjectMigrationTestUtils` to **auto-discover** `.ts` page objects containing `encapsulated(`, introspect which getters create `EncapsulatedElement`s, and generate tests asserting **Detox context uses only `Matchers`** while **Appium (iOS/Android) uses only `PlaywrightMatchers`**.
> 
> Introduces `migrated-page-objects.test.ts`, which wires the discovery into Jest with mocks for logger/gestures/matchers and runs the generated assertions over `tests/page-objects`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75d4526624720cfaebd70c5a9a431e8b455a6ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->