### PR TITLE
refactor(rewards): simplify claimable reward calculation and update tests

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -6,7 +6,6 @@ import {
   useMerklRewards,
 } from './useMerklRewards';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
-import { renderFromTokenMinimalUnit } from '../../../../../../util/number';
 import { TokenI } from '../../../../Tokens/types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import {
@@ -17,10 +16,6 @@ import { AGLAMERKL_ADDRESS_MAINNET } from '../constants';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
-}));
-
-jest.mock('../../../../../../util/number', () => ({
-  renderFromTokenMinimalUnit: jest.fn(),
 }));
 
 jest.mock('../merkl-client', () => ({
@@ -59,10 +54,6 @@ jest.mock('../../../../../../util/Logger', () => ({
 global.fetch = jest.fn();
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockRenderFromTokenMinimalUnit =
-  renderFromTokenMinimalUnit as jest.MockedFunction<
-    typeof renderFromTokenMinimalUnit
-  >;
 const mockFetchMerklRewardsForAsset =
   fetchMerklRewardsForAsset as jest.MockedFunction<
     typeof fetchMerklRewardsForAsset
@@ -158,7 +149,6 @@ describe('useMerklRewards', () => {
     mockGetClaimedAmountFromContract.mockReset();
     // Default: return null to fall back to API's claimed value
     mockGetClaimedAmountFromContract.mockResolvedValue(null);
-    mockRenderFromTokenMinimalUnit.mockReset();
     (global.fetch as jest.Mock).mockClear();
 
     mockUseSelector.mockImplementation((selector: unknown) => {
@@ -167,26 +157,6 @@ describe('useMerklRewards', () => {
       }
       return undefined;
     });
-
-    // Default implementation for renderFromTokenMinimalUnit
-    // This calculates the actual value from the input, which is what most tests need
-    mockRenderFromTokenMinimalUnit.mockImplementation(
-      (value: string | number | unknown, decimals: number) => {
-        let stringValue: string;
-        if (typeof value === 'string') {
-          stringValue = value;
-        } else if (typeof value === 'number') {
-          stringValue = value.toString();
-        } else {
-          // Handle BN or other types
-          stringValue = String(value);
-        }
-        const bigIntValue = BigInt(stringValue);
-        const divisor = BigInt(10 ** decimals);
-        const result = Number(bigIntValue) / Number(divisor);
-        return result.toFixed(2);
-      },
-    );
   });
 
   it('initializes with null claimableReward', () => {
@@ -277,12 +247,6 @@ describe('useMerklRewards', () => {
       mockSelectedAddress,
       mockAsset.address,
       '0xe708', // CHAIN_IDS.LINEA_MAINNET
-    );
-
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '1500000000000000000',
-      18,
-      2,
     );
   });
 
@@ -411,13 +375,6 @@ describe('useMerklRewards', () => {
       },
       { timeout: 3000 },
     );
-
-    // Verify it found the reward
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '2500000000000000000',
-      18,
-      2,
-    );
   });
 
   it('returns null claimableReward when unclaimed amount is zero', async () => {
@@ -505,13 +462,11 @@ describe('useMerklRewards', () => {
 
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
-    // Simulate renderFromTokenMinimalUnit returning a value without trailing zero
-    mockRenderFromTokenMinimalUnit.mockReturnValueOnce('0.9');
 
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
     await waitFor(() => {
-      // Should format to 2 decimal places
+      // Should format to 2 decimal places (0.9 * 10^18 base units → "0.90")
       expect(result.current.claimableReward).toBe('0.90');
     });
   });
@@ -536,13 +491,11 @@ describe('useMerklRewards', () => {
 
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
-    // Simulate renderFromTokenMinimalUnit returning a whole number
-    mockRenderFromTokenMinimalUnit.mockReturnValueOnce('1');
 
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
     await waitFor(() => {
-      // Should format to 2 decimal places
+      // Should format to 2 decimal places (1 * 10^18 base units → "1.00")
       expect(result.current.claimableReward).toBe('1.00');
     });
   });
@@ -567,13 +520,11 @@ describe('useMerklRewards', () => {
 
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
-    // Simulate renderFromTokenMinimalUnit returning single decimal
-    mockRenderFromTokenMinimalUnit.mockReturnValueOnce('12.5');
 
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
     await waitFor(() => {
-      // Should format to 2 decimal places
+      // Should format to 2 decimal places (12.5 * 10^18 base units → "12.50")
       expect(result.current.claimableReward).toBe('12.50');
     });
   });
@@ -599,13 +550,40 @@ describe('useMerklRewards', () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
 
-    // renderFromTokenMinimalUnit returns "< 0.00001" for very small amounts
-    mockRenderFromTokenMinimalUnit.mockReturnValue('< 0.00001');
+    const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
+
+    await waitFor(() => {
+      // 100 base units with 18 decimals = 1e-16, below 0.01 → "< 0.01"
+      expect(result.current.claimableReward).toBe('< 0.01');
+    });
+  });
+
+  it('shows "< 0.01" when actual amount is below 0.01 but would round to 0.01', async () => {
+    // 7401 with 6 decimals = 0.007401; renderFromTokenMinimalUnit(7401, 6, 2) returns "0.01" (rounds)
+    const mockRewardData = {
+      token: {
+        address: AGLAMERKL_ADDRESS_MAINNET,
+        chainId: 1,
+        symbol: 'aglaMerkl',
+        decimals: 6,
+        price: null,
+      },
+      accumulated: '0',
+      unclaimed: '7401',
+      pending: '0',
+      proofs: [],
+      amount: '7401',
+      claimed: '0',
+      recipient: mockSelectedAddress,
+    };
+
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
 
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
     await waitFor(() => {
-      // Should convert to "< 0.01" for consistency with 2 decimal places
+      // 7401 with 6 decimals = 0.007401, below 0.01 → "< 0.01"
       expect(result.current.claimableReward).toBe('< 0.01');
     });
   });
@@ -726,13 +704,6 @@ describe('useMerklRewards', () => {
       },
       { timeout: 3000 },
     );
-
-    // Should use token decimals from API (18) not asset decimals (6)
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '1500000000000000000',
-      18,
-      2,
-    );
   });
 
   it('defaults to 18 decimals when token and asset decimals are undefined', async () => {
@@ -769,12 +740,6 @@ describe('useMerklRewards', () => {
     await waitFor(() => {
       expect(result.current.claimableReward).toBe('1.50');
     });
-
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '1500000000000000000',
-      18,
-      2,
-    );
   });
 
   it('falls back to API claimed value when contract call fails', async () => {
@@ -806,14 +771,6 @@ describe('useMerklRewards', () => {
         expect(result.current.claimableReward).toBe('0.50');
       },
       { timeout: 3000 },
-    );
-
-    // Should use API's claimed value (1.0) instead of contract value
-    // unclaimed = amount - claimed = 1.5 - 1.0 = 0.5
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '500000000000000000',
-      18,
-      2,
     );
   });
 
@@ -849,17 +806,10 @@ describe('useMerklRewards', () => {
       },
       { timeout: 3000 },
     );
-
-    // Should use contract value (1.2) not API value (1.0)
-    // unclaimed = amount - claimed = 1.5 - 1.2 = 0.3
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '300000000000000000',
-      18,
-      2,
-    );
   });
 
