### PR TITLE
fix(perps): abstract breadcrumb calls and remove external dependencies

### DIFF
--- a/app/components/UI/Perps/__mocks__/serviceMocks.ts
+++ b/app/components/UI/Perps/__mocks__/serviceMocks.ts
@@ -61,6 +61,7 @@ export const createMockInfrastructure =
         trace: jest.fn(() => undefined),
         endTrace: jest.fn(),
         setMeasurement: jest.fn(),
+        addBreadcrumb: jest.fn(),
       },
 
       // === Platform Services ===

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -11,7 +11,11 @@ import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../../util/analytics/analytics';
 import { trace, endTrace, TraceName } from '../../../../util/trace';
-import { setMeasurement } from '@sentry/react-native';
+import {
+  setMeasurement,
+  addBreadcrumb,
+  type SeverityLevel,
+} from '@sentry/react-native';
 import performance from 'react-native-performance';
 import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
 import Engine from '../../../../core/Engine';
@@ -216,6 +220,14 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
       },
       setMeasurement(name: string, value: number, unit: string): void {
         setMeasurement(name, value, unit);
+      },
+      addBreadcrumb(breadcrumb: {
+        category: string;
+        message: string;
+        level: SeverityLevel;
+        data?: Record<string, unknown>;
+      }): void {
+        addBreadcrumb(breadcrumb);
       },
     },
 

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -8,7 +8,6 @@ import type { StateChangeListener } from '@metamask/base-controller';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
-import { addBreadcrumb } from '@sentry/react-native';
 import { v4 as uuidv4 } from 'uuid';
 
 import { CandlePeriod } from './constants/chartConfig';
@@ -2019,7 +2018,7 @@ export class PerpsController extends BaseController<
         skipInitialGasEstimate: true,
       };
 
