### PR TITLE
fix(network-details): require network name in NetworkDetails form

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -175,6 +175,7 @@ const createMockValidation = () => ({
   validateName: jest.fn(),
   validateRpcAndChainId: jest.fn(),
   disabledByChainId: jest.fn(() => false),
+  disabledByName: jest.fn(() => false),
   disabledBySymbol: jest.fn(() => false),
   checkIfChainIdExists: jest.fn(() => false),
   checkIfNetworkExists: jest.fn().mockResolvedValue([]),
@@ -443,6 +444,20 @@ describe('NetworkDetailsView', () => {
     mockValidation.mockReturnValue({
       ...createMockValidation(),
       disabledByChainId: jest.fn(() => true),
+    });
+
+    const { getByTestId } = render(<NetworkDetailsView />);
+
+    const saveButton = getByTestId(
+      NetworkDetailsViewSelectorsIDs.ADD_CUSTOM_NETWORK_BUTTON,
+    );
+    expect(saveButton.props.disabled).toBe(true);
+  });
+
+  it('disables save button when validation disables network name', () => {
+    mockValidation.mockReturnValue({
+      ...createMockValidation(),
+      disabledByName: jest.fn(() => true),
     });
 
     const { getByTestId } = render(<NetworkDetailsView />);

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -110,12 +110,14 @@ const NetworkDetailsView = () => {
     !formHook.enableAction ||
     formHook.form.editable === false ||
     validation.disabledByChainId(formHook.form) ||
+    validation.disabledByName(formHook.form) ||
     validation.disabledBySymbol(formHook.form);
 
   const handleSave = useCallback(async () => {
     await operations.saveNetwork(formHook.form, {
       enableAction: formHook.enableAction,
       disabledByChainId: validation.disabledByChainId(formHook.form),
+      disabledByName: validation.disabledByName(formHook.form),
       disabledBySymbol: validation.disabledBySymbol(formHook.form),
       isCustomMainnet,
       shouldNetworkSwitchPopToWallet,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/NetworkFormFields.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/NetworkFormFields.tsx
@@ -131,6 +131,7 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
   } = formHook;
 
   const { warningName } = validation;
+  const isRequiredNameWarning = warningName === strings('app_settings.required');
 
   const handleNameBlur = useCallback(() => {
     onValidateName();
@@ -146,7 +147,7 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
         value={nickname}
         isDisabled={isAnyModalVisible || editable === false}
         onChangeText={onNicknameChange}
-        placeholder={strings('app_settings.network_name_placeholder')}
+        placeholder={strings('app_settings.network_name_label')}
         placeholderTextColor={placeholderTextColor}
         onBlur={handleNameBlur}
         onFocus={onNameFocused}
@@ -157,19 +158,27 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
       />
       {warningName ? (
         <Box>
-          <Text variant={TextVariant.BodySm} twClassName="text-warning-default">
-            {strings('wallet.incorrect_network_name_warning')}
-          </Text>
-          <Text variant={TextVariant.BodySm} twClassName="text-warning-default">
-            {strings('wallet.suggested_name')}{' '}
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-info-default"
-              onPress={() => autoFillNameField(warningName)}
-            >
+          {isRequiredNameWarning ? (
+            <Text variant={TextVariant.BodySm} twClassName="text-error-default">
               {warningName}
             </Text>
-          </Text>
+          ) : (
+            <>
+              <Text variant={TextVariant.BodySm} twClassName="text-warning-default">
+                {strings('wallet.incorrect_network_name_warning')}
+              </Text>
+              <Text variant={TextVariant.BodySm} twClassName="text-warning-default">
+                {strings('wallet.suggested_name')}{' '}
+                <Text
+                  variant={TextVariant.BodySm}
+                  twClassName="text-info-default"
+                  onPress={() => autoFillNameField(warningName)}
+                >
+                  {warningName}
+                </Text>
+              </Text>
+            </>
+          )}
         </Box>
       ) : null}
     </Box>

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/NetworkFormFields.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/NetworkFormFields.tsx
@@ -131,7 +131,8 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
   } = formHook;
 
   const { warningName } = validation;
-  const isRequiredNameWarning = warningName === strings('app_settings.required');
+  const isRequiredNameWarning =
+    warningName === strings('app_settings.required');
 
   const handleNameBlur = useCallback(() => {
     onValidateName();
@@ -164,10 +165,16 @@ const NetworkNameField: React.FC<NetworkNameFieldProps> = ({
             </Text>
           ) : (
             <>
-              <Text variant={TextVariant.BodySm} twClassName="text-warning-default">
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-warning-default"
+              >
                 {strings('wallet.incorrect_network_name_warning')}
               </Text>
-              <Text variant={TextVariant.BodySm} twClassName="text-warning-default">
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-warning-default"
+              >
                 {strings('wallet.suggested_name')}{' '}
                 <Text
                   variant={TextVariant.BodySm}

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
@@ -137,6 +137,7 @@ const baseForm: NetworkFormState = {
 const defaultSaveOpts = () => ({
   enableAction: true,
   disabledByChainId: false,
+  disabledByName: false,
   disabledBySymbol: false,
   isCustomMainnet: false,
   shouldNetworkSwitchPopToWallet: true,
@@ -314,6 +315,20 @@ describe('useNetworkOperations', () => {
     expect(mockUpdateNetwork).not.toHaveBeenCalled();
   });
 
+  it('does nothing when disabledByName is true', async () => {
+    const { result } = renderHook(() => useNetworkOperations());
+
+    await act(async () => {
+      await result.current.saveNetwork(baseForm, {
+        ...defaultSaveOpts(),
+        disabledByName: true,
+      });
+    });
+
+    expect(mockAddNetwork).not.toHaveBeenCalled();
+    expect(mockUpdateNetwork).not.toHaveBeenCalled();
+  });
+
   it('does nothing when rpcUrl is missing', async () => {
     const { result } = renderHook(() => useNetworkOperations());
 
@@ -355,7 +370,7 @@ describe('useNetworkOperations', () => {
     expect(callArgs.nativeCurrency).toBe('');
   });
 
-  it('uses empty string when nickname is undefined', async () => {
+  it('does nothing when nickname is undefined', async () => {
     const { result } = renderHook(() => useNetworkOperations());
 
     await act(async () => {
@@ -365,8 +380,8 @@ describe('useNetworkOperations', () => {
       );
     });
 
-    const callArgs = mockAddNetwork.mock.calls[0][0];
-    expect(callArgs.name).toBe('');
+    expect(mockAddNetwork).not.toHaveBeenCalled();
+    expect(mockUpdateNetwork).not.toHaveBeenCalled();
   });
 
   it('sets individual chain filter when isAllNetworks is false', async () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
@@ -45,6 +45,7 @@ export interface UseNetworkOperationsReturn {
     params: {
       enableAction: boolean;
       disabledByChainId: boolean;
+      disabledByName: boolean;
       disabledBySymbol: boolean;
       isCustomMainnet: boolean;
       shouldNetworkSwitchPopToWallet: boolean;
@@ -197,6 +198,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       params: {
         enableAction: boolean;
         disabledByChainId: boolean;
+        disabledByName: boolean;
         disabledBySymbol: boolean;
         isCustomMainnet: boolean;
         shouldNetworkSwitchPopToWallet: boolean;
@@ -211,6 +213,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       const {
         enableAction,
         disabledByChainId,
+        disabledByName,
         disabledBySymbol,
         isCustomMainnet,
         shouldNetworkSwitchPopToWallet,
@@ -218,7 +221,14 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         validateChainIdOnSubmit,
       } = params;
 
-      if (!enableAction || disabledByChainId || disabledBySymbol) return;
+      if (
+        !enableAction ||
+        disabledByChainId ||
+        disabledByName ||
+        disabledBySymbol
+      ) {
+        return;
+      }
 
       const {
         rpcUrl,
@@ -232,7 +242,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
 
       const ticker = form.ticker ? form.ticker.toUpperCase() : undefined;
 
-      if (!stateChainId || !rpcUrl) return;
+      if (!stateChainId || !rpcUrl || !nickname?.trim()) return;
 
       // Check if network with this chainId already exists
       const isNetworkNew = addMode

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.test.ts
@@ -192,6 +192,20 @@ describe('useNetworkValidation', () => {
     });
   });
 
+  describe('disabledByName', () => {
+    it('returns true when network name is empty', () => {
+      const { result } = renderHook(() => useNetworkValidation());
+      expect(
+        result.current.disabledByName({ ...baseForm, nickname: undefined }),
+      ).toBe(true);
+    });
+
+    it('returns false when network name is present', () => {
+      const { result } = renderHook(() => useNetworkValidation());
+      expect(result.current.disabledByName(baseForm)).toBe(false);
+    });
+  });
+
   describe('onRpcUrlValidationChange', () => {
     it('updates validatedRpcURL state', () => {
       const { result } = renderHook(() => useNetworkValidation());
@@ -333,6 +347,16 @@ describe('useNetworkValidation', () => {
   });
 
   describe('validateName', () => {
+    it('sets required warning when network name is empty', () => {
+      const { result } = renderHook(() => useNetworkValidation());
+
+      act(() => {
+        result.current.validateName({ ...baseForm, nickname: '' });
+      });
+
+      expect(result.current.warningName).toBeDefined();
+    });
+
     it('does nothing when useSafeChainsListValidation is false', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector.name?.includes('SafeChainsListValidation')) return false;

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.ts
@@ -40,6 +40,7 @@ export interface UseNetworkValidationReturn extends ValidationState {
   ) => void;
   validateRpcAndChainId: (form: NetworkFormState) => void;
   disabledByChainId: (form: NetworkFormState) => boolean;
+  disabledByName: (form: NetworkFormState) => boolean;
   disabledBySymbol: (form: NetworkFormState) => boolean;
   checkIfChainIdExists: (chainId: string) => boolean;
   checkIfNetworkExists: (rpcUrl: string) => Promise<NetworkConfiguration[]>;
@@ -302,7 +303,15 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
   const validateName = useCallback(
     (form: NetworkFormState, chainToMatch: SafeChain | null = null) => {
       const { nickname, chainId } = form;
-      if (!useSafeChainsListValidation) return;
+      const trimmedNickname = nickname?.trim();
+      if (!trimmedNickname) {
+        setWarningName(strings('app_settings.required'));
+        return;
+      }
+      if (!useSafeChainsListValidation) {
+        setWarningName(undefined);
+        return;
+      }
 
       const name =
         NETWORK_TO_NAME_MAP[chainId as keyof typeof NETWORK_TO_NAME_MAP] ||
@@ -310,7 +319,7 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
         networkList?.name ||
         null;
 
-      const nameToUse = isValidNetworkName(chainId ?? '', name, nickname ?? '')
+      const nameToUse = isValidNetworkName(chainId ?? '', name, trimmedNickname)
         ? undefined
         : name;
 
@@ -343,6 +352,11 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
     [validatedChainId, warningChainId],
   );
 
+  const disabledByName = useCallback(
+    (form: NetworkFormState): boolean => !form.nickname?.trim(),
+    [],
+  );
+
   const disabledBySymbol = useCallback(
     (form: NetworkFormState): boolean => !form.ticker,
     [],
@@ -362,6 +376,7 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
     validateName,
     validateRpcAndChainId,
     disabledByChainId,
+    disabledByName,
     disabledBySymbol,
     checkIfChainIdExists,
     checkIfNetworkExists,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3060,6 +3060,7 @@
     "networks_no_results": "No networks found",
     "network_name_label": "Network name",
     "network_name_placeholder": "Network name (optional)",
+    "required": "Required",
     "network_rpc_url_label": "RPC URL",
     "network_rpc_name_label": "RPC name",
     "network_rpc_placeholder": "New RPC network",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This fixes the NetworkDetails form so **Network name is no longer optional**.

### What changed
- Made the `Network name` field required in validation logic.
- Added `disabledByName` validation and wired it into:
  - save-button disabled state
  - save operation guard (prevents save if name is empty)
- Updated the name field placeholder text to remove optional wording (`Network name` instead of `Network name (optional)`).
- Updated tests for validation, screen behavior, and save operation guards.
- Applied Prettier formatting fix for `NetworkFormFields.tsx` to satisfy `format:check` CI.

## **Changelog**

CHANGELOG entry: Fixed Network Details so network name is required and no longer labeled optional.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-537

## **Manual testing steps**

```gherkin
Feature: Required network name in NetworkDetails

  Scenario: user cannot save a network without a name
    Given user is on Add custom network screen
    When user leaves Network name empty
    Then the Save button is disabled

  Scenario: optional verbiage removed from network name input
    Given user is on Add custom network screen
    When user views the Network name input placeholder
    Then it shows "Network name" and does not include "optional"

  Scenario: user can save when required fields are filled
    Given user is on Add custom network screen
    And user enters Network name, RPC URL, Chain ID, and Symbol
    When user taps Save
    Then the network is saved successfully
```

## **Screenshots/Recordings**

### **Before**
<img width="391" height="835" alt="Screenshot 2026-03-17 at 17 12 38" src="https://github.com/user-attachments/assets/189bd646-b81b-4ae7-b62a-cb2f344b69d6" />

### **After**
<img width="389" height="826" alt="Screenshot 2026-03-17 at 17 10 05" src="https://github.com/user-attachments/assets/edb7540b-9569-4502-b4ec-cd03daf03b74" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d0615c4-6417-4f20-bf23-635bd695f613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d0615c4-6417-4f20-bf23-635bd695f613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

