### PR TITLE
refactor(AccountBackupStep1): migrate to design system components

### DIFF
--- a/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
   style={
     {
       "backgroundColor": "#ffffff",
-      "flex": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "paddingTop": 24,
     }
   }
@@ -27,8 +29,9 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
     style={
       {
         "backgroundColor": "#ffffff",
-        "flex": 1,
-        "paddingTop": 24,
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
     testID="protect-your-account-screen"
@@ -36,49 +39,69 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
     <View>
       <View
         style={
-          {
-            "flex": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "display": "flex",
+              "flexBasis": "0%",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Step 2 of 3
         </Text>
         <View
           style={
-            {
-              "alignItems": "center",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "marginBottom": 10,
-            }
+            [
+              {
+                "alignItems": "center",
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 10,
+              },
+              undefined,
+            ]
           }
         >
           <Text
             accessibilityRole="text"
             style={
-              {
-                "alignSelf": "flex-start",
-                "color": "#131416",
-                "fontFamily": "Geist-Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-                "marginBottom": 16,
-                "textAlign": "left",
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "color": "#131416",
+                  "fontFamily": "Geist-Bold",
+                  "fontSize": 32,
+                  "fontWeight": 700,
+                  "letterSpacing": 0,
+                  "lineHeight": 40,
+                  "marginBottom": 16,
+                  "textAlign": "left",
+                },
+                undefined,
+              ]
             }
           >
             Secure your wallet
@@ -88,32 +111,40 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
             style={
               {
                 "height": 250,
-                "marginHorizontal": "auto",
+                "marginLeft": "auto",
+                "marginRight": "auto",
                 "width": 250,
               }
             }
           />
           <View
             style={
-              {
-                "alignSelf": "flex-start",
-                "flexDirection": "column",
-                "justifyContent": "center",
-                "marginTop": 32,
-                "rowGap": 16,
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "marginTop": 32,
+                  "rowGap": 16,
+                },
+                undefined,
+              ]
             }
           >
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               Don’t risk losing your funds. Protect your wallet by saving your
@@ -122,13 +153,17 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
                 accessibilityRole="text"
                 onPress={[Function]}
                 style={
-                  {
-                    "color": "#4459ff",
-                    "fontFamily": "Geist-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
                 testID="seedphrase-link"
               >
@@ -141,13 +176,17 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               It’s the only way to recover your wallet if you get locked out of the app or get a new device.
@@ -156,16 +195,30 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
         </View>
         <View
           style={
-            {
-              "flex": 1,
-              "flexDirection": "column",
-              "justifyContent": "flex-end",
-              "marginBottom": 16,
-              "rowGap": 16,
-            }
+            [
+              {
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 24,
+                "rowGap": 16,
+              },
+              undefined,
+            ]
           }
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -203,7 +256,16 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
               </Text>
             </TouchableOpacity>
           </View>
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -264,7 +326,9 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
   style={
     {
       "backgroundColor": "#ffffff",
-      "flex": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "paddingTop": 24,
     }
   }
@@ -278,8 +342,9 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
     style={
       {
         "backgroundColor": "#ffffff",
-        "flex": 1,
-        "paddingTop": 24,
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
     testID="protect-your-account-screen"
@@ -287,49 +352,69 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
     <View>
       <View
         style={
-          {
-            "flex": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "display": "flex",
+              "flexBasis": "0%",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Step 2 of 3
         </Text>
         <View
           style={
-            {
-              "alignItems": "center",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "marginBottom": 10,
-            }
+            [
+              {
+                "alignItems": "center",
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 10,
+              },
+              undefined,
+            ]
           }
         >
           <Text
             accessibilityRole="text"
             style={
-              {
-                "alignSelf": "flex-start",
-                "color": "#131416",
-                "fontFamily": "Geist-Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-                "marginBottom": 16,
-                "textAlign": "left",
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "color": "#131416",
+                  "fontFamily": "Geist-Bold",
+                  "fontSize": 32,
+                  "fontWeight": 700,
+                  "letterSpacing": 0,
+                  "lineHeight": 40,
+                  "marginBottom": 16,
+                  "textAlign": "left",
+                },
+                undefined,
+              ]
             }
           >
             Secure your wallet
@@ -339,32 +424,40 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
             style={
               {
                 "height": 250,
-                "marginHorizontal": "auto",
+                "marginLeft": "auto",
+                "marginRight": "auto",
                 "width": 250,
               }
             }
           />
           <View
             style={
-              {
-                "alignSelf": "flex-start",
-                "flexDirection": "column",
-                "justifyContent": "center",
-                "marginTop": 32,
-                "rowGap": 16,
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "marginTop": 32,
+                  "rowGap": 16,
+                },
+                undefined,
+              ]
             }
           >
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               Don’t risk losing your funds. Protect your wallet by saving your
@@ -373,13 +466,17 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
                 accessibilityRole="text"
                 onPress={[Function]}
                 style={
-                  {
-                    "color": "#4459ff",
-                    "fontFamily": "Geist-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
                 testID="seedphrase-link"
               >
@@ -392,13 +489,17 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               It’s the only way to recover your wallet if you get locked out of the app or get a new device.
@@ -407,16 +508,30 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
         </View>
         <View
           style={
-            {
-              "flex": 1,
-              "flexDirection": "column",
-              "justifyContent": "flex-end",
-              "marginBottom": 16,
-              "rowGap": 16,
-            }
+            [
+              {
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 24,
+                "rowGap": 16,
+              },
+              undefined,
+            ]
           }
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -454,7 +569,16 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
               </Text>
             </TouchableOpacity>
           </View>
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -515,7 +639,9 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
   style={
     {
       "backgroundColor": "#ffffff",
-      "flex": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "paddingTop": 8,
     }
   }
@@ -529,8 +655,9 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
     style={
       {
         "backgroundColor": "#ffffff",
-        "flex": 1,
-        "paddingTop": 8,
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
     testID="protect-your-account-screen"
@@ -538,49 +665,69 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
     <View>
       <View
         style={
-          {
-            "flex": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "display": "flex",
+              "flexBasis": "0%",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Step 2 of 3
         </Text>
         <View
           style={
-            {
-              "alignItems": "center",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "marginBottom": 10,
-            }
+            [
+              {
+                "alignItems": "center",
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 10,
+              },
+              undefined,
+            ]
           }
         >
           <Text
             accessibilityRole="text"
             style={
-              {
-                "alignSelf": "flex-start",
-                "color": "#131416",
-                "fontFamily": "Geist-Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-                "marginBottom": 16,
-                "textAlign": "left",
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "color": "#131416",
+                  "fontFamily": "Geist-Bold",
+                  "fontSize": 32,
+                  "fontWeight": 700,
+                  "letterSpacing": 0,
+                  "lineHeight": 40,
+                  "marginBottom": 16,
+                  "textAlign": "left",
+                },
+                undefined,
+              ]
             }
           >
             Secure your wallet
@@ -590,32 +737,40 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
             style={
               {
                 "height": 250,
-                "marginHorizontal": "auto",
+                "marginLeft": "auto",
+                "marginRight": "auto",
                 "width": 250,
               }
             }
           />
           <View
             style={
-              {
-                "alignSelf": "flex-start",
-                "flexDirection": "column",
-                "justifyContent": "center",
-                "marginTop": 32,
-                "rowGap": 16,
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "marginTop": 32,
+                  "rowGap": 16,
+                },
+                undefined,
+              ]
             }
           >
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               Don’t risk losing your funds. Protect your wallet by saving your
@@ -624,13 +779,17 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
                 accessibilityRole="text"
                 onPress={[Function]}
                 style={
-                  {
-                    "color": "#4459ff",
-                    "fontFamily": "Geist-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
                 testID="seedphrase-link"
               >
@@ -643,13 +802,17 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               It’s the only way to recover your wallet if you get locked out of the app or get a new device.
@@ -658,16 +821,30 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
         </View>
         <View
           style={
-            {
-              "flex": 1,
-              "flexDirection": "column",
-              "justifyContent": "flex-end",
-              "marginBottom": 16,
-              "rowGap": 16,
-            }
+            [
+              {
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 16,
+                "rowGap": 16,
+              },
+              undefined,
+            ]
           }
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -705,7 +882,16 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
               </Text>
             </TouchableOpacity>
           </View>
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -766,7 +952,9 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
   style={
     {
       "backgroundColor": "#ffffff",
-      "flex": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "paddingTop": 24,
     }
   }
@@ -780,8 +968,9 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
     style={
       {
         "backgroundColor": "#ffffff",
-        "flex": 1,
-        "paddingTop": 24,
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
     testID="protect-your-account-screen"
@@ -789,49 +978,69 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
     <View>
       <View
         style={
-          {
-            "flex": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "display": "flex",
+              "flexBasis": "0%",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Step 2 of 3
         </Text>
         <View
           style={
-            {
-              "alignItems": "center",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "marginBottom": 10,
-            }
+            [
+              {
+                "alignItems": "center",
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 10,
+              },
+              undefined,
+            ]
           }
         >
           <Text
             accessibilityRole="text"
             style={
-              {
-                "alignSelf": "flex-start",
-                "color": "#131416",
-                "fontFamily": "Geist-Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-                "marginBottom": 16,
-                "textAlign": "left",
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "color": "#131416",
+                  "fontFamily": "Geist-Bold",
+                  "fontSize": 32,
+                  "fontWeight": 700,
+                  "letterSpacing": 0,
+                  "lineHeight": 40,
+                  "marginBottom": 16,
+                  "textAlign": "left",
+                },
+                undefined,
+              ]
             }
           >
             Secure your wallet
@@ -841,32 +1050,40 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
             style={
               {
                 "height": 250,
-                "marginHorizontal": "auto",
+                "marginLeft": "auto",
+                "marginRight": "auto",
                 "width": 250,
               }
             }
           />
           <View
             style={
-              {
-                "alignSelf": "flex-start",
-                "flexDirection": "column",
-                "justifyContent": "center",
-                "marginTop": 32,
-                "rowGap": 16,
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "marginTop": 32,
+                  "rowGap": 16,
+                },
+                undefined,
+              ]
             }
           >
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               Don’t risk losing your funds. Protect your wallet by saving your
@@ -875,13 +1092,17 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
                 accessibilityRole="text"
                 onPress={[Function]}
                 style={
-                  {
-                    "color": "#4459ff",
-                    "fontFamily": "Geist-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
                 testID="seedphrase-link"
               >
@@ -894,13 +1115,17 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               It’s the only way to recover your wallet if you get locked out of the app or get a new device.
@@ -909,16 +1134,30 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
         </View>
         <View
           style={
-            {
-              "flex": 1,
-              "flexDirection": "column",
-              "justifyContent": "flex-end",
-              "marginBottom": 16,
-              "rowGap": 16,
-            }
+            [
+              {
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 24,
+                "rowGap": 16,
+              },
+              undefined,
+            ]
           }
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -956,7 +1195,16 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
               </Text>
             </TouchableOpacity>
           </View>
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -1017,7 +1265,9 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
   style={
     {
       "backgroundColor": "#ffffff",
-      "flex": 1,
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
       "paddingTop": 24,
     }
   }
@@ -1031,8 +1281,9 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
     style={
       {
         "backgroundColor": "#ffffff",
-        "flex": 1,
-        "paddingTop": 24,
+        "flexBasis": "0%",
+        "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
     testID="protect-your-account-screen"
@@ -1040,49 +1291,69 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
     <View>
       <View
         style={
-          {
-            "flex": 1,
-            "paddingHorizontal": 16,
-          }
+          [
+            {
+              "display": "flex",
+              "flexBasis": "0%",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+            },
+            undefined,
+          ]
         }
       >
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Step 2 of 3
         </Text>
         <View
           style={
-            {
-              "alignItems": "center",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "marginBottom": 10,
-            }
+            [
+              {
+                "alignItems": "center",
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 10,
+              },
+              undefined,
+            ]
           }
         >
           <Text
             accessibilityRole="text"
             style={
-              {
-                "alignSelf": "flex-start",
-                "color": "#131416",
-                "fontFamily": "Geist-Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-                "marginBottom": 16,
-                "textAlign": "left",
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "color": "#131416",
+                  "fontFamily": "Geist-Bold",
+                  "fontSize": 32,
+                  "fontWeight": 700,
+                  "letterSpacing": 0,
+                  "lineHeight": 40,
+                  "marginBottom": 16,
+                  "textAlign": "left",
+                },
+                undefined,
+              ]
             }
           >
             Secure your wallet
@@ -1092,32 +1363,40 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
             style={
               {
                 "height": 250,
-                "marginHorizontal": "auto",
+                "marginLeft": "auto",
+                "marginRight": "auto",
                 "width": 250,
               }
             }
           />
           <View
             style={
-              {
-                "alignSelf": "flex-start",
-                "flexDirection": "column",
-                "justifyContent": "center",
-                "marginTop": 32,
-                "rowGap": 16,
-              }
+              [
+                {
+                  "alignSelf": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "marginTop": 32,
+                  "rowGap": 16,
+                },
+                undefined,
+              ]
             }
           >
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               Don’t risk losing your funds. Protect your wallet by saving your
@@ -1126,13 +1405,17 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
                 accessibilityRole="text"
                 onPress={[Function]}
                 style={
-                  {
-                    "color": "#4459ff",
-                    "fontFamily": "Geist-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist-Regular",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    },
+                    undefined,
+                  ]
                 }
                 testID="seedphrase-link"
               >
@@ -1145,13 +1428,17 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
             <Text
               accessibilityRole="text"
               style={
-                {
-                  "color": "#66676a",
-                  "fontFamily": "Geist-Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
+                [
+                  {
+                    "color": "#66676a",
+                    "fontFamily": "Geist-Regular",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  },
+                  undefined,
+                ]
               }
             >
               It’s the only way to recover your wallet if you get locked out of the app or get a new device.
@@ -1160,16 +1447,30 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
         </View>
         <View
           style={
-            {
-              "flex": 1,
-              "flexDirection": "column",
-              "justifyContent": "flex-end",
-              "marginBottom": 16,
-              "rowGap": 16,
-            }
+            [
+              {
+                "display": "flex",
+                "flexBasis": "0%",
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "marginBottom": 24,
+                "rowGap": 16,
+              },
+              undefined,
+            ]
           }
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}
@@ -1207,7 +1508,16 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
               </Text>
             </TouchableOpacity>
           </View>
-          <View>
+          <View
+            style={
+              [
+                {
+                  "display": "flex",
+                },
+                undefined,
+              ]
+            }
+          >
             <TouchableOpacity
               accessibilityRole="button"
               accessible={true}

--- a/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
@@ -123,7 +123,6 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
                 {
                   "alignSelf": "flex-start",
                   "display": "flex",
-                  "flexDirection": "column",
                   "marginTop": 32,
                   "rowGap": 16,
                 },
@@ -199,7 +198,6 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
               {
                 "display": "flex",
                 "flexBasis": "0%",
-                "flexDirection": "column",
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "marginBottom": 24,
@@ -210,101 +208,175 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
           }
         >
           <View
+            accessibilityLabel="Get started"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
                 {
-                  "display": "flex",
-                },
-                undefined,
-              ]
-            }
-          >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#131416",
                   "borderRadius": 12,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Get started
-              </Text>
-            </TouchableOpacity>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "display": "flex",
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
                 },
-                undefined,
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
               ]
             }
           >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
               style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Get started
+            </Text>
+          </View>
+          <View
+            accessibilityLabel="Remind me later"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
                 {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#b4b4b528",
                   "borderColor": "transparent",
                   "borderRadius": 12,
                   "borderWidth": 1,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID="remind-me-later-button"
-            >
-              <Text
-                accessibilityRole="text"
-                style={
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
+                },
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
+              ]
+            }
+            testID="remind-me-later-button"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
                   {
                     "color": "#131416",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
                     "fontFamily": "Geist-Medium",
                     "fontSize": 16,
+                    "fontWeight": 400,
                     "letterSpacing": 0,
                     "lineHeight": 24,
-                  }
-                }
-              >
-                Remind me later
-              </Text>
-            </TouchableOpacity>
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Remind me later
+            </Text>
           </View>
         </View>
       </View>
@@ -436,7 +508,6 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
                 {
                   "alignSelf": "flex-start",
                   "display": "flex",
-                  "flexDirection": "column",
                   "marginTop": 32,
                   "rowGap": 16,
                 },
@@ -512,7 +583,6 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
               {
                 "display": "flex",
                 "flexBasis": "0%",
-                "flexDirection": "column",
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "marginBottom": 24,
@@ -523,101 +593,175 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
           }
         >
           <View
+            accessibilityLabel="Get started"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
                 {
-                  "display": "flex",
-                },
-                undefined,
-              ]
-            }
-          >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#131416",
                   "borderRadius": 12,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Get started
-              </Text>
-            </TouchableOpacity>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "display": "flex",
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
                 },
-                undefined,
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
               ]
             }
           >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
               style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Get started
+            </Text>
+          </View>
+          <View
+            accessibilityLabel="Remind me later"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
                 {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#b4b4b528",
                   "borderColor": "transparent",
                   "borderRadius": 12,
                   "borderWidth": 1,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID="remind-me-later-button"
-            >
-              <Text
-                accessibilityRole="text"
-                style={
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
+                },
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
+              ]
+            }
+            testID="remind-me-later-button"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
                   {
                     "color": "#131416",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
                     "fontFamily": "Geist-Medium",
                     "fontSize": 16,
+                    "fontWeight": 400,
                     "letterSpacing": 0,
                     "lineHeight": 24,
-                  }
-                }
-              >
-                Remind me later
-              </Text>
-            </TouchableOpacity>
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Remind me later
+            </Text>
           </View>
         </View>
       </View>
@@ -749,7 +893,6 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
                 {
                   "alignSelf": "flex-start",
                   "display": "flex",
-                  "flexDirection": "column",
                   "marginTop": 32,
                   "rowGap": 16,
                 },
@@ -825,7 +968,6 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
               {
                 "display": "flex",
                 "flexBasis": "0%",
-                "flexDirection": "column",
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "marginBottom": 16,
@@ -836,101 +978,175 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
           }
         >
           <View
+            accessibilityLabel="Get started"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
                 {
-                  "display": "flex",
-                },
-                undefined,
-              ]
-            }
-          >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#131416",
                   "borderRadius": 12,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Get started
