### PR TITLE
feat: add risk label to PRs from Smart E2E selection output                                                                     

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -41,6 +41,9 @@ outputs:
   ai_confidence:
     description: 'AI confidence score (0-100)'
     value: ${{ steps.final-outputs.outputs.ai_confidence }}
+  ai_risk_level:
+    description: 'Risk level of the PR (low, medium, high) — indicates testing need and bug introduction likelihood'
+    value: ${{ steps.final-outputs.outputs.ai_risk_level }}
   ai_performance_test_tags:
     description: 'Performance test tags to run (JSON array format, empty [] means no performance tests)'
     value: ${{ steps.final-outputs.outputs.ai_performance_test_tags }}
@@ -188,6 +191,15 @@ runs:
         else
           echo "force_run=false" >> "$GITHUB_OUTPUT"
         fi
+        # Risk level: force_run → always high; otherwise use AI output
+        AI_RISK='${{ steps.ai-analysis.outputs.ai_risk_level }}'
+        if [[ "$FORCE_RUN" == "true" ]]; then
+          echo "ai_risk_level=high" >> "$GITHUB_OUTPUT"
+        elif [[ -n "$AI_RISK" ]]; then
+          echo "ai_risk_level=$AI_RISK" >> "$GITHUB_OUTPUT"
+        else
+          echo "ai_risk_level=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Display AI Analysis Outputs
       if: always()
@@ -197,6 +209,7 @@ runs:
         echo "================================"
         echo "ai_e2e_test_tags: ${{ steps.final-outputs.outputs.ai_e2e_test_tags }}"
         echo "ai_confidence: ${{ steps.final-outputs.outputs.ai_confidence }}"
+        echo "ai_risk_level: ${{ steps.final-outputs.outputs.ai_risk_level }}"
         echo "ai_performance_test_tags: ${{ steps.final-outputs.outputs.ai_performance_test_tags }}"
         echo "force_run: ${{ steps.final-outputs.outputs.force_run }}"
         echo "================================"
@@ -230,6 +243,16 @@ runs:
         else
           echo "📝 No Smart E2E selection comments found"
         fi
+
+    - name: Apply risk label to PR
+      if: inputs.pr-number != '' && inputs.github-token != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ inputs.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        RISK_LEVEL: ${{ steps.final-outputs.outputs.ai_risk_level }}
+      run: node .github/scripts/e2e-risk-label.mjs
 
     - name: Create PR comment
       if: inputs.post-comment == 'true' && inputs.pr-number != '' && inputs.github-token != ''

