### PR TITLE
fix: add defensive guard to selectTransactionsStrict selector

### DIFF
--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -12,7 +12,8 @@ const selectTransactionControllerState = (state: RootState) =>
 
 const selectTransactionsStrict = createSelector(
   selectTransactionControllerState,
-  (transactionControllerState) => transactionControllerState.transactions,
+  (transactionControllerState) =>
+    transactionControllerState?.transactions ?? [],
 );
 
 const selectTransactionBatchesStrict = createSelector(


### PR DESCRIPTION
## **Description**

Adds optional chaining and a fallback to `selectTransactionsStrict` in `app/selectors/transactionController.ts` to prevent a `TypeError: Cannot read property 'transactions' of undefined` crash observed in production via [Sentry](https://metamask.sentry.io/issues/7288972780/?project=2299799&query=is%3Aunresolved%20Cannot%20read%20property%20%27transactions&referrer=issue-stream).

### Root Cause

The crash occurs when `state.engine.backgroundState.TransactionController` is `undefined`. This happens during a race condition at app startup: `EngineService.start()` can fail internally (e.g. corrupted vault) and swallow the error, causing the saga to proceed and set `appServicesReady = true` without `INIT_BG_STATE` ever being dispatched — leaving `backgroundState` as `{}`.

The `selectTransactionsStrict` selector accessed `.transactions` on the controller state without a nil check, while 16+ other selectors in the codebase already use optional chaining (`?.`) on `backgroundState` controllers for exactly this reason.

### What This Fixes

This is a **targeted safeguard** to stop the production crash immediately. The selector now returns an empty array when `TransactionController` is not yet initialized, matching the defensive pattern used by `tokensController`, `networkController`, `preferencesController`, `accountsController`, and others.

### What This Does NOT Fix

The deeper architectural issue — that `ControllersGate` gates on `appServicesReady` (a proxy signal) rather than verifying `backgroundState` is actually populated — remains. A follow-up PR will address the root cause so that `App` cannot render before the engine background state is fully initialized.

## **Changelog**

CHANGELOG entry: Fixed a crash that could occur during login when transaction controller state was not yet initialized

## **Related issues**

Fixes: https://metamask.sentry.io/issues/7288972780/

## **Manual testing steps**

```gherkin
Feature: Transaction selector crash guard

  Scenario: App renders before engine background state is fully initialized
    Given the user opens the app and the engine fails to initialize on first attempt (e.g. vault recovery scenario)

    When the app renders the main component tree before backgroundState is populated
    Then the selectTransactionsStrict selector returns an empty array instead of crashing
```

## **Screenshots/Recordings**

### **Before**

`TypeError: Cannot read property 'transactions' of undefined` crash in production (Sentry).

### **After**

Selector gracefully returns `[]` when `TransactionController` state is not yet available.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change; alters selector output during early initialization by returning an empty list instead of throwing when `TransactionController` state is missing.
> 
> **Overview**
> Prevents a startup crash by making `selectTransactionsStrict` tolerate an undefined `TransactionController` state.
> 
> The selector now uses optional chaining and falls back to `[]`, so downstream selectors operate on an empty transactions list rather than throwing a `TypeError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec04505e5bfedfb5b675fa8293cc46992e0ab33b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->