### PR TITLE
test: MMQA-1598: move nock API mocking to component-view framework and align TrendingView tests

### DIFF
--- a/.agents/skills/component-view-test/SKILL.md
+++ b/.agents/skills/component-view-test/SKILL.md
@@ -56,6 +56,7 @@ tests/component-view/
 ├── mocks.ts              ← Engine + native mocks (import this first, always)
 ├── render.tsx            ← renderComponentViewScreen, renderScreenWithRoutes
 ├── stateFixture.ts       ← StateFixtureBuilder (createStateFixture)
+├── api-mocking/          ← HTTP API mocks (nock) — extensible, one file per feature
 ├── presets/              ← initialState<Feature>() builders — one file per feature area
 └── renderers/            ← render<Feature>View() functions — one file per feature area
 ```

--- a/.agents/skills/component-view-test/references/navigation-mocking.md
+++ b/.agents/skills/component-view-test/references/navigation-mocking.md
@@ -134,102 +134,62 @@ Route names live in `app/constants/navigation/Routes.ts`.
 
 ## External Service / API Mocking
 
-Some views call external services **directly** (not through Engine controllers) — e.g. a `getTrendingTokens()` function imported from a package, or a `fetch()` call to an external API. These cannot be driven through Redux state overrides.
+Some views call **external HTTP APIs** (e.g. `fetch()` to a REST endpoint). Those requests cannot be driven through Redux state. The framework provides an **api-mocking** layer using [nock](https://github.com/nock/nock) so tests intercept HTTP at the network level **without** using `jest.mock` on service modules (which would violate the “only Engine and allowed native mocks” rule).
 
-### Current pattern — jest.mock on the service module
+### Preferred pattern — nock (api-mocking folder)
 
-When a view calls an external service function directly, mock the module in a dedicated file under `tests/component-view/mocks/` and expose setup/clear helpers:
+All HTTP API mocks for component view tests live under `tests/component-view/api-mocking/`. Each feature has one file (e.g. `trending.ts`) that exports:
 
-```typescript
-// tests/component-view/mocks/myFeatureApiMocks.ts
-import { getMyFeatureData } from '@metamask/some-package';
+- Mock response data (e.g. `mockTrendingTokensData`)
+- A **setup** function (e.g. `setupTrendingApiFetchMock(responseData?, customReply?)`) that uses nock to intercept the endpoint
+- A **clear** function (e.g. `clearTrendingApiMocks()`) to call in `afterEach`
 
-export const getMyFeatureDataMock = getMyFeatureData as jest.Mock;
+Shared nock lifecycle helpers (`clearAllNockMocks`, `disableNetConnect`, `teardownNock`) are in `api-mocking/nockHelpers.ts`. To **add a new API mock** for another view, add a file `api-mocking/<feature>.ts` following the pattern in `api-mocking/trending.ts` (mock data, `setupXxxApiMock`, `clearXxxApiMocks` using `nockHelpers`), and call setup/clear in the view test’s `beforeEach`/`afterEach`.
 
-export const mockFeatureData = [
-  { id: 'item-1', name: 'Token A', price: '100.00', change24h: 5.2 },
-  { id: 'item-2', name: 'Token B', price: '200.00', change24h: -1.8 },
-];
-
-export const setupMyFeatureApiMock = (data = mockFeatureData) => {
-  getMyFeatureDataMock.mockImplementation(async () => data);
-};
-
-export const clearMyFeatureApiMocks = () => {
-  jest.clearAllMocks();
-};
-```
-
-In the test file, declare the `jest.mock` at module scope and use `beforeEach`/`afterEach` for lifecycle:
+**Example (trending):**
 
 ```typescript
-// NOTE: antipattern — only Engine and native modules should be mocked in view tests.
-// This is a temporary workaround for service functions called directly from components,
-// not through Engine. Track removal in the linked issue.
-// eslint-disable-next-line no-restricted-syntax
-jest.mock('@metamask/some-package', () => {
-  const actual = jest.requireActual('@metamask/some-package');
-  return { ...actual, getMyFeatureData: jest.fn().mockResolvedValue([]) };
-});
-
 import {
-  setupMyFeatureApiMock,
-  clearMyFeatureApiMocks,
-  mockFeatureData,
-  getMyFeatureDataMock,
-} from '../../../../tests/component-view/mocks/myFeatureApiMocks';
+  setupTrendingApiFetchMock,
+  clearTrendingApiMocks,
+  mockTrendingTokensData,
+  mockBnbChainToken,
+} from '../../../../tests/component-view/api-mocking/trending';
 
