### PR TITLE
fix: Throw if Snaps execution webview is missing

### DIFF
--- a/app/lib/snaps/SnapsExecutionWebView.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.tsx
@@ -51,7 +51,7 @@ export class SnapsExecutionWebView extends Component {
               this.webViews[jobId]?.ref,
               'Snaps execution webview reference not found.',
             );
-            this.webViews[jobId].ref.injectJavaScript(js);
+            this.webViews[jobId].ref?.injectJavaScript(js);
           },
           registerMessageListener: (
             listener: (event: PostMessageEvent) => void,
@@ -74,7 +74,7 @@ export class SnapsExecutionWebView extends Component {
       const onWebViewMessage = (data: WebViewMessageEvent) => {
         if (this.webViews[jobId]?.listener) {
           try {
-            this.webViews[jobId].listener(
+            this.webViews[jobId].listener?.(
               data.nativeEvent as unknown as PostMessageEvent,
             );
           } catch (error) {

--- a/app/lib/snaps/SnapsExecutionWebView.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.tsx
@@ -9,6 +9,8 @@ import { PostMessageEvent } from '@metamask/post-message-stream';
 // @ts-expect-error Types are currently broken for this.
 import WebViewHTML from '@metamask/snaps-execution-environments/dist/webpack/webview/index.html';
 import { EmptyObject } from '@metamask/snaps-sdk';
+import { assert } from '@metamask/utils';
+import Logger from '../../util/Logger';
 
 const styles = createStyles();
 
@@ -45,7 +47,11 @@ export class SnapsExecutionWebView extends Component {
       const onWebViewLoad = () => {
         const api = {
           injectJavaScript: (js: string) => {
-            this.webViews[jobId]?.ref?.injectJavaScript(js);
+            assert(
+              this.webViews[jobId]?.ref,
+              'Snaps execution webview reference not found.',
+            );
+            this.webViews[jobId].ref.injectJavaScript(js);
           },
           registerMessageListener: (
             listener: (event: PostMessageEvent) => void,
@@ -67,9 +73,13 @@ export class SnapsExecutionWebView extends Component {
 
       const onWebViewMessage = (data: WebViewMessageEvent) => {
         if (this.webViews[jobId]?.listener) {
-          this.webViews[jobId].listener?.(
-            data.nativeEvent as unknown as PostMessageEvent,
-          );
+          try {
+            this.webViews[jobId].listener(
+              data.nativeEvent as unknown as PostMessageEvent,
+            );
+          } catch (error) {
+            Logger.log('Snaps execution webview failure:', error);
+          }
         }
       };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Throw right away if messages cannot be delivered to the Snaps execution webview because the reference does not exist. Discovered this potential error state while investigating some Sentry errors, this additional error state may help us identify problems with Snaps execution on mobile in the future.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive runtime checks in the Snaps WebView bridge; behavior changes only when the WebView ref or message handler misbehaves, but could surface new thrown errors in those edge cases.
> 
> **Overview**
> Adds defensive error handling to `SnapsExecutionWebView` when bridging to the Snaps execution WebView.
> 
> `injectJavaScript` now `assert`s that the WebView `ref` exists (failing fast if the WebView can’t be reached), and message delivery to the registered listener is wrapped in a `try/catch` that logs failures via `Logger` instead of letting exceptions propagate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5f8abdbab19c2f6ccbf448a8d605daffaf55f70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->