### PR TITLE
feat(perps): enhance tutorial navigation with redirect options

### DIFF
--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
@@ -57,6 +57,12 @@ jest.mock('rive-react-native', () => {
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
   useRoute: jest.fn(),
+  StackActions: {
+    replace: (name: string, params?: object) => ({
+      type: 'REPLACE',
+      payload: { name, params },
+    }),
+  },
 }));
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -66,6 +72,7 @@ jest.mock('react-native-safe-area-context', () => ({
 // Mock NavigationService
 const mockNavigationServiceMethods = {
   navigate: jest.fn(),
+  dispatch: jest.fn(),
   setParams: jest.fn(),
 };
 
@@ -236,14 +243,15 @@ describe('PerpsTutorialCarousel', () => {
         fireEvent.press(continueButton);
       });
 
-      // Should mark tutorial as completed and navigate to perps home screen
+      // Should mark tutorial as completed and replace tutorial with perps home
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-        Routes.PERPS.ROOT,
-        {
-          screen: Routes.PERPS.PERPS_HOME,
+      expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+        type: 'REPLACE',
+        payload: {
+          name: Routes.PERPS.ROOT,
+          params: { screen: Routes.PERPS.PERPS_HOME },
         },
-      );
+      });
     });
 
     it('should navigate to markets list when pressing Skip on first screen', () => {
@@ -253,12 +261,13 @@ describe('PerpsTutorialCarousel', () => {
         fireEvent.press(screen.getByText(strings('perps.tutorial.skip')));
       });
 
-      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-        Routes.PERPS.ROOT,
-        {
-          screen: Routes.PERPS.PERPS_HOME,
+      expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+        type: 'REPLACE',
+        payload: {
+          name: Routes.PERPS.ROOT,
+          params: { screen: Routes.PERPS.PERPS_HOME },
         },
-      );
+      });
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
     });
 
@@ -315,13 +324,120 @@ describe('PerpsTutorialCarousel', () => {
         fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
       });
 
-      // Should navigate to perps home screen
-      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-        Routes.PERPS.ROOT,
-        {
-          screen: Routes.PERPS.PERPS_HOME,
+      // Should replace tutorial with perps home screen
+      expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+        type: 'REPLACE',
+        payload: {
+          name: Routes.PERPS.ROOT,
+          params: { screen: Routes.PERPS.PERPS_HOME },
         },
-      );
+      });
+    });
+  });
+
+  describe('Post-tutorial redirect', () => {
+    it('redirects to specified screen with params after completing tutorial', async () => {
+      const redirectParams = {
+        market: { symbol: 'BTC' },
+        source: 'home_section',
+      };
+      (useRoute as jest.Mock).mockReturnValue({
+        params: {
+          source: 'home_section',
+          redirectScreen: Routes.PERPS.MARKET_DETAILS,
+          redirectParams,
+        },
+      });
+
+      render(<PerpsTutorialCarousel />);
+      await navigateToScreen(5);
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
+      });
+
+      expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+        type: 'REPLACE',
+        payload: {
+          name: Routes.PERPS.ROOT,
+          params: {
+            screen: Routes.PERPS.MARKET_DETAILS,
+            params: redirectParams,
+          },
+        },
+      });
+    });
+
+    it('redirects to specified screen on skip', () => {
+      const redirectParams = { source: 'home_section' };
+      (useRoute as jest.Mock).mockReturnValue({
+        params: {
+          source: 'home_section',
+          redirectScreen: Routes.PERPS.MARKET_LIST,
+          redirectParams,
+        },
+      });
+
+      render(<PerpsTutorialCarousel />);
+
+      act(() => {
+        fireEvent.press(screen.getByText(strings('perps.tutorial.skip')));
+      });
+
+      expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+        type: 'REPLACE',
+        payload: {
+          name: Routes.PERPS.ROOT,
+          params: {
+            screen: Routes.PERPS.MARKET_LIST,
+            params: redirectParams,
+          },
+        },
+      });
+    });
+
+    it('redirects to screen without params key when only redirectScreen is provided', async () => {
+      (useRoute as jest.Mock).mockReturnValue({
+        params: {
+          source: 'home_section',
+          redirectScreen: Routes.PERPS.MARKET_LIST,
+        },
+      });
+
+      render(<PerpsTutorialCarousel />);
+      await navigateToScreen(5);
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
+      });
+
+      const dispatchCall =
+        mockNavigationServiceMethods.dispatch.mock.calls[0][0];
+      expect(dispatchCall.type).toBe('REPLACE');
+      expect(dispatchCall.payload.name).toBe(Routes.PERPS.ROOT);
+      expect(dispatchCall.payload.params).toEqual({
+        screen: Routes.PERPS.MARKET_LIST,
+      });
+      expect(dispatchCall.payload.params).not.toHaveProperty('params');
+    });
+
+    it('falls back to perps home when no redirect params provided', async () => {
+      (useRoute as jest.Mock).mockReturnValue({ params: {} });
+
+      render(<PerpsTutorialCarousel />);
+      await navigateToScreen(5);
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
+      });
+
+      expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+        type: 'REPLACE',
+        payload: {
+          name: Routes.PERPS.ROOT,
+          params: { screen: Routes.PERPS.PERPS_HOME },
+        },
+      });
     });
   });
 
