### PR TITLE
test: removes llamarpc.com as an allowed rpc url

### DIFF
--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -659,7 +659,7 @@ export default class MockServerE2E implements Resource {
       .slice() as ((...args: unknown[]) => void)[];
     process.removeAllListeners('uncaughtException');
 
-    this._abortExceptionHandler = (error: unknown) => {
+    this._abortExceptionHandler = (error: unknown, origin: unknown) => {
       if (MockServerE2E._isMockttpAbortError(error)) {
         this._abortSuppressCount++;
         logger.debug(
@@ -675,7 +675,7 @@ export default class MockServerE2E implements Resource {
       let firstError: unknown;
       for (const handler of this._originalExceptionHandlers) {
         try {
-          handler(error);
+          handler(error, origin);
         } catch (err) {
           if (firstError === undefined) {
             firstError = err;

--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -194,8 +194,10 @@ export default class MockServerE2E implements Resource {
   private _activeRequests = 0;
   private _shuttingDown = false;
   private _abortFilterHandler: ((...args: unknown[]) => void) | null = null;
+  private _abortExceptionHandler: ((...args: unknown[]) => void) | null = null;
   private _abortSuppressCount = 0;
   private _originalRejectionHandlers: ((...args: unknown[]) => void)[] = [];
+  private _originalExceptionHandlers: ((...args: unknown[]) => void)[] = [];
 
   constructor(params: {
     events: MockEventsObject;
@@ -562,7 +564,8 @@ export default class MockServerE2E implements Resource {
       }
       // Brief drain period: 'aborted' events from destroyed sockets may fire
       // asynchronously on the next event-loop tick after `stop()` resolves.
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      // 500ms is generous for CI environments where event-loop ticks may be delayed.
+      await new Promise((resolve) => setTimeout(resolve, 500));
     } catch (error) {
       logger.error('Error stopping mock server:', error);
     } finally {
@@ -577,19 +580,31 @@ export default class MockServerE2E implements Resource {
   }
 
   /**
-   * Installs a lifecycle-wide filter for mockttp "Aborted" unhandled promise rejections.
+   * Checks whether an error is a mockttp "Aborted" error from streamToBuffer.
+   */
+  private static _isMockttpAbortError(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      error.message === 'Aborted' &&
+      (error.stack?.includes('mockttp') ?? false)
+    );
+  }
+
+  /**
+   * Installs lifecycle-wide filters for mockttp "Aborted" errors on BOTH
+   * `unhandledRejection` AND `uncaughtException`.
    *
    * When the app unexpectedly drops connections during a test (e.g., UI transitions,
    * RN bridge interruptions), mockttp's internal `streamToBuffer` rejects with
-   * `Error('Aborted')` from `buffer-utils.ts`. Since this happens in mockttp's pipeline
-   * before reaching our handler callback, the rejection is unhandled and Jest catches it
-   * as a test failure.
+   * `Error('Aborted')` from `buffer-utils.ts`. Depending on the Node.js runtime
+   * behaviour and how the error surfaces through mockttp's internals, this can appear
+   * as either an unhandled promise rejection OR an uncaught exception (e.g. from a
+   * stream 'error' event with no listener, or a throw inside a setImmediate callback).
    *
-   * This filter is active for the entire server lifecycle (start → stop), not just
-   * during shutdown. It removes all existing `unhandledRejection` handlers (e.g. Jest's)
-   * and replaces them with a single filter that suppresses mockttp Aborted errors and
-   * forwards everything else to the original handlers. This ensures Jest never sees
-   * the Aborted rejections.
+   * jest-circus installs the same `uncaught` handler on both event types, so we must
+   * intercept both to prevent the error from being recorded as a test failure.
+   *
+   * The filters are active for the entire server lifecycle (start → stop).
    */
   private _installAbortFilter(): void {
     if (this._abortFilterHandler) {
@@ -598,7 +613,7 @@ export default class MockServerE2E implements Resource {
 
     this._abortSuppressCount = 0;
 
-    // Snapshot and remove all existing handlers so Jest never sees Aborted errors.
+    // --- unhandledRejection filter ---
     this._originalRejectionHandlers = process
       .rawListeners('unhandledRejection')
       .slice() as ((...args: unknown[]) => void)[];
@@ -606,15 +621,14 @@ export default class MockServerE2E implements Resource {
 
     this._abortFilterHandler = (reason: unknown, promise: unknown) => {
       const rejectedPromise = promise as Promise<unknown>;
-      if (
-        reason instanceof Error &&
-        reason.message === 'Aborted' &&
-        reason.stack?.includes('mockttp')
-      ) {
+      if (MockServerE2E._isMockttpAbortError(reason)) {
         // Mark the promise as handled so Node.js does not consider it unhandled.
         // eslint-disable-next-line no-empty-function
         rejectedPromise.catch(() => {});
         this._abortSuppressCount++;
+        logger.debug(
+          `Suppressed mockttp Aborted rejection (#${this._abortSuppressCount})`,
+        );
         return;
       }
 
@@ -638,11 +652,50 @@ export default class MockServerE2E implements Resource {
     };
 
     process.on('unhandledRejection', this._abortFilterHandler);
-    logger.debug('Installed lifecycle-wide Aborted error filter');
+
+    // --- uncaughtException filter ---
+    this._originalExceptionHandlers = process
+      .rawListeners('uncaughtException')
+      .slice() as ((...args: unknown[]) => void)[];
+    process.removeAllListeners('uncaughtException');
+
+    this._abortExceptionHandler = (error: unknown) => {
+      if (MockServerE2E._isMockttpAbortError(error)) {
+        this._abortSuppressCount++;
+        logger.debug(
+          `Suppressed mockttp Aborted exception (#${this._abortSuppressCount})`,
+        );
+        return;
+      }
+
+      // Forward any other exception to the original handlers (e.g. Jest).
+      if (this._originalExceptionHandlers.length === 0) {
+        throw error;
+      }
+      let firstError: unknown;
+      for (const handler of this._originalExceptionHandlers) {
+        try {
+          handler(error);
+        } catch (err) {
+          if (firstError === undefined) {
+            firstError = err;
+          }
+        }
+      }
+      if (firstError !== undefined) {
+        throw firstError;
+      }
+    };
+
+    process.on('uncaughtException', this._abortExceptionHandler);
+
+    logger.info(
+      `Abort filter installed — listeners: unhandledRejection=${process.listenerCount('unhandledRejection')}, uncaughtException=${process.listenerCount('uncaughtException')}`,
+    );
   }
 
   /**
-   * Removes the lifecycle-wide Aborted error filter and restores original handlers.
+   * Removes the lifecycle-wide Aborted error filters and restores original handlers.
    * Any handlers added by other code during the filter's lifetime are preserved.
    */
   private _removeAbortFilter(): void {
@@ -650,10 +703,11 @@ export default class MockServerE2E implements Resource {
       return;
     }
 
-    // Preserve any handlers that were added by other code during the
-    // filter's lifetime so they are not permanently lost.
-    const currentHandlers = process.rawListeners('unhandledRejection').slice();
-    const addedDuringLifecycle = currentHandlers.filter(
+    // --- Restore unhandledRejection handlers ---
+    const currentRejectionHandlers = process
+      .rawListeners('unhandledRejection')
+      .slice();
+    const addedRejectionDuringLifecycle = currentRejectionHandlers.filter(
       (h) =>
         h !== this._abortFilterHandler &&
         !this._originalRejectionHandlers.includes(
@@ -661,23 +715,44 @@ export default class MockServerE2E implements Resource {
         ),
     );
 
-    // Remove all and restore: originals first, then any newly added handlers.
     process.removeAllListeners('unhandledRejection');
     for (const handler of [
       ...this._originalRejectionHandlers,
-      ...(addedDuringLifecycle as ((...args: unknown[]) => void)[]),
+      ...(addedRejectionDuringLifecycle as ((...args: unknown[]) => void)[]),
     ]) {
       process.on('unhandledRejection', handler);
     }
 
-    this._abortFilterHandler = null;
-    this._originalRejectionHandlers = [];
-
-    if (this._abortSuppressCount > 0) {
-      logger.info(
-        `Suppressed ${this._abortSuppressCount} mockttp "Aborted" rejection(s) during server lifecycle`,
+    // --- Restore uncaughtException handlers ---
+    if (this._abortExceptionHandler) {
+      const currentExceptionHandlers = process
+        .rawListeners('uncaughtException')
+        .slice();
+      const addedExceptionDuringLifecycle = currentExceptionHandlers.filter(
+        (h) =>
+          h !== this._abortExceptionHandler &&
+          !this._originalExceptionHandlers.includes(
+            h as (...args: unknown[]) => void,
+          ),
       );
+
+      process.removeAllListeners('uncaughtException');
+      for (const handler of [
+        ...this._originalExceptionHandlers,
+        ...(addedExceptionDuringLifecycle as ((...args: unknown[]) => void)[]),
+      ]) {
+        process.on('uncaughtException', handler);
+      }
     }
+
+    this._abortFilterHandler = null;
+    this._abortExceptionHandler = null;
+    this._originalRejectionHandlers = [];
+    this._originalExceptionHandlers = [];
+
+    logger.info(
+      `Abort filter removed — suppressed ${this._abortSuppressCount} mockttp "Aborted" error(s) during server lifecycle`,
+    );
     this._abortSuppressCount = 0;
   }
 

--- a/tests/api-mocking/mock-e2e-allowlist.ts
+++ b/tests/api-mocking/mock-e2e-allowlist.ts
@@ -58,5 +58,4 @@ export const ALLOWLISTED_URLS = [
   'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0xaa36a7',
   'https://price.api.cx.metamask.io/v1/exchange-rates?baseCurrency=usd',
   'https://api.hyperliquid.xyz/exchange',
-  'https://api.hyperliquid.xyz/info',
 ];

--- a/tests/api-mocking/mock-e2e-allowlist.ts
+++ b/tests/api-mocking/mock-e2e-allowlist.ts
@@ -47,7 +47,6 @@ export const ALLOWLISTED_URLS = [
   'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=LINEAETH',
   'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x539',
   'https://mainnet.era.zksync.io/',
-  'https://eth.llamarpc.com/',
   'https://rpc.atlantischain.network/',
   'https://nft.api.cx.metamask.io/collections?chainId=0x539&contract=0xb2552e4f4bc23e1572041677234d192774558bf0',
   'https://metamask.github.io/test-dapp/metamask-fox.svg',

--- a/tests/api-mocking/mock-responses/custom-rpc-provider-mocks.ts
+++ b/tests/api-mocking/mock-responses/custom-rpc-provider-mocks.ts
@@ -1,0 +1,75 @@
+/**
+ * Mock responses for custom RPC provider endpoints (e.g. eth.llamarpc.com)
+ * that are not covered by Infura mocks.
+ */
+
+import type { Mockttp } from 'mockttp';
+import type { TestSpecificMock } from '../../framework';
+
+// Ethereum mainnet block-like response
+const MOCK_BLOCK = {
+  number: '0x178a60b',
+  hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  timestamp: '0x' + Math.floor(Date.now() / 1000).toString(16),
+  gasLimit: '0x1c9c380',
+  gasUsed: '0x5208',
+  transactions: [],
+};
+
+// Method-specific mock responses for Ethereum mainnet RPC calls
+const MOCK_RESPONSES: Record<string, unknown> = {
+  eth_blockNumber: '0x178a60b',
+  net_version: '1',
+  eth_chainId: '0x1',
+  eth_getBlockByNumber: MOCK_BLOCK,
+  eth_call:
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+  eth_getBalance: '0x0',
+  eth_getTransactionCount: '0x0',
+  eth_gasPrice: '0x3b9aca00',
+  eth_estimateGas: '0x5208',
+};
+
+const LLAMARPC_URL = 'https://eth.llamarpc.com';
+
+/**
+ * TestSpecificMock that intercepts eth.llamarpc.com RPC calls
+ * through the mobile proxy, returning static responses per JSON-RPC method.
+ */
+export const CUSTOM_RPC_PROVIDER_MOCKS: TestSpecificMock = async (
+  mockServer: Mockttp,
+) => {
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const urlParam = new URL(request.url).searchParams.get('url');
+      return Boolean(urlParam?.startsWith(LLAMARPC_URL));
+    })
+    .asPriority(1000)
+    .thenCallback(async (request) => {
+      try {
+        const bodyText = await request.body.getText();
+        const body = bodyText ? JSON.parse(bodyText) : undefined;
+        const method = body?.method as string | undefined;
+        const result = method ? (MOCK_RESPONSES[method] ?? '0x') : '0x';
+
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            id: body?.id ?? 1,
+            jsonrpc: '2.0',
+            result,
+          }),
+        };
+      } catch {
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            result: '0x',
+          }),
+        };
+      }
+    });
+};

--- a/tests/api-mocking/mock-responses/defaults/perps-hyperliquid.ts
+++ b/tests/api-mocking/mock-responses/defaults/perps-hyperliquid.ts
@@ -12,6 +12,12 @@ export const PERPS_HYPERLIQUID_MOCKS: MockEventsObject = {
     },
     {
       urlEndpoint: hyperliquidInfoEndpoint,
+      requestBody: { type: 'meta' },
+      responseCode: 200,
+      response: {},
+    },
+    {
+      urlEndpoint: hyperliquidInfoEndpoint,
       requestBody: { type: 'perpDexs' },
       responseCode: 200,
       response: {},

--- a/tests/api-mocking/mock-responses/defaults/perps-hyperliquid.ts
+++ b/tests/api-mocking/mock-responses/defaults/perps-hyperliquid.ts
@@ -1,10 +1,27 @@
 import { MockEventsObject } from '../../../framework';
 
+const hyperliquidInfoEndpoint = 'https://api.hyperliquid.xyz/info';
+
 export const PERPS_HYPERLIQUID_MOCKS: MockEventsObject = {
   POST: [
     {
-      urlEndpoint: 'https://api.hyperliquid.xyz/info',
-      requestBody: { type: 'meta' },
+      urlEndpoint: hyperliquidInfoEndpoint,
+      requestBody: { type: 'allMids' },
+      responseCode: 200,
+      response: {},
+    },
+    {
+      urlEndpoint: hyperliquidInfoEndpoint,
+      requestBody: { type: 'perpDexs' },
+      responseCode: 200,
+      response: {},
+    },
+    {
+      urlEndpoint: hyperliquidInfoEndpoint,
+      requestBody: {
+        type: 'frontendOpenOrders',
+      },
+      ignoreFields: ['user'],
       responseCode: 200,
       response: {},
     },

--- a/tests/smoke/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.ts
+++ b/tests/smoke/multichain/permissions/chains/permission-system-dapp-chain-switch-grant.spec.ts
@@ -12,6 +12,7 @@ import ConnectedAccountsModal from '../../../../page-objects/Browser/ConnectedAc
 import NetworkConnectMultiSelector from '../../../../page-objects/Browser/NetworkConnectMultiSelector';
 import NetworkNonPemittedBottomSheet from '../../../../page-objects/Network/NetworkNonPemittedBottomSheet';
 import { DappVariants } from '../../../../framework/Constants';
+import { CUSTOM_RPC_PROVIDER_MOCKS } from '../../../../api-mocking/mock-responses/custom-rpc-provider-mocks';
 
 describe(SmokeNetworkAbstractions('Chain Permission System'), () => {
   beforeAll(async () => {
@@ -32,9 +33,9 @@ describe(SmokeNetworkAbstractions('Chain Permission System'), () => {
             .withNetworkController(
               CustomNetworks.EthereumMainCustom.providerConfig,
             )
-            .withPermissionController()
             .build(),
           restartDevice: true,
+          testSpecificMock: CUSTOM_RPC_PROVIDER_MOCKS,
         },
         async () => {
           // Setup: Login and navigate to browser

--- a/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.ts
+++ b/tests/smoke/multichain/permissions/chains/permission-system-initial-connection.spec.ts
@@ -25,7 +25,7 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
             dappVariant: DappVariants.TEST_DAPP,
           },
         ],
-        fixture: new FixtureBuilder().withPermissionController().build(),
+        fixture: new FixtureBuilder().build(),
         restartDevice: true,
       },
       async () => {
@@ -53,7 +53,7 @@ describe(SmokeNetworkExpansion('Chain Permission Management'), () => {
             dappVariant: DappVariants.TEST_DAPP,
           },
         ],
-        fixture: new FixtureBuilder().withPermissionController().build(),
+        fixture: new FixtureBuilder().build(),
         restartDevice: true,
       },
       async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Filter mockttp "Aborted" errors on both unhandledRejection and uncaughtException. When the app drops connections mid-request (e.g. UI navigation, AbortController), mockttp's streamToBuffer rejects with Error('Aborted'). Depending on how Node.js surfaces the error, it can appear as either event type — both must be intercepted to prevent Jest from recording false test failures. Also increased the post-stop drain period from 150ms to 500ms for CI reliability.

This PR also migrates permission system tests to ts and adds mocks for custom RPC to reduce the allow list.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the E2E mock server’s global `process` error handlers and shutdown timing, which can affect how Jest reports failures across the whole test run. Changes are test-only but could mask real errors if the abort detection is too broad or handler restoration is incorrect.
> 
> **Overview**
> Improves E2E reliability by suppressing mockttp `Error('Aborted')` failures across the full server lifecycle: `MockServerE2E` now filters these errors from both `unhandledRejection` and `uncaughtException`, preserves/restores any handlers added during runtime, and increases the post-stop drain wait from 150ms to 500ms.
> 
> Reduces reliance on live allowlisted endpoints by removing `https://eth.llamarpc.com/` and adding `CUSTOM_RPC_PROVIDER_MOCKS` to intercept `eth.llamarpc.com` JSON-RPC calls via `/proxy`. Updates Hyperliquid mocks to cover additional `POST /info` request bodies (`allMids`, `perpDexs`, `frontendOpenOrders`) and adjusts permission-system smoke tests to use the new fixture setup (dropping explicit `.withPermissionController()` and adding the custom RPC test-specific mock where needed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4abd2a1c1ecd311a85e5832f0d6de793e0875fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->