### PR TITLE
feat: Default predict withdraw token from last used selection or from feature flags

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -580,7 +580,9 @@ describe('useAutomaticTransactionPayToken', () => {
               transactions: [
                 {
                   id: transactionIdMock,
-                  nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
                   status: 'unapproved',
                   time: 200,
                   txParams: { from: '0x123' },
@@ -592,7 +594,9 @@ describe('useAutomaticTransactionPayToken', () => {
                     chainId: CHAIN_ID_2_MOCK,
                     tokenAddress: TOKEN_ADDRESS_2_MOCK,
                   },
-                  nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
                   status: 'confirmed',
                   time: 100,
                   txParams: { from: '0x123' },

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -5,7 +5,10 @@ import {
   SetPayTokenRequest,
 } from './useAutomaticTransactionPayToken';
 import { useTransactionPayToken } from './useTransactionPayToken';
-import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import {
   MetaMaskPayTokensFlags,
@@ -18,12 +21,16 @@ import { Hex } from '@metamask/utils';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { AssetType } from '../../types/token';
+import { useSendTokens } from '../send/useSendTokens';
+import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('../../../../../util/address');
 jest.mock('../../../../../selectors/transactionPayController');
 jest.mock('./useTransactionPayData');
 jest.mock('./useTransactionPayAvailableTokens');
+jest.mock('../send/useSendTokens');
+jest.mock('./useWithdrawTokenFilter');
 jest.mock(
   '../../../../../selectors/featureFlagController/confirmations',
   () => ({
@@ -82,6 +89,8 @@ describe('useAutomaticTransactionPayToken', () => {
   const useTransactionPayAvailableTokensMock = jest.mocked(
     useTransactionPayAvailableTokens,
   );
+  const useSendTokensMock = jest.mocked(useSendTokens);
+  const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
   const isHardwareAccountMock = jest.mocked(isHardwareAccount);
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
@@ -110,6 +119,8 @@ describe('useAutomaticTransactionPayToken', () => {
     ]);
 
     isHardwareAccountMock.mockReturnValue(false);
+    useSendTokensMock.mockReturnValue([]);
+    useWithdrawTokenFilterMock.mockReturnValue((tokens) => tokens);
 
     selectMetaMaskPayTokensFlagsMock.mockReturnValue({
       preferredTokens: { default: [], overrides: {} },
@@ -553,6 +564,94 @@ describe('useAutomaticTransactionPayToken', () => {
 
     renderHookWithProvider(() => useAutomaticTransactionPayToken(), {
       state: predictStateMock,
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_2_MOCK,
+      chainId: CHAIN_ID_2_MOCK,
+    });
+  });
+
+  it('selects last used token for predict withdraw from nested transaction history', () => {
+    const predictWithdrawStateMock = merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: transactionIdMock,
+                  nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+                  status: 'unapproved',
+                  time: 200,
+                  txParams: { from: '0x123' },
+                  type: TransactionType.batch,
+                },
+                {
+                  id: 'previous-predict-withdraw',
+                  metamaskPay: {
+                    chainId: CHAIN_ID_2_MOCK,
+                    tokenAddress: TOKEN_ADDRESS_2_MOCK,
+                  },
+                  nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+                  status: 'confirmed',
+                  time: 100,
+                  txParams: { from: '0x123' },
+                  type: TransactionType.batch,
+                },
+              ],
+            },
+          },
+        },
+      },
+    );
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [] as AssetType[],
+      hasTokens: true,
+    });
+    useSendTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        balance: '1',
+        chainId: CHAIN_ID_2_MOCK,
+        symbol: 'BNB',
+      },
+      {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK,
+        balance: '1',
+        chainId: PREFERRED_CHAIN_ID_MOCK,
+        symbol: 'MUSD',
+      },
+    ] as AssetType[]);
+    selectMetaMaskPayTokensFlagsMock.mockReturnValue({
+      preferredTokens: {
+        default: [],
+        overrides: {
+          predictWithdraw: [
+            {
+              address: PREFERRED_TOKEN_ADDRESS_MOCK,
+              chainId: PREFERRED_CHAIN_ID_MOCK,
+              successRate: 1,
+            },
+          ],
+        },
+      },
+      minimumRequiredTokenBalance: 0,
+      blockedTokens: {
+        default: {
+          chainIds: [],
+          tokens: [],
+        },
+        overrides: {},
+      },
+    } as MetaMaskPayTokensFlags);
+
+    renderHookWithProvider(() => useAutomaticTransactionPayToken(), {
+      state: predictWithdrawStateMock,
     });
 
     expect(setPayTokenMock).toHaveBeenCalledWith({

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -21,7 +21,6 @@ import { Hex } from '@metamask/utils';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { AssetType } from '../../types/token';
-import { useSendTokens } from '../send/useSendTokens';
 import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 jest.mock('./useTransactionPayToken');
@@ -29,7 +28,6 @@ jest.mock('../../../../../util/address');
 jest.mock('../../../../../selectors/transactionPayController');
 jest.mock('./useTransactionPayData');
 jest.mock('./useTransactionPayAvailableTokens');
-jest.mock('../send/useSendTokens');
 jest.mock('./useWithdrawTokenFilter');
 jest.mock(
   '../../../../../selectors/featureFlagController/confirmations',
@@ -89,7 +87,6 @@ describe('useAutomaticTransactionPayToken', () => {
   const useTransactionPayAvailableTokensMock = jest.mocked(
     useTransactionPayAvailableTokens,
   );
-  const useSendTokensMock = jest.mocked(useSendTokens);
   const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
   const isHardwareAccountMock = jest.mocked(isHardwareAccount);
   const useTransactionPayRequiredTokensMock = jest.mocked(
@@ -119,7 +116,6 @@ describe('useAutomaticTransactionPayToken', () => {
     ]);
 
     isHardwareAccountMock.mockReturnValue(false);
-    useSendTokensMock.mockReturnValue([]);
     useWithdrawTokenFilterMock.mockReturnValue((tokens) => tokens);
 
     selectMetaMaskPayTokensFlagsMock.mockReturnValue({
@@ -610,23 +606,22 @@ describe('useAutomaticTransactionPayToken', () => {
     );
 
     useTransactionPayAvailableTokensMock.mockReturnValue({
-      availableTokens: [] as AssetType[],
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_2_MOCK,
+          balance: '1',
+          chainId: CHAIN_ID_2_MOCK,
+          symbol: 'BNB',
+        },
+        {
+          address: PREFERRED_TOKEN_ADDRESS_MOCK,
+          balance: '1',
+          chainId: PREFERRED_CHAIN_ID_MOCK,
+          symbol: 'MUSD',
+        },
+      ] as AssetType[],
       hasTokens: true,
     });
-    useSendTokensMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        balance: '1',
-        chainId: CHAIN_ID_2_MOCK,
-        symbol: 'BNB',
-      },
-      {
-        address: PREFERRED_TOKEN_ADDRESS_MOCK,
-        balance: '1',
-        chainId: PREFERRED_CHAIN_ID_MOCK,
-        symbol: 'MUSD',
-      },
-    ] as AssetType[]);
     selectMetaMaskPayTokensFlagsMock.mockReturnValue({
       preferredTokens: {
         default: [],

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -8,13 +8,19 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { AssetType } from '../../types/token';
-import { isTransactionPayWithdraw } from '../../utils/transaction';
+import {
+  getPostQuoteTransactionType,
+  isTransactionPayWithdraw,
+} from '../../utils/transaction';
 import { useSelector } from 'react-redux';
 import {
   selectMetaMaskPayTokensFlags,
   PreferredToken,
   getPreferredTokensForTransactionType,
 } from '../../../../../selectors/featureFlagController/confirmations';
+import { RootState } from '../../../../../reducers';
+import { selectLastWithdrawTokenByType } from '../../../../../selectors/transactionController';
+import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 export interface SetPayTokenRequest {
   address: Hex;
@@ -30,22 +36,19 @@ export function useAutomaticTransactionPayToken({
   disable?: boolean;
   preferredToken?: SetPayTokenRequest;
 } = {}) {
-  const isUpdated = useRef(false);
-  const { setPayToken } = useTransactionPayToken();
+  const isUpdated = useRef<string | undefined>();
+  const { payToken, setPayToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
-  const { availableTokens: tokens } = useTransactionPayAvailableTokens();
+  const { availableTokens } = useTransactionPayAvailableTokens();
   const payTokensFlags = useSelector(selectMetaMaskPayTokensFlags);
-
-  const tokensWithBalance = useMemo(
-    () => tokens.filter((t) => !t.disabled),
-    [tokens],
-  );
 
   const transactionMetaRequest = useTransactionMetadataRequest();
   const transactionMeta = useMemo(
     () => transactionMetaRequest ?? ({ txParams: {} } as TransactionMeta),
     [transactionMetaRequest],
   );
+  const transactionId = transactionMeta.id;
+  const postQuoteTransactionType = getPostQuoteTransactionType(transactionMeta);
 
   const {
     txParams: { from },
@@ -65,24 +68,45 @@ export function useAutomaticTransactionPayToken({
     () =>
       getPreferredTokensForTransactionType(
         payTokensFlags.preferredTokens,
-        transactionMeta.type,
+        postQuoteTransactionType ?? transactionMeta.type,
       ),
-    [transactionMeta.type, payTokensFlags.preferredTokens],
+    [
+      transactionMeta.type,
+      postQuoteTransactionType,
+      payTokensFlags.preferredTokens,
+    ],
   );
 
-  // For withdrawals, skip auto-selection — the default token is derived
-  // from required tokens and shown via PayWithRow
   const isWithdraw = isTransactionPayWithdraw(transactionMeta);
+  const lastWithdrawToken = useSelector((state: RootState) =>
+    selectLastWithdrawTokenByType(state, postQuoteTransactionType),
+  );
+  const withdrawTokenFilter = useWithdrawTokenFilter();
+
+  const tokens = useMemo(
+    () =>
+      isWithdraw
+        ? withdrawTokenFilter(availableTokens)
+        : availableTokens.filter((t) => !t.disabled),
+    [availableTokens, isWithdraw, withdrawTokenFilter],
+  );
 
   useEffect(() => {
-    if (disable || isWithdraw || isUpdated.current) {
+    if (
+      disable ||
+      payToken ||
+      !transactionId ||
+      isUpdated.current === transactionId
+    ) {
       return;
     }
 
     const automaticToken = getBestToken({
       isHardwareWallet,
+      isWithdraw,
+      lastWithdrawToken,
       targetToken,
-      tokens: tokensWithBalance,
+      tokens,
       preferredToken,
       preferredTokensFromFlags,
       minimumRequiredTokenBalance: payTokensFlags.minimumRequiredTokenBalance,
@@ -98,25 +122,30 @@ export function useAutomaticTransactionPayToken({
       chainId: automaticToken.chainId,
     });
 
-    isUpdated.current = true;
+    isUpdated.current = transactionId;
 
     log('Automatically selected pay token', automaticToken);
   }, [
     disable,
     isHardwareWallet,
     isWithdraw,
+    lastWithdrawToken,
     payTokensFlags.minimumRequiredTokenBalance,
+    payToken,
     preferredToken,
     preferredTokensFromFlags,
     requiredTokens,
     setPayToken,
     targetToken,
-    tokensWithBalance,
+    tokens,
+    transactionId,
   ]);
 }
 
 function getBestToken({
   isHardwareWallet,
+  isWithdraw,
+  lastWithdrawToken,
   preferredToken,
   preferredTokensFromFlags,
   minimumRequiredTokenBalance,
@@ -124,6 +153,8 @@ function getBestToken({
   tokens,
 }: {
   isHardwareWallet: boolean;
+  isWithdraw: boolean;
+  lastWithdrawToken?: SetPayTokenRequest;
   preferredToken?: SetPayTokenRequest;
   preferredTokensFromFlags: PreferredToken[];
   minimumRequiredTokenBalance: number;
@@ -139,6 +170,18 @@ function getBestToken({
 
   if (isHardwareWallet) {
     return targetTokenFallback;
+  }
+
+  if (isWithdraw && lastWithdrawToken) {
+    const lastWithdrawTokenAvailable = tokens.some(
+      (token) =>
+        token.address.toLowerCase() === lastWithdrawToken.address.toLowerCase() &&
+        token.chainId?.toLowerCase() === lastWithdrawToken.chainId.toLowerCase(),
+    );
+
+    if (lastWithdrawTokenAvailable) {
+      return lastWithdrawToken;
+    }
   }
 
   if (preferredToken) {
@@ -166,6 +209,13 @@ function getBestToken({
       );
 
       if (matchingToken) {
+        if (isWithdraw) {
+          return {
+            address: matchingToken.address as Hex,
+            chainId: matchingToken.chainId as Hex,
+          };
+        }
+
         const fiatBalance = matchingToken.fiat?.balance ?? 0;
 
         if (fiatBalance >= minimumRequiredTokenBalance) {
@@ -179,6 +229,10 @@ function getBestToken({
   }
 
   if (tokens?.length) {
+    if (isWithdraw) {
+      return undefined;
+    }
+
     return {
       address: tokens[0].address as Hex,
       chainId: tokens[0].chainId as Hex,

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -175,8 +175,10 @@ function getBestToken({
   if (isWithdraw && lastWithdrawToken) {
     const lastWithdrawTokenAvailable = tokens.some(
       (token) =>
-        token.address.toLowerCase() === lastWithdrawToken.address.toLowerCase() &&
-        token.chainId?.toLowerCase() === lastWithdrawToken.chainId.toLowerCase(),
+        token.address.toLowerCase() ===
+          lastWithdrawToken.address.toLowerCase() &&
+        token.chainId?.toLowerCase() ===
+          lastWithdrawToken.chainId.toLowerCase(),
     );
 
     if (lastWithdrawTokenAvailable) {

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -1,8 +1,6 @@
 import { SmartTransaction } from '@metamask/smart-transactions-controller';
 import { RootState } from '../components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
-import {
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import {
   selectTransactions,
   selectLastWithdrawTokenByType,

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -1,7 +1,11 @@
 import { SmartTransaction } from '@metamask/smart-transactions-controller';
 import { RootState } from '../components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
 import {
+  TransactionType,
+} from '@metamask/transaction-controller';
+import {
   selectTransactions,
+  selectLastWithdrawTokenByType,
   selectNonReplacedTransactions,
   selectSwapsTransactions,
   selectTransactionMetadataById,
@@ -214,6 +218,129 @@ describe('TransactionController Selectors', () => {
       ];
 
       expect(selectSortedTransactions(state)).toStrictEqual(expectedSorted);
+    });
+  });
+
+  describe('selectLastWithdrawTokenByType', () => {
+    it('returns token from latest nested predictWithdraw transaction', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'older',
+                  metamaskPay: {
+                    chainId: '0x89',
+                    tokenAddress: '0xolder',
+                  },
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
+                  time: 100,
+                  type: TransactionType.batch,
+                },
+                {
+                  id: 'latest',
+                  metamaskPay: {
+                    chainId: '0x38',
+                    tokenAddress: '0xlatest',
+                  },
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
+                  time: 200,
+                  type: TransactionType.batch,
+                },
+              ],
+            },
+          },
+        },
+        pendingSmartTransactions: [],
+      } as unknown as RootState;
+
+      const result = selectLastWithdrawTokenByType(
+        state,
+        TransactionType.predictWithdraw,
+      );
+
+      expect(result).toStrictEqual({
+        address: '0xlatest',
+        chainId: '0x38',
+      });
+    });
+
+    it('ignores nested predictWithdraw transactions without metamaskPay and uses the latest one with metamaskPay', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'newer-without-metamask-pay',
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
+                  time: 300,
+                  type: TransactionType.batch,
+                },
+                {
+                  id: 'latest-with-metamask-pay',
+                  metamaskPay: {
+                    chainId: '0x38',
+                    tokenAddress: '0xlatest',
+                  },
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
+                  time: 200,
+                  type: TransactionType.batch,
+                },
+              ],
+            },
+          },
+        },
+        pendingSmartTransactions: [],
+      } as unknown as RootState;
+
+      const result = selectLastWithdrawTokenByType(
+        state,
+        TransactionType.predictWithdraw,
+      );
+
+      expect(result).toStrictEqual({
+        address: '0xlatest',
+        chainId: '0x38',
+      });
+    });
+
+    it('returns undefined when matching nested predictWithdraw transaction has no metamaskPay token', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'latest',
+                  nestedTransactions: [
+                    { type: TransactionType.predictWithdraw },
+                  ],
+                  time: 200,
+                  type: TransactionType.batch,
+                },
+              ],
+            },
+          },
+        },
+        pendingSmartTransactions: [],
+      } as unknown as RootState;
+
+      const result = selectLastWithdrawTokenByType(
+        state,
+        TransactionType.predictWithdraw,
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -35,10 +35,10 @@ function matchesTransactionType(
   return (
     transaction.type === transactionType ||
     transaction.originalType === transactionType ||
-    Boolean(transaction.metamaskPay) &&
+    (Boolean(transaction.metamaskPay) &&
       getNestedTransactionTypes(transaction).some(
         (nestedTransactionType) => nestedTransactionType === transactionType,
-      )
+      ))
   );
 }
 
@@ -90,12 +90,14 @@ export const selectLastWithdrawTokenByType = createSelector(
       return undefined;
     }
 
-    const latestTransaction = [...transactions].reverse().find(
-      (transaction) =>
-        matchesTransactionType(transaction, transactionType) &&
-        transaction.metamaskPay?.tokenAddress &&
-        transaction.metamaskPay?.chainId,
-    );
+    const latestTransaction = [...transactions]
+      .reverse()
+      .find(
+        (transaction) =>
+          matchesTransactionType(transaction, transactionType) &&
+          transaction.metamaskPay?.tokenAddress &&
+          transaction.metamaskPay?.chainId,
+      );
 
     const tokenAddress = latestTransaction?.metamaskPay?.tokenAddress;
     const chainId = latestTransaction?.metamaskPay?.chainId;

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -11,10 +11,10 @@ import {
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
-type MetaMaskPayToken = {
+interface MetaMaskPayToken {
   address: Hex;
   chainId: Hex;
-};
+}
 
 function getNestedTransactionTypes(
   transaction: TransactionMeta,

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -11,7 +11,7 @@ import {
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
-type LastWithdrawToken = {
+type MetaMaskPayToken = {
   address: Hex;
   chainId: Hex;
 };
@@ -85,7 +85,7 @@ export const selectSortedTransactions = createDeepEqualSelector(
 export const selectLastWithdrawTokenByType = createSelector(
   selectNonReplacedTransactions,
   (_state: RootState, transactionType?: string) => transactionType,
-  (transactions, transactionType): LastWithdrawToken | undefined => {
+  (transactions, transactionType): MetaMaskPayToken | undefined => {
     if (!transactionType) {
       return undefined;
     }

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -5,7 +5,42 @@ import {
   selectPendingSmartTransactionsBySender,
   selectPendingSmartTransactionsForSelectedAccountGroup,
 } from './smartTransactionsController';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+type LastWithdrawToken = {
+  address: Hex;
+  chainId: Hex;
+};
+
+function getNestedTransactionTypes(
+  transaction: TransactionMeta,
+): TransactionType[] {
+  if (!transaction.nestedTransactions) {
+    return [];
+  }
+
+  return transaction.nestedTransactions
+    .map((nestedTransaction) => nestedTransaction.type)
+    .filter((type): type is TransactionType => Boolean(type));
+}
+
+function matchesTransactionType(
+  transaction: TransactionMeta,
+  transactionType: string,
+): boolean {
+  return (
+    transaction.type === transactionType ||
+    transaction.originalType === transactionType ||
+    Boolean(transaction.metamaskPay) &&
+      getNestedTransactionTypes(transaction).some(
+        (nestedTransactionType) => nestedTransactionType === transactionType,
+      )
+  );
+}
 
 const selectTransactionControllerState = (state: RootState) =>
   state.engine.backgroundState.TransactionController;
@@ -45,6 +80,35 @@ export const selectSortedTransactions = createDeepEqualSelector(
     [...nonReplacedTransactions, ...pendingSmartTransactions].sort(
       (a, b) => (b?.time ?? 0) - (a?.time ?? 0),
     ),
+);
+
+export const selectLastWithdrawTokenByType = createSelector(
+  selectNonReplacedTransactions,
+  (_state: RootState, transactionType?: string) => transactionType,
+  (transactions, transactionType): LastWithdrawToken | undefined => {
+    if (!transactionType) {
+      return undefined;
+    }
+
+    const latestTransaction = [...transactions].reverse().find(
+      (transaction) =>
+        matchesTransactionType(transaction, transactionType) &&
+        transaction.metamaskPay?.tokenAddress &&
+        transaction.metamaskPay?.chainId,
+    );
+
+    const tokenAddress = latestTransaction?.metamaskPay?.tokenAddress;
+    const chainId = latestTransaction?.metamaskPay?.chainId;
+
+    if (!tokenAddress || !chainId) {
+      return undefined;
+    }
+
+    return {
+      address: tokenAddress,
+      chainId,
+    };
+  },
 );
 
 export const selectSortedEVMTransactionsForSelectedAccountGroup =


### PR DESCRIPTION
## **Description**

This PR updates Predict withdraw token auto-selection to prefer the user’s most recent withdraw destination token before falling back to the remote preferred token configuration.

## **Changelog**

CHANGELOG entry: Updated Predict withdraw to default to the user’s last used destination token before falling back to the remote preferred token.

## **Related issues**

Fixes: [MetaMask-planning#7081](https://consensyssoftware.atlassian.net/browse/CONF-972)

## **Manual testing steps**

```gherkin
Feature: Predict withdraw default destination token

  Scenario: user sees the last used withdraw token preselected
    Given the user has previously completed a Predict withdraw to BNB
    And the user has a valid preferred withdraw token configured in remote feature flags
    When the user opens the Predict withdraw flow again
    Then the withdraw screen preselects BNB instead of the remote preferred token

  Scenario: user falls back to the preferred token from feature flags
    Given the user has not completed any previous Predict withdraw with metamaskPay destination metadata
    And the remote feature flag `confirmations_pay_tokens.preferredTokens.overrides.predictWithdraw` is set to mUSD on Ethereum
    When the user opens the Predict withdraw flow
    Then the withdraw screen preselects mUSD on Ethereum
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

Pre-selected token from the last withdraw:
<img width="439" height="890" alt="image" src="https://github.com/user-attachments/assets/3c261235-31e0-49fe-8433-27b11f80d143" />

Pre-selected token from feature flags:
<img width="451" height="823" alt="image" src="https://github.com/user-attachments/assets/23bc8f21-5e85-450d-b1dc-8d14e4577bbc" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
```

Tests I ran:
- `npx jest app/selectors/transactionController.test.ts --no-coverage`
- `npx jest app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts --no-coverage`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automatic pay-token selection for withdraw flows by introducing transaction-history based defaults and new filtering, which could affect which token is preselected for users in post-quote transactions.
> 
> **Overview**
> Updates `useAutomaticTransactionPayToken` to treat post-quote/withdraw transactions differently: it now uses `getPostQuoteTransactionType`, applies a withdraw-specific token filter (`useWithdrawTokenFilter`), and prefers the **last used withdraw destination token** (from transaction history) before falling back to feature-flag preferred tokens. It also avoids repeatedly auto-setting the token by keying the update guard to `transactionId` and skipping when `payToken` is already set.
> 
> Adds `selectLastWithdrawTokenByType` to `transactionController` selectors to extract the most recent `metamaskPay` `tokenAddress`/`chainId` for a given (including nested) transaction type, and extends unit tests to cover nested `predictWithdraw` history selection and selector behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90f5c36f551b03fe076abc9fb6d5bb62dc02e8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->