### PR TITLE
fix: amount formatting in simulation section for approve confirmations

### DIFF
--- a/app/components/Views/confirmations/components/approve-static-simulations/approve-and-permit2/approve-and-permit2.test.tsx
+++ b/app/components/Views/confirmations/components/approve-static-simulations/approve-and-permit2/approve-and-permit2.test.tsx
@@ -115,6 +115,52 @@ describe('ApproveAndPermit2', () => {
     expect(getByText('0x12345...56789')).toBeTruthy();
   });
 
+  it('formats large amounts with full precision', () => {
+    const mockUseApproveTransactionData = jest.spyOn(
+      useApproveTransactionDataModule,
+      'useApproveTransactionData',
+    );
+    mockUseApproveTransactionData.mockReturnValue({
+      approveMethod: ApproveMethod.APPROVE,
+      amount: '1000000.123456',
+      decimals: 18,
+      tokenBalance: '0',
+      tokenStandard: TokenStandard.ERC20,
+      rawAmount: '1000000.123456',
+      spender: '0x123456789',
+      isLoading: false,
+    } as ReturnType<
+      typeof useApproveTransactionDataModule.useApproveTransactionData
+    >);
+    const { getByText } = renderWithProvider(<ApproveAndPermit2 />, {
+      state: approveERC20TransactionStateMock,
+    });
+    expect(getByText('1,000,000.123456')).toBeTruthy();
+  });
+
+  it('displays Unlimited as-is without formatting', () => {
+    const mockUseApproveTransactionData = jest.spyOn(
+      useApproveTransactionDataModule,
+      'useApproveTransactionData',
+    );
+    mockUseApproveTransactionData.mockReturnValue({
+      approveMethod: ApproveMethod.APPROVE,
+      amount: 'Unlimited',
+      decimals: 18,
+      tokenBalance: '0',
+      tokenStandard: TokenStandard.ERC20,
+      rawAmount: '0',
+      spender: '0x123456789',
+      isLoading: false,
+    } as ReturnType<
+      typeof useApproveTransactionDataModule.useApproveTransactionData
+    >);
+    const { getByText } = renderWithProvider(<ApproveAndPermit2 />, {
+      state: approveERC20TransactionStateMock,
+    });
+    expect(getByText('Unlimited')).toBeTruthy();
+  });
+
   describe('revoke', () => {
     it('renders spending cap and spender for ERC20', () => {
       const { getByText } = renderWithProvider(<ApproveAndPermit2 />, {

--- a/app/components/Views/confirmations/components/approve-static-simulations/approve-and-permit2/approve-and-permit2.tsx
+++ b/app/components/Views/confirmations/components/approve-static-simulations/approve-and-permit2/approve-and-permit2.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { View } from 'react-native';
+import { BigNumber } from 'bignumber.js';
 import { TransactionMeta } from '@metamask/transaction-controller';
 
-import { strings } from '../../../../../../../locales/i18n';
+import I18n, { strings } from '../../../../../../../locales/i18n';
+import { formatAmountMaxPrecision } from '../../../../../UI/SimulationDetails/formatAmount';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { ApproveComponentIDs } from '../../../ConfirmationView.testIds';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
@@ -129,6 +131,14 @@ interface PillAndAddressProps {
   transactionMetadata: TransactionMeta;
 }
 
+function formatDisplayAmount(amount: string | undefined): string {
+  if (!amount) {
+    return '';
+  }
+  const value = new BigNumber(amount);
+  return value.isNaN() ? amount : formatAmountMaxPrecision(I18n.locale, value);
+}
+
 function PillAndAddress({
   amount,
   isERC20,
@@ -139,7 +149,7 @@ function PillAndAddress({
     <>
       <Pill
         testID={ApproveComponentIDs.SPENDING_CAP_VALUE}
-        text={isERC20 ? (amount ?? '') : `#${tokenId}`}
+        text={isERC20 ? formatDisplayAmount(amount) : `#${tokenId}`}
       />
       <Address
         address={transactionMetadata?.txParams?.to as string}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix amount formatting in simulation section for approve confirmations.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-732

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
<img width="396" height="849" alt="Screenshot 2026-03-17 at 5 06 45 PM" src="https://github.com/user-attachments/assets/9ddb5501-3c48-4f8e-99ae-e6f01fc1fac8" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts display formatting for approval spending caps and adds coverage for large numbers and non-numeric values like "Unlimited".
> 
> **Overview**
> Fixes spending-cap amount rendering in `ApproveAndPermit2` by formatting numeric ERC20 amounts using locale-aware `formatAmountMaxPrecision` (preserving full decimal precision and adding thousands separators) while leaving non-numeric strings (e.g., `Unlimited`) unchanged.
> 
> Adds tests to verify large-number full-precision formatting and that `Unlimited` is displayed as-is.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91e0095d7bef5f01db2dd41d9da2b767c69c7cad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->