### PR TITLE
fix(ci): namespace node_modules artifact names by build_name to prevent conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       build_name: ${{ inputs.build_name }}
       use-tarball: true
       upload-artifact: true
-      artifact-name: node-modules-${{ matrix.platform }}
+      artifact-name: node-modules-${{ inputs.build_name }}-${{ matrix.platform }}
       artifact-retention-days: 1
 
   # Build
@@ -165,7 +165,7 @@ jobs:
       - name: Download node_modules tarball
         uses: actions/download-artifact@v4
         with:
-          name: node-modules-${{ matrix.platform }}
+          name: node-modules-${{ inputs.build_name }}-${{ matrix.platform }}
 
       - name: Extract tarball (preserves symlinks)
         run: |


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When multiple `build.yml` invocations run in parallel within the same workflow run (e.g. nightly builds triggering `main-exp` and `main-rc` simultaneously), the `setup-dependencies` job uploads node_modules tarballs as artifacts named `node-modules-{platform}`. Since GitHub Actions requires unique artifact names per workflow run, the second upload fails with a `409 Conflict`.

This PR namespaces the artifact name by including `build_name`, changing from `node-modules-{platform}` to `node-modules-{build_name}-{platform}`. This produces unique names like `node-modules-main-exp-android` and `node-modules-main-rc-android`, allowing parallel invocations to coexist. The tarball filename inside the artifact remains unchanged (`node-modules-{platform}.tar.gz`), so the extract step requires no modification.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A -- CI-only change. Verified by triggering a nightly build that invokes `build.yml` twice in parallel (main-exp + main-rc) and confirming both setup-dependencies jobs succeed without artifact name conflicts.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just adjusts artifact naming to avoid collisions when multiple `build.yml` invocations run in the same workflow run.
> 
> **Overview**
> Prevents GitHub Actions artifact upload/download name collisions when `build.yml` runs concurrently for different `build_name` values.
> 
> The `setup-dependencies` job now uploads `node_modules` tarballs with `build_name` included (e.g., `node-modules-${{ inputs.build_name }}-${{ matrix.platform }}`), and the `build` job downloads artifacts using the same names; the tarball filename inside the artifact remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 149822efa106b39b2661eb3a348e730c5d4e2d76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->