### PR TITLE
refactor(AccountBackupStep1B): migrate to design system components

### DIFF
--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -1,19 +1,27 @@
+/* eslint-disable react/prop-types */
 import React, { useState, useEffect, useCallback } from 'react';
-import { connect, useSelector } from 'react-redux';
 import {
   ScrollView,
   TouchableOpacity,
-  Text,
-  View,
   SafeAreaView,
-  StyleSheet,
   Image,
   Dimensions,
 } from 'react-native';
-import PropTypes from 'prop-types';
+import { connect, useSelector } from 'react-redux';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  BoxBackgroundColor,
+  BoxBorderColor,
+  Text as DSText,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { fontStyles } from '../../../styles/common';
-import StyledButton from '../../UI/StyledButton';
 import OnboardingProgress from '../../UI/OnboardingProgress';
 import { strings } from '../../../../locales/i18n';
 import AndroidBackHandler from '../AndroidBackHandler';
@@ -23,13 +31,17 @@ import { getOnboardingNavbarOptions } from '../../UI/Navbar';
 import { CHOOSE_PASSWORD_STEPS } from '../../../constants/onboarding';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { saveOnboardingEvent as saveEvent } from '../../../actions/onboarding';
-
 import { useTheme } from '../../../util/theme';
 import { ManualBackUpStepsSelectorsIDs } from '../ManualBackupStep1/ManualBackUpSteps.testIds';
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import Routes from '../../../constants/navigation/Routes';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
+import Button, {
+  ButtonVariants,
+  ButtonWidthTypes,
+  ButtonSize,
+} from '../../../component-library/components/Buttons/Button';
 
 const explain_backup_seedphrase = require('../../../images/explain-backup-seedphrase.png'); // eslint-disable-line
 
@@ -37,182 +49,16 @@ const IMAGE_1_RATIO = 162.8 / 138;
 const DEVICE_WIDTH = Dimensions.get('window').width;
 const IMG_PADDING = Device.isIphoneX() ? 100 : Device.isIphone5S() ? 180 : 220;
 
