### PR TITLE
fix(homepage): show skeleton loading state in tokens section

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton.tsx
@@ -23,7 +23,11 @@ const createStyles = (colors: Colors) =>
     },
   });
 
-const TokenListSkeleton = () => {
+interface TokenListSkeletonProps {
+  count?: number;
+}
+
+const TokenListSkeleton = ({ count = 10 }: TokenListSkeletonProps) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
@@ -33,7 +37,7 @@ const TokenListSkeleton = () => {
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}
       >
-        {Array.from({ length: 10 }, (_, index) => (
+        {Array.from({ length: count }, (_, index) => (
           <View key={index} style={styles.skeletonItem}>
             {/* Token icon skeleton */}
             <SkeletonPlaceholder.Item

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -93,13 +93,15 @@ jest.mock(
 
 jest.mock('react-native-skeleton-placeholder', () => {
   const { View } = jest.requireActual('react-native');
-  return function MockSkeletonPlaceholder({
+  const MockSkeletonPlaceholder = ({
     children,
   }: {
     children: React.ReactNode;
-  }) {
-    return <View testID="skeleton-placeholder">{children}</View>;
-  };
+  }) => <View testID="skeleton-placeholder">{children}</View>;
+  MockSkeletonPlaceholder.Item = (props: Record<string, unknown>) => (
+    <View {...props} />
+  );
+  return MockSkeletonPlaceholder;
 });
 
 jest.mock('../../UI/Predict/selectors/featureFlags', () => ({

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -219,7 +219,7 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
             </SectionRow>
           ) : (
             <SectionRow>
-              {displayTokenKeys.length === 0 ? (
+              {displayTokenKeys.length === 0 && sortedTokenKeys.length === 0 ? (
                 <TokenListSkeleton count={MAX_TOKENS_DISPLAYED} />
               ) : (
                 displayTokenKeys.map((tokenKey, index) => (

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -36,6 +36,7 @@ import { SolScope } from '@metamask/keyring-api';
 import { toHex } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 import { refreshTokens } from '../../../../UI/Tokens/util/refreshTokens';
+import TokenListSkeleton from '../../../../UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton';
 import { useRemoveToken } from '../../../../UI/Tokens/hooks/useRemoveToken';
 import useHomeViewedEvent, {
   HomeSectionNames,
@@ -218,17 +219,21 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
             </SectionRow>
           ) : (
             <SectionRow>
-              {displayTokenKeys.map((tokenKey, index) => (
-                <ListItemComponent
-                  key={`${tokenKey.chainId}-${tokenKey.address}-${tokenKey.isStaked ? 'staked' : 'unstaked'}-${index}`}
-                  assetKey={tokenKey}
-                  showRemoveMenu={showRemoveMenu}
-                  setShowScamWarningModal={setShowScamWarningModal}
-                  privacyMode={privacyMode}
-                  showPercentageChange
-                  shouldShowTokenListItemCta={shouldShowTokenListItemCta}
-                />
-              ))}
+              {displayTokenKeys.length === 0 ? (
+                <TokenListSkeleton count={MAX_TOKENS_DISPLAYED} />
+              ) : (
+                displayTokenKeys.map((tokenKey, index) => (
+                  <ListItemComponent
+                    key={`${tokenKey.chainId}-${tokenKey.address}-${tokenKey.isStaked ? 'staked' : 'unstaked'}-${index}`}
+                    assetKey={tokenKey}
+                    showRemoveMenu={showRemoveMenu}
+                    setShowScamWarningModal={setShowScamWarningModal}
+                    privacyMode={privacyMode}
+                    showPercentageChange
+                    shouldShowTokenListItemCta={shouldShowTokenListItemCta}
+                  />
+                ))
+              )}
             </SectionRow>
           )}
         </Box>


### PR DESCRIPTION
## **Description**

Show `TokenListSkeleton` shimmer rows while the token controller is still loading data, instead of briefly rendering an empty token list on the homepage. This fixes a flash of empty content when the account has a non-zero balance but `displayTokenKeys` hasn't been populated yet.

Changes:
- Add an optional `count` prop to `TokenListSkeleton` (defaults to `10`) so callers can control the number of shimmer rows
- In `TokensSection`, render `<TokenListSkeleton count={MAX_TOKENS_DISPLAYED} />` when the account has balance but token keys are empty (controller still loading)
- Fix the `react-native-skeleton-placeholder` mock in `Homepage.test.tsx` to include `.Item` so `TokenListSkeleton` renders correctly in tests

## **Changelog**

CHANGELOG entry: Fixed a brief flash of empty content in the Tokens section while token data loads on the homepage.

## **Related issues**

https://consensyssoftware.atlassian.net/browse/TMCU-567

## **Manual testing steps**

```gherkin
Feature: Tokens section loading state

  Scenario: user opens the homepage before token data loads
    Given the user has tokens in their wallet
    And the homepage is loading

    When the token controller has not yet populated the token list
    Then the Tokens section shows shimmer skeleton rows
    And the skeleton rows match the max display count

  Scenario: user opens the homepage after token data loads
    Given the user has tokens in their wallet

    When the token controller has finished loading
    Then the Tokens section shows the actual token list rows
```

## **Screenshots/Recordings**

### **Before**

<img width="300" src="https://github.com/user-attachments/assets/7a0859f8-5673-4fe2-805a-de05fe654234" />

### **After**

<img width="300" src="https://github.com/user-attachments/assets/a9465e5a-2b19-4644-beea-4352b961179e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts conditional rendering in the homepage Tokens section and updates a Jest mock; main risk is minor regressions in when the skeleton vs. empty/error states appear.
> 
> **Overview**
> Prevents a brief flash of an empty Tokens section on the homepage by rendering `TokenListSkeleton` when both `displayTokenKeys` and `sortedTokenKeys` are still empty (initial token-controller load).
> 
> Adds a `count` prop to `TokenListSkeleton` (default `10`) so callers can match the shimmer row count (homepage uses `MAX_TOKENS_DISPLAYED`), and updates the `react-native-skeleton-placeholder` test mock to include `.Item` so skeleton rendering works in `Homepage.test.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0dabc471d823f95e5672460ac0112ca2756ca48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->