### PR TITLE
fix(networks): align network header trash icon color

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { strings } from '../../../../../locales/i18n';
+import { IconColor } from '../../../../component-library/components/Icons/Icon';
 import { NetworkDetailsViewSelectorsIDs } from './NetworkDetailsView.testIds';
 import NetworkDetailsView from './NetworkDetailsView';
 
@@ -746,6 +747,18 @@ describe('NetworkDetailsView', () => {
       expect(
         getByText(strings('app_settings.network_delete')),
       ).toBeOnTheScreen();
+    });
+
+    it('renders header trash icon using default icon color', () => {
+      mockFormHook.mockReturnValue(editForm());
+
+      const { getByTestId } = render(<NetworkDetailsView />);
+
+      const trashIcon = getByTestId(
+        NetworkDetailsViewSelectorsIDs.CONTAINER,
+      ).findAllByProps({ name: 'Trash' })[0];
+
+      expect(trashIcon.props.color).toBe(IconColor.Default);
     });
 
     it('calls operations.removeNetwork on confirm delete', () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -204,7 +204,7 @@ const NetworkDetailsView = () => {
               <Icon
                 name={IconName.Trash}
                 size={IconSize.Md}
-                color={IconColor.Error}
+                color={IconColor.Default}
               />
             </Pressable>
           ) : undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This PR fixes a UI inconsistency in the custom network details screen.

- The header trash icon on `NetworkDetailsView` was using `IconColor.Error` (red).
- Other network delete/trash icons in the app use the default icon color.
- Updated the header trash icon to use `IconColor.Default` so it aligns with the existing app pattern.
- Added a regression unit test to assert the header trash icon uses the default icon color in edit mode.

## **Changelog**

CHANGELOG entry: Fixed the custom network header trash icon color to match other trash icons in the app.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-534

## **Manual testing steps**

```gherkin
Feature: Custom network delete icon consistency

  Scenario: user opens custom network details in edit mode
    Given the user has at least one deletable custom network

    When user opens that network in the network details screen
    Then the trash icon in the header is displayed with the standard default icon color (not red)

  Scenario: delete flow still works
    Given the user is on the custom network details screen in edit mode

    When user taps the header trash icon
    Then the delete confirmation modal is shown
```

## **Screenshots/Recordings**

### **Before**
<img width="391" height="834" alt="Screenshot 2026-03-16 at 14 24 11" src="https://github.com/user-attachments/assets/41733a5c-62cd-417e-b844-ba1266e33aba" />

### **After**
<img width="387" height="836" alt="Screenshot 2026-03-16 at 14 22 32" src="https://github.com/user-attachments/assets/d5ab99d9-c132-42ea-9447-805edff92c9c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6a7c920-216a-42e9-851d-93400aaf3720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6a7c920-216a-42e9-851d-93400aaf3720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

