### PR TITLE
refactor: update NetworkDetailsView to use KeyboardProvider and improve keyboard handling

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -7,7 +7,10 @@ import React, {
 } from 'react';
 import { ImageSourcePropType, Platform, Pressable } from 'react-native';
 import { useRoute, RouteProp, useNavigation } from '@react-navigation/native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import {
+  KeyboardAwareScrollView,
+  KeyboardProvider,
+} from 'react-native-keyboard-controller';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -181,7 +184,7 @@ const NetworkDetailsView = () => {
 
   const placeholderTextColor = colors.text.muted;
 
-  return (
+  const content = (
     <SafeAreaView
       style={tw.style('flex-1 bg-background-default')}
       edges={['top', 'bottom']}
@@ -234,10 +237,9 @@ const NetworkDetailsView = () => {
       <KeyboardAwareScrollView
         contentContainerStyle={tw.style('flex-grow px-4')}
         showsVerticalScrollIndicator={false}
-        enableOnAndroid
-        enableAutomaticScroll
-        extraScrollHeight={Platform.OS === 'android' ? 120 : 20}
         keyboardShouldPersistTaps="handled"
+        bottomOffset={Platform.OS === 'android' ? 120 : 20}
+        disableScrollOnKeyboardHide
       >
         <Box twClassName="flex-1 gap-4 pt-4 mb-6">
           {/* Network Name */}
@@ -356,6 +358,8 @@ const NetworkDetailsView = () => {
       )}
     </SafeAreaView>
   );
+
+  return <KeyboardProvider>{content}</KeyboardProvider>;
 };
 
 export default NetworkDetailsView;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On the Add/Edit Network screen (Network Details), when the keyboard was already open and the user tapped a second input (e.g. Symbol then Block explorer URL), the scroll view would first scroll correctly to show the focused field, then a second scroll event would move the content back up so the input was partly hidden behind the keyboard.

**Reason for the change:** The previous implementation used `react-native-keyboard-aware-scroll-view`, which on focus switch (e.g. `keyboardWillHide` then `keyboardWillShow`) was updating `contentInset` and triggering a native scroll adjustment that caused the jump.

**Solution:** Use `react-native-keyboard-controller` for this screen instead: wrap the view in `KeyboardProvider` and use its `KeyboardAwareScrollView` with `bottomOffset` and `disableScrollOnKeyboardHide`. This matches the approach used on other long multi-field forms (Import New Secret Recovery Phrase, Import From Secret Recovery Phrase) and avoids the contentInset-based scroll reset.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed scroll position jumping when switching between form fields with the keyboard open on the Add/Edit Network screen.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-532

## **Manual testing steps**

```gherkin
Feature: Add/Edit Network form keyboard and scroll behaviour

  Scenario: user switches focus between bottom fields with keyboard open
    Given the user is on the Add Network or Edit Network screen
    And the keyboard is open (e.g. after focusing Network Name or RPC URL)

    When the user taps the Symbol (or Chain ID) field
    Then the scroll view scrolls so the Symbol field is visible above the keyboard

    When the user taps the Block explorer URL field
    Then the scroll view scrolls so the Block explorer field is visible above the keyboard
    And the view does not jump back up so that the field is hidden behind the keyboard
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/5868bc0d-d4a4-424d-b619-33d512e65c63


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/7e340157-ec60-403f-8dfe-611d80ac27ff


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the keyboard-aware scroll implementation to prevent scroll jumps when switching focused inputs; main risk is platform-specific keyboard/scroll behavior regressions on the Add/Edit Network form.
> 
> **Overview**
> Fixes keyboard-driven scroll jumping on the Add/Edit Network form by replacing `react-native-keyboard-aware-scroll-view` with `react-native-keyboard-controller`.
> 
> `NetworkDetailsView` is now wrapped in `KeyboardProvider`, and its `KeyboardAwareScrollView` configuration is updated to use `bottomOffset` and `disableScrollOnKeyboardHide` (removing the prior Android auto-scroll/inset settings) to keep focused fields visible without a second “bounce” scroll.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfad0b80df661d041caaaa206406d27267b5c50b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->