### PR TITLE
fix: GE-148 fetch params when reconstructing URI from Branch

### DIFF
--- a/app/core/DeeplinkManager/DeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.test.ts
@@ -312,6 +312,89 @@ describe('rewriteBranchUri', () => {
       rewriteBranchUri(uri, { '+clicked_branch_link': true } as BranchParams),
     ).toBe(uri);
   });
+
+  it('merges custom data from Branch params onto the URL for deferred deeplinks', () => {
+    const uri = 'https://metamask-alternate.app.link/AbCdEf123';
+    const params: BranchParams = {
+      '+clicked_branch_link': true,
+      '+is_first_session': true,
+      $deeplink_path: 'buy',
+      '~channel': 'marketing',
+      address: '0xabc',
+      amount: '100',
+      chainid: '1',
+      utm_source: 'rewards',
+      utm_campaign: 'musd_launch',
+    };
+    const result = rewriteBranchUri(uri, params);
+    expect(result).toBeDefined();
+    const resultUrl = new URL(result as string);
+    expect(resultUrl.origin + resultUrl.pathname).toBe(
+      'https://link.metamask.io/buy',
+    );
+    expect(resultUrl.searchParams.get('address')).toBe('0xabc');
+    expect(resultUrl.searchParams.get('amount')).toBe('100');
+    expect(resultUrl.searchParams.get('chainid')).toBe('1');
+    expect(resultUrl.searchParams.get('utm_source')).toBe('rewards');
+    expect(resultUrl.searchParams.get('utm_campaign')).toBe('musd_launch');
+  });
+
+  it('does not overwrite URI query params with Branch params', () => {
+    const uri = 'https://metamask-alternate.app.link/AbCdEf123?amount=500';
+    const params: BranchParams = {
+      '+clicked_branch_link': true,
+      $deeplink_path: 'buy',
+      amount: '100',
+      utm_source: 'twitter',
+    };
+    const result = rewriteBranchUri(uri, params);
+    expect(result).toBeDefined();
+    const resultUrl = new URL(result as string);
+    // URI param takes precedence
+    expect(resultUrl.searchParams.get('amount')).toBe('500');
+    // Branch custom data still added for keys not on the URI
+    expect(resultUrl.searchParams.get('utm_source')).toBe('twitter');
+  });
+
+  it('skips Branch internal keys prefixed with +, ~, $', () => {
+    const uri = 'https://metamask-alternate.app.link/AbCdEf123';
+    const params: BranchParams = {
+      '+clicked_branch_link': true,
+      '+is_first_session': true,
+      '+match_guaranteed': true,
+      '~channel': 'marketing',
+      '~feature': 'deeplink',
+      $deeplink_path: 'swap',
+      $canonical_url: 'https://example.com',
+      BNCUpdateStateInstall: 1,
+      utm_source: 'email',
+    };
+    const result = rewriteBranchUri(uri, params);
+    expect(result).toBeDefined();
+    const resultUrl = new URL(result as string);
+    // Only custom data key should be present
+    expect(resultUrl.searchParams.get('utm_source')).toBe('email');
+    expect(resultUrl.searchParams.has('BNCUpdateStateInstall')).toBe(false);
+    // Branch internal keys should not appear
+    expect(result).not.toContain('clicked_branch_link');
+    expect(result).not.toContain('channel');
+    expect(result).not.toContain('canonical_url');
+  });
+
+  it('handles numeric and boolean custom data values', () => {
+    const uri = 'https://metamask-alternate.app.link/AbCdEf123';
+    const params: BranchParams = {
+      '+clicked_branch_link': true,
+      $deeplink_path: 'buy',
+      chainid: 1 as unknown as string,
+      debug: true as unknown as string,
+    };
+    const result = rewriteBranchUri(uri, params);
+    expect(result).toBeDefined();
+    const resultUrl = new URL(result as string);
+    expect(resultUrl.searchParams.get('chainid')).toBe('1');
+    expect(resultUrl.searchParams.get('debug')).toBe('true');
+  });
 });
 
 describe('DeeplinkManager.start Branch deeplink handling', () => {
@@ -348,6 +431,26 @@ describe('DeeplinkManager.start Branch deeplink handling', () => {
     expect(handleDeeplink).toHaveBeenCalledWith({
       uri: 'https://link.metamask.io/swap?amount=500',
     });
+  });
+
+  it('merges Branch custom data (including UTMs) onto cold start deferred deeplink', async () => {
+    (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({
+      '+clicked_branch_link': true,
+      '+is_first_session': true,
+      $deeplink_path: 'buy',
+      '~referring_link': 'https://metamask-alternate.app.link/AbCdEf123',
+      address: '0xabc',
+      utm_source: 'rewards',
+      utm_campaign: 'musd_launch',
+    });
+    DeeplinkManager.start();
+    await new Promise((resolve) => setImmediate(resolve));
+    const calledUri = (handleDeeplink as jest.Mock).mock.calls[0][0].uri;
+    const parsed = new URL(calledUri);
+    expect(parsed.pathname).toBe('/buy');
+    expect(parsed.searchParams.get('address')).toBe('0xabc');
+    expect(parsed.searchParams.get('utm_source')).toBe('rewards');
+    expect(parsed.searchParams.get('utm_campaign')).toBe('musd_launch');
   });
 
   it('falls back to +non_branch_link on cold start when +clicked_branch_link is false', async () => {
@@ -392,6 +495,35 @@ describe('DeeplinkManager.start Branch deeplink handling', () => {
     expect(handleDeeplink).toHaveBeenCalledWith({
       uri: 'https://link.metamask.io/swap?amount=1000000&from=eip155%3A1%2Ferc20%3A0xabc',
     });
+  });
+
+  it('merges Branch custom data including UTMs onto subscription deeplink', async () => {
+    DeeplinkManager.start();
+    const callback = (branch.subscribe as jest.Mock).mock.calls[0][0];
+
+    callback({
+      uri: 'https://metamask-alternate.app.link/AbCdEf123',
+      params: {
+        '+clicked_branch_link': true,
+        '+is_first_session': true,
+        $deeplink_path: 'swap',
+        from: 'eip155:1/slip44:60',
+        to: 'eip155:1/erc20:0xabc',
+        utm_source: 'rewards',
+        utm_campaign: 'swap_promo',
+      },
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    const calledUri = (handleDeeplink as jest.Mock).mock.calls[0][0].uri;
+    const parsed = new URL(calledUri);
+    expect(parsed.origin + parsed.pathname).toBe(
+      'https://link.metamask.io/swap',
+    );
+    expect(parsed.searchParams.get('from')).toBe('eip155:1/slip44:60');
+    expect(parsed.searchParams.get('to')).toBe('eip155:1/erc20:0xabc');
+    expect(parsed.searchParams.get('utm_source')).toBe('rewards');
+    expect(parsed.searchParams.get('utm_campaign')).toBe('swap_promo');
   });
 
   it('passes URI through unchanged when +clicked_branch_link is false', async () => {

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -14,6 +14,11 @@ import { BranchParams } from './types/deepLinkAnalytics.types';
  * the URI path may be link ID, not an in-app route. If the resolved params indicate
  * a clicked Branch link with a $deeplink_path, replace the host and path segment
  * with link.metamask.io/$deeplink_path while preserving the original query string.
+ *
+ * For deferred deeplinks (app installed via Branch link), the original URL's query
+ * parameters are stored as custom data in Branch params rather than on the URI itself.
+ * This function merges those custom data keys onto the reconstructed URL so that
+ * UTM parameters and other query params flow downstream to handlers and analytics.
  */
 export function rewriteBranchUri(
   uri: string | undefined,
@@ -26,8 +31,31 @@ export function rewriteBranchUri(
 
     const parsed = new URL(uri);
     parsed.host = AppConstants.MM_IO_UNIVERSAL_LINK_HOST;
-    // Set the pathname to the sanitized $deeplink_path
     parsed.pathname = `/${rawPath.replace(/^\//, '')}`;
+
+    // Merge custom data from Branch params onto the URL.
+    // Branch stores the original link's query parameters as top-level keys.
+    // Skip Branch internal keys (prefixed with +, ~, $) and known Branch metadata.
+    for (const [key, value] of Object.entries(params)) {
+      if (
+        key.startsWith('+') ||
+        key.startsWith('~') ||
+        key.startsWith('$') ||
+        key === 'BNCUpdateStateInstall'
+      ) {
+        continue;
+      }
+      // Only add params that aren't already on the URL (URI params take precedence)
+      if (
+        !parsed.searchParams.has(key) &&
+        (typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean')
+      ) {
+        parsed.searchParams.set(key, String(value));
+      }
+    }
+
     return parsed.toString();
   } catch (error) {
     Logger.error(error as Error, `Error rewriting Branch URI: ${uri}`);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Problem: When Branch resolves a deferred deeplink (user installs the app from a Branch link), rewriteBranchUri reconstructed the URL using only $deeplink_path (e.g., buy) and the short link's host/query. But the short link URL (e.g., https://metamask-alternate.app.link/AbCdEf123) has no query parameters — Branch stores the original link's query parameters (address, amount, utm_source, utm_campaign, etc.) as custom data keys in the params object. These were being completely discarded.

Fix in rewriteBranchUri: After setting the host and path, the function now iterates over all keys in the Branch params and merges custom data keys onto the reconstructed URL as query parameters. It:

Skips Branch internal keys — anything prefixed with + (system keys like +clicked_branch_link), ~ (metadata like ~channel), $ (control params like $deeplink_path), or the known BNCUpdateStateInstall key.

Preserves URI precedence — if a param already exists on the URI (from the original short link URL), it won't be overwritten by the Branch custom data.

Handles primitive types — only string, number, and boolean values are added (no objects/arrays).

This ensures that UTM parameters (utm_source, utm_campaign, etc.) and all other query parameters flow through to handleDeeplink, which passes them to extractURLParams and ultimately to createDeepLinkUsedEventBuilder for analytics capture — the same path that non-deferred deeplinks already take.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-148

## **Manual testing steps**

```gherkin
Feature: fetch params for deferred deeplinks

  Scenario: user taps on a deeplink to MetaMask
    Given the app is not installed, and the deeplink has parameters

    When user finishes installing the app
    Then the deeplink handler includes the original parameters when navigating to the destination
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Branch deeplinks are reconstructed by merging Branch custom-data keys into the rewritten URL, which can affect routing and downstream analytics parameters. Low surface area but touches core deeplink entrypoints (cold start + subscription).
> 
> **Overview**
> Fixes deferred Branch deeplink reconstruction by having `rewriteBranchUri` **merge Branch custom-data params (e.g., UTMs, address/amount)** into the rebuilt `link.metamask.io/$deeplink_path` URL, while **skipping Branch internal keys**, **not overwriting existing URI query params**, and only accepting primitive values.
> 
> Expands tests to cover the new merge behavior for both direct `rewriteBranchUri` usage and `DeeplinkManager.start()` flows (cold start `getLatestReferringParams` and `branch.subscribe`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ba72281199872261a833ffbef86484676d6a2c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->