### PR TITLE
fix(homepage): fix session summary section tracking and visibility detection

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -163,7 +163,7 @@ jest.mock('../../UI/Earn/hooks/useMusdConversionTokens', () => ({
 
 // Mock useHomeViewedEvent to avoid analytics side-effects in
 // Homepage-level tests — section-level analytics are covered by the hook tests.
-const mockUseHomeViewedEvent = jest.fn();
+const mockUseHomeViewedEvent = jest.fn(() => ({ onLayout: jest.fn() }));
 jest.mock('./hooks/useHomeViewedEvent', () => ({
   __esModule: true,
   default: (...args: unknown[]) => mockUseHomeViewedEvent(...args),

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -14,8 +14,8 @@ jest.mock('@react-navigation/native', () => {
       navigate: jest.fn(),
     }),
     useFocusEffect: (callback: () => void) => {
-      const React = jest.requireActual('react');
-      React.useEffect(callback, [callback]);
+      const ReactLib = jest.requireActual('react');
+      ReactLib.useEffect(callback, [callback]);
     },
   };
 });
@@ -134,6 +134,37 @@ jest.mock(
   }),
 );
 
+/** Shape of first argument to useHomeViewedEvent (for asserting in tests). */
+interface UseHomeViewedEventParamsSnapshot {
+  sectionName?: string;
+  sectionIndex?: number;
+  totalSectionsLoaded?: number;
+}
+
+// Mock useHomeViewedEvent to avoid analytics side-effects in
+// Homepage-level tests — section-level analytics are covered by the hook tests.
+const mockUseHomeViewedEvent = jest.fn(() => ({ onLayout: jest.fn() }));
+jest.mock('./hooks/useHomeViewedEvent', () => ({
+  __esModule: true,
+  default: (params: UseHomeViewedEventParamsSnapshot) =>
+    (mockUseHomeViewedEvent as jest.Mock)(params),
+  HomeSectionNames: {
+    CASH: 'cash',
+    TOKENS: 'tokens',
+    PERPS: 'perps',
+    DEFI: 'defi',
+    PREDICT: 'predict',
+    NFTS: 'nfts',
+  },
+}));
+
+/** Returns mock useHomeViewedEvent calls with typed first argument. */
+function getUseHomeViewedEventCalls(): [UseHomeViewedEventParamsSnapshot][] {
+  return mockUseHomeViewedEvent.mock.calls as unknown as [
+    UseHomeViewedEventParamsSnapshot,
+  ][];
+}
+
 jest.mock('../../UI/Earn/selectors/featureFlags', () => ({
   selectIsMusdConversionFlowEnabledFlag: jest.fn(() => false),
   selectPooledStakingEnabledFlag: jest.fn(() => false),
@@ -159,22 +190,6 @@ const mockUseMusdConversionTokens = jest.fn(() => ({
 }));
 jest.mock('../../UI/Earn/hooks/useMusdConversionTokens', () => ({
   useMusdConversionTokens: () => mockUseMusdConversionTokens(),
-}));
-
-// Mock useHomeViewedEvent to avoid analytics side-effects in
-// Homepage-level tests — section-level analytics are covered by the hook tests.
-const mockUseHomeViewedEvent = jest.fn(() => ({ onLayout: jest.fn() }));
-jest.mock('./hooks/useHomeViewedEvent', () => ({
-  __esModule: true,
-  default: (...args: unknown[]) => mockUseHomeViewedEvent(...args),
-  HomeSectionNames: {
-    CASH: 'cash',
-    TOKENS: 'tokens',
-    PERPS: 'perps',
-    DEFI: 'defi',
-    PREDICT: 'predict',
-    NFTS: 'nfts',
-  },
 }));
 
 const mockEnableAllPopularNetworks = jest.fn();
@@ -268,7 +283,7 @@ describe('Homepage', () => {
       renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
       // Tokens=0, Perps=1, Predict=2, DeFi=3, NFTs=4 → total=5
-      const calls = mockUseHomeViewedEvent.mock.calls;
+      const calls = getUseHomeViewedEventCalls();
       const callBySectionName = (name: string) =>
         calls.find((c) => c[0]?.sectionName === name)?.[0];
 
@@ -282,7 +297,7 @@ describe('Homepage', () => {
     it('passes totalSectionsLoaded=5 when all flags are enabled', () => {
       renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
-      const calls = mockUseHomeViewedEvent.mock.calls;
+      const calls = getUseHomeViewedEventCalls();
       calls.forEach((call) => {
         expect(call[0]?.totalSectionsLoaded).toBe(5);
       });
@@ -299,7 +314,7 @@ describe('Homepage', () => {
     it('shifts indices when Perps is disabled', () => {
       renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
-      const calls = mockUseHomeViewedEvent.mock.calls;
+      const calls = getUseHomeViewedEventCalls();
       const callBySectionName = (name: string) =>
         calls.find((c) => c[0]?.sectionName === name)?.[0];
 
@@ -312,7 +327,7 @@ describe('Homepage', () => {
     it('passes totalSectionsLoaded=4 when Perps is disabled', () => {
       renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
-      const calls = mockUseHomeViewedEvent.mock.calls;
+      const calls = getUseHomeViewedEventCalls();
       calls.forEach((call) => {
         expect(call[0]?.totalSectionsLoaded).toBe(4);
       });
@@ -337,7 +352,7 @@ describe('Homepage', () => {
     it('passes totalSectionsLoaded=2 when only Tokens and NFTs are enabled', () => {
       renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
-      const calls = mockUseHomeViewedEvent.mock.calls;
+      const calls = getUseHomeViewedEventCalls();
       const callBySectionName = (name: string) =>
         calls.find((c) => c[0]?.sectionName === name)?.[0];
 
@@ -358,7 +373,7 @@ describe('Homepage', () => {
     it('passes sectionIndex 0 to Cash and shifts others when Cash is enabled', () => {
       renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
-      const calls = mockUseHomeViewedEvent.mock.calls;
+      const calls = getUseHomeViewedEventCalls();
       const callBySectionName = (name: string) =>
         calls.find((c) => c[0]?.sectionName === name)?.[0];
 

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../../../UI/Earn/hooks/useMusdBalance', () => ({
 
 jest.mock('../../hooks/useHomeViewedEvent', () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => ({ onLayout: jest.fn() })),
   HomeSectionNames: {
     CASH: 'cash',
     TOKENS: 'tokens',

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
@@ -46,7 +46,7 @@ const CashSection = ({
     navigation.navigate(Routes.WALLET.CASH_TOKENS_FULL_VIEW as never);
   }, [navigation]);
 
-  useHomeViewedEvent({
+  const { onLayout } = useHomeViewedEvent({
     sectionRef: sectionViewRef,
     isLoading: false,
     sectionName: HomeSectionNames.CASH,
@@ -66,7 +66,7 @@ const CashSection = ({
   const title = strings('homepage.sections.cash');
 
   return (
-    <View ref={sectionViewRef}>
+    <View ref={sectionViewRef} onLayout={onLayout}>
       <Box gap={3}>
         <SectionHeader title={title} onPress={handleViewCashTokens} />
         {!hasMusdBalanceOnAnyChain ? (

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
@@ -36,7 +36,7 @@ jest.mock('../../../../../selectors/preferencesController', () => ({
 
 jest.mock('../../hooks/useHomeViewedEvent', () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => ({ onLayout: jest.fn() })),
   HomeSectionNames: {
     TOKENS: 'tokens',
     PERPS: 'perps',

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -139,7 +139,7 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
     }
 
     return (
-      <View ref={sectionViewRef}>
+      <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
           <SectionHeader title={title} onPress={handleViewAllDeFi} />
           <SectionRow>

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -101,7 +101,7 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
     // no premature immediate fire via the null path.
     const willRender = !isLoading;
 
-    useHomeViewedEvent({
+    const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,
       isLoading,
       sectionName: HomeSectionNames.DEFI,
@@ -124,7 +124,7 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
     // Show retry UI on error
     if (!isLoading && hasError) {
       return (
-        <View ref={sectionViewRef}>
+        <View ref={sectionViewRef} onLayout={onLayout}>
           <Box gap={3}>
             <SectionHeader title={title} onPress={handleViewAllDeFi} />
             <ErrorState

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
@@ -58,7 +58,7 @@ jest.mock('./hooks', () => ({
 
 jest.mock('../../hooks/useHomeViewedEvent', () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => ({ onLayout: jest.fn() })),
   HomeSectionNames: {
     TOKENS: 'tokens',
     PERPS: 'perps',

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -132,7 +132,7 @@ const NFTsSection = forwardRef<SectionRefreshHandle, NFTsSectionProps>(
     const isLoadingSection = isNftFetchingProgress && !hasNfts;
     const willRender = !isLoadingSection;
 
-    useHomeViewedEvent({
+    const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,
       isLoading: isLoadingSection,
       sectionName: HomeSectionNames.NFTS,
@@ -143,7 +143,7 @@ const NFTsSection = forwardRef<SectionRefreshHandle, NFTsSectionProps>(
     });
 
     return (
-      <View ref={sectionViewRef}>
+      <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
           <SectionHeader title={title} onPress={handleViewAllNfts} />
           {hasNfts ? (

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -219,7 +219,7 @@ const makeTrendingMarket = (overrides: Record<string, unknown> = {}) => ({
 
 jest.mock('../../hooks/useHomeViewedEvent', () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => ({ onLayout: jest.fn() })),
   HomeSectionNames: {
     TOKENS: 'tokens',
     PERPS: 'perps',

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -229,7 +229,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     const isLoadingSection = hookLoading || deferredLoading || pendingTrending;
     const willRender = !isLoadingSection;
 
-    useHomeViewedEvent({
+    const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,
       isLoading: isLoadingSection,
       sectionName: HomeSectionNames.PERPS,
@@ -241,7 +241,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     if (connectionError) {
       return (
-        <View ref={sectionViewRef}>
+        <View ref={sectionViewRef} onLayout={onLayout}>
           <Box gap={3}>
             <SectionHeader title={title} onPress={handleViewAllPerps} />
             <ErrorState
@@ -256,7 +256,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     }
 
     return (
-      <View ref={sectionViewRef}>
+      <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
           <SectionHeader title={title} onPress={handleViewAllPerps} />
           {showSkeleton || pendingTrending ? (

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -43,7 +43,7 @@ jest.mock('./hooks', () => ({
 
 jest.mock('../../hooks/useHomeViewedEvent', () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => ({ onLayout: jest.fn() })),
   HomeSectionNames: {
     TOKENS: 'tokens',
     PERPS: 'perps',

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -116,7 +116,7 @@ const PredictionsSection = forwardRef<
   // itemCount/isEmpty values before data arrives.
   const willRender = isPredictEnabled && !isLoading && !isEmpty;
 
-  useHomeViewedEvent({
+  const { onLayout } = useHomeViewedEvent({
     sectionRef: willRender ? sectionViewRef : null,
     isLoading,
     sectionName: HomeSectionNames.PREDICT,
@@ -160,7 +160,7 @@ const PredictionsSection = forwardRef<
 
   if (hasError) {
     return (
-      <View ref={sectionViewRef}>
+      <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
           <SectionHeader
             title={title}
@@ -183,7 +183,7 @@ const PredictionsSection = forwardRef<
   // Render positions if user has any
   if (hasPositions || isLoadingPositions) {
     return (
-      <View ref={sectionViewRef}>
+      <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
           <SectionHeader
             title={title}
@@ -230,7 +230,7 @@ const PredictionsSection = forwardRef<
 
   // Render trending markets if no positions
   return (
-    <View ref={sectionViewRef}>
+    <View ref={sectionViewRef} onLayout={onLayout}>
       <Box gap={3}>
         <SectionHeader
           title={title}

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -179,7 +179,7 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
 
     const itemCount = isZeroBalanceAccount ? 0 : displayTokenKeys.length;
 
-    useHomeViewedEvent({
+    const { onLayout } = useHomeViewedEvent({
       sectionRef: sectionViewRef,
       isLoading: false,
       sectionName: HomeSectionNames.TOKENS,
@@ -199,7 +199,7 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
     }, [refresh]);
 
     return (
-      <View ref={sectionViewRef}>
+      <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
           <SectionHeader title={title} onPress={handleViewAllTokens} />
           {showTokensError ? (

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
@@ -331,9 +331,9 @@ describe('useHomeViewedEvent', () => {
       expect(mockTrackEvent).not.toHaveBeenCalled();
     });
 
-    it('fires for a section taller than the viewport when it covers ≥50% of the viewport', () => {
-      // viewportHeight=800, height=2000 → threshold = min(1000, 400) = 400
-      // y=0 → visiblePx = min(2000, 800) - 0 = 800 ≥ 400
+    it('fires for a section taller than the viewport when it covers ≥30% of the viewport', () => {
+      // viewportHeight=800, height=2000 → threshold = min(600, 240) = 240
+      // y=0 → visiblePx = min(2000, 800) - 0 = 800 ≥ 240
       const mockRef = createMockRef(0, 2000);
       renderHook(() =>
         useHomeViewedEvent({
@@ -345,10 +345,10 @@ describe('useHomeViewedEvent', () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
     });
 
-    it('does not fire for a tall section covering <50% of the viewport', () => {
-      // viewportHeight=800, height=2000 → threshold = min(1000, 400) = 400
-      // y=450 → visiblePx = min(2450, 800) - 450 = 350 < 400
-      const mockRef = createMockRef(450, 2000);
+    it('does not fire for a tall section covering <30% of the viewport', () => {
+      // viewportHeight=800, height=2000 → threshold = min(600, 240) = 240
+      // y=600 → visiblePx = min(2600, 800) - 600 = 200 < 240
+      const mockRef = createMockRef(600, 2000);
       renderHook(() =>
         useHomeViewedEvent({
           ...defaultParams,

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
@@ -41,7 +41,7 @@ interface UseHomeViewedEventParams {
 
 /**
  * Fires a `Home Viewed` Segment event when a homepage section enters the
- * user's viewport (≥ 50 % of the section is visible).
+ * user's viewport (≥ 30 % of the section is visible).
  *
  * - Re-fires on every homepage visit (when `visitId` increments).
  * - For sections that do not render (e.g. DeFi with no positions), fires
@@ -126,6 +126,10 @@ const useHomeViewedEvent = ({
     fireEvent();
   }, [sectionRef, isLoading, fireEvent, visitId]);
 
+  // Holds the latest checkVisibility so the onLayout callback can re-trigger
+  // a check after the native layout pass completes.
+  const checkVisibilityRef = useRef<() => void>(() => undefined);
+
   // For sections that DO render: check viewport visibility on mount and on
   // every scroll event. Uses subscribeToScroll so no React re-renders occur
   // during scrolling.
@@ -144,15 +148,17 @@ const useHomeViewedEvent = ({
         const visiblePx =
           Math.min(y + height, viewportBottom) - Math.max(y, viewportTop);
         // For sections taller than the viewport (e.g. a long NFTs list),
-        // 50% of the section height can exceed the full viewport, making the
-        // event nearly impossible to trigger. Cap the threshold at 50% of
+        // 30% of the section height can exceed the full viewport, making the
+        // event nearly impossible to trigger. Cap the threshold at 30% of
         // the viewport so tall sections fire reliably.
-        const threshold = Math.min(height * 0.5, viewportHeight * 0.5);
+        const threshold = Math.min(height * 0.3, viewportHeight * 0.3);
         if (visiblePx >= threshold) {
           fireEvent();
         }
       });
     };
+
+    checkVisibilityRef.current = checkVisibility;
 
     // Initial check (covers sections already in viewport on mount/revisit).
     checkVisibility();
@@ -168,6 +174,15 @@ const useHomeViewedEvent = ({
     subscribeToScroll,
     fireEvent,
   ]);
+
+  // Sections attach this to their root View's onLayout prop. onLayout fires
+  // after the native layout pass, at which point measureInWindow returns real
+  // dimensions — fixing the height === 0 early-return on initial mount.
+  const onLayout = useCallback(() => {
+    checkVisibilityRef.current();
+  }, []);
+
+  return { onLayout };
 };
 
 export default useHomeViewedEvent;

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1283,10 +1283,16 @@ const Wallet = ({
     return () => scrollSubscribersRef.current.delete(cb);
   }, []);
 
-  // Reset viewed sections on each new visit so session summary starts fresh.
-  useEffect(() => {
-    viewedSectionsRef.current.clear();
-  }, [visitId]);
+  // Reset viewed sections synchronously on focus, before the new visitId
+  // propagates to child effects that re-add sections. A useEffect on [visitId]
+  // runs after children's effects (React runs children before parents), so
+  // sections would add themselves then the parent would clear them — causing
+  // total_sections_viewed to always be 0 on the second+ visit.
+  useFocusEffect(
+    useCallback(() => {
+      viewedSectionsRef.current.clear();
+    }, []),
+  );
 
   const notifySectionViewed = useCallback((sectionName: string) => {
     viewedSectionsRef.current.add(sectionName);


### PR DESCRIPTION
## **Description**

## **Description**

Fixes two bugs in the homepage `Home Viewed` session summary analytics event that caused `total_sections_viewed` to be inaccurate.

**Bug 1 — `total_sections_viewed` always 0 on second+ visit**

`viewedSectionsRef` was cleared inside a `useEffect([visitId])` in the parent Wallet component. React runs children's effects before parents, so sections would re-add themselves to the set (in response to the new `visitId`) _before_ the parent cleared it — leaving the set empty when the blur event fired.

Fix: replaced the `useEffect` with a `useFocusEffect` in `Wallet/index.tsx` that clears the set synchronously on focus, before `setVisitId` schedules a re-render and child effects re-populate the set.

**Bug 2 — sections require hard scrolling to be counted as viewed**

`useHomeViewedEvent` calls `checkVisibility()` immediately on mount inside a `useEffect`. In React Native, `useEffect` runs before the native layout pass completes, so `measureInWindow` returns `height = 0` and bails early. Nothing re-checks until a scroll event fires.

Fix: added a `checkVisibilityRef` inside the scroll effect and returned a stable `onLayout` callback from the hook. Each section attaches it to its root `<View onLayout={onLayout}>`. By the time `onLayout` fires (post-native layout), `measureInWindow` returns real dimensions.

**Additional:** Lowered the visibility threshold from 50% → 30% so sections that are partially in view count as seen more readily. Removed leftover debug `console.log` statements.


## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-562

## **Manual testing steps**

```gherkin
 Scenario: user views sections and navigates away multiple times
    Given the user is on the homepage
    When the user scrolls to view all sections
    And navigates to the Explore tab
    Then a Home Viewed session_summary event fires with total_sections_viewed matching the number of sections scrolled into view

    When the user returns to the homepage
    And navigates away again without scrolling
    Then a Home Viewed session_summary event fires with total_sections_viewed reflecting only sections visible on load

  Scenario: sections visible without scrolling are counted
    Given the user is on the homepage
    When sections are visible in the initial viewport (no scrolling)
    Then those sections fire section_viewed events without requiring any scroll
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics firing conditions and focus/scroll timing; mistakes could over/under-count section_viewed events or regress scroll performance, but changes are localized to homepage section tracking.
> 
> **Overview**
> Fixes `Home Viewed` section analytics so counts and firing are reliable across repeated homepage visits.
> 
> `Wallet/index.tsx` now clears the per-visit `viewedSectionsRef` via `useFocusEffect` (instead of `useEffect([visitId])`) to avoid a parent/child effect ordering race that zeroed `total_sections_viewed` on later visits.
> 
> `useHomeViewedEvent` now returns an `onLayout` callback that re-runs the visibility check after native layout (avoiding initial `measureInWindow` height=0), and lowers the visibility threshold from **50% → 30%**. All homepage sections wire `onLayout` into their root `View`, and tests update mocks/assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9717df13d7eb5589484689b517bc3a0aa24d6271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->