### PR TITLE
fix(perps): resolve blank activity tabs from perps home

### DIFF
--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
@@ -610,6 +610,55 @@ describe('TabsList', () => {
       );
     });
 
+    it('stale callback from previous tab does not cancel current tab load', async () => {
+      jest.useFakeTimers();
+
+      // Capture callbacks so we can fire them manually
+      let capturedCallbackA: (() => void) | null = null;
+
+      (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
+        (cb: () => void) => {
+          // Capture only the first callback (Tab 1); don't auto-invoke any
+          if (!capturedCallbackA) capturedCallbackA = cb;
+          return { cancel: jest.fn() };
+        },
+      );
+
+      try {
+        const { getAllByText, getByText, queryByText } = render(
+          <TabsList initialActiveIndex={0}>
+            <View {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
+              <Text>Content 1</Text>
+            </View>
+            <View {...({ tabLabel: 'Tab 2' } as TabViewProps)}>
+              <Text>Content 2</Text>
+            </View>
+          </TabsList>,
+        );
+
+        // Tab 1 scheduled but not yet loaded (InteractionManager not fired)
+        expect(queryByText('Content 1')).toBeNull();
+
+        // Switch to Tab 2 before Tab 1's callback fires
+        await act(async () => {
+          fireEvent.press(getAllByText('Tab 2')[0]);
+        });
+
+        // Now fire Tab 1's stale callback — this must NOT cancel Tab 2's fallback
+        await act(async () => {
+          capturedCallbackA?.();
+        });
+
+        // Tab 2 must still load via its fallback timeout
+        await act(async () => {
+          jest.advanceTimersByTime(250);
+        });
+        expect(getByText('Content 2')).toBeOnTheScreen();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('uses fallback timeout if InteractionManager callback does not run', async () => {
       jest.useFakeTimers();
       (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
@@ -1,6 +1,6 @@
 // Third party dependencies.
 import React from 'react';
-import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { View, InteractionManager } from 'react-native';
 
 // External dependencies.
@@ -71,7 +71,7 @@ describe('TabsList', () => {
       </TabsList>,
     );
 
-    // Assert - Active tab loads via InteractionManager
+    // Assert - active tab is loaded immediately
     expect(getByText('Tokens Content')).toBeOnTheScreen();
 
     // Other tabs should not be loaded yet (on-demand loading)
@@ -82,10 +82,7 @@ describe('TabsList', () => {
       fireEvent.press(getAllByText('NFTs')[0]);
     });
 
-    // Wait for the deferred loading to complete
-    await waitFor(() => {
-      expect(getByText('NFTs Content')).toBeOnTheScreen();
-    });
+    expect(getByText('NFTs Content')).toBeOnTheScreen();
   });
 
   it('switches tab content when tab is pressed', () => {
@@ -198,46 +195,66 @@ describe('TabsList', () => {
     expect(getByText('Tab 2 Content')).toBeOnTheScreen();
   });
 
-  it('goToTabIndex loads target tab even when InteractionManager callback is delayed', async () => {
-    // Arrange
-    const originalJestWorkerId = process.env.JEST_WORKER_ID;
-    delete process.env.JEST_WORKER_ID;
-
-    (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
-      () => ({ cancel: jest.fn() }),
-    );
-
+  it('goToTabIndex loads target tab immediately', async () => {
     const ref = React.createRef<TabsListRef>();
     const tabs = ['Tab 1', 'Tab 2'];
 
-    try {
-      const { getByText } = render(
-        <TabsList ref={ref}>
-          {tabs.map((label, index) => (
-            <View
-              key={`tab${index}`}
-              {...({ tabLabel: label } as TabViewProps)}
-            >
-              <Text>{label} Content</Text>
-            </View>
-          ))}
-        </TabsList>,
-      );
+    const { getByText } = render(
+      <TabsList ref={ref}>
+        {tabs.map((label, index) => (
+          <View key={`tab${index}`} {...({ tabLabel: label } as TabViewProps)}>
+            <Text>{label} Content</Text>
+          </View>
+        ))}
+      </TabsList>,
+    );
 
-      // Act
-      await act(async () => {
-        ref.current?.goToTabIndex(1);
-      });
+    // Act
+    await act(async () => {
+      ref.current?.goToTabIndex(1);
+    });
 
-      // Assert
-      expect(getByText('Tab 2 Content')).toBeOnTheScreen();
-    } finally {
-      if (originalJestWorkerId === undefined) {
-        delete process.env.JEST_WORKER_ID;
-      } else {
-        process.env.JEST_WORKER_ID = originalJestWorkerId;
-      }
-    }
+    // Assert
+    expect(getByText('Tab 2 Content')).toBeOnTheScreen();
+  });
+
+  it('renders initial active tab immediately', () => {
+    // Act
+    const { getByText } = render(
+      <TabsList initialActiveIndex={0}>
+        <View {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
+          <Text>Content 1</Text>
+        </View>
+        <View {...({ tabLabel: 'Tab 2' } as TabViewProps)}>
+          <Text>Content 2</Text>
+        </View>
+      </TabsList>,
+    );
+
+    // Assert
+    expect(getByText('Content 1')).toBeOnTheScreen();
+  });
+
+  it('loads target tab on user press immediately', async () => {
+    // Arrange
+    const { getAllByText, getByText } = render(
+      <TabsList initialActiveIndex={0}>
+        <View {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
+          <Text>Content 1</Text>
+        </View>
+        <View {...({ tabLabel: 'Tab 2' } as TabViewProps)}>
+          <Text>Content 2</Text>
+        </View>
+      </TabsList>,
+    );
+
+    // Act
+    await act(async () => {
+      fireEvent.press(getAllByText('Tab 2')[0]);
+    });
+
+    // Assert
+    expect(getByText('Content 2')).toBeOnTheScreen();
   });
 
   it('exposes getCurrentIndex method via ref', () => {
@@ -496,17 +513,8 @@ describe('TabsList', () => {
     // even when the tab was temporarily removed and re-added
   });
 
-  describe('Deferred Content Loading', () => {
-    it('loads active tab content via InteractionManager', () => {
-      // Arrange
-      const mockRunAfterInteractions = jest.fn((callback) => {
-        callback();
-        return { cancel: jest.fn() };
-      });
-      (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
-        mockRunAfterInteractions,
-      );
-
+  describe('Content Loading', () => {
+    it('loads active tab content immediately without InteractionManager', () => {
       // Act
       const { getByText } = render(
         <TabsList initialActiveIndex={0}>
@@ -519,9 +527,9 @@ describe('TabsList', () => {
         </TabsList>,
       );
 
-      // Assert - InteractionManager used for initial tab load
-      expect(mockRunAfterInteractions).toHaveBeenCalled();
+      // Assert
       expect(getByText('Content 1')).toBeOnTheScreen();
+      expect(InteractionManager.runAfterInteractions).not.toHaveBeenCalled();
     });
 
     it('defers loading of inactive tabs until switched to', () => {
@@ -541,17 +549,8 @@ describe('TabsList', () => {
       expect(queryByText('Content 2')).toBeNull();
     });
 
-    it('cancels pending content load when switching tabs quickly', async () => {
+    it('switches quickly without scheduling interaction work', async () => {
       // Arrange
-      const mockCancel = jest.fn();
-      let capturedCallback: (() => void) | null = null;
-      (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
-        (callback: () => void) => {
-          capturedCallback = callback;
-          return { cancel: mockCancel };
-        },
-      );
-
       const { getAllByText } = render(
         <TabsList initialActiveIndex={0}>
           <View {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
@@ -566,28 +565,18 @@ describe('TabsList', () => {
         </TabsList>,
       );
 
-      // Act - Switch tabs quickly before interaction completes
+      // Act
       await act(async () => {
         fireEvent.press(getAllByText('Tab 2')[0]);
         fireEvent.press(getAllByText('Tab 3')[0]);
-        if (capturedCallback) {
-          capturedCallback();
-        }
       });
 
-      // Assert - Previous interaction was cancelled
-      expect(mockCancel).toHaveBeenCalled();
+      // Assert
+      expect(InteractionManager.runAfterInteractions).not.toHaveBeenCalled();
     });
 
-    it('loads already-loaded tabs immediately without InteractionManager delay', async () => {
+    it('loads already-loaded tabs immediately', async () => {
       // Arrange
-      const mockRunAfterInteractions = jest.fn((callback) => {
-        callback();
-        return { cancel: jest.fn() };
-      });
-      (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
-        mockRunAfterInteractions,
-      );
 
       const { getAllByText, getByText } = render(
         <TabsList initialActiveIndex={0}>
@@ -605,19 +594,14 @@ describe('TabsList', () => {
         fireEvent.press(getAllByText('Tab 2')[0]);
       });
 
-      const callCountAfterFirstSwitch =
-        mockRunAfterInteractions.mock.calls.length;
-
       // Act - Switch back to Tab 1 (already loaded)
       await act(async () => {
         fireEvent.press(getAllByText('Tab 1')[0]);
       });
 
-      // Assert - Already loaded tab displays immediately without new InteractionManager call
+      // Assert
       expect(getByText('Content 1')).toBeOnTheScreen();
-      expect(mockRunAfterInteractions).toHaveBeenCalledTimes(
-        callCountAfterFirstSwitch,
-      );
+      expect(InteractionManager.runAfterInteractions).not.toHaveBeenCalled();
     });
   });
 

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
@@ -514,7 +514,7 @@ describe('TabsList', () => {
   });
 
   describe('Content Loading', () => {
-    it('loads active tab content immediately without InteractionManager', () => {
+    it('loads active tab content via InteractionManager scheduling', () => {
       // Act
       const { getByText } = render(
         <TabsList initialActiveIndex={0}>
@@ -529,7 +529,7 @@ describe('TabsList', () => {
 
       // Assert
       expect(getByText('Content 1')).toBeOnTheScreen();
-      expect(InteractionManager.runAfterInteractions).not.toHaveBeenCalled();
+      expect(InteractionManager.runAfterInteractions).toHaveBeenCalled();
     });
 
     it('defers loading of inactive tabs until switched to', () => {
@@ -549,7 +549,7 @@ describe('TabsList', () => {
       expect(queryByText('Content 2')).toBeNull();
     });
 
-    it('switches quickly without scheduling interaction work', async () => {
+    it('switches quickly while keeping loads scheduled and stable', async () => {
       // Arrange
       const { getAllByText } = render(
         <TabsList initialActiveIndex={0}>
@@ -572,12 +572,13 @@ describe('TabsList', () => {
       });
 
       // Assert
-      expect(InteractionManager.runAfterInteractions).not.toHaveBeenCalled();
+      expect(InteractionManager.runAfterInteractions).toHaveBeenCalled();
     });
 
-    it('loads already-loaded tabs immediately', async () => {
+    it('does not re-schedule loading for already-loaded tabs', async () => {
       // Arrange
-
+      const mockRunAfterInteractions =
+        InteractionManager.runAfterInteractions as jest.Mock;
       const { getAllByText, getByText } = render(
         <TabsList initialActiveIndex={0}>
           <View {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
@@ -594,6 +595,9 @@ describe('TabsList', () => {
         fireEvent.press(getAllByText('Tab 2')[0]);
       });
 
+      const callCountAfterFirstLoad =
+        mockRunAfterInteractions.mock.calls.length;
+
       // Act - Switch back to Tab 1 (already loaded)
       await act(async () => {
         fireEvent.press(getAllByText('Tab 1')[0]);
@@ -601,7 +605,93 @@ describe('TabsList', () => {
 
       // Assert
       expect(getByText('Content 1')).toBeOnTheScreen();
-      expect(InteractionManager.runAfterInteractions).not.toHaveBeenCalled();
+      expect(mockRunAfterInteractions).toHaveBeenCalledTimes(
+        callCountAfterFirstLoad,
+      );
+    });
+
+    it('uses fallback timeout if InteractionManager callback does not run', async () => {
+      jest.useFakeTimers();
+      (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
+        () => ({ cancel: jest.fn() }),
+      );
+
+      try {
+        const { getAllByText, getByText, queryByText } = render(
+          <TabsList initialActiveIndex={0}>
+            <View {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
+              <Text>Content 1</Text>
+            </View>
+            <View {...({ tabLabel: 'Tab 2' } as TabViewProps)}>
+              <Text>Content 2</Text>
+            </View>
+          </TabsList>,
+        );
+
+        expect(queryByText('Content 1')).toBeNull();
+        expect(queryByText('Content 2')).toBeNull();
+
+        await act(async () => {
+          jest.advanceTimersByTime(250);
+        });
+        expect(getByText('Content 1')).toBeOnTheScreen();
+
+        await act(async () => {
+          fireEvent.press(getAllByText('Tab 2')[0]);
+        });
+        expect(queryByText('Content 2')).toBeNull();
+
+        await act(async () => {
+          jest.advanceTimersByTime(250);
+        });
+        expect(getByText('Content 2')).toBeOnTheScreen();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not lose scheduled load across a rerender', async () => {
+      jest.useFakeTimers();
+      (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
+        () => ({ cancel: jest.fn() }),
+      );
+
+      try {
+        const renderTabs = () => (
+          <TabsList initialActiveIndex={0}>
+            <View key="tab1" {...({ tabLabel: 'Tab 1' } as TabViewProps)}>
+              <Text>Content 1</Text>
+            </View>
+            <View key="tab2" {...({ tabLabel: 'Tab 2' } as TabViewProps)}>
+              <Text>Content 2</Text>
+            </View>
+          </TabsList>
+        );
+
+        const { getAllByText, getByText, queryByText, rerender } =
+          render(renderTabs());
+
+        expect(queryByText('Content 1')).toBeNull();
+
+        await act(async () => {
+          jest.advanceTimersByTime(250);
+        });
+        expect(getByText('Content 1')).toBeOnTheScreen();
+
+        await act(async () => {
+          fireEvent.press(getAllByText('Tab 2')[0]);
+        });
+        expect(queryByText('Content 2')).toBeNull();
+
+        rerender(renderTabs());
+
+        await act(async () => {
+          jest.advanceTimersByTime(250);
+        });
+        expect(getByText('Content 2')).toBeOnTheScreen();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.test.tsx
@@ -198,6 +198,48 @@ describe('TabsList', () => {
     expect(getByText('Tab 2 Content')).toBeOnTheScreen();
   });
 
+  it('goToTabIndex loads target tab even when InteractionManager callback is delayed', async () => {
+    // Arrange
+    const originalJestWorkerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+
+    (InteractionManager.runAfterInteractions as jest.Mock).mockImplementation(
+      () => ({ cancel: jest.fn() }),
+    );
+
+    const ref = React.createRef<TabsListRef>();
+    const tabs = ['Tab 1', 'Tab 2'];
+
+    try {
+      const { getByText } = render(
+        <TabsList ref={ref}>
+          {tabs.map((label, index) => (
+            <View
+              key={`tab${index}`}
+              {...({ tabLabel: label } as TabViewProps)}
+            >
+              <Text>{label} Content</Text>
+            </View>
+          ))}
+        </TabsList>,
+      );
+
+      // Act
+      await act(async () => {
+        ref.current?.goToTabIndex(1);
+      });
+
+      // Assert
+      expect(getByText('Tab 2 Content')).toBeOnTheScreen();
+    } finally {
+      if (originalJestWorkerId === undefined) {
+        delete process.env.JEST_WORKER_ID;
+      } else {
+        process.env.JEST_WORKER_ID = originalJestWorkerId;
+      }
+    }
+  });
+
   it('exposes getCurrentIndex method via ref', () => {
     // Arrange
     const ref = React.createRef<TabsListRef>();

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
@@ -5,13 +5,11 @@ import React, {
   forwardRef,
   useCallback,
   useMemo,
-  useRef,
 } from 'react';
 
 import { Box } from '@metamask/design-system-react-native';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
-import { InteractionManager } from 'react-native';
 
 import TabsBar from '../TabsBar';
 import { TabsListProps, TabsListRef, TabItem } from './TabsList.types';
@@ -29,10 +27,6 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
     },
     ref,
   ) => {
-    const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
-    const [loadedTabs, setLoadedTabs] = useState<Set<number>>(new Set());
-    const interactionHandleRef = useRef<{ cancel: () => void } | null>(null);
-
     const tabs: TabItem[] = useMemo(
       () =>
         React.Children.toArray(children)
@@ -56,40 +50,65 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       [children],
     );
 
-    // Cache only the actively viewed tab (no preloading of adjacent tabs)
-    // Use InteractionManager to defer content loading until after animations complete
-    useEffect(() => {
-      if (activeIndex >= 0 && activeIndex < tabs.length) {
-        if (interactionHandleRef.current) {
-          interactionHandleRef.current.cancel();
+    const getFirstEnabledIndex = useCallback(
+      () => tabs.findIndex((tab) => !tab.isDisabled),
+      [tabs],
+    );
+
+    const normalizeTabIndex = useCallback(
+      (tabIndex: number) => {
+        if (
+          tabIndex >= 0 &&
+          tabIndex < tabs.length &&
+          !tabs[tabIndex]?.isDisabled
+        ) {
+          return tabIndex;
         }
+        const firstEnabledIndex = getFirstEnabledIndex();
+        return firstEnabledIndex >= 0 ? firstEnabledIndex : -1;
+      },
+      [getFirstEnabledIndex, tabs],
+    );
 
-        const isAlreadyLoaded = loadedTabs.has(activeIndex);
+    const [activeIndex, setActiveIndex] = useState(() =>
+      normalizeTabIndex(initialActiveIndex),
+    );
+    const [loadedTabs, setLoadedTabs] = useState<Set<number>>(() => {
+      const normalizedInitialIndex = normalizeTabIndex(initialActiveIndex);
+      return normalizedInitialIndex >= 0
+        ? new Set([normalizedInitialIndex])
+        : new Set();
+    });
 
-        if (isAlreadyLoaded) {
+    const markTabLoaded = useCallback(
+      (tabIndex: number) => {
+        if (
+          tabIndex < 0 ||
+          tabIndex >= tabs.length ||
+          tabs[tabIndex]?.isDisabled
+        ) {
           return;
         }
 
-        const handle = InteractionManager.runAfterInteractions(() => {
-          setLoadedTabs((prev) => {
-            const newLoadedTabs = new Set(prev);
-            newLoadedTabs.add(activeIndex);
-            return newLoadedTabs.size !== prev.size ? newLoadedTabs : prev;
-          });
+        setLoadedTabs((prev) => {
+          if (prev.has(tabIndex)) {
+            return prev;
+          }
+          const nextLoadedTabs = new Set(prev);
+          nextLoadedTabs.add(tabIndex);
+          return nextLoadedTabs;
         });
-
-        interactionHandleRef.current = handle;
-      }
-
-      return () => {
-        if (interactionHandleRef.current) {
-          interactionHandleRef.current.cancel();
-        }
-      };
-    }, [activeIndex, tabs.length, loadedTabs]);
+      },
+      [tabs],
+    );
 
     useEffect(() => {
-      const currentActiveTabKey = tabs[activeIndex]?.key;
+      const currentActiveTabKey =
+        activeIndex >= 0 && activeIndex < tabs.length
+          ? tabs[activeIndex]?.key
+          : undefined;
+
+      let nextIndex = -1;
 
       if (currentActiveTabKey && tabs.length > 0) {
         const newIndexForCurrentTab = tabs.findIndex(
@@ -97,30 +116,30 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
         );
         if (
           newIndexForCurrentTab >= 0 &&
-          !tabs[newIndexForCurrentTab].isDisabled &&
-          newIndexForCurrentTab !== activeIndex
+          !tabs[newIndexForCurrentTab].isDisabled
         ) {
-          setActiveIndex(newIndexForCurrentTab);
-          return;
+          nextIndex = newIndexForCurrentTab;
         }
       }
 
-      if (
-        activeIndex >= 0 &&
-        activeIndex < tabs.length &&
-        !tabs[activeIndex]?.isDisabled
-      ) {
-        return;
+      if (nextIndex === -1) {
+        nextIndex = normalizeTabIndex(initialActiveIndex);
       }
 
-      const targetTab = tabs[initialActiveIndex];
-      if (targetTab && !targetTab.isDisabled) {
-        setActiveIndex(initialActiveIndex);
-      } else {
-        const firstEnabledIndex = tabs.findIndex((tab) => !tab.isDisabled);
-        setActiveIndex(firstEnabledIndex >= 0 ? firstEnabledIndex : -1);
+      if (nextIndex !== activeIndex) {
+        setActiveIndex(nextIndex);
       }
-    }, [initialActiveIndex, tabs, activeIndex]);
+
+      if (nextIndex >= 0) {
+        markTabLoaded(nextIndex);
+      }
+    }, [
+      activeIndex,
+      initialActiveIndex,
+      markTabLoaded,
+      normalizeTabIndex,
+      tabs,
+    ]);
 
     const handleTabPress = useCallback(
       (tabIndex: number) => {
@@ -135,13 +154,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
         const tabChanged = tabIndex !== activeIndex;
 
         setActiveIndex(tabIndex);
-
-        if (
-          (process.env.JEST_WORKER_ID || process.env.E2E) &&
-          !loadedTabs.has(tabIndex)
-        ) {
-          setLoadedTabs((prev) => new Set(prev).add(tabIndex));
-        }
+        markTabLoaded(tabIndex);
 
         if (onChangeTab && tabChanged) {
           onChangeTab({
@@ -150,7 +163,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
           });
         }
       },
-      [activeIndex, tabs, onChangeTab, loadedTabs],
+      [activeIndex, markTabLoaded, onChangeTab, tabs],
     );
 
     const goToPreviousTab = useCallback(() => {
@@ -199,19 +212,11 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       ref,
       () => ({
         goToTabIndex: (tabIndex: number) => {
-          if (
-            tabIndex >= 0 &&
-            tabIndex < tabs.length &&
-            !tabs[tabIndex]?.isDisabled &&
-            !loadedTabs.has(tabIndex)
-          ) {
-            setLoadedTabs((prev) => new Set(prev).add(tabIndex));
-          }
           handleTabPress(tabIndex);
         },
         getCurrentIndex: () => activeIndex,
       }),
-      [activeIndex, handleTabPress, loadedTabs, tabs],
+      [activeIndex, handleTabPress],
     );
 
     const tabBarPropsComputed = useMemo(

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
@@ -54,11 +54,6 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       [children],
     );
 
-    const getFirstEnabledIndex = useCallback(
-      () => tabs.findIndex((tab) => !tab.isDisabled),
-      [tabs],
-    );
-
     const normalizeTabIndex = useCallback(
       (tabIndex: number) => {
         if (
@@ -68,85 +63,66 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
         ) {
           return tabIndex;
         }
-        const firstEnabledIndex = getFirstEnabledIndex();
-        return firstEnabledIndex >= 0 ? firstEnabledIndex : -1;
+        const firstEnabled = tabs.findIndex((tab) => !tab.isDisabled);
+        return firstEnabled >= 0 ? firstEnabled : -1;
       },
-      [getFirstEnabledIndex, tabs],
+      [tabs],
     );
 
     const [activeIndex, setActiveIndex] = useState(() =>
       normalizeTabIndex(initialActiveIndex),
     );
-    const [loadedTabs, setLoadedTabs] = useState<Set<number>>(() => new Set());
-    const interactionHandleRef = useRef<{ cancel?: () => void } | undefined>(
-      undefined,
-    );
-    const fallbackTimeoutRef = useRef<
-      ReturnType<typeof setTimeout> | undefined
-    >(undefined);
-
-    const markTabLoaded = useCallback(
-      (tabIndex: number) => {
-        if (
-          tabIndex < 0 ||
-          tabIndex >= tabs.length ||
-          tabs[tabIndex]?.isDisabled
-        ) {
-          return;
-        }
-
-        setLoadedTabs((prev) => {
-          if (prev.has(tabIndex)) {
-            return prev;
-          }
-          const nextLoadedTabs = new Set(prev);
-          nextLoadedTabs.add(tabIndex);
-          return nextLoadedTabs;
-        });
-      },
-      [tabs],
+    const [loadedTabs, setLoadedTabs] = useState<Set<number>>(new Set());
+    const interactionHandleRef = useRef<{ cancel?: () => void } | null>(null);
+    const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null,
     );
 
-    const cancelScheduledTabLoad = useCallback(() => {
+    // Cancel any pending InteractionManager + fallback timeout
+    const cancelPendingLoad = useCallback(() => {
       if (interactionHandleRef.current) {
         interactionHandleRef.current.cancel?.();
-        interactionHandleRef.current = undefined;
+        interactionHandleRef.current = null;
       }
-
       if (fallbackTimeoutRef.current) {
         clearTimeout(fallbackTimeoutRef.current);
-        fallbackTimeoutRef.current = undefined;
+        fallbackTimeoutRef.current = null;
       }
     }, []);
 
-    const scheduleTabLoad = useCallback(
-      (tabIndex: number) => {
-        if (
-          tabIndex < 0 ||
-          tabIndex >= tabs.length ||
-          tabs[tabIndex]?.isDisabled ||
-          loadedTabs.has(tabIndex)
-        ) {
+    // Schedule tab content loading via InteractionManager with a fallback timeout
+    // in case the InteractionManager callback never fires (observed in repeated
+    // Perps Home -> Activity navigation)
+    useEffect(() => {
+      if (activeIndex >= 0 && activeIndex < tabs.length) {
+        cancelPendingLoad();
+
+        if (loadedTabs.has(activeIndex)) {
           return;
         }
 
-        cancelScheduledTabLoad();
-
-        const completeTabLoad = () => {
-          markTabLoaded(tabIndex);
-          cancelScheduledTabLoad();
+        const markLoaded = () => {
+          setLoadedTabs((prev) => {
+            if (prev.has(activeIndex)) return prev;
+            const next = new Set(prev);
+            next.add(activeIndex);
+            return next;
+          });
         };
 
         interactionHandleRef.current =
-          InteractionManager.runAfterInteractions(completeTabLoad);
+          InteractionManager.runAfterInteractions(markLoaded);
 
         fallbackTimeoutRef.current = setTimeout(
-          completeTabLoad,
+          markLoaded,
           TAB_LOAD_FALLBACK_TIMEOUT_MS,
         );
-      },
-      [cancelScheduledTabLoad, loadedTabs, markTabLoaded, tabs],
-    );
+      }
+
+      return () => {
+        cancelPendingLoad();
+      };
+    }, [activeIndex, tabs.length, loadedTabs, cancelPendingLoad]);
 
     useEffect(() => {
       const currentActiveTabKey =
@@ -175,24 +151,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       if (nextIndex !== activeIndex) {
         setActiveIndex(nextIndex);
       }
-
-      if (nextIndex >= 0) {
-        scheduleTabLoad(nextIndex);
-      }
-    }, [
-      activeIndex,
-      initialActiveIndex,
-      normalizeTabIndex,
-      scheduleTabLoad,
-      tabs,
-    ]);
-
-    useEffect(
-      () => () => {
-        cancelScheduledTabLoad();
-      },
-      [cancelScheduledTabLoad],
-    );
+    }, [activeIndex, initialActiveIndex, normalizeTabIndex, tabs]);
 
     const handleTabPress = useCallback(
       (tabIndex: number) => {
@@ -207,7 +166,6 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
         const tabChanged = tabIndex !== activeIndex;
 
         setActiveIndex(tabIndex);
-        scheduleTabLoad(tabIndex);
 
         if (onChangeTab && tabChanged) {
           onChangeTab({
@@ -216,7 +174,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
           });
         }
       },
-      [activeIndex, onChangeTab, scheduleTabLoad, tabs],
+      [activeIndex, tabs, onChangeTab],
     );
 
     const goToPreviousTab = useCallback(() => {

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
@@ -80,9 +80,9 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
     const [loadedTabs, setLoadedTabs] = useState<Set<number>>(() => new Set());
     const loadedTabsRef = useRef<Set<number>>(new Set());
     const scheduledTabsRef = useRef<Set<number>>(new Set());
-    const interactionHandlesRef = useRef<Map<number, { cancel: () => void }>>(
-      new Map(),
-    );
+    const interactionHandlesRef = useRef<
+      Map<number, { cancel?: () => void } | undefined>
+    >(new Map());
     const fallbackTimeoutsRef = useRef<
       Map<number, ReturnType<typeof setTimeout>>
     >(new Map());
@@ -112,7 +112,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
     const clearScheduledTabLoad = useCallback((tabIndex: number) => {
       const interactionHandle = interactionHandlesRef.current.get(tabIndex);
       if (interactionHandle) {
-        interactionHandle.cancel();
+        interactionHandle.cancel?.();
         interactionHandlesRef.current.delete(tabIndex);
       }
 
@@ -202,7 +202,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
 
     useEffect(
       () => () => {
-        interactionHandlesRef.current.forEach((handle) => handle.cancel());
+        interactionHandlesRef.current.forEach((handle) => handle?.cancel?.());
         interactionHandlesRef.current.clear();
 
         fallbackTimeoutsRef.current.forEach((timeoutId) =>

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
@@ -199,11 +199,19 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       ref,
       () => ({
         goToTabIndex: (tabIndex: number) => {
+          if (
+            tabIndex >= 0 &&
+            tabIndex < tabs.length &&
+            !tabs[tabIndex]?.isDisabled &&
+            !loadedTabs.has(tabIndex)
+          ) {
+            setLoadedTabs((prev) => new Set(prev).add(tabIndex));
+          }
           handleTabPress(tabIndex);
         },
         getCurrentIndex: () => activeIndex,
       }),
-      [activeIndex, handleTabPress],
+      [activeIndex, handleTabPress, loadedTabs, tabs],
     );
 
     const tabBarPropsComputed = useMemo(

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
@@ -78,14 +78,12 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       normalizeTabIndex(initialActiveIndex),
     );
     const [loadedTabs, setLoadedTabs] = useState<Set<number>>(() => new Set());
-    const loadedTabsRef = useRef<Set<number>>(new Set());
-    const scheduledTabsRef = useRef<Set<number>>(new Set());
-    const interactionHandlesRef = useRef<
-      Map<number, { cancel?: () => void } | undefined>
-    >(new Map());
-    const fallbackTimeoutsRef = useRef<
-      Map<number, ReturnType<typeof setTimeout>>
-    >(new Map());
+    const interactionHandleRef = useRef<{ cancel?: () => void } | undefined>(
+      undefined,
+    );
+    const fallbackTimeoutRef = useRef<
+      ReturnType<typeof setTimeout> | undefined
+    >(undefined);
 
     const markTabLoaded = useCallback(
       (tabIndex: number) => {
@@ -109,20 +107,16 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       [tabs],
     );
 
-    const clearScheduledTabLoad = useCallback((tabIndex: number) => {
-      const interactionHandle = interactionHandlesRef.current.get(tabIndex);
-      if (interactionHandle) {
-        interactionHandle.cancel?.();
-        interactionHandlesRef.current.delete(tabIndex);
+    const cancelScheduledTabLoad = useCallback(() => {
+      if (interactionHandleRef.current) {
+        interactionHandleRef.current.cancel?.();
+        interactionHandleRef.current = undefined;
       }
 
-      const fallbackTimeout = fallbackTimeoutsRef.current.get(tabIndex);
-      if (fallbackTimeout) {
-        clearTimeout(fallbackTimeout);
-        fallbackTimeoutsRef.current.delete(tabIndex);
+      if (fallbackTimeoutRef.current) {
+        clearTimeout(fallbackTimeoutRef.current);
+        fallbackTimeoutRef.current = undefined;
       }
-
-      scheduledTabsRef.current.delete(tabIndex);
     }, []);
 
     const scheduleTabLoad = useCallback(
@@ -131,35 +125,28 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
           tabIndex < 0 ||
           tabIndex >= tabs.length ||
           tabs[tabIndex]?.isDisabled ||
-          loadedTabsRef.current.has(tabIndex) ||
-          scheduledTabsRef.current.has(tabIndex)
+          loadedTabs.has(tabIndex)
         ) {
           return;
         }
 
-        scheduledTabsRef.current.add(tabIndex);
+        cancelScheduledTabLoad();
 
         const completeTabLoad = () => {
           markTabLoaded(tabIndex);
-          clearScheduledTabLoad(tabIndex);
+          cancelScheduledTabLoad();
         };
 
-        const interactionHandle =
+        interactionHandleRef.current =
           InteractionManager.runAfterInteractions(completeTabLoad);
-        interactionHandlesRef.current.set(tabIndex, interactionHandle);
 
-        const fallbackTimeout = setTimeout(
+        fallbackTimeoutRef.current = setTimeout(
           completeTabLoad,
           TAB_LOAD_FALLBACK_TIMEOUT_MS,
         );
-        fallbackTimeoutsRef.current.set(tabIndex, fallbackTimeout);
       },
-      [clearScheduledTabLoad, markTabLoaded, tabs],
+      [cancelScheduledTabLoad, loadedTabs, markTabLoaded, tabs],
     );
-
-    useEffect(() => {
-      loadedTabsRef.current = loadedTabs;
-    }, [loadedTabs]);
 
     useEffect(() => {
       const currentActiveTabKey =
@@ -202,17 +189,9 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
 
     useEffect(
       () => () => {
-        interactionHandlesRef.current.forEach((handle) => handle?.cancel?.());
-        interactionHandlesRef.current.clear();
-
-        fallbackTimeoutsRef.current.forEach((timeoutId) =>
-          clearTimeout(timeoutId),
-        );
-        fallbackTimeoutsRef.current.clear();
-
-        scheduledTabsRef.current.clear();
+        cancelScheduledTabLoad();
       },
-      [],
+      [cancelScheduledTabLoad],
     );
 
     const handleTabPress = useCallback(

--- a/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsList/TabsList.tsx
@@ -5,14 +5,18 @@ import React, {
   forwardRef,
   useCallback,
   useMemo,
+  useRef,
 } from 'react';
 
 import { Box } from '@metamask/design-system-react-native';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
+import { InteractionManager } from 'react-native';
 
 import TabsBar from '../TabsBar';
 import { TabsListProps, TabsListRef, TabItem } from './TabsList.types';
+
+const TAB_LOAD_FALLBACK_TIMEOUT_MS = 250;
 
 const TabsList = forwardRef<TabsListRef, TabsListProps>(
   (
@@ -73,12 +77,15 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
     const [activeIndex, setActiveIndex] = useState(() =>
       normalizeTabIndex(initialActiveIndex),
     );
-    const [loadedTabs, setLoadedTabs] = useState<Set<number>>(() => {
-      const normalizedInitialIndex = normalizeTabIndex(initialActiveIndex);
-      return normalizedInitialIndex >= 0
-        ? new Set([normalizedInitialIndex])
-        : new Set();
-    });
+    const [loadedTabs, setLoadedTabs] = useState<Set<number>>(() => new Set());
+    const loadedTabsRef = useRef<Set<number>>(new Set());
+    const scheduledTabsRef = useRef<Set<number>>(new Set());
+    const interactionHandlesRef = useRef<Map<number, { cancel: () => void }>>(
+      new Map(),
+    );
+    const fallbackTimeoutsRef = useRef<
+      Map<number, ReturnType<typeof setTimeout>>
+    >(new Map());
 
     const markTabLoaded = useCallback(
       (tabIndex: number) => {
@@ -101,6 +108,58 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       },
       [tabs],
     );
+
+    const clearScheduledTabLoad = useCallback((tabIndex: number) => {
+      const interactionHandle = interactionHandlesRef.current.get(tabIndex);
+      if (interactionHandle) {
+        interactionHandle.cancel();
+        interactionHandlesRef.current.delete(tabIndex);
+      }
+
+      const fallbackTimeout = fallbackTimeoutsRef.current.get(tabIndex);
+      if (fallbackTimeout) {
+        clearTimeout(fallbackTimeout);
+        fallbackTimeoutsRef.current.delete(tabIndex);
+      }
+
+      scheduledTabsRef.current.delete(tabIndex);
+    }, []);
+
+    const scheduleTabLoad = useCallback(
+      (tabIndex: number) => {
+        if (
+          tabIndex < 0 ||
+          tabIndex >= tabs.length ||
+          tabs[tabIndex]?.isDisabled ||
+          loadedTabsRef.current.has(tabIndex) ||
+          scheduledTabsRef.current.has(tabIndex)
+        ) {
+          return;
+        }
+
+        scheduledTabsRef.current.add(tabIndex);
+
+        const completeTabLoad = () => {
+          markTabLoaded(tabIndex);
+          clearScheduledTabLoad(tabIndex);
+        };
+
+        const interactionHandle =
+          InteractionManager.runAfterInteractions(completeTabLoad);
+        interactionHandlesRef.current.set(tabIndex, interactionHandle);
+
+        const fallbackTimeout = setTimeout(
+          completeTabLoad,
+          TAB_LOAD_FALLBACK_TIMEOUT_MS,
+        );
+        fallbackTimeoutsRef.current.set(tabIndex, fallbackTimeout);
+      },
+      [clearScheduledTabLoad, markTabLoaded, tabs],
+    );
+
+    useEffect(() => {
+      loadedTabsRef.current = loadedTabs;
+    }, [loadedTabs]);
 
     useEffect(() => {
       const currentActiveTabKey =
@@ -131,15 +190,30 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
       }
 
       if (nextIndex >= 0) {
-        markTabLoaded(nextIndex);
+        scheduleTabLoad(nextIndex);
       }
     }, [
       activeIndex,
       initialActiveIndex,
-      markTabLoaded,
       normalizeTabIndex,
+      scheduleTabLoad,
       tabs,
     ]);
+
+    useEffect(
+      () => () => {
+        interactionHandlesRef.current.forEach((handle) => handle.cancel());
+        interactionHandlesRef.current.clear();
+
+        fallbackTimeoutsRef.current.forEach((timeoutId) =>
+          clearTimeout(timeoutId),
+        );
+        fallbackTimeoutsRef.current.clear();
+
+        scheduledTabsRef.current.clear();
+      },
+      [],
+    );
 
     const handleTabPress = useCallback(
       (tabIndex: number) => {
@@ -154,7 +228,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
         const tabChanged = tabIndex !== activeIndex;
 
         setActiveIndex(tabIndex);
-        markTabLoaded(tabIndex);
+        scheduleTabLoad(tabIndex);
 
         if (onChangeTab && tabChanged) {
           onChangeTab({
@@ -163,7 +237,7 @@ const TabsList = forwardRef<TabsListRef, TabsListProps>(
           });
         }
       },
-      [activeIndex, markTabLoaded, onChangeTab, tabs],
+      [activeIndex, onChangeTab, scheduleTabLoad, tabs],
     );
 
     const goToPreviousTab = useCallback(() => {

--- a/app/components/UI/Perps/Views/PerpsActiveTraderFlow.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsActiveTraderFlow.view.test.tsx
@@ -277,7 +277,7 @@ describe('Active Trader Flow', () => {
     ).toBeOnTheScreen();
     expect(screen.queryAllByText(MARKET_ORDERS)).toHaveLength(0);
     expect(
-      screen.getByTestId(PerpsMarketTabsSelectorsIDs.STATISTICS_CONTENT),
+      await screen.findByTestId(PerpsMarketTabsSelectorsIDs.STATISTICS_CONTENT),
     ).toBeOnTheScreen();
 
     // ── PHASE 2: Review individual order rows ────────────────────────────

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -29,11 +29,16 @@ const mockBuild = jest.fn(() => ({ name: 'test-event' }));
 const mockCreateEventBuilder = jest.fn();
 
 const mockNavigate = jest.fn();
+const mockRefetchTransactions = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
   }),
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const ReactActual = jest.requireActual('react');
+    ReactActual.useEffect(() => callback(), [callback]);
+  },
 }));
 
 jest.mock('../../hooks', () => ({
@@ -130,6 +135,7 @@ describe('PerpsTransactionsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockNavigate.mockClear();
+    mockRefetchTransactions.mockClear();
 
     // Set up analytics mock
     const { useAnalytics } = jest.requireMock(
@@ -160,7 +166,7 @@ describe('PerpsTransactionsView', () => {
       transactions: mockTransactions,
       isLoading: false,
       error: null,
-      refetch: jest.fn(),
+      refetch: mockRefetchTransactions,
     });
 
     mockUsePerpsEventTracking.mockReturnValue({
@@ -189,6 +195,30 @@ describe('PerpsTransactionsView', () => {
         skipInitialFetch: false,
       });
     });
+  });
+
+  it('refreshes transaction history when screen becomes focused', async () => {
+    renderWithProvider(<PerpsTransactionsView />, {
+      state: mockInitialState,
+    });
+
+    await waitFor(() => {
+      expect(mockRefetchTransactions).toHaveBeenCalled();
+    });
+  });
+
+  it('skips initial fetch and focus refresh when tab is not visible', async () => {
+    renderWithProvider(<PerpsTransactionsView isVisible={false} />, {
+      state: mockInitialState,
+    });
+
+    await waitFor(() => {
+      expect(mockUsePerpsTransactionHistory).toHaveBeenCalledWith({
+        skipInitialFetch: true,
+      });
+    });
+
+    expect(mockRefetchTransactions).not.toHaveBeenCalled();
   });
 
   it('should not load transactions when not connected', () => {
@@ -292,6 +322,34 @@ describe('PerpsTransactionsView', () => {
         ),
       ).toBeTruthy();
     });
+  });
+
+  it('shows loading skeleton instead of blank list when disconnected with no data', () => {
+    mockUsePerpsConnection.mockReturnValue({
+      isConnected: false,
+      isConnecting: false,
+      isInitialized: true,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
+    });
+
+    mockUsePerpsTransactionHistory.mockReturnValue({
+      transactions: [],
+      isLoading: false,
+      error: null,
+      refetch: mockRefetchTransactions,
+    });
+
+    const component = renderWithProvider(<PerpsTransactionsView />, {
+      state: mockInitialState,
+    });
+
+    expect(
+      component.getByTestId('perps-transactions-loading-skeleton'),
+    ).toBeOnTheScreen();
   });
 
   it('should handle API errors gracefully', async () => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -217,65 +217,14 @@ describe('PerpsTransactionsView', () => {
     });
   });
 
-  it('skips initial fetch and focus refresh when tab is not visible', async () => {
-    renderWithProvider(<PerpsTransactionsView isVisible={false} />, {
-      state: mockInitialState,
-    });
-
-    await waitFor(() => {
-      expect(mockUsePerpsTransactionHistory).toHaveBeenCalledWith({
-        skipInitialFetch: true,
-      });
-    });
-
-    expect(mockRefetchTransactions).not.toHaveBeenCalled();
-  });
-
-  it('renders lightweight hidden state when tab is not visible even if connection is loading', () => {
-    mockUsePerpsConnection.mockReturnValue({
-      isConnected: false,
-      isConnecting: true,
-      isInitialized: true,
-      error: null,
-      connect: jest.fn(),
-      disconnect: jest.fn(),
-      resetError: jest.fn(),
-      reconnectWithNewContext: jest.fn(),
-    });
-
-    mockUsePerpsTransactionHistory.mockReturnValue({
-      transactions: [],
-      isLoading: true,
-      error: null,
-      refetch: mockRefetchTransactions,
-    });
-
-    const component = renderWithProvider(
-      <PerpsTransactionsView isVisible={false} />,
-      {
-        state: mockInitialState,
-      },
-    );
-
-    expect(component.queryByText('Trades')).toBeNull();
-    expect(
-      component.queryByTestId('perps-transactions-loading-skeleton'),
-    ).toBeNull();
-    expect(
-      component.queryByText(
-        'No trades transactions yet. Your trading history will appear here',
-      ),
-    ).toBeNull();
-  });
-
-  it('tracks measurement as not-ready while hidden', () => {
-    renderWithProvider(<PerpsTransactionsView isVisible={false} />, {
+  it('tracks measurement as ready when initial loading is complete', () => {
+    renderWithProvider(<PerpsTransactionsView />, {
       state: mockInitialState,
     });
 
     expect(mockUsePerpsMeasurement).toHaveBeenCalledWith(
       expect.objectContaining({
-        conditions: [false],
+        conditions: [true],
         resetConditions: [],
       }),
     );

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -22,6 +22,7 @@ import { createMockAccountsControllerState } from '../../../../../util/test/acco
 import { mockNetworkState } from '../../../../../util/test/network';
 import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
+import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 
 const mockTrackEvent = jest.fn();
 const mockAddProperties = jest.fn();
@@ -53,6 +54,10 @@ jest.mock('../../hooks/usePerpsAssetsMetadata', () => ({
     assetUrl: null,
     error: null,
   }),
+}));
+
+jest.mock('../../hooks/usePerpsMeasurement', () => ({
+  usePerpsMeasurement: jest.fn(),
 }));
 
 const mockInitialState: DeepPartial<RootState> = {
@@ -131,6 +136,9 @@ describe('PerpsTransactionsView', () => {
     >;
   const mockUsePerpsEventTracking =
     usePerpsEventTracking as jest.MockedFunction<typeof usePerpsEventTracking>;
+  const mockUsePerpsMeasurement = usePerpsMeasurement as jest.MockedFunction<
+    typeof usePerpsMeasurement
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -172,6 +180,8 @@ describe('PerpsTransactionsView', () => {
     mockUsePerpsEventTracking.mockReturnValue({
       track: jest.fn(),
     });
+
+    mockUsePerpsMeasurement.mockImplementation(() => undefined);
   });
 
   it('should render with filter tabs', () => {
@@ -219,6 +229,56 @@ describe('PerpsTransactionsView', () => {
     });
 
     expect(mockRefetchTransactions).not.toHaveBeenCalled();
+  });
+
+  it('renders lightweight hidden state when tab is not visible even if connection is loading', () => {
+    mockUsePerpsConnection.mockReturnValue({
+      isConnected: false,
+      isConnecting: true,
+      isInitialized: true,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
+    });
+
+    mockUsePerpsTransactionHistory.mockReturnValue({
+      transactions: [],
+      isLoading: true,
+      error: null,
+      refetch: mockRefetchTransactions,
+    });
+
+    const component = renderWithProvider(
+      <PerpsTransactionsView isVisible={false} />,
+      {
+        state: mockInitialState,
+      },
+    );
+
+    expect(component.queryByText('Trades')).toBeNull();
+    expect(
+      component.queryByTestId('perps-transactions-loading-skeleton'),
+    ).toBeNull();
+    expect(
+      component.queryByText(
+        'No trades transactions yet. Your trading history will appear here',
+      ),
+    ).toBeNull();
+  });
+
+  it('tracks measurement as not-ready while hidden', () => {
+    renderWithProvider(<PerpsTransactionsView isVisible={false} />, {
+      state: mockInitialState,
+    });
+
+    expect(mockUsePerpsMeasurement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conditions: [false],
+        resetConditions: [],
+      }),
+    );
   });
 
   it('should not load transactions when not connected', () => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -36,7 +36,6 @@ import {
   FilterTab,
   ListItem,
   PerpsTransaction,
-  PerpsTransactionsViewProps,
   TransactionSection,
 } from '../../types/transactionHistory';
 import { formatDateSection } from '../../utils/formatUtils';
@@ -45,18 +44,7 @@ import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { TraceName } from '../../../../../util/trace';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
-const EMPTY_TRANSACTIONS: PerpsTransaction[] = [];
-const EMPTY_LIST_ITEMS: ListItem[] = [];
-const EMPTY_GROUPED_TRANSACTIONS: Record<FilterTab, TransactionSection[]> = {
-  Trades: [],
-  Orders: [],
-  Funding: [],
-  Deposits: [],
-};
-
-const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
-  isVisible = true,
-}) => {
+const PerpsTransactionsView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
   const navigation = useNavigation();
@@ -89,14 +77,9 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
     isLoading: transactionsLoading,
     refetch: refreshTransactions,
   } = usePerpsTransactionHistory({
-    skipInitialFetch: !isConnected || !isVisible,
+    skipInitialFetch: !isConnected,
     accountId,
   });
-
-  const transactionsForRender = useMemo(
-    () => (isVisible ? allTransactions : EMPTY_TRANSACTIONS),
-    [allTransactions, isVisible],
-  );
 
   // Helper function to group transactions by date
   const groupTransactionsByDate = useCallback(
@@ -148,34 +131,30 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
 
   // Filter transactions by type from the single source of truth
   const fillTransactions = useMemo(
-    () => transactionsForRender.filter((tx) => tx.type === 'trade'),
-    [transactionsForRender],
+    () => allTransactions.filter((tx) => tx.type === 'trade'),
+    [allTransactions],
   );
 
   const orderTransactions = useMemo(
-    () => transactionsForRender.filter((tx) => tx.type === 'order'),
-    [transactionsForRender],
+    () => allTransactions.filter((tx) => tx.type === 'order'),
+    [allTransactions],
   );
 
   const fundingTransactions = useMemo(
-    () => transactionsForRender.filter((tx) => tx.type === 'funding'),
-    [transactionsForRender],
+    () => allTransactions.filter((tx) => tx.type === 'funding'),
+    [allTransactions],
   );
 
   const depositWithdrawalTransactions = useMemo(
     () =>
-      transactionsForRender.filter(
+      allTransactions.filter(
         (tx) => tx.type === 'deposit' || tx.type === 'withdrawal',
       ),
-    [transactionsForRender],
+    [allTransactions],
   );
 
   // Memoized grouped transactions to avoid recalculation on every filter change
   const allGroupedTransactions = useMemo(() => {
-    if (!isVisible) {
-      return EMPTY_GROUPED_TRANSACTIONS;
-    }
-
     const grouped = {
       Trades: groupTransactionsByDate(fillTransactions),
       Orders: groupTransactionsByDate(orderTransactions),
@@ -185,7 +164,6 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
 
     return grouped;
   }, [
-    isVisible,
     fillTransactions,
     orderTransactions,
     fundingTransactions,
@@ -194,17 +172,14 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
   ]);
 
   const flatListData = useMemo(() => {
-    if (!isVisible) {
-      return EMPTY_LIST_ITEMS;
-    }
     const currentGrouped = allGroupedTransactions[activeFilter] || [];
     return flattenGroupedTransactions(currentGrouped, activeFilter);
-  }, [activeFilter, allGroupedTransactions, isVisible]);
+  }, [activeFilter, allGroupedTransactions]);
 
   // Note: Removed automatic scroll to top on tab change to allow switching tabs while scrolling
 
   const onRefresh = useCallback(async () => {
-    if (!isConnected || !isVisible) {
+    if (!isConnected) {
       return;
     }
     setRefreshing(true);
@@ -216,11 +191,11 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
     } finally {
       setRefreshing(false);
     }
-  }, [isConnected, isVisible, refreshTransactions]);
+  }, [isConnected, refreshTransactions]);
 
   useFocusEffect(
     useCallback(() => {
-      if (!isConnected || !isVisible) {
+      if (!isConnected) {
         setIsFocusRefreshing(false);
         return;
       }
@@ -245,7 +220,7 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
       return () => {
         isMounted = false;
       };
-    }, [isConnected, isVisible, refreshTransactions]),
+    }, [isConnected, refreshTransactions]),
   );
 
   const renderFilterTab = useCallback(
@@ -417,20 +392,15 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
   }, [activeFilter]);
 
   // Determine if we should show loading skeleton
-  const isInitialLoading = useMemo(() => {
-    if (!isVisible) {
-      return false;
-    }
-
+  const isInitialLoading = useMemo(() =>
     // Show loading for connection/data fetch states and focus-refresh with no cached rows.
-    return (
+     (
       isConnecting ||
       transactionsLoading ||
       (!isConnected && flatListData.length === 0) ||
       (isFocusRefreshing && flatListData.length === 0)
-    );
-  }, [
-    isVisible,
+    )
+  , [
     isConnecting,
     transactionsLoading,
     isConnected,
@@ -442,23 +412,18 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
   // Only measures once per session (no reset on refresh/tab switch)
   usePerpsMeasurement({
     traceName: TraceName.PerpsTransactionsView,
-    conditions: [isVisible && !isInitialLoading],
+    conditions: [!isInitialLoading],
     resetConditions: [], // Prevent automatic reset on subsequent loads
   });
 
   // Determine if we should show empty state (only after loading is complete and no data)
   const shouldShowEmptyState = useMemo(() => {
-    if (!isVisible) return false;
     if (isInitialLoading) return false;
     if (!isConnected) return false;
 
     // Show empty state only if loading is complete and we have no data
     return flatListData.length === 0;
-  }, [isVisible, isInitialLoading, isConnected, flatListData.length]);
-
-  if (!isVisible) {
-    return <View style={styles.container} />;
-  }
+  }, [isInitialLoading, isConnected, flatListData.length]);
 
   // Show loading skeleton during initial load
   if (isInitialLoading) {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -45,6 +45,15 @@ import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { TraceName } from '../../../../../util/trace';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
+const EMPTY_TRANSACTIONS: PerpsTransaction[] = [];
+const EMPTY_LIST_ITEMS: ListItem[] = [];
+const EMPTY_GROUPED_TRANSACTIONS: Record<FilterTab, TransactionSection[]> = {
+  Trades: [],
+  Orders: [],
+  Funding: [],
+  Deposits: [],
+};
+
 const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
   isVisible = true,
 }) => {
@@ -83,6 +92,11 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
     skipInitialFetch: !isConnected || !isVisible,
     accountId,
   });
+
+  const transactionsForRender = useMemo(
+    () => (isVisible ? allTransactions : EMPTY_TRANSACTIONS),
+    [allTransactions, isVisible],
+  );
 
   // Helper function to group transactions by date
   const groupTransactionsByDate = useCallback(
@@ -134,30 +148,34 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
 
   // Filter transactions by type from the single source of truth
   const fillTransactions = useMemo(
-    () => allTransactions.filter((tx) => tx.type === 'trade'),
-    [allTransactions],
+    () => transactionsForRender.filter((tx) => tx.type === 'trade'),
+    [transactionsForRender],
   );
 
   const orderTransactions = useMemo(
-    () => allTransactions.filter((tx) => tx.type === 'order'),
-    [allTransactions],
+    () => transactionsForRender.filter((tx) => tx.type === 'order'),
+    [transactionsForRender],
   );
 
   const fundingTransactions = useMemo(
-    () => allTransactions.filter((tx) => tx.type === 'funding'),
-    [allTransactions],
+    () => transactionsForRender.filter((tx) => tx.type === 'funding'),
+    [transactionsForRender],
   );
 
   const depositWithdrawalTransactions = useMemo(
     () =>
-      allTransactions.filter(
+      transactionsForRender.filter(
         (tx) => tx.type === 'deposit' || tx.type === 'withdrawal',
       ),
-    [allTransactions],
+    [transactionsForRender],
   );
 
   // Memoized grouped transactions to avoid recalculation on every filter change
   const allGroupedTransactions = useMemo(() => {
+    if (!isVisible) {
+      return EMPTY_GROUPED_TRANSACTIONS;
+    }
+
     const grouped = {
       Trades: groupTransactionsByDate(fillTransactions),
       Orders: groupTransactionsByDate(orderTransactions),
@@ -167,6 +185,7 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
 
     return grouped;
   }, [
+    isVisible,
     fillTransactions,
     orderTransactions,
     fundingTransactions,
@@ -175,9 +194,12 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
   ]);
 
   const flatListData = useMemo(() => {
+    if (!isVisible) {
+      return EMPTY_LIST_ITEMS;
+    }
     const currentGrouped = allGroupedTransactions[activeFilter] || [];
     return flattenGroupedTransactions(currentGrouped, activeFilter);
-  }, [allGroupedTransactions, activeFilter]);
+  }, [activeFilter, allGroupedTransactions, isVisible]);
 
   // Note: Removed automatic scroll to top on tab change to allow switching tabs while scrolling
 
@@ -395,38 +417,48 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
   }, [activeFilter]);
 
   // Determine if we should show loading skeleton
-  const isInitialLoading = useMemo(
-    () =>
-      // Show loading for connection/data fetch states and focus-refresh with no cached rows.
+  const isInitialLoading = useMemo(() => {
+    if (!isVisible) {
+      return false;
+    }
+
+    // Show loading for connection/data fetch states and focus-refresh with no cached rows.
+    return (
       isConnecting ||
       transactionsLoading ||
       (!isConnected && flatListData.length === 0) ||
-      (isFocusRefreshing && flatListData.length === 0),
-    [
-      isConnecting,
-      transactionsLoading,
-      isConnected,
-      isFocusRefreshing,
-      flatListData.length,
-    ],
-  );
+      (isFocusRefreshing && flatListData.length === 0)
+    );
+  }, [
+    isVisible,
+    isConnecting,
+    transactionsLoading,
+    isConnected,
+    isFocusRefreshing,
+    flatListData.length,
+  ]);
 
   // Track screen load performance - measures time until all data is loaded and UI is interactive
   // Only measures once per session (no reset on refresh/tab switch)
   usePerpsMeasurement({
     traceName: TraceName.PerpsTransactionsView,
-    conditions: [!isInitialLoading],
+    conditions: [isVisible && !isInitialLoading],
     resetConditions: [], // Prevent automatic reset on subsequent loads
   });
 
   // Determine if we should show empty state (only after loading is complete and no data)
   const shouldShowEmptyState = useMemo(() => {
+    if (!isVisible) return false;
     if (isInitialLoading) return false;
     if (!isConnected) return false;
 
     // Show empty state only if loading is complete and we have no data
     return flatListData.length === 0;
-  }, [isInitialLoading, isConnected, flatListData.length]);
+  }, [isVisible, isInitialLoading, isConnected, flatListData.length]);
+
+  if (!isVisible) {
+    return <View style={styles.container} />;
+  }
 
   // Show loading skeleton during initial load
   if (isInitialLoading) {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -392,21 +392,21 @@ const PerpsTransactionsView: React.FC = () => {
   }, [activeFilter]);
 
   // Determine if we should show loading skeleton
-  const isInitialLoading = useMemo(() =>
-    // Show loading for connection/data fetch states and focus-refresh with no cached rows.
-     (
+  const isInitialLoading = useMemo(
+    () =>
+      // Show loading for connection/data fetch states and focus-refresh with no cached rows.
       isConnecting ||
       transactionsLoading ||
       (!isConnected && flatListData.length === 0) ||
-      (isFocusRefreshing && flatListData.length === 0)
-    )
-  , [
-    isConnecting,
-    transactionsLoading,
-    isConnected,
-    isFocusRefreshing,
-    flatListData.length,
-  ]);
+      (isFocusRefreshing && flatListData.length === 0),
+    [
+      isConnecting,
+      transactionsLoading,
+      isConnected,
+      isFocusRefreshing,
+      flatListData.length,
+    ],
+  );
 
   // Track screen load performance - measures time until all data is loaded and UI is interactive
   // Only measures once per session (no reset on refresh/tab switch)

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -1,12 +1,6 @@
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { RefreshControl, ScrollView, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
@@ -51,15 +45,16 @@ import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { TraceName } from '../../../../../util/trace';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
-const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
+const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = ({
+  isVisible = true,
+}) => {
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
   const navigation = useNavigation();
 
-  // Transaction data is now computed from hooks instead of stored in state
-  const [flatListData, setFlatListData] = useState<ListItem[]>([]);
   const [activeFilter, setActiveFilter] = useState<FilterTab>('Trades');
   const [refreshing, setRefreshing] = useState(false);
+  const [isFocusRefreshing, setIsFocusRefreshing] = useState(false);
 
   // Ref for FlashList to control scrolling
   const flashListRef = useRef(null);
@@ -85,7 +80,7 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     isLoading: transactionsLoading,
     refetch: refreshTransactions,
   } = usePerpsTransactionHistory({
-    skipInitialFetch: !isConnected,
+    skipInitialFetch: !isConnected || !isVisible,
     accountId,
   });
 
@@ -179,21 +174,15 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     groupTransactionsByDate,
   ]);
 
-  // Memoized flat data for current filter - prevents re-flattening on every change
-  const currentFlatListData = useMemo(() => {
+  const flatListData = useMemo(() => {
     const currentGrouped = allGroupedTransactions[activeFilter] || [];
     return flattenGroupedTransactions(currentGrouped, activeFilter);
   }, [allGroupedTransactions, activeFilter]);
 
-  // Update state only when needed - much faster tab switching
-  useEffect(() => {
-    setFlatListData(currentFlatListData);
-  }, [allGroupedTransactions, activeFilter, currentFlatListData]);
-
   // Note: Removed automatic scroll to top on tab change to allow switching tabs while scrolling
 
   const onRefresh = useCallback(async () => {
-    if (!isConnected) {
+    if (!isConnected || !isVisible) {
       return;
     }
     setRefreshing(true);
@@ -205,9 +194,37 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     } finally {
       setRefreshing(false);
     }
-  }, [isConnected, refreshTransactions]);
+  }, [isConnected, isVisible, refreshTransactions]);
 
-  // Initial loading is handled by the hooks themselves
+  useFocusEffect(
+    useCallback(() => {
+      if (!isConnected || !isVisible) {
+        setIsFocusRefreshing(false);
+        return;
+      }
+
+      let isMounted = true;
+
+      const refreshOnFocus = async () => {
+        setIsFocusRefreshing(true);
+        try {
+          await refreshTransactions();
+        } catch (error) {
+          console.warn('Failed to refresh perps transactions on focus:', error);
+        } finally {
+          if (isMounted) {
+            setIsFocusRefreshing(false);
+          }
+        }
+      };
+
+      refreshOnFocus();
+
+      return () => {
+        isMounted = false;
+      };
+    }, [isConnected, isVisible, refreshTransactions]),
+  );
 
   const renderFilterTab = useCallback(
     (tab: FilterTab, index: number) => {
@@ -380,9 +397,18 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
   // Determine if we should show loading skeleton
   const isInitialLoading = useMemo(
     () =>
-      // Show loading if we're connecting or if transaction data is loading
-      isConnecting || transactionsLoading,
-    [isConnecting, transactionsLoading],
+      // Show loading for connection/data fetch states and focus-refresh with no cached rows.
+      isConnecting ||
+      transactionsLoading ||
+      (!isConnected && flatListData.length === 0) ||
+      (isFocusRefreshing && flatListData.length === 0),
+    [
+      isConnecting,
+      transactionsLoading,
+      isConnected,
+      isFocusRefreshing,
+      flatListData.length,
+    ],
   );
 
   // Track screen load performance - measures time until all data is loaded and UI is interactive

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.test.tsx
@@ -509,7 +509,7 @@ describe('PerpsMarketTabs', () => {
       expect(onActiveTabChange).toHaveBeenLastCalledWith('position');
     });
 
-    it('handles initialTab when data loads after component mount', () => {
+    it('handles initialTab when data loads after component mount', async () => {
       const onActiveTabChange = jest.fn();
       mockUsePerpsLivePositions.mockReturnValue({
         positions: [{ ...mockPosition, symbol: 'BTC' }],
@@ -525,9 +525,11 @@ describe('PerpsMarketTabs', () => {
         />,
       );
 
-      expect(
-        getByTestId(PerpsMarketTabsSelectorsIDs.POSITION_CONTENT),
-      ).toBeDefined();
+      await waitFor(() => {
+        expect(
+          getByTestId(PerpsMarketTabsSelectorsIDs.POSITION_CONTENT),
+        ).toBeDefined();
+      });
       expect(onActiveTabChange).toHaveBeenCalledWith('position');
     });
   });
@@ -646,7 +648,7 @@ describe('PerpsMarketTabs', () => {
   });
 
   describe('Order Sorting', () => {
-    it('sorts orders by detailedOrderType then by orderId', () => {
+    it('sorts orders by detailedOrderType then by orderId', async () => {
       const limitOrder = {
         ...mockOrder,
         symbol: 'BTC',
@@ -682,10 +684,12 @@ describe('PerpsMarketTabs', () => {
         />,
       );
 
-      expect(getAllByTestId('mock-perps-open-order-card')).toHaveLength(3);
+      await waitFor(() => {
+        expect(getAllByTestId('mock-perps-open-order-card')).toHaveLength(3);
+      });
     });
 
-    it('falls back to orderType when detailedOrderType is missing', () => {
+    it('falls back to orderType when detailedOrderType is missing', async () => {
       const orderWithoutDetailedType = {
         ...mockOrder,
         symbol: 'BTC',
@@ -707,7 +711,9 @@ describe('PerpsMarketTabs', () => {
         />,
       );
 
-      expect(getByTestId('mock-perps-open-order-card')).toBeDefined();
+      await waitFor(() => {
+        expect(getByTestId('mock-perps-open-order-card')).toBeDefined();
+      });
     });
   });
 

--- a/app/components/UI/Perps/types/transactionHistory.ts
+++ b/app/components/UI/Perps/types/transactionHistory.ts
@@ -99,7 +99,9 @@ export type ListItem =
 
 export type FilterTab = 'Trades' | 'Orders' | 'Funding' | 'Deposits';
 
-export interface PerpsTransactionsViewProps {}
+export interface PerpsTransactionsViewProps {
+  isVisible?: boolean;
+}
 
 export type PerpsPositionTransactionRouteProp = RouteProp<
   PerpsNavigationParamList,

--- a/app/components/UI/Perps/types/transactionHistory.ts
+++ b/app/components/UI/Perps/types/transactionHistory.ts
@@ -99,10 +99,6 @@ export type ListItem =
 
 export type FilterTab = 'Trades' | 'Orders' | 'Funding' | 'Deposits';
 
-export interface PerpsTransactionsViewProps {
-  isVisible?: boolean;
-}
-
 export type PerpsPositionTransactionRouteProp = RouteProp<
   PerpsNavigationParamList,
   'PerpsPositionTransaction'

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -1,5 +1,5 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
@@ -98,14 +98,12 @@ const ActivityView = () => {
 
   const currentNetworkName = getNetworkInfo(0)?.networkName;
 
-  const tabViewRef = useRef();
   const params = useParams();
   const perpsEnabledFlag = useSelector(selectPerpsEnabledFlag);
   const isPerpsEnabled = useMemo(
     () => perpsEnabledFlag && isEvmSelected,
     [perpsEnabledFlag, isEvmSelected],
   );
-  const [activeTabIndex, setActiveTabIndex] = useState(0);
   const predictEnabledFlag = useSelector(selectPredictEnabledFlag);
   const isPredictEnabled = useMemo(
     () => predictEnabledFlag,
@@ -129,6 +127,17 @@ const ActivityView = () => {
   // Perps comes after Transactions (0) and Orders (1)
   const perpsTabIndex = useMemo(() => 2, []);
 
+  const [initialTabIndex] = useState(() => {
+    if (params.redirectToOrders) {
+      return 1;
+    }
+    if (isPerpsEnabled && params.redirectToPerpsTransactions) {
+      return perpsTabIndex;
+    }
+    return 0;
+  });
+  const [activeTabIndex, setActiveTabIndex] = useState(initialTabIndex);
+
   // Predict comes after Transactions (0), Orders (1), and optionally Perps
   const predictTabIndex = useMemo(
     () => (isPerpsEnabled ? 3 : 2),
@@ -141,23 +150,20 @@ const ActivityView = () => {
 
   useFocusEffect(
     useCallback(() => {
+      const nextParams = {};
       if (params.redirectToOrders) {
-        const orderTabNumber = 1;
-        setActiveTabIndex(orderTabNumber);
-        navigation.setParams({ redirectToOrders: false });
-        tabViewRef.current?.goToTabIndex(orderTabNumber);
-      } else if (isPerpsEnabled && params.redirectToPerpsTransactions) {
-        setActiveTabIndex(perpsTabIndex);
-        navigation.setParams({ redirectToPerpsTransactions: false });
-        tabViewRef.current?.goToTabIndex(perpsTabIndex);
+        nextParams.redirectToOrders = false;
+      }
+      if (params.redirectToPerpsTransactions) {
+        nextParams.redirectToPerpsTransactions = false;
+      }
+      if (Object.keys(nextParams).length > 0) {
+        navigation.setParams(nextParams);
       }
     }, [
       navigation,
-      setActiveTabIndex,
       params.redirectToOrders,
-      isPerpsEnabled,
       params.redirectToPerpsTransactions,
-      perpsTabIndex,
     ]),
   );
 
@@ -193,7 +199,7 @@ const ActivityView = () => {
 
         <Box twClassName="flex-1 gap-4">
           <TabsList
-            ref={tabViewRef}
+            initialActiveIndex={initialTabIndex}
             onChangeTab={({ i }) => setActiveTabIndex(i)}
             tabsListContentTwClassName="px-0 pb-3"
             testID={ActivitiesViewSelectorsIDs.TABS_CONTAINER}

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -264,7 +264,7 @@ const ActivityView = () => {
               >
                 <PerpsConnectionProvider>
                   <PerpsStreamProvider>
-                    <PerpsTransactionsView isVisible={isPerpsTabActive} />
+                    {isPerpsTabActive ? <PerpsTransactionsView /> : null}
                   </PerpsStreamProvider>
                 </PerpsConnectionProvider>
               </View>

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -143,14 +143,17 @@ const ActivityView = () => {
     useCallback(() => {
       if (params.redirectToOrders) {
         const orderTabNumber = 1;
+        setActiveTabIndex(orderTabNumber);
         navigation.setParams({ redirectToOrders: false });
         tabViewRef.current?.goToTabIndex(orderTabNumber);
       } else if (isPerpsEnabled && params.redirectToPerpsTransactions) {
+        setActiveTabIndex(perpsTabIndex);
         navigation.setParams({ redirectToPerpsTransactions: false });
         tabViewRef.current?.goToTabIndex(perpsTabIndex);
       }
     }, [
       navigation,
+      setActiveTabIndex,
       params.redirectToOrders,
       isPerpsEnabled,
       params.redirectToPerpsTransactions,
@@ -249,13 +252,11 @@ const ActivityView = () => {
                 tabLabel={strings('perps.transactions.title')}
                 style={styles.tabWrapper}
               >
-                {isPerpsTabActive ? (
-                  <PerpsConnectionProvider>
-                    <PerpsStreamProvider>
-                      <PerpsTransactionsView />
-                    </PerpsStreamProvider>
-                  </PerpsConnectionProvider>
-                ) : null}
+                <PerpsConnectionProvider>
+                  <PerpsStreamProvider>
+                    <PerpsTransactionsView isVisible={isPerpsTabActive} />
+                  </PerpsStreamProvider>
+                </PerpsConnectionProvider>
               </View>
             )}
 

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -148,6 +148,10 @@ const ActivityView = () => {
   const isPredictTabActive =
     isPredictEnabled && activeTabIndex === predictTabIndex;
 
+  const handleChangeTab = useCallback(({ i }) => {
+    setActiveTabIndex(i);
+  }, []);
+
   useFocusEffect(
     useCallback(() => {
       const nextParams = {};
@@ -200,7 +204,7 @@ const ActivityView = () => {
         <Box twClassName="flex-1 gap-4">
           <TabsList
             initialActiveIndex={initialTabIndex}
-            onChangeTab={({ i }) => setActiveTabIndex(i)}
+            onChangeTab={handleChangeTab}
             tabsListContentTwClassName="px-0 pb-3"
             testID={ActivitiesViewSelectorsIDs.TABS_CONTAINER}
           >

--- a/app/components/Views/ActivityView/index.test.tsx
+++ b/app/components/Views/ActivityView/index.test.tsx
@@ -473,10 +473,10 @@ describe('ActivityView', () => {
       mockPerpsEnabled = true;
       mockIsEvmSelected = true;
 
-      const { getByTestId } = renderComponent(mockInitialState);
+      const { getByTestId, queryByTestId } = renderComponent(mockInitialState);
 
       expect(getByTestId('tab-perps')).toBeTruthy();
-      expect(getByTestId('perps-transactions-view')).toBeTruthy();
+      expect(queryByTestId('perps-transactions-view')).toBeNull();
       expect(getRenderedTabs()).toContain('perps');
     });
 

--- a/app/components/Views/ActivityView/index.test.tsx
+++ b/app/components/Views/ActivityView/index.test.tsx
@@ -27,12 +27,14 @@ jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
 
 // Track which tabs are rendered - populated by mock
 let renderedTabs: string[] = [];
-let mockShouldIgnoreGoToTabIndexCallback = false;
+let lastInitialActiveIndex: number | undefined;
 
 // Helper to get rendered tabs for assertions
 const getRenderedTabs = () => renderedTabs;
+const getLastInitialActiveIndex = () => lastInitialActiveIndex;
 const clearRenderedTabs = () => {
   renderedTabs = [];
+  lastInitialActiveIndex = undefined;
 };
 
 jest.mock('../../../component-library/components-temp/Tabs', () => {
@@ -43,10 +45,11 @@ jest.mock('../../../component-library/components-temp/Tabs', () => {
     (
       props: {
         children?: React.ReactElement[];
+        initialActiveIndex?: number;
         onChangeTab?: (params: { i: number }) => void;
         [key: string]: unknown;
       },
-      ref: React.Ref<{ goToTabIndex: (index: number) => void }>,
+      _ref: React.Ref<{ goToTabIndex: (index: number) => void }>,
     ) => {
       const children = Array.isArray(props.children) ? props.children : [];
 
@@ -63,15 +66,8 @@ jest.mock('../../../component-library/components-temp/Tabs', () => {
         });
         // Update module-level variable for test assertions
         renderedTabs = tabKeys;
-      }, [children]);
-
-      ReactActual.useImperativeHandle(ref, () => ({
-        goToTabIndex: (index: number) => {
-          if (!mockShouldIgnoreGoToTabIndexCallback) {
-            props.onChangeTab?.({ i: index });
-          }
-        },
-      }));
+        lastInitialActiveIndex = props.initialActiveIndex;
+      }, [children, props.initialActiveIndex]);
 
       return ReactActual.createElement(
         View,
@@ -267,8 +263,8 @@ describe('ActivityView', () => {
     mockIsEvmSelected = true;
     mockPerpsEnabled = false;
     mockPredictEnabled = false;
-    mockShouldIgnoreGoToTabIndexCallback = false;
     clearRenderedTabs();
+    mockRoute.params = {};
   });
 
   it('matches snapshot', () => {
@@ -502,10 +498,9 @@ describe('ActivityView', () => {
       expect(getRenderedTabs()).not.toContain('perps');
     });
 
-    it('renders Perps transactions when redirected even if tab callback is skipped', () => {
+    it('uses Perps as initial tab when redirected to Perps transactions', () => {
       mockPerpsEnabled = true;
       mockIsEvmSelected = true;
-      mockShouldIgnoreGoToTabIndexCallback = true;
       mockRoute.params = {
         redirectToPerpsTransactions: true,
         showBackButton: true,
@@ -514,6 +509,32 @@ describe('ActivityView', () => {
       const { getByTestId } = renderComponent(mockInitialState);
 
       expect(getByTestId('perps-transactions-view')).toBeTruthy();
+      expect(getLastInitialActiveIndex()).toBe(2);
+      expect(mockNavigation.setParams).toHaveBeenCalledWith({
+        redirectToPerpsTransactions: false,
+      });
+    });
+  });
+
+  describe('Orders tab', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRoute.params = {};
+    });
+
+    it('renders orders list and clears redirect param when redirected to orders', () => {
+      mockRoute.params = {
+        redirectToOrders: true,
+        showBackButton: true,
+      };
+
+      const { getByTestId } = renderComponent(mockInitialState);
+
+      expect(getByTestId('ramp-orders-list')).toBeTruthy();
+      expect(getLastInitialActiveIndex()).toBe(1);
+      expect(mockNavigation.setParams).toHaveBeenCalledWith({
+        redirectToOrders: false,
+      });
     });
   });
 

--- a/app/components/Views/ActivityView/index.test.tsx
+++ b/app/components/Views/ActivityView/index.test.tsx
@@ -27,6 +27,7 @@ jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
 
 // Track which tabs are rendered - populated by mock
 let renderedTabs: string[] = [];
+let mockShouldIgnoreGoToTabIndexCallback = false;
 
 // Helper to get rendered tabs for assertions
 const getRenderedTabs = () => renderedTabs;
@@ -66,7 +67,9 @@ jest.mock('../../../component-library/components-temp/Tabs', () => {
 
       ReactActual.useImperativeHandle(ref, () => ({
         goToTabIndex: (index: number) => {
-          props.onChangeTab?.({ i: index });
+          if (!mockShouldIgnoreGoToTabIndexCallback) {
+            props.onChangeTab?.({ i: index });
+          }
         },
       }));
 
@@ -100,6 +103,7 @@ const Stack = createStackNavigator();
 
 const mockNavigation = {
   navigate: jest.fn(),
+  setParams: jest.fn(),
   setOptions: jest.fn(),
   goBack: jest.fn(),
   canGoBack: jest.fn(() => true),
@@ -263,6 +267,7 @@ describe('ActivityView', () => {
     mockIsEvmSelected = true;
     mockPerpsEnabled = false;
     mockPredictEnabled = false;
+    mockShouldIgnoreGoToTabIndexCallback = false;
     clearRenderedTabs();
   });
 
@@ -475,6 +480,7 @@ describe('ActivityView', () => {
       const { getByTestId } = renderComponent(mockInitialState);
 
       expect(getByTestId('tab-perps')).toBeTruthy();
+      expect(getByTestId('perps-transactions-view')).toBeTruthy();
       expect(getRenderedTabs()).toContain('perps');
     });
 
@@ -494,6 +500,20 @@ describe('ActivityView', () => {
       renderComponent(mockInitialState);
 
       expect(getRenderedTabs()).not.toContain('perps');
+    });
+
+    it('renders Perps transactions when redirected even if tab callback is skipped', () => {
+      mockPerpsEnabled = true;
+      mockIsEvmSelected = true;
+      mockShouldIgnoreGoToTabIndexCallback = true;
+      mockRoute.params = {
+        redirectToPerpsTransactions: true,
+        showBackButton: true,
+      };
+
+      const { getByTestId } = renderComponent(mockInitialState);
+
+      expect(getByTestId('perps-transactions-view')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes intermittent Activity tab rendering issues and tab-switch latency when entering Activity from Perps Home (Perps Home -> Activity -> back -> Activity, and subsequent tab switches).

  Reason for the change

  - Users could see a selected Activity tab with no rows rendered, especially on repeated entry from Perps.
  - This was caused by timing issues between initial tab selection and deferred tab content loading.

  Improvement / solution

- Updated ActivityView to set the initial tab index from route params on mount (instead of relying on post-mount tab switching), then clear redirect params on focus.
- Hardened shared TabsList tab loading with InteractionManager scheduling plus a fallback timeout, so tab content still loads when interaction callbacks are delayed.
- Added a stale callback safeguard in TabsList so an older interaction callback cannot cancel a newer tab's pending load.
- Added/updated regression tests for async tab-loading behavior, stale-callback handling, and repeated Perps entry navigation paths.

Out of scope / follow-up

- This PR intentionally does not fix the Predictions tab infinite spinner.
- The Predictions behavior appears to be a separate feature-specific loading lifecycle issue and is deferred to a
  follow-up with the Predictions owners.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where Perps activity could appear blank after reopening the Activity screen from Perps home.

## **Related issues**

https://consensyssoftware.atlassian.net/browse/TAT-2614

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```
```
Feature: Activity tab loading and switching from Perps entry

    Scenario: user re-enters Activity from Perps and sees data
      Given the user is on Perps Home with account activity available
      When user opens Activity, goes back to Perps Home, and opens Activity again
      Then the selected Activity tab loads its rows instead of showing a blank body

    Scenario: user switches tabs in Activity from Perps entry
      Given the user opened Activity from Perps Home
      When user taps Transactions, Transfers, and Perps tabs
      Then each tab becomes selected promptly and shows loading/content without a multi-second delay

    Scenario: user opens Perps tab repeatedly without blank state
      Given the user is on Activity with Perps tab enabled
      When user switches away from Perps and then back to Perps multiple times
      Then Perps activity content continues to render reliably on each return

    Scenario: user does not hit tab-switch crash
      Given the user is on Activity opened from Perps Home
      When user taps between Activity tabs
      Then the app does not crash and no red-screen error is shown
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/b425e3dd-37c1-45f8-bf06-62e176bc4046



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/6a92a910-4fad-44d4-9646-dfef510cc138



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `TabsList` loading/scheduling and Activity/Perps screen focus behavior; mistakes could reintroduce blank tabs or regress tab switching/refresh timing.
> 
> **Overview**
> Fixes intermittent **blank Activity tab content** when entering Activity from Perps by selecting the correct tab *at mount time* (`ActivityView` now derives `initialActiveIndex` from route params and clears redirect params on focus, instead of imperatively switching tabs post-mount).
> 
> Hardens `TabsList` on-demand rendering by scheduling active-tab loading via `InteractionManager` **with a 250ms fallback timeout** and centralized cancellation, improving reliability when `runAfterInteractions` callbacks are delayed/missed.
> 
> Updates Perps Activity content behavior: `PerpsTransactionsView` now **refetches on screen focus** and shows a skeleton when disconnected/focus-refreshing with no cached rows; tests were expanded/adjusted across tabs and Perps views to cover the new timing and loading guarantees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36e8a2a3ee18424d207b937791c820e34be9d508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->