### PR TITLE
fix(perps): harden reconnect recovery and error tagging

### DIFF
--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react-native';
+import Logger from '../../../../../util/Logger';
 import PerpsAdjustMarginView from './PerpsAdjustMarginView';
 import { type Position } from '@metamask/perps-controller';
 
@@ -55,7 +56,10 @@ jest.mock('../../hooks/usePerpsMeasurement', () => ({
 }));
 
 jest.mock('../../../../../util/Logger', () => ({
-  error: jest.fn(),
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
 }));
 
 jest.mock('../../utils/formatUtils', () => ({
@@ -339,6 +343,41 @@ describe('PerpsAdjustMarginView', () => {
       expect(
         screen.getByText('perps.errors.position_not_found'),
       ).toBeOnTheScreen();
+    });
+
+    it('logs add-margin errors from the hook callback with perps context', () => {
+      mockRouteParams = {
+        position: mockPosition,
+        mode: 'add',
+      };
+
+      render(<PerpsAdjustMarginView />);
+
+      const options = mockUsePerpsMarginAdjustment.mock.calls[0][0] as {
+        onError?: (errorMessage: string) => void;
+      };
+
+      options.onError?.('Failed to add margin');
+
+      const [loggedError, loggerContext] = (Logger.error as jest.Mock).mock
+        .calls[0];
+      expect(loggedError).toBeInstanceOf(Error);
+      expect((loggedError as Error).message).toBe('Failed to add margin');
+      expect(loggerContext).toEqual(
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: expect.any(String),
+          }),
+          context: {
+            name: 'PerpsAdjustMarginView',
+            data: {
+              action: 'add_margin',
+              symbol: 'ETH',
+              error: 'Failed to add margin',
+            },
+          },
+        }),
+      );
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
@@ -78,10 +78,19 @@ const PerpsAdjustMarginView: React.FC = () => {
       onSuccess: () => navigation.goBack(),
       onError: (errorMessage) => {
         submittedEstimateRef.current = null;
-        Logger.error(
-          new Error(errorMessage),
-          `Failed to ${mode} margin for ${routePosition?.symbol}`,
-        );
+        Logger.error(new Error(errorMessage), {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+          },
+          context: {
+            name: 'PerpsAdjustMarginView',
+            data: {
+              action: mode === 'remove' ? 'remove_margin' : 'add_margin',
+              symbol: routePosition?.symbol,
+              error: errorMessage,
+            },
+          },
+        });
       },
     });
 

--- a/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectProviderView/PerpsSelectProviderView.tsx
@@ -7,6 +7,7 @@ import { usePerpsNetworkConfig } from '../../hooks/usePerpsNetworkConfig';
 import { selectPerpsNetwork } from '../../selectors/perpsController';
 import PerpsProviderSelectorSheet from '../../components/PerpsProviderSelector/PerpsProviderSelectorSheet';
 import type { ProviderNetworkOption } from '../../components/PerpsProviderSelector/PerpsProviderSelector.types';
