### PR TITLE
refactor(ramp): align TokenSelection rows with app token list typography and cadence

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -3184,7 +3184,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -3219,10 +3222,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3329,7 +3332,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -3348,7 +3351,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3361,10 +3364,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3413,7 +3416,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -3448,10 +3454,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3558,7 +3564,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -3577,7 +3583,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3590,10 +3596,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3627,7 +3633,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -3662,10 +3671,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3772,7 +3781,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -3791,7 +3800,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3804,10 +3813,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3841,7 +3850,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -3876,10 +3888,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3986,7 +3998,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4005,7 +4017,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4018,10 +4030,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4055,7 +4067,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -4090,10 +4105,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4200,7 +4215,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4219,7 +4234,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4232,10 +4247,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -3184,10 +3184,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -3416,10 +3415,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -3633,10 +3631,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -3850,10 +3847,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -4067,10 +4063,9 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -1686,7 +1686,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -1721,10 +1724,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -1831,7 +1834,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -1850,7 +1853,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -1863,10 +1866,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -1877,7 +1880,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -1986,7 +1989,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -2021,10 +2027,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -2131,7 +2137,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -2150,7 +2156,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -2163,10 +2169,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2177,7 +2183,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -2286,7 +2292,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -2321,10 +2330,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -2431,7 +2440,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -2450,7 +2459,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -2463,10 +2472,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2477,7 +2486,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -2586,7 +2595,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -2621,10 +2633,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -2731,7 +2743,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -2750,7 +2762,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -2763,10 +2775,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -2777,7 +2789,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -2886,7 +2898,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -2921,10 +2936,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -3031,7 +3046,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -3050,7 +3065,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -3063,10 +3078,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -3077,7 +3092,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4006,7 +4021,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -4041,10 +4059,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4151,7 +4169,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4170,7 +4188,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4183,10 +4201,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4197,7 +4215,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4306,7 +4324,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -4341,10 +4362,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4451,7 +4472,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4470,7 +4491,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4483,10 +4504,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4497,7 +4518,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4606,7 +4627,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -4641,10 +4665,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -4751,7 +4775,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4770,7 +4794,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -4783,10 +4807,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -4797,7 +4821,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -4906,7 +4930,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -4941,10 +4968,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -5051,7 +5078,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -5070,7 +5097,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -5083,10 +5110,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -5097,7 +5124,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -5206,7 +5233,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
+                                        "height": 64,
                                         "padding": 16,
+                                        "paddingHorizontal": 16,
+                                        "paddingVertical": 12,
                                       }
                                     }
                                   >
@@ -5241,10 +5271,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                               style={
                                                 {
                                                   "backgroundColor": "#ffffff",
-                                                  "borderRadius": 16,
-                                                  "height": 32,
+                                                  "borderRadius": 20,
+                                                  "height": 40,
                                                   "overflow": "hidden",
-                                                  "width": 32,
+                                                  "width": 40,
                                                 }
                                               }
                                             >
@@ -5351,7 +5381,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"
@@ -5370,7 +5400,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
+                                              "fontSize": 16,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             }
@@ -5383,10 +5413,10 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                           style={
                                             {
                                               "color": "#66676a",
-                                              "fontFamily": "Geist-Regular",
-                                              "fontSize": 16,
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 14,
                                               "letterSpacing": 0,
-                                              "lineHeight": 24,
+                                              "lineHeight": 22,
                                             }
                                           }
                                         >
@@ -5397,7 +5427,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                         accessible={false}
                                         style={
                                           {
-                                            "width": 16,
+                                            "width": 20,
                                           }
                                         }
                                         testID="listitem-gap"

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -1686,10 +1686,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -1989,10 +1988,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -2292,10 +2290,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -2595,10 +2592,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -2898,10 +2894,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -4021,10 +4016,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -4324,10 +4318,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -4627,10 +4620,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -4930,10 +4922,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >
@@ -5233,10 +5224,9 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                     accessible={true}
                                     style={
                                       {
-                                        "height": 64,
                                         "padding": 16,
                                         "paddingHorizontal": 16,
-                                        "paddingVertical": 12,
+                                        "paddingVertical": 8,
                                       }
                                     }
                                   >