-              </Text>
-            </TouchableOpacity>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "display": "flex",
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
                 },
-                undefined,
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
               ]
             }
           >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
               style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Get started
+            </Text>
+          </View>
+          <View
+            accessibilityLabel="Remind me later"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
                 {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#b4b4b528",
                   "borderColor": "transparent",
                   "borderRadius": 12,
                   "borderWidth": 1,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID="remind-me-later-button"
-            >
-              <Text
-                accessibilityRole="text"
-                style={
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
+                },
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
+              ]
+            }
+            testID="remind-me-later-button"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
                   {
                     "color": "#131416",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
                     "fontFamily": "Geist-Medium",
                     "fontSize": 16,
+                    "fontWeight": 400,
                     "letterSpacing": 0,
                     "lineHeight": 24,
-                  }
-                }
-              >
-                Remind me later
-              </Text>
-            </TouchableOpacity>
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Remind me later
+            </Text>
           </View>
         </View>
       </View>
@@ -1062,7 +1278,6 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
                 {
                   "alignSelf": "flex-start",
                   "display": "flex",
-                  "flexDirection": "column",
                   "marginTop": 32,
                   "rowGap": 16,
                 },
@@ -1138,7 +1353,6 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
               {
                 "display": "flex",
                 "flexBasis": "0%",
-                "flexDirection": "column",
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "marginBottom": 24,
@@ -1149,101 +1363,175 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
           }
         >
           <View