+import { PERPS_CONSTANTS } from '@metamask/perps-controller';
 
 /**
  * PerpsSelectProviderView
@@ -47,7 +48,19 @@ const PerpsSelectProviderView: React.FC = () => {
             new Error(
               `Failed to switch perps provider to ${option.providerId}`,
             ),
-            { message: result.error },
+            {
+              tags: {
+                feature: PERPS_CONSTANTS.FeatureName,
+              },
+              context: {
+                name: 'PerpsSelectProviderView',
+                data: {
+                  action: 'switch_provider',
+                  providerId: option.providerId,
+                  error: result.error,
+                },
+              },
+            },
           );
           return;
         }
@@ -58,7 +71,17 @@ const PerpsSelectProviderView: React.FC = () => {
         const result = await toggleTestnet();
         if (!result.success) {
           Logger.error(new Error(`Failed to toggle perps testnet`), {
-            message: result.error,
+            tags: {
+              feature: PERPS_CONSTANTS.FeatureName,
+            },
+            context: {
+              name: 'PerpsSelectProviderView',
+              data: {
+                action: 'toggle_testnet',
+                targetNetwork: option.isTestnet ? 'testnet' : 'mainnet',
+                error: result.error,
+              },
+            },
           });
           return;
         }

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.test.tsx
@@ -1,18 +1,40 @@
 import { useNavigation } from '@react-navigation/native';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { PerpsWithdrawViewSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import Engine from '../../../../../core/Engine';
 import { PerpsStreamProvider } from '../../providers/PerpsStreamManager';
+import Logger from '../../../../../util/Logger';
 import PerpsWithdrawView from './PerpsWithdrawView';
 import { ToastContext } from '../../../../../component-library/components/Toast';
 
 // Mock component-library Button to avoid IconSize import issues during tests
 jest.mock('../../../../../component-library/components/Buttons/Button', () => ({
   __esModule: true,
-  default: 'Button',
+  default: ({
+    label,
+    onPress,
+    testID,
+  }: {
+    label?: string;
+    onPress?: () => void;
+    testID?: string;
+  }) => {
+    const ReactModule = jest.requireActual('react');
+    const RNModule = jest.requireActual('react-native');
+    return ReactModule.createElement(
+      RNModule.TouchableOpacity,
+      { onPress, testID },
+      ReactModule.createElement(RNModule.Text, null, label),
+    );
+  },
   ButtonSize: { Lg: 'Lg', Md: 'Md' },
   ButtonVariants: { Primary: 'Primary', Secondary: 'Secondary' },
   ButtonWidthTypes: { Full: 'Full', Auto: 'Auto' },
@@ -199,6 +221,13 @@ jest.mock('../../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
 // Mock Toast
 jest.mock('../../../../../component-library/components/Toast', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
@@ -333,6 +362,58 @@ describe('PerpsWithdrawView', () => {
         jest.requireMock('../../hooks').useWithdrawValidation;
 
       expect(mockUseWithdrawValidation).toBeDefined();
+    });
+
+    it('logs withdraw execution errors with perps context', async () => {
+      const mockHooks = jest.requireMock('../../hooks');
+      mockHooks.useWithdrawValidation.mockReturnValue({
+        hasAmount: true,
+        isBelowMinimum: false,
+        hasInsufficientBalance: false,
+        getMinimumAmount: jest.fn(() => '10.00'),
+      });
+
+      Engine.context.PerpsController.withdraw = jest
+        .fn()
+        .mockRejectedValue(new Error('withdraw failed'));
+
+      renderWithProviders(<PerpsWithdrawView />);
+
+      fireEvent.press(screen.getByText('10%'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(PerpsWithdrawViewSelectorsIDs.CONTINUE_BUTTON),
+        ).toBeOnTheScreen();
+      });
+
+      fireEvent.press(
+        screen.getByTestId(PerpsWithdrawViewSelectorsIDs.CONTINUE_BUTTON),
+      );
+
+      await waitFor(() => {
+        expect(Logger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'withdraw failed',
+          }),
+          expect.objectContaining({
+            tags: expect.objectContaining({
+              feature: expect.any(String),
+              component: 'PerpsWithdrawView',
+              action: 'financial_withdrawal',
+            }),
+            context: {
+              name: 'PerpsWithdrawView',
+              data: expect.objectContaining({
+                amount: '100.000000',
+                destination: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+                chainId: '0xa4b1',
+                isTestnet: false,
+              }),
+            },
+          }),
+        );
+      });
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/native';
-import { captureException } from '@sentry/react-native';
 import React, {
   useCallback,
   useEffect,
@@ -30,12 +29,15 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import Engine from '../../../../../core/Engine';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../../util/Logger';
+import { ensureError } from '../../../../../util/errorUtils';
 import Keypad from '../../../../Base/Keypad';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import PerpsBottomSheetTooltip from '../../components/PerpsBottomSheetTooltip';
 import { PerpsTooltipContentKey } from '../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
 import {
   HYPERLIQUID_ASSET_CONFIGS,
+  PERPS_CONSTANTS,
   USDC_DECIMALS,
   USDC_SYMBOL,
   USDC_TOKEN_ICON_URL,
@@ -287,26 +289,30 @@ const PerpsWithdrawView: React.FC = () => {
       }
       // Success/error toast will be shown by usePerpsWithdrawStatus hook
     } catch (error) {
-      // Capture exception with withdrawal context
-      captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            component: 'PerpsWithdrawView',
-            action: 'financial_withdrawal',
-            operation: 'financial_operations',
-          },
-          extra: {
-            withdrawalContext: {
-              amount: withdrawAmountDetailed,
-              assetId,
-              destination: destToken.address,
-              chainId: destToken.chainId,
-              isTestnet,
-            },
+      Logger.error(ensureError(error, 'PerpsWithdrawView.handleWithdraw'), {
+        tags: {
+          feature: PERPS_CONSTANTS.FeatureName,
+          component: 'PerpsWithdrawView',
+          action: 'financial_withdrawal',
+          operation: 'financial_operations',
+        },
+        context: {
+          name: 'PerpsWithdrawView',
+          data: {
+            amount: withdrawAmountDetailed,
+            assetId,
+            destination: destToken.address,
+            chainId: destToken.chainId,
+            isTestnet,
+            rawError:
+              error instanceof Error
+                ? undefined
+                : error === undefined
+                  ? 'undefined'
+                  : String(error),
           },
         },
-      );
+      });
 
       DevLogger.log('Error preparing withdrawal:', error);
     } finally {

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
@@ -1,6 +1,7 @@
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../../util/analytics/analytics';
+import Logger from '../../../../util/Logger';
 import type { PerpsAnalyticsEvent } from '@metamask/perps-controller';
 import { createMobileInfrastructure } from './mobileInfrastructure';
 import Engine from '../../../../core/Engine';
@@ -28,7 +29,10 @@ jest.mock('../../../../core/Analytics', () => ({
 }));
 
 jest.mock('../../../../util/Logger', () => ({
-  error: jest.fn(),
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
 }));
 
 jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
@@ -158,6 +162,37 @@ describe('createMobileInfrastructure', () => {
       expect(analytics.trackEvent).toHaveBeenCalledWith({
         name: 'fallback-event',
       });
+    });
+  });
+
+  describe('logger', () => {
+    it('preserves logger options and injects the perps feature tag', () => {
+      const infra = createMobileInfrastructure();
+      const error = new Error('boom');
+
+      infra.logger.error(error, {
+        tags: { component: 'test_component' },
+        context: {
+          name: 'test_context',
+          data: { foo: 'bar' },
+        },
+        extras: { traceId: '123' },
+      });
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: expect.any(String),
+            component: 'test_component',
+          }),
+          context: {
+            name: 'test_context',
+            data: { foo: 'bar' },
+          },
+          extras: { traceId: '123' },
+        }),
+      );
     });
   });
 

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -16,6 +16,7 @@ import performance from 'react-native-performance';
 import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
 import Engine from '../../../../core/Engine';
 import {
+  PERPS_CONSTANTS,
   type PerpsPlatformDependencies,
   type PerpsMetrics,
   type PerpsTraceName,
@@ -166,8 +167,13 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
           extras?: Record<string, unknown>;
         },
       ): void {
-        // Logger.error expects (error, context) format
-        Logger.error(error, options?.context ?? options);
+        Logger.error(error, {
+          ...options,
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            ...options?.tags,
+          },
+        });
       },
     },
     debugLogger: {

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
@@ -21,13 +21,15 @@ import {
 } from '../../../../../component-library/components-temp/Tabs';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../hooks/useStyles';
-import { captureException } from '@sentry/react-native';
+import Logger from '../../../../../util/Logger';
+import { ensureError } from '../../../../../util/errorUtils';
 import PerpsMarketStatisticsCard from '../PerpsMarketStatisticsCard';
 import PerpsPositionCard from '../PerpsPositionCard';
 import { PerpsMarketTabsProps, PerpsTabId } from './PerpsMarketTabs.types';
 import styleSheet from './PerpsMarketTabs.styles';
 import {
   OrderDirection,
+  PERPS_CONSTANTS,
   type Position,
   type Order,
 } from '@metamask/perps-controller';
@@ -576,28 +578,32 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
 
         showToast(PerpsToastOptions.orderManagement.shared.cancellationFailed);
 
-        // Capture exception with order context
-        captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: {
-              component: 'PerpsMarketTabs',
-              action: 'order_cancellation',
-              operation: 'order_management',
-            },
-            extra: {
-              orderContext: {
-                orderId: orderToCancel.orderId,
-                symbol: orderToCancel.symbol,
-                side: orderToCancel.side,
-                orderType: orderToCancel.orderType,
-                size: orderToCancel.size,
-                price: orderToCancel.price,
-                reduceOnly: orderToCancel.reduceOnly,
-              },
+        Logger.error(ensureError(error, 'PerpsMarketTabs.handleCancelOrder'), {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            component: 'PerpsMarketTabs',
+            action: 'order_cancellation',
+            operation: 'order_management',
+          },
+          context: {
+            name: 'PerpsMarketTabs',
+            data: {
+              orderId: orderToCancel.orderId,
+              symbol: orderToCancel.symbol,
+              side: orderToCancel.side,
+              orderType: orderToCancel.orderType,
+              size: orderToCancel.size,
+              price: orderToCancel.price,
+              reduceOnly: orderToCancel.reduceOnly,
+              rawError:
+                error instanceof Error
+                  ? undefined
+                  : error === undefined
+                    ? 'undefined'
+                    : String(error),
             },
           },
-        );
+        });
       } finally {
         // Remove from UI loading state
         setCancellingOrderIds((prev) => {

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../util/Logger';
 import { type OrderResult, type Position } from '@metamask/perps-controller';
 import { usePerpsClosePosition } from './usePerpsClosePosition';
 import { usePerpsTrading } from './usePerpsTrading';
@@ -18,6 +19,12 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('./usePerpsTrading');
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => key),
 }));
@@ -228,6 +235,28 @@ describe('usePerpsClosePosition', () => {
           result.current.handleClosePosition({ position: mockPosition }),
         ).rejects.toThrow('perps.close_position.error_unknown');
       });
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'perps.close_position.error_unknown',
+        }),
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: 'perps',
+            component: 'usePerpsClosePosition',
+            action: 'close_position',
+          }),
+          context: expect.objectContaining({
+            name: 'usePerpsClosePosition',
+            data: expect.objectContaining({
+              symbol: 'BTC',
+              orderType: 'market',
+              isFullClose: true,
+              rawError: undefined,
+            }),
+          }),
+        }),
+      );
     });
 
     it('should handle exceptions thrown by closePosition', async () => {
@@ -248,6 +277,25 @@ describe('usePerpsClosePosition', () => {
       expect(DevLogger.log).toHaveBeenCalledWith(
         'usePerpsClosePosition: Error closing position',
         error,
+      );
+      expect(Logger.error).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: 'perps',
+            component: 'usePerpsClosePosition',
+            action: 'close_position',
+          }),
+          context: expect.objectContaining({
+            name: 'usePerpsClosePosition',
+            data: expect.objectContaining({
+              symbol: 'BTC',
+              requestedSize: undefined,
+              orderType: 'market',
+              isFullClose: true,
+            }),
+          }),
+        }),
       );
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -1,7 +1,9 @@
 import { useCallback, useState } from 'react';
 import { strings } from '../../../../../locales/i18n';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../util/Logger';
 import {
+  PERPS_CONSTANTS,
   type OrderResult,
   type Position,
   type TrackingData,
@@ -55,6 +57,7 @@ export const usePerpsClosePosition = (
         marketPrice,
         slippage,
       } = params;
+      const isFullClose = size === undefined || size === '';
 
       try {
         setIsClosing(true);
@@ -70,8 +73,6 @@ export const usePerpsClosePosition = (
         const direction = isLong
           ? strings('perps.market.long')
           : strings('perps.market.short');
-
-        const isFullClose = size === undefined || size === '';
 
         if (orderType === 'market') {
           // Market closing full position
@@ -202,6 +203,38 @@ export const usePerpsClosePosition = (
           'usePerpsClosePosition: Error closing position',
           closeError,
         );
+        Logger.error(closeError, {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            component: 'usePerpsClosePosition',
+            action: 'close_position',
+            operation: 'position_management',
+          },
+          context: {
+            name: 'usePerpsClosePosition',
+            data: {
+              symbol: position.symbol,
+              positionSize: position.size,
+              requestedSize: size,
+              orderType,
+              isFullClose,
+              limitPrice,
+              marketPrice,
+              trackingSource: trackingData?.source,
+              tradeAction: trackingData?.tradeAction,
+              inputMethod: trackingData?.inputMethod,
+              totalFee: trackingData?.totalFee,
+              realizedPnl: trackingData?.realizedPnl,
+              receivedAmount: trackingData?.receivedAmount,
+              rawError:
+                err instanceof Error
+                  ? undefined
+                  : err === undefined
+                    ? 'undefined'
+                    : String(err),
+            },
+          },
+        });
         setError(closeError);
 
         // Call error callback

--- a/app/components/UI/Perps/hooks/usePerpsFlipPosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsFlipPosition.test.ts
@@ -1,10 +1,10 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { usePerpsFlipPosition } from './usePerpsFlipPosition';
 import { type Position } from '@metamask/perps-controller';
+import Logger from '../../../../util/Logger';
 
 const mockFlipPosition = jest.fn();
 const mockShowToast = jest.fn();
-const mockCaptureException = jest.fn();
 
 jest.mock('./usePerpsTrading', () => ({
   usePerpsTrading: () => ({
@@ -35,9 +35,11 @@ jest.mock('./usePerpsToasts', () => ({
   }),
 }));
 
-jest.mock('@sentry/react-native', () => ({
-  captureException: (error: Error, context: unknown) =>
-    mockCaptureException(error, context),
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
 }));
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -197,7 +199,7 @@ describe('usePerpsFlipPosition', () => {
     expect(mockOnError).toHaveBeenCalledWith('perps.errors.unknown');
   });
 
-  it('handles exceptions and captures to Sentry', async () => {
+  it('handles exceptions and logs via Logger.error', async () => {
     const testError = new Error('Network error');
     mockFlipPosition.mockRejectedValue(testError);
     const mockOnError = jest.fn();
@@ -210,17 +212,23 @@ describe('usePerpsFlipPosition', () => {
       await result.current.handleFlipPosition(mockLongPosition);
     });
 
-    expect(mockCaptureException).toHaveBeenCalledWith(
+    expect(Logger.error).toHaveBeenCalledWith(
       testError,
       expect.objectContaining({
         tags: expect.objectContaining({
+          feature: 'perps',
           component: 'usePerpsFlipPosition',
           action: 'flip_position',
+          operation: 'position_management',
         }),
-        extra: expect.objectContaining({
-          positionContext: expect.objectContaining({
+        context: expect.objectContaining({
+          name: 'usePerpsFlipPosition',
+          data: expect.objectContaining({
             symbol: 'ETH',
             size: '2.5',
+            currentDirection: 'long',
+            targetDirection: 'short',
+            positionSize: 2.5,
           }),
         }),
       }),
@@ -240,9 +248,18 @@ describe('usePerpsFlipPosition', () => {
       await result.current.handleFlipPosition(mockLongPosition);
     });
 
-    expect(mockCaptureException).toHaveBeenCalledWith(
-      expect.any(Error),
-      expect.anything(),
+    const [loggedError, loggerContext] = (Logger.error as jest.Mock).mock
+      .calls[0];
+    expect(loggedError).toBeInstanceOf(Error);
+    expect((loggedError as Error).message).toBe('String error');
+    expect(loggerContext).toEqual(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          data: expect.objectContaining({
+            rawError: 'String error',
+          }),
+        }),
+      }),
     );
     expect(mockOnError).toHaveBeenCalledWith('perps.errors.unknown');
   });

--- a/app/components/UI/Perps/hooks/usePerpsFlipPosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsFlipPosition.ts
@@ -1,13 +1,15 @@
 import { useCallback, useState } from 'react';
 import { strings } from '../../../../../locales/i18n';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../util/Logger';
+import { ensureError } from '../../../../util/errorUtils';
 import { usePerpsTrading } from './usePerpsTrading';
 import {
   getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
   type Position,
   type OrderDirection,
 } from '@metamask/perps-controller';
-import { captureException } from '@sentry/react-native';
 import usePerpsToasts from './usePerpsToasts';
 
 export interface UsePerpsFlipPositionOptions {
@@ -79,29 +81,33 @@ export function usePerpsFlipPosition(options?: UsePerpsFlipPositionOptions) {
       } catch (error) {
         DevLogger.log('Error flipping position:', error);
 
-        // Capture exception with position context
-        captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: {
-              component: 'usePerpsFlipPosition',
-              action: 'flip_position',
-              operation: 'position_management',
-            },
-            extra: {
-              positionContext: {
-                symbol: position.symbol,
-                size: position.size,
-                currentDirection,
-                targetDirection: oppositeDirection,
-                positionSize,
-                entryPrice: position.entryPrice,
-                unrealizedPnl: position.unrealizedPnl,
-                leverage: position.leverage,
-              },
+        Logger.error(ensureError(error, 'usePerpsFlipPosition.handle'), {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            component: 'usePerpsFlipPosition',
+            action: 'flip_position',
+            operation: 'position_management',
+          },
+          context: {
+            name: 'usePerpsFlipPosition',
+            data: {
+              symbol: position.symbol,
+              size: position.size,
+              currentDirection,
+              targetDirection: oppositeDirection,
+              positionSize,
+              entryPrice: position.entryPrice,
+              unrealizedPnl: position.unrealizedPnl,
+              leverage: position.leverage,
+              rawError:
+                error instanceof Error
+                  ? undefined
+                  : error === undefined
+                    ? 'undefined'
+                    : String(error),
             },
           },
-        );
+        });
 
         const errorMessage =
           error instanceof Error

--- a/app/components/UI/Perps/hooks/usePerpsMarginAdjustment.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarginAdjustment.test.ts
@@ -1,9 +1,9 @@
 import { renderHook, act } from '@testing-library/react-native';
+import Logger from '../../../../util/Logger';
 import { usePerpsMarginAdjustment } from './usePerpsMarginAdjustment';
 
 const mockUpdateMargin = jest.fn();
 const mockShowToast = jest.fn();
-const mockCaptureException = jest.fn();
 
 jest.mock('./usePerpsTrading', () => ({
   usePerpsTrading: () => ({
@@ -38,9 +38,11 @@ jest.mock('./usePerpsToasts', () => ({
   }),
 }));
 
-jest.mock('@sentry/react-native', () => ({
-  captureException: (error: Error, context: unknown) =>
-    mockCaptureException(error, context),
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
 }));
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -54,6 +56,7 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 }));
 
 jest.mock('@metamask/perps-controller', () => ({
+  PERPS_CONSTANTS: { FeatureName: 'perps' },
   getPerpsDisplaySymbol: jest.fn((symbol: string) => symbol),
 }));
 
@@ -236,7 +239,7 @@ describe('usePerpsMarginAdjustment', () => {
       expect(mockOnError).toHaveBeenCalledWith('perps.errors.unknown');
     });
 
-    it('handles exceptions and captures to Sentry', async () => {
+    it('handles exceptions and logs via Logger.error', async () => {
       const testError = new Error('Network error');
       mockUpdateMargin.mockRejectedValue(testError);
       const mockOnError = jest.fn();
@@ -249,18 +252,22 @@ describe('usePerpsMarginAdjustment', () => {
         await result.current.handleAddMargin('ETH', 100);
       });
 
-      expect(mockCaptureException).toHaveBeenCalledWith(
+      expect(Logger.error).toHaveBeenCalledWith(
         testError,
         expect.objectContaining({
           tags: expect.objectContaining({
+            feature: 'perps',
             component: 'usePerpsMarginAdjustment',
             action: 'margin_add',
+            operation: 'position_management',
           }),
-          extra: expect.objectContaining({
-            marginContext: expect.objectContaining({
+          context: expect.objectContaining({
+            name: 'usePerpsMarginAdjustment',
+            data: expect.objectContaining({
               symbol: 'ETH',
               amount: 100,
               action: 'add',
+              adjustmentAmount: 100,
             }),
           }),
         }),
@@ -268,7 +275,7 @@ describe('usePerpsMarginAdjustment', () => {
       expect(mockOnError).toHaveBeenCalledWith('Network error');
     });
 
-    it('captures remove action in Sentry context', async () => {
+    it('captures remove action in Logger context', async () => {
       const testError = new Error('API error');
       mockUpdateMargin.mockRejectedValue(testError);
 
@@ -278,14 +285,15 @@ describe('usePerpsMarginAdjustment', () => {
         await result.current.handleRemoveMargin('BTC', 50);
       });
 
-      expect(mockCaptureException).toHaveBeenCalledWith(
+      expect(Logger.error).toHaveBeenCalledWith(
         testError,
         expect.objectContaining({
           tags: expect.objectContaining({
+            feature: 'perps',
             action: 'margin_remove',
           }),
-          extra: expect.objectContaining({
-            marginContext: expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({
               action: 'remove',
               adjustmentAmount: -50,
             }),
@@ -306,9 +314,18 @@ describe('usePerpsMarginAdjustment', () => {
         await result.current.handleAddMargin('ETH', 100);
       });
 
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.anything(),
+      const [loggedError, loggerContext] = (Logger.error as jest.Mock).mock
+        .calls[0];
+      expect(loggedError).toBeInstanceOf(Error);
+      expect((loggedError as Error).message).toBe('String error');
+      expect(loggerContext).toEqual(
+        expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({
+              rawError: 'String error',
+            }),
+          }),
+        }),
       );
       expect(mockOnError).toHaveBeenCalledWith('perps.errors.unknown');
     });

--- a/app/components/UI/Perps/hooks/usePerpsMarginAdjustment.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarginAdjustment.ts
@@ -1,10 +1,14 @@
 import { useCallback, useState } from 'react';
 import { strings } from '../../../../../locales/i18n';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../util/Logger';
+import { ensureError } from '../../../../util/errorUtils';
 import { usePerpsTrading } from './usePerpsTrading';
-import { captureException } from '@sentry/react-native';
 import usePerpsToasts from './usePerpsToasts';
-import { getPerpsDisplaySymbol } from '@metamask/perps-controller';
+import {
+  getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
+} from '@metamask/perps-controller';
 
 export interface UsePerpsMarginAdjustmentOptions {
   onSuccess?: () => void;
@@ -78,25 +82,29 @@ export function usePerpsMarginAdjustment(
       } catch (error) {
         DevLogger.log('Error adjusting margin:', error);
 
-        // Capture exception with margin context
-        captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: {
-              component: 'usePerpsMarginAdjustment',
-              action: `margin_${action}`,
-              operation: 'position_management',
-            },
-            extra: {
-              marginContext: {
-                symbol,
-                amount,
-                action,
-                adjustmentAmount: action === 'remove' ? -amount : amount,
-              },
+        Logger.error(ensureError(error, 'usePerpsMarginAdjustment.handle'), {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            component: 'usePerpsMarginAdjustment',
+            action: `margin_${action}`,
+            operation: 'position_management',
+          },
+          context: {
+            name: 'usePerpsMarginAdjustment',
+            data: {
+              symbol,
+              amount,
+              action,
+              adjustmentAmount: action === 'remove' ? -amount : amount,
+              rawError:
+                error instanceof Error
+                  ? undefined
+                  : error === undefined
+                    ? 'undefined'
+                    : String(error),
             },
           },
-        );
+        });
 
         const errorMessage =
           error instanceof Error

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -1,10 +1,12 @@
-import { captureException } from '@sentry/react-native';
 import { useCallback, useState } from 'react';
 import { strings } from '../../../../../locales/i18n';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { TraceName, TraceOperation } from '../../../../util/trace';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import Logger from '../../../../util/Logger';
+import { ensureError } from '../../../../util/errorUtils';
 import {
+  PERPS_CONSTANTS,
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
   type OrderParams,
@@ -184,6 +186,10 @@ export function usePerpsOrderExecution(
           onError?.(errorMessage);
         }
       } catch (err) {
+        const errorObject = ensureError(
+          err,
+          'usePerpsOrderExecution.placeOrder',
+        );
         const errorMessage =
           err instanceof Error
             ? err.message
@@ -191,15 +197,16 @@ export function usePerpsOrderExecution(
         setError(errorMessage);
         DevLogger.log('usePerpsOrderExecution: Error placing order', err);
 
-        // Capture exception with order context
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        Logger.error(errorObject, {
           tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
             component: 'usePerpsOrderExecution',
             action: 'order_creation',
             operation: 'order_management',
           },
-          extra: {
-            orderContext: {
+          context: {
+            name: 'usePerpsOrderExecution',
+            data: {
               symbol: orderParams.symbol,
               isBuy: orderParams.isBuy,
               orderType: orderParams.orderType,

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -1,12 +1,14 @@
 import { useCallback, useState } from 'react';
 import { strings } from '../../../../../locales/i18n';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import Logger from '../../../../util/Logger';
+import { ensureError } from '../../../../util/errorUtils';
 import { usePerpsTrading } from './usePerpsTrading';
 import {
+  PERPS_CONSTANTS,
   type Position,
   type TPSLTrackingData,
 } from '@metamask/perps-controller';
-import { captureException } from '@sentry/react-native';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 
@@ -83,28 +85,32 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       } catch (error) {
         DevLogger.log('Error updating position TP/SL:', error);
 
-        // Capture exception with position context
-        captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: {
-              component: 'usePerpsTPSLUpdate',
-              action: 'position_tpsl_update',
-              operation: 'position_management',
-            },
-            extra: {
-              positionContext: {
-                symbol: position.symbol,
-                size: position.size,
-                entryPrice: position.entryPrice,
-                unrealizedPnl: position.unrealizedPnl,
-                leverage: position.leverage,
-                takeProfitPrice,
-                stopLossPrice,
-              },
+        Logger.error(ensureError(error, 'usePerpsTPSLUpdate.handle'), {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            component: 'usePerpsTPSLUpdate',
+            action: 'position_tpsl_update',
+            operation: 'position_management',
+          },
+          context: {
+            name: 'usePerpsTPSLUpdate',
+            data: {
+              symbol: position.symbol,
+              size: position.size,
+              entryPrice: position.entryPrice,
+              unrealizedPnl: position.unrealizedPnl,
+              leverage: position.leverage,
+              takeProfitPrice,
+              stopLossPrice,
+              rawError:
+                error instanceof Error
+                  ? undefined
+                  : error === undefined
+                    ? 'undefined'
+                    : String(error),
             },
           },
-        );
+        });
 
         const errorMessage =
           error instanceof Error

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -411,6 +411,7 @@ describe('HyperLiquidProvider', () => {
         const prices: Record<string, string> = { BTC: '50000', ETH: '3000' };
         return prices[symbol];
       }),
+      getLastAllMidsSnapshot: jest.fn().mockReturnValue(null),
       // Orders cache used by updatePositionTPSL and getOpenOrders
       isOrdersCacheInitialized: jest.fn().mockReturnValue(false),
       getCachedOrders: jest.fn().mockReturnValue([]),
@@ -1265,6 +1266,105 @@ describe('HyperLiquidProvider', () => {
       const result = await provider.closePosition(closeParams);
 
       expect(result.success).toBe(true);
+    });
+
+    it('repairs missing HIP-3 asset IDs during closePosition after degraded discovery', async () => {
+      const hip3Provider = createTestProvider({
+        hip3Enabled: true,
+        allowlistMarkets: ['xyz:*'],
+        useDexAbstraction: true,
+      });
+      const mockOrder = jest.fn().mockResolvedValue({
+        status: 'ok',
+        response: { data: { statuses: [{ resting: { oid: 123 } }] } },
+      });
+      const mockInfoClient = createMockInfoClient({
+        perpDexs: jest
+          .fn()
+          .mockResolvedValue([null, { name: 'xyz', url: 'https://xyz.com' }]),
+        metaAndAssetCtxs: jest
+          .fn()
+          .mockImplementation((params?: { dex?: string }) => {
+            if (params?.dex === 'xyz') {
+              return Promise.reject(
+                new Error('Transient xyz discovery failure'),
+              );
+            }
+
+            return Promise.resolve([
+              { universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }] },
+              [
+                {
+                  funding: '0.0001',
+                  openInterest: '1000',
+                  prevDayPx: '49000',
+                  dayNtlVlm: '1000000',
+                  markPx: '50000',
+                  midPx: '50000',
+                  oraclePx: '50000',
+                },
+              ],
+            ]);
+          }),
+        meta: jest.fn().mockImplementation((params?: { dex?: string }) => {
+          if (params?.dex === 'xyz') {
+            return Promise.resolve({
+              universe: [
+                { name: 'xyz:STOCK1', szDecimals: 2, maxLeverage: 20 },
+              ],
+            });
+          }
+
+          return Promise.resolve({
+            universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+          });
+        }),
+        allMids: jest.fn().mockImplementation((params?: { dex?: string }) => {
+          if (params?.dex === 'xyz') {
+            return Promise.resolve({ 'xyz:STOCK1': '100' });
+          }
+
+          return Promise.resolve({ BTC: '50000' });
+        }),
+      });
+
+      mockClientService.getInfoClient = jest
+        .fn()
+        .mockReturnValue(mockInfoClient);
+      mockClientService.getExchangeClient = jest
+        .fn()
+        .mockReturnValue(createMockExchangeClient({ order: mockOrder }));
+
+      const result = await hip3Provider.closePosition({
+        symbol: 'xyz:STOCK1',
+        orderType: 'market',
+        position: {
+          symbol: 'xyz:STOCK1',
+          size: '10',
+          entryPrice: '95',
+          positionValue: '1000',
+          unrealizedPnl: '50',
+          marginUsed: '100',
+          leverage: { type: 'isolated', value: 5 },
+          liquidationPrice: '70',
+          maxLeverage: 20,
+          returnOnEquity: '10',
+          cumulativeFunding: {
+            allTime: '0',
+            sinceOpen: '0',
+            sinceChange: '0',
+          },
+          takeProfitCount: 0,
+          stopLossCount: 0,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orders: [expect.objectContaining({ a: 110000, r: true })],
+        }),
+      );
     });
   });
 
@@ -3482,8 +3582,57 @@ describe('HyperLiquidProvider', () => {
         mockWalletService.getUserAddressWithDefault.mockResolvedValue('0x123');
 
         await expect(provider.getAccountState()).rejects.toThrow(
-          'Account state fetch failed',
+          'Failed to fetch account state (failedDexs=[main], spotError=none)',
         );
+      });
+
+      it('returns partial account state when one HIP-3 DEX fails', async () => {
+        const hip3Provider = createTestProvider({
+          hip3Enabled: true,
+          allowlistMarkets: ['xyz:*'],
+        });
+        const mockInfoClient = createMockInfoClient({
+          perpDexs: jest
+            .fn()
+            .mockResolvedValue([null, { name: 'xyz', url: 'https://xyz.com' }]),
+          clearinghouseState: jest
+            .fn()
+            .mockImplementation((params?: { dex?: string }) => {
+              if (params?.dex === 'xyz') {
+                return Promise.reject(new Error('xyz DEX unavailable'));
+              }
+
+              return Promise.resolve({
+                marginSummary: {
+                  totalMarginUsed: '500',
+                  accountValue: '10500',
+                },
+                withdrawable: '9500',
+                assetPositions: [],
+                crossMarginSummary: {
+                  accountValue: '10500',
+                  totalMarginUsed: '500',
+                },
+              });
+            }),
+          spotClearinghouseState: jest.fn().mockResolvedValue({
+            balances: [{ coin: 'USDC', hold: '1000', total: '10000' }],
+          }),
+        });
+
+        mockClientService.getInfoClient = jest
+          .fn()
+          .mockReturnValue(mockInfoClient);
+        mockWalletService.getUserAddressWithDefault.mockResolvedValue('0x123');
+
+        const accountState = await hip3Provider.getAccountState();
+
+        expect(parseFloat(accountState.totalBalance)).toBe(20500);
+        expect(parseFloat(accountState.marginUsed)).toBe(500);
+        expect(mockInfoClient.clearinghouseState).toHaveBeenCalledWith({
+          user: '0x123',
+          dex: 'xyz',
+        });
       });
     });
 
@@ -3625,6 +3774,63 @@ describe('HyperLiquidProvider', () => {
         expect(result[0]).toHaveProperty('name');
         expect(result[0]).toHaveProperty('price');
         expect(result[0]).toHaveProperty('fundingRate');
+      });
+
+      it('returns stale cached market data after retry failure', async () => {
+        jest.useFakeTimers();
+
+        try {
+          mockClientService.getInfoClient = jest.fn().mockReturnValue(
+            createMockInfoClient({
+              meta: jest.fn().mockResolvedValue({
+                universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+              }),
+              allMids: jest.fn().mockResolvedValue({ BTC: '50000' }),
+              metaAndAssetCtxs: jest.fn().mockResolvedValue([
+                { universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }] },
+                [
+                  {
+                    funding: '0.001',
+                    openInterest: '1000000',
+                    prevDayPx: '49000',
+                    dayNtlVlm: '1000000',
+                    markPx: '50000',
+                    midPx: '50000',
+                    oraclePx: '50000',
+                  },
+                ],
+              ]),
+            }),
+          );
+
+          const freshProvider = createTestProvider();
+          const freshMarketData = await freshProvider.getMarketDataWithPrices();
+
+          expect(freshMarketData[0].isStale).toBe(false);
+
+          await freshProvider.disconnect();
+
+          mockClientService.getInfoClient = jest.fn().mockReturnValue(
+            createMockInfoClient({
+              metaAndAssetCtxs: jest
+                .fn()
+                .mockRejectedValue(new Error('market data unavailable')),
+              allMids: jest
+                .fn()
+                .mockRejectedValue(new Error('market data unavailable')),
+            }),
+          );
+
+          const staleMarketDataPromise =
+            freshProvider.getMarketDataWithPrices();
+          await jest.advanceTimersByTimeAsync(2000);
+          const staleMarketData = await staleMarketDataPromise;
+
+          expect(staleMarketData[0].symbol).toBe(freshMarketData[0].symbol);
+          expect(staleMarketData[0].isStale).toBe(true);
+        } finally {
+          jest.useRealTimers();
+        }
       });
     });
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -3832,6 +3832,79 @@ describe('HyperLiquidProvider', () => {
           jest.useRealTimers();
         }
       });
+
+      it('excludes a cached-meta DEX when assetCtx refresh fails and no aligned ctx cache exists', async () => {
+        const xyzMeta = {
+          universe: [{ name: 'xyz:XYZ100', szDecimals: 2, maxLeverage: 20 }],
+        };
+        const xyzAssetCtx = {
+          funding: '0.0002',
+          openInterest: '250',
+          prevDayPx: '40',
+          dayNtlVlm: '20000',
+          markPx: '42',
+          midPx: '42',
+          oraclePx: '42',
+        };
+        const mainMeta = {
+          universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+        };
+        const mainAssetCtx = {
+          funding: '0.001',
+          openInterest: '1000000',
+          prevDayPx: '49000',
+          dayNtlVlm: '1000000',
+          markPx: '50000',
+          midPx: '50000',
+          oraclePx: '50000',
+        };
+
+        const xyzMetaFetches = { count: 0 };
+        const mockInfoClient = createMockInfoClient({
+          perpDexs: jest
+            .fn()
+            .mockResolvedValue([null, { name: 'xyz', url: 'https://xyz.com' }]),
+          metaAndAssetCtxs: jest
+            .fn()
+            .mockImplementation((params?: { dex?: string }) => {
+              if (params?.dex === 'xyz') {
+                xyzMetaFetches.count += 1;
+                if (xyzMetaFetches.count === 1) {
+                  return Promise.resolve([xyzMeta, [xyzAssetCtx]]);
+                }
+
+                return Promise.reject(
+                  new Error('xyz assetCtxs refresh unavailable'),
+                );
+              }
+
+              return Promise.resolve([mainMeta, [mainAssetCtx]]);
+            }),
+          allMids: jest.fn().mockImplementation((params?: { dex?: string }) => {
+            if (params?.dex === 'xyz') {
+              return Promise.resolve({ 'xyz:XYZ100': '42' });
+            }
+
+            return Promise.resolve({ BTC: '50000' });
+          }),
+        });
+
+        mockClientService.getInfoClient = jest
+          .fn()
+          .mockReturnValue(mockInfoClient);
+
+        const hip3Provider = createTestProvider({
+          hip3Enabled: true,
+          allowlistMarkets: ['xyz:*'],
+        });
+
+        const result = await hip3Provider.getMarketDataWithPrices();
+
+        expect(result.map((market) => market.symbol)).toEqual(['BTC']);
+        expect(mockInfoClient.metaAndAssetCtxs).toHaveBeenCalledWith({
+          dex: 'xyz',
+        });
+      });
     });
 
     describe('withdrawal edge cases', () => {

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -3685,6 +3685,39 @@ describe('HyperLiquidProvider', () => {
         });
       });
 
+      it('prefers the last WebSocket allMids snapshot over REST when available', async () => {
+        const mockInfoClient = createMockInfoClient({
+          metaAndAssetCtxs: jest.fn().mockResolvedValue([
+            { universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }] },
+            [
+              {
+                funding: '0.0001',
+                openInterest: '1000',
+                prevDayPx: '49000',
+                dayNtlVlm: '1000000',
+                markPx: '50000',
+                midPx: '50000',
+                oraclePx: '50000',
+              },
+            ],
+          ]),
+          allMids: jest.fn().mockResolvedValue({ BTC: '49999' }),
+        });
+
+        mockClientService.getInfoClient = jest
+          .fn()
+          .mockReturnValue(mockInfoClient);
+        mockSubscriptionService.getLastAllMidsSnapshot.mockReturnValue({
+          BTC: '51000',
+        });
+
+        const freshProvider = createTestProvider();
+        const result = await freshProvider.getMarketDataWithPrices();
+
+        expect(result[0].price).toBe('$51000.00');
+        expect(mockInfoClient.allMids).not.toHaveBeenCalled();
+      });
+
       it('includes diagnostic context in error when all DEX fetches fail', async () => {
         mockClientService.getInfoClient = jest.fn().mockReturnValue(
           createMockInfoClient({
@@ -3828,6 +3861,73 @@ describe('HyperLiquidProvider', () => {
 
           expect(staleMarketData[0].symbol).toBe(freshMarketData[0].symbol);
           expect(staleMarketData[0].isStale).toBe(true);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('recovers on retry when cached meta refresh initially returns mismatched asset contexts', async () => {
+        jest.useFakeTimers();
+
+        try {
+          const mainMeta = {
+            universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+          };
+          const mainAssetCtx = {
+            funding: '0.001',
+            openInterest: '1000000',
+            prevDayPx: '49000',
+            dayNtlVlm: '1000000',
+            markPx: '50000',
+            midPx: '50000',
+            oraclePx: '50000',
+          };
+          let metaAndAssetCtxsCallCount = 0;
+
+          const mockInfoClient = createMockInfoClient({
+            metaAndAssetCtxs: jest.fn().mockImplementation(() => {
+              metaAndAssetCtxsCallCount += 1;
+
+              if (metaAndAssetCtxsCallCount === 1) {
+                return Promise.resolve([mainMeta, [mainAssetCtx]]);
+              }
+
+              if (metaAndAssetCtxsCallCount === 2) {
+                return Promise.resolve([mainMeta, []]);
+              }
+
+              return Promise.resolve([mainMeta, [mainAssetCtx]]);
+            }),
+            allMids: jest.fn().mockResolvedValue({ BTC: '50000' }),
+          });
+
+          mockClientService.getInfoClient = jest
+            .fn()
+            .mockReturnValue(mockInfoClient);
+          mockSubscriptionService.getDexAssetCtxsCache.mockReturnValue([]);
+
+          const freshProvider = createTestProvider();
+          const resultPromise = freshProvider.getMarketDataWithPrices();
+
+          await jest.advanceTimersByTimeAsync(2000);
+
+          const result = await resultPromise;
+
+          expect(result).toEqual([
+            expect.objectContaining({
+              symbol: 'BTC',
+              price: '$50000.00',
+              isStale: false,
+            }),
+          ]);
+          expect(metaAndAssetCtxsCallCount).toBe(3);
+          expect(mockInfoClient.allMids).toHaveBeenCalledTimes(1);
+          expect(mockPlatformDependencies.debugLogger.log).toHaveBeenCalledWith(
+            '[getMarketDataWithPrices] Retry succeeded',
+            expect.objectContaining({
+              marketCount: 1,
+            }),
+          );
         } finally {
           jest.useRealTimers();
         }

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -168,6 +168,35 @@ type GetAssetInfoParams = {
   dexName: string | null;
 };
 
+type DexFetchFailureStep = 'metaAndAssetCtxs' | 'allMids';
+
+type DexFetchResult = {
+  dex: string | null;
+  meta: MetaResponse | null;
+  assetCtxs: PerpsAssetCtx[];
+  allMids: Record<string, string>;
+  success: boolean;
+  failedStep?: DexFetchFailureStep;
+  errorMessage?: string;
+};
+
+type DexQueryResult<TResult> = {
+  dex: string | null;
+  data: TResult;
+};
+
+type DexQueryResponse<TResult> = {
+  results: DexQueryResult<TResult>[];
+  failedDexs: { dex: string | null; error: Error }[];
+};
+
+type CachedMarketDataSnapshot = {
+  data: PerpsMarketData[];
+  timestamp: number;
+  contributingDexs: string[];
+  failedDexs: string[];
+};
+
 type GetAssetInfoResult = {
   assetInfo: {
     name: string;
@@ -269,6 +298,9 @@ export class HyperLiquidProvider implements PerpsProvider {
   // Cache for raw meta responses (shared across methods to avoid redundant API calls)
   // Filtering is applied on-demand (cheap array operations) - no need for separate processed cache
   readonly #cachedMetaByDex = new Map<string, MetaResponse>();
+
+  // Last known-good market list for stale fallback when every enabled DEX fails in one fetch window.
+  #cachedMarketDataWithPrices: CachedMarketDataSnapshot | null = null;
 
   // Session cache for spot metadata (contains USDC/USDH token info for HIP-3 collateral checks)
   // Pre-fetched in ensureReadyForTrading() to avoid API failures during order placement
@@ -1275,6 +1307,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Store raw meta response for reuse
     this.#cachedMetaByDex.set(dexKey, meta);
+    await this.#backfillAssetMapForDex(dexName, meta);
 
     this.#deps.debugLogger.log(
       '[getCachedMeta] Fetched and cached meta response',
@@ -1286,6 +1319,124 @@ export class HyperLiquidProvider implements PerpsProvider {
     );
 
     return meta;
+  }
+
+  /**
+   * Backfill the asset ID map for a single DEX from a fresh meta response.
+   * Used to repair partial asset mapping when an individual DEX becomes available later.
+   *
+   * @param dex - DEX name (null for main DEX).
+   * @param meta - Meta response containing the DEX universe.
+   * @returns True if the mapping was rebuilt for the DEX.
+   */
+  async #backfillAssetMapForDex(
+    dex: string | null,
+    meta: MetaResponse,
+  ): Promise<boolean> {
+    if (!meta?.universe || !Array.isArray(meta.universe)) {
+      return false;
+    }
+
+    if (!this.#cachedAllPerpDexs) {
+      try {
+        await this.#getValidatedDexs();
+      } catch (error) {
+        this.#deps.debugLogger.log(
+          '[backfillAssetMapForDex] Unable to refresh validated DEXs before rebuilding asset map',
+          {
+            dex: dex ?? 'main',
+            error: ensureError(
+              error,
+              'HyperLiquidProvider.backfillAssetMapForDex',
+            ).message,
+          },
+        );
+      }
+    }
+
+    const allPerpDexs = this.#cachedAllPerpDexs ?? [null];
+    const perpDexIndex = allPerpDexs.findIndex((entry) => {
+      if (dex === null) {
+        return entry === null;
+      }
+      return entry !== null && entry.name === dex;
+    });
+
+    if (perpDexIndex === -1) {
+      this.#deps.debugLogger.log(
+        '[backfillAssetMapForDex] Could not find perpDexIndex for DEX',
+        { dex: dex ?? 'main' },
+      );
+      return false;
+    }
+
+    const { symbolToAssetId } = buildAssetMapping({
+      metaUniverse: meta.universe,
+      dex,
+      perpDexIndex,
+    });
+
+    symbolToAssetId.forEach((assetId, coin) => {
+      this.#symbolToAssetId.set(coin, assetId);
+    });
+
+    this.#deps.debugLogger.log(
+      '[backfillAssetMapForDex] Rebuilt asset mapping for DEX',
+      {
+        dex: dex ?? 'main',
+        dexAssetCount: symbolToAssetId.size,
+        totalAssetCount: this.#symbolToAssetId.size,
+      },
+    );
+
+    return symbolToAssetId.size > 0;
+  }
+
+  /**
+   * Resolve an asset ID, repairing the DEX-specific map when meta is available but the map is stale.
+   *
+   * @param params - Resolution parameters.
+   * @param params.symbol - Asset symbol to resolve.
+   * @param params.dexName - DEX name (null for main DEX).
+   * @param params.meta - Optional pre-fetched meta for the DEX.
+   * @returns The asset ID.
+   */
+  async #getAssetIdWithRepair(params: {
+    symbol: string;
+    dexName: string | null;
+    meta?: MetaResponse;
+  }): Promise<number> {
+    const { symbol, dexName } = params;
+    const existingAssetId = this.#symbolToAssetId.get(symbol);
+
+    if (existingAssetId !== undefined) {
+      return existingAssetId;
+    }
+
+    const meta =
+      params.meta ?? (await this.#getCachedMeta({ dexName: dexName ?? null }));
+    const assetExistsInMeta = meta.universe.some(
+      (asset) => asset.name === symbol,
+    );
+
+    if (assetExistsInMeta) {
+      await this.#backfillAssetMapForDex(dexName, meta);
+      const repairedAssetId = this.#symbolToAssetId.get(symbol);
+      if (repairedAssetId !== undefined) {
+        return repairedAssetId;
+      }
+    }
+
+    this.#deps.debugLogger.log('Asset ID lookup failed', {
+      requestedCoin: symbol,
+      dexName: dexName ?? 'main',
+      mapSize: this.#symbolToAssetId.size,
+      mapContainsAsset: this.#symbolToAssetId.has(symbol),
+      assetExistsInMeta,
+      allKeys: Array.from(this.#symbolToAssetId.keys()).slice(0, 20),
+    });
+
+    throw new Error(`Asset ID not found for ${symbol}`);
   }
 
   /**
@@ -1958,13 +2109,6 @@ export class HyperLiquidProvider implements PerpsProvider {
     let dexsToMap: (string | null)[];
     try {
       dexsToMap = await this.#getValidatedDexs();
-      // Mark DEX discovery as complete only when we got real data (not a fallback).
-      // #cachedValidatedDexs is null when #fetchValidatedDexsInternal returned [null]
-      // without caching (transient failure) — in that case we stay incomplete so
-      // #ensureReady resets its promise and retries on the next call.
-      if (this.#cachedValidatedDexs !== null) {
-        this.#dexDiscoveryComplete = true;
-      }
     } catch (dexError) {
       // If getValidatedDexs fails, fall back to main DEX only to keep the provider
       // functional. Without this, a transient perpDexs() failure would permanently
@@ -2062,6 +2206,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Build mapping with DEX prefixes for HIP-3 DEXs using the utility function
     this.#symbolToAssetId.clear();
+    let dexDiscoveryComplete = this.#cachedValidatedDexs !== null;
 
     allMetas.forEach((result) => {
       if (
@@ -2082,6 +2227,7 @@ export class HyperLiquidProvider implements PerpsProvider {
               isArray: Array.isArray(meta.universe),
             },
           );
+          dexDiscoveryComplete = false;
           return;
         }
 
@@ -2101,6 +2247,7 @@ export class HyperLiquidProvider implements PerpsProvider {
               dex ?? 'main'
             }`,
           );
+          dexDiscoveryComplete = false;
           return;
         }
 
@@ -2115,8 +2262,12 @@ export class HyperLiquidProvider implements PerpsProvider {
         symbolToAssetId.forEach((assetId, coin) => {
           this.#symbolToAssetId.set(coin, assetId);
         });
+      } else {
+        dexDiscoveryComplete = false;
       }
     });
+
+    this.#dexDiscoveryComplete = dexDiscoveryComplete;
 
     const allKeys = Array.from(this.#symbolToAssetId.keys());
     const mainDexKeys = allKeys.filter((key) => !key.includes(':')).slice(0, 5);
@@ -2170,20 +2321,38 @@ export class HyperLiquidProvider implements PerpsProvider {
   >(
     baseParams: TParams,
     queryFn: (params: TParams & { dex?: string }) => Promise<TResult>,
-  ): Promise<{ dex: string | null; data: TResult }[]> {
+  ): Promise<DexQueryResponse<TResult>> {
     const enabledDexs = await this.#getValidatedDexs();
 
-    const results = await Promise.all(
+    const settledResults = await Promise.allSettled(
       enabledDexs.map(async (dex) => {
         const params = dex
           ? ({ ...baseParams, dex } as TParams & { dex: string })
           : (baseParams as TParams & { dex?: string });
-        const data = await queryFn(params);
-        return { dex, data };
+        return queryFn(params);
       }),
     );
 
-    return results;
+    const results: DexQueryResult<TResult>[] = [];
+    const failedDexs: DexQueryResponse<TResult>['failedDexs'] = [];
+
+    settledResults.forEach((result, index) => {
+      const dex = enabledDexs[index];
+      if (result.status === 'fulfilled') {
+        results.push({ dex, data: result.value });
+        return;
+      }
+
+      failedDexs.push({
+        dex,
+        error: ensureError(
+          result.reason,
+          'HyperLiquidProvider.queryUserDataAcrossDexs',
+        ),
+      });
+    });
+
+    return { results, failedDexs };
   }
 
   /**
@@ -3349,7 +3518,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       const { dex: dexName } = parseAssetName(params.symbol);
 
       // 1. Get asset info and current price
-      const { assetInfo, currentPrice } = await this.#getAssetInfo({
+      const { assetInfo, currentPrice, meta } = await this.#getAssetInfo({
         symbol: params.symbol,
         dexName,
       });
@@ -3392,17 +3561,11 @@ export class HyperLiquidProvider implements PerpsProvider {
         });
 
       // 4. Get asset ID and validate it exists
-      const assetId = this.#symbolToAssetId.get(params.symbol);
-      if (assetId === undefined) {
-        this.#deps.debugLogger.log('Asset ID lookup failed', {
-          requestedCoin: params.symbol,
-          dexName: dexName ?? 'main',
-          mapSize: this.#symbolToAssetId.size,
-          mapContainsAsset: this.#symbolToAssetId.has(params.symbol),
-          allKeys: Array.from(this.#symbolToAssetId.keys()).slice(0, 20),
-        });
-        throw new Error(`Asset ID not found for ${params.symbol}`);
-      }
+      const assetId = await this.#getAssetIdWithRepair({
+        symbol: params.symbol,
+        dexName,
+        meta,
+      });
 
       this.#deps.debugLogger.log('Resolved DEX-specific asset ID', {
         coin: params.symbol,
@@ -3614,10 +3777,11 @@ export class HyperLiquidProvider implements PerpsProvider {
         price: orderPrice,
         szDecimals: assetInfo.szDecimals,
       });
-      const assetId = this.#symbolToAssetId.get(params.newOrder.symbol);
-      if (assetId === undefined) {
-        throw new Error(`Asset ID not found for ${params.newOrder.symbol}`);
-      }
+      const assetId = await this.#getAssetIdWithRepair({
+        symbol: params.newOrder.symbol,
+        dexName,
+        meta,
+      });
 
       // Build new order parameters
       const newOrder: SDKOrderParams = {
@@ -3690,10 +3854,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       await this.#ensureReadyForTrading();
 
       const exchangeClient = this.#clientService.getExchangeClient();
-      const asset = this.#symbolToAssetId.get(params.symbol);
-      if (asset === undefined) {
-        throw new Error(`Asset not found for symbol: ${params.symbol}`);
-      }
+      const asset = await this.#getAssetIdWithRepair({
+        symbol: params.symbol,
+        dexName: parseAssetName(params.symbol).dex,
+      });
 
       const result = await exchangeClient.cancel({
         cancels: [
@@ -3753,16 +3917,18 @@ export class HyperLiquidProvider implements PerpsProvider {
       const exchangeClient = this.#clientService.getExchangeClient();
 
       // Map orders to SDK format and validate coins
-      const cancelRequests = params.map((order) => {
-        const asset = this.#symbolToAssetId.get(order.symbol);
-        if (asset === undefined) {
-          throw new Error(`Asset not found for symbol: ${order.symbol}`);
-        }
-        return {
-          a: asset,
-          o: parseInt(order.orderId, 10),
-        };
-      });
+      const cancelRequests = await Promise.all(
+        params.map(async (order) => {
+          const asset = await this.#getAssetIdWithRepair({
+            symbol: order.symbol,
+            dexName: parseAssetName(order.symbol).dex,
+          });
+          return {
+            a: asset,
+            o: parseInt(order.orderId, 10),
+          };
+        }),
+      );
 
       // Single batch API call
       const result = await exchangeClient.cancel({
@@ -3897,10 +4063,11 @@ export class HyperLiquidProvider implements PerpsProvider {
         }
 
         // Get asset ID
-        const assetId = this.#symbolToAssetId.get(position.symbol);
-        if (assetId === undefined) {
-          throw new Error(`Asset ID not found for ${position.symbol}`);
-        }
+        const assetId = await this.#getAssetIdWithRepair({
+          symbol: position.symbol,
+          dexName,
+          meta,
+        });
 
         // Calculate position details (always full close)
         const positionSize = parseFloat(position.size);
@@ -4121,10 +4288,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       // Cancel existing TP/SL orders for this position
       // OPTIMIZATION: Use WebSocket cache first (0 weight), fall back to single-DEX REST (20 weight)
       // Previously: queryUserDataAcrossDexs queried ALL DEXs (20 weight × N DEXs = 40+ weight)
-      const assetId = this.#symbolToAssetId.get(symbol);
-      if (assetId === undefined) {
-        throw new Error(`Asset ID not found for ${symbol}`);
-      }
+      const assetId = await this.#getAssetIdWithRepair({
+        symbol,
+        dexName,
+      });
 
       let cancelRequests: { a: number; o: number }[] = [];
 
@@ -4517,10 +4684,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       const isBuy = parseFloat(position.size) > 0; // true for long, false for short
 
       // Get asset ID for the symbol
-      const assetId = this.#symbolToAssetId.get(symbol);
-      if (assetId === undefined) {
-        throw new Error(`Asset ID not found for ${symbol}`);
-      }
+      const assetId = await this.#getAssetIdWithRepair({
+        symbol,
+        dexName: parseAssetName(symbol).dex,
+      });
 
       // Convert amount to micro-units (HyperLiquid SDK requirement)
       const amountFloat = parseFloat(amount);
@@ -4710,7 +4877,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       );
 
       // Query positions and orders across all enabled DEXs in parallel
-      const [stateResults, orderResults] = await Promise.all([
+      const [stateResponse, orderResponse] = await Promise.all([
         this.#queryUserDataAcrossDexs({ user: userAddress }, (userParam) =>
           infoClient.clearinghouseState(userParam),
         ),
@@ -4718,6 +4885,24 @@ export class HyperLiquidProvider implements PerpsProvider {
           infoClient.frontendOpenOrders(userParam),
         ),
       ]);
+      const { results: stateResults, failedDexs: failedStateDexs } =
+        stateResponse;
+      const { results: orderResults, failedDexs: failedOrderDexs } =
+        orderResponse;
+
+      if (failedStateDexs.length > 0 || failedOrderDexs.length > 0) {
+        this.#deps.debugLogger.log(
+          'Partial multi-DEX position fetch completed with failures',
+          {
+            failedStateDexs: failedStateDexs.map(
+              ({ dex, error }) => `${dex ?? 'main'}:${error.message}`,
+            ),
+            failedOrderDexs: failedOrderDexs.map(
+              ({ dex, error }) => `${dex ?? 'main'}:${error.message}`,
+            ),
+          },
+        );
+      }
 
       // Combine all orders from all DEXs for TP/SL lookup
       const allOrders = orderResults.flatMap((result) => result.data);
@@ -5112,10 +5297,22 @@ export class HyperLiquidProvider implements PerpsProvider {
       );
 
       // Query orders across all enabled DEXs in parallel
-      const orderResults = await this.#queryUserDataAcrossDexs(
-        { user: userAddress },
-        (userParam) => infoClient.frontendOpenOrders(userParam),
-      );
+      const { results: orderResults, failedDexs } =
+        await this.#queryUserDataAcrossDexs(
+          { user: userAddress },
+          (userParam) => infoClient.frontendOpenOrders(userParam),
+        );
+
+      if (failedDexs.length > 0) {
+        this.#deps.debugLogger.log(
+          'Partial multi-DEX open order fetch completed with failures',
+          {
+            failedDexs: failedDexs.map(
+              ({ dex, error }) => `${dex ?? 'main'}:${error.message}`,
+            ),
+          },
+        );
+      }
 
       // Combine all orders from all DEXs
       const rawOrders = orderResults.flatMap((result) => result.data);
@@ -5424,13 +5621,70 @@ export class HyperLiquidProvider implements PerpsProvider {
         this.#clientService.isTestnetMode() ? 'TESTNET' : 'MAINNET',
       );
 
-      // Get Spot balance (global, not DEX-specific) and Perps states across all DEXs
-      const [spotState, perpsStateResults] = await Promise.all([
+      // Get Spot balance (global, not DEX-specific) and Perps states across all DEXs.
+      // One transient DEX failure should not blank the entire account state.
+      const [spotStateResult, perpsStateResult] = await Promise.allSettled([
         infoClient.spotClearinghouseState({ user: userAddress }),
         this.#queryUserDataAcrossDexs({ user: userAddress }, (userParam) =>
           infoClient.clearinghouseState(userParam),
         ),
       ]);
+      const spotState =
+        spotStateResult.status === 'fulfilled' ? spotStateResult.value : null;
+      const perpsResponse =
+        perpsStateResult.status === 'fulfilled'
+          ? perpsStateResult.value
+          : {
+              results: [],
+              failedDexs: [
+                {
+                  dex: null,
+                  error: ensureError(
+                    perpsStateResult.reason,
+                    'HyperLiquidProvider.getAccountState.perps',
+                  ),
+                },
+              ],
+            };
+      const perpsStateResults = perpsResponse.results;
+      const failedPerpsDexs = perpsResponse.failedDexs;
+
+      if (spotStateResult.status === 'rejected') {
+        this.#deps.debugLogger.log(
+          'Spot state fetch failed during account state aggregation',
+          {
+            error: ensureError(
+              spotStateResult.reason,
+              'HyperLiquidProvider.getAccountState.spot',
+            ).message,
+          },
+        );
+      }
+
+      if (failedPerpsDexs.length > 0) {
+        this.#deps.debugLogger.log(
+          'Perps account state completed with partial DEX failures',
+          {
+            failedDexs: failedPerpsDexs.map(
+              ({ dex, error }) => `${dex ?? 'main'}:${error.message}`,
+            ),
+          },
+        );
+      }
+
+      if (perpsStateResults.length === 0) {
+        const failedDexNames = failedPerpsDexs.map(({ dex }) => dex ?? 'main');
+        const spotErrorMessage =
+          spotStateResult.status === 'rejected'
+            ? ensureError(
+                spotStateResult.reason,
+                'HyperLiquidProvider.getAccountState.spot',
+              ).message
+            : undefined;
+        throw new Error(
+          `Failed to fetch account state (failedDexs=[${failedDexNames.join(',')}], spotError=${spotErrorMessage ?? 'none'})`,
+        );
+      }
 
       this.#deps.debugLogger.log('Spot state:', spotState);
       this.#deps.debugLogger.log('Perps states (all DEXs):', {
@@ -5500,7 +5754,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       );
       // Re-throw the error so the controller can handle it properly
       // This allows the UI to show proper error messages instead of zeros
-      throw error;
+      throw ensureError(error, 'HyperLiquidProvider.getAccountState');
     }
   }
 
@@ -5744,13 +5998,163 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Get allMids for a DEX — uses WS snapshot as primary source, REST as fallback.
+   *
+   * @param infoClient - The HyperLiquid info client (used only on cold start).
+   * @param dexParam - Optional DEX parameter (empty string for main DEX).
+   * @returns allMids record.
+   */
+  async #getAllMids(
+    infoClient: ReturnType<
+      typeof HyperLiquidClientService.prototype.getInfoClient
+    >,
+    dexParam?: string,
+  ): Promise<Record<string, string>> {
+    const wsSnapshot =
+      this.#subscriptionService.getLastAllMidsSnapshot?.(dexParam);
+    if (wsSnapshot) {
+      return wsSnapshot;
+    }
+
+    this.#deps.debugLogger.log(
+      '[getMarketDataWithPrices] No WS allMids snapshot, falling back to REST',
+      { dexParam: dexParam ?? 'main' },
+    );
+    const mids = await infoClient.allMids(
+      dexParam ? { dex: dexParam } : undefined,
+    );
+    return mids ?? {};
+  }
+
+  async #fetchSingleDexFresh(
+    infoClient: ReturnType<
+      typeof HyperLiquidClientService.prototype.getInfoClient
+    >,
+    dex: string | null,
+  ): Promise<DexFetchResult> {
+    const dexParam = dex ?? '';
+
+    let metaAndCtxs: [MetaResponse | null, PerpsAssetCtx[]] | null = null;
+    try {
+      metaAndCtxs = (await infoClient.metaAndAssetCtxs(
+        dexParam ? { dex: dexParam } : undefined,
+      )) as [MetaResponse | null, PerpsAssetCtx[]] | null;
+    } catch (error) {
+      return {
+        dex,
+        meta: null,
+        assetCtxs: [],
+        allMids: {},
+        success: false,
+        failedStep: 'metaAndAssetCtxs',
+        errorMessage: ensureError(
+          error,
+          'HyperLiquidProvider.getMarketDataWithPrices.metaAndAssetCtxs',
+        ).message,
+      };
+    }
+
+    const meta = metaAndCtxs?.[0] ?? null;
+    const assetCtxs = metaAndCtxs?.[1] ?? [];
+
+    let dexAllMids: Record<string, string> = {};
+    let allMidsErrorMessage: string | undefined;
+    try {
+      dexAllMids = await this.#getAllMids(infoClient, dexParam || undefined);
+    } catch (error) {
+      allMidsErrorMessage = ensureError(
+        error,
+        'HyperLiquidProvider.getMarketDataWithPrices.allMids',
+      ).message;
+    }
+
+    if (meta?.universe) {
+      this.#cachedMetaByDex.set(dexParam, meta);
+      this.#subscriptionService.setDexMetaCache(dexParam, meta);
+      this.#subscriptionService.setDexAssetCtxsCache(dexParam, assetCtxs);
+      await this.#backfillAssetMapForDex(dex, meta);
+    }
+
+    return {
+      dex,
+      meta,
+      assetCtxs,
+      allMids: dexAllMids,
+      success: Boolean(meta?.universe),
+      failedStep: allMidsErrorMessage ? 'allMids' : undefined,
+      errorMessage: allMidsErrorMessage,
+    };
+  }
+
+  #mergeDexResultsInto(
+    results: DexFetchResult[],
+    combinedUniverse: MetaResponse['universe'],
+    combinedAssetCtxs: PerpsAssetCtx[],
+    combinedAllMids: Record<string, string>,
+  ): void {
+    results.forEach((result) => {
+      if (result.success && result.meta?.universe) {
+        const marketsFromDex = result.meta.universe;
+        const filteredMarkets =
+          result.dex === null
+            ? marketsFromDex
+            : marketsFromDex.filter((asset) =>
+                shouldIncludeMarket(
+                  asset.name,
+                  result.dex,
+                  this.#hip3Enabled,
+                  this.#compiledAllowlistPatterns,
+                  this.#compiledBlocklistPatterns,
+                ),
+              );
+
+        combinedUniverse.push(...filteredMarkets);
+        combinedAssetCtxs.push(...result.assetCtxs);
+        Object.assign(combinedAllMids, result.allMids);
+      }
+    });
+  }
+
+  #cacheFreshMarketDataSnapshot(
+    marketData: PerpsMarketData[],
+    results: DexFetchResult[],
+  ): PerpsMarketData[] {
+    const freshMarketData = marketData.map((market) => ({
+      ...market,
+      isStale: false,
+    }));
+    this.#cachedMarketDataWithPrices = {
+      data: freshMarketData.map((market) => ({ ...market })),
+      timestamp: Date.now(),
+      contributingDexs: results
+        .filter((result) => result.success && result.meta?.universe)
+        .map((result) => result.dex ?? 'main'),
+      failedDexs: results
+        .filter((result) => !result.success)
+        .map((result) => result.dex ?? 'main'),
+    };
+    return freshMarketData;
+  }
+
+  #getStaleMarketDataSnapshot(): PerpsMarketData[] | null {
+    if (!this.#cachedMarketDataWithPrices) {
+      return null;
+    }
+
+    return this.#cachedMarketDataWithPrices.data.map((market) => ({
+      ...market,
+      isStale: true,
+    }));
+  }
+
+  /**
    * Get market data with prices, volumes, and 24h changes
    * Aggregates data from all enabled DEXs (main + HIP-3) when equity is enabled
    *
    * Note: This is called once during initialization and cached by PerpsStreamManager.
    * Real-time price updates come from WebSocket subscriptions, not this method.
    *
-   * @returns A promise that resolves to the result.
+   * @returns A promise that resolves to the combined market data from all enabled DEXs.
    */
   async getMarketDataWithPrices(): Promise<PerpsMarketData[]> {
     this.#deps.debugLogger.log(
@@ -5770,95 +6174,70 @@ export class HyperLiquidProvider implements PerpsProvider {
     // Get enabled DEXs respecting feature flags (uses cached perpDexs)
     const enabledDexs = await this.#getValidatedDexs();
 
-    // Fetch meta, assetCtxs, and allMids for each enabled DEX in parallel
-    // Optimization: Check cache first to avoid redundant API calls when buildAssetMapping
-    // has already fetched, or populate cache for buildAssetMapping to reuse
+    // Fetch meta, assetCtxs, and allMids for each enabled DEX in parallel.
+    // Check the meta cache first to avoid redundant API calls when buildAssetMapping
+    // has already populated it; on cache miss, delegate to #fetchSingleDexFresh.
     const dexDataResults = await Promise.all(
       enabledDexs.map(async (dex) => {
         const dexKey = dex ?? '';
         const dexParam = dex ?? '';
-        try {
-          let meta: MetaResponse | null = null;
-          let assetCtxs: PerpsAssetCtx[] = [];
+        const cachedMeta = this.#cachedMetaByDex.get(dexKey);
+        if (!cachedMeta) {
+          this.#deps.debugLogger.log(
+            `[getMarketDataWithPrices] Cache miss for ${dex ?? 'main'}, fetching`,
+          );
+          return this.#fetchSingleDexFresh(infoClient, dex);
+        }
 
-          // Check if meta is already cached (e.g., from previous fetch or buildAssetMapping)
-          const cachedMeta = this.#cachedMetaByDex.get(dexKey);
-          if (cachedMeta) {
-            this.#deps.debugLogger.log(
-              `[getMarketDataWithPrices] Using cached meta for ${dex ?? 'main'}`,
-              { universeSize: cachedMeta.universe.length },
-            );
-            meta = cachedMeta;
-            // Try to get cached assetCtxs from subscription service
-            const cachedCtxs =
-              this.#subscriptionService.getDexAssetCtxsCache(dexKey);
-            if (cachedCtxs) {
-              assetCtxs = cachedCtxs;
-            } else {
-              // Need fresh assetCtxs, fetch via metaAndAssetCtxs (meta will be same)
-              const metaAndCtxs = await infoClient.metaAndAssetCtxs(
-                dexParam ? { dex: dexParam } : undefined,
-              );
-              assetCtxs = metaAndCtxs?.[1] || [];
-              // Cache assetCtxs for future calls
-              this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
-            }
-          } else {
-            // Cache miss - fetch and populate cache for buildAssetMapping to reuse
-            this.#deps.debugLogger.log(
-              `[getMarketDataWithPrices] Cache miss for ${dex ?? 'main'}, fetching`,
-            );
-            const metaAndCtxs = await infoClient.metaAndAssetCtxs(
+        this.#deps.debugLogger.log(
+          `[getMarketDataWithPrices] Using cached meta for ${dex ?? 'main'}`,
+          { universeSize: cachedMeta.universe.length },
+        );
+
+        let assetCtxs =
+          this.#subscriptionService.getDexAssetCtxsCache(dexKey) ?? [];
+        let failedStep: DexFetchFailureStep | undefined;
+        let errorMessage: string | undefined;
+
+        if (assetCtxs.length === 0) {
+          try {
+            const freshResult = await infoClient.metaAndAssetCtxs(
               dexParam ? { dex: dexParam } : undefined,
             );
-            meta = metaAndCtxs?.[0] || null;
-            assetCtxs = metaAndCtxs?.[1] || [];
-
-            // IMPORTANT: Populate cache for buildAssetMapping and other methods to reuse
-            if (meta?.universe) {
-              this.#cachedMetaByDex.set(dexKey, meta);
-              this.#subscriptionService.setDexMetaCache(dexKey, meta);
-              // Also cache assetCtxs for consistency with buildAssetMapping
-              this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
-              this.#deps.debugLogger.log(
-                `[getMarketDataWithPrices] Cached meta for ${dex ?? 'main'}`,
-                { universeSize: meta.universe.length },
-              );
-            }
+            assetCtxs = freshResult?.[1] ?? [];
+            this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
+          } catch (error) {
+            failedStep = 'metaAndAssetCtxs';
+            errorMessage = ensureError(
+              error,
+              'HyperLiquidProvider.getMarketDataWithPrices.metaAndAssetCtxs',
+            ).message;
           }
-
-          // Always fetch fresh allMids for current prices
-          const dexAllMids = await infoClient.allMids(
-            dexParam ? { dex: dexParam } : undefined,
-          );
-
-          return {
-            dex,
-            meta,
-            assetCtxs,
-            allMids: dexAllMids || {},
-            success: true,
-          };
-        } catch (error) {
-          // Log per-DEX failures locally only — the aggregate error at the end
-          // of this method reports to Sentry, avoiding duplicate events.
-          this.#deps.debugLogger.log(
-            `[getMarketDataWithPrices] DEX fetch failed for ${dex ?? 'main'}`,
-            {
-              error: ensureError(
-                error,
-                'HyperLiquidProvider.getMarketDataWithPrices',
-              ).message,
-            },
-          );
-          return {
-            dex,
-            meta: null,
-            assetCtxs: [],
-            allMids: {},
-            success: false,
-          };
         }
+
+        let dexAllMids: Record<string, string> = {};
+        try {
+          dexAllMids = await this.#getAllMids(
+            infoClient,
+            dexParam || undefined,
+          );
+        } catch (error) {
+          failedStep = 'allMids';
+          errorMessage = ensureError(
+            error,
+            'HyperLiquidProvider.getMarketDataWithPrices.allMids',
+          ).message;
+        }
+
+        return {
+          dex,
+          meta: cachedMeta,
+          assetCtxs,
+          allMids: dexAllMids,
+          success: true,
+          failedStep,
+          errorMessage,
+        };
       }),
     );
 
