### PR TITLE
test: handles aborted calls on mockServer

### DIFF
--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -185,7 +185,7 @@ export async function setupMockRequest(
     requestRuleBuilder = server.forHead('/proxy');
   }
 
-  await requestRuleBuilder
+  const ruleBuilder = requestRuleBuilder
     ?.matching((request) => {
       const url = getDecodedProxiedURL(request.url);
 
@@ -196,18 +196,27 @@ export async function setupMockRequest(
       const matches = url.includes(String(response.url));
       return matches;
     })
-    .asPriority(priority ?? 999) // Adding priority to this mock request helper as we want TestSpecificMocks to always take precedence
-    .thenCallback((request) => {
-      logger.info(
-        `Mocking ${request.method} request to: ${getDecodedProxiedURL(
-          request.url,
-        )}`,
-      );
-      logger.debug(`Returning response:`, response.response);
-      return typeof response.response === 'string'
-        ? { statusCode: response.responseCode ?? 200, body: response.response }
-        : { statusCode: response.responseCode ?? 200, json: response.response };
-    });
+    .asPriority(priority ?? 999); // Adding priority to this mock request helper as we want TestSpecificMocks to always take precedence
+
+  // Use thenReply/thenJson instead of thenCallback to avoid mockttp's
+  // internal body buffering (waitForCompletedRequest → streamToBuffer).
+  // When clients abort connections (e.g., bridge controller AbortController),
+  // streamToBuffer rejects with Error('Aborted'). Since CallbackHandler
+  // eagerly buffers the body BEFORE calling the callback, the rejection
+  // propagates through mockttp's internals and reaches Jest as a test failure.
+  // SimpleHandler (used by thenReply/thenJson) never reads the request body,
+  // eliminating this error source entirely.
+  if (typeof response.response === 'string') {
+    await ruleBuilder?.thenReply(
+      response.responseCode ?? 200,
+      response.response,
+    );
+  } else {
+    await ruleBuilder?.thenJson(
+      response.responseCode ?? 200,
+      response.response as object,
+    );
+  }
 }
 
 /**

--- a/tests/smoke/swap/swap-action-smoke.spec.ts
+++ b/tests/smoke/swap/swap-action-smoke.spec.ts
@@ -39,9 +39,7 @@ const expectedEventNames = [
   expectedEvents.UnifiedSwapBridgeCompleted,
 ];
 
-// Disabling as this test is flaky and needs to be reworked
-// https://github.com/MetaMask/metamask-mobile/actions/runs/23176367570/job/67340273878
-describe.skip(SmokeTrade('Swap from Actions'), (): void => {
+describe(SmokeTrade('Swap from Actions'), (): void => {
   beforeEach(async (): Promise<void> => {
     jest.setTimeout(180000);
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes the flaky swap-action-smoke test that intermittently fails with multiple Error('Aborted') from
  mockttp/src/util/buffer-utils.ts.

### Root Cause
`setupMockRequest` used thenCallback, which internally uses mockttp's CallbackHandler. This handler calls `await waitForCompletedRequest(request)` — eagerly buffering the request body via streamToBuffer — before invoking ourcallback. When the bridge controller's AbortController cancels in-flight requests, the body stream aborts mid-buffering, and streamToBuffer rejects with `Error('Aborted')`. This rejection occurs outside the callback's try-catch, propagating through mockttp's internal pipeline to Jest.

Previous fix attempts (safe body reading, catch blocks, drain mode, unhandledRejection filter) were all reactive — they tried to catch the error after it happened. None could intercept it because it originates in mockttp's own await chain before our code ever runs.

### Fix
Switch setupMockRequest from thenCallback (→ CallbackHandler → reads body) to thenReply/thenJson (→ SimpleHandler → never reads the request body). This eliminates the error at the source.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts shared mock-server helper behavior, which could change how existing E2E mocks match/resolve and potentially affect other tests, but impacts test infrastructure only.
> 
> **Overview**
> Fixes intermittent E2E failures caused by aborted HTTP requests by changing `setupMockRequest` in `mockHelpers.ts` to use `thenReply`/`thenJson` instead of `thenCallback`, avoiding mockttp’s eager request-body buffering that can throw `Error('Aborted')`.
> 
> Re-enables the previously skipped `Swap from Actions` smoke test now that the aborted-request flakiness is addressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c7a6d2019f4548f08f5628c4932e29a045833e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->