### PR TITLE
feat: migrate Button (bridge scope)

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -29,6 +29,7 @@ import { MOCK_ENTROPY_SOURCE as mockEntropySource } from '../../../../../util/te
 import { RootState } from '../../../../../reducers';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 import { BridgeTrendingTokensSectionTestIds } from '../../components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.testIds';
+import { Button } from '@metamask/design-system-react-native';
 
 // Mock the account-tree-controller file that imports the problematic module
 jest.mock(
@@ -1536,14 +1537,21 @@ describe('BridgeView', () => {
         mockState,
       );
 
-      const { getByTestId } = renderScreen(
+      const rendered = renderScreen(
         BridgeView,
         { name: Routes.BRIDGE.ROOT },
         { state: testState },
       );
 
+      // The new Pressable-based Button does not expose onPress on the host View
+      // when disabled, so we find the Button component instance and call onPress directly.
+      const buttons = rendered.UNSAFE_getAllByType(Button);
+      const confirmButton = buttons.find(
+        (b) => b.props.testID === BridgeViewSelectorsIDs.CONFIRM_BUTTON,
+      );
+
       await act(async () => {
-        fireEvent.press(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON));
+        confirmButton?.props.onPress?.();
       });
 
       await waitFor(() => {

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -324,7 +324,7 @@ describe('SwapsConfirmButton', () => {
         },
       };
 
-      const { queryByText } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
           location={MetaMetricsSwapsEventSource.MainView}
@@ -334,9 +334,9 @@ describe('SwapsConfirmButton', () => {
         },
       );
 
-      // When submitting, buttonIsInLoadingState is true so Button renders
-      // an ActivityIndicator instead of the label text
-      expect(queryByText(strings('bridge.submitting_transaction'))).toBeNull();
+      // When submitting, buttonIsInLoadingState is true so Button shows
+      // a spinner overlay (label text is rendered but visually hidden via opacity-0)
+      expect(getByTestId('spinner-container')).toBeTruthy();
     });
   });
 