--- a/.github/scripts/e2e-risk-label.mjs
+++ b/.github/scripts/e2e-risk-label.mjs
@@ -71,6 +71,11 @@ async function main() {
 
   // Fetch current PR labels
   const labelsRes = await githubApi(`/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels`);
+  if (!labelsRes.ok) {
+    const body = await labelsRes.text();
+    console.error(`❌ Failed to fetch PR labels: ${labelsRes.status} ${body}`);
+    process.exit(1);
+  }
   const currentLabels = await labelsRes.json();
 
   // Remove stale risk labels

--- a/.github/scripts/e2e-risk-label.mjs
+++ b/.github/scripts/e2e-risk-label.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Applies a risk label (risk-low / risk-medium / risk-high) to a PR based on
+ * the risk level output from the Smart E2E selection step.
+ *
+ * Required environment variables:
+ *   RISK_LEVEL          - 'low' | 'medium' | 'high'
+ *   GH_TOKEN            - GitHub token with pull-requests:write and issues:write
+ *   GITHUB_REPOSITORY   - owner/repo
+ *   PR_NUMBER           - pull request number
+ */
+
+const RISK_LEVEL = process.env.RISK_LEVEL || '';
+const GH_TOKEN = process.env.GH_TOKEN || '';
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY || '';
+const PR_NUMBER = process.env.PR_NUMBER || '';
+
+const RISK_LABELS = {
+  low: {
+    color: '0E8A16',
+    description: 'Low testing needed · Low bug introduction risk',
+  },
+  medium: {
+    color: 'FBCA04',
+    description: 'Moderate testing recommended · Possible bug introduction risk',
+  },
+  high: {
+    color: 'B60205',
+    description: 'Extensive testing required · High bug introduction risk',
+  },
+};
+
+async function githubApi(path, options = {}) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${GH_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+  return res;
+}
+
+async function main() {
+  if (!RISK_LEVEL) {
+    console.log('⏭️ No risk level provided, skipping label');
+    return;
+  }
+
+  if (!RISK_LABELS[RISK_LEVEL]) {
+    console.error(`❌ Unknown risk level: "${RISK_LEVEL}"`);
+    process.exit(1);
+  }
+
+  if (!GH_TOKEN || !GITHUB_REPOSITORY || !PR_NUMBER) {
+    console.error('❌ Missing required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER');
+    process.exit(1);
+  }
+
+  // Ensure all three risk labels exist on the repo (idempotent — 422 = already exists)
+  for (const [level, meta] of Object.entries(RISK_LABELS)) {
+    await githubApi(`/repos/${GITHUB_REPOSITORY}/labels`, {
+      method: 'POST',
+      body: JSON.stringify({ name: `risk-${level}`, color: meta.color, description: meta.description }),
+    });
+  }
+
+  // Fetch current PR labels
+  const labelsRes = await githubApi(`/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels`);
+  const currentLabels = await labelsRes.json();
+
+  // Remove stale risk labels
+  for (const label of currentLabels) {
+    if (Object.keys(RISK_LABELS).map(l => `risk-${l}`).includes(label.name)) {
+      await githubApi(`/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${encodeURIComponent(label.name)}`, {
+        method: 'DELETE',
+      });
+      console.log(`🗑️ Removed stale label: ${label.name}`);
+    }
+  }
+
+  // Add the new risk label
+  const newLabel = `risk-${RISK_LEVEL}`;
+  const addRes = await githubApi(`/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels`, {
+    method: 'POST',
+    body: JSON.stringify({ labels: [newLabel] }),
+  });
+
+  if (!addRes.ok) {
+    const body = await addRes.text();
+    console.error(`❌ Failed to add label "${newLabel}": ${addRes.status} ${body}`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Applied risk label: ${newLabel}`);
+}
+
+main().catch(error => {
+  console.error('❌ Unexpected error:', error);
+  process.exit(1);
+});

--- a/.github/scripts/e2e-smart-selection.mjs
+++ b/.github/scripts/e2e-smart-selection.mjs
@@ -62,9 +62,10 @@ function generatePRComment(summaryContent) {
 }
 
 function setGitHubOutputs(analysis) {
-  const { tags, confidence, performanceTests } = analysis;
+  const { tags, confidence, riskLevel, performanceTests } = analysis;
   setGithubOutputs('ai_e2e_test_tags', tags);
   setGithubOutputs('ai_confidence', confidence);
+  setGithubOutputs('ai_risk_level', riskLevel);
   // Performance test tags (empty array means no performance tests needed)
   setGithubOutputs('ai_performance_test_tags', JSON.stringify(performanceTests.selectedTags));
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,7 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     outputs:
       ai_e2e_test_tags: ${{ steps.e2e-selection.outputs.ai_e2e_test_tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/smart-e2e-selection
+            .github/scripts/e2e-risk-label.mjs
           sparse-checkout-cone-mode: false
           fetch-depth: 1
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

  - Surfaces the `riskLevel` output (`low` / `medium` / `high`) from the Smart E2E AI analyzer as a GitHub Actions output
  (`ai_risk_level`) on the `smart-e2e-selection` action
  - Adds a new standalone script (`e2e-risk-label.mjs`) that applies a `risk-low`, `risk-medium`, or `risk-high` label to the PR
  based on that output
  - Stale risk labels are removed before the new one is applied, so re-runs always reflect the latest assessment
  - When `force_run=true` (i.e. `skip-smart-e2e-selection` label is present), risk is pinned to `high`
  - Adds `issues: write` permission to the `smart-e2e-selection` CI job to allow repo-level label creation

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI workflow permissions and adds GitHub API automation that can fail or mislabel PRs, affecting the PR workflow but not production code.
> 
> **Overview**
> Surfaces the AI analyzer’s `riskLevel` as a new `ai_risk_level` output from the `smart-e2e-selection` composite action (with `force_run=true` overriding the value to `high`).
> 
> Adds a new script, `e2e-risk-label.mjs`, that ensures `risk-low`/`risk-medium`/`risk-high` labels exist, removes any stale risk label from the PR, and applies the current one.
> 
> Updates the `ci.yml` `smart-e2e-selection` job to grant `issues: write` and to sparse-checkout the new script so the job can create and manage labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fd7dbf603dbd279c464ad8b1458e9b2948a9609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->