@@ -418,14 +534,15 @@ describe('PerpsTutorialCarousel', () => {
           fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
         });
 
-        // Should mark tutorial as completed and navigate to perps home
+        // Should mark tutorial as completed and replace tutorial with perps home
         expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-        expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-          Routes.PERPS.ROOT,
-          {
-            screen: Routes.PERPS.PERPS_HOME,
+        expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+          type: 'REPLACE',
+          payload: {
+            name: Routes.PERPS.ROOT,
+            params: { screen: Routes.PERPS.PERPS_HOME },
           },
-        );
+        });
       });
 
       it('shows skip button for eligible users on non-last screens', () => {
@@ -444,14 +561,15 @@ describe('PerpsTutorialCarousel', () => {
           fireEvent.press(screen.getByTestId('perps-tutorial-skip-button'));
         });
 
-        // Should mark tutorial as completed and navigate to markets list
+        // Should mark tutorial as completed and replace tutorial with perps home
         expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-        expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-          Routes.PERPS.ROOT,
-          {
-            screen: Routes.PERPS.PERPS_HOME,
+        expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+          type: 'REPLACE',
+          payload: {
+            name: Routes.PERPS.ROOT,
+            params: { screen: Routes.PERPS.PERPS_HOME },
           },
-        );
+        });
       });
     });
 
@@ -559,14 +677,15 @@ describe('PerpsTutorialCarousel', () => {
           fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
         });
 
-        // Should mark tutorial as completed and navigate to markets list
+        // Should mark tutorial as completed and replace tutorial with perps home
         expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-        expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-          Routes.PERPS.ROOT,
-          {
-            screen: Routes.PERPS.PERPS_HOME,
+        expect(mockNavigationServiceMethods.dispatch).toHaveBeenCalledWith({
+          type: 'REPLACE',
+          payload: {
+            name: Routes.PERPS.ROOT,
+            params: { screen: Routes.PERPS.PERPS_HOME },
           },
-        );
+        });
         // Should NOT navigate using the mocked navigation (uses NavigationService instead)
         expect(mockNavigation.navigate).not.toHaveBeenCalled();
       });

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -12,7 +12,11 @@ import {
   useColorScheme,
   ScrollView,
 } from 'react-native';
