### PR TITLE
chore(ci): migrate nightly build from Bitrise to GitHub Actions with TestFlight deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: 'Git ref to checkout when skip_version_bump is true. Defaults to the triggering event ref.'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       build_name:
@@ -141,7 +146,13 @@ jobs:
           submodules: recursive
 
       - uses: actions/checkout@v4
-        if: ${{ inputs.skip_version_bump }}
+        if: ${{ inputs.skip_version_bump && inputs.ref != '' }}
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - uses: actions/checkout@v4
+        if: ${{ inputs.skip_version_bump && inputs.ref == '' }}
         with:
           submodules: recursive
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -20,20 +20,34 @@ permissions:
   id-token: write
 
 jobs:
+  bump-version:
+    name: Bump build version
+    uses: ./.github/workflows/update-latest-build-version.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      base-branch: ${{ github.ref_name }}
+    secrets: inherit
+
   build-exp:
     name: Nightly exp build (main-exp)
+    needs: [bump-version]
     uses: ./.github/workflows/build.yml
     with:
       build_name: main-exp
       platform: both
+      skip_version_bump: true
     secrets: inherit
 
   build-rc:
     name: Nightly RC build (main-rc)
+    needs: [bump-version]
     uses: ./.github/workflows/build.yml
     with:
       build_name: main-rc
       platform: both
+      skip_version_bump: true
     secrets: inherit
 
   upload-exp-testflight:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,24 +2,21 @@ name: Nightly Build
 
 # Triggered by every push to chore/temp-nightly (which nightly-temp-branch-sync.yml
 # force-pushes daily at 4 AM UTC to match main).
+# Temporarily now this is pointing to build/temp-nightly instead of chore/temp-nightly.
 #
-# [skip ci] commits (e.g. version bumps pushed by Bitrise's bump_version_code job via
-# update-latest-build-version.yml) are automatically skipped by GitHub Actions, so
-# this workflow will NOT double-trigger on those commits.
-#
-# skip_version_bump=true is passed to build.yml because Bitrise already owns the
-# version bump for chore/temp-nightly during the parallel transition period.
-# When Bitrise is deprecated, remove skip_version_bump: true and the version bump
-# will be handled by build.yml as normal.
+# [skip ci] commits (e.g. version bumps pushed via update-latest-build-version.yml)
+# are automatically skipped by GitHub Actions, so this workflow will NOT
+# double-trigger on those commits.
 
 on:
   push:
     branches:
-      - chore/temp-nightly
+      - build/temp-nightly
   workflow_dispatch:
 
+# contents: write required by build.yml update-build-version job (version bump commit push)
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -29,7 +26,6 @@ jobs:
     with:
       build_name: main-exp
       platform: both
-      skip_version_bump: true
     secrets: inherit
 
   build-rc:
@@ -38,5 +34,122 @@ jobs:
     with:
       build_name: main-rc
       platform: both
-      skip_version_bump: true
     secrets: inherit
