### PR TITLE
ci: adapt automated tests metrics logic

### DIFF
--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -7,7 +7,7 @@
  *
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
- *   WORKFLOW_RUN_ID   — ID of the main CI run that produced tests artifacts
+ *   GITHUB_REPOSITORY — Repository in "owner/repo" format (set automatically in Actions)
  * 
  * How to add a new metric:
  *   1. Add a collector function that returns a plain object
@@ -31,9 +31,9 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const WORKFLOW_RUN_ID = process.env.WORKFLOW_RUN_ID;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';
+const WORKFLOW_RUN_ID = "23197782954";
 
-if (!WORKFLOW_RUN_ID) throw new Error('Missing required WORKFLOW_RUN_ID env var');
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
 
@@ -41,7 +41,42 @@ if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 // GitHub artifact helpers
 // ---------------------------------------------------------------------------
 
+let _runId = null;
 let _artifactList = null;
+
+/**
+ * Fetches the ID of the latest successful CI workflow run on `main`.
+ *
+ * @returns {Promise<string>}
+ */
+async function getLatestCiRunId() {
+  const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=1`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch CI workflow runs: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  const run = data.workflow_runs?.[0];
+  if (!run) {
+    throw new Error('No successful CI workflow runs found on main');
+  }
+
+  console.log(`[run] Using latest successful ci run #${run.run_number} (id=${run.id}, ${run.created_at})`);
+  return String(run.id);
+}
+
+async function getRunId() {
+  if (_runId) return _runId;
+  _runId = await getLatestCiRunId();
+  return _runId;
+}
 
 /**
  * Fetches (and caches) the list of artifact names for the triggering CI run.
@@ -52,11 +87,13 @@ let _artifactList = null;
 async function getArtifactList() {
   if (_artifactList) return _artifactList;
 
+  const runId = await getRunId();
   const artifacts = [];
   let page = 1;
 
   while (true) {
-    const url = `https://api.github.com/repos/MetaMask/metamask-mobile/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
+    // const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -89,10 +126,11 @@ async function getArtifactList() {
 async function downloadArtifact(artifactName) {
   const artifacts = await getArtifactList();
   const artifact = artifacts.find((a) => a.name === artifactName);
+  const runId = await getRunId();
 
   if (!artifact) {
     throw new Error(
-      `Artifact "${artifactName}" not found in run ${WORKFLOW_RUN_ID}`,
+      `Artifact "${artifactName}" not found in run ${runId}`,
     );
   }
 
@@ -384,8 +422,8 @@ async function main() {
   const stats = {};
 
   const collectors = [
-    { namespace: 'component_view', collect: collectComponentViewTestCount },
     { namespace: 'unit', collect: collectUnitTestCount },
+    { namespace: 'component_view', collect: collectComponentViewTestCount },
     { namespace: 'e2e', collect: collectE2ECounts },
     { namespace: 'performance', collect: collectPerformanceTestCounts },
   ];

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -36,6 +36,8 @@ import { join } from 'path';
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';
 
+const WORKFLOW_RUN_ID = "23209543808";
+
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
 
@@ -94,7 +96,8 @@ async function getArtifactList() {
   let page = 1;
 
   while (true) {
-    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
+    // const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -314,10 +317,10 @@ async function collectComponentViewTestCount() {
     const destDir = await downloadArtifact('cv-test-coverage-summary');
     const summary = JSON.parse(await readFile(join(destDir, 'coverage-summary.json'), 'utf8'));
     const { lines, statements, branches, functions } = summary.total;
-    result.line_coverage = Math.round(lines.pct);
-    result.statement_coverage = Math.round(statements.pct);
-    result.branch_coverage = Math.round(branches.pct);
-    result.function_coverage = Math.round(functions.pct);
+    result.line_coverage = Math.round(lines.pct * 10) / 10;
+    result.statement_coverage = Math.round(statements.pct * 10) / 10;
+    result.branch_coverage = Math.round(branches.pct * 10) / 10;
+    result.function_coverage = Math.round(functions.pct * 10) / 10;
     console.log(
       `[component-view] coverage — line: ${result.line_coverage}%, stmt: ${result.statement_coverage}%, branch: ${result.branch_coverage}%, fn: ${result.function_coverage}%`,
     );
@@ -347,6 +350,24 @@ async function collectUnitTestCount() {
   }
   result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
+
+  // Coverage from the pre-computed nyc json-summary report produced by
+  // the merge-unit-and-component-view-tests job in ci.yml.
+  try {
+    const destDir = await downloadArtifact('unit-test-coverage-summary');
+    const summary = JSON.parse(await readFile(join(destDir, 'coverage-summary.json'), 'utf8'));
+    const { lines, statements, branches, functions } = summary.total;
+    result.line_coverage = Math.round(lines.pct * 10) / 10;
+    result.statement_coverage = Math.round(statements.pct * 10) / 10;
+    result.branch_coverage = Math.round(branches.pct * 10) / 10;
+    result.function_coverage = Math.round(functions.pct * 10) / 10;
+    console.log(
+      `[unit] coverage — line: ${result.line_coverage}%, stmt: ${result.statement_coverage}%, branch: ${result.branch_coverage}%, fn: ${result.function_coverage}%`,
+    );
+  } catch (err) {
+    console.warn(`[unit] coverage summary not available, skipping: ${err.message}`);
+  }
+
   return result;
 }
 
@@ -461,7 +482,7 @@ async function collectE2ECounts() {
   // Static scan — independent of which platform/channel ran
   const isSpecTs = (name) => /\.spec\.[jt]sx?$/.test(name);
   let defined = 0, skips = 0;
-  for (const dir of ['tests/regression', 'tests/smoke']) {
+  for (const dir of ['tests/smoke']) {
     const files = await walkFiles(dir, isSpecTs);
     for (const f of files) {
       const source = await readFile(f, 'utf8');

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
  *
- * Collects QA metrics from a CI run and writes qa-stats.json, key: value format.
+ * Collects QA metrics into a qa-stats.json file, key: value format.
  * Metrics that could not be collected (missing artifacts, tests did not run)
- * are omitted from the output — they will never appear as zero.
+ * are omitted from the output, i.e., they will not appear in the output file.
  *
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
@@ -13,10 +13,13 @@
  *   1. Add a collector function that returns a plain object
  *   2. Register it in the collectors array in main()
  * 
- * The only rule: never rename existing keys. The DB key is (project, run_id, namespace, metric_key). 
+ * The only rule: never rename existing keys. The DB key used for storing the metrics is (project, run_id, namespace, metric_key). 
  * Renaming a key in the JSON creates a new series in the DB while the old name stops getting new data, 
  * which breaks the Grafana time series continuity. Adding and removing keys is fine.
- * 
+ *
+ * Artifact names used below are coupled to `name:` fields in ci.yml and run-e2e-workflow.yml —
+ * renaming either side silently drops that metric from the output.
+ *
  * Example output:
  *   {
  *     "unit":          { "total_tests_run": 41957, "total_tests_skipped": 17, "bridge_tests_run": 5000, "other_tests_run": 1000 },
@@ -36,9 +39,23 @@ import { join } from 'path';
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';
 
-const WORKFLOW_RUN_ID = "23209543808";
-
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
+
+const WORKFLOW_RUN_ID = "23242979306";
+
+// ---------------------------------------------------------------------------
+// Static-scan targets
+// Update these if the repository directory structure or file-naming conventions
+// change — the collectors below rely on them for skip/defined counts.
+// ---------------------------------------------------------------------------
+const SCAN_APP_DIR        = 'app';
+const SCAN_E2E_SMOKE_DIRS = ['tests/smoke'];
+const SCAN_PERFORMANCE_DIR = 'tests/performance';
+
+const PATTERN_CV_TEST_FILE   = /\.view(?:\..+)?\.test\.[jt]sx?$/;
+const PATTERN_UNIT_TEST_FILE = /\.test\.[jt]sx?$/;
+const PATTERN_E2E_SPEC_FILE  = /\.spec\.[jt]sx?$/;
+const PATTERN_PERF_SPEC_FILE = /\.spec\.js$/;
 
 
 // ---------------------------------------------------------------------------
@@ -300,8 +317,8 @@ async function collectComponentViewTestCount() {
   const result = await collectShardCounts(/^coverage-cv-\d+$/, 'component-view');
   if (Object.keys(result).length === 0) return result;
 
-  const isViewTestFile = (name) => /\.view(?:\..+)?\.test\.[jt]sx?$/.test(name);
-  const files = await walkFiles('app', isViewTestFile);
+  const isViewTestFile = (name) => PATTERN_CV_TEST_FILE.test(name);
+  const files = await walkFiles(SCAN_APP_DIR, isViewTestFile);
   let defined = 0, skips = 0;
   for (const f of files) {
     const source = await readFile(f, 'utf8');
@@ -340,8 +357,8 @@ async function collectUnitTestCount() {
 
   // Unit test files: *.test.{ts,tsx,js} excluding *.view[.*].test.*
   const isUnitTestFile = (name) =>
-    /\.test\.[jt]sx?$/.test(name) && !/\.view(?:\..+)?\.test\.[jt]sx?$/.test(name);
-  const files = await walkFiles('app', isUnitTestFile);
+    PATTERN_UNIT_TEST_FILE.test(name) && !PATTERN_CV_TEST_FILE.test(name);
+  const files = await walkFiles(SCAN_APP_DIR, isUnitTestFile);
   let defined = 0, skips = 0;
   for (const f of files) {
     const source = await readFile(f, 'utf8');
@@ -480,9 +497,9 @@ async function collectE2ECounts() {
   }
 
   // Static scan — independent of which platform/channel ran
-  const isSpecTs = (name) => /\.spec\.[jt]sx?$/.test(name);
+  const isSpecTs = (name) => PATTERN_E2E_SPEC_FILE.test(name);
   let defined = 0, skips = 0;
-  for (const dir of ['tests/smoke']) {
+  for (const dir of SCAN_E2E_SMOKE_DIRS) {
     const files = await walkFiles(dir, isSpecTs);
     for (const f of files) {
       const source = await readFile(f, 'utf8');
@@ -516,7 +533,7 @@ async function collectPerformanceTestCounts() {
       if (entry.isDirectory()) {
         // Top-level subdirectory determines the category
         await scanDir(fullPath, category ?? entry.name);
-      } else if (entry.isFile() && entry.name.endsWith('.spec.js')) {
+      } else if (entry.isFile() && PATTERN_PERF_SPEC_FILE.test(entry.name)) {
         const source = await readFile(fullPath, 'utf8');
         // Count all test() calls — including test.skip() — for total_tests_defined
         const matches = source.match(/^\s*test(?:\.skip)?\s*\(/gm) ?? [];
@@ -530,7 +547,7 @@ async function collectPerformanceTestCounts() {
     }
   }
 
-  await scanDir('tests/performance', null);
+  await scanDir(SCAN_PERFORMANCE_DIR, null);
 
   const total = Object.values(categoryCounts).reduce((s, n) => s + n, 0);
 

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -185,6 +185,18 @@ function countSkips(source) {
 }
 
 /**
+ * Counts all individual test definitions in a source string — both active and
+ * skipped. Matches it(, it.skip(, test(, test.skip(.
+ * Excludes describe() which is a grouper, not an individual test.
+ *
+ * @param {string} source
+ * @returns {number}
+ */
+function countDefinedTests(source) {
+  return (source.match(/\b(?:it|test)(?:\.skip)?\s*\(/g) ?? []).length;
+}
+
+/**
  * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
  *
  * @param {string} dir
@@ -289,8 +301,13 @@ async function collectComponentViewTestCount() {
 
   const isViewTestFile = (name) => /\.view(?:\..+)?\.test\.[jt]sx?$/.test(name);
   const files = await walkFiles('app', isViewTestFile);
-  let skips = 0;
-  for (const f of files) skips += countSkips(await readFile(f, 'utf8'));
+  let defined = 0, skips = 0;
+  for (const f of files) {
+    const source = await readFile(f, 'utf8');
+    defined += countDefinedTests(source);
+    skips += countSkips(source);
+  }
+  result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
   return result;
 }
@@ -306,8 +323,13 @@ async function collectUnitTestCount() {
   const isUnitTestFile = (name) =>
     /\.test\.[jt]sx?$/.test(name) && !/\.view(?:\..+)?\.test\.[jt]sx?$/.test(name);
   const files = await walkFiles('app', isUnitTestFile);
-  let skips = 0;
-  for (const f of files) skips += countSkips(await readFile(f, 'utf8'));
+  let defined = 0, skips = 0;
+  for (const f of files) {
+    const source = await readFile(f, 'utf8');
+    defined += countDefinedTests(source);
+    skips += countSkips(source);
+  }
+  result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
   return result;
 }
@@ -420,13 +442,18 @@ async function collectE2ECounts() {
     result[`${tag}_tests_run`] = count;
   }
 
-  // Static scan for skip counts — independent of which platform/channel ran
+  // Static scan — independent of which platform/channel ran
   const isSpecTs = (name) => /\.spec\.[jt]sx?$/.test(name);
-  let skips = 0;
+  let defined = 0, skips = 0;
   for (const dir of ['tests/regression', 'tests/smoke']) {
     const files = await walkFiles(dir, isSpecTs);
-    for (const f of files) skips += countSkips(await readFile(f, 'utf8'));
+    for (const f of files) {
+      const source = await readFile(f, 'utf8');
+      defined += countDefinedTests(source);
+      skips += countSkips(source);
+    }
   }
+  result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
 
   return result;
@@ -454,8 +481,8 @@ async function collectPerformanceTestCounts() {
         await scanDir(fullPath, category ?? entry.name);
       } else if (entry.isFile() && entry.name.endsWith('.spec.js')) {
         const source = await readFile(fullPath, 'utf8');
-        // Count test() calls, excluding test.skip()
-        const matches = source.match(/^\s*test\s*\(/gm) ?? [];
+        // Count all test() calls — including test.skip() — for total_tests_defined
+        const matches = source.match(/^\s*test(?:\.skip)?\s*\(/gm) ?? [];
         const count = matches.length;
         if (count > 0 && category) {
           const key = category.replace(/-/g, '_');

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -189,15 +189,52 @@ async function downloadArtifact(artifactName) {
 // ---------------------------------------------------------------------------
 
 /**
- * Counts skip calls in a source string.
- * Matches it.skip(, test.skip(, describe.skip( — anchored to avoid false
- * positives like result.current.skip().
+ * Counts the number of individual test cases that are skipped in a source string.
+ *
+ * Two categories:
+ *   1. Explicit: `it.skip()` / `test.skip()` outside any `describe.skip` block — 1 skipped test each.
+ *   2. Implicit: every `it()` / `test()` call (including `.skip` variants) inside a `describe.skip`
+ *      block, because the whole block is skipped by the runner.
+ *
+ * `describe.skip` blocks are extracted via brace matching so their contents are
+ * not double-counted against the explicit-skip pass.
  *
  * @param {string} source
  * @returns {number}
  */
 function countSkips(source) {
-  return (source.match(/\b(?:it|test|describe)\.skip\s*\(/g) ?? []).length;
+  // Find all describe.skip blocks using brace matching.
+  const describeBlocks = [];
+  const re = /\bdescribe\.skip\s*\(/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const braceStart = source.indexOf('{', m.index + m[0].length);
+    if (braceStart === -1) continue;
+    let depth = 1, pos = braceStart + 1;
+    while (pos < source.length && depth > 0) {
+      if (source[pos] === '{') depth++;
+      else if (source[pos] === '}') depth--;
+      pos++;
+    }
+    describeBlocks.push({ start: m.index, end: pos, content: source.slice(braceStart + 1, pos - 1) });
+  }
+
+  // Strip describe.skip regions from source (reverse order to preserve indices).
+  let outside = source;
+  for (let i = describeBlocks.length - 1; i >= 0; i--) {
+    outside = outside.slice(0, describeBlocks[i].start) + outside.slice(describeBlocks[i].end);
+  }
+
+  // Part 1: it.skip / test.skip outside describe.skip blocks.
+  const explicitSkips = (outside.match(/\b(?:it|test)\.skip\s*\(/g) ?? []).length;
+
+  // Part 2: all it() / test() (including .skip) inside describe.skip blocks.
+  const implicitSkips = describeBlocks.reduce(
+    (sum, { content }) => sum + (content.match(/\b(?:it|test)(?:\.skip)?\s*\(/g) ?? []).length,
+    0,
+  );
+
+  return explicitSkips + implicitSkips;
 }
 
 /**

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -307,6 +307,24 @@ async function collectComponentViewTestCount() {
   }
   result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
+
+  // Coverage from the pre-computed nyc json-summary report produced by
+  // the merge-unit-and-component-view-tests job in ci.yml.
+  try {
+    const destDir = await downloadArtifact('cv-test-coverage-summary');
+    const summary = JSON.parse(await readFile(join(destDir, 'coverage-summary.json'), 'utf8'));
+    const { lines, statements, branches, functions } = summary.total;
+    result.line_coverage = Math.round(lines.pct);
+    result.statement_coverage = Math.round(statements.pct);
+    result.branch_coverage = Math.round(branches.pct);
+    result.function_coverage = Math.round(functions.pct);
+    console.log(
+      `[component-view] coverage — line: ${result.line_coverage}%, stmt: ${result.statement_coverage}%, branch: ${result.branch_coverage}%, fn: ${result.function_coverage}%`,
+    );
+  } catch (err) {
+    console.warn(`[component-view] coverage summary not available, skipping: ${err.message}`);
+  }
+
   return result;
 }
 

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -41,11 +41,10 @@ const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mo
 
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
-const WORKFLOW_RUN_ID = "23242979306";
 
 // ---------------------------------------------------------------------------
 // Static-scan targets
-// Update these if the repository directory structure or file-naming conventions
+// Update these (easy with AI) if the repository directory structure or file-naming conventions
 // change — the collectors below rely on them for skip/defined counts.
 // ---------------------------------------------------------------------------
 const SCAN_APP_DIR        = 'app';
@@ -113,8 +112,7 @@ async function getArtifactList() {
   let page = 1;
 
   while (true) {
-    // const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
-    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -334,12 +332,12 @@ async function collectComponentViewTestCount() {
     const destDir = await downloadArtifact('cv-test-coverage-summary');
     const summary = JSON.parse(await readFile(join(destDir, 'coverage-summary.json'), 'utf8'));
     const { lines, statements, branches, functions } = summary.total;
-    result.line_coverage = Math.round(lines.pct * 10) / 10;
-    result.statement_coverage = Math.round(statements.pct * 10) / 10;
-    result.branch_coverage = Math.round(branches.pct * 10) / 10;
-    result.function_coverage = Math.round(functions.pct * 10) / 10;
+    result.coverage_line = Math.round(lines.pct * 10) / 10;
+    result.coverage_statement = Math.round(statements.pct * 10) / 10;
+    result.coverage_branch = Math.round(branches.pct * 10) / 10;
+    result.coverage_function = Math.round(functions.pct * 10) / 10;
     console.log(
-      `[component-view] coverage — line: ${result.line_coverage}%, stmt: ${result.statement_coverage}%, branch: ${result.branch_coverage}%, fn: ${result.function_coverage}%`,
+      `[component-view] coverage — line: ${result.coverage_line}%, stmt: ${result.coverage_statement}%, branch: ${result.coverage_branch}%, fn: ${result.coverage_function}%`,
     );
   } catch (err) {
     console.warn(`[component-view] coverage summary not available, skipping: ${err.message}`);
@@ -374,12 +372,12 @@ async function collectUnitTestCount() {
     const destDir = await downloadArtifact('unit-test-coverage-summary');
     const summary = JSON.parse(await readFile(join(destDir, 'coverage-summary.json'), 'utf8'));
     const { lines, statements, branches, functions } = summary.total;
-    result.line_coverage = Math.round(lines.pct * 10) / 10;
-    result.statement_coverage = Math.round(statements.pct * 10) / 10;
-    result.branch_coverage = Math.round(branches.pct * 10) / 10;
-    result.function_coverage = Math.round(functions.pct * 10) / 10;
+    result.coverage_line = Math.round(lines.pct * 10) / 10;
+    result.coverage_statement = Math.round(statements.pct * 10) / 10;
+    result.coverage_branch = Math.round(branches.pct * 10) / 10;
+    result.coverage_function = Math.round(functions.pct * 10) / 10;
     console.log(
-      `[unit] coverage — line: ${result.line_coverage}%, stmt: ${result.statement_coverage}%, branch: ${result.branch_coverage}%, fn: ${result.function_coverage}%`,
+      `[unit] coverage — line: ${result.coverage_line}%, stmt: ${result.coverage_statement}%, branch: ${result.coverage_branch}%, fn: ${result.coverage_function}%`,
     );
   } catch (err) {
     console.warn(`[unit] coverage summary not available, skipping: ${err.message}`);

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -35,7 +35,6 @@ import { join } from 'path';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';
-const WORKFLOW_RUN_ID = "23197782954";
 
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
@@ -95,8 +94,7 @@ async function getArtifactList() {
   let page = 1;
 
   while (true) {
-    // const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
-    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${GITHUB_TOKEN}`,

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -19,10 +19,13 @@
  * 
  * Example output:
  *   {
- *     "component_view": { "tests_count": 94 },
- *     "unit":           { "tests_count": 41957 },
- *     "e2e":            { "tests_count": 420, "main_tests_count": 276, "confirmations_tests_count": 62, "flask_tests_count": 144 },
- *     "performance":    { "tests_count": 21, "login_tests_count": 11, "onboarding_tests_count": 4, "mm_connect_tests_count": 6 }
+ *     "unit":          { "total_tests_run": 41957, "total_tests_skipped": 17, "bridge_tests_run": 5000, "other_tests_run": 1000 },
+ *     "component_view":{ "total_tests_run": 94,    "total_tests_skipped": 0 },
+ *     "e2e":           { "total_tests_run": 420,   "total_tests_skipped": 27,
+ *                        "main_tests_run": 276, "main_android_tests_run": 276, "main_ios_tests_run": 276,
+ *                        "flask_tests_run": 144, "confirmations_tests_run": 62 },
+ *     "performance":   { "total_tests_defined": 21, "total_tests_skipped": 1,
+ *                        "login_tests_defined": 11, "onboarding_tests_defined": 4, "mm_connect_tests_defined": 6 }
  *   }
  */
 
@@ -170,6 +173,39 @@ async function downloadArtifact(artifactName) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Counts skip calls in a source string.
+ * Matches it.skip(, test.skip(, describe.skip( — anchored to avoid false
+ * positives like result.current.skip().
+ *
+ * @param {string} source
+ * @returns {number}
+ */
+function countSkips(source) {
+  return (source.match(/\b(?:it|test|describe)\.skip\s*\(/g) ?? []).length;
+}
+
+/**
+ * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
+ *
+ * @param {string} dir
+ * @param {(name: string) => boolean} predicate
+ * @returns {Promise<string[]>}
+ */
+async function walkFiles(dir, predicate) {
+  const results = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkFiles(fullPath, predicate)));
+    } else if (entry.isFile() && predicate(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
  * Extracts a feature folder name from a Jest test file path.
  *
  * Priority:
@@ -235,12 +271,12 @@ async function collectShardCounts(artifactPattern, label, minFolderCount = 0) {
   }
 
   console.log(`[${label}] total: ${total}`);
-  const result = { tests_count: total };
+  const result = { total_tests_run: total };
   for (const [folder, count] of Object.entries(folderCounts)) {
     if (minFolderCount > 0 && count < minFolderCount) {
-      result.other_tests_count = (result.other_tests_count ?? 0) + count;
+      result.other_tests_run = (result.other_tests_run ?? 0) + count;
     } else {
-      result[`${folder}_tests_count`] = count;
+      result[`${folder}_tests_run`] = count;
     }
   }
   return result;
@@ -248,14 +284,32 @@ async function collectShardCounts(artifactPattern, label, minFolderCount = 0) {
 
 async function collectComponentViewTestCount() {
   console.log('[component-view] collecting per-suite counts from shard artifacts...');
-  return collectShardCounts(/^coverage-cv-\d+$/, 'component-view');
+  const result = await collectShardCounts(/^coverage-cv-\d+$/, 'component-view');
+  if (Object.keys(result).length === 0) return result;
+
+  const isViewTestFile = (name) => /\.view(?:\..+)?\.test\.[jt]sx?$/.test(name);
+  const files = await walkFiles('app', isViewTestFile);
+  let skips = 0;
+  for (const f of files) skips += countSkips(await readFile(f, 'utf8'));
+  result.total_tests_skipped = skips;
+  return result;
 }
 
 async function collectUnitTestCount() {
   console.log('[unit] collecting per-suite counts from shard artifacts...');
   // minFolderCount=200: buckets individual component-level folders into `other`,
   // keeping only meaningful team-level categories (bridge, perps, confirmations, etc.)
-  return collectShardCounts(/^coverage-unit-\d+$/, 'unit', 200);
+  const result = await collectShardCounts(/^coverage-unit-\d+$/, 'unit', 200);
+  if (Object.keys(result).length === 0) return result;
+
+  // Unit test files: *.test.{ts,tsx,js} excluding *.view[.*].test.*
+  const isUnitTestFile = (name) =>
+    /\.test\.[jt]sx?$/.test(name) && !/\.view(?:\..+)?\.test\.[jt]sx?$/.test(name);
+  const files = await walkFiles('app', isUnitTestFile);
+  let skips = 0;
+  for (const f of files) skips += countSkips(await readFile(f, 'utf8'));
+  result.total_tests_skipped = skips;
+  return result;
 }
 
 /**
@@ -351,20 +405,29 @@ async function collectE2ECounts() {
   // Canonical unique counts (Android as source of truth — same tests run on iOS)
   // A missing key means that channel did not run; present-but-zero means it ran and found nothing.
   if (androidMain > 0 || iosMain > 0) {
-    result.main_tests_count = androidMain; // unique count
-    result.main_android_tests_count = androidMain; // platform health signal
-    result.main_ios_tests_count = iosMain; // drops to 0 if iOS infrastructure is broken
+    result.main_tests_run = androidMain; // unique count
+    result.main_android_tests_run = androidMain; // platform health signal
+    result.main_ios_tests_run = iosMain; // drops to 0 if iOS infrastructure is broken
   }
   if (androidFlask > 0 || iosFlask > 0) {
-    result.flask_tests_count = androidFlask; // unique count
-    result.flask_android_tests_count = androidFlask;
-    result.flask_ios_tests_count = iosFlask;
+    result.flask_tests_run = androidFlask; // unique count
+    result.flask_android_tests_run = androidFlask;
+    result.flask_ios_tests_run = iosFlask;
   }
-  result.tests_count = androidMain + androidFlask;
+  result.total_tests_run = androidMain + androidFlask;
 
   for (const [tag, count] of Object.entries(suiteCounts)) {
-    result[`${tag}_tests_count`] = count;
+    result[`${tag}_tests_run`] = count;
   }
+
+  // Static scan for skip counts — independent of which platform/channel ran
+  const isSpecTs = (name) => /\.spec\.[jt]sx?$/.test(name);
+  let skips = 0;
+  for (const dir of ['tests/regression', 'tests/smoke']) {
+    const files = await walkFiles(dir, isSpecTs);
+    for (const f of files) skips += countSkips(await readFile(f, 'utf8'));
+  }
+  result.total_tests_skipped = skips;
 
   return result;
 }
@@ -380,6 +443,7 @@ async function collectPerformanceTestCounts() {
   console.log('[performance] scanning tests/performance/ for scenarios...');
 
   const categoryCounts = {};
+  let totalSkips = 0;
 
   async function scanDir(dir, category) {
     const entries = await readdir(dir, { withFileTypes: true });
@@ -397,6 +461,7 @@ async function collectPerformanceTestCounts() {
           const key = category.replace(/-/g, '_');
           categoryCounts[key] = (categoryCounts[key] ?? 0) + count;
         }
+        totalSkips += countSkips(source);
       }
     }
   }
@@ -405,12 +470,12 @@ async function collectPerformanceTestCounts() {
 
   const total = Object.values(categoryCounts).reduce((s, n) => s + n, 0);
 
-  const result = { tests_count: total };
+  const result = { total_tests_defined: total, total_tests_skipped: totalSkips };
   for (const [cat, count] of Object.entries(categoryCounts)) {
-    result[`${cat}_tests_count`] = count;
+    result[`${cat}_tests_defined`] = count;
     console.log(`[performance] ${cat}: ${count}`);
   }
-  console.log(`[performance] total: ${total}`);
+  console.log(`[performance] total: ${total}, skips: ${totalSkips}`);
   return result;
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,11 +340,16 @@ jobs:
           path: ./unit-test-stats.json
           if-no-files-found: error
       - name: Generate CV test HTML coverage report
-        run: yarn nyc report --temp-dir ./tests/coverage-cv-merged --report-dir ./tests/coverage-cv-lcov --reporter html
+        run: yarn nyc report --temp-dir ./tests/coverage-cv-merged --report-dir ./tests/coverage-cv-lcov --reporter html --reporter json-summary
       - uses: actions/upload-artifact@v4
         with:
           name: cv-test-coverage-html
           path: ./tests/coverage-cv-lcov/
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cv-test-coverage-summary
+          path: ./tests/coverage-cv-lcov/coverage-summary.json
           if-no-files-found: error
       - name: Require clean working directory
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
             echo "No changes detected"
           fi
 
+  # We need to merge both unit and component view tests into a single coverage report so the PR coverage
+  # threshold calculation is accurate.
   merge-unit-and-component-view-tests:
     runs-on: ubuntu-latest
     needs: [unit-tests, component-view-tests]
@@ -321,6 +323,11 @@ jobs:
             [ -f "$file" ] && cp "$file" ./tests/coverage-cv-merged/
           done
 
+          mkdir -p tests/coverage-unit-merged
+          for file in ./tests/coverage/coverage-unit-*/coverage-unit-*.json; do
+            [ -f "$file" ] && cp "$file" ./tests/coverage-unit-merged/
+          done
+
           find ./tests/coverage/coverage-* -name 'coverage-*.json' -exec mv {} ./tests/coverage/ \;
       - run: yarn test:merge-coverage
       - run: yarn test:validate-coverage
@@ -350,6 +357,13 @@ jobs:
         with:
           name: cv-test-coverage-summary
           path: ./tests/coverage-cv-lcov/coverage-summary.json
+          if-no-files-found: error
+      - name: Generate unit test coverage summary
+        run: yarn nyc report --temp-dir ./tests/coverage-unit-merged --report-dir ./tests/coverage-unit-lcov --reporter json-summary
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-coverage-summary
+          path: ./tests/coverage-unit-lcov/coverage-summary.json
           if-no-files-found: error
       - name: Require clean working directory
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
         with:
           name: ios-bundle
           path: ios/main.jsbundle
+          retention-days: 7
 
   ship-js-bundle-size-check:
     runs-on: ubuntu-latest
@@ -262,6 +263,7 @@ jobs:
           name: coverage-unit-${{ matrix.shard }}
           path: ./tests/coverage/
           if-no-files-found: error
+          retention-days: 7
       - name: Require clean working directory
         shell: bash
         run: |
@@ -336,28 +338,33 @@ jobs:
           name: lcov.info
           path: ./tests/merged-coverage/lcov.info
           if-no-files-found: error
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         with:
           name: cv-test-stats
           path: ./cv-test-stats.json
           if-no-files-found: error
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         with:
           name: unit-test-stats
           path: ./unit-test-stats.json
           if-no-files-found: error
-      - name: Generate CV test HTML coverage report
+          retention-days: 7
+      - name: Generate CV test coverage report
         run: yarn nyc report --temp-dir ./tests/coverage-cv-merged --report-dir ./tests/coverage-cv-lcov --reporter html --reporter json-summary
       - uses: actions/upload-artifact@v4
         with:
           name: cv-test-coverage-html
           path: ./tests/coverage-cv-lcov/
           if-no-files-found: error
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         with:
           name: cv-test-coverage-summary
           path: ./tests/coverage-cv-lcov/coverage-summary.json
           if-no-files-found: error
+          retention-days: 7
       - name: Generate unit test coverage summary
         run: yarn nyc report --temp-dir ./tests/coverage-unit-merged --report-dir ./tests/coverage-unit-lcov --reporter json-summary
       - uses: actions/upload-artifact@v4
@@ -365,6 +372,7 @@ jobs:
           name: unit-test-coverage-summary
           path: ./tests/coverage-unit-lcov/coverage-summary.json
           if-no-files-found: error
+          retention-days: 7
       - name: Require clean working directory
         shell: bash
         run: |
@@ -416,6 +424,7 @@ jobs:
           name: coverage-cv-${{ matrix.shard }}
           path: ./tests/coverage/
           if-no-files-found: error
+          retention-days: 7
 
   needs_e2e_build:
     uses: ./.github/workflows/needs-e2e-build.yml

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -2,8 +2,7 @@ name: QA Stats
 
 on:
   schedule:
-    - cron: '0 3 * * *'
-    - cron: '0 15 * * *'
+    - cron: '0 4 * * *'
 
 jobs:
   collect-qa-stats:

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -1,19 +1,14 @@
 name: QA Stats
 
 on:
-  workflow_run:
-    workflows:
-      - ci
-    types:
-      - completed
-    branches:
-      - main
+  schedule:
+    - cron: '0 3 * * *'
+    - cron: '0 15 * * *'
 
 jobs:
   collect-qa-stats:
     name: Collect QA Stats
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository }}
 
     steps:
       - uses: actions/checkout@v6
@@ -26,7 +21,7 @@ jobs:
         run: node .github/scripts/collect-qa-stats.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Upload QA stats artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -205,3 +205,4 @@ jobs:
         with:
           name: e2e-smoke-android-flask-all-test-artifacts
           path: all-test-artifacts/
+          retention-days: 7

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -259,6 +259,7 @@ jobs:
         with:
           name: e2e-smoke-android-all-test-artifacts
           path: all-test-artifacts/
+          retention-days: 7
 
       - name: Create mobile JSON test report
         id: create-json-report
@@ -290,3 +291,4 @@ jobs:
         with:
           name: test-e2e-android-json-report
           path: test/test-results/test-runs-android.json
+          retention-days: 7

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -181,3 +181,4 @@ jobs:
         with:
           name: e2e-smoke-ios-flask-all-test-artifacts
           path: all-test-artifacts/
+          retention-days: 7

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -283,6 +283,7 @@ jobs:
         with:
           name: e2e-smoke-ios-all-test-artifacts
           path: all-test-artifacts/
+          retention-days: 7
 
       - name: Create mobile JSON test report
         id: create-json-report
@@ -314,3 +315,4 @@ jobs:
         with:
           name: test-e2e-ios-json-report
           path: test/test-results/test-runs-ios.json
+          retention-days: 7


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates QA stats collection to emit richer, more explicit metrics. Example:

```
✅ QA stats written to ./qa-stats.json: {
  unit: {
    total_tests_run: 42997,
    predict_tests_run: 3604,
    selectors_tests_run: 1141,
    core_tests_run: 5153,
    other_tests_run: 4923,
    store_tests_run: 1047,
    tokens_tests_run: 240,
    bridge_tests_run: 1796,
    earn_tests_run: 1519,
    rewards_tests_run: 2037,
    util_tests_run: 2328,
    perps_tests_run: 5439,
    networksmanagement_tests_run: 234,
    reducers_tests_run: 641,
    card_tests_run: 2738,
    homepage_tests_run: 284,
    controllers_tests_run: 1440,
    confirmations_tests_run: 2502,
    components_base_tests_run: 323,
    components_hooks_tests_run: 784,
    settings_tests_run: 229,
    browsertab_tests_run: 232,
    multichainaccounts_tests_run: 356,
    ramp_tests_run: 2128,
    stake_tests_run: 207,
    component_library_tests_run: 1006,
    trending_tests_run: 325,
    total_tests_defined: 40267,
    total_tests_skipped: 17,
    line_coverage: 87.4,
    statement_coverage: 87,
    branch_coverage: 79.1,
    function_coverage: 83.3
  },
  component_view: {
    total_tests_run: 104,
    perps_tests_run: 32,
    earn_tests_run: 28,
    confirmations_tests_run: 5,
    predict_tests_run: 17,
    wallet_tests_run: 5,
    assetdetails_tests_run: 1,
    bridge_tests_run: 9,
    trendingview_tests_run: 6,
    walletactions_tests_run: 1,
    total_tests_defined: 102,
    total_tests_skipped: 0,
    line_coverage: 15.8,
    statement_coverage: 15.7,
    branch_coverage: 9.4,
    function_coverage: 13
  },
  e2e: {
    main_tests_run: 140,
    main_android_tests_run: 140,
    main_ios_tests_run: 140,
    flask_tests_run: 72,
    flask_android_tests_run: 72,
    flask_ios_tests_run: 72,
    total_tests_run: 212,
    multichain_api_tests_run: 12,
    prediction_market_tests_run: 10,
    wallet_platform_tests_run: 35,
    network_expansion_tests_run: 10,
    confirmations_tests_run: 31,
    trade_tests_run: 12,
    identity_tests_run: 6,
    network_abstraction_tests_run: 12,
    accounts_tests_run: 2,
    ramps_tests_run: 3,
    card_tests_run: 6,
    perps_tests_run: 1,
    total_tests_defined: 225,
    total_tests_skipped: 18
  },
  performance: {
    total_tests_defined: 22,
    total_tests_skipped: 1,
    login_tests_defined: 11,
    mm_connect_tests_defined: 6,
    onboarding_tests_defined: 5
  }
}
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how QA metrics are keyed/collected and updates CI artifact production/retention; mismatches in artifact names or parsing could silently drop metrics or skew dashboards.
> 
> **Overview**
> Updates the QA stats pipeline to generate **richer, explicitly named metrics** (e.g., `*_tests_run`, `total_tests_defined`, `total_tests_skipped`) and adds static source scanning to estimate defined/skipped tests across unit, component-view, E2E smoke, and performance suites.
> 
> The collector no longer depends on a passed `WORKFLOW_RUN_ID`; it now resolves the **latest successful `ci.yml` run on `main`** via the GitHub API and pulls additional artifacts to include **coverage percentages** for unit and component-view tests.
> 
> CI workflows are adjusted to support this by producing/uploading new coverage-summary artifacts and setting **7-day retention** on several uploaded artifacts, and the `qa-stats.yml` workflow switches from `workflow_run` triggering to a **daily scheduled run**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea63d48fec2b43369a2fe303a1c61737aaa5b9d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->