### PR TITLE
feat: MUSD-508 align earn balance rows with parent asset layout and add privacy mode support

### DIFF
--- a/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
+++ b/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
@@ -1,4 +1,8 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, TextStyle } from 'react-native';
+import {
+  getFontFamily,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
 import { Theme } from '../../../../../util/theme/models';
 
 const styleSheet = (params: {
@@ -16,10 +20,7 @@ const styleSheet = (params: {
       gap: 16,
     },
     buttonsContainer: {
-      marginTop: 16,
-      padding: 16,
       borderRadius: 12,
-      backgroundColor: theme.colors.background.section,
     },
     button: {
       flex: 1,
@@ -29,10 +30,16 @@ const styleSheet = (params: {
     },
     balances: {
       flex: 1,
-      justifyContent: 'center',
-      marginLeft: 16,
-      alignSelf: 'center',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      alignContent: 'flex-start',
+      paddingLeft: 16,
     },
+    tokenAmount: {
+      ...theme.typography.sBodySM,
+      fontFamily: getFontFamily(TextVariant.BodySM),
+      color: theme.colors.text.alternative,
+    } as TextStyle,
     musdConversionCta: {
       paddingTop: 16,
       paddingBottom: userHasLendingPositions ? 8 : 0,
@@ -41,7 +48,6 @@ const styleSheet = (params: {
       paddingTop: 16,
     },
     earnings: {
-      paddingHorizontal: 16,
       paddingTop: 16,
     },
   });

--- a/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
+++ b/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
@@ -1,8 +1,4 @@
 import { StyleSheet, TextStyle } from 'react-native';
-import {
-  getFontFamily,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { Theme } from '../../../../../util/theme/models';
 
 const styleSheet = (params: {
@@ -37,7 +33,6 @@ const styleSheet = (params: {
     },
     tokenAmount: {
       ...theme.typography.sBodySM,
-      fontFamily: getFontFamily(TextVariant.BodySM),
       color: theme.colors.text.alternative,
     } as TextStyle,
     musdConversionCta: {

--- a/app/components/UI/Earn/components/EarnLendingBalance/__snapshots__/EarnLendingBalance.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnLendingBalance/__snapshots__/EarnLendingBalance.test.tsx.snap
@@ -87,13 +87,17 @@ exports[`EarnLendingBalance does renders earnings for output tokens 1`] = `
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Withdraw
@@ -602,13 +606,17 @@ exports[`EarnLendingBalance renders balance and buttons when user has lending po
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Withdraw
@@ -685,13 +693,17 @@ exports[`EarnLendingBalance renders balance and buttons when user has lending po
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Deposit more

--- a/app/components/UI/Earn/components/EarnLendingBalance/__snapshots__/EarnLendingBalance.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnLendingBalance/__snapshots__/EarnLendingBalance.test.tsx.snap
@@ -12,59 +12,98 @@ exports[`EarnLendingBalance does renders earnings for output tokens 1`] = `
           "paddingTop": 14,
         },
         {
-          "backgroundColor": "#f3f3f4",
           "borderRadius": 12,
-          "marginTop": 16,
-          "padding": 16,
         },
       ]
     }
   >
-    <TouchableOpacity
+    <View
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 40,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "flex": 1,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
       testID="withdraw-button"
     >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#131416",
-            "fontFamily": "Geist-Medium",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
-        }
+      <View
+        style={{}}
       >
-        Withdraw
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#131416",
+              "fontFamily": "Geist-Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Withdraw
+        </Text>
+      </View>
+    </View>
   </View>
   <View
     style={
       {
-        "paddingHorizontal": 16,
         "paddingTop": 16,
       }
     }
@@ -398,10 +437,11 @@ exports[`EarnLendingBalance renders balance and buttons when user has lending po
     <View
       style={
         {
-          "alignSelf": "center",
+          "alignContent": "flex-start",
+          "alignItems": "flex-start",
           "flex": 1,
-          "justifyContent": "center",
-          "marginLeft": 16,
+          "flexDirection": "column",
+          "paddingLeft": 16,
         }
       }
     >
@@ -420,22 +460,21 @@ exports[`EarnLendingBalance renders balance and buttons when user has lending po
       >
         ADAI
       </Text>
-      <View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#457a39",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 14,
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
+      <Text
+        accessibilityRole="text"
+        style={
+          {
+            "color": "#66676a",
+            "fontFamily": "Geist-Regular",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "lineHeight": 22,
           }
-        >
-          +5.20%
-        </Text>
-      </View>
+        }
+      >
+        32.05 ADAI
+      </Text>
     </View>
     <View
       style={
@@ -460,28 +499,22 @@ exports[`EarnLendingBalance renders balance and buttons when user has lending po
       >
         $76.00
       </Text>
-      <TouchableOpacity
-        disabled={true}
-        onPress={[Function]}
-        testID="secondary-balance-button-test-id"
-      >
+      <View>
         <Text
           accessibilityRole="text"
           style={
             {
-              "color": "#66676a",
+              "color": "#457a39",
               "fontFamily": "Geist-Medium",
               "fontSize": 14,
               "letterSpacing": 0,
               "lineHeight": 22,
-              "paddingHorizontal": 0,
             }
           }
-          testID="secondary-balance-test-id"
         >
-          32.05 ADAI
+          +5.20%
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </TouchableOpacity>
   <View
@@ -494,94 +527,177 @@ exports[`EarnLendingBalance renders balance and buttons when user has lending po
           "paddingTop": 14,
         },
         {
-          "backgroundColor": "#f3f3f4",
           "borderRadius": 12,
-          "marginTop": 16,
-          "padding": 16,
         },
       ]
     }
   >
-    <TouchableOpacity
+    <View
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 40,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "flex": 1,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
       testID="withdraw-button"
     >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#131416",
-            "fontFamily": "Geist-Medium",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
-        }
+      <View
+        style={{}}
       >
-        Withdraw
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#131416",
+              "fontFamily": "Geist-Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Withdraw
+        </Text>
+      </View>
+    </View>
+    <View
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flex": 1,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 40,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "flex": 1,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
       testID="deposit-button"
     >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#131416",
-            "fontFamily": "Geist-Medium",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
-        }
+      <View
+        style={{}}
       >
-        Deposit more
-      </Text>
-    </TouchableOpacity>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#131416",
+              "fontFamily": "Geist-Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Deposit more
+        </Text>
+      </View>
+    </View>
   </View>
 </View>
 `;

--- a/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
@@ -48,6 +48,7 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Text as DesignSystemText,
 } from '@metamask/design-system-react-native';
 
 export const EARN_LENDING_BALANCE_TEST_IDS = {
@@ -276,7 +277,7 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
                 {receiptToken.name}
               </Text>
               <SensitiveText
-                variant={TextVariant.BodySMMedium}
+                variant={TextVariant.BodySM}
                 style={styles.tokenAmount}
                 isHidden={privacyMode}
                 length={SensitiveTextLength.Short}
@@ -298,7 +299,7 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
               onPress={handleNavigateToWithdrawalInputScreen}
               testID={EARN_LENDING_BALANCE_TEST_IDS.WITHDRAW_BUTTON}
             >
-              <Text>{strings('earn.withdraw')}</Text>
+              <DesignSystemText>{strings('earn.withdraw')}</DesignSystemText>
             </Button>
           )}
           {userHasUnderlyingTokensAvailableToLend &&
@@ -311,7 +312,9 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
                 onPress={handleNavigateToDepositInputScreen}
                 testID={EARN_LENDING_BALANCE_TEST_IDS.DEPOSIT_BUTTON}
               >
-                <Text>{strings('earn.deposit_more')}</Text>
+                <DesignSystemText>
+                  {strings('earn.deposit_more')}
+                </DesignSystemText>
               </Button>
             )}
         </View>

--- a/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
@@ -14,10 +14,9 @@ import Badge, {
 import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../component-library/components/Texts/SensitiveText';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -26,6 +25,7 @@ import Engine from '../../../../../core/Engine';
 import { RootState } from '../../../../../reducers';
 import { earnSelectors } from '../../../../../selectors/earnController';
 import { selectNetworkConfigurationByChainId } from '../../../../../selectors/networkController';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useStyles } from '../../../../hooks/useStyles';
@@ -44,6 +44,11 @@ import { trace, TraceName } from '../../../../../util/trace';
 import MusdConversionAssetOverviewCta from '../Musd/MusdConversionAssetOverviewCta';
 import useStakingEligibility from '../../../Stake/hooks/useStakingEligibility';
 import { useMusdCtaVisibility } from '../../hooks/useMusdCtaVisibility';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 
 export const EARN_LENDING_BALANCE_TEST_IDS = {
   RECEIPT_TOKEN_BALANCE_ASSET_LOGO: 'receipt-token-balance-asset-logo',
@@ -74,6 +79,7 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
   const isStablecoinLendingEnabled = useSelector(
     selectStablecoinLendingEnabledFlag,
   );
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const navigation = useNavigation();
 
@@ -236,7 +242,11 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
           <AssetElement
             asset={receiptToken as TokenI}
             balance={receiptToken.balanceFiat}
-            secondaryBalance={receiptToken.balanceFormatted}
+            privacyMode={privacyMode}
+            hideSecondaryBalanceInPrivacyMode={false}
+            secondaryBalanceElement={
+              <PercentageChange value={pricePercentChange1d ?? 0} />
+            }
           >
             <BadgeWrapper
               badgePosition={BadgePosition.BottomRight}
@@ -265,7 +275,14 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
               >
                 {receiptToken.name}
               </Text>
-              <PercentageChange value={pricePercentChange1d ?? 0} />
+              <SensitiveText
+                variant={TextVariant.BodySMMedium}
+                style={styles.tokenAmount}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Short}
+              >
+                {receiptToken.balanceFormatted}
+              </SensitiveText>
             </View>
           </AssetElement>
         )}
@@ -275,25 +292,27 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
         <View style={[styles.container, styles.buttonsContainer]}>
           {Boolean(receiptToken) && (
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               style={styles.button}
-              size={ButtonSize.Lg}
-              label={strings('earn.withdraw')}
+              size={ButtonSize.Md}
               onPress={handleNavigateToWithdrawalInputScreen}
               testID={EARN_LENDING_BALANCE_TEST_IDS.WITHDRAW_BUTTON}
-            />
+            >
+              <Text>{strings('earn.withdraw')}</Text>
+            </Button>
           )}
           {userHasUnderlyingTokensAvailableToLend &&
             !isAssetReceiptToken &&
             isEligible && (
               <Button
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 style={styles.button}
-                size={ButtonSize.Lg}
-                label={strings('earn.deposit_more')}
+                size={ButtonSize.Md}
                 onPress={handleNavigateToDepositInputScreen}
                 testID={EARN_LENDING_BALANCE_TEST_IDS.DEPOSIT_BUTTON}
-              />
+              >
+                <Text>{strings('earn.deposit_more')}</Text>
+              </Button>
             )}
         </View>
       )}

--- a/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import Button, {
+  ButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
@@ -37,6 +38,7 @@ const EarningsHistoryButton = ({ asset }: EarningsHistoryButtonProps) => {
         testID={WalletViewSelectorsIDs.EARN_EARNINGS_HISTORY_BUTTON}
         width={ButtonWidthTypes.Full}
         variant={ButtonVariants.Secondary}
+        size={ButtonSize.Md}
         label={
           outputToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
             ? strings('earn.view_earnings_history.lending')

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
@@ -1,16 +1,17 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, TextStyle } from 'react-native';
+import {
+  getFontFamily,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
 import { Theme } from '../../../../../util/theme/models';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
     container: {
       marginTop: 16,
-      padding: 16,
       borderRadius: 12,
-      backgroundColor: params.theme.colors.background.section,
     },
     stakingEarnings: {
-      paddingHorizontal: 16,
       paddingTop: 16,
     },
     badgeWrapper: {
@@ -18,16 +19,22 @@ const styleSheet = (params: { theme: Theme }) =>
     },
     balances: {
       flex: 1,
-      justifyContent: 'center',
-      marginLeft: 16,
-      alignSelf: 'center',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      alignContent: 'flex-start',
+      paddingLeft: 16,
     },
     ethLogo: {
-      width: 32,
-      height: 32,
-      borderRadius: 16,
+      width: 40,
+      height: 40,
+      borderRadius: 20,
       overflow: 'hidden',
     },
+    tokenAmount: {
+      ...params.theme.typography.sBodySM,
+      fontFamily: getFontFamily(TextVariant.BodySM),
+      color: params.theme.colors.text.alternative,
+    } as TextStyle,
     bannerStyles: {
       marginVertical: 8,
     },

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.styles.ts
@@ -1,8 +1,4 @@
 import { StyleSheet, TextStyle } from 'react-native';
-import {
-  getFontFamily,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { Theme } from '../../../../../util/theme/models';
 
 const styleSheet = (params: { theme: Theme }) =>
@@ -32,7 +28,6 @@ const styleSheet = (params: { theme: Theme }) =>
     },
     tokenAmount: {
       ...params.theme.typography.sBodySM,
-      fontFamily: getFontFamily(TextVariant.BodySM),
       color: params.theme.colors.text.alternative,
     } as TextStyle,
     bannerStyles: {

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
@@ -12,12 +12,16 @@ import Badge, {
 import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../component-library/components/Texts/SensitiveText';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import { RootState } from '../../../../../reducers';
 import { selectNetworkConfigurationByChainId } from '../../../../../selectors/networkController';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { getTimeDifferenceFromNow } from '../../../../../util/date';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -68,6 +72,7 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
   );
 
   const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const privacyMode = useSelector(selectPrivacyMode);
 
   const { styles } = useStyles(styleSheet, { theme });
 
@@ -211,8 +216,12 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
       {hasEthToUnstake && !isLoadingPooledStakesData && (
         <AssetElement
           asset={asset}
-          secondaryBalance={stakedBalanceETH}
           balance={stakedBalanceFiat}
+          privacyMode={privacyMode}
+          hideSecondaryBalanceInPrivacyMode={false}
+          secondaryBalanceElement={
+            <PercentageChange value={pricePercentChange1d ?? 0} />
+          }
         >
           <BadgeWrapper
             badgePosition={BadgePosition.BottomRight}
@@ -238,9 +247,14 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
             <Text variant={TextVariant.BodyMD} testID="staked-ethereum-label">
               {strings('stake.staked_ethereum')}
             </Text>
-            <Text>
-              <PercentageChange value={pricePercentChange1d ?? 0} />
-            </Text>
+            <SensitiveText
+              variant={TextVariant.BodySMMedium}
+              style={styles.tokenAmount}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+            >
+              {stakedBalanceETH}
+            </SensitiveText>
           </View>
         </AssetElement>
       )}

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
@@ -248,7 +248,7 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
               {strings('stake.staked_ethereum')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodySMMedium}
+              variant={TextVariant.BodySM}
               style={styles.tokenAmount}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}

--- a/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
@@ -3,9 +3,6 @@ import React from 'react';
 import { View, ViewProps } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
-import Button, {
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../../component-library/hooks';
 import Routes from '../../../../../../constants/navigation/Routes';
 import Engine from '../../../../../../core/Engine';
@@ -21,6 +18,12 @@ import useStakingChain from '../../../hooks/useStakingChain';
 import styleSheet from './StakingButtons.styles';
 import { trace, TraceName } from '../../../../../../util/trace';
 import useStakingEligibility from '../../../hooks/useStakingEligibility';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+} from '@metamask/design-system-react-native';
 
 interface StakingButtonsProps extends Pick<ViewProps, 'style'> {
   asset: TokenI;
@@ -106,23 +109,27 @@ const StakingButtons = ({
         <Button
           testID={'unstake-button'}
           style={styles.balanceActionButton}
-          variant={ButtonVariants.Secondary}
-          label={strings('stake.unstake')}
+          variant={ButtonVariant.Secondary}
           onPress={onUnstakePress}
-        />
+          size={ButtonSize.Md}
+        >
+          <Text>{strings('stake.unstake')}</Text>
+        </Button>
       )}
       {isPooledStakingEnabled && isEligible && (
         <Button
           testID={'stake-more-button'}
           style={styles.balanceActionButton}
-          variant={ButtonVariants.Secondary}
-          label={
-            hasStakedPositions
-              ? strings('stake.stake_more')
-              : strings('stake.stake')
-          }
+          variant={ButtonVariant.Secondary}
           onPress={onStakePress}
-        />
+          size={ButtonSize.Md}
+        >
+          <Text>
+            {hasStakedPositions
+              ? strings('stake.stake_more')
+              : strings('stake.stake')}
+          </Text>
+        </Button>
       )}
     </View>
   );

--- a/app/components/UI/Stake/components/StakingBalance/__snapshots__/StakingBalance.test.tsx.snap
+++ b/app/components/UI/Stake/components/StakingBalance/__snapshots__/StakingBalance.test.tsx.snap
@@ -49,10 +49,10 @@ exports[`StakingBalance render matches snapshot 1`] = `
                 false,
                 false,
                 {
-                  "borderRadius": 16,
-                  "height": 32,
+                  "borderRadius": 20,
+                  "height": 40,
                   "overflow": "hidden",
-                  "width": 32,
+                  "width": 40,
                 },
               ]
             }
@@ -75,10 +75,10 @@ exports[`StakingBalance render matches snapshot 1`] = `
               style={
                 [
                   {
-                    "borderRadius": 16,
-                    "height": 32,
+                    "borderRadius": 20,
+                    "height": 40,
                     "overflow": "hidden",
-                    "width": 32,
+                    "width": 40,
                   },
                   {
                     "backgroundColor": "#eee",
@@ -172,10 +172,11 @@ exports[`StakingBalance render matches snapshot 1`] = `
     <View
       style={
         {
-          "alignSelf": "center",
+          "alignContent": "flex-start",
+          "alignItems": "flex-start",
           "flex": 1,
-          "justifyContent": "center",
-          "marginLeft": 16,
+          "flexDirection": "column",
+          "paddingLeft": 16,
         }
       }
     >
@@ -198,31 +199,15 @@ exports[`StakingBalance render matches snapshot 1`] = `
         accessibilityRole="text"
         style={
           {
-            "color": "#131416",
+            "color": "#66676a",
             "fontFamily": "Geist-Regular",
-            "fontSize": 16,
+            "fontSize": 14,
+            "fontWeight": "400",
             "letterSpacing": 0,
-            "lineHeight": 24,
+            "lineHeight": 22,
           }
         }
-      >
-        <View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#ca3542",
-                "fontFamily": "Geist-Medium",
-                "fontSize": 14,
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
-          >
-            +0.00%
-          </Text>
-        </View>
-      </Text>
+      />
     </View>
     <View
       style={
@@ -231,15 +216,30 @@ exports[`StakingBalance render matches snapshot 1`] = `
           "flexShrink": 0,
         }
       }
-    />
+    >
+      <View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ca3542",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 14,
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          +0.00%
+        </Text>
+      </View>
+    </View>
   </TouchableOpacity>
   <View
     style={
       {
-        "backgroundColor": "#f3f3f4",
         "borderRadius": 12,
         "marginTop": 16,
-        "padding": 16,
       }
     }
   >
@@ -414,92 +414,185 @@ exports[`StakingBalance render matches snapshot 1`] = `
         ]
       }
     >
-      <TouchableOpacity
+      <View
         accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
+        accessibilityState={
           {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#b4b4b528",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 40,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "flex-start",
+              "backgroundColor": "#b4b4b528",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 40,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            {
+              "flex": 1,
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="unstake-button"
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
+        <View
+          style={{}}
         >
-          Unstake
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
+          <Text
+            accessibilityRole="text"
+            style={
+              [
+                {
+                  "color": "#131416",
+                  "fontFamily": "Geist-Regular",
+                  "fontSize": 16,
+                  "fontWeight": 400,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                },
+                undefined,
+              ]
+            }
+          >
+            Unstake
+          </Text>
+        </View>
+      </View>
+      <View
         accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
+        accessibilityState={
           {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#b4b4b528",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 40,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "flex-start",
+              "backgroundColor": "#b4b4b528",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 40,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            {
+              "flex": 1,
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="stake-more-button"
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
+        <View
+          style={{}}
         >
-          Stake more
-        </Text>
-      </TouchableOpacity>
+          <Text
+            accessibilityRole="text"
+            style={
+              [
+                {
+                  "color": "#131416",
+                  "fontFamily": "Geist-Regular",
+                  "fontSize": 16,
+                  "fontWeight": 400,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                },
+                undefined,
+              ]
+            }
+          >
+            Stake more
+          </Text>
+        </View>
+      </View>
     </View>
   </View>
   <View
     style={
       {
-        "paddingHorizontal": 16,
         "paddingTop": 16,
       }
     }
@@ -526,7 +619,13 @@ exports[`StakingBalance render matches snapshot 1`] = `
       >
         Your earnings
       </Text>
-      <View>
+      <View
+        style={
+          {
+            "paddingBottom": 24,
+          }
+        }
+      >
         <View
           style={
             {
@@ -842,10 +941,10 @@ exports[`StakingBalance should match the snapshot 1`] = `
                 false,
                 false,
                 {
-                  "borderRadius": 16,
-                  "height": 32,
+                  "borderRadius": 20,
+                  "height": 40,
                   "overflow": "hidden",
-                  "width": 32,
+                  "width": 40,
                 },
               ]
             }
@@ -868,10 +967,10 @@ exports[`StakingBalance should match the snapshot 1`] = `
               style={
                 [
                   {
-                    "borderRadius": 16,
-                    "height": 32,
+                    "borderRadius": 20,
+                    "height": 40,
                     "overflow": "hidden",
-                    "width": 32,
+                    "width": 40,
                   },
                   {
                     "backgroundColor": "#eee",
@@ -965,10 +1064,11 @@ exports[`StakingBalance should match the snapshot 1`] = `
     <View
       style={
         {
-          "alignSelf": "center",
+          "alignContent": "flex-start",
+          "alignItems": "flex-start",
           "flex": 1,
-          "justifyContent": "center",
-          "marginLeft": 16,
+          "flexDirection": "column",
+          "paddingLeft": 16,
         }
       }
     >
@@ -991,31 +1091,15 @@ exports[`StakingBalance should match the snapshot 1`] = `
         accessibilityRole="text"
         style={
           {
-            "color": "#131416",
+            "color": "#66676a",
             "fontFamily": "Geist-Regular",
-            "fontSize": 16,
+            "fontSize": 14,
+            "fontWeight": "400",
             "letterSpacing": 0,
-            "lineHeight": 24,
+            "lineHeight": 22,
           }
         }
-      >
-        <View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#ca3542",
-                "fontFamily": "Geist-Medium",
-                "fontSize": 14,
-                "letterSpacing": 0,
-                "lineHeight": 22,
-              }
-            }
-          >
-            +0.00%
-          </Text>
-        </View>
-      </Text>
+      />
     </View>
     <View
       style={
@@ -1024,15 +1108,30 @@ exports[`StakingBalance should match the snapshot 1`] = `
           "flexShrink": 0,
         }
       }
-    />
+    >
+      <View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ca3542",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 14,
+              "letterSpacing": 0,
+              "lineHeight": 22,
+            }
+          }
+        >
+          +0.00%
+        </Text>
+      </View>
+    </View>
   </TouchableOpacity>
   <View
     style={
       {
-        "backgroundColor": "#f3f3f4",
         "borderRadius": 12,
         "marginTop": 16,
-        "padding": 16,
       }
     }
   >
@@ -1207,92 +1306,185 @@ exports[`StakingBalance should match the snapshot 1`] = `
         ]
       }
     >
-      <TouchableOpacity
+      <View
         accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
+        accessibilityState={
           {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#b4b4b528",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 40,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "flex-start",
+              "backgroundColor": "#b4b4b528",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 40,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            {
+              "flex": 1,
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="unstake-button"
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
+        <View
+          style={{}}
         >
-          Unstake
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
+          <Text
+            accessibilityRole="text"
+            style={
+              [
+                {
+                  "color": "#131416",
+                  "fontFamily": "Geist-Regular",
+                  "fontSize": 16,
+                  "fontWeight": 400,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                },
+                undefined,
+              ]
+            }
+          >
+            Unstake
+          </Text>
+        </View>
+      </View>
+      <View
         accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
+        accessibilityState={
           {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#b4b4b528",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "height": 40,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "flex-start",
+              "backgroundColor": "#b4b4b528",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 1,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 40,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            {
+              "flex": 1,
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="stake-more-button"
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
+        <View
+          style={{}}
         >
-          Stake more
-        </Text>
-      </TouchableOpacity>
+          <Text
+            accessibilityRole="text"
+            style={
+              [
+                {
+                  "color": "#131416",
+                  "fontFamily": "Geist-Regular",
+                  "fontSize": 16,
+                  "fontWeight": 400,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                },
+                undefined,
+              ]
+            }
+          >
+            Stake more
+          </Text>
+        </View>
+      </View>
     </View>
   </View>
   <View
     style={
       {
-        "paddingHorizontal": 16,
         "paddingTop": 16,
       }
     }
@@ -1319,7 +1511,13 @@ exports[`StakingBalance should match the snapshot 1`] = `
       >
         Your earnings
       </Text>
-      <View>
+      <View
+        style={
+          {
+            "paddingBottom": 24,
+          }
+        }
+      >
         <View
           style={
             {

--- a/app/components/UI/Stake/components/StakingEarnings/StakingEarnings.styles.tsx
+++ b/app/components/UI/Stake/components/StakingEarnings/StakingEarnings.styles.tsx
@@ -30,6 +30,9 @@ const styleSheet = (params: { theme: Theme }) => {
     keyValueSecondaryText: {
       alignItems: 'flex-end',
     },
+    stakingEarningsContent: {
+      paddingBottom: 24,
+    },
   });
 };
 

--- a/app/components/UI/Stake/components/StakingEarnings/__snapshots__/StakingEarnings.test.tsx.snap
+++ b/app/components/UI/Stake/components/StakingEarnings/__snapshots__/StakingEarnings.test.tsx.snap
@@ -23,7 +23,13 @@ exports[`Staking Earnings displays pooled-staking maintenance banner when featur
   >
     Your earnings
   </Text>
-  <View>
+  <View
+    style={
+      {
+        "paddingBottom": 24,
+      }
+    }
+  >
     <View
       style={
         {
@@ -370,7 +376,13 @@ exports[`Staking Earnings should render correctly 1`] = `
   >
     Your earnings
   </Text>
-  <View>
+  <View
+    style={
+      {
+        "paddingBottom": 24,
+      }
+    }
+  >
     <View
       style={
         {

--- a/app/components/UI/Stake/components/StakingEarnings/index.tsx
+++ b/app/components/UI/Stake/components/StakingEarnings/index.tsx
@@ -78,7 +78,7 @@ const StakingEarningsContent = ({ asset }: StakingEarningsProps) => {
       <Text variant={TextVariant.HeadingMD} style={styles.title}>
         {strings('stake.your_earnings')}
       </Text>
-      <View>
+      <View style={styles.stakingEarningsContent}>
         {isPooledStakingServiceInterruptionBannerEnabled && (
           <EarnMaintenanceBanner />
         )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes visual inconsistencies in the "Staked Ethereum" (`StakingBalance`) and Stablecoin lending (`EarnLendingBalance`) balance rows so they match the layout of their parent asset rows above them.

**Layout fixes (both components):**
- Increased asset logo from 32×32 to 40×40 to match parent row
- Removed explicit `size={AvatarSize.Lg}` from the network `Badge` to use the default size
- Moved percentage change to the right side (as `secondaryBalanceElement` on `AssetElement`)
- Moved crypto balance to the left side, directly beneath the asset name

**Privacy mode:**
- Fiat balance (right, top) is now hidden via `AssetElement`'s `privacyMode` prop
- Crypto balance (left, bottom) is now wrapped in `SensitiveText` and hidden when privacy mode is on
- Percentage change remains visible in privacy mode (matching parent row behaviour)
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update earn balance row layout (logo size, badge size, balance/percentage placement) and add privacy mode support for StakingBalance and EarnLendingBalance


## **Related issues**

Fixes: [MUSD-508: Earn asset details screen paper cuts](https://consensyssoftware.atlassian.net/browse/MUSD-508)

## **Manual testing steps**

```gherkin
Feature: Earn balance row layout and privacy mode

  Scenario: user views earn balance rows
    Given user has staked ETH or lent stablecoins
    When user views the asset details screen
    Then the earn balance row matches the layout of the parent asset row above it
    And the asset logo, network badge, crypto balance, fiat balance, and percentage change are correctly positioned

  Scenario: user enables privacy mode with earn positions
    Given user has staked ETH or lent stablecoins
    When user enables privacy mode
    Then the fiat balance and crypto balance in the earn balance row are masked
    And the percentage change remains visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/4c67b8fc-a89a-4bea-a497-f52fb0d32b65

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: changes how balances/percent change render and switches some buttons to the design-system components, which could affect layout, accessibility, or privacy masking behavior.
> 
> **Overview**
> Updates `EarnLendingBalance` and `StakingBalance` to match the parent asset-row layout by moving **percentage change** into `AssetElement`’s `secondaryBalanceElement` (right side) and displaying the **token amount** beneath the asset name (left side), along with associated style tweaks (spacing/alignment and larger 40×40 logos for staking).
> 
> Adds **privacy mode support** to these rows by passing `privacyMode` into `AssetElement` (masking fiat) and wrapping the token amount in `SensitiveText` (masking crypto), while keeping percentage change visible.
> 
> Standardizes several action buttons (`EarnLendingBalance`, `StakingButtons`) to `@metamask/design-system-react-native` and adjusts sizing (`Md`), updates `EarningsHistoryButton` button size, and refreshes Jest snapshots accordingly (plus adds bottom padding in `StakingEarnings`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e2bf3bb575dc1f127bcfc8c8141b0a529d116e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->