### PR TITLE
chore: cherry-pick fix: Updated root pages scrollable behavior with safeareaview cp-7.69.1-ota (#27446)

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -331,13 +331,12 @@ const RewardsDashboard: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="RewardsView">
       <SafeAreaView
-        edges={{ bottom: 'additive' }}
+        edges={{ top: 'additive' }}
         style={tw.style('flex-1 bg-default')}
         testID={REWARDS_VIEW_SELECTORS.SAFE_AREA_VIEW}
       >
         <HeaderRoot
           title={strings('rewards.main_title')}
-          includesTopInset
           endButtonIconProps={[
             {
               iconName: IconName.Setting,

--- a/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ActivityView/__snapshots__/index.test.tsx.snap
@@ -315,10 +315,10 @@ exports[`ActivityView matches snapshot 1`] = `
                     <RNCSafeAreaView
                       edges={
                         {
-                          "bottom": "additive",
+                          "bottom": "off",
                           "left": "off",
                           "right": "off",
-                          "top": "off",
+                          "top": "additive",
                         }
                       }
                       style={
@@ -346,9 +346,7 @@ exports[`ActivityView matches snapshot 1`] = `
                               "paddingLeft": 16,
                               "paddingRight": 8,
                             },
-                            {
-                              "marginTop": 0,
-                            },
+                            false,
                             undefined,
                           ]
                         }

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -167,7 +167,7 @@ const ActivityView = () => {
   return (
     <ErrorBoundary navigation={navigation} view="ActivityView">
       <SafeAreaView
-        edges={{ bottom: 'additive' }}
+        edges={{ top: 'additive' }}
         style={[
           tw.style('flex-1'),
           { backgroundColor: colors.background.default },
@@ -178,14 +178,12 @@ const ActivityView = () => {
           <HeaderCompactStandard
             title={strings('activity_view.title')}
             onBack={handleBackPress}
-            includesTopInset
             backButtonProps={{ testID: 'activity-view-back-button' }}
             testID={ActivitiesViewSelectorsIDs.HEADER_COMPACT_STANDARD}
           />
         ) : (
           <HeaderRoot
             title={strings('activity_view.title')}
-            includesTopInset
             testID={ActivitiesViewSelectorsIDs.HEADER_ROOT}
           />
         )}

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -185,13 +185,12 @@ export const ExploreFeed: React.FC = () => {
 
   return (
     <SafeAreaView
-      edges={{ bottom: 'additive' }}
+      edges={{ top: 'additive' }}
       style={tw.style('flex-1 bg-default')}
       testID={TrendingViewSelectorsIDs.EXPLORE_SAFE_AREA}
     >
       <HeaderRoot
         title={strings('trending.title')}
-        includesTopInset
         testID={TrendingViewSelectorsIDs.EXPLORE_HEADER_ROOT}
       />
 

--- a/app/components/Views/Wallet/WalletView.testIds.ts
+++ b/app/components/Views/Wallet/WalletView.testIds.ts
@@ -1,6 +1,7 @@
 import enContent from '../../../../locales/languages/en.json';
 
 export const WalletViewSelectorsIDs = {
+  WALLET_SAFE_AREA: 'wallet-safe-area',
   WALLET_CONTAINER: 'wallet-screen',
   NETWORK_NAME: 'network-name',
   NFT_CONTAINER: 'collectible-name',

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -17,14 +17,12 @@ import {
   ActivityIndicator,
   DeviceEventEmitter,
   Linking,
-  NativeSyntheticEvent,
-  NativeScrollEvent,
   RefreshControl,
   ScrollView,
   StyleSheet as RNStyleSheet,
   View,
 } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import {
@@ -111,7 +109,6 @@ import {
 } from '../../../util/networks';
 import NotificationsService from '../../../util/notifications/services/NotificationService';
 import { useTheme } from '../../../util/theme';
-import { colorWithOpacity } from '../../../util/colors';
 import { useAccountGroupName } from '../../hooks/multichainAccounts/useAccountGroupName';
 import { useAccountName } from '../../hooks/useAccountName';
 import usePrevious from '../../hooks/usePrevious';
@@ -211,12 +208,6 @@ const createStyles = ({ colors }: Theme) =>
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
     },
-    bottomFadeOverlay: {
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      bottom: 0,
-      height: 40,
     },
   });
 
@@ -1107,28 +1098,6 @@ const Wallet = ({
   const shouldEnableParentScroll =
     isHomepageRedesignV1Enabled || isHomepageSectionsV1Enabled;
 
-  const [bottomFadeOpacity, setBottomFadeOpacity] = useState(0);
-
-  const scrollContentHeight = useRef(0);
-  const scrollLayoutHeight = useRef(0);
-  const scrollOffsetY = useRef(0);
-
-  const computeFadeOpacity = useCallback(
-    (contentH: number, layoutH: number, offsetY: number) => {
-      const scrollableHeight = contentH - layoutH;
-      if (scrollableHeight <= 0) {
-        setBottomFadeOpacity(0);
-        return;
-      }
-      const distanceFromEnd = scrollableHeight - offsetY;
-      const fadeThreshold = 100;
-      setBottomFadeOpacity(
-        Math.min(1, Math.max(0, distanceFromEnd / fadeThreshold)),
-      );
-    },
-    [],
-  );
-
   // Notifies scroll subscribers directly (no React state update = no re-renders).
   const handleHomepageScroll = useCallback(() => {
     if (!isHomepageSectionsV1Enabled) return;
@@ -1139,42 +1108,6 @@ const Wallet = ({
     }
   }, [isHomepageSectionsV1Enabled]);
 
-  const handleVerticalScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } =
-        event.nativeEvent;
-      scrollContentHeight.current = contentSize.height;
-      scrollLayoutHeight.current = layoutMeasurement.height;
-      scrollOffsetY.current = contentOffset.y;
-      computeFadeOpacity(
-        contentSize.height,
-        layoutMeasurement.height,
-        contentOffset.y,
-      );
-      handleHomepageScroll();
-    },
-    [computeFadeOpacity, handleHomepageScroll],
-  );
-
-  const handleScrollContentSizeChange = useCallback(
-    (_w: number, h: number) => {
-      scrollContentHeight.current = h;
-      computeFadeOpacity(h, scrollLayoutHeight.current, scrollOffsetY.current);
-    },
-    [computeFadeOpacity],
-  );
-
-  const handleScrollLayout = useCallback(
-    (event: { nativeEvent: { layout: { height: number } } }) => {
-      scrollLayoutHeight.current = event.nativeEvent.layout.height;
-      computeFadeOpacity(
-        scrollContentHeight.current,
-        event.nativeEvent.layout.height,
-        scrollOffsetY.current,
-      );
-    },
-    [computeFadeOpacity],
-  );
 
   useEffect(() => {
     if (!selectedInternalAccount) return;
@@ -1467,7 +1400,14 @@ const Wallet = ({
 
   return (
     <ErrorBoundary navigation={navigation} view="Wallet">
-      <View style={baseStyles.flexGrow}>
+      <SafeAreaView
+        style={[
+          baseStyles.flexGrow,
+          { backgroundColor: colors.background.default },
+        ]}
+        edges={{ top: 'additive' }}
+        testID={WalletViewSelectorsIDs.WALLET_SAFE_AREA}
+      >
         {selectedInternalAccount ? (
           <View
             ref={containerViewRef}
@@ -1490,13 +1430,7 @@ const Wallet = ({
                 contentContainerStyle: scrollViewContentStyle,
                 showsVerticalScrollIndicator: false,
                 onScroll: isHomepageSectionsV1Enabled
-                  ? handleVerticalScroll
-                  : undefined,
-                onContentSizeChange: isHomepageSectionsV1Enabled
-                  ? handleScrollContentSizeChange
-                  : undefined,
-                onLayout: isHomepageSectionsV1Enabled
-                  ? handleScrollLayout
+                  ? handleHomepageScroll
                   : undefined,
                 scrollEventThrottle: 16,
                 refreshControl: shouldEnableParentScroll ? (
@@ -1511,26 +1445,11 @@ const Wallet = ({
             >
               {content}
             </ConditionalScrollView>
-            {isHomepageSectionsV1Enabled && bottomFadeOpacity > 0 && (
-              <LinearGradient
-                pointerEvents="none"
-                colors={[
-                  colorWithOpacity(colors.background.default, 0),
-                  colors.background.default,
-                ]}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 0, y: 1 }}
-                style={[
-                  styles.bottomFadeOverlay,
-                  { opacity: bottomFadeOpacity },
-                ]}
-              />
-            )}
           </View>
         ) : (
           renderLoader()
         )}
-      </View>
+      </SafeAreaView>
     </ErrorBoundary>
   );
 };

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -208,7 +208,6 @@ const createStyles = ({ colors }: Theme) =>
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
     },
-    },
   });
 
 interface WalletProps {

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1107,7 +1107,6 @@ const Wallet = ({
     }
   }, [isHomepageSectionsV1Enabled]);
 
-
   useEffect(() => {
     if (!selectedInternalAccount) return;
     navigation.setOptions(


### PR DESCRIPTION
Cherry-pick of #27446 into release/7.69.1-ota OTA hotfix branch.

Standardizes safe area and header inset behavior across the main tab views (Wallet, Explore, Activity, Rewards).

- Switched to `edges={{ top: 'additive' }}` on SafeAreaView
- Removed bottom fade overlay from Wallet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches layout/inset handling on core screens (Wallet/Explore/Activity/Rewards), so regressions could show up as clipped headers or changed scroll behavior across devices.
> 
> **Overview**
> Standardizes main tab screens (Wallet, Explore/Trending, Activity, Rewards) to apply safe area padding via `SafeAreaView edges={{ top: 'additive' }}` and removes `includesTopInset` from `HeaderRoot`/`HeaderCompactStandard`.
> 
> Refactors `Wallet` to wrap the root container in `SafeAreaView` (with a new `WALLET_SAFE_AREA` testID), simplifies scroll handling to only notify homepage section subscribers, and removes the bottom fade `LinearGradient` overlay and its opacity/scroll bookkeeping. Activity snapshot output is updated to match the new inset/edge behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86980f5de940e2a8d62a02011014217714f0562a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->