### PR TITLE
fix(seedless-onboarding): handle both vault formats in encryptorAdapter

### DIFF
--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -6,7 +6,7 @@ import otaConfig from '../../ota.config.js';
  * Reset to v0 when releasing a new native build
  * We keep this OTA_VERSION here to because changes in ota.config.js will affect the fingerprint and break the workflow in Github Actions
  */
-export const OTA_VERSION: string = 'v7.67.2';
+export const OTA_VERSION: string = 'v7.68.2';
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
@@ -68,11 +68,15 @@ const getAuthTokenHandlerMocks = () => {
 jest.mock('../../../Encryptor', () => {
   const mockEncryptWithKeyFn = jest.fn();
   const mockDecryptWithKeyFn = jest.fn();
+  const mockDecryptFn = jest.fn();
+  const mockDecryptWithDetailFn = jest.fn();
 
   return {
     Encryptor: jest.fn().mockImplementation(() => ({
       encryptWithKey: mockEncryptWithKeyFn,
       decryptWithKey: mockDecryptWithKeyFn,
+      decrypt: mockDecryptFn,
+      decryptWithDetail: mockDecryptWithDetailFn,
     })),
     LEGACY_DERIVATION_OPTIONS: {
       algorithm: 'PBKDF2',
@@ -80,6 +84,8 @@ jest.mock('../../../Encryptor', () => {
     },
     __mockEncryptWithKey: mockEncryptWithKeyFn,
     __mockDecryptWithKey: mockDecryptWithKeyFn,
+    __mockDecrypt: mockDecryptFn,
+    __mockDecryptWithDetail: mockDecryptWithDetailFn,
   };
 });
 
@@ -88,10 +94,14 @@ const getEncryptorMocks = () => {
   const mocks = jest.requireMock('../../../Encryptor') as {
     __mockEncryptWithKey: jest.Mock;
     __mockDecryptWithKey: jest.Mock;
+    __mockDecrypt: jest.Mock;
+    __mockDecryptWithDetail: jest.Mock;
   };
   return {
     mockEncryptWithKey: mocks.__mockEncryptWithKey,
     mockDecryptWithKey: mocks.__mockDecryptWithKey,
+    mockDecrypt: mocks.__mockDecrypt,
+    mockDecryptWithDetail: mocks.__mockDecryptWithDetail,
   };
 };
 
@@ -116,9 +126,20 @@ describe('seedless onboarding controller init', () => {
     // Reset web3AuthNetwork to valid value before each test
     mockWeb3AuthNetwork.value = 'sapphire_devnet';
 
-    const { mockEncryptWithKey, mockDecryptWithKey } = getEncryptorMocks();
+    const {
+      mockEncryptWithKey,
+      mockDecryptWithKey,
+      mockDecrypt,
+      mockDecryptWithDetail,
+    } = getEncryptorMocks();
     mockEncryptWithKey.mockResolvedValue(mockEncryptResult);
     mockDecryptWithKey.mockResolvedValue({ test: 'decrypted-data' });
+    mockDecrypt.mockResolvedValue({ test: 'decrypted-data' });
+    mockDecryptWithDetail.mockResolvedValue({
+      vault: { test: 'decrypted-data' },
+      exportedKeyString: 'mock-key-string',
+      salt: 'mock-salt',
+    });
 
     const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
       namespace: MOCK_ANY_NAMESPACE,
@@ -229,6 +250,245 @@ describe('seedless onboarding controller init', () => {
         keyMetadata: encryptedObject.keyMetadata,
       });
       expect(decrypted).toEqual({ test: 'decrypted-data' });
+    });
+
+    it('decryptWithKey falls back to cipher field for pre-adapter vaults', async () => {
+      const { mockDecryptWithKey } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const mockKey = { key: 'test-key', lib: 'test-lib', exportable: true };
+      // Legacy vault format: uses 'cipher' instead of 'data'
+      const legacyEncryptedObject = {
+        cipher: 'legacy-cipher-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      };
+
+      // Cast as never: the package type expects `data` (DefaultEncryptionResult), but we
+      // intentionally pass a legacy vault with `cipher` only to test the fallback path.
+      await encryptorAdapter.decryptWithKey(
+        mockKey,
+        legacyEncryptedObject as never,
+      );
+
+      expect(mockDecryptWithKey).toHaveBeenCalledWith(mockKey, {
+        cipher: 'legacy-cipher-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+        lib: undefined,
+        keyMetadata: undefined,
+      });
+    });
+
+    it('decryptWithKey throws when both data and cipher are absent', async () => {
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const mockKey = { key: 'test-key', lib: 'test-lib', exportable: true };
+      const malformedObject = { iv: 'test-iv', salt: 'test-salt' };
+
+      // Cast as never: the package type expects `data` (DefaultEncryptionResult), but we
+      // intentionally pass a malformed vault (missing both fields) to test the error path.
+      await expect(
+        encryptorAdapter.decryptWithKey(mockKey, malformedObject as never),
+      ).rejects.toThrow(
+        'SeedlessOnboardingController encryptorAdapter: vault is missing both "data" and "cipher" fields',
+      );
+    });
+
+    it('decrypt normalizes data-format vault before decryption', async () => {
+      const { mockDecrypt } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const dataFormatVault = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decrypt('password', dataFormatVault);
+
+      // Should normalize 'data' → 'cipher' before passing to underlying encryptor
+      const expectedNormalized = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+        cipher: 'encrypted-data',
+      });
+      expect(mockDecrypt).toHaveBeenCalledWith('password', expectedNormalized);
+    });
+
+    it('decrypt passes cipher-format vault through unchanged', async () => {
+      const { mockDecrypt } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const cipherFormatVault = JSON.stringify({
+        cipher: 'encrypted-cipher',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decrypt('password', cipherFormatVault);
+
+      expect(mockDecrypt).toHaveBeenCalledWith('password', cipherFormatVault);
+    });
+
+    it('decryptWithDetail normalizes data-format vault before decryption', async () => {
+      const { mockDecryptWithDetail } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const dataFormatVault = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decryptWithDetail('password', dataFormatVault);
+
+      const expectedNormalized = JSON.stringify({
+        data: 'encrypted-data',
+        iv: 'test-iv',
+        salt: 'test-salt',
+        cipher: 'encrypted-data',
+      });
+      expect(mockDecryptWithDetail).toHaveBeenCalledWith(
+        'password',
+        expectedNormalized,
+      );
+    });
+
+    it('decryptWithDetail passes cipher-format vault through unchanged', async () => {
+      const { mockDecryptWithDetail } = getEncryptorMocks();
+      seedlessOnboardingControllerInit(initRequestMock);
+
+      const encryptorAdapter =
+        seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+      const cipherFormatVault = JSON.stringify({
+        cipher: 'encrypted-cipher',
+        iv: 'test-iv',
+        salt: 'test-salt',
+      });
+
+      await encryptorAdapter.decryptWithDetail('password', cipherFormatVault);
+
+      expect(mockDecryptWithDetail).toHaveBeenCalledWith(
+        'password',
+        cipherFormatVault,
+      );
+    });
+
+    /**
+     * End-to-end bug reproduction scenario:
+     *
+     * Bug (pre-fix): While the wallet is unlocked, a background JWT token
+     * refresh triggers SeedlessOnboardingController#updateVault, which calls
+     * encryptWithKey via the adapter. The adapter returns { data, iv, salt }
+     * (browser-passworder format). This vault string (with `data`, no `cipher`)
+     * is persisted to state.
+     *
+     * On next unlock, the controller reads the persisted vault and calls
+     * decrypt / decryptWithDetail. The underlying mobile Encryptor reads
+     * `cipher` from the parsed vault — finds undefined — and crashes with
+     * "TypeError: The first argument must be one of type string, Buffer..."
+     *
+     * Fix: normalizeVaultFormat detects a vault that has `data` but no
+     * `cipher` and injects cipher = data before handing it to the Encryptor.
+     */
+    describe('end-to-end: background token refresh followed by unlock', () => {
+      it('decrypt can read a vault written by encryptWithKey (data-format vault)', async () => {
+        const { mockDecrypt } = getEncryptorMocks();
+        seedlessOnboardingControllerInit(initRequestMock);
+
+        const encryptorAdapter =
+          seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+        const mockKey = {
+          key: 'test-key',
+          lib: 'test-lib',
+          exportable: true,
+          keyMetadata: { algorithm: 'PBKDF2', params: { iterations: 600000 } },
+        };
+
+        // Step 1: background token refresh writes vault via encryptWithKey
+        // → adapter converts cipher → data, returning browser-passworder format
+        const encryptedVault = await encryptorAdapter.encryptWithKey(mockKey, {
+          secret: 'seed-phrase',
+        });
+        expect(encryptedVault).toHaveProperty('data'); // data, not cipher
+        expect(encryptedVault).not.toHaveProperty('cipher');
+
+        // Step 2: controller serializes and persists the vault
+        const persistedVaultString = JSON.stringify(encryptedVault);
+
+        // Step 3: wallet locks, vaultEncryptionKey is cleared (persist: false).
+        // On next unlock the controller calls decrypt with the persisted string.
+        // Without the fix this would crash because the Encryptor reads `cipher`
+        // (undefined here) and passes it to QuickCryptoLib.decrypt.
+        await encryptorAdapter.decrypt('user-password', persistedVaultString);
+
+        // The underlying Encryptor must receive the vault with `cipher` injected
+        const expectedNormalized = JSON.stringify({
+          ...encryptedVault,
+          cipher: encryptedVault.data,
+        });
+        expect(mockDecrypt).toHaveBeenCalledWith(
+          'user-password',
+          expectedNormalized,
+        );
+      });
+
+      it('decryptWithDetail can read a vault written by encryptWithKey (data-format vault)', async () => {
+        const { mockDecryptWithDetail } = getEncryptorMocks();
+        seedlessOnboardingControllerInit(initRequestMock);
+
+        const encryptorAdapter =
+          seedlessOnboardingControllerClassMock.mock.calls[0][0].encryptor;
+
+        const mockKey = {
+          key: 'test-key',
+          lib: 'test-lib',
+          exportable: true,
+          keyMetadata: { algorithm: 'PBKDF2', params: { iterations: 600000 } },
+        };
+
+        // Step 1: background token refresh writes vault via encryptWithKey
+        const encryptedVault = await encryptorAdapter.encryptWithKey(mockKey, {
+          secret: 'seed-phrase',
+        });
+
+        // Step 2: persist
+        const persistedVaultString = JSON.stringify(encryptedVault);
+
+        // Step 3: unlock via decryptWithDetail (used when vaultEncryptionKey is absent)
+        await encryptorAdapter.decryptWithDetail(
+          'user-password',
+          persistedVaultString,
+        );
+
+        const expectedNormalized = JSON.stringify({
+          ...encryptedVault,
+          cipher: encryptedVault.data,
+        });
+        expect(mockDecryptWithDetail).toHaveBeenCalledWith(
+          'user-password',
+          expectedNormalized,
+        );
+      });
     });
   });
 

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
@@ -32,6 +32,25 @@ interface ControllerEncryptionResult {
 }
 
 /**
+ * Normalizes a serialized vault so the mobile Encryptor can decrypt it
+ * regardless of whether the vault was written by the adapter (using 'data')
+ * or by the original mobile Encryptor (using 'cipher').
+ *
+ * Background: the SeedlessOnboardingController stores vaults via
+ * encryptWithKey (adapter, 'data' field) and via encryptWithDetail (mobile
+ * Encryptor, 'cipher' field).  The mobile Encryptor's decrypt / decryptWithDetail
+ * always reads 'cipher', so vaults produced by the adapter must be normalized
+ * before being handed to those methods.
+ */
+function normalizeVaultFormat(text: string): string {
+  const payload: Record<string, unknown> = JSON.parse(text);
+  if (payload.data !== undefined && payload.cipher === undefined) {
+    return JSON.stringify({ ...payload, cipher: payload.data });
+  }
+  return text;
+}
+
+/**
  * Adapter that wraps the mobile Encryptor to be compatible with
  * SeedlessOnboardingController's VaultEncryptor interface.
  * Maps 'cipher' <-> 'data' between mobile and controller formats.
@@ -53,15 +72,33 @@ const encryptorAdapter = {
   },
   decryptWithKey: async (
     key: EncryptionKey,
-    encryptedObject: ControllerEncryptionResult,
-  ): Promise<unknown> =>
-    encryptor.decryptWithKey(key, {
-      cipher: encryptedObject.data,
+    // Accept both adapter format ('data') and legacy mobile format ('cipher').
+    // 'data' is intentionally optional here: pre-adapter vaults only carry
+    // 'cipher', so making 'data' required would be a lie about the runtime
+    // shape and would allow the fallback to be silently removed.
+    encryptedObject: Omit<ControllerEncryptionResult, 'data'> & {
+      data?: string;
+      cipher?: string;
+    },
+  ): Promise<unknown> => {
+    const cipher = encryptedObject.data ?? encryptedObject.cipher;
+    if (!cipher) {
+      throw new Error(
+        'SeedlessOnboardingController encryptorAdapter: vault is missing both "data" and "cipher" fields',
+      );
+    }
+    return encryptor.decryptWithKey(key, {
+      cipher,
       iv: encryptedObject.iv,
       salt: encryptedObject.salt,
       lib: encryptedObject.lib,
       keyMetadata: encryptedObject.keyMetadata,
-    }),
+    });
+  },
+  decrypt: async (password: string, text: string): Promise<unknown> =>
+    encryptor.decrypt(password, normalizeVaultFormat(text)),
+  decryptWithDetail: async (password: string, text: string) =>
+    encryptor.decryptWithDetail(password, normalizeVaultFormat(text)),
 };
 
 /**


### PR DESCRIPTION
The encryptorAdapter introduced in PR #26258 overrides encryptWithKey to return browser-passworder format ({ data }) instead of the mobile Encryptor format ({ cipher }). However, decrypt and decryptWithDetail were not overridden — they were spread from the mobile Encryptor, which reads the cipher field. This caused a crash on the next unlock after any background JWT token refresh:

  TypeError: The first argument must be one of type string, Buffer...
  Received type undefined (quick-crypto.ts:101)

Fix: add normalizeVaultFormat which injects cipher = data when a vault has data but no cipher, and override decrypt and decryptWithDetail in the adapter to normalize before delegating to the underlying Encryptor.

Also harden decryptWithKey to accept both data and cipher fields (for pre-adapter vaults that only carry cipher), and throw explicitly when both fields are absent.

Adds end-to-end tests that reproduce the bug scenario: background token refresh writes a data-format vault via encryptWithKey, then decrypt / decryptWithDetail must recover it on the next unlock.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches seedless onboarding vault decryption/adapter logic, which impacts unlock behavior and could cause regressions in handling persisted vault payloads. Change is localized and covered by expanded unit tests, but affects critical user flow.
> 
> **Overview**
> Fixes a crash on unlock by making the `SeedlessOnboardingController` encryptor adapter handle **both vault encodings** (`data` vs `cipher`). The adapter now normalizes serialized vault strings before `decrypt`/`decryptWithDetail`, and hardens `decryptWithKey` to fall back to legacy `cipher` payloads (and throw a clear error if neither field exists).
> 
> Adds/extends unit tests to cover normalization, legacy vault fallback, explicit error behavior, and an end-to-end scenario where a background token refresh writes a `data`-format vault that must be readable on the next unlock.
> 
> Also bumps `OTA_VERSION` from `v7.67.2` to `v7.68.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb24aba1410893d3d8ade4fb1b948e2f422bb06a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->