-const createStyles = (colors) =>
-  StyleSheet.create({
-    mainWrapper: {
-      backgroundColor: colors.background.default,
-      flex: 1,
-    },
-    scrollviewWrapper: {
-      flexGrow: 1,
-    },
-    wrapper: {
-      flex: 1,
-      padding: 20,
-      paddingTop: 0,
-      paddingBottom: 0,
-      marginTop: 16,
-    },
-    content: {
-      alignItems: 'center',
-      paddingBottom: 16,
-    },
-    title: {
-      fontSize: 24,
-      marginLeft: 0,
-      marginTop: 16,
-      marginBottom: 16,
-      color: colors.text.default,
-      justifyContent: 'center',
-      ...fontStyles.bold,
-    },
-    text: {
-      marginBottom: 16,
-      justifyContent: 'center',
-    },
-    label: {
-      lineHeight: 20,
-      fontSize: 16,
-      color: colors.text.default,
-      textAlign: 'left',
-      ...fontStyles.normal,
-    },
-    bold: {
-      lineHeight: 25,
-      ...fontStyles.bold,
-    },
-    image: {
-      marginTop: 14,
-      marginBottom: 8,
-      width: DEVICE_WIDTH - IMG_PADDING,
-      height: (DEVICE_WIDTH - IMG_PADDING) * IMAGE_1_RATIO,
-    },
-    card: {
-      backgroundColor: colors.background.default,
-      borderWidth: 1,
-      borderColor: colors.border.default,
-      borderRadius: 10,
-      elevation: 4,
-      padding: 16,
-      marginBottom: 20,
-    },
-
-    modalNoBorder: {
-      borderTopWidth: 0,
-    },
-    secureModalContainer: { flex: 1, padding: 27, flexDirection: 'column' },
-    secureModalXButton: {
-      padding: 5,
-      alignItems: 'flex-end',
-    },
-    whySecureTitle: {
-      flex: 1,
-      fontSize: 18,
-      color: colors.text.default,
-      textAlign: 'center',
-      ...fontStyles.bold,
-    },
-    learnMoreText: {
-      marginTop: 21,
-      textAlign: 'center',
-      fontSize: 15,
-      lineHeight: 20,
-      color: colors.primary.default,
-      ...fontStyles.normal,
-    },
-    blue: {
-      color: colors.primary.default,
-    },
-    titleIcon: {
-      fontSize: 32,
-    },
-    centerContent: {
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    infoIcon: {
-      fontSize: 15,
-      marginRight: 6,
-    },
-    whyImportantText: {
-      fontSize: 14,
-      color: colors.primary.default,
-    },
-    manualTitle: {
-      fontSize: 16,
-      marginBottom: 8,
-      lineHeight: 17,
-      color: colors.text.default,
-      ...fontStyles.bold,
-    },
-    paragraph: {
-      lineHeight: 17,
-      marginBottom: 20,
-      fontSize: 12,
-      color: colors.text.default,
-    },
-    smallParagraph: {
-      lineHeight: 17,
-      fontSize: 12,
-      color: colors.text.default,
-    },
-    barsTitle: {
-      lineHeight: 17,
-      marginBottom: 8,
-      fontSize: 12,
-      color: colors.text.default,
-    },
-    barsContainer: {
-      lineHeight: 17,
-      flexDirection: 'row',
-      marginBottom: 20,
-    },
-    bar: {
-      lineHeight: 17,
-      width: 32,
-      height: 6,
-      backgroundColor: colors.primary.default,
-      marginRight: 2,
-    },
-    secureModalXIcon: {
-      fontSize: 16,
-      color: colors.text.default,
-    },
-    auxCenterView: {
-      width: 26,
-    },
-    secureModalTitleContainer: {
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'center',
-      marginBottom: 16,
-    },
-    explainBackupContainer: {
-      flexDirection: 'column',
-      alignItems: 'center',
-    },
-    whySecureText: {
-      textAlign: 'center',
-      lineHeight: 20,
-      color: colors.text.default,
-    },
-  });
-
-/**
- * View that's shown during the first step of
- * the backup seed phrase flow
- */
 const AccountBackupStep1B = (props) => {
   const { navigation, route } = props;
   const [showWhySecureWalletModal, setWhySecureWalletModal] = useState(false);
   const { colors } = useTheme();
-  const styles = createStyles(colors);
+  const tw = useTailwind();
   const isSeedlessOnboardingLoginFlow = useSelector(
     selectSeedlessOnboardingLoginFlow,
   );
 
-  const headerLeft = useCallback(() => <View />, []);
+  const headerLeft = useCallback(() => <Box />, []);
   const track = (event, properties) => {
     const eventBuilder = MetricsEventBuilder.createEventBuilder(event);
     eventBuilder.addProperties(properties);
@@ -264,163 +110,253 @@ const AccountBackupStep1B = (props) => {
     });
   };
 
+  const imgWidth = DEVICE_WIDTH - IMG_PADDING;
+  const imgHeight = imgWidth * IMAGE_1_RATIO;
+
   return (
-    <SafeAreaView style={styles.mainWrapper}>
+    <SafeAreaView style={tw.style('flex-1 bg-default')}>
       <ScrollView
-        contentContainerStyle={styles.scrollviewWrapper}
-        style={styles.mainWrapper}
+        contentContainerStyle={tw.style('flex-grow')}
+        style={tw.style('flex-1 bg-default')}
       >
-        <View
-          style={styles.wrapper}
+        <Box
+          twClassName="flex-1 p-5 pt-0 pb-0 mt-4"
           testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
         >
           <OnboardingProgress steps={CHOOSE_PASSWORD_STEPS} currentStep={1} />
-          <View style={styles.content}>
-            <Text style={styles.titleIcon}>🔒</Text>
-            <Text style={styles.title}>
+          <Box alignItems={BoxAlignItems.Center} twClassName="pb-4">
+            <DSText twClassName="text-[32px] leading-[44px]">🔒</DSText>
+            <DSText
+              variant={TextVariant.HeadingLg}
+              color={TextColor.TextDefault}
+              fontWeight={FontWeight.Bold}
+              twClassName="ml-0 mt-4 mb-4"
+            >
               {strings('account_backup_step_1B.title')}
-            </Text>
-            <View style={styles.text}>
-              <Text style={styles.label}>
+            </DSText>
+            <Box twClassName="mb-4 justify-center">
+              <DSText variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {strings('account_backup_step_1B.subtitle_1')}{' '}
-                <Text style={styles.blue} onPress={showWhatIsSeedphrase}>
+                <DSText
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.PrimaryDefault}
+                  onPress={showWhatIsSeedphrase}
+                >
                   {strings('account_backup_step_1B.subtitle_2')}
-                </Text>
-              </Text>
-            </View>
+                </DSText>
+              </DSText>
+            </Box>
             <TouchableOpacity
               onPress={showWhySecureWallet}
-              style={styles.centerContent}
+              style={tw.style('flex-row justify-center items-center')}
             >
               <Icon
                 name="info-circle"
-                style={styles.infoIcon}
+                style={tw.style('text-[15px] mr-1.5')}
                 color={colors.primary.default}
               />
-              <Text style={styles.whyImportantText}>
+              <DSText
+                variant={TextVariant.BodySm}
+                color={TextColor.PrimaryDefault}
+              >
                 {strings('account_backup_step_1B.why_important')}
-              </Text>
+              </DSText>
             </TouchableOpacity>
-          </View>
-          <View style={styles.card}>
-            <Text style={styles.manualTitle}>
-              {strings('account_backup_step_1B.manual_title')}
-            </Text>
-            <Text style={styles.paragraph}>
-              {strings('account_backup_step_1B.manual_subtitle')}
-            </Text>
-            <Text style={styles.barsTitle}>
-              {strings('account_backup_step_1B.manual_security')}
-            </Text>
-            <View style={styles.barsContainer}>
-              <View style={styles.bar} />
-              <View style={styles.bar} />
-              <View style={styles.bar} />
-            </View>
-            <Text style={styles.smallParagraph}>
-              {strings('account_backup_step_1B.risks_title')}
-            </Text>
-            <Text style={styles.smallParagraph}>
-              • {strings('account_backup_step_1B.risks_1')}
-            </Text>
-            <Text style={styles.smallParagraph}>
-              • {strings('account_backup_step_1B.risks_2')}
-            </Text>
-            <Text style={styles.paragraph}>
-              • {strings('account_backup_step_1B.risks_3')}
-            </Text>
-            <Text style={styles.paragraph}>
-              {strings('account_backup_step_1B.other_options')}
-            </Text>
-            <Text style={styles.smallParagraph}>
-              {strings('account_backup_step_1B.tips_title')}
-            </Text>
-            <Text style={styles.smallParagraph}>
-              • {strings('account_backup_step_1B.tips_1')}
-            </Text>
-            <Text style={styles.smallParagraph}>
-              • {strings('account_backup_step_1B.tips_2')}
-            </Text>
-            <Text style={styles.paragraph}>
-              • {strings('account_backup_step_1B.tips_3')}
-            </Text>
-
-            <StyledButton
-              containerStyle={styles.button}
-              type={'confirm'}
-              onPress={goNext}
+          </Box>
+          <Box
+            backgroundColor={BoxBackgroundColor.BackgroundDefault}
+            borderWidth={1}
+            borderColor={BoxBorderColor.BorderDefault}
+            twClassName="rounded-[10px] p-4 mb-5"
+          >
+            <DSText
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextDefault}
+              fontWeight={FontWeight.Bold}
+              twClassName="mb-2 leading-[17px]"
             >