-      addBreadcrumb({
+      this.#options.infrastructure.tracer.addBreadcrumb({
         category: 'perps',
         message: 'Deposit action started',
         level: 'info',

--- a/app/controllers/perps/constants/hyperLiquidConfig.ts
+++ b/app/controllers/perps/constants/hyperLiquidConfig.ts
@@ -30,8 +30,6 @@ export const USDC_SYMBOL = 'USDC';
 export const USDC_NAME = 'USD Coin';
 export const USDC_DECIMALS = 6;
 export const TOKEN_DECIMALS = 18;
-export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-export const ZERO_BALANCE = '0x0';
 
 // Network constants
 export const ARBITRUM_SEPOLIA_CHAIN_ID = '0x66eee'; // 421614 in decimal

--- a/app/controllers/perps/constants/perpsConfig.ts
+++ b/app/controllers/perps/constants/perpsConfig.ts
@@ -8,6 +8,9 @@
  * UI-only constants (layout, display, navigation) live in:
  * app/components/UI/Perps/constants/perpsConfig.ts
  */
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const ZERO_BALANCE = '0x0';
+
 export const PERPS_CONSTANTS = {
   FeatureFlagKey: 'perpsEnabled',
   FeatureName: 'perps', // Constant for Sentry error filtering - enables "feature:perps" dashboard queries

--- a/app/controllers/perps/services/MYXClientService.ts
+++ b/app/controllers/perps/services/MYXClientService.ts
@@ -15,13 +15,12 @@ import type {
 } from '@myx-trade/sdk';
 import { MyxClient } from '@myx-trade/sdk';
 
-import { ZERO_ADDRESS } from '../constants/hyperLiquidConfig';
 import {
   MYX_PRICE_POLLING_INTERVAL_MS,
   getMYXChainId,
   getMYXHttpEndpoint,
 } from '../constants/myxConfig';
-import { PERPS_CONSTANTS } from '../constants/perpsConfig';
+import { PERPS_CONSTANTS, ZERO_ADDRESS } from '../constants/perpsConfig';
 import type { PerpsPlatformDependencies } from '../types';
 import type {
   MYXAuthConfig,

--- a/app/controllers/perps/services/MYXClientService.ts
+++ b/app/controllers/perps/services/MYXClientService.ts
@@ -15,7 +15,7 @@ import type {
 } from '@myx-trade/sdk';
 import { MyxClient } from '@myx-trade/sdk';
 
-import AppConstants from '../../../core/AppConstants';
+import { ZERO_ADDRESS } from '../constants/hyperLiquidConfig';
 import {
   MYX_PRICE_POLLING_INTERVAL_MS,
   getMYXChainId,
@@ -113,10 +113,9 @@ export class MYXClientService {
       brokerAddress: '',
     };
 
-    const brokerAddress =
-      this.#authConfig.brokerAddress || AppConstants.ZERO_ADDRESS;
+    const brokerAddress = this.#authConfig.brokerAddress || ZERO_ADDRESS;
 
-    if (brokerAddress === AppConstants.ZERO_ADDRESS) {
+    if (brokerAddress === ZERO_ADDRESS) {
       this.#deps.debugLogger.log(
         '[MYXClientService] brokerAddress not configured, using zero address',
       );
@@ -139,9 +138,7 @@ export class MYXClientService {
       chainId: this.#chainId,
       wsConnected: true,
       brokerAddress:
-        brokerAddress === AppConstants.ZERO_ADDRESS
-          ? 'zero (not configured)'
-          : 'configured',
+        brokerAddress === ZERO_ADDRESS ? 'zero (not configured)' : 'configured',
     });
   }
 

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -1,4 +1,3 @@
-import { addBreadcrumb } from '@sentry/react-native';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { RewardsIntegrationService } from './RewardsIntegrationService';
@@ -370,7 +369,7 @@ export class TradingService {
         : 'perps_balance';
 
     try {
-      addBreadcrumb({
+      this.#deps.tracer.addBreadcrumb({
         category: 'perps',
         message: 'Order execution started',
         level: 'info',

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -1405,6 +1405,13 @@ export type PerpsTracer = {
   }): void;
 
   setMeasurement(name: string, value: number, unit: string): void;
+
+  addBreadcrumb(breadcrumb: {
+    category: string;
+    message: string;
+    level: 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug';
+    data?: Record<string, unknown>;
+  }): void;
 };
 
 // ============================================================================

--- a/app/controllers/perps/utils/myxAdapter.ts
+++ b/app/controllers/perps/utils/myxAdapter.ts
@@ -455,12 +455,10 @@ export function adaptAccountStateFromMYX(
   // accountInfo structure varies; extract what we can
   // TODO: Verify SDK semantics — if totalCollateral already includes unrealizedPnl,
   // the totalBalance formula below double-counts. Needs SDK documentation check.
-  const marginUsed = accountInfo
-    ? fromMYXCollateral(String(accountInfo.totalCollateral ?? '0'))
-    : 0;
-  const unrealizedPnl = accountInfo
-    ? fromMYXCollateral(String(accountInfo.unrealizedPnl ?? '0'))
-    : 0;
+  const rawCollateral = accountInfo?.totalCollateral ?? '0';
+  const rawPnl = accountInfo?.unrealizedPnl ?? '0';
+  const marginUsed = accountInfo ? fromMYXCollateral(String(rawCollateral)) : 0;
+  const unrealizedPnl = accountInfo ? fromMYXCollateral(String(rawPnl)) : 0;
   const balance = walletBalance ? fromMYXCollateral(walletBalance) : 0;
 
   const totalBalance = balance + marginUsed + unrealizedPnl;

--- a/scripts/perps/validate-core-sync.sh
+++ b/scripts/perps/validate-core-sync.sh
@@ -336,13 +336,13 @@ step_eslint_fix() {
   fi
 
   progress "  ├─ Running --fix"
-  yarn eslint packages/perps-controller/src/ --ext .ts --fix || true
+  yarn eslint 'packages/perps-controller/src/**/*.ts' --fix || true
 
   progress "  ├─ Running --suppress-all"
-  yarn eslint packages/perps-controller/src/ --ext .ts --suppress-all || true
+  yarn eslint 'packages/perps-controller/src/**/*.ts' --suppress-all || true
 
   progress "  └─ Running --prune-suppressions"
-  yarn eslint packages/perps-controller/src/ --ext .ts --prune-suppressions || true
+  yarn eslint 'packages/perps-controller/src/**/*.ts' --prune-suppressions || true
 
   # Count suppressions
   if [[ -f "$supp_file" ]]; then
@@ -378,7 +378,7 @@ step_lint() {
   cd "$CORE_PATH"
   # No workspace-level lint script exists; run eslint directly to verify
   # all violations are either fixed or suppressed (exit 0 = clean).
-  yarn eslint packages/perps-controller/src/ --ext .ts
+  yarn eslint 'packages/perps-controller/src/**/*.ts'
   cd "$MOBILE_ROOT"
 }
 


### PR DESCRIPTION
## **Description**

Abstracts direct `@sentry/react-native` `addBreadcrumb` calls behind the `PerpsTracer` interface and removes the `AppConstants` external dependency from `MYXClientService`, replacing it with a local `ZERO_ADDRESS` constant. Also fixes eslint glob patterns in `validate-core-sync.sh` for the updated core ESLint configuration.

These changes improve core-sync parity by ensuring no platform-specific imports leak into controller code.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (internal cleanup)

## **Manual testing steps**

```gherkin
Feature: Perps trading functionality

  Scenario: user places a perps order after breadcrumb abstraction
    Given the user has an active perps account with funds
    When user places a market order on any symbol
    Then the order executes successfully and breadcrumbs are recorded in Sentry

  Scenario: user initiates a deposit after breadcrumb abstraction
    Given the user is on the perps deposit screen
    When user submits a deposit transaction
    Then the deposit processes and Sentry breadcrumb shows "Deposit action started"
```

## **Screenshots/Recordings**

### **Before**

N/A — no UI changes

### **After**

N/A — no UI changes

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on observability and constants; main behavior change is how breadcrumbs are emitted, so any risk is limited to missing/incorrect Sentry logging if adapters aren’t wired correctly.
> 
> **Overview**
> **Decouples Perps controller/services from platform-specific Sentry imports** by adding `addBreadcrumb` to the `PerpsTracer` interface and routing breadcrumb calls (e.g., order execution and deposit start) through injected `infrastructure.tracer` instead of `@sentry/react-native`.
> 
> Moves `ZERO_ADDRESS`/`ZERO_BALANCE` into controller-portable `perpsConfig` and updates `MYXClientService` to use the local `ZERO_ADDRESS` rather than `AppConstants`, reducing external/mobile-only dependencies.
> 
> Updates `scripts/perps/validate-core-sync.sh` eslint invocations to use the `packages/perps-controller/src/**/*.ts` glob for `--fix`, `--suppress-all`, `--prune-suppressions`, and lint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25d62e71b0f39fc499ed15677eda0a38fae506f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->