### PR TITLE
chore: add visual-regression-pr skill for automated before/after screenshots

### DIFF
--- a/.agents/skills/visual-regression-collect/SKILL.md
+++ b/.agents/skills/visual-regression-collect/SKILL.md
@@ -1,0 +1,509 @@
+# Visual Regression Collect
+
+Batch-process component migration PRs: capture before/after Storybook screenshots on the iOS Simulator, push them to a dedicated screenshots branch, and post before/after comparison tables as PR comments.
+
+## Prerequisites
+
+Before running this workflow, ensure:
+
+1. **iOS Simulator booted** with a MetaMask development build installed
+2. **Storybook running** — `index.js` has Storybook enabled and Metro is serving
+3. **`gh` CLI authenticated** — `gh auth status` succeeds
+4. **Clean working tree** — `git status` shows no uncommitted changes
+
+If Storybook is NOT already running, set it up first:
+
+```bash
+# 1. Enable Storybook in index.js (uncomment lines 102-103, comment lines 108-111)
+# 2. Regenerate story manifest
+yarn storybook-generate
+# 3. Start Metro
+yarn watch:clean
+# 4. Build and run on simulator
+yarn start:ios
+```
+
+---
+
+## Phase 1 — Discover Target PRs
+
+### Mode A — Auto-discover (default)
+
+Find all open migration PRs that don't yet have a visual regression comment:
+
+```bash
+gh pr list --search "refactor: migrate Text in:title" --state open --json number,title,headRefName,baseRefName,url --limit 20
+```
+
+For each PR, check if it already has a visual regression comment:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments --jq '.[] | select(.body | startswith("## Visual Regression Screenshots")) | .id'
+```
+
+If a comment ID is returned, skip that PR (already processed). Collect the remaining PRs as `TARGET_PRS`.
+
+### Mode B — Explicit PR numbers
+
+If the user provides PR numbers (e.g., `27565 27580`), use those directly:
+
+```bash
+gh pr view {PR_NUMBER} --json number,title,headRefName,baseRefName,url,files
+```
+
+### For each PR in TARGET_PRS
+
+Fetch the changed files:
+
+```bash
+gh pr view {PR_NUMBER} --json files --jq '.files[].path'
+```
+
+**Filter to renderable components.** Keep only files where ALL of:
+
+- Extension is `.tsx`
+- Basename is PascalCase (starts uppercase letter)
+
+**Skip if any:**
+
+- Path contains `__snapshots__`
+- Filename ends in `.test.tsx` or `.spec.tsx`
+- Filename contains `.styles.` or `.types.` or `.constants.`
+- Basename is `index.tsx`
+- Path contains: `/hooks/`, `/utils/`, `/util/`, `/routes/`, `/sdk/`, `/context/`, `/selectors/`, `/actions/`
+
+Record the result as a per-PR component list. Also build a **deduplicated master list** of all unique component file paths across all PRs (for the before pass).
+
+If a PR has zero renderable components after filtering, skip it and note why.
+
+### Save current state
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+git stash push -u -m "visual-regression-collect-autostash"
+```
+
+Record whether a stash was created.
+
+### Create temp directories
+
+```bash
+BATCH_DIR=/tmp/vr-batch-$(date +%Y%m%d-%H%M%S)
+mkdir -p $BATCH_DIR/before
+# Per-PR after directories created in Phase 3
+```
+
+---
+
+## Phase 2 — Before Pass (main branch, once)
+
+### Step 2a — Checkout main
+
+```bash
+git checkout main
+git pull origin main --ff-only
+```
+
+### Step 2b — Create sandbox story directory
+
+```bash
+mkdir -p app/components/VisualRegressionSandbox
+```
+
+Write initial stub to `app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`:
+
+```tsx
+// TEMP FILE — visual regression only, do not commit
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+
+storiesOf('VisualRegression', module).add('Current', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 16 }} />
+));
+```
+
+### Step 2c — Regenerate Storybook manifest
+
+```bash
+yarn storybook-generate
+```
+
+Wait for Metro to pick up the new story.
+
+### Step 2d — For each component in the master list
+
+Process every unique component across all PRs. **Never abort on a single failure — mark it SKIPPED and continue.**
+
+#### 2d-i. Derive flat PNG filename
+
+Replace every `/` with `_` in the relative path, change extension to `.png`:
+
+- `app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.tsx`
+  -> `app_components_UI_Ramp_components_RampUnsupportedModal_RampUnsupportedModal.png`
+
+#### 2d-ii. Write sandbox story
+
+Read the component's TypeScript interface and any test files or call sites to derive realistic props.
+
+Overwrite `app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`:
+
+```tsx
+// TEMP FILE — visual regression only, do not commit
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import ComponentName from '../relative/path/to/ComponentName';
+
+storiesOf('VisualRegression', module).add('Current', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+    <ComponentName prop1="value" prop2={42} />
+  </View>
+));
+```
+
+**Props must reflect real usage** — read the component's TypeScript interface, existing test files, or call sites to pick realistic static values. The goal is the same visual output the user would see.
+
+If the component requires context providers beyond what `.storybook/preview.js` supplies (theme, navigation, safe area, mock store are already provided), wrap it appropriately.
+
+#### 2d-iii. Navigate to the story in Storybook
+
+Use `mcp__ios-simulator__ui_describe_all` to confirm Storybook is visible.
+
+Navigate to **VisualRegression -> Current** using `mcp__ios-simulator__ui_tap`.
+
+Wait for the component to render fully. If Storybook shows a red error screen, mark this component SKIPPED with reason "Story crashed — missing context" and continue to the next component.
+
+#### 2d-iv. Take the screenshot
+
+```
+mcp__ios-simulator__screenshot -> $BATCH_DIR/before/<derived-filename>
+```
+
+### Step 2e — Teardown after before pass
+
+1. Delete sandbox:
+
+   ```bash
+   rm -f app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx
+   rmdir app/components/VisualRegressionSandbox 2>/dev/null || true
+   ```
+
+2. Regenerate Storybook manifest:
+
+   ```bash
+   yarn storybook-generate
+   ```
+
+3. Verify clean working tree:
+
+   ```bash
+   git checkout -- .
+   git diff --name-only
+   ```
+
+   Output must be empty. If files appear, reset them before proceeding.
+
+---
+
+## Phase 3 — After Pass (per PR branch)
+
+Repeat this entire phase for each PR in `TARGET_PRS`.
+
+### Step 3a — Checkout PR branch
+
+```bash
+git fetch origin {HEAD_BRANCH}
+git checkout {HEAD_BRANCH}
+```
+
+### Step 3b — Create sandbox and after directory
+
+```bash
+mkdir -p app/components/VisualRegressionSandbox
+mkdir -p $BATCH_DIR/pr-{PR_NUMBER}/after
+```
+
+Write the initial stub story (same as Step 2b).
+
+### Step 3c — Regenerate Storybook manifest
+
+```bash
+yarn storybook-generate
+```
+
+### Step 3d — For each component in THIS PR's file list
+
+Skip any component already marked SKIPPED in the before pass (no before image = skip after too).
+
+#### 3d-i. Add pink highlight borders to MMDS `<Text>` elements
+
+In the target component file (on the PR branch), temporarily add `style={{ borderWidth: 2, borderColor: '#FF00FF' }}` to **every** `<Text>` element imported from `@metamask/design-system-react-native`.
+
+Rules:
+
+- No existing `style` prop -> add `style={{ borderWidth: 2, borderColor: '#FF00FF' }}`
+- Existing inline object -> merge: `style={{ ...existingStyles, borderWidth: 2, borderColor: '#FF00FF' }}`
+- Existing `styles.foo` reference -> array: `style={[styles.foo, { borderWidth: 2, borderColor: '#FF00FF' }]}`
+- Do **not** modify any other element types (Box, Button, etc.)
+
+#### 3d-ii. Write sandbox story
+
+Same as Step 2d-ii — overwrite the sandbox story to render this component with realistic props. Metro hot-reloads the pink-bordered component.
+
+#### 3d-iii. Navigate to the story in Storybook
+
+Same as Step 2d-iii. Mark SKIPPED on red error screen.
+
+#### 3d-iv. Take the screenshot
+
+```
+mcp__ios-simulator__screenshot -> $BATCH_DIR/pr-{PR_NUMBER}/after/<derived-filename>
+```
+
+#### 3d-v. Remove pink borders
+
+Revert only the `borderWidth`/`borderColor` changes:
+
+```bash
+git checkout -- {component-file-path}
+```
+
+Verify with `git diff {component-file-path}` — no changes should remain.
+
+### Step 3e — Teardown after this PR's after pass
+
+1. Delete sandbox:
+
+   ```bash
+   rm -f app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx
+   rmdir app/components/VisualRegressionSandbox 2>/dev/null || true
+   ```
+
+2. Regenerate Storybook manifest:
+
+   ```bash
+   yarn storybook-generate
+   ```
+
+3. Verify clean working tree:
+
+   ```bash
+   git checkout -- .
+   git diff --name-only
+   ```
+
+**Then proceed to the next PR (loop back to Step 3a), or continue to Phase 4 if all PRs are done.**
+
+---
+
+## Phase 4 — Upload Screenshots
+
+Use a git worktree so the main checkout stays undisturbed.
+
+```bash
+WORKTREE=/tmp/mm-screenshots-worktree-$(date +%s)
+
+# Check if branch exists on remote
+git fetch origin screenshots/visual-regression 2>/dev/null
+BRANCH_EXISTS=$?
+
+if [ $BRANCH_EXISTS -ne 0 ]; then
+  # Branch does not exist — create orphan
+  git worktree add --orphan -b screenshots/visual-regression $WORKTREE
+  cd $WORKTREE
+  echo "# MetaMask Mobile Visual Regression Screenshots" > README.md
+  git add README.md
+  git commit --author="georgewrmarshall <george.marshall@consensys.net>" -m "chore: initialize screenshots/visual-regression branch"
+  git push -u origin screenshots/visual-regression
+else
+  # Branch exists — check it out
+  git worktree add $WORKTREE screenshots/visual-regression
+  cd $WORKTREE
+  git pull --ff-only
+fi
+```
+
+### Copy screenshots for each PR
+
+```bash
+for each PR_NUMBER in TARGET_PRS:
+  mkdir -p $WORKTREE/pr-{PR_NUMBER}/before
+  mkdir -p $WORKTREE/pr-{PR_NUMBER}/after
+
+  # Copy before images (only the ones relevant to this PR)
+  for each component in PR's file list:
+    cp $BATCH_DIR/before/<derived-filename> $WORKTREE/pr-{PR_NUMBER}/before/
+  done
+
+  # Copy after images
+  cp $BATCH_DIR/pr-{PR_NUMBER}/after/*.png $WORKTREE/pr-{PR_NUMBER}/after/
+done
+```
+
+### Commit and push
+
+```bash
+cd $WORKTREE
+git add .
+git commit --author="georgewrmarshall <george.marshall@consensys.net>" \
+  -m "chore: visual regression screenshots for PRs #NUM1, #NUM2, ..."
+git push origin screenshots/visual-regression
+```
+
+### Clean up worktree
+
+```bash
+cd -
+git worktree remove $WORKTREE --force
+```
+
+If `git push` fails, copy screenshots to `~/Desktop/vr-batch/` as fallback and skip to Phase 5 (print comment body to stdout instead).
+
+---
+
+## Phase 5 — Post Inline File Comments
+
+Post before/after screenshots as **inline file-level comments** on each changed component file. These appear directly on the file in the "Files changed" tab.
+
+### Get the PR head commit SHA
+
+```bash
+COMMIT_SHA=$(gh pr view {PR_NUMBER} --json headRefOid --jq '.headRefOid')
+```
+
+### Image URL base
+
+```
+https://raw.githubusercontent.com/MetaMask/metamask-mobile/screenshots/visual-regression/pr-{PR_NUMBER}/
+```
+
+### For each successfully captured component
+
+Post a file-level review comment using the GitHub API. The two `<img>` tags must be on the same line with no space so GitHub renders them side-by-side.
+
+```bash
+gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments \
+  -f body='### Before / After
+
+<img width="350" alt="Before" src="{BASE_URL}before/{DERIVED_FILENAME}" /><img width="350" alt="After (pink borders = migrated Text)" src="{BASE_URL}after/{DERIVED_FILENAME}" />' \
+  -f commit_id="$COMMIT_SHA" \
+  -f path="{COMPONENT_FILE_PATH}" \
+  -f subject_type="file"
+```
+
+Replace:
+
+- `{OWNER}/{REPO}` with the repository (e.g. `MetaMask/metamask-mobile`)
+- `{PR_NUMBER}` with the PR number
+- `{BASE_URL}` with the raw GitHub URL base
+- `{DERIVED_FILENAME}` with the flat PNG filename (e.g. `app_components_UI_Ramp_components_EligibilityFailedModal_EligibilityFailedModal.png`)
+- `{COMPONENT_FILE_PATH}` with the relative file path in the repo
+
+Skip any component where either the before or after screenshot is missing.
+
+If `gh api` fails, print the comment body to stdout with the file path for manual paste.
+
+### Update the PR description
+
+Replace the `## **Screenshots/Recordings**` section in the PR body to reference the inline comments.
+
+1. Fetch the current body: `gh pr view {PR_NUMBER} --json body --jq '.body' > /tmp/pr-body.md`
+2. Edit `/tmp/pr-body.md` — replace everything between `## **Screenshots/Recordings**` and the next `## **` heading with:
+
+   ```
+   ## **Screenshots/Recordings**
+
+   Before/after screenshots added as inline comments on each changed file in the **Files changed** tab. Pink borders highlight migrated `<Text>` elements.
+   ```
+
+3. Push via REST API (avoids `gh pr edit` issues with classic projects):
+   ```bash
+   gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER} --method PATCH --field body="$(cat /tmp/pr-body.md)"
+   ```
+
+---
+
+## Phase 6 — Restore and Cleanup
+
+```bash
+git checkout {CURRENT_BRANCH}
+```
+
+If a stash was created in Phase 1:
+
+```bash
+git stash pop
+```
+
+If `stash pop` conflicts, report them and do NOT auto-resolve. Leave the stash in place.
+
+```bash
+rm -rf $BATCH_DIR
+```
+
+### Final verification
+
+```bash
+git status
+git worktree list
+```
+
+`git status` should show a clean working tree (or only original untracked files). `git worktree list` should show no `/tmp/mm-screenshots-worktree*` entries.
+
+---
+
+## Final Summary
+
+Print a summary report:
+
+```
+Visual Regression Batch — {TODAY_DATE}
+
+PRs processed: {N}
+
+PR #{NUM1}: {PR_TITLE}
+  Branch: {HEAD_BRANCH} -> {BASE_BRANCH}
+  Captured: {X} components
+    ✓ app/components/.../ComponentA.tsx
+    ✓ app/components/.../ComponentB.tsx
+  Skipped: {Y} components
+    ✗ app/components/.../ComponentC.tsx — Story crashed
+  Comment: posted ✓
+
+PR #{NUM2}: {PR_TITLE}
+  ...
+
+Screenshots branch: https://github.com/MetaMask/metamask-mobile/tree/screenshots/visual-regression
+Working tree: clean
+Worktrees: no leftovers
+```
+
+---
+
+## Error Handling Reference
+
+| Situation                              | Action                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------ |
+| `gh` auth failure                      | Stop immediately. Print: `Run 'gh auth login' then retry.`               |
+| PR not found                           | Skip that PR, continue to next. Report at end.                           |
+| Zero renderable components in a PR     | Skip that PR. Note in summary.                                           |
+| Dirty working tree after cleanup       | Stop. Do not proceed to next `git checkout`. Fix first.                  |
+| Story crashes (red screen)             | Mark SKIPPED, continue to next component. Never abort.                   |
+| `git push` to screenshots branch fails | Copy PNGs to `~/Desktop/vr-batch/`. Print comment body to stdout.        |
+| `stash pop` conflicts                  | Report to user. Leave stash in place. Do not auto-resolve.               |
+| Metro not responding                   | Verify `yarn watch:clean` is running. Restart if needed.                 |
+| Simulator not visible                  | Run `mcp__ios-simulator__get_booted_sim_id` to verify. Reboot if needed. |
+| Missing `before` PNG for a component   | Omit from PR comment table. Do not post broken image URL.                |
+
+---
+
+## Notes
+
+- **Storybook must be running before starting.** This workflow does NOT build or install the app — it assumes hot reload is active.
+- **`index.js` is NOT modified.** Unlike the standalone visual-regression-pr command, this workflow assumes Storybook is already enabled. The sandbox story + hot reload handles all component switching.
+- **The sandbox story is always temporary.** Never committed. `yarn storybook-generate` is run to register/unregister it.
+- **Pink borders are temporary debug markup.** Always revert with `git checkout -- <file>` after each component.
+- **Git worktree** keeps the main checkout undisturbed during upload. Always remove with `--force` before finishing.
+- **Before screenshots are shared across PRs.** A component that appears in multiple PRs gets one before screenshot, copied into each PR's directory.
+- **The `screenshots/visual-regression` orphan branch** has no shared history with `main`. Safe to push freely.

