### PR TITLE
fix(snaps): Improve WebView loading detection

### DIFF
--- a/app/lib/snaps/SnapsExecutionWebView.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.tsx
@@ -1,15 +1,18 @@
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import React, { Component } from 'react';
-import { View, NativeSyntheticEvent } from 'react-native';
+import { View } from 'react-native';
 import { WebViewMessageEvent, WebView } from '@metamask/react-native-webview';
 import { createStyles } from './styles';
 import { WebViewInterface } from '@metamask/snaps-controllers/react-native';
-import { WebViewError } from '@metamask/react-native-webview/src/WebViewTypes';
+import {
+  WebViewNavigationEvent,
+  WebViewErrorEvent,
+} from '@metamask/react-native-webview/src/WebViewTypes';
 import { PostMessageEvent } from '@metamask/post-message-stream';
 // @ts-expect-error Types are currently broken for this.
 import WebViewHTML from '@metamask/snaps-execution-environments/dist/webpack/webview/index.html';
 import { EmptyObject } from '@metamask/snaps-sdk';
-import { assert } from '@metamask/utils';
+import { assert, hasProperty } from '@metamask/utils';
 import Logger from '../../util/Logger';
 
 const styles = createStyles();
@@ -25,8 +28,7 @@ interface WebViewState {
   listener?: (event: PostMessageEvent) => void;
   props: {
     onWebViewMessage: (data: WebViewMessageEvent) => void;
-    onWebViewLoad: () => void;
-    onWebViewError: (error: NativeSyntheticEvent<WebViewError>) => void;
+    onWebViewLoad: (event: WebViewNavigationEvent | WebViewErrorEvent) => void;
     ref: (ref: WebView) => void;
   };
 }
@@ -44,34 +46,46 @@ export class SnapsExecutionWebView extends Component {
 
   createWebView(jobId: string) {
     const promise = new Promise<WebViewInterface>((resolve, reject) => {
-      const onWebViewLoad = () => {
-        const api = {
-          injectJavaScript: (js: string) => {
-            assert(
-              this.webViews[jobId]?.ref,
-              'Snaps execution webview reference not found.',
-            );
-            this.webViews[jobId].ref?.injectJavaScript(js);
-          },
-          registerMessageListener: (
-            listener: (event: PostMessageEvent) => void,
-          ) => {
-            if (this.webViews[jobId]) {
-              this.webViews[jobId].listener = listener;
-            }
-          },
-          unregisterMessageListener: (
-            _listener: (event: PostMessageEvent) => void,
-          ) => {
-            if (this.webViews[jobId]) {
-              this.webViews[jobId].listener = undefined;
-            }
-          },
-        };
-        resolve(api);
+      const api = {
+        injectJavaScript: (js: string) => {
+          assert(
+            this.webViews[jobId]?.ref,
+            'Snaps execution webview reference not found.',
+          );
+          this.webViews[jobId].ref?.injectJavaScript(js);
+        },
+        registerMessageListener: (
+          listener: (event: PostMessageEvent) => void,
+        ) => {
+          if (this.webViews[jobId]) {
+            this.webViews[jobId].listener = listener;
+          }
+        },
+        unregisterMessageListener: (
+          _listener: (event: PostMessageEvent) => void,
+        ) => {
+          if (this.webViews[jobId]) {
+            this.webViews[jobId].listener = undefined;
+          }
+        },
+      };
+
+      const onWebViewLoad = (
+        event: WebViewNavigationEvent | WebViewErrorEvent,
+      ) => {
+        if (hasProperty(event.nativeEvent, 'code')) {
+          reject(
+            new Error(
+              `Snaps execution webview failed to load with error code: ${event.nativeEvent.code}`,
+            ),
+          );
+        }
       };
 
       const onWebViewMessage = (data: WebViewMessageEvent) => {
+        // We resolve the promise on the first message received
+        resolve(api);
+
         if (this.webViews[jobId]?.listener) {
           try {
             this.webViews[jobId].listener?.(
@@ -83,10 +97,6 @@ export class SnapsExecutionWebView extends Component {
         }
       };
 
-      const onWebViewError = (error: NativeSyntheticEvent<WebViewError>) => {
-        reject(error);
-      };
-
       const setWebViewRef = (ref: WebView) => {
         if (this.webViews[jobId]) {
           this.webViews[jobId].ref = ref;
@@ -96,7 +106,6 @@ export class SnapsExecutionWebView extends Component {
       this.webViews[jobId] = {
         props: {
           onWebViewLoad,
-          onWebViewError,
           onWebViewMessage,
           ref: setWebViewRef,
         },
@@ -126,7 +135,6 @@ export class SnapsExecutionWebView extends Component {
             ref={props.ref}
             source={{ html: WebViewHTML, baseUrl: 'https://localhost' }}
             onMessage={props.onWebViewMessage}
-            onError={props.onWebViewError}
             onLoadEnd={props.onWebViewLoad}
             originWhitelist={['*']}
             javaScriptEnabled


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Apparently `onLoadEnd` may trigger even if loading the WebView fails. Therefore, we delay resolving the WebView promise for a Snap until the first message is received from the WebView. We strictly use `onLoadEnd` to detect errors instead.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-517

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the readiness/creation flow for snaps execution WebViews to resolve only after the first `onMessage`, and uses `onLoadEnd` solely for error rejection; this could affect snap startup timing or lead to hangs if a WebView never posts its initial message.
> 
> **Overview**
> Adjusts `SnapsExecutionWebView` so `createWebView()` no longer resolves when `onLoadEnd` fires; it now resolves on the **first `onMessage` received** from the WebView.
> 
> `onLoadEnd` is repurposed to **only detect load failures**, rejecting the promise when the event contains an error `code`, and the explicit `onError` handler is removed along with updated WebView event typings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c54c9703732a5adc5f53dcf6d20d2a0fe2fe9ab1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->