+
+  upload-exp-testflight:
+    name: Upload exp to TestFlight
+    needs: [build-exp]
+    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia-xl
+    environment: apple
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby (iOS)
+        uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb #v1
+        with:
+          ruby-version: '3.2.9'
+          working-directory: ios
+          bundler-cache: true
+
+      - name: Download iOS build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-main-exp
+
+      - name: Find IPA path
+        id: ipa
+        run: |
+          IPA=$(find . -name '*.ipa' -type f | head -1)
+          if [ -z "$IPA" ]; then
+            echo "::error::No .ipa file found in artifact"
+            exit 1
+          fi
+          case "$IPA" in /*) ABS="$IPA" ;; *) ABS="$PWD/$IPA" ;; esac
+          echo "path=$ABS" >> "$GITHUB_OUTPUT"
+
+      - name: Setup App Store Connect API Key
+        run: |
+          bash scripts/setup-app-store-connect-api-key.sh \
+            "$APP_STORE_CONNECT_API_KEY_ISSUER_ID" \
+            "$APP_STORE_CONNECT_API_KEY_KEY_ID" \
+            "$APP_STORE_CONNECT_API_KEY_KEY_CONTENT"
+        env:
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CONTENT }}
+
+      - name: Upload to TestFlight
+        run: |
+          bash scripts/upload-to-testflight.sh \
+            "github_actions_main-exp" \
+            "${{ github.ref_name }}" \
+            "${{ steps.ipa.outputs.path }}" \
+            "MetaMask BETA & Release Candidates"
+
+      - name: Cleanup API Key
+        if: always()
+        run: |
+          rm -f ios/AuthKey.p8
+          echo "🧹 Cleaned up API key file"
+
+  upload-rc-testflight:
+    name: Upload RC to TestFlight
+    needs: [build-rc]
+    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia-xl
+    environment: apple
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby (iOS)
+        uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb #v1
+        with:
+          ruby-version: '3.2.9'
+          working-directory: ios
+          bundler-cache: true
+
+      - name: Download iOS build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-main-rc
+
+      - name: Find IPA path
+        id: ipa
+        run: |
+          IPA=$(find . -name '*.ipa' -type f | head -1)
+          if [ -z "$IPA" ]; then
+            echo "::error::No .ipa file found in artifact"
+            exit 1
+          fi
+          case "$IPA" in /*) ABS="$IPA" ;; *) ABS="$PWD/$IPA" ;; esac
+          echo "path=$ABS" >> "$GITHUB_OUTPUT"
+
+      - name: Setup App Store Connect API Key
+        run: |
+          bash scripts/setup-app-store-connect-api-key.sh \
+            "$APP_STORE_CONNECT_API_KEY_ISSUER_ID" \
+            "$APP_STORE_CONNECT_API_KEY_KEY_ID" \
+            "$APP_STORE_CONNECT_API_KEY_KEY_CONTENT"
+        env:
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CONTENT }}
+
+      - name: Upload to TestFlight
+        run: |
+          bash scripts/upload-to-testflight.sh \
+            "github_actions_main-rc" \
+            "${{ github.ref_name }}" \
+            "${{ steps.ipa.outputs.path }}" \
+            "MetaMask BETA & Release Candidates"
+
+      - name: Cleanup API Key
+        if: always()
+        run: |
+          rm -f ios/AuthKey.p8
+          echo "🧹 Cleaned up API key file"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,7 +2,7 @@ name: Nightly Build
 
 # Triggered by every push to chore/temp-nightly (which nightly-temp-branch-sync.yml
 # force-pushes daily at 4 AM UTC to match main).
-# Temporarily now this is pointing to build/temp-nightly instead of chore/temp-nightly.
+# Temporarily now this is pointing to test/temp-nightly instead of chore/temp-nightly.
 #
 # [skip ci] commits (e.g. version bumps pushed via update-latest-build-version.yml)
 # are automatically skipped by GitHub Actions, so this workflow will NOT
@@ -11,7 +11,7 @@ name: Nightly Build
 on:
   push:
     branches:
-      - build/temp-nightly
+      - test/temp-nightly
   workflow_dispatch:
 
 # contents: write required by build.yml update-build-version job (version bump commit push)

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -38,6 +38,7 @@ jobs:
       build_name: main-exp
       platform: both
       skip_version_bump: true
+      ref: ${{ needs.bump-version.outputs.commit-hash }}
     secrets: inherit
 
   build-rc:
@@ -48,6 +49,7 @@ jobs:
       build_name: main-rc
       platform: both
       skip_version_bump: true
+      ref: ${{ needs.bump-version.outputs.commit-hash }}
     secrets: inherit
 
   upload-exp-testflight:


### PR DESCRIPTION
## **Description**

The nightly build pipeline previously relied on Bitrise for version bumping and deploying iOS exp/RC builds to TestFlight (`exp_builds_to_testflight_pipeline` and `rc_builds_to_testflight_pipeline`). The GitHub Actions `nightly-build.yml` existed alongside Bitrise but passed `skip_version_bump: true` because Bitrise owned the version bump during the parallel transition period.

This PR completes the migration by making GitHub Actions the sole owner of the nightly build pipeline:

- **Enabled version bumping** -- removed `skip_version_bump: true` from both `build-exp` and `build-rc` jobs so `build.yml` → `update-latest-build-version.yml` handles the version bump (commits use `[skip ci]` to prevent re-triggering)
- **Updated permissions** -- changed `contents: read` to `contents: write` (required for the version bump commit push)
- **Added TestFlight upload jobs** -- two new jobs (`upload-exp-testflight` and `upload-rc-testflight`) that download the iOS build artifact from their respective build jobs and upload to TestFlight via the existing `scripts/upload-to-testflight.sh`, using the `apple` GitHub Environment for App Store Connect API secrets
- **Cleaned up comments** -- removed outdated references to Bitrise owning the version bump

The existing sync workflow (`nightly-temp-branch-sync.yml`) remains unchanged and continues to sync `chore/temp-nightly` with `main` at 4 AM UTC, triggering this nightly build via the push event.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Nightly build with TestFlight deployment

  Scenario: Nightly build triggers with version bump and TestFlight upload
    Given the nightly-temp-branch-sync workflow has synced chore/temp-nightly with main
    When the push to chore/temp-nightly triggers nightly-build.yml
    Then the build-exp job builds main-exp for both platforms with version bump enabled
    And the build-rc job builds main-rc for both platforms with version bump enabled
    And the upload-exp-testflight job uploads the iOS exp IPA to TestFlight
    And the upload-rc-testflight job uploads the iOS RC IPA to TestFlight

  Scenario: Manual trigger via workflow_dispatch
    Given a user navigates to Actions > Nightly Build
    When the user triggers the workflow manually
    Then both exp and rc builds run with version bumping
    And both iOS builds are uploaded to TestFlight
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI orchestration, adds write permissions, and introduces automated TestFlight uploads using App Store Connect secrets; failures or misconfiguration could impact nightly release artifacts and deployments.
> 
> **Overview**
> Adds a new `ref` input to the reusable `build.yml` workflow so callers skipping the built-in version bump can explicitly checkout a specific commit/ref (with conditional checkout logic based on `skip_version_bump` + `ref`).
> 
> Updates `nightly-build.yml` to run an explicit version-bump reusable workflow first, pass the resulting commit hash into the build jobs, grant `contents: write`, and add two new jobs to download the iOS artifacts and upload exp/RC IPAs to TestFlight via the existing upload scripts (including API key setup/cleanup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed747972103db2a7be3bb0a2c98dfc2f5c423ee8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->