### PR TITLE
refactor(MusdConversionAssetListCta): enhance CTA component with full view support and update event tracking locations

### DIFF
--- a/app/components/UI/Earn/constants/events/musdEvents.ts
+++ b/app/components/UI/Earn/constants/events/musdEvents.ts
@@ -16,6 +16,10 @@ const EVENT_LOCATIONS = {
     'quick_convert_max_bottom_sheet_confirmation_screen',
   CUSTOM_AMOUNT_NAVBAR: 'custom_amount_navbar',
   PERCENTAGE_ROW: 'percentage_row',
+  /** Primary CTA / token list item on homepage compact view */
+  MOBILE_TOKEN_LIST: 'mobile-token-list',
+  /** Primary CTA / token list item on full page token list */
+  MOBILE_TOKEN_LIST_PAGE: 'mobile-token-list-page',
 };
 
 const MUSD_CTA_TYPES = {

--- a/app/components/UI/Earn/constants/events/musdEvents.ts
+++ b/app/components/UI/Earn/constants/events/musdEvents.ts
@@ -16,9 +16,7 @@ const EVENT_LOCATIONS = {
     'quick_convert_max_bottom_sheet_confirmation_screen',
   CUSTOM_AMOUNT_NAVBAR: 'custom_amount_navbar',
   PERCENTAGE_ROW: 'percentage_row',
-  /** Primary CTA / token list item on homepage compact view */
-  MOBILE_TOKEN_LIST: 'mobile-token-list',
-  /** Primary CTA / token list item on full page token list */
+  /** CTA on full page Cash token list */
   MOBILE_TOKEN_LIST_PAGE: 'mobile-token-list-page',
 };
 

--- a/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
@@ -48,7 +48,7 @@ const CashTokensFullView = () => {
       {!hasMusdBalanceOnAnyChain ? (
         <Box twClassName="flex-1">
           <SectionRow>
-            <CashGetMusdEmptyState />
+            <CashGetMusdEmptyState isFullView />
           </SectionRow>
         </Box>
       ) : (

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
@@ -126,7 +126,7 @@ describe('CashGetMusdEmptyState', () => {
     expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
   });
 
-  it('tracks MUSD_CONVERSION_CTA_CLICKED with home_cash_section when Get mUSD is pressed', () => {
+  it('tracks MUSD_CONVERSION_CTA_CLICKED with mobile-token-list when Get mUSD is pressed on homepage', () => {
     renderWithProvider(<CashGetMusdEmptyState />);
 
     fireEvent.press(screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON));
@@ -136,7 +136,25 @@ describe('CashGetMusdEmptyState', () => {
     );
     expect(mockAddProperties).toHaveBeenCalledWith(
       expect.objectContaining({
-        location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.HOME_CASH_SECTION,
+        location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.MOBILE_TOKEN_LIST,
+        cta_type: MUSD_EVENTS_CONSTANTS.MUSD_CTA_TYPES.PRIMARY,
+        cta_text: 'Get mUSD',
+      }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('tracks MUSD_CONVERSION_CTA_CLICKED with mobile-token-list-page when Get mUSD is pressed on full view', () => {
+    renderWithProvider(<CashGetMusdEmptyState isFullView />);
+
+    fireEvent.press(screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON));
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.MUSD_CONVERSION_CTA_CLICKED,
+    );
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.MOBILE_TOKEN_LIST_PAGE,
         cta_type: MUSD_EVENTS_CONSTANTS.MUSD_CTA_TYPES.PRIMARY,
         cta_text: 'Get mUSD',
       }),

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
@@ -126,7 +126,7 @@ describe('CashGetMusdEmptyState', () => {
     expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
   });
 
-  it('tracks MUSD_CONVERSION_CTA_CLICKED with mobile-token-list when Get mUSD is pressed on homepage', () => {
+  it('tracks MUSD_CONVERSION_CTA_CLICKED with home_cash_section when Get mUSD is pressed on homepage', () => {
     renderWithProvider(<CashGetMusdEmptyState />);
 
     fireEvent.press(screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON));
@@ -136,7 +136,7 @@ describe('CashGetMusdEmptyState', () => {
     );
     expect(mockAddProperties).toHaveBeenCalledWith(
       expect.objectContaining({
-        location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.MOBILE_TOKEN_LIST,
+        location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.HOME_CASH_SECTION,
         cta_type: MUSD_EVENTS_CONSTANTS.MUSD_CTA_TYPES.PRIMARY,
         cta_text: 'Get mUSD',
       }),

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -125,7 +125,7 @@ const CashGetMusdEmptyState = ({
         .addProperties({
           location: isFullView
             ? EVENT_LOCATIONS.MOBILE_TOKEN_LIST_PAGE
-            : EVENT_LOCATIONS.MOBILE_TOKEN_LIST,
+            : EVENT_LOCATIONS.HOME_CASH_SECTION,
           redirects_to: getRedirectLocation(),
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: strings('earn.musd_conversion.get_musd'),

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -44,12 +44,18 @@ import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { CashGetMusdEmptyStateSelectors } from './CashGetMusdEmptyState.testIds';
 import { MUSD_MAINNET_ASSET_FOR_DETAILS } from './CashGetMusdEmptyState.constants';
 
+interface CashGetMusdEmptyStateProps {
+  isFullView?: boolean;
+}
+
 /**
  * Empty state for the Cash (mUSD) full view when the user has no mUSD.
  * Shows a "Get mUSD" card: token row (navigates to Mainnet mUSD Asset Details) + Get mUSD button.
  * Button routes to Buy flow (empty wallet + mUSD buyable) or Convert flow (non-empty + has convertible tokens).
  */
-const CashGetMusdEmptyState = () => {
+const CashGetMusdEmptyState = ({
+  isFullView = false,
+}: CashGetMusdEmptyStateProps) => {
   const tw = useTailwind();
   const { goToBuy } = useRampNavigation();
   const {
@@ -117,7 +123,9 @@ const CashGetMusdEmptyState = () => {
     trackEvent(
       createEventBuilder(MetaMetricsEvents.MUSD_CONVERSION_CTA_CLICKED)
         .addProperties({
-          location: EVENT_LOCATIONS.HOME_CASH_SECTION,
+          location: isFullView
+            ? EVENT_LOCATIONS.MOBILE_TOKEN_LIST_PAGE
+            : EVENT_LOCATIONS.MOBILE_TOKEN_LIST,
           redirects_to: getRedirectLocation(),
           cta_type: MUSD_CTA_TYPES.PRIMARY,
           cta_text: strings('earn.musd_conversion.get_musd'),
@@ -166,6 +174,7 @@ const CashGetMusdEmptyState = () => {
     isMusdBuyableOnAnyChain,
     hasConvertibleTokens,
     hasSeenConversionEducationScreen,
+    isFullView,
     isQuickConvertEnabled,
     getPaymentTokenForSelectedNetwork,
     goToBuy,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


The `mUSD Conversion CTA Clicked` event in `CashGetMusdEmptyState` always sent `location: 'home_cash_section'`, even when the CTA was tapped from the full Cash token list page.

This PR adds a new `MOBILE_TOKEN_LIST_PAGE` event location and an `isFullView` prop to `CashGetMusdEmptyState` so the full-page context is reported correctly, while the homepage default (`home_cash_section`) remains unchanged:

- **`CashGetMusdEmptyState`** — accepts `isFullView`; sends `mobile-token-list-page` when true, keeps `home_cash_section` otherwise.
- **`CashTokensFullView`** — passes `isFullView` to `CashGetMusdEmptyState`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-560

## **Manual testing steps**

```gherkin
Feature: mUSD Conversion CTA location tracking in Cash section

  Scenario: CTA clicked on homepage Cash section keeps home_cash_section location
    Given the user is on the wallet homepage with mUSD conversion enabled
    And the user has no mUSD balance (Cash empty state is shown)

    When user taps the "Get mUSD" button in the Cash section
    Then the mUSD Conversion CTA Clicked event fires with location "home_cash_section"

  Scenario: CTA clicked on full Cash token list page sends mobile-token-list-page location
    Given the user navigates to the full Cash token list page (via ">" from homepage Cash section)
    And the user has no mUSD balance (Cash empty state is shown)

    When user taps the "Get mUSD" button
    Then the mUSD Conversion CTA Clicked event fires with location "mobile-token-list-page"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to analytics metadata and a new optional prop wiring for `CashGetMusdEmptyState`, with updated unit coverage.
> 
> **Overview**
> Updates mUSD conversion CTA analytics so the `MUSD_CONVERSION_CTA_CLICKED` event reports the correct `location` when triggered from the full Cash token list page.
> 
> Adds `EVENT_LOCATIONS.MOBILE_TOKEN_LIST_PAGE` and an `isFullView` prop to `CashGetMusdEmptyState`, passes it from `CashTokensFullView`, and extends tests to cover both homepage (`home_cash_section`) and full-view tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 720ef20aecfa6c10b3c7c35448810504567e1c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->