### PR TITLE
refactor: simplify button styles in AdditionalNetworkItem component

### DIFF
--- a/app/components/Views/NetworksManagement/components/AdditionalNetworkItem.tsx
+++ b/app/components/Views/NetworksManagement/components/AdditionalNetworkItem.tsx
@@ -56,7 +56,7 @@ const AdditionalNetworkItem = ({ item, onAdd }: AdditionalNetworkItemProps) => {
         hitSlop={HIT_SLOP}
         style={({ pressed }) =>
           tw.style(
-            'w-7 h-7 items-center justify-center rounded-lg bg-background-muted mr-2.5',
+            'w-7 h-7 items-center justify-center mr-2.5',
             pressed && 'opacity-70',
           )
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes background on the "+" icon in the new Network management view.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Remove background from Additional Networks in Network Management

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-521

## **Manual testing steps**

```gherkin
Feature: Network management

  Scenario: user can access network management and sees updated additional network icons
    Given the app is opened and the user is logged in
    When the user goes to Account Menu and opens Networks
    Then the Networks management screen is shown
    And each additional network item shows its icon without a rounded muted background
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="384" height="833" alt="Screenshot 2026-03-16 at 11 27 32" src="https://github.com/user-attachments/assets/cfb05217-da81-4434-9d42-31c4f5fc395a" />

<!-- [screenshots/recordings] -->

### **After**
<img width="388" height="837" alt="Screenshot 2026-03-16 at 11 27 41" src="https://github.com/user-attachments/assets/7818cb86-088c-4cb4-af68-a2eb7302192c" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts styling for the add (+) button with no logic or data flow changes.
> 
> **Overview**
> Updates `AdditionalNetworkItem` so the add (+) `Pressable` no longer renders with a muted rounded background, leaving only sizing/alignment and pressed opacity styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c27272cdfdec179344ae8ddb0ff80e134a2cc2e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->