--- a/.claude/commands/visual-regression-collect.md
+++ b/.claude/commands/visual-regression-collect.md
@@ -1,0 +1,19 @@
+# Visual Regression Collect
+
+Batch-capture before/after Storybook screenshots for component migration PRs, push to the screenshots branch, and post comparison tables as PR comments.
+
+**Usage:**
+
+```
+/visual-regression-collect                  # Auto-discover open migration PRs
+/visual-regression-collect 27565            # Process specific PR
+/visual-regression-collect 27565 27580      # Process multiple PRs
+```
+
+## Instructions
+
+1. Load the `visual-regression-collect` skill for the full workflow.
+2. Verify prerequisites: iOS Simulator booted, Storybook running, `gh auth status` passes, clean git tree.
+3. Follow the skill phases in order: Discover -> Before Pass -> After Pass -> Upload -> Comment -> Cleanup.
+
+The arguments to this command are: $ARGUMENTS

--- a/.cursor/automations/migrate-text-component.md
+++ b/.cursor/automations/migrate-text-component.md
@@ -11,7 +11,7 @@ There are 2000+ legacy Text instances across the codebase. This automation plays
 ## Cursor Automation Configuration
 
 **Trigger:** Schedule — run once per day (or on demand via webhook)
-**Tools required:** GitHub (read repo, create branches), Slack (send DM to george.marshall), Memory (track progress across runs)
+**Tools required:** GitHub (read repo, create branches, open PRs), Slack (configured recipient), Memory (track progress across runs)
 **Prompt:** See "Agent Instructions" section below
 
 ---
@@ -34,18 +34,20 @@ If no memory exists yet, treat everything as fresh.
 
 **Pick one code owner** from the table below. Choose one that has remaining deprecated Text usages and has not been fully migrated.
 
-| Path pattern                                                    | Owner                     |
-| --------------------------------------------------------------- | ------------------------- |
-| `app/components/UI/Ramp/`, `**/Ramp/**`                         | @MetaMask/ramp            |
-| `app/components/Views/confirmations/`                           | @MetaMask/confirmations   |
-| `app/components/UI/Bridge/`, `app/components/UI/Swaps`          | @MetaMask/swaps-engineers |
-| `app/components/UI/Earn/`, `**/Earn/**`                         | @MetaMask/metamask-earn   |
-| `app/components/UI/Perps/`, `**/Perps/**`                       | @MetaMask/perps           |
-| `app/components/UI/Predict/`, `**/Predict/**`                   | @MetaMask/predict         |
-| `app/components/UI/Card/`                                       | @MetaMask/card            |
-| `app/components/UI/Assets/`, `app/components/UI/TokenDetails/`  | @MetaMask/metamask-assets |
-| `app/components/Views/Login/`, `app/components/Views/Settings/` | @MetaMask/mobile-core-ux  |
-| `app/components/Views/Onboarding/`                              | @MetaMask/web3auth        |
+| Path pattern                                                                                           | Owner                     |
+| ------------------------------------------------------------------------------------------------------ | ------------------------- |
+| `app/components/UI/Ramp/components/`, `app/components/UI/Ramp/hooks/`, `app/components/UI/Ramp/Views/` | @MetaMask/ramp            |
+| `app/components/Views/confirmations/`                                                                  | @MetaMask/confirmations   |
+| `app/components/UI/Bridge/`, `app/components/UI/Swaps`                                                 | @MetaMask/swaps-engineers |
+| `app/components/UI/Earn/`, `**/Earn/**`                                                                | @MetaMask/metamask-earn   |
+| `app/components/UI/Perps/`, `**/Perps/**`                                                              | @MetaMask/perps           |
+| `app/components/UI/Predict/`, `**/Predict/**`                                                          | @MetaMask/predict         |
+| `app/components/UI/Card/`                                                                              | @MetaMask/card            |
+| `app/components/UI/Assets/`, `app/components/UI/TokenDetails/`                                         | @MetaMask/metamask-assets |
+| `app/components/Views/Login/`, `app/components/Views/Settings/`                                        | @MetaMask/mobile-core-ux  |
+| `app/components/Views/Onboarding/`                                                                     | @MetaMask/web3auth        |
+
+**Note for @MetaMask/ramp:** Only target the new combined flow folders — `Ramp/components/`, `Ramp/hooks/`, and `Ramp/Views/`. **Do not touch** `Ramp/Aggregator/` or `Ramp/Deposit/` — these are legacy experiences that will not be refactored and are excluded from DS adoption work.
 
 **Find deprecated Text imports** within that owner's paths. Search for files containing any of:
 
