### PR TITLE
feat: add metrics property mm_pay_time_to_complete_s

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -491,7 +491,7 @@ describe('Metamask Pay Metrics', () => {
     });
 
     it('adds mm_pay_time_to_complete_s for finalized parent MM Pay transaction', () => {
-      jest.spyOn(Date, 'now').mockReturnValue(1060000);
+      jest.spyOn(Date, 'now').mockReturnValue(1060500);
 
       request.transactionMeta.type = TransactionType.perpsDeposit;
       request.transactionMeta.submittedTime = 1000000;
@@ -500,7 +500,28 @@ describe('Metamask Pay Metrics', () => {
 
       expect(result.properties).toStrictEqual(
         expect.objectContaining({
-          mm_pay_time_to_complete_s: 60,
+          mm_pay_time_to_complete_s: 60.5,
+        }),
+      );
+    });
+
+    it('adds mm_pay_time_to_complete_s for finalized child transaction using parent submittedTime', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(2045123);
+
+      request.allTransactions = [
+        {
+          id: 'parent-1',
+          type: TransactionType.perpsDeposit,
+          requiredTransactionIds: ['child-1'],
+          submittedTime: 2000000,
+        } as TransactionMeta,
+      ];
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties).toStrictEqual(
+        expect.objectContaining({
+          mm_pay_time_to_complete_s: 45.123,
         }),
       );
     });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -484,4 +484,54 @@ describe('Metamask Pay Metrics', () => {
       sensitiveProperties: {},
     });
   });
+
+  describe('mm_pay_time_to_complete_s', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('adds mm_pay_time_to_complete_s for finalized parent MM Pay transaction', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1060000);
+
+      request.transactionMeta.type = TransactionType.perpsDeposit;
+      request.transactionMeta.submittedTime = 1000000;
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties).toStrictEqual(
+        expect.objectContaining({
+          mm_pay_time_to_complete_s: 60,
+        }),
+      );
+    });
+
+    it('does not add mm_pay_time_to_complete_s for non-finalized events', () => {
+      request.eventType = TRANSACTION_EVENTS.TRANSACTION_SUBMITTED;
+      request.transactionMeta.type = TransactionType.perpsDeposit;
+      request.transactionMeta.submittedTime = 1000000;
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties).not.toHaveProperty('mm_pay_time_to_complete_s');
+    });
+
+    it('does not add mm_pay_time_to_complete_s when submittedTime is undefined', () => {
+      request.transactionMeta.type = TransactionType.perpsDeposit;
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties).not.toHaveProperty('mm_pay_time_to_complete_s');
+    });
+
+    it('does not add mm_pay_time_to_complete_s for non-MM-Pay transactions', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1060000);
+
+      request.transactionMeta.type = TransactionType.contractInteraction;
+      request.transactionMeta.submittedTime = 1000000;
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties).not.toHaveProperty('mm_pay_time_to_complete_s');
+    });
+  });
 });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -153,9 +153,8 @@ function addTimeToComplete(
     return;
   }
 
-  properties.mm_pay_time_to_complete_s = Math.round(
-    (Date.now() - submittedTime) / 1000,
-  );
+  properties.mm_pay_time_to_complete_s =
+    Math.round(Date.now() - submittedTime) / 1000;
 }
 
 function addFallbackProperties(

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -15,6 +15,7 @@ import {
 import { RootState } from '../../../../../reducers';
 import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
 import { Hex } from '@metamask/utils';
+import { TRANSACTION_EVENTS } from '../../../../Analytics/events/confirmations';
 
 const FOUR_BYTE_SAFE_PROXY_CREATE = '0xa1884d2c';
 
@@ -34,6 +35,7 @@ const PAY_TYPES = [
 ];
 
 export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
+  eventType,
   transactionMeta,
   allTransactions,
   getUIMetrics,
@@ -57,6 +59,10 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
 
   if (hasTransactionType(transactionMeta, PAY_TYPES) || !parentTransaction) {
     addFallbackProperties(properties, transactionMeta, getState());
+
+    if (hasTransactionType(transactionMeta, PAY_TYPES) || properties.mm_pay) {
+      addTimeToComplete(properties, eventType, transactionMeta.submittedTime);
+    }
 
     return {
       properties,
@@ -127,11 +133,30 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
     }
   }
 
+  addTimeToComplete(properties, eventType, parentTransaction.submittedTime);
+
   return {
     properties,
     sensitiveProperties,
   };
 };
+
+function addTimeToComplete(
+  properties: JsonMap,
+  eventType: Parameters<TransactionMetricsBuilder>[0]['eventType'],
+  submittedTime: number | undefined,
+) {
+  if (
+    eventType !== TRANSACTION_EVENTS.TRANSACTION_FINALIZED ||
+    typeof submittedTime !== 'number'
+  ) {
+    return;
+  }
+
+  properties.mm_pay_time_to_complete_s = Math.round(
+    (Date.now() - submittedTime) / 1000,
+  );
+}
 
 function addFallbackProperties(
   properties: JsonMap,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add new property for MM Pay transaction metrics `mm_pay_time_to_complete_s`. Which is time from when transaction is submitted to what it is finalized.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-721

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that adds a derived timing property on `TRANSACTION_FINALIZED` events; main risk is incorrect/undefined `submittedTime` leading to missing or skewed metrics.
> 
> **Overview**
> Adds a new MetaMetrics property, `mm_pay_time_to_complete_s`, to MetaMask Pay transaction metrics, computed as seconds from `submittedTime` to `TRANSACTION_FINALIZED`.
> 
> The metric is emitted for both parent pay transactions and child bridge/swap steps (using the parent transaction’s `submittedTime`), with unit tests covering finalized vs non-finalized events and missing timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3f5da6f00f9f9a307e91acdbd546c3a5fba5e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->