@@ -361,7 +361,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
 
     it('disables button when balance is insufficient', () => {
@@ -378,7 +378,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
 
     it('disables button when transaction is submitting', () => {
@@ -401,7 +401,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
 
     it('disables button for hardware wallet with Solana source', () => {
@@ -433,7 +433,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
 
     it('disables button when blockaid error exists', () => {
@@ -455,7 +455,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
 
     it('disables button when gas is insufficient', () => {
@@ -472,7 +472,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
 
     it('disables button when walletAddress is missing', () => {
@@ -489,7 +489,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
     });
   });
 
@@ -503,7 +503,7 @@ describe('SwapsConfirmButton', () => {
           activeQuote: null,
         }));
 
-      const { queryByText, getByTestId } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
           location={MetaMetricsSwapsEventSource.MainView}
@@ -515,9 +515,9 @@ describe('SwapsConfirmButton', () => {
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
       // Button is disabled (isLoading && !activeQuote)
-      expect(button.props.disabled).toBe(true);
-      // Label text is hidden behind ActivityIndicator
-      expect(queryByText(strings('bridge.confirm_swap'))).toBeNull();
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      // Spinner overlay is shown (label text rendered but visually hidden via opacity-0)
+      expect(getByTestId('spinner-container')).toBeTruthy();
     });
 
     it('shows loading indicator when submitting transaction', () => {
@@ -529,7 +529,7 @@ describe('SwapsConfirmButton', () => {
         },
       };
 
-      const { queryByText, getByTestId } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
           location={MetaMetricsSwapsEventSource.MainView}
@@ -540,9 +540,9 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
-      // Label hidden by loading indicator
-      expect(queryByText(strings('bridge.submitting_transaction'))).toBeNull();
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      // Spinner overlay is shown (label text rendered but visually hidden via opacity-0)
+      expect(getByTestId('spinner-container')).toBeTruthy();
     });
 
     it('shows loading when awaiting quote (valid amount, no quote, not loading)', () => {
@@ -554,7 +554,7 @@ describe('SwapsConfirmButton', () => {
           activeQuote: null,
         }));
 
-      const { queryByText, getByTestId } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
           location={MetaMetricsSwapsEventSource.MainView}
@@ -565,9 +565,9 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
-      // Label hidden by loading indicator during debounce gap
-      expect(queryByText(strings('bridge.confirm_swap'))).toBeNull();
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      // Spinner overlay is shown (label text rendered but visually hidden via opacity-0)
+      expect(getByTestId('spinner-container')).toBeTruthy();
     });
 
     it('does not show loading when source amount is empty', () => {
@@ -656,7 +656,7 @@ describe('SwapsConfirmButton', () => {
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
       // Not disabled because activeQuote exists
-      expect(button.props.disabled).toBe(false);
+      expect(button.props.accessibilityState?.disabled).toBe(false);
       // Label is visible (no loading indicator)
       expect(getByText(strings('bridge.confirm_swap'))).toBeTruthy();
     });
@@ -676,7 +676,7 @@ describe('SwapsConfirmButton', () => {
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
       // Button is disabled
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
       // But not in loading state (isLoading=false, isSubmittingTx=false)
       // so the label is visible
       expect(getByText(strings('bridge.insufficient_funds'))).toBeTruthy();
@@ -696,7 +696,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
       // Label visible because not loading/submitting
       expect(getByText(strings('bridge.insufficient_gas'))).toBeTruthy();
     });
@@ -705,7 +705,7 @@ describe('SwapsConfirmButton', () => {
   describe('Stale Quote (isQuoteStale)', () => {
     it('shows loading when amount changes to non-zero and quote is stale', () => {
       // First render with sourceAmount='1.0' — settledAmountRef latches to '1.0'
-      const { queryByText, getByTestId, store } = renderWithProvider(
+      const { getByTestId, store } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
           location={MetaMetricsSwapsEventSource.MainView}
@@ -722,9 +722,9 @@ describe('SwapsConfirmButton', () => {
       });
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
-      // Label hidden by loading indicator
-      expect(queryByText(strings('bridge.confirm_swap'))).toBeNull();
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      // Spinner overlay is shown (label text rendered but visually hidden via opacity-0)
+      expect(getByTestId('spinner-container')).toBeTruthy();
     });
 
     it('disables button without loading when amount changes to zero and quote is stale', () => {
@@ -747,7 +747,7 @@ describe('SwapsConfirmButton', () => {
       });
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(true);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
       // Label visible (not loading) — shows default "Confirm swap"
       expect(getByText(strings('bridge.confirm_swap'))).toBeTruthy();
     });
@@ -765,7 +765,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(false);
+      expect(button.props.accessibilityState?.disabled).toBe(false);
       expect(getByText(strings('bridge.confirm_swap'))).toBeTruthy();
     });
   });
@@ -815,7 +815,7 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(false);
+      expect(button.props.accessibilityState?.disabled).toBe(false);
     });
 
     it('calls resetState and updateQuoteParams when expired quote button is pressed', async () => {
@@ -874,7 +874,7 @@ describe('SwapsConfirmButton', () => {
       ).toBeTruthy();
       // Button is not disabled — user can press "Get new quote"
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(button.props.disabled).toBe(false);
+      expect(button.props.accessibilityState?.disabled).toBe(false);
     });
 
     it('does not show "Get new quote" when expired and loading with active quote', () => {
@@ -1099,7 +1099,7 @@ describe('SwapsConfirmButton', () => {
 
       // Button should be disabled when walletAddress is missing
       const continueButton = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
-      expect(continueButton.props.disabled).toBe(true);
+      expect(continueButton.props.accessibilityState?.disabled).toBe(true);
 
       // Verify submitBridgeTx is not called since button is disabled
       expect(mockSubmitBridgeTx).not.toHaveBeenCalled();

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useEffect, useRef } from 'react';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
 import { useSelector } from 'react-redux';
@@ -213,14 +213,15 @@ export const SwapsConfirmButton = ({
 
   return (
     <Button
-      variant={ButtonVariants.Primary}
-      size={ButtonSize.Lg}
-      loading={buttonIsInLoadingState}
-      label={label}
+      variant={ButtonVariant.Primary}
+      size={ButtonBaseSize.Lg}
+      isLoading={buttonIsInLoadingState}
       onPress={needsNewQuote ? handleGetNewQuote : handleContinue}
-      width={ButtonWidthTypes.Full}
+      isFullWidth
       testID={testID ?? BridgeViewSelectorsIDs.CONFIRM_BUTTON}
       isDisabled={needsNewQuote ? false : isSubmitDisabled}
-    />
+    >
+      {label}
+    </Button>
   );
 };

--- a/app/components/UI/Bridge/components/SwapsKeypad/QuickPickButtons.tsx
+++ b/app/components/UI/Bridge/components/SwapsKeypad/QuickPickButtons.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { View } from 'react-native';
 import { quickPickButtonsStyles as styles } from './styles';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import { QuickPickButtonOption } from './types';
 
 interface Props {
@@ -22,12 +23,13 @@ export const QuickPickButtons = ({ options, show }: Props) => {
       {options.map((option) => (
         <Button
           key={option.label}
-          variant={ButtonVariants.Secondary}
-          size={ButtonSize.Lg}
-          label={option.label}
+          variant={ButtonVariant.Secondary}
+          size={ButtonBaseSize.Lg}
           onPress={option.onPress}
           style={styles.button}
-        />
+        >
+          {option.label}
+        </Button>
       ))}
     </View>
   );

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -22,6 +22,9 @@ import { BigNumber } from 'ethers';
 import { BridgeToken } from '../../types';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { Button, ButtonVariant } from '@metamask/design-system-react-native';
+import OldButton, {
+  ButtonVariants as OldButtonVariants,
+} from '../../../../../component-library/components/Buttons/Button';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
@@ -354,14 +357,13 @@ export const TokenInputArea = forwardRef<
                     tokenBalance &&
                     onMaxPress &&
                     shouldShowMaxButton && (
-                      <Button
-                        variant={ButtonVariant.Tertiary}
+                      <OldButton
+                        variant={OldButtonVariants.Link}
+                        label={strings('bridge.max')}
                         onPress={onMaxPress}
-                        isDisabled={!subtitle}
+                        disabled={!subtitle}
                         testID="token-input-area-max-button"
-                      >
-                        {strings('bridge.max')}
-                      </Button>
+                      />
                     )}
                 </Box>
               </>

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -21,9 +21,7 @@ import { selectCurrentCurrency } from '../../../../../selectors/currencyRateCont
 import { BigNumber } from 'ethers';
 import { BridgeToken } from '../../types';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
-import Button, {
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
@@ -309,15 +307,16 @@ export const TokenInputArea = forwardRef<
               />
             ) : (
               <Button
-                variant={ButtonVariants.Primary}
-                label={strings(tokenButtonText)}
+                variant={ButtonVariant.Primary}
                 onPress={
                   isSourceToken
                     ? navigateToSourceTokenSelector
                     : navigateToDestTokenSelector
                 }
                 testID={testID}
-              />
+              >
+                {strings(tokenButtonText)}
+              </Button>
             )}
           </Box>
           <Box style={styles.row}>
@@ -356,12 +355,13 @@ export const TokenInputArea = forwardRef<
                     onMaxPress &&
                     shouldShowMaxButton && (
                       <Button
-                        variant={ButtonVariants.Link}
-                        label={strings('bridge.max')}
+                        variant={ButtonVariant.Tertiary}
                         onPress={onMaxPress}
-                        disabled={!subtitle}
+                        isDisabled={!subtitle}
                         testID="token-input-area-max-button"
-                      />
+                      >
+                        {strings('bridge.max')}
+                      </Button>
                     )}
                 </Box>
               </>

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { Box } from '../../../Box/Box';
 import {
   AlignItems,
@@ -91,24 +88,8 @@ const BlockExplorersModal = (props: BlockExplorersModalProps) => {
         </Text>
         {srcExplorerData?.explorerTxUrl && (
           <Button
-            variant={ButtonVariants.Secondary}
-            width={ButtonWidthTypes.Full}
-            label={
-              <Box
-                flexDirection={FlexDirection.Row}
-                alignItems={AlignItems.center}
-                gap={8}
-              >
-                <Badge
-                  variant={BadgeVariant.Network}
-                  name={srcExplorerData.chainName}
-                  imageSource={srcExplorerData.networkImageSource}
-                />
-                <Text variant={TextVariant.BodyMDMedium} style={styles.text}>
-                  {srcExplorerData.explorerName}
-                </Text>
-              </Box>
-            }
+            variant={ButtonVariant.Secondary}
+            isFullWidth
             onPress={() => {
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
@@ -117,29 +98,28 @@ const BlockExplorersModal = (props: BlockExplorersModalProps) => {
                 },
               });
             }}
-          />
+          >
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={8}
+            >
+              <Badge
+                variant={BadgeVariant.Network}
+                name={srcExplorerData.chainName}
+                imageSource={srcExplorerData.networkImageSource}
+              />
+              <Text variant={TextVariant.BodyMDMedium} style={styles.text}>
+                {srcExplorerData.explorerName}
+              </Text>
+            </Box>
+          </Button>
         )}
 
         {bridgeDestExplorerData?.explorerTxUrl && (
           <Button
-            variant={ButtonVariants.Secondary}
-            width={ButtonWidthTypes.Full}
-            label={
-              <Box
-                flexDirection={FlexDirection.Row}
-                alignItems={AlignItems.center}
-                gap={8}
-              >
-                <Badge
-                  variant={BadgeVariant.Network}
-                  name={bridgeDestExplorerData.chainName}
-                  imageSource={bridgeDestExplorerData.networkImageSource}
-                />
-                <Text variant={TextVariant.BodyMDMedium} style={styles.text}>
-                  {bridgeDestExplorerData.explorerName}
-                </Text>
-              </Box>
-            }
+            variant={ButtonVariant.Secondary}
+            isFullWidth
             onPress={() => {
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
@@ -148,7 +128,22 @@ const BlockExplorersModal = (props: BlockExplorersModalProps) => {
                 },
               });
             }}
-          />
+          >
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={8}
+            >
+              <Badge
+                variant={BadgeVariant.Network}
+                name={bridgeDestExplorerData.chainName}
+                imageSource={bridgeDestExplorerData.networkImageSource}
+              />
+              <Text variant={TextVariant.BodyMDMedium} style={styles.text}>
+                {bridgeDestExplorerData.explorerName}
+              </Text>
+            </Box>
+          </Button>
         )}
       </Box>
     </BottomSheet>

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -25,9 +25,7 @@ import { StyleSheet, TouchableOpacity } from 'react-native';
 import { calcHexGasTotal } from '../../utils/transactionGas';
 import { strings } from '../../../../../../locales/i18n';
 import BridgeStepList from './BridgeStepList';
-import Button, {
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { BridgeToken } from '../../types';
 import {
@@ -417,8 +415,7 @@ export const BridgeTransactionDetails = (
         {isIntentNotCompletedItem || (
           <Button
             style={styles.blockExplorerButton}
-            variant={ButtonVariants.Secondary}
-            label={strings('bridge_transaction_details.view_on_block_explorer')}
+            variant={ButtonVariant.Secondary}
             onPress={() => {
               // For swaps, go directly to block explorer web view
               if (isSwap && swapSrcExplorerData?.explorerTxUrl) {
@@ -440,7 +437,9 @@ export const BridgeTransactionDetails = (
                 });
               }
             }}
-          />
+          >
+            {strings('bridge_transaction_details.view_on_block_explorer')}
+          </Button>
         )}
       </Box>
     </ScreenView>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replaced `Button` with DSRN component equivalent.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/62fd7302-f338-4936-8a78-54cbc9ecde5b

### **After**

https://github.com/user-attachments/assets/8bcbcb1b-f407-4970-bf2a-7e94b1357ce6

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces multiple Bridge UI actions (confirm swap, quick-picks, token select, block explorer links) with the new design-system `Button`, which can subtly change press/disabled/loading behavior and accessibility. Risk is moderate because it touches core swap/bridge user interactions but is largely a UI component swap with updated tests.
> 
> **Overview**
> Migrates Bridge-scoped buttons from the legacy component-library `Button` to `@metamask/design-system-react-native` `Button`, updating props/APIs (e.g., `variant`, `isDisabled`, `isLoading`, `isFullWidth`) and switching from `label` prop to children rendering.
> 
> Updates Bridge tests to match the new button behavior: disabled state assertions now use `accessibilityState.disabled`, loading assertions look for a `spinner-container` overlay, and one navigation test invokes the `Button` component’s `onPress` directly due to Pressable host limitations when disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1edf81a88a21cbdecd306868ae4651506c54f811. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->