### PR TITLE
fix: improve hardware wallet icon colors and copy

### DIFF
--- a/app/core/HardwareWallet/errors/helpers.test.ts
+++ b/app/core/HardwareWallet/errors/helpers.test.ts
@@ -132,42 +132,46 @@ describe('error helpers', () => {
   });
 
   describe('getIconColorForErrorCode', () => {
-    it('returns Error color for DeviceDisconnected', () => {
-      const color = getIconColorForErrorCode(ErrorCode.DeviceDisconnected);
-
-      expect(color).toBe(IconColor.Error);
-    });
-
-    it('returns Info color for UserRejected', () => {
-      const color = getIconColorForErrorCode(ErrorCode.UserRejected);
-
-      expect(color).toBe(IconColor.Info);
-    });
-
-    it('returns Info color for UserCancelled', () => {
-      const color = getIconColorForErrorCode(ErrorCode.UserCancelled);
-
-      expect(color).toBe(IconColor.Info);
-    });
-
-    it('returns Warning color for UserConfirmationRequired', () => {
-      const color = getIconColorForErrorCode(
+    it('returns Default for most errors', () => {
+      const defaultCodes = [
+        ErrorCode.AuthenticationDeviceLocked,
+        ErrorCode.AuthenticationDeviceBlocked,
+        ErrorCode.DeviceStateEthAppClosed,
+        ErrorCode.DeviceDisconnected,
+        ErrorCode.DeviceNotFound,
+        ErrorCode.DeviceMissingCapability,
+        ErrorCode.DeviceStateBlindSignNotSupported,
+        ErrorCode.DeviceUnresponsive,
+        ErrorCode.ConnectionClosed,
+        ErrorCode.ConnectionTimeout,
+        ErrorCode.UserRejected,
+        ErrorCode.UserCancelled,
         ErrorCode.UserConfirmationRequired,
-      );
+        ErrorCode.PermissionBluetoothDenied,
+        ErrorCode.PermissionLocationDenied,
+        ErrorCode.PermissionNearbyDevicesDenied,
+        ErrorCode.BluetoothDisabled,
+        ErrorCode.BluetoothScanFailed,
+        ErrorCode.BluetoothConnectionFailed,
+        ErrorCode.DeviceNotReady,
+        ErrorCode.MobileNotSupported,
+      ];
+
+      for (const code of defaultCodes) {
+        expect(getIconColorForErrorCode(code)).toBe(IconColor.Default);
+      }
+    });
+
+    it('returns Warning color for Unknown', () => {
+      const color = getIconColorForErrorCode(ErrorCode.Unknown);
 
       expect(color).toBe(IconColor.Warning);
     });
 
-    it('returns Error color for Unknown', () => {
-      const color = getIconColorForErrorCode(ErrorCode.Unknown);
-
-      expect(color).toBe(IconColor.Error);
-    });
-
-    it('returns default Error color for unmapped codes', () => {
+    it('returns default Warning color for unmapped codes', () => {
       const color = getIconColorForErrorCode(999 as ErrorCode);
 
-      expect(color).toBe(IconColor.Error);
+      expect(color).toBe(IconColor.Warning);
     });
   });
 

--- a/app/core/HardwareWallet/errors/helpers.ts
+++ b/app/core/HardwareWallet/errors/helpers.ts
@@ -43,7 +43,7 @@ export function getIconForErrorCode(errorCode: ErrorCode): IconName {
  */
 export function getIconColorForErrorCode(errorCode: ErrorCode): IconColor {
   const ext = MOBILE_ERROR_EXTENSIONS[errorCode];
-  return ext?.iconColor ?? IconColor.Error;
+  return ext?.iconColor ?? IconColor.Warning;
 }
 
 /**

--- a/app/core/HardwareWallet/errors/mappings.ts
+++ b/app/core/HardwareWallet/errors/mappings.ts
@@ -26,7 +26,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.AuthenticationDeviceLocked]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Lock,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: (walletType) =>
       strings('hardware_wallet.error.device_locked_title', {
         device: getHardwareWalletTypeName(walletType),
@@ -39,7 +39,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.AuthenticationDeviceBlocked]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Lock,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: (walletType) =>
       strings('hardware_wallet.error.device_locked_title', {
         device: getHardwareWalletTypeName(walletType),
@@ -54,14 +54,14 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.DeviceStateEthAppClosed]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Setting,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.app_not_open'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.app_not_open'),
   },
   [ErrorCode.DeviceDisconnected]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Plug,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: (walletType) =>
       strings('hardware_wallet.error.device_disconnected_title', {
         device: getHardwareWalletTypeName(walletType),
@@ -74,7 +74,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.DeviceNotFound]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Search,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: (walletType) =>
       strings('hardware_wallet.error.device_not_found_title', {
         device: getHardwareWalletTypeName(walletType),
@@ -87,7 +87,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.DeviceNotReady]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Clock,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.something_went_wrong'),
     getLocalizedMessage: () =>
@@ -96,14 +96,14 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.DeviceMissingCapability]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Setting,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.app_not_open'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.app_not_open'),
   },
   [ErrorCode.DeviceStateBlindSignNotSupported]: {
     recoveryAction: RecoveryAction.ACKNOWLEDGE,
     icon: IconName.Eye,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.blind_signing_disabled'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.blind_signing'),
@@ -111,7 +111,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.DeviceUnresponsive]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Clock,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.connection_timeout'),
     getLocalizedMessage: () =>
@@ -122,7 +122,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.ConnectionClosed]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Close,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.connection_closed'),
     getLocalizedMessage: () =>
       strings('hardware_wallet.errors.connection_closed'),
@@ -130,7 +130,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.ConnectionTimeout]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Clock,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.connection_timeout'),
     getLocalizedMessage: () =>
@@ -141,21 +141,21 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.UserRejected]: {
     recoveryAction: RecoveryAction.ACKNOWLEDGE,
     icon: IconName.Close,
-    iconColor: IconColor.Info,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.user_cancelled'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.user_cancelled'),
   },
   [ErrorCode.UserCancelled]: {
     recoveryAction: RecoveryAction.ACKNOWLEDGE,
     icon: IconName.Close,
-    iconColor: IconColor.Info,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.user_cancelled'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.user_cancelled'),
   },
   [ErrorCode.UserConfirmationRequired]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.SecurityTick,
-    iconColor: IconColor.Warning,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.pending_confirmation'),
     getLocalizedMessage: () =>
@@ -166,7 +166,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.PermissionBluetoothDenied]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Connect,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.bluetooth_permission_denied'),
     getLocalizedMessage: () =>
@@ -175,7 +175,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.PermissionLocationDenied]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Location,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.location_permission_denied'),
     getLocalizedMessage: () =>
@@ -184,7 +184,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.PermissionNearbyDevicesDenied]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Connect,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.nearby_devices_permission_denied'),
     getLocalizedMessage: () =>
@@ -193,7 +193,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.BluetoothDisabled]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Connect,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.bluetooth_required'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.bluetooth_off'),
@@ -201,7 +201,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.BluetoothScanFailed]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Connect,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.scan_failed'),
     getLocalizedMessage: () =>
       strings('hardware_wallet.errors.bluetooth_scan_failed'),
@@ -209,7 +209,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.BluetoothConnectionFailed]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Connect,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () => strings('hardware_wallet.error.connection_closed'),
     getLocalizedMessage: () =>
       strings('hardware_wallet.errors.bluetooth_connection_failed'),
@@ -219,7 +219,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.MobileNotSupported]: {
     recoveryAction: RecoveryAction.ACKNOWLEDGE,
     icon: IconName.Danger,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Default,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.something_went_wrong'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.not_supported'),
@@ -229,7 +229,7 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
   [ErrorCode.Unknown]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Danger,
-    iconColor: IconColor.Error,
+    iconColor: IconColor.Warning,
     getLocalizedTitle: () =>
       strings('hardware_wallet.error.something_went_wrong'),
     getLocalizedMessage: (walletType) =>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8043,7 +8043,7 @@
       "nearby_permission_denied": "Nearby devices permission is required",
       "bluetooth_off": "Please turn on Bluetooth to connect to your device",
       "bluetooth_scan_failed": "Failed to scan for devices. Please try again",
-      "bluetooth_connection_failed": "Enable Bluetooth on your device to continue",
+      "bluetooth_connection_failed": "The connection to your device failed. Please try again",
       "not_supported": "This operation is not supported",
       "unknown_error": "Make sure your {{device}} is set up with the Secret Recovery Phrase or passphrase for this account"
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

no manual testing steps

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX-only changes affecting hardware-wallet error presentation (icon color selection and one localized string), with tests updated to match.
> 
> **Overview**
> Updates hardware-wallet error presentation to reduce overly-severe styling: most `ErrorCode`s now use `IconColor.Default`, while `Unknown` (and unmapped codes via fallback) use `IconColor.Warning` instead of `Error`.
> 
> Updates unit tests to assert the new icon-color behavior, and tweaks the English copy for `hardware_wallet.errors.bluetooth_connection_failed` to a more accurate connection-failure message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d522ba68dc0b092b8dcb4f94247349a76cab6e39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->