### PR TITLE
refactor: migrate Text to design system in swaps-engineers components

### DIFF
--- a/app/components/UI/Bridge/components/BlockaidModal/BlockaidModal.tsx
+++ b/app/components/UI/Bridge/components/BlockaidModal/BlockaidModal.tsx
@@ -7,9 +7,7 @@ import BottomSheet, {
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import BottomSheetFooter from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
 import {
   ButtonSize,
   ButtonVariants,
@@ -24,9 +22,6 @@ const createStyles = () =>
     footer: {
       paddingVertical: 20,
       paddingHorizontal: 16,
-    },
-    errorMessage: {
-      textAlign: 'center',
     },
   });
 
@@ -62,7 +57,7 @@ const BlockaidModal = () => {
         {strings(`blockaid_modal.${errorType}_title`)}
       </BottomSheetHeader>
       <View style={styles.container}>
-        <Text variant={TextVariant.BodyMD} style={styles.errorMessage}>
+        <Text variant={TextVariant.BodyMd} twClassName="text-center">
           {errorMessage}
         </Text>
       </View>

--- a/app/components/UI/Bridge/components/QuoteCountdownTimer/QuoteCountdownTimer.tsx
+++ b/app/components/UI/Bridge/components/QuoteCountdownTimer/QuoteCountdownTimer.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import Text, {
+import {
+  Box,
+  Text,
   TextColor,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
-import { Box } from '@metamask/design-system-react-native';
+} from '@metamask/design-system-react-native';
 import {
   selectBridgeControllerState,
   selectBridgeFeatureFlags,
@@ -68,7 +69,7 @@ const QuoteCountdownTimer: React.FC = () => {
 
   return (
     <Box style={styles.container}>
-      <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+      <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
         {`0:${formattedSeconds}`}
       </Text>
     </Box>

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -406,13 +406,17 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                 <Text
                                   accessibilityRole="text"
                                   style={
-                                    {
-                                      "color": "#66676a",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#66676a",
+                                        "fontFamily": "Geist-Regular",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   0:30

--- a/app/components/UI/Bridge/components/TokenButton.tsx
+++ b/app/components/UI/Bridge/components/TokenButton.tsx
@@ -4,9 +4,11 @@ import {
   ImageSourcePropType,
   TouchableOpacity,
 } from 'react-native';
-import Text, {
+import {
+  FontWeight,
+  Text,
   TextVariant,
-} from '../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../component-library/hooks';
 import { Theme } from '../../../../util/theme/models';
 import { Box } from '../../Box/Box';
@@ -49,11 +51,6 @@ const createStyles = (params: StylesParams) => {
       paddingRight: 11,
       ...shadows.size.xs,
     },
-    tokenSymbol: {
-      color: theme.colors.text.default,
-      fontSize: theme.typography.sHeadingLG.fontSize,
-      fontWeight: 500,
-    },
   });
 };
 
@@ -88,7 +85,7 @@ export const TokenButton: React.FC<TokenProps> = ({
           <TokenIcon symbol={symbol} icon={iconUrl} style={styles.icon} />
         </BadgeWrapper>
 
-        <Text style={styles.tokenSymbol} variant={TextVariant.HeadingLG}>
+        <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Medium}>
           {symbol}
         </Text>
       </Box>

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import Text, {
+import {
+  FontWeight,
   TextColor,
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
 import {
   AlignItems,
   FlexDirection,
@@ -110,13 +112,14 @@ const TransactionAsset = ({
         flexDirection={FlexDirection.Column}
         gap={2}
       >
-        <Text variant={TextVariant.BodyLGMedium}>
+        <Text variant={TextVariant.BodyLg} fontWeight={FontWeight.Medium}>
           {tokenAmount} {token.symbol}
         </Text>
         {txType === TransactionType.bridge && (
           <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
             style={styles.networkName}
           >
             {networkName}


### PR DESCRIPTION
## **Description**

Migrates deprecated Text components to @metamask/design-system-react-native in the
@MetaMask/swaps-engineers code owner paths. Part of the ongoing #6887 migration.

Files migrated:
- app/components/UI/Bridge/components/BlockaidModal/BlockaidModal.tsx
- app/components/UI/Bridge/components/QuoteCountdownTimer/QuoteCountdownTimer.tsx
- app/components/UI/Bridge/components/TokenButton.tsx
- app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx

**What:** Replace app/component-library/components/Texts/Text
imports with Text from @metamask/design-system-react-native.

**Why:** Part of https://github.com/MetaMask/metamask-mobile/issues/6887 — eliminating
deprecated internal Text wrappers in favour of the shared design system component.

 [!NOTE]
 This PR was produced by the migrate-text-component automation.

## **Changelog**

CHANGELOG entry: null (internal refactor, no user-visible change)

## **Related issues**

Part of: https://github.com/MetaMask/metamask-mobile/issues/6887

## **Manual testing steps**

Feature: Text migration visual parity

  Scenario: user views affected screens
    Given the app is open
    When the user navigates to the screen(s) affected by the changed files
    Then all text renders correctly with the same visual appearance as before

## **Screenshots/Recordings**

N/A — styling parity migration, no visual change intended.
(If a visual difference is noticed, add before/after screenshots.)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR. Not required for external contributors.

## **Pre-merge reviewer checklist**- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to UI text rendering; main risk is minor visual/style regressions due to updated `TextVariant`/`TextColor` mappings and moved alignment/font-weight styling.
> 
> **Overview**
> Migrates several Bridge UI components off the deprecated internal `component-library` `Text` wrapper to `@metamask/design-system-react-native` `Text`.
> 
> Updates text styling to the design-system API (e.g., `TextVariant`/`TextColor` renames, `fontWeight` props, and `twClassName` for centering) and removes now-redundant local text styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d3829f8de31d666473a20ba4b74bd8fd72e6d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->