+            accessibilityLabel="Get started"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
                 {
-                  "display": "flex",
-                },
-                undefined,
-              ]
-            }
-          >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#131416",
                   "borderRadius": 12,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Get started
-              </Text>
-            </TouchableOpacity>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "display": "flex",
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
                 },
-                undefined,
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
               ]
             }
           >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
               style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Get started
+            </Text>
+          </View>
+          <View
+            accessibilityLabel="Remind me later"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
                 {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#b4b4b528",
                   "borderColor": "transparent",
                   "borderRadius": 12,
                   "borderWidth": 1,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID="remind-me-later-button"
-            >
-              <Text
-                accessibilityRole="text"
-                style={
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
+                },
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
+              ]
+            }
+            testID="remind-me-later-button"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
                   {
                     "color": "#131416",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
                     "fontFamily": "Geist-Medium",
                     "fontSize": 16,
+                    "fontWeight": 400,
                     "letterSpacing": 0,
                     "lineHeight": 24,
-                  }
-                }
-              >
-                Remind me later
-              </Text>
-            </TouchableOpacity>
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Remind me later
+            </Text>
           </View>
         </View>
       </View>
@@ -1375,7 +1663,6 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
                 {
                   "alignSelf": "flex-start",
                   "display": "flex",
-                  "flexDirection": "column",
                   "marginTop": 32,
                   "rowGap": 16,
                 },
