### PR TITLE
fix(analytics): fix user traits types violations

### DIFF
--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -72,8 +72,8 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.THEME]: 'dark',
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.ON,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+      [UserProfileProperty.SECURITY_PROVIDERS]: ['blockaid'],
+      [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -41,11 +41,9 @@ const generateUserProfileAnalyticsMetaData = (): AnalyticsUserTraits => {
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
     [UserProfileProperty.SECURITY_PROVIDERS]:
-      preferencesController?.securityAlertsEnabled ? 'blockaid' : '',
+      preferencesController?.securityAlertsEnabled ? ['blockaid'] : [],
     [UserProfileProperty.HAS_MARKETING_CONSENT]:
-      isDataCollectionForMarketingEnabled
-        ? UserProfileProperty.ON
-        : UserProfileProperty.OFF,
+      Boolean(isDataCollectionForMarketingEnabled),
     [UserProfileProperty.CHAIN_IDS]: chainIds,
   };
   return traits;


### PR DESCRIPTION
## Description
Fixes #23970 

Addresses a Segment schema violation occurring during `identify` calls where certain user traits were being assigned incorrect types.

## Changes
- **`traits.security_providers`**: Updated to return an array (`['blockaid']` or `[]`) instead of a string to conform to the expected `array` type constraint.
- **`traits.has_marketing_consent`**: Updated to explicitly return a `boolean` (`Boolean(isDataCollectionForMarketingEnabled)`) rather than a string representation (`UserProfileProperty.ON` or `UserProfileProperty.OFF`).
- Updated the assertions inside `generateUserProfileAnalyticsMetaData.test.ts` to reflect these typing changes.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type/shape changes to analytics identify traits; main risk is downstream consumers expecting the previous string values for `security_providers` or `has_marketing_consent`.
> 
> **Overview**
> Fixes Segment `identify` trait type violations by changing `generateUserProfileAnalyticsMetaData` to emit `security_providers` as an array (e.g., `['blockaid']`/`[]`) instead of a string, and `has_marketing_consent` as a boolean instead of `ON`/`OFF`.
> 
> Updates the corresponding unit test expectation for these traits to match the new shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84cc92a6947e090144a4ece6508482077ae0012d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->