### PR TITLE
refactor(RestoreWallet): migrate to design system components

### DIFF
--- a/app/components/Views/RestoreWallet/RestoreWallet.tsx
+++ b/app/components/Views/RestoreWallet/RestoreWallet.tsx
@@ -1,30 +1,37 @@
-/* eslint-disable import/no-commonjs */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View, Image, ActivityIndicator } from 'react-native';
-import { strings } from '../../../../locales/i18n';
-import { createStyles } from './styles';
-import Text, {
+import { Image } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, StackActions } from '@react-navigation/native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
   TextVariant,
-} from '../../../component-library/components/Texts/Text';
-import StyledButton from '../../UI/StyledButton';
+  FontWeight,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../component-library/components/Buttons/Button';
 import {
   createNavigationDetails,
   useParams,
 } from '../../../util/navigation/navUtils';
 import Routes from '../../../constants/navigation/Routes';
 import EngineService from '../../../core/EngineService';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, StackActions } from '@react-navigation/native';
-import { useAppThemeFromContext } from '../../../util/theme';
 import { createWalletResetNeededNavDetails } from './WalletResetNeeded';
 import { createWalletRestoredNavDetails } from './WalletRestored';
 import { MetaMetricsEvents } from '../../../core/Analytics';
-
 import generateDeviceAnalyticsMetaData from '../../../util/metrics';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 
 /* eslint-disable import/no-commonjs, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 const onboardingDeviceImage = require('../../../images/swaps_onboard_device.png');
+
 interface RestoreWalletParams {
   previousScreen: string;
 }
@@ -34,8 +41,6 @@ export const createRestoreWalletNavDetails =
     Routes.VAULT_RECOVERY.RESTORE_WALLET,
   );
 
-// Needed for passing the proper params from outside this stack navigator
-// This occurs from the Login screen
 export const createRestoreWalletNavDetailsNested =
   createNavigationDetails<RestoreWalletParams>(
     Routes.VAULT_RECOVERY.RESTORE_WALLET,
@@ -44,13 +49,9 @@ export const createRestoreWalletNavDetailsNested =
 
 const RestoreWallet = () => {
   const { trackEvent, createEventBuilder } = useMetrics();
-  const { colors } = useAppThemeFromContext();
-  const styles = createStyles(colors);
-
+  const tw = useTailwind();
   const [loading, setLoading] = useState<boolean>(false);
-
   const navigation = useNavigation();
-
   const deviceMetaData = useMemo(() => generateDeviceAnalyticsMetaData(), []);
   const { previousScreen } = useParams<RestoreWalletParams>();
 
@@ -74,46 +75,58 @@ const RestoreWallet = () => {
         .addProperties({ ...deviceMetaData })
         .build(),
     );
+
     const restoreResult = await EngineService.initializeVaultFromBackup();
     if (restoreResult.success) {
       navigation.dispatch(
         StackActions.replace(...createWalletRestoredNavDetails()),
       );
-      setLoading(false);
     } else {
       navigation.dispatch(
         StackActions.replace(...createWalletResetNeededNavDetails()),
       );
-      setLoading(false);
     }
+    setLoading(false);
   }, [deviceMetaData, navigation, trackEvent, createEventBuilder]);
 
   return (
-    <SafeAreaView style={styles.screen}>
-      <View style={styles.content}>
-        <View style={styles.images}>
-          <Image source={onboardingDeviceImage} />
-        </View>
-        <Text variant={TextVariant.HeadingLG} style={styles.title}>
-          {strings('restore_wallet.restore_needed_title')}
-        </Text>
-        <Text variant={TextVariant.BodyMD} style={styles.description}>
-          {strings('restore_wallet.restore_needed_description')}
-        </Text>
-      </View>
-      <View style={styles.actionButtonWrapper}>
-        <StyledButton
-          type="confirm"
-          containerStyle={styles.actionButton}
-          onPress={handleOnNext}
+    <SafeAreaView style={tw.style('flex-1')}>
+      <Box
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="flex-1 px-6"
+      >
+        <Box
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+          twClassName="flex-1"
         >
-          {loading ? (
-            <ActivityIndicator size="small" color={colors.primary.inverse} />
-          ) : (
-            strings('restore_wallet.restore_needed_action')
-          )}
-        </StyledButton>
-      </View>
+          <Box alignItems={BoxAlignItems.Center} twClassName="p-4">
+            <Image source={onboardingDeviceImage} />
+          </Box>
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontWeight={FontWeight.Bold}
+            twClassName="text-center pb-4"
+          >
+            {strings('restore_wallet.restore_needed_title')}
+          </Text>
+          <Text variant={TextVariant.BodyMd} twClassName="text-center p-2">
+            {strings('restore_wallet.restore_needed_description')}
+          </Text>
+        </Box>
+        <Box twClassName="w-full">
+          <Button
+            variant={ButtonVariants.Primary}
+            size={ButtonSize.Lg}
+            width={ButtonWidthTypes.Full}
+            onPress={handleOnNext}
+            loading={loading}
+            label={strings('restore_wallet.restore_needed_action')}
+            style={tw.style('my-2.5')}
+          />
+        </Box>
+      </Box>
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
## Summary
- Replace `View` with `Box` from `@metamask/design-system-react-native`
- Replace `StyleSheet.create()` with `twClassName` Tailwind CSS utilities
- Use `Button`'s built-in `loading` prop instead of manual `ActivityIndicator`
- Remove unused `useAppThemeFromContext` import

CHANGELOG entry: null

## Test plan
- [x] All 8 existing unit tests pass
- [x] ESLint passes
- [ ] Manual visual verification on iOS/Android