-              {strings('account_backup_step_1B.cta_text')}
-            </StyledButton>
-          </View>
-        </View>
+              {strings('account_backup_step_1B.manual_title')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px] mb-5"
+            >
+              {strings('account_backup_step_1B.manual_subtitle')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px] mb-2"
+            >
+              {strings('account_backup_step_1B.manual_security')}
+            </DSText>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              twClassName="mb-5"
+            >
+              <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
+              <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
+              <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
+            </Box>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px]"
+            >
+              {strings('account_backup_step_1B.risks_title')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px]"
+            >
+              • {strings('account_backup_step_1B.risks_1')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px]"
+            >
+              • {strings('account_backup_step_1B.risks_2')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px] mb-5"
+            >
+              • {strings('account_backup_step_1B.risks_3')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px] mb-5"
+            >
+              {strings('account_backup_step_1B.other_options')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px]"
+            >
+              {strings('account_backup_step_1B.tips_title')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px]"
+            >
+              • {strings('account_backup_step_1B.tips_1')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px]"
+            >
+              • {strings('account_backup_step_1B.tips_2')}
+            </DSText>
+            <DSText
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextDefault}
+              twClassName="leading-[17px] mb-5"
+            >
+              • {strings('account_backup_step_1B.tips_3')}
+            </DSText>
+
+            <Button
+              variant={ButtonVariants.Primary}
+              onPress={goNext}
+              label={strings('account_backup_step_1B.cta_text')}
+              width={ButtonWidthTypes.Full}
+              size={ButtonSize.Lg}
+            />
+          </Box>
+        </Box>
       </ScrollView>
       {Device.isAndroid() && <AndroidBackHandler customBackPress={dismiss} />}
       <ActionModal
         modalVisible={
           showWhySecureWalletModal && !isSeedlessOnboardingLoginFlow
         }
-        actionContainerStyle={styles.modalNoBorder}
+        actionContainerStyle={tw.style('border-t-0')}
         displayConfirmButton={false}
         displayCancelButton={false}
         onRequestClose={hideWhySecureWallet}
       >
-        <View style={styles.secureModalContainer}>
-          <View style={styles.secureModalTitleContainer}>
-            <View style={styles.auxCenterView} />
-            <Text style={styles.whySecureTitle}>
+        <Box
+          flexDirection={BoxFlexDirection.Column}
+          twClassName="flex-1 p-[27px]"
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Center}
+            alignItems={BoxAlignItems.Center}
+            twClassName="mb-4"
+          >
+            <Box twClassName="w-[26px]" />
+            <DSText
+              variant={TextVariant.HeadingMd}
+              color={TextColor.TextDefault}
+              fontWeight={FontWeight.Bold}
+              twClassName="flex-1 text-center"
+            >
               {strings('account_backup_step_1B.why_secure_title')}
-            </Text>
+            </DSText>
             <TouchableOpacity
               onPress={hideWhySecureWallet}
-              style={styles.secureModalXButton}
+              style={tw.style('p-[5px] items-end')}
               hitSlop={{ top: 10, left: 10, bottom: 10, right: 10 }}
             >
-              <Icon name="times" style={styles.secureModalXIcon} />
+              <Icon
+                name="times"
+                style={tw.style('text-[16px]')}
+                color={colors.text.default}
+              />
             </TouchableOpacity>
-          </View>
-          <View style={styles.explainBackupContainer}>
+          </Box>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+          >
             <Image
               source={explain_backup_seedphrase}
-              style={styles.image}
+              style={tw.style(
+                `w-[${imgWidth}px] h-[${imgHeight}px] mt-3.5 mb-2`,
+              )}
               resizeMethod={'auto'}
               testID={'carousel-one-image'}
             />
-            <Text style={styles.whySecureText}>
+            <DSText
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextDefault}
+              twClassName="text-center leading-5"
+            >
               {strings('account_backup_step_1B.why_secure_1')}
