### PR TITLE
feat: migrate Button (acc-eng scope)

### DIFF
--- a/app/components/Views/MultichainAccounts/AccountDetails/components/RemoveAccount/RemoveAccount.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/RemoveAccount/RemoveAccount.tsx
@@ -1,14 +1,11 @@
 import React, { useCallback } from 'react';
-import { TextVariant } from '../../../../../../component-library/components/Texts/Text';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { strings } from '../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './RemoveAccount.styles';
-import Button, {
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { AccountDetailsIds } from '../../../AccountDetails.testIds';
 
 interface RemoveAccountProps {
@@ -31,10 +28,10 @@ export const RemoveAccount = ({ account }: RemoveAccountProps) => {
       testID={AccountDetailsIds.REMOVE_ACCOUNT_BUTTON}
       style={styles.button}
       isDanger
-      variant={ButtonVariants.Secondary}
-      labelTextVariant={TextVariant.BodyMDMedium}
+      variant={ButtonVariant.Secondary}
       onPress={handleRemoveAccountClick}
-      label={strings('multichain_accounts.delete_account.title')}
-    />
+    >
+      {strings('multichain_accounts.delete_account.title')}
+    </Button>
   );
 };

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.test.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.test.tsx
@@ -221,13 +221,13 @@ describe('LearnMoreBottomSheet', () => {
     );
 
     // Initially checkbox should be unchecked and confirm button disabled
-    expect(confirmButton).toHaveProp('disabled', true);
+    expect(confirmButton).toBeDisabled();
 
     // Press checkbox to check it
     fireEvent.press(checkbox);
 
     // Confirm button should now be enabled
-    expect(confirmButton).toHaveProp('disabled', false);
+    expect(confirmButton).toBeEnabled();
   });
 
   it('handles confirm button press when checkbox is checked', () => {

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
@@ -6,12 +6,10 @@ import {
   TextVariant,
   IconName,
   TextColor,
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
 } from '@metamask/design-system-react-native';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../../component-library/components/Buttons/Button';
 import Checkbox from '../../../../component-library/components/Checkbox';
 import BottomSheet, {
   BottomSheetRef,
@@ -111,14 +109,15 @@ const LearnMoreBottomSheet: React.FC<LearnMoreBottomSheetProps> = ({
 
         <View style={styles.footer}>
           <Button
-            variant={ButtonVariants.Primary}
-            label={strings('multichain_accounts.learn_more.confirm_button')}
-            size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            size={ButtonBaseSize.Lg}
+            isFullWidth
             onPress={handleConfirm}
             isDisabled={!isCheckboxChecked}
             testID={LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CONFIRM_BUTTON}
-          />
+          >
+            {strings('multichain_accounts.learn_more.confirm_button')}
+          </Button>
         </View>
       </View>
     </BottomSheet>

--- a/app/components/Views/MultichainAccounts/IntroModal/MultichainAccountsIntroModal.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/MultichainAccountsIntroModal.tsx
@@ -6,12 +6,10 @@ import {
   TextVariant,
   IconName,
   TextColor,
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
 } from '@metamask/design-system-react-native';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../../component-library/components/Buttons/Button';
 import { useNavigation, useTheme } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { createAccountSelectorNavDetails } from '../../AccountSelector';
@@ -201,24 +199,26 @@ const MultichainAccountsIntroModal = () => {
 
         <View style={styles.buttonsContainer}>
           <Button
-            variant={ButtonVariants.Primary}
-            label={renderButtonLabel()}
-            size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            size={ButtonBaseSize.Lg}
+            isFullWidth
             onPress={handleViewAccounts}
             isDisabled={isAligning}
             testID={
               MULTICHAIN_ACCOUNTS_INTRO_MODAL_TEST_IDS.VIEW_ACCOUNTS_BUTTON
             }
-          />
+          >
+            {renderButtonLabel()}
+          </Button>
           <Button
-            variant={ButtonVariants.Link}
-            label={strings('multichain_accounts.intro.learn_more_button')}
-            size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Tertiary}
+            size={ButtonBaseSize.Lg}
+            isFullWidth
             onPress={handleLearnMore}
             testID={MULTICHAIN_ACCOUNTS_INTRO_MODAL_TEST_IDS.LEARN_MORE_BUTTON}
-          />
+          >
+            {strings('multichain_accounts.intro.learn_more_button')}
+          </Button>
         </View>
       </View>
     </View>

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.test.tsx
@@ -306,7 +306,7 @@ describe('MultichainAccountConnectMultiSelector', () => {
       const updateButton = getByTestId(
         ConnectAccountBottomSheetSelectorsIDs.SELECT_MULTI_BUTTON,
       );
-      expect(updateButton.props.disabled).toBe(true);
+      expect(updateButton).toBeDisabled();
     });
   });
 

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx
@@ -5,10 +5,11 @@ import { useSelector } from 'react-redux';
 
 // External dependencies.
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import SheetHeader from '../../../../../component-library/components/Sheet/SheetHeader';
 import Text, {
   TextColor,
@@ -109,17 +110,18 @@ const MultichainAccountConnectMultiSelector = ({
         <View style={styles.connectOrUpdateButtonContainer}>
           {areAnyAccountsSelected && (
             <Button
-              variant={ButtonVariants.Primary}
-              label={strings('networks.update')}
+              variant={ButtonVariant.Primary}
               onPress={handleSubmit}
-              size={ButtonSize.Lg}
+              size={ButtonBaseSize.Lg}
               style={{
                 ...styles.button,
                 ...(isLoading && styles.disabled),
               }}
-              disabled={isLoading}
+              isDisabled={isLoading}
               testID={ConnectAccountBottomSheetSelectorsIDs.SELECT_MULTI_BUTTON}
-            />
+            >
+              {strings('networks.update')}
+            </Button>
           )}
         </View>
         {areNoAccountsSelected && showDisconnectAllButton && (
@@ -133,16 +135,17 @@ const MultichainAccountConnectMultiSelector = ({
             </View>
             <View style={styles.disconnectAllButtonContainer}>
               <Button
-                variant={ButtonVariants.Primary}
-                label={strings('accounts.disconnect')}
+                variant={ButtonVariant.Primary}
                 testID={ConnectedAccountsSelectorsIDs.DISCONNECT}
                 onPress={handleDisconnect}
                 isDanger
-                size={ButtonSize.Lg}
+                size={ButtonBaseSize.Lg}
                 style={{
                   ...styles.button,
                 }}
-              />
+              >
+                {strings('accounts.disconnect')}
+              </Button>
             </View>
           </View>
         )}

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -25,10 +25,11 @@ import TextComponent, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
 import AvatarGroup from '../../../../component-library/components/Avatars/AvatarGroup';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import { getHost } from '../../../../util/browser';
 import WebsiteIcon from '../../../UI/WebsiteIcon';
 import styleSheet from './MultichainPermissionsSummary.styles';
@@ -623,19 +624,20 @@ const MultichainPermissionsSummary = ({
           {isAlreadyConnected && isDisconnectAllShown && (
             <View style={styles.disconnectAllContainer}>
               <Button
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 testID={
                   ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS
                 }
-                label={strings('accounts.disconnect_all')}
                 onPress={toggleRevokeAllPermissionsModal}
                 startIconName={IconName.Logout}
                 isDanger
-                size={ButtonSize.Lg}
+                size={ButtonBaseSize.Lg}
                 style={{
                   ...styles.disconnectButton,
                 }}
-              />
+              >
+                {strings('accounts.disconnect_all')}
+              </Button>
             </View>
           )}
           {showActionButtons && !isNonDappNetworkSwitch && (
@@ -670,31 +672,33 @@ const MultichainPermissionsSummary = ({
             <View style={styles.nonDappNetworkSwitchButtons}>
               <View style={styles.actionButtonsContainer}>
                 <Button
-                  variant={ButtonVariants.Primary}
-                  label={strings('permissions.add_this_network')}
+                  variant={ButtonVariant.Primary}
                   testID={
                     NetworkNonPemittedBottomSheetSelectorsIDs.ADD_THIS_NETWORK_BUTTON
                   }
                   onPress={onAddNetwork}
-                  size={ButtonSize.Lg}
+                  size={ButtonBaseSize.Lg}
                   style={{
                     ...styles.disconnectButton,
                   }}
-                />
+                >
+                  {strings('permissions.add_this_network')}
+                </Button>
               </View>
               <View style={styles.actionButtonsContainer}>
                 <Button
-                  variant={ButtonVariants.Secondary}
-                  label={strings('permissions.choose_from_permitted_networks')}
+                  variant={ButtonVariant.Secondary}
                   testID={
                     NetworkNonPemittedBottomSheetSelectorsIDs.CHOOSE_FROM_PERMITTED_NETWORKS_BUTTON
                   }
                   onPress={onChooseFromPermittedNetworks}
-                  size={ButtonSize.Lg}
+                  size={ButtonBaseSize.Lg}
                   style={{
                     ...styles.disconnectButton,
                   }}
-                />
+                >
+                  {strings('permissions.choose_from_permitted_networks')}
+                </Button>
               </View>
             </View>
           )}

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -29,6 +29,7 @@ import {
   Button,
   ButtonVariant,
   ButtonBaseSize,
+  IconName as DesignSystemIconName,
 } from '@metamask/design-system-react-native';
 import { getHost } from '../../../../util/browser';
 import WebsiteIcon from '../../../UI/WebsiteIcon';
@@ -629,7 +630,7 @@ const MultichainPermissionsSummary = ({
                   ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS
                 }
                 onPress={toggleRevokeAllPermissionsModal}
-                startIconName={IconName.Logout}
+                startIconName={DesignSystemIconName.Logout}
                 isDanger
                 size={ButtonBaseSize.Lg}
                 style={{

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -38,10 +38,11 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import {
   useParams,
   createNavigationDetails,
@@ -233,21 +234,23 @@ export const PrivateKeyList = () => {
         </View>
         <View style={styles.buttons}>
           <Button
-            label={strings('multichain_accounts.private_key_list.cancel')}
-            size={ButtonSize.Lg}
-            variant={ButtonVariants.Secondary}
+            size={ButtonBaseSize.Lg}
+            variant={ButtonVariant.Secondary}
             onPress={onCancel}
             style={styles.button}
             testID={PrivateKeyListIds.CANCEL_BUTTON}
-          />
+          >
+            {strings('multichain_accounts.private_key_list.cancel')}
+          </Button>
           <Button
-            label={strings('multichain_accounts.private_key_list.continue')}
-            size={ButtonSize.Lg}
-            variant={ButtonVariants.Primary}
+            size={ButtonBaseSize.Lg}
+            variant={ButtonVariant.Primary}
             onPress={() => verifyPasswordAndUnlockKeys()}
             style={styles.button}
             testID={PrivateKeyListIds.CONTINUE_BUTTON}
-          />
+          >
+            {strings('multichain_accounts.private_key_list.continue')}
+          </Button>
         </View>
       </>
     ),

--- a/app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx
@@ -13,11 +13,11 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { Box } from '../../../../UI/Box/Box';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import styleSheet from './EditMultichainAccountName.styles';
 import { useStyles } from '../../../../hooks/useStyles';
 import { useTheme } from '../../../../../util/theme';
@@ -144,15 +144,14 @@ export const EditMultichainAccountName = () => {
         </Box>
         <Box style={styles.saveButtonContainer}>
           <Button
-            width={ButtonWidthTypes.Full}
-            variant={ButtonVariants.Primary}
-            label={strings(
-              'multichain_accounts.edit_account_name.confirm_button',
-            )}
-            size={ButtonSize.Lg}
+            isFullWidth
+            variant={ButtonVariant.Primary}
+            size={ButtonBaseSize.Lg}
             onPress={handleAccountNameChange}
             testID={EditAccountNameIds.SAVE_BUTTON}
-          />
+          >
+            {strings('multichain_accounts.edit_account_name.confirm_button')}
+          </Button>
         </Box>
       </KeyboardAvoidingView>
     </SafeAreaView>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replaced `Button` in `acc-eng` scope.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/84260d66-993a-4172-8a1f-22cd5517399c

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/64b16cd0-bc2e-40cd-98df-00fac4ec52f2

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps several Multichain Accounts/permissions screens to the design-system `Button` API (prop/variant/disabled semantics), which could subtly affect CTA styling or enabled/disabled behavior in connection and account-management flows.
> 
> **Overview**
> Migrates Multichain Accounts screens from the legacy component-library `Button` to `@metamask/design-system-react-native` `Button`, updating usage from `label` props to children, mapping variants/sizes (`ButtonVariant`, `ButtonBaseSize`), and switching width/disabled props to `isFullWidth`/`isDisabled`.
> 
> Updates affected CTAs across remove account, intro/learn-more modals, connect multi-selector, permissions summary (including `startIconName` to design-system icon enum), private key list, and edit account name. Test assertions were adjusted to use `toBeDisabled()`/`toBeEnabled()` where button disabled state is checked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5177ddfedf4379ddf2f47754e1420fccbcaeee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->