### PR TITLE
feat: migrate Button component (transactions scope)

### DIFF
--- a/app/components/Views/transactions/SmartTransactionStatus/SmartTransactionStatus.tsx
+++ b/app/components/Views/transactions/SmartTransactionStatus/SmartTransactionStatus.tsx
@@ -16,9 +16,7 @@ import {
 import { useSelector } from 'react-redux';
 import { selectEvmChainId } from '../../../../selectors/networkController';
 import { useNavigation } from '@react-navigation/native';
-import Button, {
-  ButtonVariants,
-} from '../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import Routes from '../../../../constants/navigation/Routes';
 import TransactionBackgroundTop from '../../../../images/transaction-background-top.svg';
 import TransactionBackgroundBottom from '../../../../images/transaction-background-bottom.svg';
@@ -244,9 +242,6 @@ const createStyles = (colors: ThemeColors) =>
       width: '100%',
       gap: 10,
     },
-    button: {
-      width: '100%',
-    },
   });
 
 const SmartTransactionStatus = ({
@@ -352,10 +347,9 @@ const SmartTransactionStatus = ({
   const renderPrimaryButton = () =>
     handlePrimaryButtonPress ? (
       <Button
-        variant={ButtonVariants.Primary}
-        label={primaryButtonText}
+        variant={ButtonVariant.Primary}
         onPress={handlePrimaryButtonPress}
-        style={styles.button}
+        isFullWidth
       >
         {primaryButtonText}
       </Button>
@@ -364,10 +358,9 @@ const SmartTransactionStatus = ({
   const renderSecondaryButton = () =>
     handleSecondaryButtonPress ? (
       <Button
-        variant={ButtonVariants.Secondary}
-        label={secondaryButtonText}
+        variant={ButtonVariant.Secondary}
         onPress={handleSecondaryButtonPress}
-        style={styles.button}
+        isFullWidth
       >
         {secondaryButtonText}
       </Button>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated `Button` to DSRN package usage.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/25c07e5d-4419-49d6-a8fe-e488a31f1605

### **After**

https://github.com/user-attachments/assets/1f90310e-02c5-47f9-8dc9-35dcae15974f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI component migration limited to button props/styling; main risk is minor visual/behavior differences in the new `Button` implementation.
> 
> **Overview**
> Updates `SmartTransactionStatus` to use `@metamask/design-system-react-native` `Button`/`ButtonVariant` instead of the legacy component-library button.
> 
> Adjusts button usage to the new API (children text + `isFullWidth` rather than `label` + custom width style), removing the now-unneeded `styles.button` rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 394d3b56b1d34dccbfc85ae83bbf1135fbd2076f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->