--- a/app/components/UI/Ramp/components/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Ramp/components/TokenListItem/TokenListItem.tsx
@@ -54,6 +54,10 @@ function TokenListItem({
       onPress={onPress}
       isDisabled={isDisabled}
       testID={`token-list-item-${token.assetId}`}
+      gap={20}
+      listItemProps={{
+        style: { height: 64, paddingVertical: 12, paddingHorizontal: 16 },
+      }}
     >
       <ListItemColumn widthType={WidthType.Auto}>
         <BadgeWrapper
@@ -68,13 +72,13 @@ function TokenListItem({
           <AvatarToken
             name={token.name}
             imageSource={{ uri: token.iconUrl }}
-            size={AvatarSize.Md}
+            size={AvatarSize.Lg}
           />
         </BadgeWrapper>
       </ListItemColumn>
       <ListItemColumn widthType={WidthType.Fill}>
-        <Text variant={TextVariant.BodyLGMedium}>{token.name}</Text>
-        <Text variant={TextVariant.BodyMD} color={textColor}>
+        <Text variant={TextVariant.BodyMDMedium}>{token.name}</Text>
+        <Text variant={TextVariant.BodySMMedium} color={textColor}>
           {token.symbol}
         </Text>
       </ListItemColumn>

--- a/app/components/UI/Ramp/components/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Ramp/components/TokenListItem/TokenListItem.tsx
@@ -56,7 +56,7 @@ function TokenListItem({
       isDisabled={isDisabled}
       gap={20}
       listItemProps={{
-        style: { height: 64, paddingVertical: 12, paddingHorizontal: 16 },
+        style: { paddingVertical: 8, paddingHorizontal: 16 },
       }}
       testID={`${TOKEN_LIST_ITEM_TEST_IDS.ITEM_PREFIX}${token.assetId}`}
     >

--- a/app/components/UI/Ramp/components/TokenListItem/__snapshots__/TokenListItem.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenListItem/__snapshots__/TokenListItem.test.tsx.snap
@@ -19,10 +19,9 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
     accessible={true}
     style={
       {
-        "height": 64,
         "padding": 16,
         "paddingHorizontal": 16,
-        "paddingVertical": 12,
+        "paddingVertical": 8,
       }
     }
   >
@@ -237,10 +236,9 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
     accessible={true}
     style={
       {
-        "height": 64,
         "padding": 16,
         "paddingHorizontal": 16,
-        "paddingVertical": 12,
+        "paddingVertical": 8,
       }
     }
   >

--- a/app/components/UI/Ramp/components/TokenListItem/__snapshots__/TokenListItem.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenListItem/__snapshots__/TokenListItem.test.tsx.snap
@@ -19,7 +19,10 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
     accessible={true}
     style={
       {
+        "height": 64,
         "padding": 16,
+        "paddingHorizontal": 16,
+        "paddingVertical": 12,
       }
     }
   >
@@ -54,10 +57,10 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
               style={
                 {
                   "backgroundColor": "#ffffff",
-                  "borderRadius": 16,
-                  "height": 32,
+                  "borderRadius": 20,
+                  "height": 40,
                   "overflow": "hidden",
-                  "width": 32,
+                  "width": 40,
                 }
               }
             >
@@ -168,7 +171,7 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
         accessible={false}
         style={
           {
-            "width": 16,
+            "width": 20,
           }
         }
         testID="listitem-gap"
@@ -187,7 +190,7 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
             {
               "color": "#131416",
               "fontFamily": "Geist-Medium",
-              "fontSize": 20,
+              "fontSize": 16,
               "letterSpacing": 0,
               "lineHeight": 24,
             }
@@ -200,10 +203,10 @@ exports[`TokenListItem basic rendering renders correctly and matches snapshot 1`
           style={
             {
               "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
+              "fontFamily": "Geist-Medium",
+              "fontSize": 14,
               "letterSpacing": 0,
-              "lineHeight": 24,
+              "lineHeight": 22,
             }
           }
         >
@@ -234,7 +237,10 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
     accessible={true}
     style={
       {
+        "height": 64,
         "padding": 16,
+        "paddingHorizontal": 16,
+        "paddingVertical": 12,
       }
     }
   >
@@ -269,10 +275,10 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
               style={
                 {
                   "backgroundColor": "#ffffff",
-                  "borderRadius": 16,
-                  "height": 32,
+                  "borderRadius": 20,
+                  "height": 40,
                   "overflow": "hidden",
-                  "width": 32,
+                  "width": 40,
                 }
               }
             >
@@ -383,7 +389,7 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
         accessible={false}
         style={
           {
-            "width": 16,
+            "width": 20,
           }
         }
         testID="listitem-gap"
@@ -402,7 +408,7 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
             {
               "color": "#131416",
               "fontFamily": "Geist-Medium",
-              "fontSize": 20,
+              "fontSize": 16,
               "letterSpacing": 0,
               "lineHeight": 24,
             }
@@ -415,10 +421,10 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
           style={
             {
               "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
+              "fontFamily": "Geist-Medium",
+              "fontSize": 14,
               "letterSpacing": 0,
-              "lineHeight": 24,
+              "lineHeight": 22,
             }
           }
         >
@@ -429,7 +435,7 @@ exports[`TokenListItem basic rendering renders disabled token with info button a
         accessible={false}
         style={
           {
-            "width": 16,
+            "width": 20,
           }
         }
         testID="listitem-gap"


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Token rows and spacing in the Ramp TokenSelection screen did not match the rest of the app (homepage token section, token full view, Cash section). This change aligns typography and cadence so the experience is consistent.

1. **Reason for the change:** Inconsistent token row styling in Ramp TokenSelection compared to homepage tokens, token full view, and Cash section.
2. **Improvement:** Ramp `TokenListItem` now uses the same typography (BodyMDMedium for name, BodySMMedium for symbol), avatar size (Lg), row height (64px), and avatar-to-text gap (20px) as the app token list components. Snapshots updated accordingly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update Token Selection list for the Buy flow.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramp token selection

  Scenario: user opens token selection in Ramp flow
    Given the user is in the Ramp (buy) flow and has reached the token selection screen

    When the token list is displayed
    Then token rows use the same typography and spacing as the homepage token section (name/symbol size, avatar size, row height, spacing between avatar and text)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


<img width="719" height="745" alt="tl_b" src="https://github.com/user-attachments/assets/49f65d20-784a-4534-80c1-9f9cbdd8d084" />


### **After**

<img width="719" height="745" alt="tl_a" src="https://github.com/user-attachments/assets/b6c8e5ee-b6d2-40b3-96f6-83af9ca83bc6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only adjustments to `TokenListItem` styling (spacing, typography, avatar sizing) with snapshot updates; minimal behavioral risk beyond potential visual/layout regressions.
> 
> **Overview**
> Aligns Ramp token selection rows with the app’s standard token list styling by adjusting `TokenListItem` layout and typography: increases avatar size, widens avatar-to-text gap, tweaks row padding/height, and updates name/symbol text variants.
> 
> Updates associated Jest snapshots for `TokenSelectorModal`, `TokenSelection`, and `TokenListItem` to match the new rendered styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28b4a07f500efd3fa4391123552c5f6f1febd4e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->