### PR TITLE
fix(ramp): Correct ramp v2 order detail's crypto amount formatting

### DIFF
--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
@@ -166,6 +166,38 @@ describe('OrderContent', () => {
     ).toBeOnTheScreen();
   });
 
+  it('truncates long crypto amounts to 5 decimal places', () => {
+    const longDecimalOrder: RampsOrder = {
+      ...mockOrder,
+      cryptoAmount: 0.01588973776561068,
+    };
+    renderOrder(longDecimalOrder);
+    const tokenAmount = screen.getByTestId('ramps-order-details-token-amount');
+    expect(tokenAmount.props.children).not.toContain('0.01588973776561068');
+    expect(tokenAmount).toHaveTextContent('0.01589 ETH');
+  });
+
+  it('uses subscript notation for very small crypto amounts', () => {
+    const tinyAmountOrder: RampsOrder = {
+      ...mockOrder,
+      cryptoAmount: 0.00000614,
+    };
+    renderOrder(tinyAmountOrder);
+    const tokenAmount = screen.getByTestId('ramps-order-details-token-amount');
+    // 0.00000614 has 5 leading zeros → "0.0₅614"
+    expect(tokenAmount).toHaveTextContent('0.0₅614 ETH');
+  });
+
+  it('shows "..." when cryptoAmount is missing', () => {
+    const noAmountOrder: RampsOrder = {
+      ...mockOrder,
+      cryptoAmount: undefined as unknown as number,
+    };
+    renderOrder(noAmountOrder);
+    const tokenAmount = screen.getByTestId('ramps-order-details-token-amount');
+    expect(tokenAmount).toHaveTextContent('... ETH');
+  });
+
   it('does not render info row when statusDescription is absent', () => {
     const orderWithoutDescription: RampsOrder = {
       ...mockOrder,

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
@@ -198,6 +198,16 @@ describe('OrderContent', () => {
     expect(tokenAmount).toHaveTextContent('... ETH');
   });
 
+  it('renders "0" when cryptoAmount is zero', () => {
+    const zeroAmountOrder: RampsOrder = {
+      ...mockOrder,
+      cryptoAmount: 0,
+    };
+    renderOrder(zeroAmountOrder);
+    const tokenAmount = screen.getByTestId('ramps-order-details-token-amount');
+    expect(tokenAmount).toHaveTextContent('0 ETH');
+  });
+
   it('does not render info row when statusDescription is absent', () => {
     const orderWithoutDescription: RampsOrder = {
       ...mockOrder,

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
@@ -24,9 +24,11 @@ import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
-import { strings } from '../../../../../../locales/i18n';
+import I18n, { strings } from '../../../../../../locales/i18n';
 import { toDateFormat } from '../../../../../util/date';
 import { renderFiat } from '../../../../../util/number';
+import { formatSubscriptNotation } from '../../../../../util/number/subscriptNotation';
+import { formatWithThreshold } from '../../../../../util/assets';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import Logger from '../../../../../util/Logger';
 import Button, {
@@ -318,7 +320,21 @@ const OrderContent: React.FC<OrderContentProps> = ({
           fontWeight={FontWeight.Bold}
           twClassName="mt-6 text-center"
         >
-          {order.cryptoAmount} {cryptoSymbol}
+          {order.cryptoAmount
+            ? (formatSubscriptNotation(
+                parseFloat(String(order.cryptoAmount)),
+              ) ??
+              formatWithThreshold(
+                parseFloat(String(order.cryptoAmount)),
+                0.00001,
+                I18n.locale,
+                {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 5,
+                },
+              ))
+            : '...'}{' '}
+          {cryptoSymbol}
         </Text>
       </Box>
 

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
@@ -320,7 +320,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
           fontWeight={FontWeight.Bold}
           twClassName="mt-6 text-center"
         >
-          {order.cryptoAmount
+          {order.cryptoAmount != null
             ? (formatSubscriptNotation(
                 parseFloat(String(order.cryptoAmount)),
               ) ??


### PR DESCRIPTION
## **Description**

Fixes excessive decimal places on the Order Details screen for ramp purchases. When buying crypto (e.g. ETH via Mercuryo), the `cryptoAmount` was displayed raw with up to 17 decimal digits (`0.01588973776561068`), breaking the layout.

Now the amount is formatted consistently with the home screen:
- **Normal amounts** are capped at 5 decimal places using `formatWithThreshold` (e.g. `0.01589 ETH`)
- **Very small amounts** (< 0.0001) use subscript notation via `formatSubscriptNotation` (e.g. `0.0₅4567 BTC`)
- **Missing amounts** show `...`

## **Changelog**

CHANGELOG entry: Fixed Order Details screen displaying excessive decimal places for crypto amounts after ramp purchases.

## **Related issues**

Refs: 

## **Manual testing steps**

```gherkin
Feature: Order Details crypto amount formatting

  Scenario: Normal crypto amount is truncated to 5 decimal places
    Given the user has completed a buy order (e.g. ETH via Mercuryo)
    And the order cryptoAmount has many decimal places (e.g. 0.01588973776561068)

    When the Order Details screen is displayed
    Then the crypto amount is shown as "0.01589 ETH"
    And the layout is not broken by excessive decimals

  Scenario: Very small crypto amount uses subscript notation
    Given the user has completed a buy order with a very small amount (e.g. $5 of BTC)
    And the order cryptoAmount is less than 0.0001 (e.g. 0.00000456789)

    When the Order Details screen is displayed
    Then the crypto amount is shown with subscript notation (e.g. "0.0₅4567 BTC")

```

## **Screenshots/Recordings**

### **Before**

<!-- Screenshot showing excessive decimals breaking the layout -->
<img width="328" height="412" alt="Screenshot 2026-03-13 180811" src="https://github.com/user-attachments/assets/12761747-5b28-40d7-a3f5-67ab8fab06a0" />


### **After**

<!-- Screenshot showing properly formatted amount -->
<img width="342" height="337" alt="Screenshot 2026-03-13 175207" src="https://github.com/user-attachments/assets/1ec7cd30-53e0-491e-815a-09a32f8fb78d" />

<img width="338" height="312" alt="Screenshot 2026-03-13 175321" src="https://github.com/user-attachments/assets/81378992-3d8a-401c-a83c-6e57d6554740" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts number formatting on the ramp Order Details screen and adds unit tests for edge cases (tiny, long-decimal, missing, and zero amounts).
> 
> **Overview**
> Fixes ramp v2 Order Details to **format `cryptoAmount` instead of rendering the raw number**, preventing long decimals from breaking layout.
> 
> Amounts now prefer `formatSubscriptNotation` for very small values, otherwise use `formatWithThreshold` with a 5-decimal cap and current `I18n.locale`; missing amounts render as `...`. Adds tests covering long decimals, subscript formatting, missing values, and zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 188a75430d3ed7638e63537e37e0442a23902592. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->