### PR TITLE
fix: defi empty state

### DIFF
--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
@@ -54,6 +54,24 @@ jest.mock('./hooks', () => ({
   DeFiPositionEntry: {},
 }));
 
+jest.mock('../../../../UI/DefiEmptyState', () => {
+  const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  const MockDefiEmptyState = ({ onAction }: { onAction?: () => void }) =>
+    ReactActual.createElement(
+      View,
+      { testID: 'defi-empty-state' },
+      ReactActual.createElement(Text, null, 'Lend, borrow, and trade'),
+      ReactActual.createElement(
+        TouchableOpacity,
+        { onPress: onAction },
+        ReactActual.createElement(Text, null, 'Explore DeFi'),
+      ),
+    );
+  MockDefiEmptyState.displayName = 'DefiEmptyState';
+  return { DefiEmptyState: MockDefiEmptyState };
+});
+
 // Mock DeFiPositionsListItem to avoid deep import chain issues
 jest.mock('../../../../UI/DeFiPositions/DeFiPositionsListItem', () => {
   const { Text } = jest.requireActual('react-native');
@@ -132,7 +150,7 @@ describe('DeFiSection', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('returns null when positions are empty and not loading', () => {
+  it('renders empty state when positions are empty and not loading', () => {
     mockUseDeFiPositionsForHomepage.mockReturnValue({
       positions: [],
       isLoading: false,
@@ -140,11 +158,12 @@ describe('DeFiSection', () => {
       isEmpty: true,
     });
 
-    const { toJSON } = renderWithProvider(
+    renderWithProvider(
       <DeFiSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(toJSON()).toBeNull();
+    expect(screen.getByTestId('defi-empty-state')).toBeOnTheScreen();
+    expect(screen.getByText('DeFi')).toBeOnTheScreen();
   });
 
   it('renders error state with retry when there is an error and not loading', () => {

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -14,6 +14,7 @@ import { useTheme } from '../../../../../util/theme';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import SectionRow from '../../components/SectionRow';
 import ErrorState from '../../components/ErrorState';
+import { DefiEmptyState } from '../../../../UI/DefiEmptyState';
 import { SectionRefreshHandle } from '../../types';
 import { useDeFiPositionsForHomepage, DeFiPositionEntry } from './hooks';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
@@ -95,10 +96,6 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
-    // Always pass sectionViewRef once loading is done so the viewport check
-    // decides when to fire. When the section returns null (empty, no error),
-    // sectionViewRef.current is null and the viewport check returns early —
-    // no premature immediate fire via the null path.
     const willRender = !isLoading;
 
     useHomeViewedEvent({
@@ -113,11 +110,6 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
 
     // Don't render if DeFi is disabled
     if (!isDeFiEnabled) {
-      return null;
-    }
-
-    // Don't render if empty and not loading (200 with no data)
-    if (!isLoading && isEmpty) {
       return null;
     }
 
@@ -142,12 +134,18 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
       <View ref={sectionViewRef}>
         <Box gap={3}>
           <SectionHeader title={title} onPress={handleViewAllDeFi} />
-          <SectionRow>
-            <Box>
-              {isLoading ? (
+          {isLoading ? (
+            <SectionRow>
+              <Box>
                 <DeFiPositionsSkeleton />
-              ) : (
-                positions.map((position: DeFiPositionEntry) => (
+              </Box>
+            </SectionRow>
+          ) : isEmpty ? (
+            <DefiEmptyState twClassName="mx-auto mt-2" />
+          ) : (
+            <SectionRow>
+              <Box>
+                {positions.map((position: DeFiPositionEntry) => (
                   <DeFiPositionsListItem
                     key={`${position.chainId}-${position.protocolAggregate.protocolDetails.name}`}
                     chainId={position.chainId}
@@ -155,10 +153,10 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
                     protocolAggregate={position.protocolAggregate}
                     privacyMode={privacyMode}
                   />
-                ))
-              )}
-            </Box>
-          </SectionRow>
+                ))}
+              </Box>
+            </SectionRow>
+          )}
         </Box>
       </View>
     );


### PR DESCRIPTION
## **Description**

DeFi is missing a empty state which hurts discoverability

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

<img width="350" alt="Simulator Screenshot - iPhone 16e - 2026-03-12 at 13 12 51" src="https://github.com/user-attachments/assets/88e81e7d-8fc8-446c-8b86-83dcf4cc8550" />

### **After**

<img width="350" alt="Simulator Screenshot - iPhone 16e - 2026-03-12 at 13 10 34" src="https://github.com/user-attachments/assets/b98b74dd-1153-4858-9275-cc1075d59e06" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters rendering when DeFi returns an empty dataset; minimal chance of regression outside the homepage section.
> 
> **Overview**
> Homepage DeFi section no longer returns `null` when the DeFi positions response is empty; it now renders the shared `DefiEmptyState` component under the section header to improve discoverability.
> 
> Tests are updated to mock `DefiEmptyState` and assert the empty state is rendered (instead of expecting `null`) when `isEmpty` is true and not loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf0366c7f849565860cad427ead70a291a9f77c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->