-describe('MyFeatureView', () => {
-  beforeEach(() => {
-    setupMyFeatureApiMock(mockFeatureData);
+beforeEach(() => {
+  setupTrendingApiFetchMock(mockTrendingTokensData);
+});
+afterEach(() => {
+  clearTrendingApiMocks();
+});
+
+it('user sees trending tokens section with mocked data', async () => {
+  const { findByText, queryByTestId } = renderTrendingViewWithRoutes();
+  await waitFor(async () => {
+    expect(await findByText('Ethereum')).toBeOnTheScreen();
   });
+  // assert rows with assertTrendingTokenRowsVisibility(...)
+});
 
-  afterEach(() => {
-    clearMyFeatureApiMocks();
+it('displays only BNB tokens when BNB Chain network filter is selected', async () => {
+  setupTrendingApiFetchMock(mockTrendingTokensData, (uri) => {
+    const url = new URL(uri, 'https://token.api.cx.metamask.io');
+    const chainIdsParam = url.searchParams.get('chainIds') ?? '';
+    const chainIds = chainIdsParam.split(',').map((s) => s.trim());
+    if (chainIds.length === 1 && chainIds[0] === 'eip155:56') {
+      return mockBnbChainToken;
+    }
+    return mockTrendingTokensData;
   });
-
-  it('shows token list after data loads from the external service', async () => {
-    const { findByText } = renderMyFeatureWithRoutes();
-
-    expect(await findByText('Token A')).toBeOnTheScreen();
-  });
-
-  it('shows only filtered results when a specific param is passed', async () => {
-    getMyFeatureDataMock.mockImplementation(async (params) => {
-      if (params?.chainId === 'eip155:56') return [mockBnbData];
-      return mockFeatureData;
-    });
-
-    const { findByText } = renderMyFeatureWithRoutes();
-    // ... interact to trigger the filter, then assert
-  });
+  const { getByTestId, findByText, queryByTestId } =
+    renderTrendingViewWithRoutes();
+  // ... navigate to full view, open network filter, select BNB Chain
+  // assert visible: [BNB], missing: [ETH, BTC, UNI]
 });
 ```
 
-> ⚠️ **This is a known antipattern.** The golden rule is that only Engine and allowed native modules should be mocked in `*.view.test.*` files. Mocking a service module directly bypasses the ESLint guard (note the `eslint-disable` comment). Always link to a tracking issue and plan to migrate to a proper solution.
+### Fallback — jest.mock on the service module (antipattern)
 
-### Future pattern — Mock Service Worker (MSW)
+When a view calls an external **function** (not `fetch`) from a package and that function cannot be replaced by nock (e.g. no HTTP), you may mock the module in a file under `tests/component-view/mocks/` and use setup/clear helpers. This requires an `eslint-disable` and is a **known antipattern**; prefer moving the integration to an HTTP API and using api-mocking, or drive data through Engine/Redux when possible.
 
-> 📌 **Placeholder — no example exists yet in this codebase.**
-
-For views that call HTTP endpoints directly (via `fetch`), the intended approach is [Mock Service Worker (msw)](https://mswjs.io/), which intercepts requests at the network level without needing `jest.mock`. This keeps tests closer to real behavior and avoids the module-mock antipattern.
-
-When the first MSW-based view test is written, document the setup here:
-
-```typescript
-// TODO: Add MSW setup example once the first test using it is merged.
-// Expected shape:
-//
-// import { setupServer } from 'msw/node';
-// import { http, HttpResponse } from 'msw';
-//
-// const server = setupServer(
-//   http.get('https://api.example.com/tokens', () =>
-//     HttpResponse.json(mockTokensData),
-//   ),
-// );
-//
-// beforeAll(() => server.listen());
-// afterEach(() => server.resetHandlers());
-// afterAll(() => server.close());
-```
+> ⚠️ Only Engine and allowed native modules should be mocked in `*.view.test.*` files. Mocking a service module directly bypasses the ESLint guard. Always link to a tracking issue and plan to migrate to nock (api-mocking) or Engine/Redux.

--- a/.agents/skills/component-view-test/references/reference.md
+++ b/.agents/skills/component-view-test/references/reference.md
@@ -203,6 +203,7 @@ yarn eslint <path/to/test.tsx>
 | Engine + native mocks          | `tests/component-view/mocks.ts`                                |
 | render, renderScreenWithRoutes | `tests/component-view/render.tsx`                              |
 | StateFixtureBuilder            | `tests/component-view/stateFixture.ts`                         |
+| HTTP API mocks (nock)          | `tests/component-view/api-mocking/` (per-feature)              |
 | Feature renderers (per view)   | `tests/component-view/renderers/` (e.g. bridge, wallet)        |
 | Feature presets (per view)     | `tests/component-view/presets/` (e.g. bridge, wallet)          |
 | DeepPartial type               | `app/util/test/renderWithProvider`                             |

--- a/.agents/skills/component-view-test/references/writing-tests.md
+++ b/.agents/skills/component-view-test/references/writing-tests.md
@@ -12,6 +12,7 @@ Before writing any test, read:
 - Any existing `*.view.test.tsx` for the same component
 - The relevant preset(s) in `tests/component-view/presets/`
 - The relevant renderer(s) in `tests/component-view/renderers/`
+- If the view calls an external HTTP API: `tests/component-view/api-mocking/` and any existing `api-mocking/<feature>.ts` for that API (see navigation-mocking.md, External Service / API Mocking)
 
 ---
 

--- a/app/components/Views/TrendingView/TrendingView.testIds.ts
+++ b/app/components/Views/TrendingView/TrendingView.testIds.ts
@@ -3,6 +3,15 @@ export const TrendingViewSelectorsIDs = {
   QUICK_ACTIONS_SCROLL_VIEW: 'quick-actions-scroll-view',
   EXPLORE_HEADER_ROOT: 'explore-header-root',
   EXPLORE_SAFE_AREA: 'explore-safe-area',
+  SECTION_HEADER_VIEW_ALL_TOKENS: 'section-header-view-all-tokens',
+  TRENDING_TOKENS_HEADER: 'trending-tokens-header',
+  EXPLORE_VIEW_SEARCH_BUTTON: 'explore-view-search-button',
+  EXPLORE_VIEW_SEARCH_INPUT: 'explore-view-search-input',
+  TRENDING_SEARCH_RESULTS_LIST: 'trending-search-results-list',
+  ALL_NETWORKS_BUTTON: 'all-networks-button',
+  CLOSE_BUTTON: 'close-button',
+  TRENDING_TOKENS_HEADER_SEARCH_TOGGLE: 'trending-tokens-header-search-toggle',
+  TRENDING_TOKENS_HEADER_SEARCH_BAR: 'trending-tokens-header-search-bar',
 } as const;
 
 export type TrendingViewSelectorsIDsType = typeof TrendingViewSelectorsIDs;

--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -7,7 +7,7 @@ import {
   clearTrendingApiMocks,
   mockTrendingTokensData,
   mockBnbChainToken,
-} from '../../../../tests/component-view/mocks/trendingApiMocks';
+} from '../../../../tests/component-view/api-mocking/trending';
 import {
   fireEvent,
   waitFor,
@@ -79,31 +79,35 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
     clearTrendingApiMocks();
   });
 
-  it('renders Explore screen wrapped in SafeAreaView', async () => {
-    const { getByTestId } = renderTrendingViewWithRoutes();
+  it('Explore screen shows safe area, header and title and user can open trending full view', async () => {
+    const { getByTestId, getByText } = renderTrendingViewWithRoutes();
 
     await waitFor(() => {
       expect(
         getByTestId(TrendingViewSelectorsIDs.EXPLORE_SAFE_AREA),
       ).toBeOnTheScreen();
-    });
-  });
-
-  it('renders HeaderRoot on Explore screen', async () => {
-    const { getByTestId } = renderTrendingViewWithRoutes();
-
-    await waitFor(() => {
       expect(
         getByTestId(TrendingViewSelectorsIDs.EXPLORE_HEADER_ROOT),
       ).toBeOnTheScreen();
+      expect(getByText('Explore')).toBeOnTheScreen();
     });
-  });
-
-  it('renders Explore title on Explore screen', async () => {
-    const { getByText } = renderTrendingViewWithRoutes();
 
     await waitFor(() => {
-      expect(getByText('Explore')).toBeOnTheScreen();
+      expect(
+        getByTestId(TrendingViewSelectorsIDs.TRENDING_FEED_SCROLL_VIEW),
+      ).toBeOnTheScreen();
+    });
+
+    const viewAllButton = getByTestId(
+      TrendingViewSelectorsIDs.SECTION_HEADER_VIEW_ALL_TOKENS,
+    );
+    await actButtonPress(viewAllButton);
+
+    await waitFor(() => {
+      const header = getByTestId(
+        TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER,
+      );
+      expect(header).toHaveTextContent('Trending tokens');
     });
   });
 
@@ -145,11 +149,15 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
       ).toBeOnTheScreen();
     });
 
-    const viewAllButton = getByTestId('section-header-view-all-tokens');
+    const viewAllButton = getByTestId(
+      TrendingViewSelectorsIDs.SECTION_HEADER_VIEW_ALL_TOKENS,
+    );
     await actButtonPress(viewAllButton);
 
     await waitFor(() => {
-      const header = getByTestId('trending-tokens-header');
+      const header = getByTestId(
+        TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER,
+      );
       expect(header).toHaveTextContent('Trending tokens');
     });
 
@@ -184,16 +192,20 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
       ).toBeOnTheScreen();
     });
 
-    const searchButton = getByTestId('explore-view-search-button');
+    const searchButton = getByTestId(
+      TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_BUTTON,
+    );
     await actButtonPress(searchButton);
 
-    const searchInput = await findByTestId('explore-view-search-input');
+    const searchInput = await findByTestId(
+      TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_INPUT,
+    );
     expect(searchInput).toBeOnTheScreen();
 
     await userEvent.type(searchInput, 'ethereum');
 
     const searchResultsList = await findByTestId(
-      'trending-search-results-list',
+      TrendingViewSelectorsIDs.TRENDING_SEARCH_RESULTS_LIST,
     );
 
     await assertTrendingTokenRowsVisibility({
@@ -238,11 +250,15 @@ describeForPlatforms('TrendingTokensFullView - Component Tests', () => {
       ).toBeOnTheScreen();
     });
 
-    const viewAllButton = getByTestId('section-header-view-all-tokens');
+    const viewAllButton = getByTestId(
+      TrendingViewSelectorsIDs.SECTION_HEADER_VIEW_ALL_TOKENS,
+    );
     await actButtonPress(viewAllButton);
 
     await waitFor(() => {
-      expect(getByTestId('trending-tokens-header')).toBeOnTheScreen();
+      expect(
+        getByTestId(TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER),
+      ).toBeOnTheScreen();
     });
 
     await assertTrendingTokenRowsVisibility({
@@ -255,11 +271,15 @@ describeForPlatforms('TrendingTokensFullView - Component Tests', () => {
       missing: [{ id: TRENDING_BNB_ID }],
     });
 
-    const networkButton = getByTestId('all-networks-button');
+    const networkButton = getByTestId(
+      TrendingViewSelectorsIDs.ALL_NETWORKS_BUTTON,
+    );
     await actButtonPress(networkButton);
 
     await waitFor(() => {
-      expect(getByTestId('close-button')).toBeOnTheScreen();
+      expect(
+        getByTestId(TrendingViewSelectorsIDs.CLOSE_BUTTON),
+      ).toBeOnTheScreen();
     });
 
     const bnbNetworkOption = await findByText('BNB Chain');
@@ -288,17 +308,25 @@ describeForPlatforms('TrendingTokensFullView - Component Tests', () => {
       ).toBeOnTheScreen();
     });
 
-    const viewAllButton = getByTestId('section-header-view-all-tokens');
+    const viewAllButton = getByTestId(
+      TrendingViewSelectorsIDs.SECTION_HEADER_VIEW_ALL_TOKENS,
+    );
     await actButtonPress(viewAllButton);
 
     await waitFor(() => {
-      expect(getByTestId('trending-tokens-header')).toBeOnTheScreen();
+      expect(
+        getByTestId(TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER),
+      ).toBeOnTheScreen();
     });
 
-    const searchToggle = getByTestId('trending-tokens-header-search-toggle');
+    const searchToggle = getByTestId(
+      TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER_SEARCH_TOGGLE,
+    );
     await actButtonPress(searchToggle);
 
-    const searchInput = await findByTestId('trending-tokens-header-search-bar');
+    const searchInput = await findByTestId(
+      TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER_SEARCH_BAR,
+    );
     expect(searchInput).toBeOnTheScreen();
 
     await userEvent.type(searchInput, 'ethereum');

--- a/tests/component-view/AGENTS.md
+++ b/tests/component-view/AGENTS.md
@@ -29,9 +29,16 @@ tests/component-view/
 ├── mocks.ts              ← Engine + native mocks (import this first, always)
 ├── render.tsx            ← renderComponentViewScreen, renderScreenWithRoutes
 ├── stateFixture.ts       ← StateFixtureBuilder, createStateFixture, deepMerge
+├── api-mocking/          ← HTTP API mocks (nock) — one file per feature, extensible
 ├── presets/              ← initialState<Feature>() builders — one file per feature
 └── renderers/            ← render<Feature>View() functions — one file per feature
 ```
+
+### API mocking (external HTTP) {#api-mocking}
+
+- **Directory:** [api-mocking/](api-mocking/)
+- **Role:** Intercept external HTTP APIs used by views (e.g. trending tokens) via [nock](https://github.com/nock/nock). No `jest.mock` of service modules; network-level interception is allowed. One file per feature (e.g. `trending.ts`); shared helpers in `nockHelpers.ts`.
+- **Usage:** In view tests that need an API mock, import `setupXxxApiMock` and `clearXxxApiMocks` from `tests/component-view/api-mocking/<feature>`, call setup in `beforeEach` and clear in `afterEach`. To add a new API mock, copy the pattern from `api-mocking/trending.ts` and use `nockHelpers.ts`; see also navigation-mocking.md (External Service / API Mocking).
 
 ### Mocks {#framework-mocks}
 
@@ -98,6 +105,7 @@ For run-by-name, watch mode, or other options, see the skill’s [references/ref
 ## Implementation reference {#implementation-reference}
 
 - Mocks: [mocks.ts](mocks.ts)
+- API mocking (nock): [api-mocking/](api-mocking/)
 - Presets: [presets/](presets/)
 - Renderers: [renderers/](renderers/)
 - State fixture: [stateFixture.ts](stateFixture.ts)

--- a/tests/component-view/api-mocking/nockHelpers.ts
+++ b/tests/component-view/api-mocking/nockHelpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared nock helpers for component view tests that mock external HTTP APIs.
+ * Use these so all API-mocking features share the same teardown behavior and
+ * tests can combine multiple feature mocks without leaks.
+ *
+ * Usage:
+ * - In your feature's setup (e.g. setupXxxApiMock): call nock.cleanAll() and
+ * nock.disableNetConnect() before defining interceptors, then nock('<origin>').get(...).reply(...).persist().
+ * - In afterEach: call clearAllNockMocks() (or your feature's clearXxxMocks() which should call this).
+ *
+ * @see tests/component-view/api-mocking/ (e.g. trending.ts) and references/navigation-mocking.md
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import nock from 'nock';
+
+/**
+ * Clears all nock interceptors. Call in afterEach of any test file that uses
+ * API mocks so the next test or suite does not see previous interceptors.
+ * Feature-specific clear helpers (e.g. clearTrendingApiMocks) should call this
+ * and any feature-specific cleanup (e.g. jest.clearAllMocks).
+ */
+export function clearAllNockMocks(): void {
+  nock.cleanAll();
+}
+
+/**
+ * Disables real network connections for the current test run. Call at the
+ * start of your feature's setup (e.g. in setupXxxApiMock) so unmocked requests
+ * fail fast instead of hitting the network.
+ */
+export function disableNetConnect(): void {
+  nock.disableNetConnect();
+}
+
+/**
+ * Restores nock to a clean state: removes all interceptors and re-enables
+ * net connect. Use in afterEach if you need to fully reset nock (e.g. when
+ * switching between test suites that use different mock strategies).
+ * Most tests only need clearAllNockMocks().
+ */
+export function teardownNock(): void {
+  nock.cleanAll();
+  nock.enableNetConnect();
+}

--- a/tests/component-view/api-mocking/trending.ts
+++ b/tests/component-view/api-mocking/trending.ts
@@ -1,5 +1,15 @@
+/**
+ * Trending tokens API mock for component view tests.
+ * Intercepts GET https://token.api.cx.metamask.io/v3/tokens/trending via nock.
+ *
+ * Use in beforeEach/afterEach of TrendingView.view.test.tsx (or any view that
+ * loads trending data). See tests/component-view/api-mocking/ and references/navigation-mocking.md for adding other API mocks.
+ */
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import nock from 'nock';
+import { clearAllNockMocks, disableNetConnect } from './nockHelpers';
+
 export interface MockTrendingToken {
   assetId: string;
   name: string;
@@ -70,36 +80,39 @@ export const mockBnbChainToken: MockTrendingToken[] = [
   },
 ];
 
+const TRENDING_ORIGIN = 'https://token.api.cx.metamask.io';
+const TRENDING_PATH = '/v3/tokens/trending';
+
 /**
- * Setup mock for the trending tokens API using nock.
+ * Sets up the nock mock for the trending tokens API.
  * Intercepts GET requests to the trending URL (any query params) and replies with the given data.
  * Optional customReply(uri) can return different data based on the request URL (e.g. for BNB-only requests).
- * Call in beforeEach: setupTrendingApiFetchMock(...) or await setupTrendingApiFetchMock(...)
+ * Call in beforeEach: setupTrendingApiFetchMock(...)
  */
 export function setupTrendingApiFetchMock(
   responseData: MockTrendingToken[] = mockTrendingTokensData,
   customReply?: (uri: string) => MockTrendingToken[],
 ): void {
-  nock.cleanAll();
-  nock.disableNetConnect();
+  clearAllNockMocks();
+  disableNetConnect();
 
   const replyBody =
-    customReply !== undefined
-      ? (uri: string) => customReply(uri)
-      : () => responseData;
+    customReply === undefined
+      ? () => responseData
+      : (uri: string) => customReply(uri);
 
-  nock('https://token.api.cx.metamask.io')
-    .get('/v3/tokens/trending')
+  nock(TRENDING_ORIGIN)
+    .get(TRENDING_PATH)
     .query(true)
-    .reply(200, (uri) => replyBody(uri))
+    .reply(200, (uri: string) => replyBody(uri))
     .persist();
 }
 
 /**
- * Clear nock interceptors and Jest mocks.
- * Call this in afterEach of your tests.
+ * Clears nock interceptors and Jest mocks for trending tests.
+ * Call in afterEach of your tests.
  */
 export function clearTrendingApiMocks(): void {
   jest.clearAllMocks();
-  nock.cleanAll();
+  clearAllNockMocks();
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
*Reason for the change**

- Component view tests that mock external HTTP APIs (e.g. trending tokens) were using a one-off mock under `tests/component-view/mocks/`, which was not reusable or documented for other views.
- `TrendingView.view.test.tsx` had three render-only tests (framework rule: every test must be interaction-driven) and used raw testID strings instead of constants.

**Improvement / solution**

1. **Extensible API-mocking in the framework**
   - Added `tests/component-view/api-mocking/` with:
     - `nockHelpers.ts`: shared helpers `clearAllNockMocks()`, `disableNetConnect()`, `teardownNock()` for nock lifecycle.
     - `trending.ts`: trending tokens API mock (moved from `mocks/trendingApiMocks.ts`), using the helpers. Other views can add their own `api-mocking/<feature>.ts` following the same pattern.
   - Removed `tests/component-view/mocks/trendingApiMocks.ts`.
   - Updated `TrendingView.view.test.tsx` to import from `api-mocking/trending`.

2. **TrendingView component view tests**
   - Replaced the three render-only tests (“renders Explore screen…”, “renders HeaderRoot…”, “renders Explore title…”) with a single interaction-driven test: “Explore screen shows safe area, header and title and user can open trending full view” (layout assertions + tap “View all” + assert full view).
   - Replaced all raw `getByTestId` / `findByTestId` strings with constants from `TrendingView.testIds.ts`.
   - Added missing testIDs to `TrendingView.testIds.ts` (e.g. `SECTION_HEADER_VIEW_ALL_TOKENS`, `TRENDING_TOKENS_HEADER`, `EXPLORE_VIEW_SEARCH_BUTTON`, etc.).

3. **Documentation**
   - Updated `tests/component-view/AGENTS.md` (framework structure + API mocking section).
   - Updated component-view-test skill: `SKILL.md`, `references/navigation-mocking.md` (nock as preferred pattern for external HTTP APIs), `references/reference.md` (Key locations), `references/writing-tests.md` (read api-mocking when view calls HTTP APIs).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces network-level HTTP mocking for component view tests and updates TrendingView tests to rely on it, which may affect test isolation and any suites that implicitly depend on real network connectivity.
> 
> **Overview**
> Adds a new `tests/component-view/api-mocking/` layer for component view tests that intercepts external HTTP requests via **nock**, including shared lifecycle utilities (`nockHelpers.ts`) and a first feature mock for the trending tokens endpoint.
> 
> Migrates `TrendingView.view.test.tsx` to use the new nock-based mocks (replacing prior service-module mocking) and expands/standardizes selector usage by adding missing `TrendingViewSelectorsIDs` constants and removing raw `testID` strings.
> 
> Updates the component-view testing documentation (skill + references + `tests/component-view/AGENTS.md`) to document the preferred HTTP API mocking approach and relegate `jest.mock` of service modules to an explicit antipattern/fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc96ab394c92f5046e2672aee5ec45d2c248c549. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->