### PR TITLE
chore(ci): add RAMP_DEV_BUILD env flag to main-dev and flask-dev builds

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -32,6 +32,7 @@ _public_envs: &public_envs # Servers (production)
   # Build flags (production defaults)
   BRIDGE_USE_DEV_APIS: 'false'
   RAMP_INTERNAL_BUILD: 'false'
+  RAMP_DEV_BUILD: 'false'
   IS_TEST: 'false'
   SEEDLESS_ONBOARDING_ENABLED: 'true'
   MM_NOTIFICATIONS_UI_ENABLED: 'true'
@@ -275,6 +276,7 @@ builds:
       BAANX_API_URL: 'https://dev.api.baanx.com'
       DIGEST_API_URL: 'https://digest.dev-api.cx.metamask.io/api/v1'
       RAMPS_ENVIRONMENT: 'staging'
+      RAMP_DEV_BUILD: 'true'
       BRIDGE_USE_DEV_APIS: 'true'
       RAMP_INTERNAL_BUILD: 'true'
       IS_TEST: 'false'
@@ -356,6 +358,7 @@ builds:
       RAMPS_ENVIRONMENT: 'staging'
       BRIDGE_USE_DEV_APIS: 'true'
       RAMP_INTERNAL_BUILD: 'true'
+      RAMP_DEV_BUILD: 'true'
       IS_TEST: 'false'
       MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS: 'true'
       IS_SIM_BUILD: 'true'


### PR DESCRIPTION

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Ramp Aggregator SDK uses `RAMP_DEV_BUILD` to determine whether the build is a development instance, which enables verbose SDK logging and activates dev/internal behavior (`isDevelopmentOrInternalBuild`). Previously this relied solely on `process.env.NODE_ENV !== 'production'`, but native dev/simulator builds can produce production-mode bundles where `NODE_ENV` is `'production'`, causing the Ramp SDK to behave as a production build even in local development.

This PR wires up `RAMP_DEV_BUILD` as a first-class env var in `builds.yml`:

- Adds `RAMP_DEV_BUILD: 'false'` to `_public_envs` as the default (off for all production, RC, beta, test, e2e, and exp builds)
- Sets `RAMP_DEV_BUILD: 'true'` for `main-dev` and `flask-dev` (local/simulator development builds)

This ensures developers get the expected Ramp SDK dev-mode behavior (verbose logging, dev environment) when running local builds, without affecting any deployed or QA environments.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: RAMP_DEV_BUILD flag in dev builds

  Scenario: Ramp SDK uses dev mode in local development builds
    Given a main-dev or flask-dev build is triggered
    When the Ramp feature is opened
    Then the Ramp SDK initializes with isDevelopment = true
    And verbose SDK logging is active

  Scenario: Ramp SDK uses production mode in non-dev builds
    Given any non-dev build (main-prod, main-rc, main-test, main-e2e, etc.)
    When the Ramp feature is opened
    Then the Ramp SDK initializes with isDevelopment = false
    And RAMP_DEV_BUILD resolves to 'false'
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change to `builds.yml` that affects environment variables for `main-dev` and `flask-dev` builds without touching production/release builds or runtime logic.
> 
> **Overview**
> **Introduces a first-class `RAMP_DEV_BUILD` environment flag in `builds.yml`.**
> 
> Sets `RAMP_DEV_BUILD: 'false'` in the shared `*public_envs` defaults, and explicitly enables `RAMP_DEV_BUILD: 'true'` for the `main-dev` and `flask-dev` build configs so dev/simulator builds can reliably run Ramp in development mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eabadc1be5a920d2f291f73aadc651ab2d82585c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->