### PR TITLE
test: fix flaky

### DIFF
--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -711,13 +711,16 @@ class WalletView {
    */
   async scrollAndTapPredictionsSection(
     direction: 'up' | 'down' = 'down',
+    options: {
+      overshootSwipe?: { direction: 'up' | 'down'; percentage?: number };
+    } = {},
   ): Promise<void> {
     await this.scrollAndTapSection(
       this.predictionsSectionHeader,
       'Predictions section',
       direction,
       {
-        overshootSwipe: {
+        overshootSwipe: options.overshootSwipe ?? {
           direction: 'up',
           percentage: 0.15,
         },

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -38,20 +38,40 @@ class WalletView {
     return Matchers.getIdentifier(WalletViewSelectorsIDs.WALLET_SCROLL_VIEW);
   }
 
+  /** Wallet ScrollView as element (for gestures like swipe). */
+  get walletScrollView(): DetoxElement {
+    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_SCROLL_VIEW);
+  }
+
   /**
    * Progressive scroll for homepage sections:
    * try tap -> small scroll down -> retry, until the section is tappable.
+   * @param options.scrollAmount - Pixels to scroll per step.
+   * @param options.overshootSwipe - After scroll, perform a small swipe to move the section away
+   * from the tab bar (e.g. direction 'up' = one more scroll down = section moves higher on screen).
    */
   private async scrollAndTapSection(
     target: DetoxElement,
     description: string,
     direction: 'up' | 'down' = 'down',
+    options: {
+      scrollAmount?: number;
+      overshootSwipe?: { direction: 'up' | 'down'; percentage?: number };
+    } = {},
   ): Promise<void> {
+    const { scrollAmount = 200, overshootSwipe } = options;
     await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
       direction,
-      scrollAmount: 200,
+      scrollAmount,
       elemDescription: `Scroll to ${description}`,
     });
+    if (overshootSwipe) {
+      await Gestures.swipe(this.walletScrollView, overshootSwipe.direction, {
+        percentage: overshootSwipe.percentage ?? 0.15,
+        speed: 'slow',
+        elemDescription: `Overshoot swipe for ${description}`,
+      });
+    }
     await Gestures.waitAndTap(target, {
       elemDescription: description,
     });
@@ -685,6 +705,10 @@ class WalletView {
     );
   }
 
+  /**
+   * Scrolls to the Predictions section and taps it. After scroll, does a small overshoot swipe
+   * so the section sits higher on screen and the tap does not hit the main menu "+" button.
+   */
   async scrollAndTapPredictionsSection(
     direction: 'up' | 'down' = 'down',
   ): Promise<void> {
@@ -692,6 +716,12 @@ class WalletView {
       this.predictionsSectionHeader,
       'Predictions section',
       direction,
+      {
+        overshootSwipe: {
+          direction: 'up',
+          percentage: 0.15,
+        },
+      },
     );
   }
 

--- a/tests/smoke/predict/predict-claim-positions.spec.ts
+++ b/tests/smoke/predict/predict-claim-positions.spec.ts
@@ -124,7 +124,6 @@ describe(SmokePredictions('Claim winnings:'), () => {
         // Claim button is animated - disabling sync on iOS to prevent test hang
         await device.disableSynchronization();
 
-        //await WalletView.scrollAndTapPredictionsSection();
         await WalletView.tapClaimButton();
 
         await postClaimMocks(mockServer);
@@ -160,7 +159,12 @@ describe(SmokePredictions('Claim winnings:'), () => {
           description:
             'Wallet screen should be visible after returning from activity',
         });
-        await WalletView.scrollAndTapPredictionsSection('up');
+        await WalletView.scrollAndTapPredictionsSection('down', {
+          overshootSwipe: {
+            direction: 'down',
+            percentage: 0.15,
+          },
+        });
         await Assertions.expectTextDisplayed('$48.16');
 
         // Verify analytics events


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- **Problem:** E2E test `predict-existing-polymarket-balance` was flaky because after scrolling to the Predictions section the tap sometimes hit the main tab bar "+" button.
- **Approach:** Keep the existing scroll behaviour and add an optional **overshoot swipe** after scrolling so the section sits higher on screen and away from the tab bar.
- **Changes:**
  - `WalletView`: added `walletScrollView` getter (ScrollView as element for gestures).
  - `scrollAndTapSection`: new optional `overshootSwipe?: { direction; percentage? }`; when set, a small swipe is performed on the wallet scroll view after `scrollToElement`, then the tap.
  - `scrollAndTapPredictionsSection`: uses `overshootSwipe: { direction: 'up', percentage: 0.15 }` so one extra small scroll-down moves the Predictions section up and avoids tapping the "+".


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Detox page-object gesture helpers and a smoke test, with no production code impact. Main risk is altering scroll/tap behavior that could affect other wallet section interactions if reused broadly.
> 
> **Overview**
> Fixes flakiness in the Predictions E2E flow where tapping the Predictions section could hit the tab bar "+" button after scrolling.
> 
> `WalletView.scrollAndTapSection` now supports optional tuning (`scrollAmount`) and an optional post-scroll **overshoot swipe** on the wallet ScrollView before tapping; `scrollAndTapPredictionsSection` defaults to using this overshoot behavior and the smoke test overrides the swipe direction/options when returning to Wallet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80b5f4598aa058165a23b8e783f9d76b259a43b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->