### PR TITLE
chore: correct token price formatting in wallet token list cp-7.69.1 cp-7.70.0

### DIFF
--- a/app/components/UI/Predict/utils/format.test.ts
+++ b/app/components/UI/Predict/utils/format.test.ts
@@ -1618,6 +1618,22 @@ describe('format utils', () => {
         // Assert
         expect(result).toBe('$0.5678');
       });
+
+      it('truncates to 2 decimals for prices >= 1 with extra decimal places', () => {
+        // Arrange & Act
+        const result = formatPriceWithSubscriptNotation(2285.013);
+
+        // Assert
+        expect(result).toBe('$2,285.01');
+      });
+
+      it('truncates to 2 decimals for prices >= 1 with 4 decimal places', () => {
+        // Arrange & Act
+        const result = formatPriceWithSubscriptNotation(1.2345);
+
+        // Assert
+        expect(result).toBe('$1.23');
+      });
     });
 
     describe('Zero value', () => {

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -114,15 +114,17 @@ export const formatPrice = (
  * - Uses subscript notation for values with 4+ leading zeros (e.g., 0.00000614 → $0.0₅614)
  * - The subscript indicates the number of leading zeros after the decimal point
  * - Returns "—" for zero values
- * - Uses min 2, max 4 decimal places for regular values
+ * - Values >= 1: exactly 2 decimal places (e.g. $2,285.01)
+ * - Values < 1: up to 4 decimal places (e.g. $0.1446)
  * @param price - The price value to format (string or number)
  * @param currencyCode - ISO 4217 currency code (e.g. 'USD', 'EUR'). Defaults to 'USD'.
  * @returns Formatted price string with currency symbol or "—" for zero
+ * @example formatPriceWithSubscriptNotation(2285.013) => "$2,285.01"
  * @example formatPriceWithSubscriptNotation(1.99) => "$1.99"
  * @example formatPriceWithSubscriptNotation(0.144566) => "$0.1446"
  * @example formatPriceWithSubscriptNotation(0.00000614) => "$0.0₅614"
  * @example formatPriceWithSubscriptNotation(0) => "—"
- * @example formatPriceWithSubscriptNotation(1.2345, 'EUR') => "€1.2345"
+ * @example formatPriceWithSubscriptNotation(1.2345, 'EUR') => "€1.23"
  */
 export const formatPriceWithSubscriptNotation = (
   price: string | number,
@@ -151,7 +153,7 @@ export const formatPriceWithSubscriptNotation = (
   const formattedNumber = new Intl.NumberFormat('en-US', {
     style: 'decimal',
     minimumFractionDigits: 2,
-    maximumFractionDigits: 4,
+    maximumFractionDigits: num >= 1 ? 2 : 4,
   }).format(num);
   return addSymbol(formattedNumber);
 };

--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
@@ -72,7 +72,7 @@ import {
 } from '../../../../../selectors/networkController';
 import { selectShowFiatInTestnets } from '../../../../../selectors/settings';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { addCurrencySymbol } from '../../../../../util/number';
+import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
 import { safeToChecksumAddress } from '../../../../../util/address';
 import generateTestId from '../../../../../../wdio/utils/generateTestId';
 import { getAssetTestId } from '../../../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
@@ -631,7 +631,7 @@ export const TokenListItemV2 = React.memo(
                   asset.balanceFiat === TOKEN_RATE_UNDEFINED ||
                   hideFiatForTestnet
                     ? CLTextVariant.BodySM
-                    : CLTextVariant.BodyMDBold
+                    : CLTextVariant.BodyMDMedium
                 }
                 isHidden={privacyMode}
                 length={SensitiveTextLength.Medium}
@@ -662,11 +662,9 @@ export const TokenListItemV2 = React.memo(
                       twClassName="uppercase"
                     >
                       {tokenPriceInFiat && !hideFiatForScamWarning
-                        ? addCurrencySymbol(
+                        ? formatPriceWithSubscriptNotation(
                             tokenPriceInFiat,
                             currentCurrency,
-                            true,
-                            true,
                           )
                         : '-'}
                       {' \u2022 '}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Two visual bugs were affecting the token price display in the wallet token list (`TokenListItemV2`) and the explore/trending page.

**Bug 1 — Missing thousand-separator commas**
The token price in the second row of each list item (e.g. `$2283.65` for ETH) was formatted with `addCurrencySymbol`, which constructs the string via a plain `.toString()` call and never applies locale-aware number formatting. This meant that prices ≥ $1,000 rendered without commas (e.g. `$2283.65` instead of `$2,283.65`).

Fixed by switching to `formatPriceWithSubscriptNotation`, the same formatter already used on the asset-overview/price chart page, which uses `Intl.NumberFormat('en-US', …)` and produces properly comma-separated output.

**Bug 2 — Too many decimal places for large prices**
`formatPriceWithSubscriptNotation` was configured with `maximumFractionDigits: 4` unconditionally, so a price like `$2,285.013` (3 significant decimal digits within the allowed 2–4 range) rendered incorrectly. This also affected the explore/trending token row.

Fixed by scoping `maximumFractionDigits` to the magnitude of the price: 2 decimals for values ≥ 1, 4 decimals for values < 1 (where extra precision matters, e.g. `$0.1446`). Subscript notation for very small values is unaffected.

**Bug 3 — Unintentional bold weight on fiat balance**
The fiat balance text variant was `BodyMDBold` instead of `BodyMDMedium`, making the balance appear heavier than intended.

The full description has been saved to `.agent/chore-remove-bold-and-add-commas-list-item-v2.PR-desc.md`.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed token prices in the wallet list displaying without thousand-separator commas and with too many decimal places

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-2909 & https://consensyssoftware.atlassian.net/browse/ASSETS-2921

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/3916037a-33b4-4e7e-8fbe-1dd033256037" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/84efa704-d986-4e2d-95f2-d277906975df" />


### **After**
Look at the title and the USD amount. As you can see it is not bold anymore:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/3a267238-9137-4849-9961-fc1af621b384" />

Look at the decimals in Ethereum on Mainnet:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/c4275147-836d-4446-9ce4-f2b9b46b31ef" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts a shared price formatter and switches wallet token list rendering to it, which could change how fiat prices appear across multiple screens. Risk is limited to display/formatting (no transaction or balance calculations).
> 
> **Overview**
> Fixes token price display in the wallet token list by replacing `addCurrencySymbol` with `formatPriceWithSubscriptNotation`, restoring locale-aware formatting (e.g., thousand separators) and consistent currency symbol/suffix handling.
> 
> Updates `formatPriceWithSubscriptNotation` to **cap decimals at 2 for values >= 1** while keeping up to 4 decimals (and subscript notation) for smaller values, and adds unit tests to cover the new truncation behavior. Also tweaks the fiat balance text style in `TokenListItemV2` from bold to a medium weight.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f74fe5b4279af2e31b33336972905096b9f6c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->