@@ -1451,7 +1738,6 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
               {
                 "display": "flex",
                 "flexBasis": "0%",
-                "flexDirection": "column",
                 "flexGrow": 1,
                 "flexShrink": 1,
                 "marginBottom": 24,
@@ -1462,101 +1748,175 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
           }
         >
           <View
+            accessibilityLabel="Get started"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               [
                 {
-                  "display": "flex",
-                },
-                undefined,
-              ]
-            }
-          >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
-                {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#131416",
                   "borderRadius": 12,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Get started
-              </Text>
-            </TouchableOpacity>
-          </View>
-          <View
-            style={
-              [
-                {
-                  "display": "flex",
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
                 },
-                undefined,
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
               ]
             }
           >
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
               style={
+                [
+                  {
+                    "color": "#ffffff",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "fontFamily": "Geist-Medium",
+                    "fontSize": 16,
+                    "fontWeight": 400,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Get started
+            </Text>
+          </View>
+          <View
+            accessibilityLabel="Remind me later"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
                 {
                   "alignItems": "center",
-                  "alignSelf": "stretch",
                   "backgroundColor": "#b4b4b528",
                   "borderColor": "transparent",
                   "borderRadius": 12,
                   "borderWidth": 1,
+                  "columnGap": 8,
                   "flexDirection": "row",
                   "height": 48,
                   "justifyContent": "center",
+                  "minWidth": 80,
+                  "opacity": 1,
                   "overflow": "hidden",
-                  "paddingHorizontal": 16,
-                }
-              }
-              testID="remind-me-later-button"
-            >
-              <Text
-                accessibilityRole="text"
-                style={
+                  "paddingLeft": 16,
+                  "paddingRight": 16,
+                  "width": "100%",
+                },
+                {
+                  "transform": [
+                    {
+                      "scale": 1,
+                    },
+                  ],
+                },
+              ]
+            }
+            testID="remind-me-later-button"
+          >
+            <Text
+              accessibilityRole="text"
+              ellipsizeMode="clip"
+              numberOfLines={1}
+              style={
+                [
                   {
                     "color": "#131416",
+                    "flexGrow": 0,
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
                     "fontFamily": "Geist-Medium",
                     "fontSize": 16,
+                    "fontWeight": 400,
                     "letterSpacing": 0,
                     "lineHeight": 24,
-                  }
-                }
-              >
-                Remind me later
-              </Text>
-            </TouchableOpacity>
+                    "textAlign": "center",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              Remind me later
+            </Text>
           </View>
         </View>
       </View>

--- a/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
         "flexBasis": "0%",
         "flexGrow": 1,
         "flexShrink": 1,
+        "paddingTop": 24,
       }
     }
     testID="protect-your-account-screen"
