### PR TITLE
chore: cherry-pick chore: correct token price formatting in wallet token list cp-7.69.1-ota (#27485)

### DIFF
--- a/app/components/UI/Predict/utils/format.test.ts
+++ b/app/components/UI/Predict/utils/format.test.ts
@@ -1618,6 +1618,22 @@ describe('format utils', () => {
         // Assert
         expect(result).toBe('$0.5678');
       });
+
+      it('truncates to 2 decimals for prices >= 1 with extra decimal places', () => {
+        // Arrange & Act
+        const result = formatPriceWithSubscriptNotation(2285.013);
+
+        // Assert
+        expect(result).toBe('$2,285.01');
+      });
+
+      it('truncates to 2 decimals for prices >= 1 with 4 decimal places', () => {
+        // Arrange & Act
+        const result = formatPriceWithSubscriptNotation(1.2345);
+
+        // Assert
+        expect(result).toBe('$1.23');
+      });
     });
 
     describe('Zero value', () => {

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -114,15 +114,17 @@ export const formatPrice = (
  * - Uses subscript notation for values with 4+ leading zeros (e.g., 0.00000614 → $0.0₅614)
  * - The subscript indicates the number of leading zeros after the decimal point
  * - Returns "—" for zero values
- * - Uses min 2, max 4 decimal places for regular values
+ * - Values >= 1: exactly 2 decimal places (e.g. $2,285.01)
+ * - Values < 1: up to 4 decimal places (e.g. $0.1446)
  * @param price - The price value to format (string or number)
  * @param currencyCode - ISO 4217 currency code (e.g. 'USD', 'EUR'). Defaults to 'USD'.
  * @returns Formatted price string with currency symbol or "—" for zero
+ * @example formatPriceWithSubscriptNotation(2285.013) => "$2,285.01"
  * @example formatPriceWithSubscriptNotation(1.99) => "$1.99"
  * @example formatPriceWithSubscriptNotation(0.144566) => "$0.1446"
  * @example formatPriceWithSubscriptNotation(0.00000614) => "$0.0₅614"
  * @example formatPriceWithSubscriptNotation(0) => "—"
- * @example formatPriceWithSubscriptNotation(1.2345, 'EUR') => "€1.2345"
+ * @example formatPriceWithSubscriptNotation(1.2345, 'EUR') => "€1.23"
  */
 export const formatPriceWithSubscriptNotation = (
   price: string | number,
@@ -151,7 +153,7 @@ export const formatPriceWithSubscriptNotation = (
   const formattedNumber = new Intl.NumberFormat('en-US', {
     style: 'decimal',
     minimumFractionDigits: 2,
-    maximumFractionDigits: 4,
+    maximumFractionDigits: num >= 1 ? 2 : 4,
   }).format(num);
   return addSymbol(formattedNumber);
 };

--- a/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItemV2/TokenListItemV2.tsx
@@ -67,7 +67,7 @@ import {
 } from '../../../../../selectors/currencyRateController';
 import { selectNativeCurrencyByChainId } from '../../../../../selectors/networkController';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { addCurrencySymbol } from '../../../../../util/number';
+import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
 import { safeToChecksumAddress } from '../../../../../util/address';
 import generateTestId from '../../../../../../wdio/utils/generateTestId';
 import { getAssetTestId } from '../../../../../../wdio/screen-objects/testIDs/Screens/WalletView.testIds';
@@ -555,7 +555,7 @@ export const TokenListItemV2 = React.memo(
                 asset?.hasBalanceError ||
                 asset.balanceFiat === TOKEN_RATE_UNDEFINED
                   ? TextVariant.BodySM
-                  : TextVariant.BodyMDBold
+                  : TextVariant.BodyMDMedium
               }
               isHidden={privacyMode}
               length={SensitiveTextLength.Medium}
@@ -588,11 +588,9 @@ export const TokenListItemV2 = React.memo(
                       style={styles.balanceFiat}
                     >
                       {tokenPriceInFiat
-                        ? addCurrencySymbol(
+                        ? formatPriceWithSubscriptNotation(
                             tokenPriceInFiat,
                             currentCurrency,
-                            true,
-                            true,
                           )
                         : '-'}
                       {' \u2022 '}


### PR DESCRIPTION
Cherry-pick of #27485 into release/7.69.1-ota OTA hotfix branch.

Fixes token price display in the wallet token list:
- Replaced addCurrencySymbol with formatPriceWithSubscriptNotation for locale-aware formatting (thousand separators)
- Changed fiat balance text from BodyMDBold to BodyMDMedium

CHANGELOG entry: fixed token prices in the wallet list displaying
without thousand-separator commas and with too many decimal places


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only formatting change, but it may affect displayed precision/rounding for token prices ≥ 1 across the wallet token list.
> 
> **Overview**
> Updates `formatPriceWithSubscriptNotation` to cap **values ≥ 1** at *2 decimal places* (while keeping *up to 4* for values < 1 and subscript formatting for very small values), and adds tests covering the new truncation behavior.
> 
> Switches the wallet `TokenListItemV2` token-price display from `addCurrencySymbol` to `formatPriceWithSubscriptNotation` (adding thousands separators/consistent decimal rules) and slightly adjusts the fiat balance text weight (`BodyMDBold` → `BodyMDMedium`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccd59db5c85f0f5992955602f6fbbff81b24285d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->