### PR TITLE
fix: Updated root pages scrollable behavior with safeareaview cp-7.69.1 cp-7.70.0

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -331,13 +331,12 @@ const RewardsDashboard: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="RewardsView">
       <SafeAreaView
-        edges={{ bottom: 'additive' }}
+        edges={{ top: 'additive' }}
         style={tw.style('flex-1 bg-default')}
         testID={REWARDS_VIEW_SELECTORS.SAFE_AREA_VIEW}
       >
         <HeaderRoot
           title={strings('rewards.main_title')}
-          includesTopInset
           endButtonIconProps={[
             {
               iconName: IconName.Setting,

--- a/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
@@ -315,10 +315,10 @@ exports[`ActivityView matches snapshot 1`] = `
                     <RNCSafeAreaView
                       edges={
                         {
-                          "bottom": "additive",
+                          "bottom": "off",
                           "left": "off",
                           "right": "off",
-                          "top": "off",
+                          "top": "additive",
                         }
                       }
                       style={
@@ -346,9 +346,7 @@ exports[`ActivityView matches snapshot 1`] = `
                               "paddingLeft": 16,
                               "paddingRight": 8,
                             },
-                            {
-                              "marginTop": 0,
-                            },
+                            false,
                             undefined,
                           ]
                         }

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -167,7 +167,7 @@ const ActivityView = () => {
   return (
     <ErrorBoundary navigation={navigation} view="ActivityView">
       <SafeAreaView
-        edges={{ bottom: 'additive' }}
+        edges={{ top: 'additive' }}
         style={[
           tw.style('flex-1'),
           { backgroundColor: colors.background.default },
@@ -178,14 +178,12 @@ const ActivityView = () => {
           <HeaderCompactStandard
             title={strings('activity_view.title')}
             onBack={handleBackPress}
-            includesTopInset
             backButtonProps={{ testID: 'activity-view-back-button' }}
             testID={ActivitiesViewSelectorsIDs.HEADER_COMPACT_STANDARD}
           />
         ) : (
           <HeaderRoot
             title={strings('activity_view.title')}
-            includesTopInset
             testID={ActivitiesViewSelectorsIDs.HEADER_ROOT}
           />
         )}

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -185,13 +185,12 @@ export const ExploreFeed: React.FC = () => {
 
   return (
     <SafeAreaView
-      edges={{ bottom: 'additive' }}
+      edges={{ top: 'additive' }}
       style={tw.style('flex-1 bg-default')}
       testID={TrendingViewSelectorsIDs.EXPLORE_SAFE_AREA}
     >
       <HeaderRoot
         title={strings('trending.title')}
-        includesTopInset
         testID={TrendingViewSelectorsIDs.EXPLORE_HEADER_ROOT}
       />
 

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1539,13 +1539,12 @@ const Wallet = ({
             baseStyles.flexGrow,
             { backgroundColor: colors.background.default },
           ]}
-          edges={{ bottom: 'additive' }}
+          edges={{ top: 'additive' }}
           testID={WalletViewSelectorsIDs.WALLET_SAFE_AREA}
         >
           {selectedInternalAccount ? (
             <>
               <HeaderRoot
-                includesTopInset
                 testID={WalletViewSelectorsIDs.WALLET_HEADER_ROOT}
                 endAccessory={
                   <View style={styles.headerEndAccessoryContainer}>

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -24,7 +24,6 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import LinearGradient from 'react-native-linear-gradient';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import {
@@ -149,7 +148,6 @@ import { useMultichainAccountsIntroModal } from '../../hooks/useMultichainAccoun
 import { useAccountsWithNetworkActivitySync } from '../../hooks/useAccountsWithNetworkActivitySync';
 import { selectUseTokenDetection } from '../../../selectors/preferencesController';
 import Logger from '../../../util/Logger';
-import { colorWithOpacity } from '../../../util/colors';
 import { useNftDetection } from '../../hooks/useNftDetection';
 import { Carousel } from '../../UI/Carousel';
 import { TokenI } from '../../UI/Tokens/types';
@@ -227,13 +225,6 @@ const createStyles = ({ colors }: Theme) =>
     },
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
-    },
-    bottomFadeOverlay: {
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      bottom: 0,
-      height: 40,
     },
     headerEndAccessoryContainer: {
       alignItems: 'flex-end',
@@ -642,10 +633,6 @@ const Wallet = ({
   const scrollSubscribersRef = useRef<Set<() => void>>(new Set());
   // Tracks which sections have been viewed this visit (reset on each focus).
   const viewedSectionsRef = useRef<Set<string>>(new Set());
-  const scrollContentHeightRef = useRef(0);
-  const scrollYRef = useRef(0);
-  const lastBottomFadeOpacityRef = useRef(0);
-  const [bottomFadeOpacity, setBottomFadeOpacity] = useState(0);
   // ─────────────────────────────────────────────────────────────────────────
 
   const isPerpsFlagEnabled = useSelector(selectPerpsEnabledFlag);
@@ -1082,44 +1069,6 @@ const Wallet = ({
       scrollSubscribersRef.current.forEach((cb) => cb());
     }
   }, [isHomepageSectionsV1Enabled]);
-
-  const handleScrollWithFade = useCallback(
-    (e: {
-      nativeEvent: {
-        contentOffset: { y: number };
-        contentSize: { height: number };
-        layoutMeasurement: { height: number };
-      };
-    }) => {
-      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
-      scrollContentHeightRef.current = contentSize.height;
-      scrollYRef.current = contentOffset.y;
-      handleHomepageScroll();
-      if (!isHomepageSectionsV1Enabled) return;
-      const remaining =
-        contentSize.height - contentOffset.y - layoutMeasurement.height;
-      const nextOpacity = remaining > 20 ? Math.min(1, remaining / 80) : 0;
-      if (Math.abs(nextOpacity - lastBottomFadeOpacityRef.current) > 0.05) {
-        lastBottomFadeOpacityRef.current = nextOpacity;
-        setBottomFadeOpacity(nextOpacity);
-      }
-    },
-    [handleHomepageScroll, isHomepageSectionsV1Enabled],
-  );
-
-  const handleScrollContentSizeChange = useCallback(
-    (_w: number, contentHeight: number) => {
-      scrollContentHeightRef.current = contentHeight;
-      if (!isHomepageSectionsV1Enabled || viewportHeight <= 0) return;
-      const remaining = contentHeight - scrollYRef.current - viewportHeight;
-      const nextOpacity = remaining > 20 ? Math.min(1, remaining / 80) : 0;
-      if (Math.abs(nextOpacity - lastBottomFadeOpacityRef.current) > 0.05) {
-        lastBottomFadeOpacityRef.current = nextOpacity;
-        setBottomFadeOpacity(nextOpacity);
-      }
-    },
-    [isHomepageSectionsV1Enabled, viewportHeight],
-  );
 
   const touchAreaSlop = useMemo(
     () => ({ top: 12, bottom: 12, left: 12, right: 12 }),
@@ -1683,10 +1632,7 @@ const Wallet = ({
                     contentContainerStyle: scrollViewContentStyle,
                     showsVerticalScrollIndicator: false,
                     onScroll: isHomepageSectionsV1Enabled
-                      ? handleScrollWithFade
-                      : undefined,
-                    onContentSizeChange: isHomepageSectionsV1Enabled
-                      ? handleScrollContentSizeChange
+                      ? handleHomepageScroll
                       : undefined,
                     scrollEventThrottle: 16,
                     refreshControl: shouldEnableParentScroll ? (
@@ -1701,21 +1647,6 @@ const Wallet = ({
                 >
                   {content}
                 </ConditionalScrollView>
-                {isHomepageSectionsV1Enabled && bottomFadeOpacity > 0 && (
-                  <LinearGradient
-                    pointerEvents="none"
-                    colors={[
-                      colorWithOpacity(colors.background.default, 0),
-                      colors.background.default,
-                    ]}
-                    start={{ x: 0, y: 0 }}
-                    end={{ x: 0, y: 1 }}
-                    style={[
-                      styles.bottomFadeOverlay,
-                      { opacity: bottomFadeOpacity },
-                    ]}
-                  />
-                )}
               </View>
             </>
           ) : (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Standardizes safe area and header inset behavior across the main tab views (Wallet, Explore, Activity, Rewards).

1. **Reason for the change:** These views used `edges={{ bottom: 'additive' }}` on `SafeAreaView` and `includesTopInset` on headers, which was inconsistent with the desired layout and could cause double insets or incorrect safe area handling.
2. **Improvement:** Switched to `edges={{ top: 'additive' }}` on `SafeAreaView` and removed `includesTopInset` from header components so the top safe area is handled by the screen container and headers align consistently.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27443 

## **Manual testing steps**

```gherkin
Feature: Safe area and header insets on main tabs

  Scenario: Wallet, Explore, Activity, and Rewards use consistent safe area
    Given the app is open on a device or simulator with a notch/safe area

    When the user switches to each main tab (Wallet, Explore, Activity, Rewards)
    Then the top safe area is applied by the screen (no double inset)
    And the header (title + accessories) aligns correctly below the safe area
    And the bottom of each view respects the tab bar / device safe area as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/0eda5978-7bd5-4428-86ea-f62637fb06ed


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/a8ff8e19-a49e-41f4-9056-7c2271da8c66


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout-only changes to core tab screens (Wallet/Explore/Activity/Rewards) that can affect safe-area padding and scroll behavior across devices, plus removal of Wallet’s bottom fade/scroll tracking logic which could subtly change UX on the homepage.
> 
> **Overview**
> Standardizes safe-area handling across the main tab views by switching root `SafeAreaView` usage from `edges={{ bottom: 'additive' }}` to `edges={{ top: 'additive' }}` and removing header `includesTopInset` so the top inset is applied consistently by the screen container.
> 
> In `Wallet`, removes the bottom fade `LinearGradient` overlay and its associated scroll/size tracking state, simplifying scroll handling to just notify homepage section subscribers via `handleHomepageScroll`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4b0e412d39fdeac5095c0e006c37a258fa3ced9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->