-              <Text style={styles.bold}>
+              <DSText
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
+                fontWeight={FontWeight.Bold}
+              >
                 {strings('account_backup_step_1B.why_secure_2')}
-              </Text>
-            </Text>
+              </DSText>
+            </DSText>
             <TouchableOpacity
-              style={styles.remindLaterButton}
               onPress={learnMore}
               hitSlop={{ top: 10, left: 10, bottom: 10, right: 10 }}
             >
-              <Text style={styles.learnMoreText}>
+              <DSText
+                variant={TextVariant.BodyMd}
+                color={TextColor.PrimaryDefault}
+                twClassName="mt-[21px] text-center leading-5"
+              >
                 {strings('account_backup_step_1B.learn_more')}
-              </Text>
+              </DSText>
             </TouchableOpacity>
-          </View>
-        </View>
+          </Box>
+        </Box>
       </ActionModal>
     </SafeAreaView>
   );
-};
-
-AccountBackupStep1B.propTypes = {
-  /**
-  /* navigation object required to push and pop other views
-  */
-  navigation: PropTypes.object,
-  /**
-   * Object that represents the current route info like params passed to it
-   */
-  route: PropTypes.object,
-  /**
-   * Action to save onboarding event
-   */
-  saveOnboardingEvent: PropTypes.func,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React, { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import {
   ScrollView,
   TouchableOpacity,
@@ -16,7 +16,7 @@ import {
   BoxJustifyContent,
   BoxBackgroundColor,
   BoxBorderColor,
-  Text as DSText,
+  Text,
   TextVariant,
   TextColor,
   FontWeight,
@@ -125,29 +125,26 @@ const AccountBackupStep1B = (props) => {
         >
           <OnboardingProgress steps={CHOOSE_PASSWORD_STEPS} currentStep={1} />
           <Box alignItems={BoxAlignItems.Center} twClassName="pb-4">
-            <DSText twClassName="text-4xl leading-tight">🔒</DSText>
-            <DSText
+            <Text twClassName="text-4xl leading-tight">🔒</Text>
+            <Text
               variant={TextVariant.HeadingLg}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
               twClassName="mt-4 mb-4"
             >
               {strings('account_backup_step_1B.title')}
-            </DSText>
+            </Text>
             <Box twClassName="mb-4 justify-center">
-              <DSText
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextDefault}
-              >
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {strings('account_backup_step_1B.subtitle_1')}{' '}
-                <DSText
+                <Text
                   variant={TextVariant.BodyMd}
                   color={TextColor.PrimaryDefault}
                   onPress={showWhatIsSeedphrase}
                 >
                   {strings('account_backup_step_1B.subtitle_2')}
-                </DSText>
-              </DSText>
+                </Text>
+              </Text>
             </Box>
             <TouchableOpacity
               onPress={showWhySecureWallet}
@@ -158,12 +155,12 @@ const AccountBackupStep1B = (props) => {
                 style={tw.style('text-sm mr-1.5')}
                 color={colors.primary.default}
               />
-              <DSText
+              <Text
                 variant={TextVariant.BodySm}
                 color={TextColor.PrimaryDefault}
               >
                 {strings('account_backup_step_1B.why_important')}
-              </DSText>
+              </Text>
             </TouchableOpacity>
           </Box>
           <Box
@@ -172,96 +169,96 @@ const AccountBackupStep1B = (props) => {
             borderColor={BoxBorderColor.BorderDefault}
             twClassName="rounded-xl p-4 mb-5"
           >
-            <DSText
+            <Text
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
               twClassName="mb-2 leading-4"
             >
               {strings('account_backup_step_1B.manual_title')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4 mb-5"
             >
               {strings('account_backup_step_1B.manual_subtitle')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4 mb-2"
             >
               {strings('account_backup_step_1B.manual_security')}
-            </DSText>
+            </Text>
             <Box flexDirection={BoxFlexDirection.Row} twClassName="mb-5">
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
             </Box>
-            <DSText
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4"
             >
               {strings('account_backup_step_1B.risks_title')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.risks_1')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.risks_2')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4 mb-5"
             >
               • {strings('account_backup_step_1B.risks_3')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4 mb-5"
             >
               {strings('account_backup_step_1B.other_options')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4"
             >
               {strings('account_backup_step_1B.tips_title')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.tips_1')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.tips_2')}
-            </DSText>
-            <DSText
+            </Text>
+            <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
               twClassName="leading-4 mb-5"
             >
               • {strings('account_backup_step_1B.tips_3')}
-            </DSText>
+            </Text>
 
             <Button
               variant={ButtonVariants.Primary}
@@ -291,14 +288,14 @@ const AccountBackupStep1B = (props) => {
             twClassName="mb-4"
           >
             <Box twClassName="w-7" />
-            <DSText
+            <Text
               variant={TextVariant.HeadingMd}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
               twClassName="flex-1 text-center"
             >
               {strings('account_backup_step_1B.why_secure_title')}
-            </DSText>
+            </Text>
             <TouchableOpacity
               onPress={hideWhySecureWallet}
               style={tw.style('p-1 items-end')}
@@ -320,37 +317,52 @@ const AccountBackupStep1B = (props) => {
               resizeMethod={'auto'}
               testID={'carousel-one-image'}
             />
-            <DSText
+            <Text
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}
               twClassName="text-center leading-5"
             >
               {strings('account_backup_step_1B.why_secure_1')}
-              <DSText
+              <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.TextDefault}
                 fontWeight={FontWeight.Bold}
               >
                 {strings('account_backup_step_1B.why_secure_2')}
-              </DSText>
-            </DSText>
+              </Text>
+            </Text>
             <TouchableOpacity
               onPress={learnMore}
               hitSlop={{ top: 10, left: 10, bottom: 10, right: 10 }}
             >
-              <DSText
+              <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.PrimaryDefault}
                 twClassName="mt-5 text-center leading-5"
               >
                 {strings('account_backup_step_1B.learn_more')}
-              </DSText>
+              </Text>
             </TouchableOpacity>
           </Box>
         </Box>
       </ActionModal>
     </SafeAreaView>
   );
+};
+
+AccountBackupStep1B.propTypes = {
+  /**
+   * Object that represents the navigator
+   */
+  navigation: PropTypes.object,
+  /**
+   * Object that represents the current route info like params passed to it
+   */
+  route: PropTypes.object,
+  /**
+   * Action to save onboarding event
+   */
+  saveOnboardingEvent: PropTypes.func,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -135,7 +135,10 @@ const AccountBackupStep1B = (props) => {
               {strings('account_backup_step_1B.title')}
             </DSText>
             <Box twClassName="mb-4 justify-center">
-              <DSText variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+              <DSText
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
+              >
                 {strings('account_backup_step_1B.subtitle_1')}{' '}
                 <DSText
                   variant={TextVariant.BodyMd}
@@ -191,10 +194,7 @@ const AccountBackupStep1B = (props) => {
             >
               {strings('account_backup_step_1B.manual_security')}
             </DSText>
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              twClassName="mb-5"
-            >
+            <Box flexDirection={BoxFlexDirection.Row} twClassName="mb-5">
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -51,6 +51,30 @@ const explain_backup_seedphrase = require('../../../images/explain-backup-seedph
 const IMAGE_1_RATIO = 162.8 / 138;
 const IMG_PADDING = Device.isIphoneX() ? 100 : Device.isIphone5S() ? 180 : 220;
 
+const BodyXsText = ({ text, twClassName }) => (
+  <Text
+    variant={TextVariant.BodyXs}
+    color={TextColor.TextDefault}
+    twClassName={twClassName}
+  >
+    {text}
+  </Text>
+);
+
+BodyXsText.propTypes = {
+  text: PropTypes.string.isRequired,
+  twClassName: PropTypes.string,
+};
+
+const BulletText = ({ text, twClassName }) => (
+  <BodyXsText text={`• ${text}`} twClassName={twClassName} />
+);
+
+BulletText.propTypes = {
+  text: PropTypes.string.isRequired,
+  twClassName: PropTypes.string,
+};
+
 const AccountBackupStep1B = (props) => {
   const { navigation, route } = props;
   const [showWhySecureWalletModal, setWhySecureWalletModal] = useState(false);
@@ -181,64 +205,37 @@ const AccountBackupStep1B = (props) => {
             >
               {strings('account_backup_step_1B.manual_title')}
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
+            <BodyXsText
+              text={strings('account_backup_step_1B.manual_subtitle')}
               twClassName="mb-5"
-            >
-              {strings('account_backup_step_1B.manual_subtitle')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
+            />
+            <BodyXsText
+              text={strings('account_backup_step_1B.manual_security')}
               twClassName="mb-2"
-            >
-              {strings('account_backup_step_1B.manual_security')}
-            </Text>
+            />
             <Box flexDirection={BoxFlexDirection.Row} twClassName="mb-5">
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
             </Box>
-            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
-              {strings('account_backup_step_1B.risks_title')}
-            </Text>
-            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
-              • {strings('account_backup_step_1B.risks_1')}
-            </Text>
-            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
-              • {strings('account_backup_step_1B.risks_2')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
+            <BodyXsText text={strings('account_backup_step_1B.risks_title')} />
+            <BulletText text={strings('account_backup_step_1B.risks_1')} />
+            <BulletText text={strings('account_backup_step_1B.risks_2')} />
+            <BulletText
+              text={strings('account_backup_step_1B.risks_3')}
               twClassName="mb-5"
-            >
-              • {strings('account_backup_step_1B.risks_3')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
+            />
+            <BodyXsText
+              text={strings('account_backup_step_1B.other_options')}
               twClassName="mb-5"
-            >
-              {strings('account_backup_step_1B.other_options')}
-            </Text>
-            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
-              {strings('account_backup_step_1B.tips_title')}
-            </Text>
-            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
-              • {strings('account_backup_step_1B.tips_1')}
-            </Text>
-            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
-              • {strings('account_backup_step_1B.tips_2')}
-            </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
+            />
+            <BodyXsText text={strings('account_backup_step_1B.tips_title')} />
+            <BulletText text={strings('account_backup_step_1B.tips_1')} />
+            <BulletText text={strings('account_backup_step_1B.tips_2')} />
+            <BulletText
+              text={strings('account_backup_step_1B.tips_3')}
               twClassName="mb-5"
-            >
-              • {strings('account_backup_step_1B.tips_3')}
-            </Text>
+            />
 
             <Button
               variant={ButtonVariant.Primary}

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -19,12 +19,17 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  ButtonIcon,
+  ButtonIconSize,
+  Icon,
+  IconName,
+  IconColor,
+  IconSize,
   Text,
   TextVariant,
   TextColor,
   FontWeight,
 } from '@metamask/design-system-react-native';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import OnboardingProgress from '../../UI/OnboardingProgress';
 import { strings } from '../../../../locales/i18n';
 import AndroidBackHandler from '../AndroidBackHandler';
@@ -128,7 +133,7 @@ const AccountBackupStep1B = (props) => {
               variant={TextVariant.HeadingLg}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
-              twClassName="mt-4 mb-4"
+              twClassName="my-4"
             >
               {strings('account_backup_step_1B.title')}
             </Text>
@@ -149,9 +154,10 @@ const AccountBackupStep1B = (props) => {
               style={tw.style('flex-row justify-center items-center')}
             >
               <Icon
-                name="info-circle"
-                style={tw.style('text-sm mr-1.5')}
-                color={colors.primary.default}
+                name={IconName.Info}
+                size={IconSize.Sm}
+                color={IconColor.PrimaryDefault}
+                twClassName="mr-1.5"
               />
               <Text
                 variant={TextVariant.BodySm}
@@ -295,17 +301,11 @@ const AccountBackupStep1B = (props) => {
             >
               {strings('account_backup_step_1B.why_secure_title')}
             </Text>
-            <TouchableOpacity
+            <ButtonIcon
+              iconName={IconName.Close}
               onPress={hideWhySecureWallet}
-              style={tw.style('p-1 items-end')}
-              hitSlop={{ top: 10, left: 10, bottom: 10, right: 10 }}
-            >
-              <Icon
-                name="times"
-                style={tw.style('text-base')}
-                color={colors.text.default}
-              />
-            </TouchableOpacity>
+              size={ButtonIconSize.Sm}
+            />
           </Box>
           <Box alignItems={BoxAlignItems.Center}>
             <Image

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -5,7 +5,7 @@ import {
   TouchableOpacity,
   SafeAreaView,
   Image,
-  Dimensions,
+  useWindowDimensions,
 } from 'react-native';
 import { connect, useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -46,7 +46,6 @@ import Button, {
 const explain_backup_seedphrase = require('../../../images/explain-backup-seedphrase.png'); // eslint-disable-line
 
 const IMAGE_1_RATIO = 162.8 / 138;
-const DEVICE_WIDTH = Dimensions.get('window').width;
 const IMG_PADDING = Device.isIphoneX() ? 100 : Device.isIphone5S() ? 180 : 220;
 
 const AccountBackupStep1B = (props) => {
@@ -54,6 +53,7 @@ const AccountBackupStep1B = (props) => {
   const [showWhySecureWalletModal, setWhySecureWalletModal] = useState(false);
   const { colors } = useTheme();
   const tw = useTailwind();
+  const { width: deviceWidth } = useWindowDimensions();
   const isSeedlessOnboardingLoginFlow = useSelector(
     selectSeedlessOnboardingLoginFlow,
   );
@@ -110,7 +110,7 @@ const AccountBackupStep1B = (props) => {
     });
   };
 
-  const imgWidth = DEVICE_WIDTH - IMG_PADDING;
+  const imgWidth = deviceWidth - IMG_PADDING;
   const imgHeight = imgWidth * IMAGE_1_RATIO;
 
   return (
@@ -120,17 +120,17 @@ const AccountBackupStep1B = (props) => {
         style={tw.style('flex-1 bg-default')}
       >
         <Box
-          twClassName="flex-1 p-5 pt-0 pb-0 mt-4"
+          twClassName="flex-1 px-5 mt-4"
           testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
         >
           <OnboardingProgress steps={CHOOSE_PASSWORD_STEPS} currentStep={1} />
           <Box alignItems={BoxAlignItems.Center} twClassName="pb-4">
-            <DSText twClassName="text-[32px] leading-[44px]">🔒</DSText>
+            <DSText twClassName="text-4xl leading-tight">🔒</DSText>
             <DSText
               variant={TextVariant.HeadingLg}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
-              twClassName="ml-0 mt-4 mb-4"
+              twClassName="mt-4 mb-4"
             >
               {strings('account_backup_step_1B.title')}
             </DSText>
@@ -155,7 +155,7 @@ const AccountBackupStep1B = (props) => {
             >
               <Icon
                 name="info-circle"
-                style={tw.style('text-[15px] mr-1.5')}
+                style={tw.style('text-sm mr-1.5')}
                 color={colors.primary.default}
               />
               <DSText
@@ -170,27 +170,27 @@ const AccountBackupStep1B = (props) => {
             backgroundColor={BoxBackgroundColor.BackgroundDefault}
             borderWidth={1}
             borderColor={BoxBorderColor.BorderDefault}
-            twClassName="rounded-[10px] p-4 mb-5"
+            twClassName="rounded-xl p-4 mb-5"
           >
             <DSText
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
-              twClassName="mb-2 leading-[17px]"
+              twClassName="mb-2 leading-4"
             >
               {strings('account_backup_step_1B.manual_title')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px] mb-5"
+              twClassName="leading-4 mb-5"
             >
               {strings('account_backup_step_1B.manual_subtitle')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px] mb-2"
+              twClassName="leading-4 mb-2"
             >
               {strings('account_backup_step_1B.manual_security')}
             </DSText>
@@ -202,63 +202,63 @@ const AccountBackupStep1B = (props) => {
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px]"
+              twClassName="leading-4"
             >
               {strings('account_backup_step_1B.risks_title')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px]"
+              twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.risks_1')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px]"
+              twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.risks_2')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px] mb-5"
+              twClassName="leading-4 mb-5"
             >
               • {strings('account_backup_step_1B.risks_3')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px] mb-5"
+              twClassName="leading-4 mb-5"
             >
               {strings('account_backup_step_1B.other_options')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px]"
+              twClassName="leading-4"
             >
               {strings('account_backup_step_1B.tips_title')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px]"
+              twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.tips_1')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px]"
+              twClassName="leading-4"
             >
               • {strings('account_backup_step_1B.tips_2')}
             </DSText>
             <DSText
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-[17px] mb-5"
+              twClassName="leading-4 mb-5"
             >
               • {strings('account_backup_step_1B.tips_3')}
             </DSText>
@@ -283,17 +283,14 @@ const AccountBackupStep1B = (props) => {
         displayCancelButton={false}
         onRequestClose={hideWhySecureWallet}
       >
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          twClassName="flex-1 p-[27px]"
-        >
+        <Box twClassName="flex-1 p-7">
           <Box
             flexDirection={BoxFlexDirection.Row}
             justifyContent={BoxJustifyContent.Center}
             alignItems={BoxAlignItems.Center}
             twClassName="mb-4"
           >
-            <Box twClassName="w-[26px]" />
+            <Box twClassName="w-7" />
             <DSText
               variant={TextVariant.HeadingMd}
               color={TextColor.TextDefault}
@@ -304,20 +301,17 @@ const AccountBackupStep1B = (props) => {
             </DSText>
             <TouchableOpacity
               onPress={hideWhySecureWallet}
-              style={tw.style('p-[5px] items-end')}
+              style={tw.style('p-1 items-end')}
               hitSlop={{ top: 10, left: 10, bottom: 10, right: 10 }}
             >
               <Icon
                 name="times"
-                style={tw.style('text-[16px]')}
+                style={tw.style('text-base')}
                 color={colors.text.default}
               />
             </TouchableOpacity>
           </Box>
-          <Box
-            flexDirection={BoxFlexDirection.Column}
-            alignItems={BoxAlignItems.Center}
-          >
+          <Box alignItems={BoxAlignItems.Center}>
             <Image
               source={explain_backup_seedphrase}
               style={tw.style(
@@ -347,7 +341,7 @@ const AccountBackupStep1B = (props) => {
               <DSText
                 variant={TextVariant.BodyMd}
                 color={TextColor.PrimaryDefault}
-                twClassName="mt-[21px] text-center leading-5"
+                twClassName="mt-5 text-center leading-5"
               >
                 {strings('account_backup_step_1B.learn_more')}
               </DSText>

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -16,6 +16,9 @@ import {
   BoxJustifyContent,
   BoxBackgroundColor,
   BoxBorderColor,
+  Button,
+  ButtonVariant,
+  ButtonSize,
   Text,
   TextVariant,
   TextColor,
@@ -37,11 +40,6 @@ import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboardi
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import Routes from '../../../constants/navigation/Routes';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../component-library/components/Buttons/Button';
 
 const explain_backup_seedphrase = require('../../../images/explain-backup-seedphrase.png'); // eslint-disable-line
 
@@ -261,12 +259,13 @@ const AccountBackupStep1B = (props) => {
             </Text>
 
             <Button
-              variant={ButtonVariants.Primary}
+              variant={ButtonVariant.Primary}
               onPress={goNext}
-              label={strings('account_backup_step_1B.cta_text')}
-              width={ButtonWidthTypes.Full}
+              isFullWidth
               size={ButtonSize.Lg}
-            />
+            >
+              {strings('account_backup_step_1B.cta_text')}
+            </Button>
           </Box>
         </Box>
       </ScrollView>

--- a/app/components/Views/AccountBackupStep1B/index.js
+++ b/app/components/Views/AccountBackupStep1B/index.js
@@ -128,7 +128,7 @@ const AccountBackupStep1B = (props) => {
         >
           <OnboardingProgress steps={CHOOSE_PASSWORD_STEPS} currentStep={1} />
           <Box alignItems={BoxAlignItems.Center} twClassName="pb-4">
-            <Text twClassName="text-4xl leading-tight">🔒</Text>
+            <Text variant={TextVariant.DisplayMd}>🔒</Text>
             <Text
               variant={TextVariant.HeadingLg}
               color={TextColor.TextDefault}
@@ -177,21 +177,21 @@ const AccountBackupStep1B = (props) => {
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Bold}
-              twClassName="mb-2 leading-4"
+              twClassName="mb-2"
             >
               {strings('account_backup_step_1B.manual_title')}
             </Text>
             <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-4 mb-5"
+              twClassName="mb-5"
             >
               {strings('account_backup_step_1B.manual_subtitle')}
             </Text>
             <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-4 mb-2"
+              twClassName="mb-2"
             >
               {strings('account_backup_step_1B.manual_security')}
             </Text>
@@ -200,66 +200,42 @@ const AccountBackupStep1B = (props) => {
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
               <Box twClassName="w-8 h-1.5 bg-primary-default mr-0.5" />
             </Box>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
-              twClassName="leading-4"
-            >
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
               {strings('account_backup_step_1B.risks_title')}
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
-              twClassName="leading-4"
-            >
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
               • {strings('account_backup_step_1B.risks_1')}
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
-              twClassName="leading-4"
-            >
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
               • {strings('account_backup_step_1B.risks_2')}
             </Text>
             <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-4 mb-5"
+              twClassName="mb-5"
             >
               • {strings('account_backup_step_1B.risks_3')}
             </Text>
             <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-4 mb-5"
+              twClassName="mb-5"
             >
               {strings('account_backup_step_1B.other_options')}
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
-              twClassName="leading-4"
-            >
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
               {strings('account_backup_step_1B.tips_title')}
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
-              twClassName="leading-4"
-            >
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
               • {strings('account_backup_step_1B.tips_1')}
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextDefault}
-              twClassName="leading-4"
-            >
+            <Text variant={TextVariant.BodyXs} color={TextColor.TextDefault}>
               • {strings('account_backup_step_1B.tips_2')}
             </Text>
             <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextDefault}
-              twClassName="leading-4 mb-5"
+              twClassName="mb-5"
             >
               • {strings('account_backup_step_1B.tips_3')}
             </Text>
@@ -319,7 +295,7 @@ const AccountBackupStep1B = (props) => {
             <Text
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}
-              twClassName="text-center leading-5"
+              twClassName="text-center"
             >
               {strings('account_backup_step_1B.why_secure_1')}
               <Text
@@ -337,7 +313,7 @@ const AccountBackupStep1B = (props) => {
               <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.PrimaryDefault}
-                twClassName="mt-5 text-center leading-5"
+                twClassName="mt-5 text-center"
               >
                 {strings('account_backup_step_1B.learn_more')}
               </Text>


### PR DESCRIPTION
## **Description**

Migrates `AccountBackupStep1B` from legacy React Native primitives to the MetaMask design system. Replaces raw `View` components with `Box`, removes `StyleSheet.create()` in favor of `twClassName` Tailwind utilities, and adds the `useTailwind` hook. Also fixes a precommit violation by replacing the static `Dimensions.get('window')` module-level call with the `useWindowDimensions()` hook (so layout responds to rotation/resize), removes redundant `BoxFlexDirection.Column` props, and replaces all arbitrary Tailwind bracket values (e.g. `text-[32px]`, `leading-[17px]`) with design system scale steps.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Account Backup Step 1B screen

  Scenario: Visual parity after design system migration
    Given the user has created a new wallet and reached the backup prompt
    When the AccountBackupStep1B screen is displayed
    Then the layout, typography, and spacing appear identical to the pre-migration design
    And the "Why is this important?" info button is tappable and opens the modal
    And the modal close button dismisses the modal
    And the "Start" CTA navigates to ManualBackupStep1
    And the SRP explanation link opens the SRP info sheet

  Scenario: Responsive layout on device rotation
    Given the user is on the AccountBackupStep1B screen
    When the device is rotated to landscape
    Then the seed phrase illustration resizes correctly without layout overflow
```

## **Screenshots/Recordings**

|             | Before | After |
|-------------|--------|-------|
| **Light**   | <img src="https://github.com/user-attachments/assets/d9dd926a-5e4f-4673-b975-ff658ee771d4" width="300"/> | <img src="https://github.com/user-attachments/assets/742d3e28-5fd8-4a68-b51f-09e7f22699d0" width="300"/> |
| **Dark**    | <img src="https://github.com/user-attachments/assets/2fcd0028-6a67-413c-8cd1-75bab51afac4" width="300"/> | <img src="https://github.com/user-attachments/assets/123fa568-aa2f-434c-908d-92ed6b39464a" width="300"/> |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to a single onboarding screen, primarily swapping UI primitives/styling; main risk is visual or interaction regressions (modal/CTA/link) across device sizes/rotation.
> 
> **Overview**
> Migrates `AccountBackupStep1B` to the MetaMask React Native design system by replacing legacy `View`/`StyleSheet`/custom button usage with `Box`, design-system `Text`, `Button`, `Icon`, and Tailwind (`useTailwind`) styling.
> 
> Updates the seed phrase illustration sizing to use `useWindowDimensions()` (instead of a module-level `Dimensions` constant) so layout recalculates on resize/rotation, and refactors repeated body/bullet copy into small helper components (`BodyXsText`, `BulletText`) while keeping navigation and metrics wiring intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5324d96a899a86b6c48c2f149df2e9864cef72bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->