@@ -197,10 +198,8 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
             [
               {
                 "display": "flex",
-                "flexBasis": "0%",
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "marginBottom": 24,
+                "marginTop": "auto",
                 "rowGap": 16,
               },
               undefined,
@@ -417,6 +416,7 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
         "flexBasis": "0%",
         "flexGrow": 1,
         "flexShrink": 1,
+        "paddingTop": 24,
       }
     }
     testID="protect-your-account-screen"
@@ -582,10 +582,8 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
             [
               {
                 "display": "flex",
-                "flexBasis": "0%",
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "marginBottom": 24,
+                "marginTop": "auto",
                 "rowGap": 16,
               },
               undefined,
@@ -802,6 +800,7 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
         "flexBasis": "0%",
         "flexGrow": 1,
         "flexShrink": 1,
+        "paddingTop": 8,
       }
     }
     testID="protect-your-account-screen"
@@ -967,10 +966,8 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
             [
               {
                 "display": "flex",
-                "flexBasis": "0%",
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "marginBottom": 16,
+                "marginTop": "auto",
                 "rowGap": 16,
               },
               undefined,
@@ -1187,6 +1184,7 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
         "flexBasis": "0%",
         "flexGrow": 1,
         "flexShrink": 1,
+        "paddingTop": 24,
       }
     }
     testID="protect-your-account-screen"
@@ -1352,10 +1350,8 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
             [
               {
                 "display": "flex",
-                "flexBasis": "0%",
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "marginBottom": 24,
+                "marginTop": "auto",
                 "rowGap": 16,
               },
               undefined,
@@ -1572,6 +1568,7 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
         "flexBasis": "0%",
         "flexGrow": 1,
         "flexShrink": 1,
+        "paddingTop": 24,
       }
     }
     testID="protect-your-account-screen"
