### PR TITLE
feat: enhance MultichainBridgeTransactionListItem to support destination perspective

### DIFF
--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.test.tsx
@@ -42,6 +42,14 @@ jest.mock('../../../util/date', () => ({
   toDateFormat: jest.fn(() => 'Mar 15, 2025'),
 }));
 
+const mockGetNetworkImageSource = jest.fn(
+  (_opts: { chainId?: string }) => ({}),
+);
+jest.mock('../../../util/networks', () => ({
+  getNetworkImageSource: (opts: { chainId?: string }) =>
+    mockGetNetworkImageSource(opts),
+}));
+
 // Create a mock store with the necessary state
 const createMockStore = () =>
   configureStore({
@@ -331,6 +339,105 @@ describe('MultichainBridgeTransactionListItem', () => {
           location: TransactionDetailLocation.AssetDetails,
         }),
       );
+    });
+  });
+
+  describe('showDestinationPerspective', () => {
+    it('displays destination amount and symbol with + prefix when showDestinationPerspective is true', () => {
+      const { getByText } = renderWithProvider(
+        <MultichainBridgeTransactionListItem
+          transaction={mockTransaction}
+          bridgeHistoryItem={mockBridgeHistoryItem}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+          showDestinationPerspective
+        />,
+      );
+
+      expect(getByText('+2 ETH')).toBeTruthy();
+    });
+
+    it('displays source amount and symbol without + when showDestinationPerspective is false', () => {
+      const { getByText, queryByText } = renderWithProvider(
+        <MultichainBridgeTransactionListItem
+          transaction={mockTransaction}
+          bridgeHistoryItem={mockBridgeHistoryItem}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+          showDestinationPerspective={false}
+        />,
+      );
+
+      expect(getByText('1 ETH')).toBeTruthy();
+      expect(queryByText('+2 ETH')).toBeNull();
+    });
+
+    it('uses destination asset chain for network badge when showDestinationPerspective is true', () => {
+      mockGetNetworkImageSource.mockClear();
+
+      renderWithProvider(
+        <MultichainBridgeTransactionListItem
+          transaction={mockTransaction}
+          bridgeHistoryItem={mockBridgeHistoryItem}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+          showDestinationPerspective
+        />,
+      );
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: 'eip155:10' }),
+      );
+    });
+
+    it('uses source asset chain for network badge when showDestinationPerspective is false', () => {
+      mockGetNetworkImageSource.mockClear();
+
+      renderWithProvider(
+        <MultichainBridgeTransactionListItem
+          transaction={mockTransaction}
+          bridgeHistoryItem={mockBridgeHistoryItem}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+          showDestinationPerspective={false}
+        />,
+      );
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: 'eip155:1' }),
+      );
+    });
+
+    it('formats destination amount with destination asset decimals when showDestinationPerspective is true', () => {
+      const customDecimalsBridgeItem = {
+        ...mockBridgeHistoryItem,
+        quote: {
+          ...mockBridgeHistoryItem.quote,
+          destAsset: {
+            ...mockBridgeHistoryItem.quote.destAsset,
+            symbol: 'OP',
+            decimals: 6,
+          },
+          destTokenAmount: '1500000',
+        },
+      };
+
+      const { getByText } = renderWithProvider(
+        <MultichainBridgeTransactionListItem
+          transaction={mockTransaction}
+          bridgeHistoryItem={customDecimalsBridgeItem}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+          showDestinationPerspective
+        />,
+      );
+
+      expect(getByText('+1.5 OP')).toBeTruthy();
     });
   });
 });

