### PR TITLE
fix: update MegaETH explorer display name to Megaeth Explorer

### DIFF
--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -513,7 +513,7 @@ export function getBlockExplorerName(blockExplorerUrl) {
   if (!blockExplorerUrl) return undefined;
   const hostname = new URL(blockExplorerUrl).hostname;
   if (!hostname) return undefined;
-  if (BLOCK_EXPLORER_NAME_OVERRIDES[hostname]) {
+  if (Object.hasOwn(BLOCK_EXPLORER_NAME_OVERRIDES, hostname)) {
     return BLOCK_EXPLORER_NAME_OVERRIDES[hostname];
   }
   const tempBlockExplorerName = fastSplit(hostname);

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -501,7 +501,7 @@ export function compareRpcUrls(rpcOne, rpcTwo) {
  * auto-derived name (first subdomain, capitalised) is not ideal.
  */
 const BLOCK_EXPLORER_NAME_OVERRIDES = {
-  'megaeth.blockscout.com': 'Megaeth Explorer',
+  'megaeth.blockscout.com': 'MegaETH Explorer',
 };
 
 /**

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -497,6 +497,14 @@ export function compareRpcUrls(rpcOne, rpcTwo) {
 }
 
 /**
+ * Hostname-to-display-name overrides for block explorers whose
+ * auto-derived name (first subdomain, capitalised) is not ideal.
+ */
+const BLOCK_EXPLORER_NAME_OVERRIDES = {
+  'megaeth.blockscout.com': 'Megaeth Explorer',
+};
+
+/**
  * From block explorer url, get rendereable name or undefined
  *
  * @param {string} blockExplorerUrl - block explorer url
@@ -505,6 +513,9 @@ export function getBlockExplorerName(blockExplorerUrl) {
   if (!blockExplorerUrl) return undefined;
   const hostname = new URL(blockExplorerUrl).hostname;
   if (!hostname) return undefined;
+  if (BLOCK_EXPLORER_NAME_OVERRIDES[hostname]) {
+    return BLOCK_EXPLORER_NAME_OVERRIDES[hostname];
+  }
   const tempBlockExplorerName = fastSplit(hostname);
   if (!tempBlockExplorerName || !tempBlockExplorerName[0]) return undefined;
   return (

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -513,7 +513,12 @@ export function getBlockExplorerName(blockExplorerUrl) {
   if (!blockExplorerUrl) return undefined;
   const hostname = new URL(blockExplorerUrl).hostname;
   if (!hostname) return undefined;
-  if (Object.hasOwn(BLOCK_EXPLORER_NAME_OVERRIDES, hostname)) {
+  if (
+    Object.prototype.hasOwnProperty.call(
+      BLOCK_EXPLORER_NAME_OVERRIDES,
+      hostname,
+    )
+  ) {
     return BLOCK_EXPLORER_NAME_OVERRIDES[hostname];
   }
   const tempBlockExplorerName = fastSplit(hostname);


### PR DESCRIPTION
## **Description**

Updates the MegaETH block explorer button text from "View on Megaeth" to "View on Megaeth Explorer" in the  
Receive flow.
                                                                              
Adds a `BLOCK_EXPLORER_NAME_OVERRIDES` map in `app/util/networks/index.js` that overrides the auto-derived  
explorer name for `megaeth.blockscout.com`. Only MegaETH is affected; all other networks continue using the
existing hostname-based auto-derivation logic.                                                              
                                                                           
## **Changelog**                                          

CHANGELOG entry: Fixed MegaETH explorer button to display "View on Megaeth Explorer" instead of "View on    
Megaeth"
                                                                              
## **Related issues**                                                                                    
                            
Fixes:

## **Manual testing steps**

```gherkin
Feature: MegaETH explorer button wording

Scenario: user views receive address for ETH on MegaETH                                                   
Given user has MegaETH network added
                                                                              
When user selects ETH on MegaETH and taps Receive                                                       
Then the button at the bottom reads "View on Megaeth Explorer"                                          
                                                                              
Scenario: other networks are unaffected                                                                
Given user has other networks added                                                                     
                                                                              
When user selects a token on another network and taps Receive                                           
Then the explorer button text remains unchanged
```                                                         
                                                                              
Screenshots/Recordings                                                                                   
                                                                              
Before                                                                                                   

<img width="463" height="763" alt="image" src="https://github.com/user-attachments/assets/776ec304-d1bf-4bf2-b043-769122635d93" />
                            
"View on Megaeth"

After

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5725e342-b118-4f11-969e-8ddd2b1ce0f6" />


"View on Megaeth Explorer"                                                                                  

Pre-merge author checklist                                                                                  
                                                                           

- [x]  I've followed https://github.com/MetaMask/contributor-docs and https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md.           
- [x] I've completed the PR template to the best of my ability                                                  
- [x] I've included tests if applicable                                                                      
- [x] I've documented my code using https://jsdoc.app/ format if applicable
- [x] I've applied the right labels on the PR (see https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not equired for external contributors.              

                                                           
                                                                              
Pre-merge reviewer checklist                                                                             
                            

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).           
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes

the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string-only change: adds a hostname-specific override for one block explorer name, leaving existing hostname-derived naming for all other explorers unchanged.
> 
> **Overview**
> Updates `getBlockExplorerName` to support hostname-specific display-name overrides via a new `BLOCK_EXPLORER_NAME_OVERRIDES` map.
> 
> This ensures `megaeth.blockscout.com` is shown as **"MegaETH Explorer"** (e.g., in “View on …” buttons) instead of relying on the default subdomain-based capitalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dad1e7eeaf19e40c44a2200c94bfac655bdaf068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->