@@ -392,45 +394,24 @@ Before opening the PR, confirm:
 
 ---
 
-### Step 5 — Send Slack DM with PR Creation Link
+### Step 5 — Open PR and Notify Slack
 
-> **Why not open the PR directly?** Cursor lacks permission to open PRs against the MetaMask org. Instead, send a pre-filled GitHub compare link to the human so they can open it in one click.
+**Open the PR** using the Open Pull Request tool with the title and body below.
 
-**Send a Slack DM to `george.marshall`** using the Slack tool. The message must include:
-
-1. **PR creation link** — the GitHub compare URL with the branch pre-filled:
-
-   ```
-   https://github.com/MetaMask/metamask-mobile/compare/main...refactor/6887_migrate-text-<owner-slug>?expand=1
-   ```
-
-2. **Suggested PR title:**
-
-   ```
-   refactor: migrate Text to design system in <owner> components
-   ```
-
-3. **Suggested PR body** — send the fully filled-out markdown as raw text in the Slack message so it can be selected and pasted directly into the GitHub PR description field. Do not summarise or shorten it — send the complete body.
-
-**Send this exact message** (replace all `<placeholders>` with real values for the run):
+**Then send a Slack message** using the Slack tool with a short summary:
 
 ```
-Hey! Today's Text migration batch is ready to PR.
+Text migration PR open for @MetaMask/<owner>:
 
 *Branch:* `refactor/6887_migrate-text-<owner-slug>`
-*Owner:* @MetaMask/<owner>
 *Files migrated:*
   • path/to/File1.tsx
   • path/to/File2.tsx
 
-*👉 Open PR:* https://github.com/MetaMask/metamask-mobile/compare/main...refactor/6887_migrate-text-<owner-slug>?expand=1
-
-*Suggested title:* `refactor: migrate Text to design system in <owner> components`
-
-*PR description — copy and paste this into GitHub:*
+*PR:* <link to opened PR>
 ```
 