--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
@@ -42,12 +42,14 @@ const MultichainBridgeTransactionListItem = ({
   navigation,
   index,
   location,
+  showDestinationPerspective,
 }: {
   transaction: Transaction;
   bridgeHistoryItem: BridgeHistoryItem;
   navigation: NavigationProp<ParamListBase>;
   index?: number;
   location?: TransactionDetailLocation;
+  showDestinationPerspective?: boolean;
 }) => {
   const { colors, typography } = useTheme();
   const osColorScheme = useColorScheme();
@@ -90,9 +92,10 @@ const MultichainBridgeTransactionListItem = ({
       appTheme,
       osColorScheme,
     );
-    const chainId = parseCaipAssetType(
-      bridgeHistoryItem.quote.srcAsset.assetId,
-    ).chainId;
+    const assetForBadge = showDestinationPerspective
+      ? bridgeHistoryItem.quote.destAsset
+      : bridgeHistoryItem.quote.srcAsset;
+    const chainId = parseCaipAssetType(assetForBadge.assetId).chainId;
     if (!chainId)
       return <Image source={icon} style={style.icon} resizeMode="stretch" />;
 
@@ -117,11 +120,18 @@ const MultichainBridgeTransactionListItem = ({
       bridgeHistoryItem.status.destChain?.txHash,
   );
 
+  const tokenAmount = showDestinationPerspective
+    ? bridgeHistoryItem.quote.destTokenAmount
+    : bridgeHistoryItem.quote.srcTokenAmount;
+  const tokenDecimals = showDestinationPerspective
+    ? bridgeHistoryItem.quote.destAsset.decimals
+    : bridgeHistoryItem.quote.srcAsset.decimals;
+  const tokenSymbol = showDestinationPerspective
+    ? bridgeHistoryItem.quote.destAsset.symbol
+    : bridgeHistoryItem.quote.srcAsset.symbol;
+
   const rawAmount = parseFloat(
-    ethers.utils.formatUnits(
-      bridgeHistoryItem.quote.srcTokenAmount,
-      bridgeHistoryItem.quote.srcAsset.decimals,
-    ),
+    ethers.utils.formatUnits(tokenAmount, tokenDecimals),
   );
 
   const displayAmount = formatAmountWithThreshold(rawAmount, 5);
@@ -168,7 +178,8 @@ const MultichainBridgeTransactionListItem = ({
               )}
             </ListItem.Body>
             <ListItem.Amount style={style.listItemAmount as TextStyle}>
-              {displayAmount} {bridgeHistoryItem.quote.srcAsset.symbol}
+              {showDestinationPerspective ? '+' : ''}
+              {displayAmount} {tokenSymbol}
             </ListItem.Amount>
           </ListItem.Content>
         </ListItem>

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
@@ -49,9 +49,10 @@ jest.mock('../../UI/AssetOverview/PriceChart/PriceChart.context', () => ({
   PriceChartProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+const mockBridgeHistoryItemsBySrcTxHash: Record<string, unknown> = {};
 jest.mock('../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
   useBridgeHistoryItemBySrcTxHash: () => ({
-    bridgeHistoryItemsBySrcTxHash: {},
+    bridgeHistoryItemsBySrcTxHash: mockBridgeHistoryItemsBySrcTxHash,
   }),
 }));
 
@@ -91,6 +92,30 @@ jest.mock('../../hooks/useBlockExplorer', () => ({
     getBlockExplorerUrl: jest.fn().mockReturnValue('https://etherscan.io'),
     getBlockExplorerName: jest.fn().mockReturnValue('Etherscan'),
   }),
+}));
+
+const mockSelectBridgeHistoryForAccount = jest.fn(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (_state: unknown) => ({}) as Record<string, unknown>,
+);
+jest.mock('../../../selectors/bridgeStatusController', () => ({
+  ...jest.requireActual('../../../selectors/bridgeStatusController'),
+  selectBridgeHistoryForAccount: (...args: unknown[]) =>
+    mockSelectBridgeHistoryForAccount(args[0]),
+}));
+
+const mockSelectNonEvmTransactions = jest.fn(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (_state: unknown) => ({
+    transactions: [] as unknown[],
+    next: null,
+    lastUpdated: 0,
+  }),
+);
+jest.mock('../../../selectors/multichain/multichain', () => ({
+  ...jest.requireActual('../../../selectors/multichain/multichain'),
+  selectNonEvmTransactionsForSelectedAccountGroup: (...args: unknown[]) =>
+    mockSelectNonEvmTransactions(args[0]),
 }));
 
 jest.mock('../../UI/TransactionElement', () => 'TransactionElement');
@@ -159,7 +184,7 @@ jest.mock(
       '../../../selectors/multichainAccounts/accountTreeController',
     ),
     selectSelectedAccountGroupInternalAccounts: () => [
-      { address: '0xabc', type: 'eip155:eoa' },
+      { id: '0xabc', address: '0xabc', type: 'eip155:eoa' },
     ],
   }),
 );
