### PR TITLE
fix(network-details): correct RPC URL focus and border styling

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.styles.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.styles.ts
@@ -55,7 +55,7 @@ const createStyles = (params: { theme: Theme }) => {
       ...typography.sBodyMD,
       fontWeight: typography.sBodyMD.fontWeight as '400',
       fontFamily: getFontFamily(TextVariant.BodyMD),
-      borderColor: colors.border.default,
+      borderColor: colors.primary.default,
       borderRadius: 12,
       borderWidth: 1,
       padding: 10,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.styles.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.styles.ts
@@ -15,6 +15,18 @@ import type { Theme } from '../../../../util/theme/models';
 const createStyles = (params: { theme: Theme }) => {
   const { colors } = params.theme;
 
+  const baseInput = {
+    ...typography.sBodyMD,
+    fontWeight: typography.sBodyMD.fontWeight as '400',
+    fontFamily: getFontFamily(TextVariant.BodyMD),
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 10,
+    height: 48,
+    color: colors.text.default,
+    backgroundColor: colors.background.muted,
+  };
+
   return StyleSheet.create({
     // ---- Modal content layout ------------------------------------------------
     rpcTitleWrapper: {
@@ -29,39 +41,16 @@ const createStyles = (params: { theme: Theme }) => {
 
     // ---- RpcUrlInput still uses these for the modal form ---------------------
     input: {
-      ...fontStyles.normal,
-      fontWeight: fontStyles.normal.fontWeight as '400',
+      ...baseInput,
       borderColor: colors.border.muted,
-      borderRadius: 12,
-      borderWidth: 1,
-      padding: 10,
-      height: 48,
-      color: colors.text.default,
-      backgroundColor: colors.background.muted,
     },
     inputWithError: {
-      ...typography.sBodyMD,
-      fontWeight: typography.sBodyMD.fontWeight as '400',
-      fontFamily: getFontFamily(TextVariant.BodyMD),
+      ...baseInput,
       borderColor: colors.error.default,
-      borderRadius: 12,
-      borderWidth: 1,
-      padding: 10,
-      height: 48,
-      color: colors.text.default,
-      backgroundColor: colors.background.muted,
     },
     inputWithFocus: {
-      ...typography.sBodyMD,
-      fontWeight: typography.sBodyMD.fontWeight as '400',
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-      borderColor: colors.primary.default,
-      borderRadius: 12,
-      borderWidth: 1,
-      padding: 10,
-      height: 48,
-      color: colors.text.default,
-      backgroundColor: colors.background.muted,
+      ...baseInput,
+      borderColor: colors.border.default,
     },
     warningText: {
       ...fontStyles.normal,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.styles.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.styles.ts
@@ -31,7 +31,7 @@ const createStyles = (params: { theme: Theme }) => {
     input: {
       ...fontStyles.normal,
       fontWeight: fontStyles.normal.fontWeight as '400',
-      borderColor: colors.border.default,
+      borderColor: colors.border.muted,
       borderRadius: 12,
       borderWidth: 1,
       padding: 10,
@@ -55,7 +55,7 @@ const createStyles = (params: { theme: Theme }) => {
       ...typography.sBodyMD,
       fontWeight: typography.sBodyMD.fontWeight as '400',
       fontFamily: getFontFamily(TextVariant.BodyMD),
-      borderColor: colors.primary.default,
+      borderColor: colors.border.default,
       borderRadius: 12,
       borderWidth: 1,
       padding: 10,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -144,6 +144,7 @@ const createMockFormHook = (overrides: Record<string, unknown> = {}) => ({
   onSymbolFocused: jest.fn(),
   onSymbolBlur: jest.fn(),
   onRpcUrlFocused: jest.fn(),
+  onRpcUrlBlur: jest.fn(),
   onChainIdFocused: jest.fn(),
   onChainIdBlur: jest.fn(),
   jumpToRpcURL: jest.fn(),
@@ -688,6 +689,19 @@ describe('NetworkDetailsView', () => {
         'blur',
       );
       expect(val.validateName).toHaveBeenCalled();
+    });
+
+    it('triggers RPC focus cleanup on RPC URL blur', () => {
+      const formReturn = createMockFormHook();
+      mockFormHook.mockReturnValue(formReturn);
+
+      const { getByTestId } = render(<NetworkDetailsView />);
+
+      fireEvent(
+        getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT),
+        'blur',
+      );
+      expect(formReturn.onRpcUrlBlur).toHaveBeenCalled();
     });
 
     it('triggers handleValidateSymbol on symbol field blur', () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
@@ -28,7 +28,7 @@ import Tag from '../../../../../component-library/components/Tags/Tag/Tag';
 import { CellComponentSelectorsIDs } from '../../../../../component-library/components/Cells/Cell/CellComponent.testIds';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import RpcUrlInput from './RpcUrlInput';
+import RpcFormFields from './RpcFormFields';
 import SelectField from './SelectField';
 import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
 import { formatNetworkRpcUrl } from '../NetworkDetailsView.utils';
@@ -87,54 +87,26 @@ const RpcEndpointSection: React.FC<RpcEndpointSectionProps> = ({
 
   if (addMode) {
     return (
-      <>
-        <Box twClassName="gap-1">
-          <Label>{strings('app_settings.network_rpc_url_label')}</Label>
-          <RpcUrlInput
-            ref={inputRpcURL}
-            style={[
-              styles.input,
-              isRpcUrlFieldFocused
-                ? styles.inputWithFocus
-                : warningRpcUrl
-                  ? styles.inputWithError
-                  : undefined,
-            ]}
-            autoCapitalize="none"
-            autoCorrect={false}
-            value={rpcUrlForm}
-            editable
-            onChangeText={onRpcUrlAdd}
-            onFocus={onRpcUrlFocused}
-            onBlur={onRpcUrlBlur}
-            placeholder={strings('app_settings.network_rpc_placeholder')}
-            placeholderTextColor={placeholderTextColor}
-            onSubmitEditing={jumpToChainId}
-            testID={NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT}
-            keyboardAppearance={themeAppearance}
-            checkIfNetworkExists={checkIfNetworkExists}
-            checkIfRpcUrlExists={checkIfRpcUrlExists}
-            onValidationSuccess={onValidationSuccess}
-            onValidationChange={onRpcUrlValidationChange}
-            warningStyle={styles.warningText}
-          />
-        </Box>
-        <Box twClassName="gap-1">
-          <Label>{strings('app_settings.network_rpc_name_label')}</Label>
-          <TextField
-            ref={inputNameRpcURL}
-            autoCapitalize="none"
-            value={rpcNameForm}
-            autoCorrect={false}
-            onChangeText={onRpcNameAdd}
-            placeholder={strings('app_settings.network_rpc_placeholder')}
-            placeholderTextColor={placeholderTextColor}
-            onSubmitEditing={jumpToChainId}
-            testID={NetworkDetailsViewSelectorsIDs.RPC_NAME_INPUT}
-            keyboardAppearance={themeAppearance}
-          />
-        </Box>
-      </>
+      <RpcFormFields
+        inputRpcURL={inputRpcURL}
+        inputNameRpcURL={inputNameRpcURL}
+        rpcUrlForm={rpcUrlForm}
+        rpcNameForm={rpcNameForm}
+        isRpcUrlFieldFocused={isRpcUrlFieldFocused}
+        warningRpcUrl={warningRpcUrl}
+        onRpcUrlAdd={onRpcUrlAdd}
+        onRpcNameAdd={onRpcNameAdd}
+        onRpcUrlFocused={onRpcUrlFocused}
+        onRpcUrlBlur={onRpcUrlBlur}
+        jumpToChainId={jumpToChainId}
+        checkIfNetworkExists={checkIfNetworkExists}
+        checkIfRpcUrlExists={checkIfRpcUrlExists}
+        onValidationSuccess={onValidationSuccess}
+        onRpcUrlValidationChange={onRpcUrlValidationChange}
+        styles={styles}
+        themeAppearance={themeAppearance}
+        placeholderTextColor={placeholderTextColor}
+      />
     );
   }
 
@@ -387,52 +359,26 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
             pointerEvents={showForm ? 'auto' : 'none'}
           >
             <Box twClassName="mx-4 mt-4 p-4 gap-4 rounded-xl bg-background-muted">
-              <Box twClassName="gap-1">
-                <Label>{strings('app_settings.network_rpc_url_label')}</Label>
-                <RpcUrlInput
-                  ref={inputRpcURL}
-                  style={[
-                    styles.input,
-                    isRpcUrlFieldFocused
-                      ? styles.inputWithFocus
-                      : warningRpcUrl
-                        ? styles.inputWithError
-                        : undefined,
-                  ]}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  value={rpcUrlForm}
-                  editable
-                  onChangeText={onRpcUrlAdd}
-                  onFocus={onRpcUrlFocused}
-                  onBlur={onRpcUrlBlur}
-                  placeholder={strings('app_settings.network_rpc_placeholder')}
-                  placeholderTextColor={placeholderTextColor}
-                  onSubmitEditing={jumpToChainId}
-                  testID={NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT}
-                  keyboardAppearance={themeAppearance}
-                  checkIfNetworkExists={checkIfNetworkExists}
-                  checkIfRpcUrlExists={checkIfRpcUrlExists}
-                  onValidationSuccess={onValidationSuccess}
-                  onValidationChange={onRpcUrlValidationChange}
-                  warningStyle={styles.warningText}
-                />
-              </Box>
-              <Box twClassName="gap-1">
-                <Label>{strings('app_settings.network_rpc_name_label')}</Label>
-                <TextField
-                  ref={inputNameRpcURL}
-                  autoCapitalize="none"
-                  value={rpcNameForm}
-                  autoCorrect={false}
-                  onChangeText={onRpcNameAdd}
-                  placeholder={strings('app_settings.network_rpc_placeholder')}
-                  placeholderTextColor={placeholderTextColor}
-                  onSubmitEditing={jumpToChainId}
-                  testID={NetworkDetailsViewSelectorsIDs.RPC_NAME_INPUT}
-                  keyboardAppearance={themeAppearance}
-                />
-              </Box>
+              <RpcFormFields
+                inputRpcURL={inputRpcURL}
+                inputNameRpcURL={inputNameRpcURL}
+                rpcUrlForm={rpcUrlForm}
+                rpcNameForm={rpcNameForm}
+                isRpcUrlFieldFocused={isRpcUrlFieldFocused}
+                warningRpcUrl={warningRpcUrl}
+                onRpcUrlAdd={onRpcUrlAdd}
+                onRpcNameAdd={onRpcNameAdd}
+                onRpcUrlFocused={onRpcUrlFocused}
+                onRpcUrlBlur={onRpcUrlBlur}
+                jumpToChainId={jumpToChainId}
+                checkIfNetworkExists={checkIfNetworkExists}
+                checkIfRpcUrlExists={checkIfRpcUrlExists}
+                onValidationSuccess={onValidationSuccess}
+                onRpcUrlValidationChange={onRpcUrlValidationChange}
+                styles={styles}
+                themeAppearance={themeAppearance}
+                placeholderTextColor={placeholderTextColor}
+              />
               <ButtonPrimary
                 label={strings('app_settings.add_rpc_url')}
                 size={ButtonSize.Lg}

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
@@ -73,6 +73,7 @@ const RpcEndpointSection: React.FC<RpcEndpointSectionProps> = ({
     onRpcUrlAdd,
     onRpcNameAdd,
     onRpcUrlFocused,
+    onRpcUrlBlur,
     jumpToChainId,
     focus: { isRpcUrlFieldFocused },
   } = formHook;
@@ -105,6 +106,7 @@ const RpcEndpointSection: React.FC<RpcEndpointSectionProps> = ({
             editable
             onChangeText={onRpcUrlAdd}
             onFocus={onRpcUrlFocused}
+            onBlur={onRpcUrlBlur}
             placeholder={strings('app_settings.network_rpc_placeholder')}
             placeholderTextColor={placeholderTextColor}
             onSubmitEditing={jumpToChainId}
@@ -290,6 +292,7 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
     onRpcUrlChangeWithName,
     onRpcUrlDelete,
     onRpcUrlFocused,
+    onRpcUrlBlur,
     jumpToChainId,
     modals: { showMultiRpcAddModal, rpcModalShowForm: showForm },
     setRpcModalShowForm: setShowForm,
@@ -402,6 +405,7 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
                   editable
                   onChangeText={onRpcUrlAdd}
                   onFocus={onRpcUrlFocused}
+                  onBlur={onRpcUrlBlur}
                   placeholder={strings('app_settings.network_rpc_placeholder')}
                   placeholderTextColor={placeholderTextColor}
                   onSubmitEditing={jumpToChainId}

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
@@ -94,11 +94,11 @@ const RpcEndpointSection: React.FC<RpcEndpointSectionProps> = ({
             ref={inputRpcURL}
             style={[
               styles.input,
-              warningRpcUrl
-                ? isRpcUrlFieldFocused
-                  ? styles.inputWithFocus
-                  : styles.inputWithError
-                : undefined,
+              isRpcUrlFieldFocused
+                ? styles.inputWithFocus
+                : warningRpcUrl
+                  ? styles.inputWithError
+                  : undefined,
             ]}
             autoCapitalize="none"
             autoCorrect={false}
@@ -393,11 +393,11 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
                   ref={inputRpcURL}
                   style={[
                     styles.input,
-                    warningRpcUrl
-                      ? isRpcUrlFieldFocused
-                        ? styles.inputWithFocus
-                        : styles.inputWithError
-                      : undefined,
+                    isRpcUrlFieldFocused
+                      ? styles.inputWithFocus
+                      : warningRpcUrl
+                        ? styles.inputWithError
+                        : undefined,
                   ]}
                   autoCapitalize="none"
                   autoCorrect={false}

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcFormFields.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcFormFields.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import RpcFormFields from './RpcFormFields';
+import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
+import createStyles from '../NetworkDetailsView.styles';
+import { mockTheme } from '../../../../../util/theme';
+
+const styles = createStyles({ theme: mockTheme });
+
+const defaultProps = {
+  inputRpcURL: { current: null },
+  inputNameRpcURL: { current: null },
+  rpcUrlForm: '',
+  rpcNameForm: '',
+  isRpcUrlFieldFocused: false,
+  warningRpcUrl: undefined as string | undefined,
+  onRpcUrlAdd: jest.fn(),
+  onRpcNameAdd: jest.fn(),
+  onRpcUrlFocused: jest.fn(),
+  onRpcUrlBlur: jest.fn(),
+  jumpToChainId: jest.fn(),
+  checkIfNetworkExists: jest.fn().mockResolvedValue([]),
+  checkIfRpcUrlExists: jest.fn().mockResolvedValue([]),
+  onValidationSuccess: jest.fn(),
+  onRpcUrlValidationChange: jest.fn(),
+  styles,
+  themeAppearance: 'light' as const,
+  placeholderTextColor: '#999',
+};
+
+describe('RpcFormFields', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders both RPC URL and RPC name inputs', () => {
+    const { getByTestId } = render(<RpcFormFields {...defaultProps} />);
+
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.RPC_NAME_INPUT),
+    ).toBeOnTheScreen();
+  });
+
+  it('applies base input style when not focused and no warning', () => {
+    const { getByTestId } = render(<RpcFormFields {...defaultProps} />);
+
+    const input = getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT);
+    const flatStyle = Array.isArray(input.props.style)
+      ? Object.assign({}, ...input.props.style.filter(Boolean))
+      : input.props.style;
+
+    expect(flatStyle.borderColor).toBe(mockTheme.colors.border.muted);
+  });
+
+  it('applies focus style when isRpcUrlFieldFocused is true', () => {
+    const { getByTestId } = render(
+      <RpcFormFields {...defaultProps} isRpcUrlFieldFocused />,
+    );
+
+    const input = getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT);
+    const flatStyle = Array.isArray(input.props.style)
+      ? Object.assign({}, ...input.props.style.filter(Boolean))
+      : input.props.style;
+
+    expect(flatStyle.borderColor).toBe(mockTheme.colors.border.default);
+  });
+
+  it('applies error style when not focused and warningRpcUrl is set', () => {
+    const { getByTestId } = render(
+      <RpcFormFields
+        {...defaultProps}
+        isRpcUrlFieldFocused={false}
+        warningRpcUrl="Invalid URL"
+      />,
+    );
+
+    const input = getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT);
+    const flatStyle = Array.isArray(input.props.style)
+      ? Object.assign({}, ...input.props.style.filter(Boolean))
+      : input.props.style;
+
+    expect(flatStyle.borderColor).toBe(mockTheme.colors.error.default);
+  });
+
+  it('focus style takes precedence over error style', () => {
+    const { getByTestId } = render(
+      <RpcFormFields
+        {...defaultProps}
+        isRpcUrlFieldFocused
+        warningRpcUrl="Invalid URL"
+      />,
+    );
+
+    const input = getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT);
+    const flatStyle = Array.isArray(input.props.style)
+      ? Object.assign({}, ...input.props.style.filter(Boolean))
+      : input.props.style;
+
+    expect(flatStyle.borderColor).toBe(mockTheme.colors.border.default);
+  });
+
+  it('calls onRpcUrlFocused on focus and onRpcUrlBlur on blur', () => {
+    const { getByTestId } = render(<RpcFormFields {...defaultProps} />);
+
+    const input = getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT);
+    fireEvent(input, 'focus');
+    expect(defaultProps.onRpcUrlFocused).toHaveBeenCalled();
+
+    fireEvent(input, 'blur');
+    expect(defaultProps.onRpcUrlBlur).toHaveBeenCalled();
+  });
+
+  it('calls onRpcNameAdd when RPC name text changes', () => {
+    const { getByTestId } = render(<RpcFormFields {...defaultProps} />);
+
+    fireEvent.changeText(
+      getByTestId(NetworkDetailsViewSelectorsIDs.RPC_NAME_INPUT),
+      'My RPC',
+    );
+    expect(defaultProps.onRpcNameAdd).toHaveBeenCalledWith('My RPC');
+  });
+
+  it('displays pre-filled values', () => {
+    const { getByTestId } = render(
+      <RpcFormFields
+        {...defaultProps}
+        rpcUrlForm="https://rpc.example.com"
+        rpcNameForm="Example RPC"
+      />,
+    );
+
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT).props.value,
+    ).toBe('https://rpc.example.com');
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.RPC_NAME_INPUT).props.value,
+    ).toBe('Example RPC');
+  });
+});

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcFormFields.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcFormFields.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { TextInput } from 'react-native';
+import { Box, Label } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import TextField from '../../../../../component-library/components/Form/TextField';
+import RpcUrlInput from './RpcUrlInput';
+import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
+import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
+
+interface RpcFormFieldsProps {
+  inputRpcURL: React.RefObject<TextInput>;
+  inputNameRpcURL: React.RefObject<TextInput>;
+  rpcUrlForm: string;
+  rpcNameForm: string;
+  isRpcUrlFieldFocused: boolean;
+  warningRpcUrl: string | undefined;
+  onRpcUrlAdd: (url: string) => void;
+  onRpcNameAdd: (name: string) => void;
+  onRpcUrlFocused: () => void;
+  onRpcUrlBlur: () => void;
+  jumpToChainId: () => void;
+  checkIfNetworkExists: (rpcUrl: string) => Promise<{ chainId: string }[]>;
+  checkIfRpcUrlExists: (rpcUrl: string) => Promise<{ chainId: string }[]>;
+  onValidationSuccess: () => void;
+  onRpcUrlValidationChange: (isValid: boolean) => void;
+  styles: NetworkDetailsStyles;
+  themeAppearance: 'light' | 'dark' | 'default';
+  placeholderTextColor: string;
+}
+
+const RpcFormFields: React.FC<RpcFormFieldsProps> = ({
+  inputRpcURL,
+  inputNameRpcURL,
+  rpcUrlForm,
+  rpcNameForm,
+  isRpcUrlFieldFocused,
+  warningRpcUrl,
+  onRpcUrlAdd,
+  onRpcNameAdd,
+  onRpcUrlFocused,
+  onRpcUrlBlur,
+  jumpToChainId,
+  checkIfNetworkExists,
+  checkIfRpcUrlExists,
+  onValidationSuccess,
+  onRpcUrlValidationChange,
+  styles,
+  themeAppearance,
+  placeholderTextColor,
+}) => (
+  <>
+    <Box twClassName="gap-1">
+      <Label>{strings('app_settings.network_rpc_url_label')}</Label>
+      <RpcUrlInput
+        ref={inputRpcURL}
+        style={[
+          styles.input,
+          isRpcUrlFieldFocused
+            ? styles.inputWithFocus
+            : warningRpcUrl
+              ? styles.inputWithError
+              : undefined,
+        ]}
+        autoCapitalize="none"
+        autoCorrect={false}
+        value={rpcUrlForm}
+        editable
+        onChangeText={onRpcUrlAdd}
+        onFocus={onRpcUrlFocused}
+        onBlur={onRpcUrlBlur}
+        placeholder={strings('app_settings.network_rpc_placeholder')}
+        placeholderTextColor={placeholderTextColor}
+        onSubmitEditing={jumpToChainId}
+        testID={NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT}
+        keyboardAppearance={themeAppearance}
+        checkIfNetworkExists={checkIfNetworkExists}
+        checkIfRpcUrlExists={checkIfRpcUrlExists}
+        onValidationSuccess={onValidationSuccess}
+        onValidationChange={onRpcUrlValidationChange}
+        warningStyle={styles.warningText}
+      />
+    </Box>
+    <Box twClassName="gap-1">
+      <Label>{strings('app_settings.network_rpc_name_label')}</Label>
+      <TextField
+        ref={inputNameRpcURL}
+        autoCapitalize="none"
+        value={rpcNameForm}
+        autoCorrect={false}
+        onChangeText={onRpcNameAdd}
+        placeholder={strings('app_settings.network_rpc_placeholder')}
+        placeholderTextColor={placeholderTextColor}
+        onSubmitEditing={jumpToChainId}
+        testID={NetworkDetailsViewSelectorsIDs.RPC_NAME_INPUT}
+        keyboardAppearance={themeAppearance}
+      />
+    </Box>
+  </>
+);
+
+export default RpcFormFields;

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcUrlInput.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcUrlInput.tsx
@@ -93,8 +93,8 @@ const RpcUrlInput = forwardRef<TextInput, RpcUrlInputProps>((props, ref) => {
     <>
       <TextInput
         ref={ref}
-        underlineColorAndroid="transparent"
         {...inputProps}
+        underlineColorAndroid="transparent"
         onChangeText={handleRpcUrlChange}
       />
       {warningRpcUrl && (

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcUrlInput.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcUrlInput.tsx
@@ -91,7 +91,12 @@ const RpcUrlInput = forwardRef<TextInput, RpcUrlInputProps>((props, ref) => {
 
   return (
     <>
-      <TextInput ref={ref} {...inputProps} onChangeText={handleRpcUrlChange} />
+      <TextInput
+        ref={ref}
+        underlineColorAndroid="transparent"
+        {...inputProps}
+        onChangeText={handleRpcUrlChange}
+      />
       {warningRpcUrl && (
         <View testID={NetworkDetailsViewSelectorsIDs.RPC_WARNING_BANNER}>
           <Text style={warningStyle}>{warningRpcUrl}</Text>

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useFormFocus.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useFormFocus.test.ts
@@ -30,11 +30,14 @@ describe('useFormFocus', () => {
     },
   );
 
-  it('sets rpc url focus on onRpcUrlFocused', () => {
+  it('toggles rpc url focus on focus/blur', () => {
     const { result } = renderHook(() => useFormFocus());
 
     act(() => result.current.onRpcUrlFocused());
     expect(result.current.focus.isRpcUrlFieldFocused).toBe(true);
+
+    act(() => result.current.onRpcUrlBlur());
+    expect(result.current.focus.isRpcUrlFieldFocused).toBe(false);
   });
 
   it('creates refs for all input fields', () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useFormFocus.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useFormFocus.ts
@@ -16,6 +16,7 @@ export interface UseFormFocusReturn {
   onSymbolFocused: () => void;
   onSymbolBlur: () => void;
   onRpcUrlFocused: () => void;
+  onRpcUrlBlur: () => void;
   onChainIdFocused: () => void;
   onChainIdBlur: () => void;
 
@@ -59,6 +60,10 @@ export const useFormFocus = (): UseFormFocusReturn => {
     () => setFocus((prev) => ({ ...prev, isRpcUrlFieldFocused: true })),
     [],
   );
+  const onRpcUrlBlur = useCallback(
+    () => setFocus((prev) => ({ ...prev, isRpcUrlFieldFocused: false })),
+    [],
+  );
   const onChainIdFocused = useCallback(
     () => setFocus((prev) => ({ ...prev, isChainIdFieldFocused: true })),
     [],
@@ -88,6 +93,7 @@ export const useFormFocus = (): UseFormFocusReturn => {
     onSymbolFocused,
     onSymbolBlur,
     onRpcUrlFocused,
+    onRpcUrlBlur,
     onChainIdFocused,
     onChainIdBlur,
     jumpToRpcURL,


### PR DESCRIPTION
## **Description**

The RPC URL input in the Add Network form had several visual inconsistencies:

1. **Focus state was never cleared** — `isRpcUrlFieldFocused` was set on focus but never reset on blur, leaving the input styled as focused permanently after the first tap.
2. **Border color mismatch** — the base (unfocused) input used `border.default`, the same token `TextField` uses for its *focused* state, so the RPC field always looked focused. The focused override used `primary.default` (blue) instead of `border.default`.
3. **Font size jump on focus** — the base style used `fontStyles.normal` (no `fontSize`), while the focused/error overrides used `typography.sBodyMD` (includes `fontSize`), causing the placeholder text to resize when the user tapped in.

**Changes:**

- Added `onRpcUrlBlur` handler in `useFormFocus` to reset `isRpcUrlFieldFocused` to `false`
- Wired `onBlur={onRpcUrlBlur}` on both `RpcUrlInput` instances (inline form + modal form)
- Fixed style precedence: focus style now takes priority over error style (focus → error → default)
- Extracted a shared `baseInput` object using `typography.sBodyMD` so all three states (default, focused, error) use identical typography
- Changed default border to `border.muted` and focused border to `border.default`, matching `TextField` conventions
- Changed focused border from `primary.default` to `border.default` to align with `TextField`
- Added `underlineColorAndroid="transparent"` on the raw `TextInput` in `RpcUrlInput`
- Extracted `RpcFormFields` component to deduplicate the identical RPC URL + name form rendered in both `RpcEndpointSection` (addMode) and `RpcEndpointModals` (modal form), resolving ~80% code duplication flagged by SonarCloud
- Added dedicated unit tests for `RpcFormFields` covering all three style states (default, focused, error), focus precedence over error, focus/blur callbacks, and pre-filled values

## **Changelog**

CHANGELOG entry: Fixed a bug where the RPC URL field in network details could appear focused after blur and had inconsistent typography between states.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-536

## **Manual testing steps**

```gherkin
Feature: Network details RPC URL focus visuals

  Scenario: RPC URL field is not visually focused on form open
    Given I open Settings > Networks > Add network
    When the form is first displayed
    Then the RPC URL field shows a neutral border (not focused blue)

  Scenario: RPC URL field focus style clears after changing field
    Given I am on Settings > Networks > Add network
    And I tap RPC URL and type an invalid URL to show validation messaging
    When I tap Symbol input
    Then the Symbol input is focused
    And RPC URL no longer shows focused blue styling

  Scenario: Android input does not show native blue underline artifact
    Given I am on Android and open Add network form
    When I focus and blur the RPC URL input
    Then no persistent native blue underline remains after blur
```

## **Screenshots/Recordings**

### **Before**
<img width="394" height="838" alt="Screenshot 2026-03-16 at 14 27 07" src="https://github.com/user-attachments/assets/c7f4a26a-02dc-4125-9c89-ecbd32ee6f15" />


### **After**
<img width="395" height="840" alt="Screenshot 2026-03-16 at 14 37 03" src="https://github.com/user-attachments/assets/d4e11708-74f1-47dc-8f5a-e434225567cd" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<div><a href="https://cursor.com/agents/bc-c1bb95bb-0c05-4edf-a8ec-fe77c2dea712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1bb95bb-0c05-4edf-a8ec-fe77c2dea712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX fix and small refactor in the network details RPC form; main risk is limited to regressions in input focus/validation wiring in add/edit RPC flows.
> 
> **Overview**
> Fixes RPC URL input focus/blur behavior and visual styling in Network Details so the field no longer appears permanently focused and uses consistent typography and border tokens across default/focus/error states.
> 
> Refactors the duplicated RPC URL + RPC name form into a reusable `RpcFormFields` component used in both add-mode and the RPC bottom-sheet modal, adds an Android `TextInput` underline suppression, and expands unit coverage to assert blur cleanup and style precedence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8dfb8ed2d13bb32d8c4ad4aba2e68e6f7e3adb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->