-Immediately follow that block with the raw PR body as a Slack code snippet (triple backtick, no language tag) so it renders as preformatted, selectable text:
+**PR body to use when opening the PR:**
 
 ```
 ## **Description**
@@ -447,10 +428,6 @@ imports with `Text`, `TextButton` from `@metamask/design-system-react-native`.
 
 **Why:** Part of https://github.com/MetaMask/metamask-mobile/issues/6887 — eliminating
 deprecated internal Text wrappers in favour of the shared design system component.
-
-> [!NOTE]
-> This PR was produced by the `migrate-text-component` automation. Cursor lacks permission
-> to open PRs directly, so it was opened manually.
 
 ## **Changelog**
 
@@ -665,6 +642,7 @@ import {
 ## Constraints
 
 - Do **not** remove the deprecated Text components themselves until **all** usages across the entire codebase are migrated.
+- For `@MetaMask/ramp`: only search within `Ramp/components/`, `Ramp/hooks/`, and `Ramp/Views/`. Files under `Ramp/Aggregator/` and `Ramp/Deposit/` are legacy, will not be refactored, and must be skipped entirely.
 - Do **not** migrate more than 5 files per run.
 - Do **not** mix files from different code owners in a single PR.
 - Do **not** refactor surrounding code, rename variables, or make unrelated improvements.

--- a/.cursor/automations/migrate-text-component.md
+++ b/.cursor/automations/migrate-text-component.md
@@ -1,0 +1,673 @@
+# Text Component Migration Automation
+
+## Purpose
+
+Migrate deprecated Text components to `@metamask/design-system-react-native` in the MetaMask Mobile codebase. Part of [MetaMask/metamask-mobile#6887](https://github.com/MetaMask/metamask-mobile/issues/6887).
+
+There are 2000+ legacy Text instances across the codebase. This automation plays the long game: each run produces one small, reviewable PR (max 5 files, one code owner). Over many runs the automation gradually eliminates all deprecated usages.
+
+---
+
+## Cursor Automation Configuration
+
+**Trigger:** Schedule — run once per day (or on demand via webhook)
+**Tools required:** GitHub (read repo, create branches), Slack (send DM to george.marshall), Memory (track progress across runs)
+**Prompt:** See "Agent Instructions" section below
+
+---
+
+## Agent Instructions
+
+### Step 0 — Consult Memory
+
+Before doing anything else, read your memory notes for this automation. Look for:
+
+- A list of files already migrated in previous runs (to avoid re-migrating or duplicating PR work)
+- The last code owner targeted (to prefer a different one this run for variety, or continue one with many files remaining)
+- Any known edge cases or patterns flagged in previous runs
+
+If no memory exists yet, treat everything as fresh.
+
+---
+
+### Step 1 — Select Target Files
+
+**Pick one code owner** from the table below. Choose one that has remaining deprecated Text usages and has not been fully migrated.
+
+| Path pattern                                                    | Owner                     |
+| --------------------------------------------------------------- | ------------------------- |
+| `app/components/UI/Ramp/`, `**/Ramp/**`                         | @MetaMask/ramp            |
+| `app/components/Views/confirmations/`                           | @MetaMask/confirmations   |
+| `app/components/UI/Bridge/`, `app/components/UI/Swaps`          | @MetaMask/swaps-engineers |
+| `app/components/UI/Earn/`, `**/Earn/**`                         | @MetaMask/metamask-earn   |
+| `app/components/UI/Perps/`, `**/Perps/**`                       | @MetaMask/perps           |
+| `app/components/UI/Predict/`, `**/Predict/**`                   | @MetaMask/predict         |
+| `app/components/UI/Card/`                                       | @MetaMask/card            |
+| `app/components/UI/Assets/`, `app/components/UI/TokenDetails/`  | @MetaMask/metamask-assets |
+| `app/components/Views/Login/`, `app/components/Views/Settings/` | @MetaMask/mobile-core-ux  |
+| `app/components/Views/Onboarding/`                              | @MetaMask/web3auth        |
+
+**Find deprecated Text imports** within that owner's paths. Search for files containing any of:
+
+- `from '../../../component-library/components/Texts/Text'`
+- `from '../../component-library/components/Texts/Text'`
+- `from 'app/component-library/components/Texts/Text'`
+- `from '../../../components/Base/Text'`
+- `from '../../components/Base/Text'`
+- `from 'app/components/Base/Text'`
+- Any relative path resolving to `app/component-library/components/Texts/Text` or `app/components/Base/Text`
+
+**Exclude** files already in memory as migrated. **Pick at most 5 files** for this run — prefer simpler files (fewer Text usages) to keep the PR reviewable.
+
+---
+
+### Step 2 — Apply Migration Rules
+
+For each selected file, apply the rules below. Preserve all existing behavior. Do not refactor anything unrelated to the Text migration.
+
+#### 2a. Import Change
+
+**Component-library Text** — replace:
+
+```ts
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '../../../component-library/components/Texts/Text';
+// or any relative path to app/component-library/components/Texts/Text
+```
+
+With:
+
+```ts
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  FontStyle,
+} from '@metamask/design-system-react-native';
+```
+
+Only import what is actually used. Remove `TextVariant`, `TextColor`, `FontWeight`, `FontStyle` from the import if not referenced in the file after migration.
+
+**Base/Text** — replace:
+
+```ts
+import Text from '../../../components/Base/Text';
+// or any relative path to app/components/Base/Text
+```
+
+With:
+
+```ts
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  FontStyle,
+} from '@metamask/design-system-react-native';
+```
+
+Same rule: only import what ends up used.
+
+If the file also imports `TextButton` for link migration, add it to the same import line:
+
+```ts
+import {
+  Text,
+  TextButton,
+  TextButtonSize,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+```
+
+#### 2b. Variant Name Casing (component-library Text)
+
+All variants use consistent mixed-case in the design system. Replace:
+
+| Old                     | New                     |
+| ----------------------- | ----------------------- |
+| `TextVariant.DisplayLG` | `TextVariant.DisplayLg` |
+| `TextVariant.DisplayMD` | `TextVariant.DisplayMd` |
+| `TextVariant.HeadingLG` | `TextVariant.HeadingLg` |
+| `TextVariant.HeadingMD` | `TextVariant.HeadingMd` |
+| `TextVariant.HeadingSM` | `TextVariant.HeadingSm` |
+| `TextVariant.BodyMD`    | `TextVariant.BodyMd`    |
+| `TextVariant.BodySM`    | `TextVariant.BodySm`    |
+| `TextVariant.BodyXS`    | `TextVariant.BodyXs`    |
+
+#### 2c. Font Weight Separation (component-library Text)
+
+Font weight is now a separate prop. Replace combined variants:
+
+| Old                        | New                                                           |
+| -------------------------- | ------------------------------------------------------------- |
+| `TextVariant.BodyLGMedium` | `variant={TextVariant.BodyLg} fontWeight={FontWeight.Medium}` |
+| `TextVariant.BodyMDMedium` | `variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}` |
+| `TextVariant.BodyMDBold`   | `variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}`   |
+| `TextVariant.BodySMMedium` | `variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}` |
+| `TextVariant.BodySMBold`   | `variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}`   |
+| `TextVariant.BodyXSMedium` | `variant={TextVariant.BodyXs} fontWeight={FontWeight.Medium}` |
+
+#### 2d. Color Mapping (component-library Text)
+
+Colors now carry semantic prefixes:
+
+| Old                            | New                                                          |
+| ------------------------------ | ------------------------------------------------------------ |
+| `TextColor.Default`            | `TextColor.TextDefault`                                      |
+| `TextColor.Alternative`        | `TextColor.TextAlternative`                                  |
+| `TextColor.Muted`              | `TextColor.TextMuted`                                        |
+| `TextColor.Primary`            | `TextColor.PrimaryDefault`                                   |
+| `TextColor.PrimaryAlternative` | `TextColor.PrimaryAlternative` _(verify — may be unchanged)_ |
+| `TextColor.Success`            | `TextColor.SuccessDefault`                                   |
+| `TextColor.Error`              | `TextColor.ErrorDefault`                                     |
+| `TextColor.ErrorAlternative`   | `TextColor.ErrorAlternative` _(verify — may be unchanged)_   |
+| `TextColor.Warning`            | `TextColor.WarningDefault`                                   |
+| `TextColor.Info`               | `TextColor.InfoDefault`                                      |
+| `TextColor.Inverse`            | `TextColor.OverlayInverse`                                   |
+
+#### 2e. Base/Text Boolean Prop Mapping
+
+The Base/Text component uses boolean shorthand props. Map each to the MMDS Text API:
+
+| Base/Text prop    | MMDS equivalent                                                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bold`            | `fontWeight={FontWeight.Bold}`                                                                                                                                      |
+| `centered`        | `twClassName="text-center"`                                                                                                                                         |
+| `right`           | `twClassName="text-right"`                                                                                                                                          |
+| `small`           | `variant={TextVariant.BodySm}`                                                                                                                                      |
+| `big`             | `variant={TextVariant.BodyLg}`                                                                                                                                      |
+| `bigger`          | `variant={TextVariant.BodyLg}` _(closest match; fontSize 18 vs BodyLg — note in PR if visually different)_                                                          |
+| `upper`           | `twClassName="uppercase"`                                                                                                                                           |
+| `bold + centered` | `fontWeight={FontWeight.Bold} twClassName="text-center"`                                                                                                            |
+| `primary`         | Omit — `TextDefault` is the MMDS Text default color                                                                                                                 |
+| `black`           | Omit — `TextDefault` is the MMDS Text default color                                                                                                                 |
+| `muted`           | `color={TextColor.TextMuted}`                                                                                                                                       |
+| `grey`            | `color={TextColor.TextAlternative}` _(maps to colors.text.alternative)_                                                                                             |
+| `red`             | `color={TextColor.ErrorDefault}`                                                                                                                                    |
+| `green`           | `color={TextColor.SuccessDefault}`                                                                                                                                  |
+| `blue`            | `color={TextColor.PrimaryDefault}` — but if combined with `underline` on a `<Text>` inside a `TouchableOpacity`, collapse both into `<TextButton>` (see Section 2f) |
+| `orange`          | `color={TextColor.WarningDefault}`                                                                                                                                  |
+| `strikethrough`   | `twClassName="line-through"`                                                                                                                                        |
+| `underline`       | `twClassName="underline"` — but if combined with `blue` or `link` on a `<Text>` inside a `TouchableOpacity`, collapse into `<TextButton>` (see Section 2f)          |
+| `noMargin`        | `twClassName="my-0"`                                                                                                                                                |
+| `reset`           | Omit default styling — just use `<Text>` with explicit props only; no special prop needed                                                                           |
+| `disclaimer`      | `variant={TextVariant.BodySm} fontStyle={FontStyle.Italic}` — add `style={{ letterSpacing: 0.15 }}` if letter-spacing is visually important                         |
+| `modal`           | `variant={TextVariant.BodyLg}` _(fontSize 16, lineHeight ~22 — note if line-height matters)_                                                                        |
+| `infoModal`       | Use `style={{ lineHeight: 20, marginVertical: 6 }}` until a Tailwind equivalent is confirmed                                                                        |
+| `link`            | **Use `<TextButton>` instead of `<Text>`** — see Section 2f                                                                                                         |
+
+When multiple boolean props combine on one element, apply all the mappings together:
+
+```tsx
+// Before (Base/Text)
+<Text bold centered red>{message}</Text>
+
+// After (MMDS)
+<Text fontWeight={FontWeight.Bold} twClassName="text-center" color={TextColor.ErrorDefault}>
+  {message}
+</Text>
+```
+
+#### 2f. Interactive / Link Text — Use TextButton
+
+A `TouchableOpacity` (or `Pressable`) wrapping a link-styled `<Text>` should collapse into a single `<TextButton>`. The `onPress` lives on the wrapper, never on `<Text>` itself — so the whole pair becomes one element.
+
+Treat the following as link patterns that warrant `<TextButton>`:
+
+1. `TouchableOpacity` wrapping `<Text link>`
+2. `TouchableOpacity` wrapping `<Text link underline>` or `<Text small link underline>`
+3. `TouchableOpacity` wrapping `<Text blue underline>` — visual link styling even without `link` prop
+4. `TouchableOpacity` wrapping any `<Text>` whose sole purpose is to be tappable (wrapper has no other layout role)
+
+```tsx
+// Before
+<TouchableOpacity onPress={handlePress}>
+  <Text small link underline centered>
+    {providerWebsite}
+  </Text>
+</TouchableOpacity>
+
+// After
+<TextButton size={TextButtonSize.BodySm} onPress={handlePress} twClassName="text-center">
+  {providerWebsite}
+</TextButton>
+```
+
+Size the TextButton to match surrounding text:
+
+```tsx
+import {
+  TextButton,
+  TextButtonSize,
+} from '@metamask/design-system-react-native';
+
+<TextButton size={TextButtonSize.BodySm} onPress={handlePress}>
+  {linkText}
+</TextButton>;
+```
+
+Available sizes: `TextButtonSize.BodySm`, `TextButtonSize.BodyMd`, `TextButtonSize.BodyLg`.
+
+If the existing code uses `Linking.openURL` in the press handler, keep that logic unchanged — just move it to `onPress` on `TextButton`.
+
+#### 2g. Style Prop — Layout vs. Text Styles
+
+The MMDS `Text` component still accepts a `style` prop for cases where the design system API does not cover the need (e.g. layout styles like `flexShrink`, `marginHorizontal` for positioning within a parent, external `StyleSheet` styles passed as props).
+
+**Rule of thumb:**
+
+- **Text-specific styles** (color, fontSize, fontWeight, textAlign, textTransform, textDecorationLine) → use Text API props and `twClassName`
+- **Layout / structural styles** (flex, margin for positioning, padding, width) → keep in `style` prop via `StyleSheet`
+- **Conditional / dynamic styles** → use `tw.style()` from `useTailwind()` hook:
+
+```tsx
+import { useTailwind } from '@metamask/design-system-react-native';
+
+const tw = useTailwind();
+<Text style={tw.style(isError && 'text-error-default')}>...</Text>;
+```
+
+Do **not** use `StyleSheet.create()` for static text-appearance styles — prefer `twClassName`.
+
+#### 2g-i. Migrate StyleSheet Text-Appearance Entries
+
+When migrating a component, **also inspect its companion styles file** (e.g. `Component.styles.ts`). Any `StyleSheet` entry that is applied exclusively to a `Text` element and contains only text-appearance properties (`fontSize`, `fontWeight`, `color`) must be migrated to Text props. Remove the entry from the `StyleSheet` and remove the `style={styles.x}` prop from the `<Text>`.
+
+Map the values as follows:
+
+| StyleSheet value                           | Text prop                           |
+| ------------------------------------------ | ----------------------------------- |
+| `fontSize: 12` (or scale equivalent)       | `variant={TextVariant.BodySm}`      |
+| `fontSize: 14` (or scale equivalent)       | _(default BodyMd — omit variant)_   |
+| `fontSize: 16`                             | `variant={TextVariant.BodyLg}`      |
+| `fontWeight: '400'`                        | _(default — omit fontWeight)_       |
+| `fontWeight: '500'`                        | `fontWeight={FontWeight.Medium}`    |
+| `fontWeight: '600'` or `'700'` or `'bold'` | `fontWeight={FontWeight.Bold}`      |
+| `color: theme.colors.text.default`         | _(default — omit color)_            |
+| `color: theme.colors.text.alternative`     | `color={TextColor.TextAlternative}` |
+| `color: theme.colors.text.muted`           | `color={TextColor.TextMuted}`       |
+| `color: theme.colors.primary.default`      | `color={TextColor.PrimaryDefault}`  |
+| `color: theme.colors.error.default`        | `color={TextColor.ErrorDefault}`    |
+| `color: theme.colors.success.default`      | `color={TextColor.SuccessDefault}`  |
+| `color: theme.colors.warning.default`      | `color={TextColor.WarningDefault}`  |
+
+If the StyleSheet entry mixes text-appearance and layout properties, **split them**: keep only the layout properties in the `StyleSheet` entry, and move the text-appearance properties to Text props.
+
+**Example** (from `SpendingLimitWarning.styles.ts`):
+
+```ts
+// Before — StyleSheet entries used on <Text> elements
+mainText: {
+  fontSize: 16,
+  fontWeight: '600',
+  color: theme.colors.text.default,
+  marginBottom: 4,         // layout — stays
+},
+subText: {
+  fontSize: 14,
+  fontWeight: '400',
+  color: theme.colors.text.alternative,
+},
+```
+
+```ts
+// After — only layout properties remain in StyleSheet
+mainText: {
+  marginBottom: 4,         // layout — kept
+},
+// subText removed entirely (no layout properties left)
+```
+
+```tsx
+// Before
+<Text style={styles.mainText}>...</Text>
+<Text style={styles.subText}>...</Text>
+
+// After
+<Text variant={TextVariant.BodyLg} fontWeight={FontWeight.Bold} style={styles.mainText}>
+  ...
+</Text>
+<Text color={TextColor.TextAlternative}>
+  ...
+</Text>
+```
+
+**Always delete the StyleSheet entry** when it contains only text-appearance properties (nothing layout-related remains). Remove the entry from `StyleSheet.create()`, remove the `style={styles.x}` prop from the `<Text>`, and delete the style key. If the `createStyles` function or styles object becomes empty as a result, delete the styles file and its import.
+
+#### 2h. Snapshot Tests
+
+If the file has a corresponding `__snapshots__` file or `.test.tsx` that renders the component, snapshot diffs are expected. Update snapshots after migration:
+
+```bash
+yarn jest <path-to-test-file> -u
+```
+
+Re-run without `-u` to confirm tests pass. Do **not** add new `.toMatchSnapshot()` calls.
+
+---
+
+### Step 3 — Verify
+
+After making all edits, run the following checks in order. Do not open a PR if any step fails.
+
+```bash
+# 1. TypeScript — no type errors in changed files
+yarn lint:tsc
+
+# 2. Lint
+yarn lint
+
+# 3. Format
+yarn format:check
+
+# 4. Unit tests for changed files (update snapshots if needed)
+yarn jest --testPathPattern="<changed-file-basename>" --passWithNoTests
+
+# 5. If snapshot updates were needed:
+yarn jest --testPathPattern="<changed-file-basename>" -u
+yarn jest --testPathPattern="<changed-file-basename>"
+```
+
+If `yarn lint:tsc` fails due to unknown props on the MMDS Text component, check the `@metamask/design-system-react-native` package types. If a prop genuinely does not exist, use `style` as a fallback and add a `// TODO: use design system prop when available` comment.
+
+---
+
+### Step 4 — Compliance Check
+
+Before opening the PR, confirm:
+
+- [ ] No `from 'react-native'` bare `Text` imports remain for display text (only `RNText` aliased imports for internal wrappers are OK)
+- [ ] No `StyleSheet.create()` entries that only exist to style text appearance (color, weight, size, align) — these must move to MMDS props
+- [ ] No `import Text from 'app/components/Base/Text'` or component-library Text imports remain in changed files
+- [ ] `FontWeight`, `FontStyle`, `TextVariant`, `TextColor` are all imported from `@metamask/design-system-react-native` (not from component-library)
+- [ ] PR title follows Conventional Commits: `refactor: migrate Text to design system in <owner> components`
+- [ ] Branch name: `refactor/6887_migrate-text-<owner-slug>` (e.g. `refactor/6887_migrate-text-ramp`)
+
+---
+
+### Step 5 — Send Slack DM with PR Creation Link
+
+> **Why not open the PR directly?** Cursor lacks permission to open PRs against the MetaMask org. Instead, send a pre-filled GitHub compare link to the human so they can open it in one click.
+
+**Send a Slack DM to `george.marshall`** using the Slack tool. The message must include:
+
+1. **PR creation link** — the GitHub compare URL with the branch pre-filled:
+
+   ```
+   https://github.com/MetaMask/metamask-mobile/compare/main...refactor/6887_migrate-text-<owner-slug>?expand=1
+   ```
+
+2. **Suggested PR title:**
+
+   ```
+   refactor: migrate Text to design system in <owner> components
+   ```
+
+3. **Suggested PR body** — send the fully filled-out markdown as raw text in the Slack message so it can be selected and pasted directly into the GitHub PR description field. Do not summarise or shorten it — send the complete body.
+
+**Send this exact message** (replace all `<placeholders>` with real values for the run):
+
+```
+Hey! Today's Text migration batch is ready to PR.
+
+*Branch:* `refactor/6887_migrate-text-<owner-slug>`
+*Owner:* @MetaMask/<owner>
+*Files migrated:*
+  • path/to/File1.tsx
+  • path/to/File2.tsx
+
+*👉 Open PR:* https://github.com/MetaMask/metamask-mobile/compare/main...refactor/6887_migrate-text-<owner-slug>?expand=1
+
+*Suggested title:* `refactor: migrate Text to design system in <owner> components`
+
+*PR description — copy and paste this into GitHub:*
+```
+
+Immediately follow that block with the raw PR body as a Slack code snippet (triple backtick, no language tag) so it renders as preformatted, selectable text:
+
+```
+## **Description**
+
+Migrates deprecated `Text` components to `@metamask/design-system-react-native` in the
+@MetaMask/<owner> code owner paths. Part of the ongoing #6887 migration.
+
+Files migrated:
+- `path/to/File1.tsx`
+- `path/to/File2.tsx`
+
+**What:** Replace `app/components/Base/Text` and `app/component-library/components/Texts/Text`
+imports with `Text`, `TextButton` from `@metamask/design-system-react-native`.
+
+**Why:** Part of https://github.com/MetaMask/metamask-mobile/issues/6887 — eliminating
+deprecated internal Text wrappers in favour of the shared design system component.
+
+> [!NOTE]
+> This PR was produced by the `migrate-text-component` automation. Cursor lacks permission
+> to open PRs directly, so it was opened manually.
+
+## **Changelog**
+
+CHANGELOG entry: null (internal refactor, no user-visible change)
+
+## **Related issues**
+
+Part of: https://github.com/MetaMask/metamask-mobile/issues/6887
+
+## **Manual testing steps**
+
+Feature: Text migration visual parity
+
+  Scenario: user views affected screens
+    Given the app is open
+    When the user navigates to the screen(s) affected by the changed files
+    Then all text renders correctly with the same visual appearance as before
+
+## **Screenshots/Recordings**
+
+N/A — styling parity migration, no visual change intended.
+*(If a visual difference is noticed, add before/after screenshots.)*
+
+### **Before**
+
+<!-- [screenshots/recordings] -->
+
+### **After**
+
+<!-- [screenshots/recordings] -->
+
+## **Pre-merge author checklist**
+
+- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
+- [x] I've completed the PR template to the best of my ability
+- [x] I've included tests if applicable
+- [ ] I've documented my code using JSDoc format if applicable
+- [ ] I've applied the right labels on the PR. Not required for external contributors.
+
+## **Pre-merge reviewer checklist**
+
+- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
+- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
+```
+
+---
+
+### Step 6 — Update Memory
+
+After the PR is opened, save to memory:
+
+- The list of files migrated in this run (append to the running list)
+- The owner targeted
+- Any edge cases or unusual patterns encountered (e.g. files using `infoModal`, `disclaimer`, `reset`, or complex conditional styles that needed `tw.style()`)
+- Any files that were skipped and why (complex, needs manual review, etc.)
+
+Example memory entry format:
+
+```
+## Run <date>
+Owner: @MetaMask/ramp
+Files migrated:
+  - app/components/UI/Ramp/Aggregator/components/Account.tsx
+  - app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+PR: #XXXXX
+Notes: Account.tsx retained StyleSheet for layout styles on Text (flexShrink, marginHorizontal).
+```
+
+---
+
+## Migration Reference
+
+### Complete Base/Text Props
+
+Sourced from `app/components/Base/Text/Text.tsx`:
+
+| Prop            | Type | Underlying style                     | MMDS migration                                                                                                                            |
+| --------------- | ---- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `reset`         | bool | removes all defaults                 | Use bare `<Text>` with explicit props                                                                                                     |
+| `centered`      | bool | `textAlign: 'center'`                | `twClassName="text-center"`                                                                                                               |
+| `right`         | bool | `textAlign: 'right'`                 | `twClassName="text-right"`                                                                                                                |
+| `bold`          | bool | `fontWeight: 'bold'`                 | `fontWeight={FontWeight.Bold}`                                                                                                            |
+| `green`         | bool | `colors.success.default`             | `color={TextColor.SuccessDefault}`                                                                                                        |
+| `black`         | bool | `colors.text.default`                | Omit — `TextDefault` is the MMDS Text default color                                                                                       |
+| `blue`          | bool | `colors.primary.default`             | `color={TextColor.PrimaryDefault}` — if combined with `underline` on a `<Text>` inside a `TouchableOpacity`, collapse into `<TextButton>` |
+| `red`           | bool | `colors.error.default`               | `color={TextColor.ErrorDefault}`                                                                                                          |
+| `grey`          | bool | `colors.text.alternative`            | `color={TextColor.TextAlternative}`                                                                                                       |
+| `orange`        | bool | `colors.warning.default`             | `color={TextColor.WarningDefault}`                                                                                                        |
+| `primary`       | bool | `colors.text.default`                | Omit — `TextDefault` is the MMDS Text default color                                                                                       |
+| `muted`         | bool | `colors.text.muted`                  | `color={TextColor.TextMuted}`                                                                                                             |
+| `small`         | bool | `fontSize: 12`                       | `variant={TextVariant.BodySm}`                                                                                                            |
+| `big`           | bool | `fontSize: 16`                       | `variant={TextVariant.BodyLg}`                                                                                                            |
+| `bigger`        | bool | `fontSize: 18`                       | `variant={TextVariant.BodyLg}` + note in PR                                                                                               |
+| `upper`         | bool | `textTransform: 'uppercase'`         | `twClassName="uppercase"`                                                                                                                 |
+| `disclaimer`    | bool | BodySm + italic + letterSpacing 0.15 | `variant={TextVariant.BodySm} fontStyle={FontStyle.Italic}` + `style={{ letterSpacing: 0.15 }}` if needed                                 |
+| `modal`         | bool | fontSize 16, lineHeight 22.4         | `variant={TextVariant.BodyLg}`                                                                                                            |
+| `infoModal`     | bool | lineHeight 20, marginVertical 6      | `style={{ lineHeight: 20, marginVertical: 6 }}`                                                                                           |
+| `link`          | bool | `colors.primary.default`             | **Replace element with `<TextButton>`**                                                                                                   |
+| `strikethrough` | bool | `textDecorationLine: 'line-through'` | `twClassName="line-through"`                                                                                                              |
+| `underline`     | bool | `textDecorationLine: 'underline'`    | `twClassName="underline"` — if combined with `blue` or `link` on a `<Text>` inside a `TouchableOpacity`, collapse into `<TextButton>`     |
+| `noMargin`      | bool | `marginVertical: 0`                  | `twClassName="my-0"`                                                                                                                      |
+
+Note: Base/Text default style adds `marginVertical: 2` and `fontSize: scale(14)`. When migrating, the MMDS BodyMd variant (the default) will have different default spacing. This may produce minor layout shifts — note these in the PR.
+
+### Complete Component-Library TextVariant Enum
+
+Sourced from `app/component-library/components/Texts/Text/Text.types.ts`:
+
+| Old enum value             | New enum value          | Font weight change needed        |
+| -------------------------- | ----------------------- | -------------------------------- |
+| `TextVariant.DisplayLG`    | `TextVariant.DisplayLg` | No                               |
+| `TextVariant.DisplayMD`    | `TextVariant.DisplayMd` | No                               |
+| `TextVariant.HeadingLG`    | `TextVariant.HeadingLg` | No                               |
+| `TextVariant.HeadingMD`    | `TextVariant.HeadingMd` | No                               |
+| `TextVariant.HeadingSM`    | `TextVariant.HeadingSm` | No                               |
+| `TextVariant.BodyLGMedium` | `TextVariant.BodyLg`    | `fontWeight={FontWeight.Medium}` |
+| `TextVariant.BodyMD`       | `TextVariant.BodyMd`    | No                               |
+| `TextVariant.BodyMDMedium` | `TextVariant.BodyMd`    | `fontWeight={FontWeight.Medium}` |
+| `TextVariant.BodyMDBold`   | `TextVariant.BodyMd`    | `fontWeight={FontWeight.Bold}`   |
+| `TextVariant.BodySM`       | `TextVariant.BodySm`    | No                               |
+| `TextVariant.BodySMMedium` | `TextVariant.BodySm`    | `fontWeight={FontWeight.Medium}` |
+| `TextVariant.BodySMBold`   | `TextVariant.BodySm`    | `fontWeight={FontWeight.Bold}`   |
+| `TextVariant.BodyXS`       | `TextVariant.BodyXs`    | No                               |
+| `TextVariant.BodyXSMedium` | `TextVariant.BodyXs`    | `fontWeight={FontWeight.Medium}` |
+
+### Complete Component-Library TextColor Enum
+
+| Old                            | New                                                                 |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `TextColor.Default`            | `TextColor.TextDefault`                                             |
+| `TextColor.Alternative`        | `TextColor.TextAlternative`                                         |
+| `TextColor.Muted`              | `TextColor.TextMuted`                                               |
+| `TextColor.Primary`            | `TextColor.PrimaryDefault`                                          |
+| `TextColor.PrimaryAlternative` | Verify against MMDS package — likely `TextColor.PrimaryAlternative` |
+| `TextColor.Success`            | `TextColor.SuccessDefault`                                          |
+| `TextColor.Error`              | `TextColor.ErrorDefault`                                            |
+| `TextColor.ErrorAlternative`   | Verify against MMDS package                                         |
+| `TextColor.Warning`            | `TextColor.WarningDefault`                                          |
+| `TextColor.Info`               | `TextColor.InfoDefault`                                             |
+| `TextColor.Inverse`            | `TextColor.OverlayInverse`                                          |
+
+---
+
+## Examples from Existing Migrations (Ramp PR)
+
+These real examples from `refactor/6887_migrate-text-ramp` show correct patterns to follow.
+
+### Pattern: Layout StyleSheet + MMDS Text
+
+Keep `StyleSheet` for structural/layout styles. Use MMDS props for text appearance:
+
+```tsx
+// app/components/UI/Ramp/Aggregator/components/Account.tsx
+const createStyles = () =>
+  StyleSheet.create({
+    accountText: {
+      flexShrink: 1, // layout — stays in StyleSheet
+      marginVertical: 3, // positioning — stays in StyleSheet
+      marginHorizontal: 5, // positioning — stays in StyleSheet
+    },
+  });
+
+<Text style={styles.accountText} twClassName="text-center" numberOfLines={1}>
+  {accountName}
+</Text>;
+```
+
+### Pattern: TextButton for Link Text
+
+```tsx
+// app/components/UI/Ramp/Aggregator/components/RegionAlert.tsx
+import {
+  TextButton,
+  TextButtonSize,
+} from '@metamask/design-system-react-native';
+
+<TextButton
+  size={TextButtonSize.BodySm}
+  onPress={handleSupportLinkPress}
+  style={styles.link}
+>
+  {link as string}
+</TextButton>;
+```
+
+### Pattern: Conditional fontWeight from a Prop
+
+```tsx
+// app/components/UI/Ramp/Aggregator/components/ScreenLayout.tsx
+<Text
+  variant={TextVariant.BodyMd}
+  color={TextColor.TextDefault}
+  fontWeight={bold ? FontWeight.Bold : undefined}
+  twClassName="text-center"
+  style={titleStyle as any}
+>
+  {typeof title === 'function' ? title() : title}
+</Text>
+```
+
+### Pattern: Simple color + alignment
+
+```tsx
+// app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+<Text color={TextColor.TextAlternative} twClassName="text-center">
+  {description}
+</Text>
+```
+
+---
+
+## Constraints
+
+- Do **not** remove the deprecated Text components themselves until **all** usages across the entire codebase are migrated.
+- Do **not** migrate more than 5 files per run.
+- Do **not** mix files from different code owners in a single PR.
+- Do **not** refactor surrounding code, rename variables, or make unrelated improvements.
+- Follow `.cursor/rules/ui-development-guidelines.mdc`: design system first, `useTailwind`, `Box`/`Text` from design system.
+- Follow `.cursor/rules/general-coding-guidelines.mdc`: TypeScript only, no `any` (except pre-existing TODOs), yarn only.
+- If a file is too complex (e.g. deeply conditional styles, many `disclaimer`/`infoModal`/`reset` props, or a custom Text wrapper), skip it for this run, note it in memory, and flag it for manual review.

--- a/.cursor/commands/visual-regression-pr.md
+++ b/.cursor/commands/visual-regression-pr.md
@@ -1,0 +1,439 @@
+# Visual Regression PR — Before/After Screenshots
+
+Automates the full visual regression workflow for a GitHub PR: fetches changed files, captures before (base branch) and after (PR branch) screenshots in Storybook, uploads them to a dedicated `screenshots/visual-regression` branch, and posts a before/after comparison table as a PR comment.
+
+**Usage:** `/visual-regression-pr {PR_NUMBER}`
+
+---
+
+## Phase 1 — Preflight
+
+### Step 1a — Fetch PR metadata
+
+```bash
+gh pr view {PR_NUMBER} --json files,baseRefName,headRefName,title,url
+```
+
+If `gh` auth fails → stop immediately and print: `Run 'gh auth login' then retry.`
+If PR not found → stop and report the PR number.
+
+Record:
+
+- `PR_NUMBER` = the number passed as argument
+- `BASE_BRANCH` = `baseRefName`
+- `HEAD_BRANCH` = `headRefName`
+- `PR_TITLE` = `title`
+- `PR_URL` = `url`
+- `CHANGED_FILES` = full list of files from `files[].path`
+
+### Step 1b — Filter to renderable components
+
+From `CHANGED_FILES`, keep only files that pass **all** of these:
+
+**Keep if:**
+
+- Extension is `.tsx`
+- Filename (basename without extension) is PascalCase (starts with an uppercase letter)
+
+**Skip if any condition is true:**
+
+- Path contains `__snapshots__`
+- Filename ends in `.test.tsx` or `.spec.tsx`
+- Filename contains `.styles.` or `.types.`
+- Basename is `index.tsx`
+- Path contains any of: `/hooks/`, `/utils/`, `/util/`, `/routes/`, `/sdk/`, `/context/`
+
+Record the final list as `TARGET_FILES`. For each skipped file, record its path and the reason it was skipped.
+
+If `TARGET_FILES` is empty → stop and print a table of all files with their skip reasons.
+
+### Step 1c — Save current state
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+git stash push -u -m "visual-regression-pr-{PR_NUMBER}-autostash"
+```
+
+Record whether a stash was created (non-zero output = stash created, "No local changes" = no stash).
+
+### Step 1d — Create temp dirs
+
+```bash
+mkdir -p /tmp/vr-pr-{PR_NUMBER}/before
+mkdir -p /tmp/vr-pr-{PR_NUMBER}/after
+```
+
+---
+
+## Phase 2 — Before Pass (base branch)
+
+### Step 2a — Check out base branch
+
+```bash
+git checkout {BASE_BRANCH}
+git pull origin {BASE_BRANCH} --ff-only
+```
+
+### Step 2b — Enable Storybook in `index.js`
+
+In `index.js` at the project root:
+
+```js
+// Uncomment these two lines (currently lines 102-103):
+import Storybook from './.storybook';
+AppRegistry.registerComponent(name, () => Storybook);
+
+// Comment out the normal app registration (currently lines 108-111):
+// AppRegistry.registerComponent(name, () =>
+//   isE2E ? Root : Sentry.wrap(Root),
+// );
+```
+
+### Step 2c — Create sandbox story directory and stub
+
+```bash
+mkdir -p app/components/VisualRegressionSandbox
+```
+
+Write a minimal stub to `app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`:
+
+```tsx
+// TEMP FILE — visual regression only, do not commit
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+
+storiesOf('VisualRegression', module).add('Current', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 16 }} />
+));
+```
+
+### Step 2d — Regenerate Storybook manifest
+
+```bash
+yarn storybook-generate
+```
+
+### Step 2e — For each file in TARGET_FILES (before pass)
+
+Repeat for every file. **Never abort on a single failure — mark it SKIPPED and continue.**
+
+#### 2e-i. Derive flat PNG filename
+
+Replace every `/` with `_` in the relative path, change extension to `.png`:
+
+- `app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx`
+  → `app_components_UI_Card_components_CardMessageBox_CardMessageBox.png`
+
+Save target path: `/tmp/vr-pr-{PR_NUMBER}/before/<derived-filename>`
+
+#### 2e-ii. Write sandbox story (no pink borders — this is the before pass)
+
+Read the component's TypeScript interface and any test files or call sites to derive realistic props.
+
+Overwrite `app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx`:
+
+```tsx
+// TEMP FILE — visual regression only, do not commit
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import ComponentName from '../relative/path/to/ComponentName';
+
+storiesOf('VisualRegression', module).add('Current', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+    <ComponentName prop1="value" />
+  </View>
+));
+```
+
+**Props must reflect real usage** — read the component's TypeScript interface and any existing test files or call sites to pick realistic static values. Global decorators (ThemeProvider, SafeArea, Navigation, MockStore) apply automatically via `.storybook/preview.js`.
+
+#### 2e-iii. Navigate to the story in Storybook
+
+Use `mcp__ios-simulator__ui_describe_all` to confirm Storybook is visible.
+Navigate to **VisualRegression → Current** using `mcp__ios-simulator__ui_tap`.
+Wait for the component to render fully.
+
+If a red error screen is visible → mark this file SKIPPED with reason "Story crashed — missing context", continue to next file.
+
+#### 2e-iv. Take the screenshot
+
+```
+mcp__ios-simulator__screenshot → /tmp/vr-pr-{PR_NUMBER}/before/<derived-filename>
+```
+
+### Step 2f — Teardown after before pass
+
+1. Delete sandbox file and directory:
+
+   ```bash
+   rm app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx
+   rmdir app/components/VisualRegressionSandbox 2>/dev/null || true
+   ```
+
+2. Restore `index.js`:
+
+   ```js
+   // Re-comment Storybook lines:
+   // import Storybook from './.storybook';
+   // AppRegistry.registerComponent(name, () => Storybook);
+
+   // Uncomment normal app registration:
+   AppRegistry.registerComponent(name, () =>
+     isE2E ? Root : Sentry.wrap(Root),
+   );
+   ```
+
+3. Regenerate Storybook manifest:
+
+   ```bash
+   yarn storybook-generate
+   ```
+
+4. Verify clean working tree:
+   ```bash
+   git diff --name-only
+   ```
+   Output must be empty. If any files appear → **stop immediately**. Do not proceed to checkout until the tree is clean.
+
+---
+
+## Phase 3 — After Pass (PR branch)
+
+### Step 3a — Check out PR branch
+
+```bash
+git fetch origin {HEAD_BRANCH}
+git checkout {HEAD_BRANCH}
+```
+
+### Step 3b — Enable Storybook in `index.js`
+
+Same as Step 2b.
+
+### Step 3c — Recreate sandbox directory
+
+Same as Step 2c.
+
+### Step 3d — Regenerate Storybook manifest
+
+```bash
+yarn storybook-generate
+```
+
+### Step 3e — For each file in TARGET_FILES (after pass)
+
+Repeat for every file that was not already SKIPPED in the before pass.
+
+#### 3e-i. Derive flat PNG filename
+
+Same derivation as before pass. Save target path: `/tmp/vr-pr-{PR_NUMBER}/after/<derived-filename>`
+
+#### 3e-ii. Add pink highlight borders to MMDS `<Text>` elements
+
+In the target component file (on the PR branch), temporarily add `style={{ borderWidth: 2, borderColor: '#FF00FF' }}` to **every** `<Text>` element imported from `@metamask/design-system-react-native`.
+
+Rules:
+
+- No existing `style` prop → add `style={{ borderWidth: 2, borderColor: '#FF00FF' }}`
+- Existing inline object → merge: `style={{ ...existingStyles, borderWidth: 2, borderColor: '#FF00FF' }}`
+- Existing `styles.foo` reference → use array: `style={[styles.foo, { borderWidth: 2, borderColor: '#FF00FF' }]}`
+- Do **not** modify any other element types.
+
+#### 3e-iii. Write sandbox story
+
+Same as Step 2e-ii. Metro hot-reloads the pink-bordered component.
+
+#### 3e-iv. Navigate to the story in Storybook
+
+Same as Step 2e-iii. Mark SKIPPED on red error screen.
+
+#### 3e-v. Take the screenshot
+
+```
+mcp__ios-simulator__screenshot → /tmp/vr-pr-{PR_NUMBER}/after/<derived-filename>
+```
+
+#### 3e-vi. Remove pink borders
+
+Revert only the `borderWidth`/`borderColor` changes added in step 3e-ii. Verify with:
+
+```bash
+git diff <file>
+```
+
+No changes should remain in the component file. If any do → fix before moving to the next file.
+
+### Step 3f — Teardown after after pass
+
+Same as Step 2f. Verify clean working tree before proceeding.
+
+---
+
+## Phase 4 — Upload to `screenshots/visual-regression` branch
+
+Use a git worktree so the main checkout stays on `{HEAD_BRANCH}`.
+
+```bash
+WORKTREE=/tmp/mm-screenshots-worktree
+
+# Check if branch exists on remote:
+git fetch origin screenshots/visual-regression 2>/dev/null
+BRANCH_EXISTS=$?
+
+if [ $BRANCH_EXISTS -ne 0 ]; then
+  # Branch does not exist — create orphan
+  git worktree add --orphan -b screenshots/visual-regression $WORKTREE
+  cd $WORKTREE
+  echo "# MetaMask Mobile Visual Regression Screenshots" > README.md
+  git add README.md
+  git commit --author="georgewrmarshall <george.marshall@consensys.net>" -m "chore: initialize screenshots/visual-regression branch"
+  git push -u origin screenshots/visual-regression
+else
+  # Branch exists — check it out
+  git worktree add $WORKTREE screenshots/visual-regression
+  cd $WORKTREE
+  git pull --ff-only
+fi
+
+# Copy screenshots
+mkdir -p $WORKTREE/pr-{PR_NUMBER}/before $WORKTREE/pr-{PR_NUMBER}/after
+cp /tmp/vr-pr-{PR_NUMBER}/before/*.png $WORKTREE/pr-{PR_NUMBER}/before/
+cp /tmp/vr-pr-{PR_NUMBER}/after/*.png  $WORKTREE/pr-{PR_NUMBER}/after/
+
+# Commit and push
+cd $WORKTREE
+git add pr-{PR_NUMBER}/
+git commit --author="georgewrmarshall <george.marshall@consensys.net>" -m "chore: visual regression screenshots for PR #{PR_NUMBER}"
+git push origin screenshots/visual-regression
+
+# Clean up worktree
+cd -
+git worktree remove $WORKTREE --force
+```
+
+If `git push` fails → copy screenshots to `~/Desktop/vr-pr-{PR_NUMBER}/` as fallback and skip to Phase 5 (post comment body to stdout instead).
+
+Raw URL base for posted images:
+`https://raw.githubusercontent.com/MetaMask/metamask-mobile/screenshots/visual-regression/pr-{PR_NUMBER}/`
+
+---
+
+## Phase 5 — Post PR Comment
+
+Build the comment body. Use `{TODAY_DATE}` in `YYYY-MM-DD` format.
+
+```markdown
+## Visual Regression Screenshots — PR #{PR_NUMBER}
+
+> Auto-generated {TODAY_DATE}. Pink borders highlight migrated `<Text>` elements from `@metamask/design-system-react-native`.
+
+| Component       |                                                                       Before                                                                        |                                                                       After                                                                       |
+| --------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: |
+| `ComponentName` | ![before](https://raw.githubusercontent.com/MetaMask/metamask-mobile/screenshots/visual-regression/pr-{PR_NUMBER}/before/app_..._ComponentName.png) | ![after](https://raw.githubusercontent.com/MetaMask/metamask-mobile/screenshots/visual-regression/pr-{PR_NUMBER}/after/app_..._ComponentName.png) |
+```
+
+Add a row for each successfully captured component (before + after both present).
+
+If there were any skipped files, append:
+
+```markdown
+### Skipped
+
+| File                    | Reason                          |
+| ----------------------- | ------------------------------- |
+| `path/to/Component.tsx` | Story crashed — missing context |
+```
+
+Post the comment:
+
+```bash
+gh pr comment {PR_NUMBER} --body "$(cat <<'COMMENT_EOF'
+{COMMENT_BODY}
+COMMENT_EOF
+)"
+```
+
+If `gh pr comment` fails → print the full Markdown to stdout with instructions for manual paste.
+
+---
+
+## Phase 6 — Restore and Cleanup
+
+```bash
+git checkout {CURRENT_BRANCH}
+```
+
+If a stash was created in Step 1c:
+
+```bash
+git stash pop
+```
+
+If `stash pop` has conflicts → report them and do NOT auto-resolve. Leave the stash in place and tell the user.
+
+```bash
+rm -rf /tmp/vr-pr-{PR_NUMBER}
+```
+
+Verify:
+
+```bash
+git status
+git worktree list
+```
+
+`git status` should show a clean working tree (or only the original untracked files). `git worktree list` should show no `/tmp/mm-screenshots-worktree` entry.
+
+---
+
+## Final Summary
+
+Print a summary report:
+
+```
+Visual Regression — PR #{PR_NUMBER}: {PR_TITLE}
+
+Branch:   {HEAD_BRANCH} → {BASE_BRANCH}
+Date:     {TODAY_DATE}
+
+Captured ({N} components):
+  ✓ app/components/.../ComponentA.tsx
+  ✓ app/components/.../ComponentB.tsx
+
+Skipped ({M} components):
+  ✗ app/components/.../ComponentC.tsx — Story crashed — missing context
+
+Screenshots branch: https://github.com/MetaMask/metamask-mobile/tree/screenshots/visual-regression
+PR comment: {PR_URL}
+
+Working tree: clean
+Worktrees:   no leftovers
+```
+
+---
+
+## Error Handling Reference
+
+| Situation                                  | Action                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `gh` auth failure                          | Stop immediately. Print: `Run 'gh auth login' then retry.`                 |
+| PR not found                               | Stop. Report the PR number.                                                |
+| Zero renderable components after filtering | Stop. Print table of all files with skip reasons.                          |
+| Dirty working tree after cleanup           | Stop. Do not proceed to the next `git checkout`.                           |
+| Story crashes (red screen)                 | Mark SKIPPED, continue to next component. Never abort the run.             |
+| `git push` to screenshots branch fails     | Copy PNGs to `~/Desktop/vr-pr-{PR_NUMBER}/`. Print comment body to stdout. |
+| `stash pop` conflicts                      | Report to user. Leave stash in place. Do not auto-resolve.                 |
+| Missing `before/` PNG for a component      | Omit it from the PR comment table rather than posting a broken image URL.  |
+
+---
+
+## Notes
+
+- **`index.js` is touched exactly twice per pass** — once to enable Storybook, once to restore it. All component swaps go through the sandbox story + hot reload.
+- **The sandbox story is always temporary.** Never committed. `yarn storybook-generate` is run at start and end of each pass.
+- **Pink borders are temporary debug markup.** Verify with `git diff` after each component — they must never remain.
+- **The `screenshots/visual-regression` orphan branch** holds only screenshots — it has no shared history with `main`. It is safe to push to freely.
+- **Git worktree** keeps the main checkout on `{HEAD_BRANCH}` throughout the upload phase. Always remove it with `git worktree remove --force` before finishing.
+- **Stash is only created if there are local changes.** Check the output of `git stash push` before recording that a stash exists.

--- a/.cursor/commands/visual-regression-text-migration.md
+++ b/.cursor/commands/visual-regression-text-migration.md
@@ -1,0 +1,201 @@
+# Visual Regression Screenshot — Text Migration
+
+Captures screenshots of every component modified in the current migration branch, with a bright pink highlight border on each migrated `<Text>` element so reviewers can see exactly what changed. Images are saved to the Desktop for before/after comparison.
+
+---
+
+## When to Run
+
+Run this command **twice** to produce a full before/after pair:
+
+1. **Before** — check out `main`, run the command, screenshots saved to `~/Desktop/mmds-text-migration-<date>/before/`
+2. **After** — check out the migration branch, run the command, screenshots saved to `~/Desktop/mmds-text-migration-<date>/after/`
+
+Or run on the migration branch only to produce "after with highlights" screenshots for the PR description.
+
+---
+
+## Steps
+
+### Step 1 — Setup
+
+1. Get today's date in `YYYY-MM-DD` format.
+2. Create the output directories on the Desktop:
+   ```bash
+   mkdir -p ~/Desktop/mmds-text-migration-<date>/before
+   mkdir -p ~/Desktop/mmds-text-migration-<date>/after
+   ```
+3. Determine which component `.tsx` files were changed in this branch (excluding snapshots and style files):
+   ```bash
+   git diff main...HEAD --name-only | grep '\.tsx$' | grep -v '__snapshots__'
+   ```
+   This is your **target file list** for the run.
+
+---
+
+### Step 2 — Switch to Storybook mode (once)
+
+Modify `index.js` at the project root **once** at the start of the run — not per component:
+
+```js
+// Uncomment these two lines (currently lines 102-103):
+import Storybook from './.storybook';
+AppRegistry.registerComponent(name, () => Storybook);
+
+// Comment out the normal app registration (currently lines 108-111):
+// AppRegistry.registerComponent(name, () =>
+//   isE2E ? Root : Sentry.wrap(Root),
+// );
+```
+
+Create (or overwrite) the sandbox story file that will be reused for every component:
+
+```
+app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx
+```
+
+Register it with Storybook by running:
+
+```bash
+yarn storybook-generate
+```
+
+Wait for Metro to reload. All subsequent component swaps use hot reload — no further `index.js` changes until the very end.
+
+---
+
+### Step 3 — For Each Target File
+
+Repeat the sub-sequence below for every file in the target list.
+
+#### 3a. Derive the screenshot filename
+
+Convert the relative file path to a flat filename by replacing every `/` with `_`:
+
+- `app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx`
+  → `CardMessageBox.tsx.png`
+
+Save path: `~/Desktop/mmds-text-migration-<date>/after/<derived-filename>`
+
+#### 3b. Add pink highlight borders
+
+In the target component file, temporarily add `style={{ borderWidth: 2, borderColor: '#FF00FF' }}` to **every** `<Text>` element imported from `@metamask/design-system-react-native`.
+
+Rules:
+
+- No existing `style` prop → add `style={{ borderWidth: 2, borderColor: '#FF00FF' }}`
+- Existing inline object → merge: `style={{ ...existingStyles, borderWidth: 2, borderColor: '#FF00FF' }}`
+- Existing `styles.foo` reference → use array: `style={[styles.foo, { borderWidth: 2, borderColor: '#FF00FF' }]}`
+- Do **not** modify any other element types.
+
+#### 3c. Update the sandbox story
+
+Overwrite `VisualRegressionSandbox.stories.tsx` to render the current component with realistic static props. Metro hot-reloads the change in seconds.
+
+```tsx
+// app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx
+// TEMP FILE — used for visual regression screenshots only, do not commit
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+// Replace this import for each component:
+import CardMessageBox from '../UI/Card/components/CardMessageBox/CardMessageBox';
+
+storiesOf('VisualRegression', module).add('Current', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+    {/* Replace props to match real usage as closely as possible */}
+    <CardMessageBox
+      config={{
+        type: 'info',
+        title: 'Sample title',
+        description: 'Sample description for visual regression',
+      }}
+    />
+  </View>
+));
+```
+
+**Props should reflect real usage.** Read the component's TypeScript interface and any existing test files or call sites to pick realistic static values. The goal is the same visual output the user would see — not a minimal stub.
+
+If the component requires context providers (theme, navigation, Redux), wrap it appropriately. Check existing stories in the codebase for the correct decorator pattern.
+
+#### 3d. Navigate to the story in Storybook
+
+Use `mcp__ios-simulator__ui_describe_all` to confirm Storybook is visible.
+Navigate to **VisualRegression → Current** using `mcp__ios-simulator__ui_tap`.
+Wait for the component to render fully.
+
+#### 3e. Take the screenshot
+
+```
+mcp__ios-simulator__screenshot → save to ~/Desktop/mmds-text-migration-<date>/after/<derived-filename>
+```
+
+#### 3f. Remove pink borders
+
+Revert only the `borderWidth`/`borderColor` changes added in step 3b. Verify with `git diff <file>` — no other changes should be present.
+
+---
+
+### Step 4 — Teardown (once, after all components)
+
+1. **Delete the sandbox story file:**
+
+   ```bash
+   rm app/components/VisualRegressionSandbox/VisualRegressionSandbox.stories.tsx
+   rmdir app/components/VisualRegressionSandbox 2>/dev/null || true
+   ```
+
+2. **Restore `index.js`:**
+
+   ```js
+   // Re-comment the Storybook lines:
+   // import Storybook from './.storybook';
+   // AppRegistry.registerComponent(name, () => Storybook);
+
+   // Uncomment the normal app registration:
+   AppRegistry.registerComponent(name, () =>
+     isE2E ? Root : Sentry.wrap(Root),
+   );
+   ```
+
+3. **Regenerate Storybook requires** (removes the deleted story):
+
+   ```bash
+   yarn storybook-generate
+   ```
+
+4. **Verify clean working tree:**
+   ```bash
+   git diff --name-only
+   ```
+   Output must be empty (or only unrelated changes). If any `.tsx` files or `index.js` appear, the cleanup is incomplete — fix before finishing.
+
+---
+
+### Step 5 — Output Summary
+
+Report:
+
+```
+Screenshots saved to: ~/Desktop/mmds-text-migration-<date>/after/
+
+Files captured:
+  ✓ app_components_UI_Card_components_CardMessageBox_CardMessageBox.tsx.png
+  ✓ app_components_UI_Card_components_ManageCardListItem_ManageCardListItem.tsx.png
+  ✓ app_components_UI_Card_components_SpendingLimitProgressBar_SpendingLimitProgressBar.tsx.png
+  ✓ app_components_UI_Card_components_SpendingLimitWarning_SpendingLimitWarning.tsx.png
+
+Files skipped (with reason):
+  ✗ path/to/File.tsx — explain why even sandbox story could not render it
+```
+
+---
+
+## Notes
+
+- **`index.js` is only touched twice** — once to enable Storybook at the start, once to restore it at the end. All component swaps go through the sandbox story file and hot-reload.
+- **The sandbox story is always temporary.** It is never committed. `yarn storybook-generate` is run at start and end to keep the Storybook manifest consistent.
+- **Pink borders are temporary debug markup.** They must never be committed. Always verify with `git diff` after each component's cleanup.
+- **File naming uses the full relative path.** This makes it easy to match a screenshot back to its source file without ambiguity.
+- **Desktop folder persists across runs.** Screenshots overwrite on re-run — intentional for iteration.


### PR DESCRIPTION
## **Description**

Adds two Claude Code skill documents to `.cursor/commands/`:

- **`visual-regression-pr.md`** — new skill that automates the full visual regression workflow when invoked as `/visual-regression-pr {PR_NUMBER}`. Given a PR number it:
  1. Fetches changed files via `gh pr view`
  2. Filters to renderable React components (PascalCase `.tsx`, skips snapshots/tests/hooks/utils)
  3. Captures **before** screenshots on the base branch (no highlights)
  4. Captures **after** screenshots on the PR branch with pink `borderWidth`/`borderColor` highlights on every `<Text>` from `@metamask/design-system-react-native`
  5. Uploads both sets to a `screenshots/visual-regression` orphan branch via `git worktree`
  6. Posts a before/after comparison table as a PR comment via `gh pr comment`
  7. Restores the original branch and cleans up all temp state

- **`visual-regression-text-migration.md`** — existing skill for the manual single-branch capture flow (moved into version control).

Both skills use the iOS Simulator MCP (`mcp__ios-simulator__*`) and the existing Storybook sandbox approach (`VisualRegressionSandbox`) with Metro hot-reload for efficient multi-component capture.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: visual regression PR skill

  Scenario: user runs /visual-regression-pr on a component migration PR
    Given a PR number with changed .tsx component files
    When user invokes /visual-regression-pr {PR_NUMBER}
    Then before/ and after/ screenshots are captured for each component
    And screenshots are pushed to screenshots/visual-regression branch
    And a before/after table is posted as a PR comment
    And the working tree is clean after the run
```

## **Screenshots/Recordings**

### **Before**

N/A — tooling/skill file only

### **After**

N/A — tooling/skill file only

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds/updates agent command workflows; no production code paths are modified.
> 
> **Overview**
> Adds new agent/assistant documentation for automating visual regression screenshot collection around `Text` migration PRs.
> 
> Introduces a batch workflow (`visual-regression-collect`) that discovers migration PRs, captures shared "before" screenshots on `main` and per-PR "after" screenshots with temporary pink-bordered MMDS `Text`, uploads images to the `screenshots/visual-regression` branch via `git worktree`, and posts results as inline PR file comments (plus updating the PR body).
> 
> Also adds a Cursor automation playbook for daily `Text` component migrations and checks in command docs for running `/visual-regression-pr` and the existing `visual-regression-text-migration` capture flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 675810947300c27e79cf0765dc9d05473f594ac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->