@@ -562,5 +587,147 @@ describe('UnifiedTransactionsView - token poisoning protection', () => {
 
     // Transaction passes filter → data is non-empty → empty state is absent
     expect(queryByText('You have no transactions')).toBeNull();
+  });
+});
+
+describe('UnifiedTransactionsView - cross-chain bridge visibility', () => {
+  const SOLANA_TX_HASH = 'SolanaTxHash123abc';
+
+  const bridgeHistoryItem = {
+    txMetaId: SOLANA_TX_HASH,
+    account: '0xabc',
+    quote: {
+      srcChainId: 1151111081099710,
+      destChainId: 10,
+      srcAsset: {
+        symbol: 'SOL',
+        chainId: 1151111081099710,
+        decimals: 9,
+        address: 'native',
+      },
+      destAsset: {
+        symbol: 'ETH',
+        chainId: 10,
+        decimals: 18,
+        address: 'native',
+        assetId: 'eip155:10/slip44:60',
+      },
+    },
+    status: {
+      srcChain: {
+        txHash: SOLANA_TX_HASH,
+        chainId: 1151111081099710,
+        amount: '1',
+      },
+      destChain: { txHash: '0xDestHash', chainId: 10, amount: '0.1' },
+      status: 'COMPLETE',
+    },
+    estimatedProcessingTimeInSeconds: 60,
+    slippagePercentage: 0,
+    completionTime: Date.now(),
+    startTime: Date.now() - 60000,
+  };
+
+  const solanaTransaction = {
+    id: SOLANA_TX_HASH,
+    chain: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    type: 'send',
+    status: 'confirmed',
+    timestamp: Math.floor(Date.now() / 1000),
+    account: '0xabc',
+    events: [],
+    from: [],
+    to: [],
+  };
+
+  const {
+    filterByAddress: mockFilterByAddress2,
+    isTransactionOnChains: mockIsTransactionOnChains2,
+    buildTrustedAddressSet: mockBuildTrustedAddressSet2,
+  } = jest.requireMock('../../../util/activity');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUnifiedTxActions as jest.Mock).mockImplementation(
+      () => mockDefaultUnifiedTxActionsReturn,
+    );
+    (mockFilterByAddress2 as jest.Mock).mockReturnValue(true);
+    (mockIsTransactionOnChains2 as jest.Mock).mockReturnValue(true);
+    (mockBuildTrustedAddressSet2 as jest.Mock).mockReturnValue(new Set());
+    mockBridgeHistoryItemsBySrcTxHash[SOLANA_TX_HASH] = bridgeHistoryItem;
+  });
+
+  afterEach(() => {
+    delete mockBridgeHistoryItemsBySrcTxHash[SOLANA_TX_HASH];
+    jest.resetAllMocks();
+  });
+
+  it('shows bridge source tx when only destination EVM chain is enabled', () => {
+    mockSelectBridgeHistoryForAccount.mockReturnValue({
+      [SOLANA_TX_HASH]: bridgeHistoryItem,
+    });
+    mockSelectNonEvmTransactions.mockReturnValue({
+      transactions: [solanaTransaction],
+      next: null,
+      lastUpdated: Date.now(),
+    });
+
+    const stateWithBridge = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          NetworkEnablementController: {
+            ...backgroundState.NetworkEnablementController,
+            enabledNetworkMap: {
+              eip155: { '0xa': true },
+            },
+          },
+        },
+      },
+    };
+
+    const { UNSAFE_queryAllByType } = renderWithProvider(
+      <UnifiedTransactionsView />,
+      { state: stateWithBridge },
+    );
+
+    const bridgeItems = UNSAFE_queryAllByType(
+      asComponentType('MultichainBridgeTransactionListItem'),
+    );
+    expect(bridgeItems.length).toBe(1);
+  });
+
+  it('does not show non-bridge non-EVM tx when only EVM chains are enabled', () => {
+    const nonBridgeSolTx = {
+      ...solanaTransaction,
+      id: 'RegularSolanaTx',
+    };
+
+    mockSelectBridgeHistoryForAccount.mockReturnValue({});
+    mockSelectNonEvmTransactions.mockReturnValue({
+      transactions: [nonBridgeSolTx],
+      next: null,
+      lastUpdated: Date.now(),
+    });
+
+    const stateWithNonBridgeTx = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          NetworkEnablementController: {
+            ...backgroundState.NetworkEnablementController,
+            enabledNetworkMap: {
+              eip155: { '0xa': true },
+            },
+          },
+        },
+      },
+    };
+
+    const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
+      state: stateWithNonBridgeTx,
+    });
+
+    expect(getByText('You have no transactions')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -2,6 +2,7 @@ import { Transaction as NonEvmTransaction } from '@metamask/keyring-api';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import { SmartTransaction } from '@metamask/smart-transactions-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { numberToHex } from '@metamask/utils';
 import { useNavigation } from '@react-navigation/native';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -305,9 +306,21 @@ const UnifiedTransactionsView = ({
     const evmConfirmedDeduped =
       filterDuplicateOutgoingTransactions(allConfirmedFiltered);
 
-    // Non-EVM: filter by enabled chains
+    // Non-EVM: filter by enabled chains, also include bridge txs
+    // whose destination chain is enabled (e.g. Solana→Optimism bridge
+    // should appear when viewing Optimism activity)
+    const bridgeHistoryValues = Object.values(bridgeHistory ?? {});
     const filteredNonEvmTransactionsForSelectedChain = nonEvmTransactions
-      .filter((tx) => enabledNonEVMChainIds.includes(tx.chain))
+      .filter((tx) => {
+        if (enabledNonEVMChainIds.includes(tx.chain)) return true;
+        const bridge = bridgeHistoryValues.find(
+          (item) => item.status?.srcChain?.txHash === tx.id,
+        );
+        return (
+          bridge?.quote?.destChainId !== undefined &&
+          enabledEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
+        );
+      })
       // deduplicate by id
       .filter(
         (tx, index, self) => index === self.findIndex((t) => t.id === tx.id),
@@ -627,6 +640,9 @@ const UnifiedTransactionsView = ({
         navigation={navigation}
         index={index}
         location={location}
+        showDestinationPerspective={
+          !enabledNonEVMChainIds.includes(item.tx.chain)
+        }
       />
     ) : (
       <MultichainTransactionListItem

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -1212,6 +1212,114 @@ describe('Engine', () => {
     });
   });
 
+  describe('BridgeStatusController:destinationTransactionCompleted', () => {
+    const EVM_CAIP_ASSET = 'eip155:10/slip44:60';
+    const NON_EVM_CAIP_ASSET =
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getBridgeStatusMessenger = (engine: any) =>
+      engine.context.BridgeStatusController.messenger;
+
+    it('refreshes tokens, balances, account tracker, and incoming transactions for EVM destination chain', () => {
+      const engine = Engine.init(TEST_ANALYTICS_ID, backgroundState);
+      const mockNetworkClientId = 'optimism-network-client';
+
+      const detectTokensSpy = jest
+        .spyOn(engine.context.TokenDetectionController, 'detectTokens')
+        .mockImplementation(() => Promise.resolve());
+      const updateBalancesSpy = jest
+        .spyOn(engine.context.TokenBalancesController, 'updateBalances')
+        .mockImplementation(() => Promise.resolve());
+      const findNetworkClientIdSpy = jest
+        .spyOn(engine.context.NetworkController, 'findNetworkClientIdByChainId')
+        .mockReturnValue(mockNetworkClientId);
+      const refreshSpy = jest
+        .spyOn(engine.context.AccountTrackerController, 'refresh')
+        .mockImplementation(() => Promise.resolve());
+      const updateIncomingSpy = jest
+        .spyOn(
+          engine.context.TransactionController,
+          'updateIncomingTransactions',
+        )
+        .mockImplementation(() => Promise.resolve());
+
+      getBridgeStatusMessenger(engine).publish(
+        'BridgeStatusController:destinationTransactionCompleted',
+        EVM_CAIP_ASSET,
+      );
+
+      expect(detectTokensSpy).toHaveBeenCalledWith({ chainIds: ['0xa'] });
+      expect(updateBalancesSpy).toHaveBeenCalledWith({ chainIds: ['0xa'] });
+      expect(findNetworkClientIdSpy).toHaveBeenCalledWith('0xa');
+      expect(refreshSpy).toHaveBeenCalledWith([mockNetworkClientId]);
+      expect(updateIncomingSpy).toHaveBeenCalled();
+    });
+
+    it('does not refresh anything for non-EVM destination chains', () => {
+      const engine = Engine.init(TEST_ANALYTICS_ID, backgroundState);
+
+      const detectTokensSpy = jest
+        .spyOn(engine.context.TokenDetectionController, 'detectTokens')
+        .mockImplementation(() => Promise.resolve());
+      const updateBalancesSpy = jest
+        .spyOn(engine.context.TokenBalancesController, 'updateBalances')
+        .mockImplementation(() => Promise.resolve());
+      const refreshSpy = jest
+        .spyOn(engine.context.AccountTrackerController, 'refresh')
+        .mockImplementation(() => Promise.resolve());
+      const updateIncomingSpy = jest
+        .spyOn(
+          engine.context.TransactionController,
+          'updateIncomingTransactions',
+        )
+        .mockImplementation(() => Promise.resolve());
+
+      getBridgeStatusMessenger(engine).publish(
+        'BridgeStatusController:destinationTransactionCompleted',
+        NON_EVM_CAIP_ASSET,
+      );
+
+      expect(detectTokensSpy).not.toHaveBeenCalled();
+      expect(updateBalancesSpy).not.toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(updateIncomingSpy).not.toHaveBeenCalled();
+    });
+
+    it('still updates incoming transactions when findNetworkClientIdByChainId throws', () => {
+      const engine = Engine.init(TEST_ANALYTICS_ID, backgroundState);
+
+      jest
+        .spyOn(engine.context.TokenDetectionController, 'detectTokens')
+        .mockImplementation(() => Promise.resolve());
+      jest
+        .spyOn(engine.context.TokenBalancesController, 'updateBalances')
+        .mockImplementation(() => Promise.resolve());
+      jest
+        .spyOn(engine.context.NetworkController, 'findNetworkClientIdByChainId')
+        .mockImplementation(() => {
+          throw new Error('Unknown chain');
+        });
+      const refreshSpy = jest
+        .spyOn(engine.context.AccountTrackerController, 'refresh')
+        .mockImplementation(() => Promise.resolve());
+      const updateIncomingSpy = jest
+        .spyOn(
+          engine.context.TransactionController,
+          'updateIncomingTransactions',
+        )
+        .mockImplementation(() => Promise.resolve());
+
+      getBridgeStatusMessenger(engine).publish(
+        'BridgeStatusController:destinationTransactionCompleted',
+        EVM_CAIP_ASSET,
+      );
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(updateIncomingSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('Engine.state', () => {
     it('throws error when accessing state before Engine exists', () => {
       expect(() => Engine.state).toThrow('Engine does not exist');

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -674,6 +674,18 @@ export class Engine {
             this.context.TokenBalancesController.updateBalances({
               chainIds: [hexChainId],
             });
+
+            const { AccountTrackerController, NetworkController } =
+              this.context;
+            try {
+              const networkClientId =
+                NetworkController.findNetworkClientIdByChainId(hexChainId);
+              AccountTrackerController.refresh([networkClientId]);
+            } catch {
+              // Chain may not be configured locally — skip balance refresh
+            }
+
+            this.context.TransactionController.updateIncomingTransactions();
           }
         } catch (error) {
           console.error(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When bridging from a non-EVM chain to an EVM chain (e.g. Solana → Optimism), the completed bridge transaction was only visible on the source chain's activity list. Switching to the destination chain's activity view showed an empty list, even though funds were correctly received. The transaction would only appear after performing another unrelated transaction on the destination chain.

**Root cause:** `UnifiedTransactionsView` filtered non-EVM transactions exclusively by source chain. When viewing Optimism-only activity, the Solana source transaction was filtered out, and no EVM-side entry existed for the bridge destination.

**Fix (3 parts):**

1. **Activity list filtering** (`UnifiedTransactionsView.tsx`): Non-EVM bridge source transactions are now also included when their destination EVM chain is enabled, by cross-referencing bridge history items.

2. **Destination perspective rendering** (`MultichainBridgeTransactionListItem.tsx`): When a bridge transaction is shown from the destination chain's perspective, the component now displays the destination chain icon, received token amount (e.g. `+0.1 ETH`), and destination token symbol instead of the source chain details.

3. **Balance/data refresh on bridge completion** (`Engine.ts`): When `BridgeStatusController:destinationTransactionCompleted` fires for an EVM destination, the handler now also triggers `AccountTrackerController.refresh` and `TransactionController.updateIncomingTransactions` to update native balances and fetch incoming transactions.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed cross-chain bridge transactions not appearing on the destination chain's activity list

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/23424

## **Manual testing steps**

```gherkin
Feature: Cross-chain bridge activity visibility

  Scenario: Bridge from Solana to Optimism shows on Optimism activity
    Given user has Solana and Optimism networks enabled
    And user has SOL balance on Solana

    When user initiates a bridge from SOL on Solana to ETH on Optimism
    And the bridge completes successfully
    And user switches network filter to show only Optimism activity
    Then the bridge transaction is visible in the Optimism activity list
    And the transaction shows the Optimism network icon
    And the transaction displays the received ETH amount with a "+" prefix

  Scenario: Bridge from Solana to Optimism shows on Solana activity
    Given user has Solana and Optimism networks enabled
    And user has completed a bridge from SOL to ETH

    When user switches network filter to show only Solana activity
    Then the bridge transaction is visible in the Solana activity list
    And the transaction shows the Solana network icon
    And the transaction displays the sent SOL amount

  Scenario: Bridge visible on All Networks view
    Given user has Solana and Optimism networks enabled
    And user has completed a bridge from SOL to ETH

    When user views All Networks activity
    Then the bridge transaction is visible
    And the transaction shows from the source (Solana) perspective

  Scenario: Non-bridge Solana transactions do not leak into EVM-only activity
    Given user has only Optimism network enabled (Solana disabled)
    And user has regular (non-bridge) Solana transactions

    When user views the activity list
    Then the regular Solana transactions are not shown
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/user-attachments/assets/857223df-1b0a-436a-a3a9-b9a3979fff0d
<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/16e441c8-6437-44b4-aa4b-d7b0393c0a0e


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction list filtering/rendering and engine-side refresh triggers on bridge completion, which can affect activity visibility and balance refresh behavior across networks. Changes are scoped and covered by new unit tests but still impact core wallet UX.
> 
> **Overview**
> Fixes cross-chain bridge activity visibility by **including non-EVM bridge source transactions when their *destination EVM chain* is the currently enabled filter** in `UnifiedTransactionsView`.
> 
> Adds a destination-view rendering mode to `MultichainBridgeTransactionListItem` (destination network badge + `+`-prefixed received amount/symbol using destination decimals), and wires it up based on whether the non-EVM source chain is enabled.
> 
> On `BridgeStatusController:destinationTransactionCompleted` for EVM assets, `Engine` now also refreshes the account tracker (best-effort) and triggers `TransactionController.updateIncomingTransactions`; unit tests were added/updated to cover these behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e18b71aec8166cbd4fe9cef5bbd82ce0ee874e01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->