-  it('returns null claimableReward when renderFromTokenMinimalUnit returns empty string', async () => {
+  it('returns null claimableReward when amount displays as 0.00', async () => {
+    // 0.001 * 10^18 = 1e15 base units with 18 decimals → 0.001 → toFixed(2) = '0.00' → we don't set
     const mockRewardData = {
       token: {
         address: AGLAMERKL_ADDRESS_MAINNET,
@@ -869,18 +819,16 @@ describe('useMerklRewards', () => {
         price: null,
       },
       accumulated: '0',
-      unclaimed: '1000000000000000000',
+      unclaimed: '1000000000000000', // 0.001 tokens (1e15 base units)
       pending: '0',
       proofs: [],
-      amount: '1000000000000000000',
+      amount: '1000000000000000',
       claimed: '0',
       recipient: mockSelectedAddress,
     };
 
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
-    // Return empty string to test the falsy check
-    mockRenderFromTokenMinimalUnit.mockReturnValueOnce('');
 
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
@@ -888,11 +836,12 @@ describe('useMerklRewards', () => {
       expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     });
 
-    // Should remain null when rendered amount is empty string
+    // 0.001 formats to "0.00", which we skip → claimableReward stays null
     expect(result.current.claimableReward).toBe(null);
   });
 
-  it('returns null claimableReward when renderFromTokenMinimalUnit returns "0"', async () => {
+  it('returns null claimableReward when amount rounds to 0.00 (tiny amount)', async () => {
+    // 1 base unit with 18 decimals → 1e-18 → toFixed(2) = '0.00' → we don't set
     const mockRewardData = {
       token: {
         address: AGLAMERKL_ADDRESS_MAINNET,
@@ -902,18 +851,16 @@ describe('useMerklRewards', () => {
         price: null,
       },
       accumulated: '0',
-      unclaimed: '1000000000000000000',
+      unclaimed: '1',
       pending: '0',
       proofs: [],
-      amount: '1000000000000000000',
+      amount: '1',
       claimed: '0',
       recipient: mockSelectedAddress,
     };
 
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
-    // Return '0' to test the exact zero check
-    mockRenderFromTokenMinimalUnit.mockReturnValueOnce('0');
 
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
@@ -921,7 +868,6 @@ describe('useMerklRewards', () => {
       expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     });
 
-    // Should remain null when rendered amount is exactly '0'
     expect(result.current.claimableReward).toBe(null);
   });
 
@@ -976,13 +922,6 @@ describe('useMerklRewards', () => {
         expect(result.current.claimableReward).toBe('1.50');
       },
       { timeout: 3000 },
-    );
-
-    // Should fall back to asset decimals (6) when token decimals is null
-    expect(mockRenderFromTokenMinimalUnit).toHaveBeenCalledWith(
-      '1500000',
-      6,
-      2,
     );
   });
 

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -808,8 +808,8 @@ describe('useMerklRewards', () => {
     );
   });
 
-  it('returns null claimableReward when amount displays as 0.00', async () => {
-    // 0.001 * 10^18 = 1e15 base units with 18 decimals → 0.001 → toFixed(2) = '0.00' → we don't set
+  it('returns "< 0.01" when amount is below 0.01 (e.g. 0.001 tokens)', async () => {
+    // 1e15 base units with 18 decimals = 0.001 → below 0.01 → displayAmount = '< 0.01'
     const mockRewardData = {
       token: {
         address: AGLAMERKL_ADDRESS_MAINNET,
@@ -833,15 +833,12 @@ describe('useMerklRewards', () => {
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
     await waitFor(() => {
-      expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
+      expect(result.current.claimableReward).toBe('< 0.01');
     });
-
-    // 0.001 formats to "0.00", which we skip → claimableReward stays null
-    expect(result.current.claimableReward).toBe(null);
   });
 
-  it('returns null claimableReward when amount rounds to 0.00 (tiny amount)', async () => {
-    // 1 base unit with 18 decimals → 1e-18 → toFixed(2) = '0.00' → we don't set
+  it('returns "< 0.01" when amount is tiny (e.g. 1 base unit)', async () => {
+    // 1 base unit with 18 decimals = 1e-18 → below 0.01 → displayAmount = '< 0.01'
     const mockRewardData = {
       token: {
         address: AGLAMERKL_ADDRESS_MAINNET,
@@ -865,10 +862,8 @@ describe('useMerklRewards', () => {
     const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
 
     await waitFor(() => {
-      expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
+      expect(result.current.claimableReward).toBe('< 0.01');
     });
-
-    expect(result.current.claimableReward).toBe(null);
   });
 
   it('ignores AbortError when fetch is cancelled', async () => {

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
-import { renderFromTokenMinimalUnit } from '../../../../../../util/number';
 import { TokenI } from '../../../../Tokens/types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../../../constants/musd';
@@ -138,31 +137,11 @@ export const useMerklRewards = ({
           matchingReward.token.decimals ?? asset.decimals ?? 18;
 
         if (unclaimedBaseUnits > 0n) {
-          // Convert from wei to token amount
-          const unclaimedAmount = renderFromTokenMinimalUnit(
-            unclaimedBaseUnits.toString(),
-            tokenDecimals,
-            2, // Show 2 decimal places
-          );
-          // Handle the "< 0.00001" case from renderFromTokenMinimalUnit
-          // by showing "< 0.01" for consistency with 2 decimal places
-          // Also ensure we always show exactly 2 decimal places for currency display
-          let displayAmount: string;
-          if (unclaimedAmount.startsWith('<')) {
-            displayAmount = '< 0.01';
-          } else {
-            // Ensure exactly 2 decimal places (e.g., "0.9" -> "0.90")
-            const numValue = parseFloat(unclaimedAmount);
-            displayAmount = numValue.toFixed(2);
-          }
-          // Double-check that the rendered amount is not '0' or '0.00'
-          // This handles edge cases where very small amounts round to zero
-          if (
-            displayAmount &&
-            displayAmount !== '0' &&
-            displayAmount !== '0.00'
-          ) {
-            // Final check before setting state to ensure effect is still active
+          const unclaimedDecimal =
+            Number(unclaimedBaseUnits) / Math.pow(10, tokenDecimals);
+          const displayAmount =
+            unclaimedDecimal < 0.01 ? '< 0.01' : unclaimedDecimal.toFixed(2);
+          if (displayAmount !== '0' && displayAmount !== '0.00') {
             if (!controller.signal.aborted) {
               setClaimableReward(displayAmount);
             }

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../../../../UI/Earn/hooks/useMusdBalance', () => ({
 }));
 
 const mockUseMerklBonusClaim = jest.fn(() => ({
-  claimableReward: { amount: '10' } as { amount: string } | null,
+  claimableReward: '10' as string | null,
   hasPendingClaim: false,
   claimRewards: mockClaimRewards,
   isClaiming: false,
@@ -49,7 +49,7 @@ describe('MusdAggregatedRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseMerklBonusClaim.mockReturnValue({
-      claimableReward: { amount: '10' },
+      claimableReward: '10',
       hasPendingClaim: false,
       claimRewards: mockClaimRewards,
       isClaiming: false,
@@ -84,7 +84,7 @@ describe('MusdAggregatedRow', () => {
 
   it('shows Spinner when isClaiming is true', () => {
     mockUseMerklBonusClaim.mockReturnValue({
-      claimableReward: { amount: '10' },
+      claimableReward: '10',
       hasPendingClaim: false,
       claimRewards: mockClaimRewards,
       isClaiming: true,
@@ -108,5 +108,62 @@ describe('MusdAggregatedRow', () => {
 
     expect(screen.queryByText('Claim bonus')).toBeNull();
     expect(screen.getByText('3% bonus')).toBeOnTheScreen();
+  });
+
+  describe('claimable bonus threshold (min $0.01)', () => {
+    it('hides Claim bonus when claimable reward is "< 0.01"', () => {
+      mockUseMerklBonusClaim.mockReturnValue({
+        claimableReward: '< 0.01',
+        hasPendingClaim: false,
+        claimRewards: mockClaimRewards,
+        isClaiming: false,
+      });
+
+      renderWithProvider(<MusdAggregatedRow />);
+
+      expect(screen.queryByText('Claim bonus')).toBeNull();
+      expect(screen.getByText('3% bonus')).toBeOnTheScreen();
+    });
+
+    it('hides Claim bonus when claimable reward is exactly 0.01', () => {
+      mockUseMerklBonusClaim.mockReturnValue({
+        claimableReward: '0.01',
+        hasPendingClaim: false,
+        claimRewards: mockClaimRewards,
+        isClaiming: false,
+      });
+
+      renderWithProvider(<MusdAggregatedRow />);
+
+      expect(screen.queryByText('Claim bonus')).toBeNull();
+      expect(screen.getByText('3% bonus')).toBeOnTheScreen();
+    });
+
+    it('hides Claim bonus when claimable reward is below 0.01', () => {
+      mockUseMerklBonusClaim.mockReturnValue({
+        claimableReward: '0.005',
+        hasPendingClaim: false,
+        claimRewards: mockClaimRewards,
+        isClaiming: false,
+      });
+
+      renderWithProvider(<MusdAggregatedRow />);
+
+      expect(screen.queryByText('Claim bonus')).toBeNull();
+      expect(screen.getByText('3% bonus')).toBeOnTheScreen();
+    });
+
+    it('shows Claim bonus when claimable reward is above 0.01', () => {
+      mockUseMerklBonusClaim.mockReturnValue({
+        claimableReward: '0.02',
+        hasPendingClaim: false,
+        claimRewards: mockClaimRewards,
+        isClaiming: false,
+      });
+
+      renderWithProvider(<MusdAggregatedRow />);
+
+      expect(screen.getByText('Claim bonus')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -125,7 +125,7 @@ describe('MusdAggregatedRow', () => {
       expect(screen.getByText('3% bonus')).toBeOnTheScreen();
     });
 
-    it('hides Claim bonus when claimable reward is exactly 0.01', () => {
+    it('shows Claim bonus when claimable reward is exactly 0.01', () => {
       mockUseMerklBonusClaim.mockReturnValue({
         claimableReward: '0.01',
         hasPendingClaim: false,
@@ -135,8 +135,7 @@ describe('MusdAggregatedRow', () => {
 
       renderWithProvider(<MusdAggregatedRow />);
 
-      expect(screen.queryByText('Claim bonus')).toBeNull();
-      expect(screen.getByText('3% bonus')).toBeOnTheScreen();
+      expect(screen.getByText('Claim bonus')).toBeOnTheScreen();
     });
 
     it('hides Claim bonus when claimable reward is below 0.01', () => {

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -47,7 +47,7 @@ import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/consta
 const MIN_CLAIMABLE_BONUS_USD = 0.01;
 
 /**
- * Returns true only when the claimable reward string represents an amount strictly greater than MIN_CLAIMABLE_BONUS_USD.
+ * Returns true when the claimable reward string represents an amount >= MIN_CLAIMABLE_BONUS_USD.
  * useMerklRewards returns "< 0.01" for very small amounts; we do not show "Claim bonus" for those.
  */
 const isClaimableBonusAboveThreshold = (reward: string | null): boolean => {

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -43,6 +43,21 @@ import { MUSD_MAINNET_ASSET_FOR_DETAILS } from './CashGetMusdEmptyState.constant
 import NavigationService from '../../../../../core/NavigationService';
 import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
 
+/** Minimum claimable bonus (USD) to show the "Claim bonus" CTA; below this we show "3% bonus" instead. */
+const MIN_CLAIMABLE_BONUS_USD = 0.01;
+
+/**
+ * Returns true only when the claimable reward string represents an amount strictly greater than MIN_CLAIMABLE_BONUS_USD.
+ * useMerklRewards returns "< 0.01" for very small amounts; we do not show "Claim bonus" for those.
+ */
+const isClaimableBonusAboveThreshold = (reward: string | null): boolean => {
+  if (!reward || typeof reward !== 'string') return false;
+  if (reward.startsWith('<')) return false;
+  const value = parseFloat(reward);
+  if (Number.isNaN(value)) return false;
+  return value >= MIN_CLAIMABLE_BONUS_USD;
+};
+
 /**
  * Minimal mUSD asset for useMerklBonusClaim (claim runs on Linea).
  * Only chainId and address are required for the claim flow.
@@ -69,7 +84,8 @@ const MusdAggregatedRow = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const networkName = useNetworkName(LINEA_MUSD_ASSET.chainId as Hex);
 
-  const hasClaimableBonus = Boolean(claimableReward) && !hasPendingClaim;
+  const hasClaimableBonus =
+    isClaimableBonusAboveThreshold(claimableReward) && !hasPendingClaim;
 
   const handleClaimBonus = useCallback(() => {
     trackEvent(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


**Reason for change:** In the Cash section (homepage), the "Claim bonus" CTA was shown even when the claimable mUSD bonus was less than $0.01 (e.g. dust after claiming). Small amounts like 0.007401 were also displayed as "0.01" because the formatting logic rounded to 2 decimals instead of showing "< 0.01".

**Improvement / solution:**

1. **MusdAggregatedRow (Cash section):** Only show the "Claim bonus" button when the claimable reward is at least $0.01. Introduced `MIN_CLAIMABLE_BONUS_USD` and `isClaimableBonusAboveThreshold(reward)`; below that threshold the row shows the static "3% bonus" text instead of the CTA.

2. **useMerklRewards:** Removed use of `renderFromTokenMinimalUnit`, which only treated values below 0.00001 as "< 0.00001" and rounded everything else (e.g. 0.007401 → "0.01"). The hook now computes the decimal value as `unclaimedBaseUnits / 10^tokenDecimals` and formats it as `"< 0.01"` when &lt; 0.01, otherwise `toFixed(2)`. This ensures amounts like 0.007401 display as "< 0.01" and the Cash section threshold logic works correctly.

3. **Tests:** MusdAggregatedRow tests for the claimable-bonus threshold (hide CTA for "< 0.01", "0.01", "0.005"; show for "0.02"). useMerklRewards tests updated to assert outcomes instead of mocking `renderFromTokenMinimalUnit`; added case for 7401 with 6 decimals → "< 0.01".

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Cash section showing "Claim bonus" for amounts under $0.01 and corrected display of small claimable amounts as "< 0.01"

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-513

## **Manual testing steps**

```gherkin
Feature: Cash section claim bonus threshold and small-amount display

  Scenario: Claim bonus CTA hidden when claimable amount is below $0.01
    Given I am on the Wallet home screen with the Cash section visible
    And my claimable mUSD bonus is less than $0.01 (e.g. dust after claiming)

    When I view the mUSD row in the Cash section
    Then I should see "3% bonus" (green text) instead of "Claim bonus"
    And I should not see a tappable "Claim bonus" link

  Scenario: Claim bonus CTA shown when claimable amount is at least $0.01
    Given I am on the Wallet home screen with the Cash section visible
    And my claimable mUSD bonus is at least $0.01

    When I view the mUSD row in the Cash section
    Then I should see the "Claim bonus" link
    And tapping it should start the claim flow
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/ec20c986-1694-4f45-9e8b-4bb9eaed36d0


<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="845" alt="Screenshot 2026-03-16 at 09 07 21" src="https://github.com/user-attachments/assets/797d36f7-bf62-47e6-a544-299becef83b0" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward amount formatting and CTA gating logic in the Cash section; incorrect numeric conversion/rounding (notably `BigInt`→`Number`) could mis-display large rewards or edge-case decimals.
> 
> **Overview**
> **Fixes dust claim UX in the Cash section.** `MusdAggregatedRow` now only shows the **"Claim bonus"** CTA when the claimable bonus is at least `$0.01`; otherwise it shows the static **"3% bonus"** label (including when the hook returns `"< 0.01"`).
> 
> **Simplifies Merkl claimable reward formatting.** `useMerklRewards` drops `renderFromTokenMinimalUnit` and instead computes the decimal amount directly from base units, returning `"< 0.01"` for anything below `$0.01` and `toFixed(2)` otherwise.
> 
> **Tests updated/added.** Merkl reward tests no longer mock the formatter and add coverage for sub-$0.01 amounts (including cases that previously rounded up), and Cash row tests cover the new $0.01 CTA threshold behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1054f6f4853049bfb65d69dd7bcd3a8a6eca0461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->