@@ -5866,41 +6245,96 @@ export class HyperLiquidProvider implements PerpsProvider {
     const combinedUniverse: MetaResponse['universe'] = [];
     const combinedAssetCtxs: PerpsAssetCtx[] = [];
     const combinedAllMids: Record<string, string> = {};
+    let latestDexResults = dexDataResults;
 
-    dexDataResults.forEach((result) => {
-      if (result.success && result.meta?.universe) {
-        // Apply market filtering for HIP-3 DEXs only (main DEX returns all markets)
-        const marketsFromDex = result.meta.universe;
-        const filteredMarkets =
-          result.dex === null
-            ? marketsFromDex // Main DEX: no filtering
-            : marketsFromDex.filter((asset) =>
-                shouldIncludeMarket(
-                  asset.name,
-                  result.dex,
-                  this.#hip3Enabled,
-                  this.#compiledAllowlistPatterns,
-                  this.#compiledBlocklistPatterns,
-                ),
-              );
-
-        combinedUniverse.push(...filteredMarkets);
-        combinedAssetCtxs.push(...result.assetCtxs);
-        // Merge price data from this DEX into combined prices
-        Object.assign(combinedAllMids, result.allMids);
-      }
-    });
+    this.#mergeDexResultsInto(
+      dexDataResults,
+      combinedUniverse,
+      combinedAssetCtxs,
+      combinedAllMids,
+    );
 
     if (combinedUniverse.length === 0) {
-      const failedDexs = dexDataResults
-        .filter((result) => !result.success)
-        .map((result) => result.dex ?? 'main');
-      const succeededDexs = dexDataResults
-        .filter((result) => result.success)
-        .map((result) => result.dex ?? 'main');
-      const wsState = this.#clientService.getConnectionState();
-      throw new Error(
-        `Failed to fetch market data - no markets available (enabledDexs=${enabledDexs.length}, failed=[${failedDexs.join(',')}], succeeded=[${succeededDexs.join(',')}], wsState=${wsState})`,
+      combinedUniverse.length = 0;
+      combinedAssetCtxs.length = 0;
+      for (const key of Object.keys(combinedAllMids)) {
+        delete combinedAllMids[key];
+      }
+
+      const retryDelayMs = 2000;
+      this.#deps.debugLogger.log(
+        `[getMarketDataWithPrices] All DEXs returned empty, retrying in ${retryDelayMs}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+
+      const retryResults = await Promise.all(
+        enabledDexs.map((dex) => this.#fetchSingleDexFresh(infoClient, dex)),
+      );
+
+      this.#mergeDexResultsInto(
+        retryResults,
+        combinedUniverse,
+        combinedAssetCtxs,
+        combinedAllMids,
+      );
+
+      latestDexResults = retryResults;
+
+      if (combinedUniverse.length === 0) {
+        const failedDexs = retryResults
+          .filter((result) => !result.success)
+          .map((result) => result.dex ?? 'main');
+        const succeededDexs = retryResults
+          .filter((result) => result.success)
+          .map((result) => result.dex ?? 'main');
+        const failedDetails = retryResults
+          .filter((result) => result.errorMessage)
+          .map(
+            (result) =>
+              `${result.dex ?? 'main'}:${result.failedStep ?? 'unknown'}:${
+                result.errorMessage
+              }`,
+          );
+        const staleMarketData = this.#getStaleMarketDataSnapshot();
+
+        if (staleMarketData) {
+          this.#deps.debugLogger.log(
+            '[getMarketDataWithPrices] Returning stale cached market data after retry failure',
+            {
+              failedDexs,
+              failedDetails,
+              cachedAt:
+                this.#cachedMarketDataWithPrices?.timestamp ?? Date.now(),
+            },
+          );
+          return staleMarketData;
+        }
+
+        const wsState = this.#clientService.getConnectionState();
+        throw new Error(
+          `Failed to fetch market data - no markets available (enabledDexs=${enabledDexs.length}, failed=[${failedDexs.join(',')}], succeeded=[${succeededDexs.join(',')}], wsState=${wsState}, details=[${failedDetails.join(';')}])`,
+        );
+      }
+
+      this.#deps.debugLogger.log('[getMarketDataWithPrices] Retry succeeded', {
+        marketCount: combinedUniverse.length,
+      });
+    }
+
+    const partialFailures = latestDexResults.filter(
+      (result) => result.errorMessage,
+    );
+    if (partialFailures.length > 0) {
+      this.#deps.debugLogger.log(
+        'Market data fetch completed with partial per-DEX failures',
+        {
+          failures: partialFailures.map(
+            (result) =>
+              `${result.dex ?? 'main'}:${result.failedStep ?? 'unknown'}:${
+                result.errorMessage
+              }`,
+          ),
+        },
       );
     }
 
@@ -5909,10 +6343,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       {
         dexCount: enabledDexs.length,
         totalMarkets: combinedUniverse.length,
-        mainDexMarkets: dexDataResults[0]?.meta?.universe?.length ?? 0,
+        mainDexMarkets: latestDexResults[0]?.meta?.universe?.length ?? 0,
         hip3Markets:
           combinedUniverse.length -
-          (dexDataResults[0]?.meta?.universe?.length ?? 0),
+          (latestDexResults[0]?.meta?.universe?.length ?? 0),
       },
     );
 
@@ -5933,7 +6367,7 @@ export class HyperLiquidProvider implements PerpsProvider {
     });
 
     // Transform to UI-friendly format using standalone utility
-    return transformMarketData(
+    const transformedMarketData = transformMarketData(
       {
         universe: combinedUniverse,
         assetCtxs: combinedAssetCtxs,
@@ -5941,6 +6375,11 @@ export class HyperLiquidProvider implements PerpsProvider {
       },
       this.#deps.marketDataFormatters,
       HIP3_ASSET_MARKET_TYPES,
+    );
+
+    return this.#cacheFreshMarketDataSnapshot(
+      transformedMarketData,
+      latestDexResults,
     );
   }
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -6194,24 +6194,55 @@ export class HyperLiquidProvider implements PerpsProvider {
           { universeSize: cachedMeta.universe.length },
         );
 
+        let metaForDex = cachedMeta;
         let assetCtxs =
           this.#subscriptionService.getDexAssetCtxsCache(dexKey) ?? [];
         let failedStep: DexFetchFailureStep | undefined;
         let errorMessage: string | undefined;
 
-        if (assetCtxs.length === 0) {
+        if (assetCtxs.length !== metaForDex.universe.length) {
           try {
             const freshResult = await infoClient.metaAndAssetCtxs(
               dexParam ? { dex: dexParam } : undefined,
             );
-            assetCtxs = freshResult?.[1] ?? [];
+            const freshMeta = freshResult?.[0] ?? null;
+            const freshAssetCtxs = freshResult?.[1] ?? [];
+
+            if (
+              !freshMeta?.universe ||
+              freshAssetCtxs.length !== freshMeta.universe.length
+            ) {
+              return {
+                dex,
+                meta: null,
+                assetCtxs: [],
+                allMids: {},
+                success: false,
+                failedStep: 'metaAndAssetCtxs' as const,
+                errorMessage:
+                  'metaAndAssetCtxs returned mismatched universe/assetCtxs lengths',
+              };
+            }
+
+            metaForDex = freshMeta;
+            assetCtxs = freshAssetCtxs;
+            this.#cachedMetaByDex.set(dexKey, freshMeta);
+            this.#subscriptionService.setDexMetaCache(dexKey, freshMeta);
             this.#subscriptionService.setDexAssetCtxsCache(dexKey, assetCtxs);
+            await this.#backfillAssetMapForDex(dex, freshMeta);
           } catch (error) {
-            failedStep = 'metaAndAssetCtxs';
-            errorMessage = ensureError(
-              error,
-              'HyperLiquidProvider.getMarketDataWithPrices.metaAndAssetCtxs',
-            ).message;
+            return {
+              dex,
+              meta: null,
+              assetCtxs: [],
+              allMids: {},
+              success: false,
+              failedStep: 'metaAndAssetCtxs' as const,
+              errorMessage: ensureError(
+                error,
+                'HyperLiquidProvider.getMarketDataWithPrices.metaAndAssetCtxs',
+              ).message,
+            };
           }
         }
 
@@ -6231,7 +6262,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
         return {
           dex,
-          meta: cachedMeta,
+          meta: metaForDex,
           assetCtxs,
           allMids: dexAllMids,
           success: true,

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -13,7 +13,10 @@ import type {
   SubscribePositionsParams,
   SubscribePricesParams,
 } from '../types';
-import { adaptAccountStateFromSDK } from '../utils/hyperLiquidAdapter';
+import {
+  adaptAccountStateFromSDK,
+  parseAssetName,
+} from '../utils/hyperLiquidAdapter';
 
 import type { HyperLiquidClientService } from './HyperLiquidClientService';
 import { HyperLiquidSubscriptionService } from './HyperLiquidSubscriptionService';
@@ -106,6 +109,10 @@ describe('HyperLiquidSubscriptionService', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     mockDeps = createMockInfrastructure();
+    jest.mocked(parseAssetName).mockImplementation((symbol: string) => ({
+      symbol,
+      dex: null,
+    }));
 
     // Mock subscription client
     const mockSubscription: MockSubscription = {
@@ -113,7 +120,11 @@ describe('HyperLiquidSubscriptionService', () => {
     };
 
     mockSubscriptionClient = {
-      allMids: jest.fn((callback: any) => {
+      allMids: jest.fn((paramsOrCallback: any, maybeCallback?: any) => {
+        const callback =
+          typeof paramsOrCallback === 'function'
+            ? paramsOrCallback
+            : maybeCallback;
         // Simulate allMids data
         setTimeout(() => {
           callback({
@@ -365,6 +376,7 @@ describe('HyperLiquidSubscriptionService', () => {
       getSubscriptionClient: jest.fn(() => mockSubscriptionClient),
       isTestnetMode: jest.fn(() => false),
       ensureTransportReady: jest.fn().mockResolvedValue(undefined),
+      getConnectionState: jest.fn(() => 'connected'),
     } as any;
 
     // Mock wallet service
@@ -3122,6 +3134,61 @@ describe('HyperLiquidSubscriptionService', () => {
         : 0;
       expect(finalCallCount).toBe(initialCallCount);
     });
+
+    it('cleans up failed assetCtxs subscriptions so later HIP-3 resubscribes reconnect cleanly', async () => {
+      const mockCallback = jest.fn();
+      jest.mocked(parseAssetName).mockImplementation((symbol: string) => ({
+        symbol,
+        dex: symbol === 'BTC:UNISWAP' ? 'UNISWAP' : null,
+      }));
+
+      mockClientService.getInfoClient = jest.fn(
+        () =>
+          ({
+            meta: jest.fn().mockResolvedValue({
+              universe: [{ name: 'BTC:UNISWAP' }],
+            }),
+          }) as any,
+      );
+
+      mockSubscriptionClient.assetCtxs = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Subscription failed'))
+        .mockResolvedValueOnce({
+          unsubscribe: jest.fn().mockResolvedValue(undefined),
+        })
+        .mockResolvedValueOnce({
+          unsubscribe: jest.fn().mockResolvedValue(undefined),
+        });
+
+      const failedUnsubscribe = await service.subscribeToPrices({
+        symbols: ['BTC:UNISWAP'],
+        callback: mockCallback,
+        includeMarketData: true,
+      });
+      await jest.runAllTimersAsync();
+      failedUnsubscribe();
+      await jest.runAllTimersAsync();
+
+      const recoveredUnsubscribe = await service.subscribeToPrices({
+        symbols: ['BTC:UNISWAP'],
+        callback: mockCallback,
+        includeMarketData: true,
+      });
+      await jest.runAllTimersAsync();
+      recoveredUnsubscribe();
+      await jest.runAllTimersAsync();
+
+      const finalUnsubscribe = await service.subscribeToPrices({
+        symbols: ['BTC:UNISWAP'],
+        callback: mockCallback,
+        includeMarketData: true,
+      });
+      await jest.runAllTimersAsync();
+
+      expect(mockSubscriptionClient.assetCtxs).toHaveBeenCalledTimes(3);
+      finalUnsubscribe();
+    });
   });
 
   describe('Market Data Cache Initialization', () => {
@@ -3986,43 +4053,30 @@ describe('HyperLiquidSubscriptionService', () => {
       unsubscribe();
     });
 
-    // TODO: Refactor to test through public disconnect/reconnect API
-    it.skip('handles errors during assetCtxs subscription restoration', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const { parseAssetName } = require('../utils/hyperLiquidAdapter');
-      jest.mocked(parseAssetName).mockImplementation((symbol: string) => {
-        if (symbol === 'BTC:UNISWAP') {
-          return { symbol, dex: 'UNISWAP' };
-        }
-        return { symbol, dex: null };
-      });
+    it('schedules retry when assetCtxs restoration fails', async () => {
+      jest.mocked(parseAssetName).mockImplementation((symbol: string) => ({
+        symbol,
+        dex: symbol === 'BTC:UNISWAP' ? 'UNISWAP' : null,
+      }));
 
-      const mockUnsubscribe = jest.fn();
-      const mockSubscription = { unsubscribe: mockUnsubscribe };
-
-      mockSubscriptionClient.activeAssetCtx.mockImplementation(
-        (params: any, callback: any) => {
-          setTimeout(() => {
-            callback({
-              coin: params.coin,
-              ctx: {
-                prevDayPx: '49000',
-                funding: '0.01',
-                openInterest: '1000000',
-                dayNtlVlm: '50000000',
-                oraclePx: '50100',
-                midPx: '50000',
-              },
-            });
-          }, 10);
-          return Promise.resolve(mockSubscription);
-        },
+      mockClientService.getInfoClient = jest.fn(
+        () =>
+          ({
+            meta: jest.fn().mockResolvedValue({
+              universe: [{ name: 'BTC:UNISWAP' }],
+            }),
+          }) as any,
       );
 
-      // Make assetCtxs fail
-      mockSubscriptionClient.assetCtxs.mockRejectedValueOnce(
-        new Error('Subscription failed'),
-      );
+      mockSubscriptionClient.assetCtxs = jest
+        .fn()
+        .mockResolvedValueOnce({
+          unsubscribe: jest.fn().mockResolvedValue(undefined),
+        })
+        .mockRejectedValueOnce(new Error('Subscription failed'))
+        .mockResolvedValueOnce({
+          unsubscribe: jest.fn().mockResolvedValue(undefined),
+        });
 
       const unsubscribe = await service.subscribeToPrices({
         symbols: ['BTC:UNISWAP'],
@@ -4032,12 +4086,13 @@ describe('HyperLiquidSubscriptionService', () => {
 
       await jest.runAllTimersAsync();
 
-      // Clear subscriptions to simulate reconnection
-      (service as any).assetCtxsSubscriptions.clear();
-      (service as any).assetCtxsSubscriptionPromises.clear();
-
-      // Restore subscriptions should not throw
       await expect(service.restoreSubscriptions()).resolves.not.toThrow();
+      expect(mockSubscriptionClient.assetCtxs).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(mockSubscriptionClient.assetCtxs).toHaveBeenCalledTimes(3);
+      expect(mockDeps.logger.error).toHaveBeenCalled();
 
       unsubscribe();
     });

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3476,6 +3476,39 @@ describe('HyperLiquidSubscriptionService', () => {
       expect(result).toBeNull();
     });
 
+    it('getLastAllMidsSnapshot returns a defensive copy and null for unknown dexes', async () => {
+      const unsubscribe = await service.subscribeToPrices({
+        symbols: ['BTC'],
+        callback: jest.fn(),
+      });
+
+      await jest.runAllTimersAsync();
+
+      const snapshot = service.getLastAllMidsSnapshot();
+      expect(snapshot).toEqual(
+        expect.objectContaining({
+          BTC: 50000,
+          ETH: 3000,
+        }),
+      );
+
+      if (!snapshot) {
+        throw new Error('Expected allMids snapshot to be populated');
+      }
+
+      delete snapshot.BTC;
+
+      expect(service.getLastAllMidsSnapshot()).toEqual(
+        expect.objectContaining({
+          BTC: 50000,
+          ETH: 3000,
+        }),
+      );
+      expect(service.getLastAllMidsSnapshot('missing-dex')).toBeNull();
+
+      unsubscribe();
+    });
+
     it('getFillsCacheIfInitialized returns null when cache not initialized', () => {
       const result = service.getFillsCacheIfInitialized();
 

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -33,6 +33,7 @@ import type {
   OrderBookLevel,
   PerpsPlatformDependencies,
   PerpsLogger,
+  WebSocketConnectionState,
 } from '../types';
 import type { HyperLiquidClientService } from './HyperLiquidClientService';
 import type { HyperLiquidWalletService } from './HyperLiquidWalletService';
@@ -167,6 +168,9 @@ export class HyperLiquidSubscriptionService {
   // Global price data cache
   #cachedPriceData: Map<string, PriceUpdate> | null = null;
 
+  // Raw allMids WS snapshots keyed by DEX ('' for main DEX)
+  readonly #allMidsSnapshots = new Map<string, Record<string, string>>();
+
   // Fills cache for cache-first pattern (similar to price caching)
   #cachedFills: OrderFill[] | null = null;
 
@@ -178,6 +182,10 @@ export class HyperLiquidSubscriptionService {
   readonly #dexAssetCtxsCache = new Map<string, AssetCtxsWsEvent['ctxs']>(); // Per-DEX asset contexts
 
   readonly #assetCtxsSubscriptionPromises = new Map<string, Promise<void>>(); // Track in-progress subscriptions
+
+  readonly #dexAllMidsSubscriptions = new Map<string, ISubscription>();
+
+  readonly #dexAllMidsSubscriptionPromises = new Map<string, Promise<void>>();
 
   readonly #clearinghouseStateSubscriptions = new Map<string, ISubscription>(); // Key: dex name ('' for main)
 
@@ -234,6 +242,11 @@ export class HyperLiquidSubscriptionService {
   // Set in clearAll() and never reset (service instance is discarded after disconnect)
   #isClearing = false;
 
+  readonly #restoreRetryTimeouts = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+
   // Platform dependencies for logging
   readonly #deps: PerpsPlatformDependencies;
 
@@ -272,6 +285,65 @@ export class HyperLiquidSubscriptionService {
       return;
     }
     this.#deps.logger.error(error, context);
+  }
+
+  #isTransientAssetCtxsError(error: unknown): boolean {
+    const ensuredError = ensureError(
+      error,
+      'HyperLiquidSubscriptionService.createAssetCtxsSubscription',
+    );
+    const connectionState = this.#clientService.getConnectionState?.();
+    const messageParts = [
+      ensuredError.message,
+      error instanceof Error ? error.name : '',
+      typeof error === 'string' ? error : '',
+      String(error),
+    ]
+      .join(' ')
+      .toLowerCase();
+    const isReconnectChurn =
+      connectionState === WebSocketConnectionState.Connecting ||
+      connectionState === WebSocketConnectionState.Disconnected;
+
+    return (
+      messageParts.includes('websocketrequesterror') ||
+      messageParts.includes('unknown error while making a websocket request') ||
+      (isReconnectChurn &&
+        (messageParts.includes('unknown error (no details provided)') ||
+          messageParts.includes('undefined')))
+    );
+  }
+
+  #scheduleRestoreRetry(dex: string, kind: 'assetCtxs' | 'allMids'): void {
+    const retryKey = `${kind}:${dex}`;
+    if (this.#isClearing || this.#restoreRetryTimeouts.has(retryKey)) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      this.#restoreRetryTimeouts.delete(retryKey);
+      const retryPromise =
+        kind === 'assetCtxs'
+          ? this.#ensureAssetCtxsSubscription(dex, {
+              incrementRefCount: false,
+            })
+          : this.#ensureDexAllMidsSubscription(dex);
+
+      retryPromise.catch((error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(
+            error,
+            'HyperLiquidSubscriptionService.restoreSubscriptions.retry',
+          ),
+          this.#getErrorContext('restoreSubscriptions.retry', {
+            dex,
+            kind,
+          }),
+        );
+      });
+    }, 1000);
+
+    this.#restoreRetryTimeouts.set(retryKey, timeoutId);
   }
 
   /**
@@ -980,6 +1052,19 @@ export class HyperLiquidSubscriptionService {
             ),
             this.#getErrorContext(
               'subscribeToPrices.ensureAssetCtxsSubscription',
+              { dex: dexName },
+            ),
+          );
+        });
+
+        this.#ensureDexAllMidsSubscription(dexName).catch((error) => {
+          this.#logErrorUnlessClearing(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.subscribeToPrices',
+            ),
+            this.#getErrorContext(
+              'subscribeToPrices.ensureDexAllMidsSubscription',
               { dex: dexName },
             ),
           );
@@ -2215,6 +2300,15 @@ export class HyperLiquidSubscriptionService {
     return this.#cachedPriceData?.get(symbol)?.price;
   }
 
+  public getLastAllMidsSnapshot(dex?: string): Record<string, string> | null {
+    const dexKey = dex ?? '';
+    const snapshot = this.#allMidsSnapshots.get(dexKey);
+    if (!snapshot) {
+      return null;
+    }
+    return { ...snapshot };
+  }
+
   /**
    * Get cached fills from WebSocket userFills subscription
    * OPTIMIZATION: Use this instead of REST userFills() to avoid rate limiting
@@ -2355,6 +2449,9 @@ export class HyperLiquidSubscriptionService {
 
         // Initialize cache if needed
         this.#cachedPriceData ??= new Map<string, PriceUpdate>();
+
+        // Store raw snapshot for the main DEX so market fetches can reuse it without REST.
+        this.#allMidsSnapshots.set('', data.mids as Record<string, string>);
 
         const subscribedSymbols = new Set<string>();
 
@@ -2565,36 +2662,125 @@ export class HyperLiquidSubscriptionService {
    * Implements reference counting to track active subscribers per DEX
    *
    * @param dex - The DEX identifier (empty string for main DEX).
+   * @param options - Subscription behavior overrides.
+   * @param options.incrementRefCount - Skip incrementing when restoring existing subscribers after reconnect.
    */
-  async #ensureAssetCtxsSubscription(dex: string): Promise<void> {
+  async #ensureAssetCtxsSubscription(
+    dex: string,
+    options: { incrementRefCount?: boolean } = {},
+  ): Promise<void> {
     const dexKey = dex || '';
+    const { incrementRefCount = true } = options;
 
-    // Increment subscriber count for this DEX
-    const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
-    this.#dexSubscriberCounts.set(dexKey, currentCount + 1);
+    if (incrementRefCount) {
+      const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
+      this.#dexSubscriberCounts.set(dexKey, currentCount + 1);
+    }
 
     // Return if subscription already exists
     if (this.#assetCtxsSubscriptions.has(dexKey)) {
       return;
     }
 
-    // Await existing promise if subscription is being established
-    if (this.#assetCtxsSubscriptionPromises.has(dexKey)) {
-      await this.#assetCtxsSubscriptionPromises.get(dexKey);
-      return;
+    let promise = this.#assetCtxsSubscriptionPromises.get(dexKey);
+    if (!promise) {
+      promise = this.#createAssetCtxsSubscription(dex);
+      this.#assetCtxsSubscriptionPromises.set(dexKey, promise);
     }
-
-    // Create new subscription promise
-    const promise = this.#createAssetCtxsSubscription(dex);
-    this.#assetCtxsSubscriptionPromises.set(dexKey, promise);
 
     try {
       await promise;
     } catch (error) {
-      // Clear promise on error so it can be retried
-      this.#assetCtxsSubscriptionPromises.delete(dexKey);
+      if (this.#assetCtxsSubscriptionPromises.get(dexKey) === promise) {
+        this.#assetCtxsSubscriptionPromises.delete(dexKey);
+      }
+      if (incrementRefCount) {
+        const currentCount = this.#dexSubscriberCounts.get(dexKey) ?? 0;
+        if (currentCount <= 1) {
+          this.#dexSubscriberCounts.delete(dexKey);
+        } else {
+          this.#dexSubscriberCounts.set(dexKey, currentCount - 1);
+        }
+      }
       throw error;
     }
+  }
+
+  /**
+   * Ensure a per-DEX allMids WS subscription exists (singleton per DEX).
+   * Mirrors the assetCtxs subscription dedup pattern and is used only for HIP-3 DEXs.
+   *
+   * @param dex - The HIP-3 DEX name.
+   */
+  async #ensureDexAllMidsSubscription(dex: string): Promise<void> {
+    if (!dex) {
+      return;
+    }
+
+    if (this.#dexAllMidsSubscriptions.has(dex)) {
+      return;
+    }
+
+    if (this.#dexAllMidsSubscriptionPromises.has(dex)) {
+      await this.#dexAllMidsSubscriptionPromises.get(dex);
+      return;
+    }
+
+    const promise = this.#createDexAllMidsSubscription(dex);
+    this.#dexAllMidsSubscriptionPromises.set(dex, promise);
+
+    try {
+      await promise;
+    } catch (error) {
+      this.#dexAllMidsSubscriptionPromises.delete(dex);
+      throw error;
+    }
+  }
+
+  /**
+   * Create allMids WS subscription for a specific HIP-3 DEX.
+   *
+   * @param dex - The HIP-3 DEX name.
+   */
+  async #createDexAllMidsSubscription(dex: string): Promise<void> {
+    await this.#clientService.ensureSubscriptionClient(
+      this.#walletService.createWalletAdapter(),
+    );
+    const subscriptionClient = this.#clientService.getSubscriptionClient();
+
+    if (!subscriptionClient) {
+      throw new Error('Subscription client not initialized');
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      subscriptionClient
+        .allMids({ dex }, (data: AllMidsWsEvent) => {
+          this.#allMidsSnapshots.set(dex, data.mids as Record<string, string>);
+        })
+        .then((sub) => {
+          this.#dexAllMidsSubscriptions.set(dex, sub);
+          this.#deps.debugLogger.log(
+            `allMids subscription established for DEX: ${dex}`,
+          );
+          resolve();
+          return undefined;
+        })
+        .catch((error) => {
+          this.#logErrorUnlessClearing(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.createDexAllMidsSubscription',
+            ),
+            this.#getErrorContext('createDexAllMidsSubscription', { dex }),
+          );
+          reject(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.createDexAllMidsSubscription',
+            ),
+          );
+        });
+    });
   }
 
   /**
@@ -2654,55 +2840,96 @@ export class HyperLiquidSubscriptionService {
 
     return new Promise<void>((resolve, reject) => {
       const subscriptionParams = dex ? { dex } : {};
+      const handleAssetCtxsUpdate = (data: AssetCtxsWsEvent): void => {
+        // Cache asset contexts for this DEX
+        this.#dexAssetCtxsCache.set(dexKey, data.ctxs);
 
-      subscriptionClient
-        .assetCtxs(subscriptionParams, (data: AssetCtxsWsEvent) => {
-          // Cache asset contexts for this DEX
-          this.#dexAssetCtxsCache.set(dexKey, data.ctxs);
+        // Use cached meta to map ctxs array indices to symbols (no REST API call!)
+        validatedMeta.universe.forEach((asset, index) => {
+          const ctx = data.ctxs[index];
+          if (ctx && 'funding' in ctx) {
+            // This is a perps context
+            const ctxPrice = ctx.midPx ?? ctx.markPx;
+            const openInterestUSD = calculateOpenInterestUSD(
+              ctx.openInterest,
+              ctxPrice,
+            );
+            const marketData = {
+              prevDayPx: ctx.prevDayPx
+                ? parseFloat(ctx.prevDayPx.toString())
+                : undefined,
+              funding: parseFloat(ctx.funding.toString()),
+              openInterest: isNaN(openInterestUSD)
+                ? undefined
+                : openInterestUSD,
+              volume24h: ctx.dayNtlVlm
+                ? parseFloat(ctx.dayNtlVlm.toString())
+                : undefined,
+              oraclePrice: parseFloat(ctx.oraclePx.toString()),
+              lastUpdated: Date.now(),
+            };
 
-          // Use cached meta to map ctxs array indices to symbols (no REST API call!)
-          validatedMeta.universe.forEach((asset, index) => {
-            const ctx = data.ctxs[index];
-            if (ctx && 'funding' in ctx) {
-              // This is a perps context
-              const ctxPrice = ctx.midPx ?? ctx.markPx;
-              const openInterestUSD = calculateOpenInterestUSD(
-                ctx.openInterest,
-                ctxPrice,
-              );
-              const marketData = {
-                prevDayPx: ctx.prevDayPx
-                  ? parseFloat(ctx.prevDayPx.toString())
-                  : undefined,
-                funding: parseFloat(ctx.funding.toString()),
-                openInterest: isNaN(openInterestUSD)
-                  ? undefined
-                  : openInterestUSD,
-                volume24h: ctx.dayNtlVlm
-                  ? parseFloat(ctx.dayNtlVlm.toString())
-                  : undefined,
-                oraclePrice: parseFloat(ctx.oraclePx.toString()),
-                lastUpdated: Date.now(),
-              };
+            this.#marketDataCache.set(asset.name, marketData);
 
-              this.#marketDataCache.set(asset.name, marketData);
-
-              // HIP-3: Extract price from assetCtx and update cached prices
-              const price = ctx.midPx?.toString() ?? ctx.markPx?.toString();
-              if (price) {
-                // For HIP-3 DEXs, meta() returns asset.name already containing the DEX prefix
-                // (e.g., "xyz:XYZ100"), so use it directly
-                const symbol = asset.name;
-                const priceUpdate = this.#createPriceUpdate(symbol, price);
-                this.#cachedPriceData ??= new Map<string, PriceUpdate>();
-                this.#cachedPriceData.set(symbol, priceUpdate);
-              }
+            // HIP-3: Extract price from assetCtx and update cached prices
+            const price = ctx.midPx?.toString() ?? ctx.markPx?.toString();
+            if (price) {
+              // For HIP-3 DEXs, meta() returns asset.name already containing the DEX prefix
+              // (e.g., "xyz:XYZ100"), so use it directly
+              const symbol = asset.name;
+              const priceUpdate = this.#createPriceUpdate(symbol, price);
+              this.#cachedPriceData ??= new Map<string, PriceUpdate>();
+              this.#cachedPriceData.set(symbol, priceUpdate);
             }
-          });
+          }
+        });
 
-          // Notify price subscribers with updated market data
-          this.#notifyAllPriceSubscribers();
-        })
+        // Notify price subscribers with updated market data
+        this.#notifyAllPriceSubscribers();
+      };
+
+      const subscribeWithRetry = async (): Promise<ISubscription> => {
+        const maxAttempts = 3;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+          try {
+            return await subscriptionClient.assetCtxs(
+              subscriptionParams,
+              handleAssetCtxsUpdate,
+            );
+          } catch (error) {
+            const ensuredError = ensureError(
+              error,
+              'HyperLiquidSubscriptionService.createAssetCtxsSubscription',
+            );
+            const isLastAttempt = attempt === maxAttempts;
+            if (
+              isLastAttempt ||
+              !this.#isTransientAssetCtxsError(ensuredError)
+            ) {
+              throw ensuredError;
+            }
+
+            const retryDelayMs = attempt * 500;
+            this.#deps.debugLogger.log(
+              'Transient assetCtxs subscription failure during reconnect, retrying',
+              {
+                dex: dexKey || 'main',
+                attempt,
+                retryDelayMs,
+                error: ensuredError.message,
+              },
+            );
+            await new Promise((_resolve) => setTimeout(_resolve, retryDelayMs));
+          }
+        }
+
+        throw new Error(
+          `Failed to establish assetCtxs subscription for ${dexIdentifier}`,
+        );
+      };
+
+      subscribeWithRetry()
         .then((sub) => {
           this.#assetCtxsSubscriptions.set(dexKey, sub);
           this.#deps.debugLogger.log(
@@ -2746,6 +2973,9 @@ export class HyperLiquidSubscriptionService {
     if (currentCount <= 1) {
       // Last subscriber - cleanup the subscription
       const subscription = this.#assetCtxsSubscriptions.get(dexKey);
+      const allMidsSubscription = dex
+        ? this.#dexAllMidsSubscriptions.get(dex)
+        : undefined;
 
       if (subscription) {
         subscription.unsubscribe().catch((error: Error) => {
@@ -2757,18 +2987,36 @@ export class HyperLiquidSubscriptionService {
             this.#getErrorContext('cleanupAssetCtxsSubscription', { dex }),
           );
         });
-
-        this.#assetCtxsSubscriptions.delete(dexKey);
-        this.#dexAssetCtxsCache.delete(dexKey);
-        this.#assetCtxsSubscriptionPromises.delete(dexKey);
-        this.#dexSubscriberCounts.delete(dexKey);
-
-        this.#deps.debugLogger.log(
-          `Cleaned up assetCtxs subscription for ${
-            dex ? `DEX: ${dex}` : 'main DEX'
-          }`,
-        );
       }
+
+      if (allMidsSubscription) {
+        allMidsSubscription.unsubscribe().catch((error: Error) => {
+          this.#logErrorUnlessClearing(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.cleanupDexAllMidsSubscription',
+            ),
+            this.#getErrorContext('cleanupDexAllMidsSubscription', { dex }),
+          );
+        });
+      }
+
+      this.#assetCtxsSubscriptions.delete(dexKey);
+      this.#dexAssetCtxsCache.delete(dexKey);
+      this.#assetCtxsSubscriptionPromises.delete(dexKey);
+      this.#dexSubscriberCounts.delete(dexKey);
+
+      if (dex) {
+        this.#dexAllMidsSubscriptions.delete(dex);
+        this.#dexAllMidsSubscriptionPromises.delete(dex);
+        this.#allMidsSnapshots.delete(dex);
+      }
+
+      this.#deps.debugLogger.log(
+        `Cleaned up assetCtxs subscription for ${
+          dex ? `DEX: ${dex}` : 'main DEX'
+        }`,
+      );
     } else {
       // Still has subscribers - just decrement count
       this.#dexSubscriberCounts.set(dexKey, currentCount - 1);
@@ -3179,8 +3427,8 @@ export class HyperLiquidSubscriptionService {
       // Clear existing subscriptions (they're dead after reconnection)
       this.#assetCtxsSubscriptions.clear();
       this.#assetCtxsSubscriptionPromises.clear();
-      // Clear reference counts to prevent double-counting after reconnection
-      this.#dexSubscriberCounts.clear();
+      this.#dexAllMidsSubscriptions.clear();
+      this.#dexAllMidsSubscriptionPromises.clear();
 
       // Re-establish subscriptions for all DEXs with market data subscribers
       const dexsNeeded = new Set<string>();
@@ -3202,14 +3450,73 @@ export class HyperLiquidSubscriptionService {
         dexsNeeded.add('');
       }
 
-      // Re-establish subscriptions
-      await Promise.all(
-        Array.from(dexsNeeded).map((dex) =>
-          this.#ensureAssetCtxsSubscription(dex).catch(() => {
-            // Ignore errors during assetCtxs subscription restoration
-          }),
-        ),
+      const marketDataRestoreOperations = Array.from(dexsNeeded).flatMap(
+        (dex) => {
+          const operations: {
+            dex: string;
+            kind: 'assetCtxs' | 'allMids';
+            promise: Promise<void>;
+          }[] = [
+            {
+              dex,
+              kind: 'assetCtxs',
+              promise: this.#ensureAssetCtxsSubscription(dex, {
+                incrementRefCount: false,
+              }),
+            },
+          ];
+
+          if (dex) {
+            operations.push({
+              dex,
+              kind: 'allMids',
+              promise: this.#ensureDexAllMidsSubscription(dex),
+            });
+          }
+
+          return operations;
+        },
       );
+
+      const marketDataRestoreResults = await Promise.allSettled(
+        marketDataRestoreOperations.map(({ promise }) => promise),
+      );
+      const marketDataRestoreFailures = marketDataRestoreResults.flatMap(
+        (result, index) => {
+          if (result.status === 'fulfilled') {
+            return [];
+          }
+
+          const operation = marketDataRestoreOperations[index];
+          return [
+            {
+              ...operation,
+              error: ensureError(
+                result.reason,
+                'HyperLiquidSubscriptionService.restoreSubscriptions',
+              ),
+            },
+          ];
+        },
+      );
+
+      if (marketDataRestoreFailures.length > 0) {
+        marketDataRestoreFailures.forEach(({ dex, kind }) => {
+          this.#scheduleRestoreRetry(dex, kind);
+        });
+
+        this.#logErrorUnlessClearing(
+          new Error(
+            `Failed to restore ${marketDataRestoreFailures.length} market data subscriptions`,
+          ),
+          this.#getErrorContext('restoreSubscriptions.marketData', {
+            failures: marketDataRestoreFailures.map(
+              ({ dex, kind, error }) =>
+                `${kind}:${dex || 'main'}:${error.message}`,
+            ),
+          }),
+        );
+      }
     }
   }
 
@@ -3241,6 +3548,7 @@ export class HyperLiquidSubscriptionService {
 
     // Clear cached data
     this.#cachedPriceData = null;
+    this.#allMidsSnapshots.clear();
     this.#cachedPositions = null;
     this.#cachedOrders = null;
     this.#cachedAccount = null;
@@ -3278,6 +3586,7 @@ export class HyperLiquidSubscriptionService {
 
     // Clear subscription references (actual cleanup handled by client service)
     this.#globalAllMidsSubscription = undefined;
+    this.#globalAllMidsPromise = undefined;
     this.#globalActiveAssetSubscriptions.clear();
     this.#globalBboSubscriptions.clear();
     this.#webData3Subscriptions.clear();
@@ -3286,6 +3595,15 @@ export class HyperLiquidSubscriptionService {
     // HIP-3: Clear assetCtxs subscriptions (clearinghouseState no longer needed with webData3)
     this.#assetCtxsSubscriptions.clear();
     this.#assetCtxsSubscriptionPromises.clear();
+
+    // HIP-3: Clear per-DEX allMids subscriptions
+    this.#dexAllMidsSubscriptions.clear();
+    this.#dexAllMidsSubscriptionPromises.clear();
+
+    this.#restoreRetryTimeouts.forEach((timeoutId) => {
+      clearTimeout(timeoutId);
+    });
+    this.#restoreRetryTimeouts.clear();
 
     // Cleanup individual subscriptions (clearinghouseState + openOrders)
     if (this.#clearinghouseStateSubscriptions.size > 0) {

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -16,6 +16,7 @@ import type {
 } from '@nktkas/hyperliquid';
 
 import { TP_SL_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
+import { WebSocketConnectionState } from '../types';
 import type {
   PriceUpdate,
   Position,
@@ -33,7 +34,6 @@ import type {
   OrderBookLevel,
   PerpsPlatformDependencies,
   PerpsLogger,
-  WebSocketConnectionState,
 } from '../types';
 import type { HyperLiquidClientService } from './HyperLiquidClientService';
 import type { HyperLiquidWalletService } from './HyperLiquidWalletService';

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -403,6 +403,10 @@ export type PerpsMarketData = {
    * Multi-provider: which provider this market data comes from (injected by aggregator)
    */
   providerId?: PerpsProviderType;
+  /**
+   * Indicates this market snapshot came from the last known good cache after live fetch failure.
+   */
+  isStale?: boolean;
 };
 
 export type ToggleTestnetResult = {


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the perps reconnect and error-reporting issues found during the connection investigation.

It hardens HyperLiquid reconnect recovery so market data and user data degrade gracefully across partial DEX failures, repairs HIP-3 asset resolution after degraded discovery, keeps stale market data available when live refreshes fail, and standardizes perps UI/controller logging so perps errors carry the expected `feature: perps` tag.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps reconnect recovery and error reporting for market data and position actions.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps reconnect recovery

  Background:
    Given I am logged into MetaMask Mobile
    And I can open the Perps experience

  Scenario: user recovers after a temporary connection interruption
    Given I am on the Perps home screen with market data loaded
    When I background and resume the app or briefly interrupt connectivity
    Then the market list should recover without remaining blank
    And previously loaded market data should still render if live refetches fail

  Scenario: user manages a HIP-3 position after reconnect
    Given I have an open HIP-3 perps position
    And the app has reconnected after a temporary WebSocket interruption
    When I close the position or update TP/SL or margin
    Then the action should resolve the HIP-3 market asset correctly
    And the operation should complete without an undefined close error
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core Perps provider/subscription logic for HIP-3 multi-DEX market data, asset-id resolution, and reconnect restoration, which can impact order routing and displayed balances/prices. Adds retry/stale-fallback paths and new logging contracts that need careful validation under real network churn.
> 
> **Overview**
> Improves Perps observability by **standardizing `Logger.error` usage with `feature: perps` tags and structured `context`** across UI views and trading hooks, replacing several `captureException` calls and adding/adjusting tests to assert the new logging shape.
> 
> Hardens HyperLiquid HIP-3 multi-DEX behavior: adds **asset-id repair/backfill** when DEX discovery/meta was degraded, changes multi-DEX queries to **return partial results with explicit failed-DEX diagnostics**, and updates `getAccountState` to **degrade gracefully** (only throwing when *no* perps state could be fetched).
> 
> Strengthens market-data resilience by preferring **last WebSocket `allMids` snapshots** (new per-DEX snapshot cache + subscriptions), adding **retry + stale cached market list fallback** on full fetch failure, and improving reconnect restoration to **retry failed `assetCtxs`/`allMids` subscriptions** and clean up failed subscription attempts. Adds `PerpsMarketData.isStale` to surface stale snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 799bca0d525724a9e630e8d70806ba5c6e41d6b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->