@@ -1737,10 +1734,8 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
             [
               {
                 "display": "flex",
-                "flexBasis": "0%",
-                "flexGrow": 1,
-                "flexShrink": 1,
                 "marginBottom": 24,
+                "marginTop": "auto",
                 "rowGap": 16,
               },
               undefined,

--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
 import {
   ScrollView,
@@ -8,6 +7,7 @@ import {
   StatusBar,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import PropTypes from 'prop-types';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -144,7 +144,12 @@ const AccountBackupStep1 = (props) => {
     >
       <ScrollView
         contentContainerStyle={tw.style('flex-grow')}
-        style={tw.style('flex-1 bg-default')}
+        style={tw.style(
+          'flex-1 bg-default',
+          Platform.OS === 'android'
+            ? `pt-[${StatusBar.currentHeight || 24}px]`
+            : 'pt-2',
+        )}
         testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
       >
         <Box twClassName="flex-1 px-4">
@@ -198,7 +203,7 @@ const AccountBackupStep1 = (props) => {
 
           <Box
             justifyContent={BoxJustifyContent.FlexEnd}
-            twClassName={`flex-1 gap-y-4 ${
+            twClassName={`mt-auto gap-y-4 ${
               Platform.OS === 'android' ? 'mb-6' : 'mb-4'
             }`}
           >
@@ -234,5 +239,16 @@ const AccountBackupStep1 = (props) => {
 const mapDispatchToProps = (dispatch) => ({
   saveOnboardingEvent: (...eventArgs) => dispatch(saveEvent(eventArgs)),
 });
+
+AccountBackupStep1.propTypes = {
+  /**
+   * Object that represents the current route info like params passed to it.
+   */
+  route: PropTypes.object,
+  /**
+   * Action to save onboarding event.
+   */
+  saveOnboardingEvent: PropTypes.func,
+};
 
 export default connect(null, mapDispatchToProps)(AccountBackupStep1);

--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -1,29 +1,28 @@
+/* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
-import {
-  ScrollView,
-  View,
-  StyleSheet,
-  BackHandler,
-  Image,
-  Platform,
-  StatusBar,
-} from 'react-native';
+import { ScrollView, BackHandler, Image, Platform, StatusBar } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import PropTypes from 'prop-types';
-import { fontStyles } from '../../../styles/common';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Text as DSText,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import AndroidBackHandler from '../AndroidBackHandler';
 import Device from '../../../util/device';
-import scaling from '../../../util/scaling';
 import Engine from '../../../core/Engine';
 import { connect } from 'react-redux';
 import { saveOnboardingEvent as saveEvent } from '../../../actions/onboarding';
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import StorageWrapper from '../../../store/storage-wrapper';
 import { useTheme } from '../../../util/theme';
 import { ManualBackUpStepsSelectorsIDs } from '../ManualBackupStep1/ManualBackUpSteps.testIds';
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
-import Routes from '../../../../app/constants/navigation/Routes';
+import Routes from '../../../constants/navigation/Routes';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import SRPDesignLight from '../../../images/secure_wallet_light.png';
 import SRPDesignDark from '../../../images/secure_wallet_dark.png';
@@ -32,10 +31,6 @@ import Button, {
   ButtonWidthTypes,
   ButtonSize,
 } from '../../../component-library/components/Buttons/Button';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../component-library/components/Texts/Text';
 import { CommonActions, useNavigation } from '@react-navigation/native';
 import { useMetrics } from '../../hooks/useMetrics';
 import {
@@ -45,75 +40,11 @@ import {
 import { TraceName, endTrace } from '../../../util/trace';
 import { AppThemeKey } from '../../../util/theme/models';
 
-const createStyles = (colors) =>
-  StyleSheet.create({
-    mainWrapper: {
-      backgroundColor: colors.background.default,
-      flex: 1,
-      paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight || 24 : 8,
-    },
-    scrollviewWrapper: {
-      flexGrow: 1,
-    },
-    wrapper: {
-      flex: 1,
-      paddingHorizontal: 16,
-    },
-    content: {
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      flex: 1,
-      marginBottom: 10,
-    },
-    title: {
-      textAlign: 'left',
-      alignSelf: 'flex-start',
-      marginBottom: 16,
-    },
-    text: {
-      marginTop: 32,
-      justifyContent: 'center',
-      alignSelf: 'flex-start',
-      flexDirection: 'column',
-      rowGap: 16,
-    },
-    label: {
-      lineHeight: scaling.scale(20),
-      fontSize: scaling.scale(14),
-      color: colors.text.default,
-      textAlign: 'left',
-      ...fontStyles.normal,
-    },
-    buttonWrapper: {
-      flex: 1,
-      justifyContent: 'flex-end',
-      flexDirection: 'column',
-      rowGap: 16,
-      marginBottom: Platform.select({
-        ios: 16,
-        android: 24,
-        default: 16,
-      }),
-    },
-    srpDesign: {
-      width: 250,
-      height: 250,
-      marginHorizontal: 'auto',
-    },
-    headerLeft: {
-      marginLeft: 16,
-    },
-  });
-
-/**
- * View that's shown during the first step of
- * the backup seed phrase flow
- */
 const AccountBackupStep1 = (props) => {
   const [hasFunds, setHasFunds] = useState(false);
-  const { colors, themeAppearance } = useTheme();
-  const styles = createStyles(colors);
+  const { themeAppearance } = useTheme();
   const { isEnabled: isMetricsEnabled } = useMetrics();
+  const tw = useTailwind();
 
   const track = (event, properties) => {
     const eventBuilder = MetricsEventBuilder.createEventBuilder(event);
@@ -125,25 +56,25 @@ const AccountBackupStep1 = (props) => {
 
   useEffect(
     () => {
-      // Check if user has funds
       if (Engine.hasFunds()) setHasFunds(true);
 
-      // Disable back press
       const hardwareBackPress = () => true;
-
-      // Add event listener
       BackHandler.addEventListener('hardwareBackPress', hardwareBackPress);
 
-      // Remove event listener on cleanup
       return () => {
-        BackHandler.removeEventListener('hardwareBackPress', hardwareBackPress);
+        BackHandler.removeEventListener(
+          'hardwareBackPress',
+          hardwareBackPress,
+        );
       };
     },
-    [], // Run only when component mounts
+    [],
   );
 
   const goNext = () => {
-    navigation.navigate('ManualBackupStep1', { ...props.route.params });
+    navigation.navigate('ManualBackupStep1', {
+      ...props.route.params,
+    });
     track(MetaMetricsEvents.WALLET_SECURITY_STARTED);
   };
 
@@ -205,57 +136,84 @@ const AccountBackupStep1 = (props) => {
   };
 
   return (
-    <SafeAreaView style={styles.mainWrapper} edges={['top', 'bottom']}>
+    <SafeAreaView
+      style={tw.style(
+        'flex-1 bg-default',
+        Platform.OS === 'android'
+          ? `pt-[${StatusBar.currentHeight || 24}px]`
+          : 'pt-2',
+      )}
+      edges={['top', 'bottom']}
+    >
       <ScrollView
-        contentContainerStyle={styles.scrollviewWrapper}
-        style={styles.mainWrapper}
+        contentContainerStyle={tw.style('flex-grow')}
+        style={tw.style('flex-1 bg-default')}
         testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
       >
-        <View style={styles.wrapper}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        <Box twClassName="flex-1 px-4">
+          <DSText variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('manual_backup_step_1.steps', {
               currentStep: 2,
               totalSteps: 3,
             })}
-          </Text>
-          <View style={styles.content}>
-            <Text
-              variant={TextVariant.DisplayMD}
-              color={TextColor.Default}
-              style={styles.title}
+          </DSText>
+          <Box
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.FlexStart}
+            twClassName="flex-1 mb-2.5"
+          >
+            <DSText
+              variant={TextVariant.DisplayMd}
+              color={TextColor.TextDefault}
+              twClassName="text-left self-start mb-4"
             >
               {strings('account_backup_step_1.title')}
-            </Text>
+            </DSText>
             <Image
               source={
                 themeAppearance === AppThemeKey.dark
                   ? SRPDesignDark
                   : SRPDesignLight
               }
-              style={styles.srpDesign}
+              style={tw.style('w-[250px] h-[250px] mx-auto')}
             />
-            <View style={styles.text}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              twClassName="mt-8 self-start gap-y-4"
+            >
+              <DSText
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('account_backup_step_1.info_text_1_1')}{' '}
-                <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Primary}
+                <DSText
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.PrimaryDefault}
                   onPress={showWhatIsSeedphrase}
                   testID={ManualBackUpStepsSelectorsIDs.SEEDPHRASE_LINK}
                 >
                   {strings('account_backup_step_1.info_text_1_2')}
-                </Text>{' '}
+                </DSText>{' '}
                 {strings('account_backup_step_1.info_text_1_3')}{' '}
-              </Text>
+              </DSText>
 
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <DSText
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('account_backup_step_1.info_text_1_4')}
-              </Text>
-            </View>
-          </View>
+              </DSText>
+            </Box>
+          </Box>
 
-          <View style={styles.buttonWrapper}>
-            <View>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            justifyContent={BoxJustifyContent.FlexEnd}
+            twClassName={`flex-1 gap-y-4 ${
+              Platform.OS === 'android' ? 'mb-6' : 'mb-4'
+            }`}
+          >
+            <Box>
               <Button
                 variant={ButtonVariants.Primary}
                 onPress={goNext}
@@ -263,9 +221,9 @@ const AccountBackupStep1 = (props) => {
                 width={ButtonWidthTypes.Full}
                 size={ButtonSize.Lg}
               />
-            </View>
+            </Box>
             {!hasFunds && (
-              <View>
+              <Box>
                 <Button
                   variant={ButtonVariants.Secondary}
                   onPress={showRemindLater}
@@ -274,27 +232,16 @@ const AccountBackupStep1 = (props) => {
                   size={ButtonSize.Lg}
                   testID={ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON}
                 />
-              </View>
+              </Box>
             )}
-          </View>
-        </View>
+          </Box>
+        </Box>
       </ScrollView>
       {Device.isAndroid() && (
         <AndroidBackHandler customBackPress={showRemindLater} />
       )}
     </SafeAreaView>
   );
-};
-
-AccountBackupStep1.propTypes = {
-  /**
-   * Object that represents the current route info like params passed to it
-   */
-  route: PropTypes.object,
-  /**
-   * Action to save onboarding event
-   */
-  saveOnboardingEvent: PropTypes.func,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -11,10 +11,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
-  BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
-  Text as DSText,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Text,
   TextVariant,
   TextColor,
 } from '@metamask/design-system-react-native';
@@ -32,11 +34,6 @@ import Routes from '../../../constants/navigation/Routes';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import SRPDesignLight from '../../../images/secure_wallet_light.png';
 import SRPDesignDark from '../../../images/secure_wallet_dark.png';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../component-library/components/Buttons/Button';
 import { CommonActions, useNavigation } from '@react-navigation/native';
 import { useMetrics } from '../../hooks/useMetrics';
 import {
@@ -151,27 +148,20 @@ const AccountBackupStep1 = (props) => {
         testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
       >
         <Box twClassName="flex-1 px-4">
-          <DSText
-            variant={TextVariant.BodyMd}
-            color={TextColor.TextAlternative}
-          >
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('manual_backup_step_1.steps', {
               currentStep: 2,
               totalSteps: 3,
             })}
-          </DSText>
-          <Box
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.FlexStart}
-            twClassName="flex-1 mb-2.5"
-          >
-            <DSText
+          </Text>
+          <Box alignItems={BoxAlignItems.Center} twClassName="flex-1 mb-2.5">
+            <Text
               variant={TextVariant.DisplayMd}
               color={TextColor.TextDefault}
               twClassName="text-left self-start mb-4"
             >
               {strings('account_backup_step_1.title')}
-            </DSText>
+            </Text>
             <Image
               source={
                 themeAppearance === AppThemeKey.dark
@@ -180,62 +170,56 @@ const AccountBackupStep1 = (props) => {
               }
               style={tw.style('w-[250px] h-[250px] mx-auto')}
             />
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              twClassName="mt-8 self-start gap-y-4"
-            >
-              <DSText
+            <Box twClassName="mt-8 self-start gap-y-4">
+              <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.TextAlternative}
               >
                 {strings('account_backup_step_1.info_text_1_1')}{' '}
-                <DSText
+                <Text
                   variant={TextVariant.BodyMd}
                   color={TextColor.PrimaryDefault}
                   onPress={showWhatIsSeedphrase}
                   testID={ManualBackUpStepsSelectorsIDs.SEEDPHRASE_LINK}
                 >
                   {strings('account_backup_step_1.info_text_1_2')}
-                </DSText>{' '}
+                </Text>{' '}
                 {strings('account_backup_step_1.info_text_1_3')}{' '}
-              </DSText>
+              </Text>
 
-              <DSText
+              <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.TextAlternative}
               >
                 {strings('account_backup_step_1.info_text_1_4')}
-              </DSText>
+              </Text>
             </Box>
           </Box>
 
           <Box
-            flexDirection={BoxFlexDirection.Column}
             justifyContent={BoxJustifyContent.FlexEnd}
             twClassName={`flex-1 gap-y-4 ${
               Platform.OS === 'android' ? 'mb-6' : 'mb-4'
             }`}
           >
-            <Box>
-              <Button
-                variant={ButtonVariants.Primary}
-                onPress={goNext}
-                label={strings('account_backup_step_1.cta_text')}
-                width={ButtonWidthTypes.Full}
-                size={ButtonSize.Lg}
-              />
-            </Box>
+            <Button
+              variant={ButtonVariant.Primary}
+              onPress={goNext}
+              isFullWidth
+              size={ButtonSize.Lg}
+            >
+              {strings('account_backup_step_1.cta_text')}
+            </Button>
             {!hasFunds && (
-              <Box>
-                <Button
-                  variant={ButtonVariants.Secondary}
-                  onPress={showRemindLater}
-                  label={strings('account_backup_step_1.remind_me_later')}
-                  width={ButtonWidthTypes.Full}
-                  size={ButtonSize.Lg}
-                  testID={ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON}
-                />
-              </Box>
+              <Button
+                variant={ButtonVariant.Secondary}
+                onPress={showRemindLater}
+                isFullWidth
+                size={ButtonSize.Lg}
+                testID={ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON}
+              >
+                {strings('account_backup_step_1.remind_me_later')}
+              </Button>
             )}
           </Box>
         </Box>

--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -1,6 +1,12 @@
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
-import { ScrollView, BackHandler, Image, Platform, StatusBar } from 'react-native';
+import {
+  ScrollView,
+  BackHandler,
+  Image,
+  Platform,
+  StatusBar,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -54,22 +60,16 @@ const AccountBackupStep1 = (props) => {
 
   const navigation = useNavigation();
 
-  useEffect(
-    () => {
-      if (Engine.hasFunds()) setHasFunds(true);
+  useEffect(() => {
+    if (Engine.hasFunds()) setHasFunds(true);
 
-      const hardwareBackPress = () => true;
-      BackHandler.addEventListener('hardwareBackPress', hardwareBackPress);
+    const hardwareBackPress = () => true;
+    BackHandler.addEventListener('hardwareBackPress', hardwareBackPress);
 
-      return () => {
-        BackHandler.removeEventListener(
-          'hardwareBackPress',
-          hardwareBackPress,
-        );
-      };
-    },
-    [],
-  );
+    return () => {
+      BackHandler.removeEventListener('hardwareBackPress', hardwareBackPress);
+    };
+  }, []);
 
   const goNext = () => {
     navigation.navigate('ManualBackupStep1', {
@@ -151,7 +151,10 @@ const AccountBackupStep1 = (props) => {
         testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
       >
         <Box twClassName="flex-1 px-4">
-          <DSText variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+          <DSText
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+          >
             {strings('manual_backup_step_1.steps', {
               currentStep: 2,
               totalSteps: 3,


### PR DESCRIPTION
## **Description**

Migrate the `AccountBackupStep1` component from legacy styling patterns to the design system:

- Replace `View` with `Box` and `StyleSheet.create()` with `twClassName` Tailwind utilities
- Replace component-library `Button` and `Text` with `@metamask/design-system-react-native` equivalents
- Remove redundant default props (`flexDirection Column`, `justifyContent FlexStart`)
- Clean up unused imports (`PropTypes`, `fontStyles`, `scaling`, `StorageWrapper`)

This is a pure refactor with no behavioral changes — functional logic, navigation, and analytics are untouched.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: AccountBackupStep1 screen

  Scenario: View secure wallet prompt after wallet creation
    Given the user has just created a new wallet
    When the user reaches the "Secure your wallet" screen
    Then they see the SRP illustration, explanation text, and two buttons

  Scenario: Proceed to manual backup
    Given the user is on the "Secure your wallet" screen
    When the user taps "Start"
    Then they navigate to ManualBackupStep1

  Scenario: Skip backup for later
    Given the user has no funds and is on the "Secure your wallet" screen
    When the user taps "Remind me later"
    Then the skip confirmation modal appears

  Scenario: Theme switching
    Given the user is on the "Secure your wallet" screen
    When the device is in dark mode
    Then the dark SRP illustration is displayed
```

## **Screenshots/Recordings**

|           | Before | After |
|-----------|--------|-------|
| **Light** | <img src="https://github.com/user-attachments/assets/5f5d1695-387b-4827-94bd-f6f915aa250e" width="300"/> | <img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-19 at 15 55 40" src="https://github.com/user-attachments/assets/22d25352-4159-41fd-b4d6-9ec0fa515e2b" /> |
| **Dark**  | <img src="https://github.com/user-attachments/assets/932503c1-fab4-4068-bb36-839a1c5c65cc" width="300"/> | <img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-19 at 15 55 48" src="https://github.com/user-attachments/assets/0e1bbd50-19b0-433b-bdc5-dee42fe90f1f" /> |






## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to the `AccountBackupStep1` UI layer, but it could cause minor layout/spacing regressions due to the styling and component swap.
> 
> **Overview**
> Migrates `AccountBackupStep1` from legacy `StyleSheet`/`View` and component-library `Button`/`Text` to the MetaMask design system (`Box`, `Button`, `Text`) with Tailwind (`useTailwind`) styling.
> 
> Keeps the existing navigation/metrics/back-handler flows, while updating padding/spacing rules and refreshing Jest snapshots to match the new rendered component tree and style output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba0f3dcc6dbccd51d58c8f2af77a4927b6595b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->