-import { useRoute, type RouteProp } from '@react-navigation/native';
+import {
+  useRoute,
+  StackActions,
+  type RouteProp,
+} from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import { strings } from '../../../../../../locales/i18n';
@@ -136,6 +140,8 @@ const PerpsTutorialCarousel: React.FC = () => {
     useRoute<RouteProp<PerpsNavigationParamList, 'PerpsTutorial'>>();
   const tutorialSource =
     route.params?.source ?? PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON;
+  const redirectScreen = route.params?.redirectScreen;
+  const redirectParams = route.params?.redirectParams;
   const { markTutorialCompleted } = usePerpsFirstTimeUser();
   const { track } = usePerpsEventTracking();
   const [currentTab, setCurrentTab] = useState(0);
@@ -257,11 +263,17 @@ const PerpsTutorialCarousel: React.FC = () => {
     [track, tutorialScreens, tutorialSource],
   );
 
-  const navigateToMarketsList = useCallback(() => {
-    NavigationService.navigation.navigate(Routes.PERPS.ROOT, {
-      screen: Routes.PERPS.PERPS_HOME,
-    });
-  }, []);
+  const navigateAfterTutorial = useCallback(() => {
+    const navParams: Record<string, unknown> = {
+      screen: redirectScreen ?? Routes.PERPS.PERPS_HOME,
+    };
+    if (redirectParams) {
+      navParams.params = redirectParams;
+    }
+    NavigationService.navigation.dispatch(
+      StackActions.replace(Routes.PERPS.ROOT, navParams),
+    );
+  }, [redirectScreen, redirectParams]);
 
   const handleContinue = useCallback(async () => {
     // Prevent double-tap on Android - if timeout exists, we're still debouncing
@@ -288,8 +300,7 @@ const PerpsTutorialCarousel: React.FC = () => {
 
       // Mark tutorial as completed
       markTutorialCompleted();
-      // Navigate all users to perps home screen for a more natural experience
-      navigateToMarketsList();
+      navigateAfterTutorial();
     } else {
       // Go to next screen using the ref
       const nextTab = Math.min(currentTab + 1, tutorialScreens.length - 1);
@@ -330,7 +341,7 @@ const PerpsTutorialCarousel: React.FC = () => {
     currentTab,
     tutorialScreens,
     markTutorialCompleted,
-    navigateToMarketsList,
+    navigateAfterTutorial,
     tutorialSource,
   ]);
 
@@ -350,14 +361,14 @@ const PerpsTutorialCarousel: React.FC = () => {
 
     // Mark tutorial as completed
     markTutorialCompleted();
-    navigateToMarketsList();
+    navigateAfterTutorial();
   }, [
     isLastScreen,
     markTutorialCompleted,
     currentTab,
     tutorialSource,
     track,
-    navigateToMarketsList,
+    navigateAfterTutorial,
   ]);
 
   const handleLearnMore = useCallback(() => {

--- a/app/components/UI/Perps/types/navigation.ts
+++ b/app/components/UI/Perps/types/navigation.ts
@@ -160,6 +160,10 @@ export interface PerpsNavigationParamList extends ParamListBase {
     isFromGTMModal?: boolean;
     /** Analytics: how the user got to the tutorial (e.g. homescreen_tab, main_action_button) */
     source?: string;
+    /** Screen to navigate to after tutorial completion instead of the default PerpsHome */
+    redirectScreen?: string;
+    /** Params to pass to the redirect screen */
+    redirectParams?: Record<string, unknown>;
   };
 
   // TP/SL screen

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -8,6 +8,7 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '@metamask/perps-controller';
+import { selectIsFirstTimePerpsUser } from '../../../../UI/Perps/selectors/perpsController';
 
 const mockNavigate = jest.fn();
 const mockTrack = jest.fn();
@@ -15,6 +16,11 @@ const mockTrack = jest.fn();
 jest.mock('../../../../../selectors/preferencesController', () => ({
   ...jest.requireActual('../../../../../selectors/preferencesController'),
   selectPrivacyMode: () => false,
+}));
+
+jest.mock('../../../../UI/Perps/selectors/perpsController', () => ({
+  ...jest.requireActual('../../../../UI/Perps/selectors/perpsController'),
+  selectIsFirstTimePerpsUser: jest.fn(),
 }));
 
 jest.mock('../../../../UI/Perps/hooks/usePerpsEventTracking', () => ({
@@ -232,6 +238,11 @@ jest.mock('../../hooks/useHomeViewedEvent', () => ({
 describe('PerpsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (
+      selectIsFirstTimePerpsUser as jest.MockedFunction<
+        typeof selectIsFirstTimePerpsUser
+      >
+    ).mockReturnValue(false);
     usePerpsLivePositions.mockReturnValue({
       positions: [],
       isInitialLoading: false,
@@ -1058,6 +1069,114 @@ describe('PerpsSection', () => {
       expect(
         screen.queryByTestId('homepage-trending-perps-carousel'),
       ).toBeNull();
+    });
+  });
+
+  describe('first-time user tutorial', () => {
+    beforeEach(() => {
+      (
+        selectIsFirstTimePerpsUser as jest.MockedFunction<
+          typeof selectIsFirstTimePerpsUser
+        >
+      ).mockReturnValue(true);
+      usePerpsConnection.mockReturnValue({
+        isConnected: true,
+        isConnecting: false,
+        isInitialized: true,
+        error: null,
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        resetError: jest.fn(),
+        reconnectWithNewContext: mockReconnectWithNewContext,
+      });
+    });
+
+    it('navigates to tutorial with redirect to perps home on title press', () => {
+      renderWithProvider(
+        <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      fireEvent.press(screen.getByText('Perpetuals'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
+        source: 'home_section',
+        redirectScreen: Routes.PERPS.PERPS_HOME,
+        redirectParams: { source: 'home_section' },
+      });
+    });
+
+    it('navigates to tutorial with redirect to market details on tile press', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'SOL', volumeNumber: 5000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(
+        <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      fireEvent.press(screen.getByTestId('perps-market-tile-SOL'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
+        source: 'home_section',
+        redirectScreen: Routes.PERPS.MARKET_DETAILS,
+        redirectParams: expect.objectContaining({
+          market: expect.objectContaining({ symbol: 'SOL' }),
+          source: 'home_section',
+        }),
+      });
+    });
+
+    it('navigates to tutorial with redirect to market details on position press', () => {
+      usePerpsLivePositions.mockReturnValue({
+        positions: [makePosition()],
+        isInitialLoading: false,
+      });
+
+      renderWithProvider(
+        <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      fireEvent.press(screen.getByTestId('perps-position-row-BTC'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
+        source: 'home_section',
+        redirectScreen: Routes.PERPS.MARKET_DETAILS,
+        redirectParams: {
+          market: { symbol: 'BTC', maxLeverage: 50 },
+          initialTab: 'position',
+          source: 'section_position',
+        },
+      });
+    });
+
+    it('navigates to tutorial with redirect to market list on "View more" press', () => {
+      usePerpsMarkets.mockReturnValue({
+        markets: [
+          makeTrendingMarket({ symbol: 'BTC', volumeNumber: 5000000000 }),
+        ],
+        isLoading: false,
+        error: null,
+        refresh: jest.fn(),
+        isRefreshing: false,
+      });
+
+      renderWithProvider(
+        <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      fireEvent.press(screen.getByTestId('perps-view-more-card'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
+        source: 'home_section',
+        redirectScreen: Routes.PERPS.MARKET_LIST,
+        redirectParams: { source: 'home_section' },
+      });
     });
   });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -30,7 +30,10 @@ import {
 } from '../../../../UI/Perps/hooks';
 import { usePerpsConnection } from '../../../../UI/Perps/hooks/usePerpsConnection';
 import { filterAndSortMarkets } from '../../../../UI/Perps/utils/filterAndSortMarkets';
-import { selectPerpsWatchlistMarkets } from '../../../../UI/Perps/selectors/perpsController';
+import {
+  selectPerpsWatchlistMarkets,
+  selectIsFirstTimePerpsUser,
+} from '../../../../UI/Perps/selectors/perpsController';
 import type { PerpsNavigationParamList } from '../../../../UI/Perps/types/navigation';
 import PerpsCard from '../../../../UI/Perps/components/PerpsCard';
 import PerpsPositionSkeleton from './components/PerpsPositionSkeleton';
@@ -95,6 +98,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     const { markets, isLoading: marketsLoading } = usePerpsMarkets();
     const watchlistSymbols = useSelector(selectPerpsWatchlistMarkets);
+    const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
 
     const displayPositions = useMemo(
       () => positions.slice(0, MAX_ITEMS),
@@ -174,19 +178,32 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       [connectionError, reconnectWithNewContext, refreshSparklines],
     );
 
+    const navigateToTutorialOrScreen = useCallback(
+      (screen: string, params: Record<string, unknown>) => {
+        if (isFirstTimePerpsUser) {
+          navigation.navigate(Routes.PERPS.TUTORIAL, {
+            source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION,
+            redirectScreen: screen,
+            redirectParams: params,
+          });
+        } else {
+          navigation.navigate(Routes.PERPS.ROOT, { screen, params });
+        }
+      },
+      [isFirstTimePerpsUser, navigation],
+    );
+
     const handleViewAllPerps = useCallback(() => {
-      navigation.navigate(Routes.PERPS.ROOT, {
-        screen: Routes.PERPS.PERPS_HOME,
-        params: { source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION },
+      navigateToTutorialOrScreen(Routes.PERPS.PERPS_HOME, {
+        source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION,
       });
-    }, [navigation]);
+    }, [navigateToTutorialOrScreen]);
 
     const handleViewMorePerps = useCallback(() => {
-      navigation.navigate(Routes.PERPS.ROOT, {
-        screen: Routes.PERPS.MARKET_LIST,
-        params: { source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION },
+      navigateToTutorialOrScreen(Routes.PERPS.MARKET_LIST, {
+        source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION,
       });
-    }, [navigation]);
+    }, [navigateToTutorialOrScreen]);
 
     const handlePositionPress = useCallback(
       (position: Position) => {
@@ -199,29 +216,26 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
             PERPS_EVENT_VALUE.BUTTON_LOCATION.WALLET_HOME,
         });
         const market = markets.find((m) => m.symbol === position.symbol);
-        navigation.navigate(Routes.PERPS.ROOT, {
-          screen: Routes.PERPS.MARKET_DETAILS,
-          params: {
-            market: market ?? {
-              symbol: position.symbol,
-              maxLeverage: position.maxLeverage,
-            },
-            initialTab: 'position',
-            source: 'section_position',
+        navigateToTutorialOrScreen(Routes.PERPS.MARKET_DETAILS, {
+          market: market ?? {
+            symbol: position.symbol,
+            maxLeverage: position.maxLeverage,
           },
+          initialTab: 'position',
+          source: 'section_position',
         });
       },
-      [navigation, markets, track],
+      [navigateToTutorialOrScreen, markets, track],
     );
 
     const handleTilePress = useCallback(
       (market: PerpsMarketData) => {
-        navigation.navigate(Routes.PERPS.ROOT, {
-          screen: Routes.PERPS.MARKET_DETAILS,
-          params: { market, source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION },
+        navigateToTutorialOrScreen(Routes.PERPS.MARKET_DETAILS, {
+          market,
+          source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION,
         });
       },
-      [navigation],
+      [navigateToTutorialOrScreen],
     );
 
     // Pass null while loading so the hook uses the immediate-fire path and


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem:** When a first-time perps user tapped any item in the Perpetuals homepage section (market tile, position row, "View more" card, or section title), they were navigated directly to the perps screens without seeing the tutorial first. The tutorial was only triggered via the main action button.

**Solution:**
- **PerpsSection:** Added a `navigateToTutorialOrScreen` wrapper that checks `selectIsFirstTimePerpsUser`. If the user hasn't completed the tutorial, all navigation actions (title press, tile press, position press, "View more") redirect to the tutorial with `redirectScreen` and `redirectParams` so the user lands on the originally intended screen after completing the tutorial. If the user has already completed the tutorial, navigation proceeds directly.
- **PerpsTutorialCarousel:** Reads `redirectScreen` and `redirectParams` from route params. After tutorial completion (or skip), navigates to the redirect target instead of always going to Perps Home. Uses `StackActions.replace` instead of `navigate` so the tutorial screen is removed from the navigation stack — pressing back won't return to the tutorial.
- **Navigation types:** Added `redirectScreen` and `redirectParams` to `PerpsTutorial` route params.

**Tests:** Unit tests added/updated for PerpsSection (first-time user tutorial redirect for each interaction type) and PerpsTutorialCarousel (redirect with params, redirect without params, skip redirect, fallback to default).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where tapping perpetuals items on the homepage did not show the tutorial for first-time users

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-566

## **Manual testing steps**

```gherkin
Feature: Homepage Perpetuals section triggers tutorial for first-time users

  Scenario: first-time user taps a market tile on the homepage perps section
    Given the user has never completed the perps tutorial
    And the Perpetuals section is visible on the homepage with trending markets

    When the user taps a market tile (e.g. SOL)
    Then the perps tutorial carousel is displayed
    And after completing or skipping the tutorial, the user lands on the Market Details screen for that market

  Scenario: first-time user taps "View more" on the homepage perps section
    Given the user has never completed the perps tutorial
    And the Perpetuals section is visible on the homepage

    When the user taps the "View more" card
    Then the perps tutorial carousel is displayed
    And after completing or skipping the tutorial, the user lands on the Market List screen

  Scenario: first-time user taps the Perpetuals section title
    Given the user has never completed the perps tutorial

    When the user taps the "Perpetuals" title
    Then the perps tutorial carousel is displayed
    And after completing or skipping the tutorial, the user lands on Perps Home

  Scenario: first-time user taps a position row on the homepage perps section
    Given the user has never completed the perps tutorial
    And the user has open positions shown in the Perpetuals section

    When the user taps a position row (e.g. BTC)
    Then the perps tutorial carousel is displayed
    And after completing or skipping the tutorial, the user lands on Market Details with the position tab selected

  Scenario: returning user navigates directly without tutorial
    Given the user has already completed the perps tutorial

    When the user taps any item in the Perpetuals section
    Then the user navigates directly to the target screen without seeing the tutorial

  Scenario: back navigation does not return to tutorial
    Given the user just completed the tutorial and was redirected to a perps screen

    When the user presses the back button
    Then the user does NOT return to the tutorial screen (it was replaced in the stack)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
`selectIsFirstTimePerpsUser` was mocked to be true

https://github.com/user-attachments/assets/895b5c4e-3127-4127-8c5d-b2dc99331c6b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation behavior for first-time perps users and replaces screens in the navigation stack, which could impact routing/back behavior if params are wrong or screens aren’t in the expected stack.
> 
> **Overview**
> Ensures first-time Perps users who tap items in the homepage Perpetuals section are routed through the tutorial first, then **redirected to their originally intended Perps destination** (home, market list, or market details) using new `redirectScreen`/`redirectParams` route params.
> 
> Updates the tutorial completion/skip flow to `StackActions.replace` into `Routes.PERPS.ROOT` (removing the tutorial from back stack) and adds test coverage for redirect cases and first-time-user homepage interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c43f6310c0234c44bb64a1f3681af59f56cf56d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->