### PR TITLE
fix(ota): use builds.yml config for OTA builds (same as native)

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -277,7 +277,7 @@ jobs:
       EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
       EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
       GIT_BRANCH: ${{ github.ref_name }}
-      RAMP_INTERNAL_BUILD: 'true'
+      # Build config (RAMP_INTERNAL_BUILD, METAMASK_ENVIRONMENT, etc.) comes from builds.yml via "Apply build config" step below.
       MM_MUSD_CONVERSION_FLOW_ENABLED: 'false'
       MM_NETWORK_UI_REDESIGN_ENABLED: 'false'
       MM_NOTIFICATIONS_UI_ENABLED: 'true'
@@ -370,6 +370,21 @@ jobs:
           fi
           echo "📦 node_modules size: $(du -sh node_modules | cut -f1)"
           echo "✅ Artifacts verified"
+
+      - name: Apply build config (builds.yml)
+        run: |
+          case "${TARGET_CHANNEL}" in
+            production) BUILD_NAME="main-prod" ;;
+            rc)         BUILD_NAME="main-rc" ;;
+            exp)        BUILD_NAME="main-exp" ;;
+            *)
+              echo "❌ Unknown channel: ${TARGET_CHANNEL}"
+              exit 1
+              ;;
+          esac
+          echo "📋 Applying build config for ${BUILD_NAME} (channel: ${TARGET_CHANNEL})"
+          node scripts/apply-build-config.js "${BUILD_NAME}" --export-github-env >> "$GITHUB_ENV"
+          echo "✅ Build config applied (METAMASK_ENVIRONMENT, RAMP_INTERNAL_BUILD, etc. from builds.yml)"
 
       - name: Determine signing secret name
         shell: bash

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -669,7 +669,10 @@ createEnvFile() {
 	echo "📝 Creating .env file from environment variables..."
 
 	# List of environment variable names to export
+	# METAMASK_ENVIRONMENT and METAMASK_BUILD_TYPE are required so OTA bundle uses correct env (e.g. production ramps, not staging).
 	local ENV_VARS=(
+		"METAMASK_ENVIRONMENT"
+		"METAMASK_BUILD_TYPE"
 		"MM_MUSD_CONVERSION_FLOW_ENABLED"
 		"MM_NETWORK_UI_REDESIGN_ENABLED"
 		"MM_NOTIFICATIONS_UI_ENABLED"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Production OTA builds (e.g. 7.68.2) were incorrectly using staging/internal ramps and other env-dependent behavior because the OTA workflow did **not** use the same build-time config as production native builds. Native production gets its env from `builds.yml` via `apply-build-config.js`; the OTA workflow used a separate, hand-maintained set of variables, so production OTA bundles could be built with wrong (or missing) flags.

**Root cause:** (1) `RAMP_INTERNAL_BUILD` was hardcoded `true` for all OTA channels; (2) `METAMASK_ENVIRONMENT` and `METAMASK_BUILD_TYPE` were not written to `.env` by `createEnvFile()` during OTA builds.

**Fix:** OTA now uses the same config as native builds. In `push-eas-update.yml` we added a step that maps channel → build name (production → main-prod, etc.) and runs `apply-build-config.js`, so all build-level vars from `builds.yml` apply. Removed the job-level `RAMP_INTERNAL_BUILD` override. In `build.sh`, `createEnvFile()` now includes `METAMASK_ENVIRONMENT` and `METAMASK_BUILD_TYPE`. Single source of truth; no duplicate env for OTA.

## **Changelog**

CHANGELOG entry: Fixed production OTA builds using incorrect build config (e.g. staging ramps) by applying the same build config as native builds via `builds.yml` in the OTA workflow.

## **Related issues**

Fixes: (add issue number if applicable)

## **Manual testing steps**

```gherkin
Feature: OTA build config

  Scenario: production OTA uses production config
    Given the Push EAS Update workflow runs for channel production

    When the "Apply build config (builds.yml)" step runs
    Then env from builds.yml (e.g. RAMP_INTERNAL_BUILD=false, METAMASK_ENVIRONMENT=production) is set for the job
    And the OTA bundle is built with production config

  Scenario: after merge, production OTA behaves as production
    Given a production app has received an OTA from this fix

    When user opens Buy / Ramps
    Then ramps point at production, not staging/UAT
```

## **Screenshots/Recordings**

### **Before**

N/A — config/build pipeline change.

### **After**

N/A — config/build pipeline change.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.