### PR TITLE
fix: use sentence case for remove-network modal header

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -746,6 +746,13 @@ describe('NetworkDetailsView', () => {
       expect(
         getByText(strings('app_settings.network_delete')),
       ).toBeOnTheScreen();
+      expect(
+        getByText(
+          `${strings('app_settings.delete')} TestNet ${strings(
+            'app_settings.network',
+          )}`,
+        ),
+      ).toBeOnTheScreen();
     });
 
     it('calls operations.removeNetwork on confirm delete', () => {

--- a/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
+++ b/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
@@ -53,7 +53,7 @@ const DeleteNetworkModal = forwardRef<BottomSheetRef, DeleteNetworkModalProps>(
         testID={NetworksManagementViewSelectorsIDs.DELETE_MODAL}
       >
         <BottomSheetHeader>
-          {`${strings('app_settings.delete')} ${networkName} ${strings('asset_details.network')}`}
+          {`${strings('app_settings.delete')} ${networkName} ${strings('app_settings.network')}`}
         </BottomSheetHeader>
         <Box alignItems={BoxAlignItems.Center} twClassName="px-4">
           <Text variant={TextVariant.BodyMd} twClassName="text-center mb-4">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Adjusted the remove-network confirmation header shown from `NetworkDetailsView` to sentence case.

- Updated `DeleteNetworkModal` header composition to use `strings('app_settings.network')` (lowercase) instead of `strings('asset_details.network')` (title case).
- This changes the UI from `Delete Mantle Network` to `Delete Mantle network`.
- Added a regression assertion in `NetworkDetailsView.test.tsx` to validate the exact header text shape.

## **Changelog**

CHANGELOG entry: Fixed remove network confirmation header casing to sentence case.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-533

## **Manual testing steps**

```gherkin
Feature: Remove network confirmation header casing

  Scenario: User opens remove network confirmation from network details
    Given the user is editing a custom network in Network Details
    When the user taps the trash icon to remove the network
    Then the bottom sheet header displays "Delete <NetworkName> network" in sentence case
```

## **Screenshots/Recordings**

### **Before**
<img width="1284" height="2778" alt="image" src="https://github.com/user-attachments/assets/15827642-6beb-4b1c-86a0-7571d8724fe8" />

### **After**
<img width="398" height="840" alt="Screenshot 2026-03-16 at 14 24 19" src="https://github.com/user-attachments/assets/43c5100b-6261-4c47-bd31-debcd2097f1b" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8705377-d383-4a2c-9ce6-89a06a2ca4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8705377-d383-4a2c-9ce6-89a06a2ca4f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

