### PR TITLE
feat(ramp): HeaderCompactStandard and DS Text/Button in buy modals

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @metamask/design-tokens/color-no-hex -- theme mock uses hex for test compatibility */
 import React from 'react';
-import { fireEvent, act } from '@testing-library/react-native';
+import { fireEvent, act, waitFor } from '@testing-library/react-native';
 import Checkout from './Checkout';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import {
@@ -84,6 +84,7 @@ const mockCallbackBaseUrl =
 
 jest.mock('../../Aggregator/sdk', () => ({
   callbackBaseUrl: mockCallbackBaseUrl,
+  useRampSDK: jest.fn(() => null),
 }));
 
 let capturedOnNavigationStateChange:
@@ -96,11 +97,15 @@ jest.mock('@metamask/react-native-webview', () => {
   return {
     WebView: ({
       onNavigationStateChange,
+      onHttpError,
       testID,
     }: {
       onNavigationStateChange?: (state: {
         url: string;
         loading?: boolean;
+      }) => void;
+      onHttpError?: (e: {
+        nativeEvent: { url: string; statusCode: number };
       }) => void;
       testID?: string;
     }) => {
@@ -147,6 +152,18 @@ jest.mock('@metamask/react-native-webview', () => {
               })
             }
           />
+          <Button
+            testID="trigger-http-error-main-uri"
+            title="TriggerHttpError"
+            onPress={() =>
+              onHttpError?.({
+                nativeEvent: {
+                  url: 'https://provider.example.com/checkout',
+                  statusCode: 502,
+                },
+              })
+            }
+          />
         </View>
       );
     },
@@ -162,6 +179,7 @@ jest.mock('react-native-safe-area-context', () => {
   const { View } = require('react-native');
   return {
     SafeAreaProvider: View,
+    SafeAreaView: View,
     useSafeAreaFrame: () => ({ x: 0, y: 0, width: 390, height: 844 }),
     useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
   };
@@ -235,25 +253,13 @@ describe('Checkout', () => {
       walletAddress: '0x1234567890abcdef',
     };
 
-    it.todo(
-      'adds order, dispatches protect wallet modal, and resets to order details when callback succeeds',
-    );
-
-    it.todo('shows V2 order toast when isV2Enabled and callback succeeds');
-
-    it.todo('displays error when getOrderFromCallback returns null');
-
-    it.todo('displays error when getOrderFromCallback throws');
-
-    it.todo('pops parent when callback URL has no query params');
-
-    it('returns early when navState.loading is true', async () => {
+    it('returns early when navState.loading is true', () => {
       mockUseParams.mockReturnValue(callbackFlowParams);
 
       renderWithProvider(<Checkout />, {}, true, false);
 
-      await act(async () => {
-        await capturedOnNavigationStateChange?.({
+      act(() => {
+        capturedOnNavigationStateChange?.({
           url: `${mockCallbackBaseUrl}?orderId=123`,
           loading: true,
         });
@@ -262,10 +268,6 @@ describe('Checkout', () => {
       expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
       expect(mockAddOrder).not.toHaveBeenCalled();
     });
-
-    it.todo(
-      'does not process callback twice when navigation fires multiple times',
-    );
 
     it('does not invoke callback handler when hasCallbackFlow is false', async () => {
       mockUseParams.mockReturnValue({
@@ -352,6 +354,90 @@ describe('Checkout', () => {
       expect(mockCallback).toHaveBeenCalledTimes(1);
 
       removeCheckoutCallback(callbackKey);
+    });
+  });
+
+  describe('WebView HTTP error and error recovery', () => {
+    it('sets error when main checkout URL returns HTTP error', async () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test Provider',
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <Checkout />,
+        {},
+        true,
+        false,
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-http-error-main-uri'));
+      });
+
+      expect(
+        getByText('WebView received error status code: 502'),
+      ).toBeOnTheScreen();
+    });
+
+    it('clears error when Try again is pressed after HTTP error', async () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test Provider',
+      });
+
+      const { getByTestId, getByText } = renderWithProvider(
+        <Checkout />,
+        {},
+        true,
+        false,
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-http-error-main-uri'));
+      });
+
+      await act(async () => {
+        fireEvent.press(getByText('Try again'));
+      });
+
+      expect(getByTestId('checkout-webview')).toBeOnTheScreen();
+    });
+  });
+
+  describe('addPrecreatedOrder registration', () => {
+    it('registers precreated order when orderId and callback flow params are present', async () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'MoonPay',
+        providerCode: 'moonpay',
+        walletAddress: '0xabcdef1234567890',
+        orderId: 'mp-order-99',
+        network: 'eip155:1',
+      });
+
+      renderWithProvider(<Checkout />, {}, true, false);
+
+      await waitFor(() => {
+        expect(mockAddPrecreatedOrder).toHaveBeenCalledWith({
+          orderId: 'mp-order-99',
+          providerCode: 'moonpay',
+          walletAddress: '0xabcdef1234567890',
+          chainId: 'eip155:1',
+        });
+      });
+    });
+  });
+
+  describe('missing checkout URL', () => {
+    it('renders ErrorView when url is not provided', () => {
+      mockUseParams.mockReturnValue({
+        providerName: 'Test Provider',
+      });
+
+      const { getByText } = renderWithProvider(<Checkout />, {}, true, false);
+
+      expect(getByText('No URL was provided to continue')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -25,16 +25,9 @@ import { useRampsOrders } from '../../hooks/useRampsOrders';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../../component-library/components/Buttons/ButtonIcon';
-import {
-  IconColor,
-  IconName,
-} from '../../../../../component-library/components/Icons/Icon';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './Checkout.styles';
 import Device from '../../../../../util/device';
@@ -312,16 +305,11 @@ const Checkout = () => {
   );
 
   const sharedHeader = (
-    <BottomSheetHeader
-      endAccessory={
-        <ButtonIcon
-          iconName={IconName.Close}
-          size={ButtonIconSizes.Lg}
-          iconColor={IconColor.Default}
-          testID={CHECKOUT_TEST_IDS.CLOSE_BUTTON}
-          onPress={handleClosePress}
-        />
-      }
+    <HeaderCompactStandard
+      onClose={handleClosePress}
+      closeButtonProps={{
+        testID: CHECKOUT_TEST_IDS.CLOSE_BUTTON,
+      }}
       style={styles.headerWithoutPadding}
     />
   );

--- a/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
@@ -3,23 +3,23 @@ import { View, ScrollView, useWindowDimensions } from 'react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import { useNavigation, type ParamListBase } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import Icon, {
   IconName,
   IconSize,
   IconColor,
 } from '../../../../../../component-library/components/Icons/Icon';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../../component-library/hooks';
 import {
   createNavigationDetails,
@@ -94,7 +94,7 @@ function ErrorDetailsModal() {
 
   return (
     <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader
+      <HeaderCompactStandard
         onClose={handleClose}
         closeButtonProps={{ testID: 'error-details-close-button' }}
       >
@@ -104,17 +104,17 @@ function ErrorDetailsModal() {
             size={IconSize.Md}
             color={IconColor.Error}
           />
-          <Text variant={TextVariant.HeadingMD}>
+          <Text variant={TextVariant.HeadingMd}>
             {strings('deposit.errors.error_details_title')}
           </Text>
         </View>
-      </BottomSheetHeader>
+      </HeaderCompactStandard>
 
       <ScrollView style={styles.scrollView}>
         <View style={styles.contentContainer}>
           <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Default}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
             style={styles.errorText}
           >
             {errorMessage}
@@ -125,31 +125,37 @@ function ErrorDetailsModal() {
       <View style={styles.buttonContainer}>
         {showChangeProvider ? (
           <Button
-            variant={ButtonVariants.Secondary}
-            size={ButtonSize.Lg}
+            variant={ButtonVariant.Secondary}
+            size={ButtonBaseSize.Lg}
             onPress={handleChangeProvider}
-            label={strings('fiat_on_ramp.change_provider_button')}
             style={styles.button}
-          />
+            isFullWidth
+          >
+            {strings('fiat_on_ramp.change_provider_button')}
+          </Button>
         ) : null}
         {!showChangeProvider && providerName && providerSupportUrl ? (
           <Button
-            variant={ButtonVariants.Secondary}
-            size={ButtonSize.Lg}
+            variant={ButtonVariant.Secondary}
+            size={ButtonBaseSize.Lg}
             onPress={handleContactSupport}
-            label={strings('fiat_on_ramp.contact_provider_support', {
+            style={styles.button}
+            isFullWidth
+          >
+            {strings('fiat_on_ramp.contact_provider_support', {
               provider: providerName,
             })}
-            style={styles.button}
-          />
+          </Button>
         ) : null}
         <Button
-          variant={ButtonVariants.Primary}
-          size={ButtonSize.Lg}
+          variant={ButtonVariant.Primary}
+          size={ButtonBaseSize.Lg}
           onPress={handleClose}
-          label={strings('fiat_on_ramp.got_it')}
           style={styles.button}
-        />
+          isFullWidth
+        >
+          {strings('fiat_on_ramp.got_it')}
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
@@ -320,11 +320,11 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -373,13 +373,17 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 20,
+                                  "fontWeight": 700,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Error details
@@ -390,39 +394,74 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="error-details-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -445,13 +484,19 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                {
+                                  "lineHeight": 24,
+                                },
+                              ]
                             }
                           >
                             This is a test error message.
@@ -468,43 +513,93 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                         }
                       }
                     >
-                      <TouchableOpacity
+                      <View
+                        accessibilityLabel="Got it"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#131416",
-                            "borderRadius": 12,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#131416",
+                              "borderRadius": 12,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#ffffff",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#ffffff",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Got it
                         </Text>
-                      </TouchableOpacity>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -838,11 +933,11 @@ exports[`ErrorDetailsModal renders with a multiline error message 1`] = `
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -891,13 +986,17 @@ exports[`ErrorDetailsModal renders with a multiline error message 1`] = `
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 20,
+                                  "fontWeight": 700,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Error details
@@ -908,39 +1007,74 @@ exports[`ErrorDetailsModal renders with a multiline error message 1`] = `
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="error-details-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -963,13 +1097,19 @@ exports[`ErrorDetailsModal renders with a multiline error message 1`] = `
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                {
+                                  "lineHeight": 24,
+                                },
+                              ]
                             }
                           >
                             Error on line 1.
@@ -988,43 +1128,93 @@ Additional context for debugging.
                         }
                       }
                     >
-                      <TouchableOpacity
+                      <View
+                        accessibilityLabel="Got it"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#131416",
-                            "borderRadius": 12,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#131416",
+                              "borderRadius": 12,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#ffffff",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#ffffff",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Got it
                         </Text>
-                      </TouchableOpacity>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -1358,11 +1548,11 @@ exports[`ErrorDetailsModal renders with an empty error message 1`] = `
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -1411,13 +1601,17 @@ exports[`ErrorDetailsModal renders with an empty error message 1`] = `
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 20,
+                                  "fontWeight": 700,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Error details
@@ -1428,39 +1622,74 @@ exports[`ErrorDetailsModal renders with an empty error message 1`] = `
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="error-details-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -1483,13 +1712,19 @@ exports[`ErrorDetailsModal renders with an empty error message 1`] = `
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                {
+                                  "lineHeight": 24,
+                                },
+                              ]
                             }
                           />
                         </View>
@@ -1504,43 +1739,93 @@ exports[`ErrorDetailsModal renders with an empty error message 1`] = `
                         }
                       }
                     >
-                      <TouchableOpacity
+                      <View
+                        accessibilityLabel="Got it"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#131416",
-                            "borderRadius": 12,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#131416",
+                              "borderRadius": 12,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#ffffff",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#ffffff",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Got it
                         </Text>
-                      </TouchableOpacity>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -1874,11 +2159,11 @@ exports[`ErrorDetailsModal renders with change provider button and matches snaps
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -1927,13 +2212,17 @@ exports[`ErrorDetailsModal renders with change provider button and matches snaps
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 20,
+                                  "fontWeight": 700,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Error details
@@ -1944,39 +2233,74 @@ exports[`ErrorDetailsModal renders with change provider button and matches snaps
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="error-details-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -1999,13 +2323,19 @@ exports[`ErrorDetailsModal renders with change provider button and matches snaps
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                {
+                                  "lineHeight": 24,
+                                },
+                              ]
                             }
                           >
                             No quotes available.
@@ -2022,82 +2352,182 @@ exports[`ErrorDetailsModal renders with change provider button and matches snaps
                         }
                       }
                     >
-                      <TouchableOpacity
+                      <View
+                        accessibilityLabel="Change provider"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#b4b4b528",
-                            "borderColor": "transparent",
-                            "borderRadius": 12,
-                            "borderWidth": 1,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#b4b4b528",
+                              "borderColor": "transparent",
+                              "borderRadius": 12,
+                              "borderWidth": 1,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#131416",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#131416",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Change provider
                         </Text>
-                      </TouchableOpacity>
-                      <TouchableOpacity
+                      </View>
+                      <View
+                        accessibilityLabel="Got it"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#131416",
-                            "borderRadius": 12,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#131416",
+                              "borderRadius": 12,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#ffffff",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#ffffff",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Got it
                         </Text>
-                      </TouchableOpacity>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -2431,11 +2861,11 @@ exports[`ErrorDetailsModal renders with provider support info and matches snapsh
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -2484,13 +2914,17 @@ exports[`ErrorDetailsModal renders with provider support info and matches snapsh
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 20,
+                                  "fontWeight": 700,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Error details
@@ -2501,39 +2935,74 @@ exports[`ErrorDetailsModal renders with provider support info and matches snapsh
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="error-details-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -2556,13 +3025,19 @@ exports[`ErrorDetailsModal renders with provider support info and matches snapsh
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                {
+                                  "lineHeight": 24,
+                                },
+                              ]
                             }
                           >
                             Provider error occurred.
@@ -2579,82 +3054,182 @@ exports[`ErrorDetailsModal renders with provider support info and matches snapsh
                         }
                       }
                     >
-                      <TouchableOpacity
+                      <View
+                        accessibilityLabel="Contact Transak support"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#b4b4b528",
-                            "borderColor": "transparent",
-                            "borderRadius": 12,
-                            "borderWidth": 1,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#b4b4b528",
+                              "borderColor": "transparent",
+                              "borderRadius": 12,
+                              "borderWidth": 1,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#131416",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#131416",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Contact Transak support
                         </Text>
-                      </TouchableOpacity>
-                      <TouchableOpacity
+                      </View>
+                      <View
+                        accessibilityLabel="Got it"
                         accessibilityRole="button"
-                        accessible={true}
-                        activeOpacity={1}
-                        onPress={[Function]}
-                        onPressIn={[Function]}
-                        onPressOut={[Function]}
-                        style={
+                        accessibilityState={
                           {
-                            "alignItems": "center",
-                            "alignSelf": "flex-start",
-                            "backgroundColor": "#131416",
-                            "borderRadius": 12,
-                            "flexDirection": "row",
-                            "height": 48,
-                            "justifyContent": "center",
-                            "overflow": "hidden",
-                            "paddingHorizontal": 16,
-                            "width": "100%",
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": false,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#131416",
+                              "borderRadius": 12,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
-                            {
-                              "color": "#ffffff",
-                              "fontFamily": "Geist-Medium",
-                              "fontSize": 16,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "color": "#ffffff",
+                                "flexGrow": 0,
+                                "flexShrink": 1,
+                                "flexWrap": "wrap",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                                "textAlign": "center",
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           Got it
                         </Text>
-                      </TouchableOpacity>
+                      </View>
                     </View>
                   </View>
                 </View>

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
@@ -4,10 +4,12 @@ import ListItemSelect from '../../../../../../component-library/components/List/
 import ListItemColumn, {
   WidthType,
 } from '../../../../../../component-library/components/List/ListItemColumn';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import { PaymentType } from '@consensys/on-ramp-sdk';
 import PaymentMethodIcon from '../../../Aggregator/components/PaymentMethodIcon';
 import QuoteDisplay from './QuoteDisplay';
@@ -97,9 +99,11 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
         </View>
       </ListItemColumn>
       <ListItemColumn widthType={WidthType.Fill}>
-        <Text variant={TextVariant.BodyLGMedium}>{paymentMethod.name}</Text>
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+          {paymentMethod.name}
+        </Text>
         {delayText ? (
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {delayText}
           </Text>
         ) : null}

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionAlert.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionAlert.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import BannerAlert from '../../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert';
 import { BannerAlertSeverity } from '../../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
-import Text, {
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
 
 interface PaymentSelectionAlertProps {
   message: string;
@@ -15,7 +13,7 @@ const PaymentSelectionAlert: React.FC<PaymentSelectionAlertProps> = ({
   severity = BannerAlertSeverity.Error,
 }) => (
   <BannerAlert
-    description={<Text variant={TextVariant.BodySM}>{message}</Text>}
+    description={<Text variant={TextVariant.BodySm}>{message}</Text>}
     severity={severity}
   />
 );

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import PaymentSelectionModal from './PaymentSelectionModal';
+import { PAYMENT_SELECTION_MODAL_TEST_IDS } from './PaymentSelectionModal.testIds';
 import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 jest.mock('../../../../../Base/RemoteImage', () => jest.fn(() => null));
@@ -206,6 +207,16 @@ describe('PaymentSelectionModal', () => {
     const { getByText } = renderWithProvider(PaymentSelectionModal);
 
     expect(getByText('fiat_on_ramp.pay_with')).toBeOnTheScreen();
+  });
+
+  it('calls onCloseBottomSheet when header close is pressed', () => {
+    const { getByTestId } = renderWithProvider(PaymentSelectionModal);
+
+    fireEvent.press(
+      getByTestId(PAYMENT_SELECTION_MODAL_TEST_IDS.HEADER_CLOSE_BUTTON),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
   });
 
   it('displays payment methods list', () => {

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.testIds.ts
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.testIds.ts
@@ -1,0 +1,3 @@
+export const PAYMENT_SELECTION_MODAL_TEST_IDS = {
+  HEADER_CLOSE_BUTTON: 'payment-selection-modal-header-close',
+} as const;

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -7,16 +7,16 @@ import { useNavigation } from '@react-navigation/native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
-import { BannerAlertSeverity } from '../../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
 import {
   Box,
   BoxAlignItems,
   BoxJustifyContent,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
+import { BannerAlertSeverity } from '../../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { strings } from '../../../../../../../locales/i18n';
 import styleSheet from './PaymentSelectionModal.styles';
@@ -247,15 +247,10 @@ function PaymentSelectionModal() {
     <BottomSheet ref={sheetRef} shouldNavigateBack>
       <View style={styles.containerOuter}>
         <View style={styles.paymentPanelContent}>
-          <Box
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Center}
-            twClassName="px-4 py-3"
-          >
-            <Text variant={TextVariant.HeadingMD}>
-              {strings('fiat_on_ramp.pay_with')}
-            </Text>
-          </Box>
+          <HeaderCompactStandard
+            title={strings('fiat_on_ramp.pay_with')}
+            onClose={() => sheetRef.current?.onCloseBottomSheet()}
+          />
           {renderListContent()}
         </View>
         {selectedProvider ? (
@@ -264,16 +259,19 @@ function PaymentSelectionModal() {
             justifyContent={BoxJustifyContent.Center}
             style={styles.footer}
           >
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
               {strings('fiat_on_ramp.buying_via', {
                 providerName: selectedProvider.name,
               })}{' '}
               <Text
-                variant={TextVariant.BodySM}
+                variant={TextVariant.BodySm}
                 color={
                   paymentMethodsError
-                    ? TextColor.Alternative
-                    : TextColor.Primary
+                    ? TextColor.TextAlternative
+                    : TextColor.PrimaryDefault
                 }
                 onPress={
                   paymentMethodsError ? undefined : handleChangeProviderPress

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -28,6 +28,7 @@ import {
 import PaymentMethodListItem from './PaymentMethodListItem';
 import PaymentMethodListSkeleton from './PaymentMethodListSkeleton';
 import PaymentSelectionAlert from './PaymentSelectionAlert';
+import { PAYMENT_SELECTION_MODAL_TEST_IDS } from './PaymentSelectionModal.testIds';
 import { useRampsController } from '../../../hooks/useRampsController';
 import { useRampsQuotes } from '../../../hooks/useRampsQuotes';
 import useRampAccountAddress from '../../../hooks/useRampAccountAddress';
@@ -250,6 +251,9 @@ function PaymentSelectionModal() {
           <HeaderCompactStandard
             title={strings('fiat_on_ramp.pay_with')}
             onClose={() => sheetRef.current?.onCloseBottomSheet()}
+            closeButtonProps={{
+              testID: PAYMENT_SELECTION_MODAL_TEST_IDS.HEADER_CLOSE_BUTTON,
+            }}
           />
           {renderListContent()}
         </View>

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/QuoteDisplay.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/QuoteDisplay.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Box } from '@metamask/design-system-react-native';
-import Text, {
+import {
+  Box,
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
   IconSize,
@@ -75,7 +77,7 @@ const QuoteDisplay: React.FC<QuoteDisplayProps> = ({
   if (quoteUnavailable) {
     return (
       <Box twClassName="items-end justify-center">
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {strings('fiat_on_ramp.quote_unavailable')}
         </Text>
       </Box>
@@ -89,10 +91,12 @@ const QuoteDisplay: React.FC<QuoteDisplayProps> = ({
   return (
     <Box twClassName="items-end">
       {cryptoAmount ? (
-        <Text variant={TextVariant.BodyMDMedium}>{cryptoAmount}</Text>
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+          {cryptoAmount}
+        </Text>
       ) : null}
       {fiatAmount !== null ? (
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {fiatAmount}
         </Text>
       ) : null}

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentMethodListItem.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentMethodListItem.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`PaymentMethodListItem matches snapshot 1`] = `
             {
               "color": "#131416",
               "fontFamily": "Geist-Medium",
-              "fontSize": 20,
+              "fontSize": 16,
               "letterSpacing": 0,
               "lineHeight": 24,
             }
@@ -247,7 +247,7 @@ exports[`PaymentMethodListItem renders as selected when isSelected is true 1`] =
             {
               "color": "#131416",
               "fontFamily": "Geist-Medium",
-              "fontSize": 20,
+              "fontSize": 16,
               "letterSpacing": 0,
               "lineHeight": 24,
             }

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentMethodListItem.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentMethodListItem.test.tsx.snap
@@ -97,13 +97,17 @@ exports[`PaymentMethodListItem matches snapshot 1`] = `
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Debit or Credit
@@ -111,13 +115,17 @@ exports[`PaymentMethodListItem matches snapshot 1`] = `
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 14,
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 14,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              },
+              undefined,
+            ]
           }
         >
           5 - 10 mins
@@ -244,13 +252,17 @@ exports[`PaymentMethodListItem renders as selected when isSelected is true 1`] =
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Medium",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              undefined,
+            ]
           }
         >
           Debit or Credit
@@ -258,13 +270,17 @@ exports[`PaymentMethodListItem renders as selected when isSelected is true 1`] =
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 14,
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 14,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              },
+              undefined,
+            ]
           }
         >
           5 - 10 mins

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionAlert.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionAlert.test.tsx.snap
@@ -46,13 +46,17 @@ exports[`PaymentSelectionAlert matches snapshot with default severity 1`] = `
     <Text
       accessibilityRole="text"
       style={
-        {
-          "color": "#131416",
-          "fontFamily": "Geist-Regular",
-          "fontSize": 14,
-          "letterSpacing": 0,
-          "lineHeight": 22,
-        }
+        [
+          {
+            "color": "#131416",
+            "fontFamily": "Geist-Regular",
+            "fontSize": 14,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          },
+          undefined,
+        ]
       }
     >
       Something went wrong.
@@ -107,13 +111,17 @@ exports[`PaymentSelectionAlert matches snapshot with warning severity 1`] = `
     <Text
       accessibilityRole="text"
       style={
-        {
-          "color": "#131416",
-          "fontFamily": "Geist-Regular",
-          "fontSize": 14,
-          "letterSpacing": 0,
-          "lineHeight": 22,
-        }
+        [
+          {
+            "color": "#131416",
+            "fontFamily": "Geist-Regular",
+            "fontSize": 14,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 22,
+          },
+          undefined,
+        ]
       }
     >
       No payment methods are available.

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionModal.test.tsx.snap
@@ -333,31 +333,142 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                             [
                               {
                                 "alignItems": "center",
-                                "display": "flex",
-                                "justifyContent": "center",
-                                "paddingBottom": 12,
-                                "paddingLeft": 16,
-                                "paddingRight": 16,
-                                "paddingTop": 12,
+                                "flexDirection": "row",
+                                "gap": 16,
+                                "minHeight": 56,
+                                "paddingLeft": 8,
+                                "paddingRight": 8,
                               },
+                              false,
                               undefined,
                             ]
                           }
+                          testID="header"
                         >
-                          <Text
-                            accessibilityRole="text"
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            />
+                          </View>
+                          <View
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexBasis": "0%",
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            fiat_on_ramp.pay_with
-                          </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  [
+                                    {
+                                      "color": "#131416",
+                                      "fontFamily": "Geist-Bold",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                fiat_on_ramp.pay_with
+                              </Text>
+                            </View>
+                          </View>
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "transparent",
+                                      "borderRadius": 8,
+                                      "height": 32,
+                                      "justifyContent": "center",
+                                      "opacity": 1,
+                                      "width": 32,
+                                    },
+                                    undefined,
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
+                                }
+                                testID="button-icon"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Close"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "height": 24,
+                                        "width": 24,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </View>
+                            </View>
+                          </View>
                         </View>
                         <RCTScrollView
                           collapsable={false}
@@ -519,13 +630,17 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                                       <Text
                                         accessibilityRole="text"
                                         style={
-                                          {
-                                            "color": "#131416",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 20,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
+                                          [
+                                            {
+                                              "color": "#131416",
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
                                         Debit or Credit
@@ -669,13 +784,17 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                                       <Text
                                         accessibilityRole="text"
                                         style={
-                                          {
-                                            "color": "#131416",
-                                            "fontFamily": "Geist-Medium",
-                                            "fontSize": 20,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 24,
-                                          }
+                                          [
+                                            {
+                                              "color": "#131416",
+                                              "fontFamily": "Geist-Medium",
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 24,
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
                                         Debit or Credit
@@ -725,13 +844,17 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                         <Text
                           accessibilityRole="text"
                           style={
-                            {
-                              "color": "#66676a",
-                              "fontFamily": "Geist-Regular",
-                              "fontSize": 14,
-                              "letterSpacing": 0,
-                              "lineHeight": 22,
-                            }
+                            [
+                              {
+                                "color": "#66676a",
+                                "fontFamily": "Geist-Regular",
+                                "fontSize": 14,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 22,
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           fiat_on_ramp.buying_via
@@ -740,13 +863,17 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                             accessibilityRole="text"
                             onPress={[Function]}
                             style={
-                              {
-                                "color": "#4459ff",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 14,
-                                "letterSpacing": 0,
-                                "lineHeight": 22,
-                              }
+                              [
+                                {
+                                  "color": "#4459ff",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 22,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             fiat_on_ramp.change_provider
@@ -1099,31 +1226,142 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                             [
                               {
                                 "alignItems": "center",
-                                "display": "flex",
-                                "justifyContent": "center",
-                                "paddingBottom": 12,
-                                "paddingLeft": 16,
-                                "paddingRight": 16,
-                                "paddingTop": 12,
+                                "flexDirection": "row",
+                                "gap": 16,
+                                "minHeight": 56,
+                                "paddingLeft": 8,
+                                "paddingRight": 8,
                               },
+                              false,
                               undefined,
                             ]
                           }
+                          testID="header"
                         >
-                          <Text
-                            accessibilityRole="text"
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            />
+                          </View>
+                          <View
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexBasis": "0%",
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            fiat_on_ramp.pay_with
-                          </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  [
+                                    {
+                                      "color": "#131416",
+                                      "fontFamily": "Geist-Bold",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                fiat_on_ramp.pay_with
+                              </Text>
+                            </View>
+                          </View>
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "transparent",
+                                      "borderRadius": 8,
+                                      "height": 32,
+                                      "justifyContent": "center",
+                                      "opacity": 1,
+                                      "width": 32,
+                                    },
+                                    undefined,
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
+                                }
+                                testID="button-icon"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Close"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "height": 24,
+                                        "width": 24,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </View>
+                            </View>
+                          </View>
                         </View>
                         <RCTScrollView
                           contentContainerStyle={
@@ -1185,13 +1423,17 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                                 <Text
                                   accessibilityRole="text"
                                   style={
-                                    {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 14,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 22,
-                                    }
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "fontFamily": "Geist-Regular",
+                                        "fontSize": 14,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 22,
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   fiat_on_ramp.no_payment_methods_available
@@ -1221,13 +1463,17 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                         <Text
                           accessibilityRole="text"
                           style={
-                            {
-                              "color": "#66676a",
-                              "fontFamily": "Geist-Regular",
-                              "fontSize": 14,
-                              "letterSpacing": 0,
-                              "lineHeight": 22,
-                            }
+                            [
+                              {
+                                "color": "#66676a",
+                                "fontFamily": "Geist-Regular",
+                                "fontSize": 14,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 22,
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           fiat_on_ramp.buying_via
@@ -1236,13 +1482,17 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                             accessibilityRole="text"
                             onPress={[Function]}
                             style={
-                              {
-                                "color": "#4459ff",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 14,
-                                "letterSpacing": 0,
-                                "lineHeight": 22,
-                              }
+                              [
+                                {
+                                  "color": "#4459ff",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 22,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             fiat_on_ramp.change_provider
@@ -1595,31 +1845,142 @@ exports[`PaymentSelectionModal matches snapshot when payment methods are loading
                             [
                               {
                                 "alignItems": "center",
-                                "display": "flex",
-                                "justifyContent": "center",
-                                "paddingBottom": 12,
-                                "paddingLeft": 16,
-                                "paddingRight": 16,
-                                "paddingTop": 12,
+                                "flexDirection": "row",
+                                "gap": 16,
+                                "minHeight": 56,
+                                "paddingLeft": 8,
+                                "paddingRight": 8,
                               },
+                              false,
                               undefined,
                             ]
                           }
+                          testID="header"
                         >
-                          <Text
-                            accessibilityRole="text"
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            />
+                          </View>
+                          <View
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexBasis": "0%",
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            fiat_on_ramp.pay_with
-                          </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  [
+                                    {
+                                      "color": "#131416",
+                                      "fontFamily": "Geist-Bold",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                fiat_on_ramp.pay_with
+                              </Text>
+                            </View>
+                          </View>
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "transparent",
+                                      "borderRadius": 8,
+                                      "height": 32,
+                                      "justifyContent": "center",
+                                      "opacity": 1,
+                                      "width": 32,
+                                    },
+                                    undefined,
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
+                                }
+                                testID="button-icon"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Close"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "height": 24,
+                                        "width": 24,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </View>
+                            </View>
+                          </View>
                         </View>
                         <RCTScrollView
                           style={
@@ -3883,31 +4244,142 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                             [
                               {
                                 "alignItems": "center",
-                                "display": "flex",
-                                "justifyContent": "center",
-                                "paddingBottom": 12,
-                                "paddingLeft": 16,
-                                "paddingRight": 16,
-                                "paddingTop": 12,
+                                "flexDirection": "row",
+                                "gap": 16,
+                                "minHeight": 56,
+                                "paddingLeft": 8,
+                                "paddingRight": 8,
                               },
+                              false,
                               undefined,
                             ]
                           }
+                          testID="header"
                         >
-                          <Text
-                            accessibilityRole="text"
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            />
+                          </View>
+                          <View
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 20,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexBasis": "0%",
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                },
+                                undefined,
+                              ]
                             }
                           >
-                            fiat_on_ramp.pay_with
-                          </Text>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "display": "flex",
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  [
+                                    {
+                                      "color": "#131416",
+                                      "fontFamily": "Geist-Bold",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                fiat_on_ramp.pay_with
+                              </Text>
+                            </View>
+                          </View>
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "transparent",
+                                      "borderRadius": 8,
+                                      "height": 32,
+                                      "justifyContent": "center",
+                                      "opacity": 1,
+                                      "width": 32,
+                                    },
+                                    undefined,
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
+                                }
+                                testID="button-icon"
+                              >
+                                <SvgMock
+                                  fill="currentColor"
+                                  name="Close"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "height": 24,
+                                        "width": 24,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                />
+                              </View>
+                            </View>
+                          </View>
                         </View>
                         <RCTScrollView
                           contentContainerStyle={
@@ -3969,13 +4441,17 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                                 <Text
                                   accessibilityRole="text"
                                   style={
-                                    {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Regular",
-                                      "fontSize": 14,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 22,
-                                    }
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "fontFamily": "Geist-Regular",
+                                        "fontSize": 14,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 22,
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Failed to fetch payment methods
@@ -4005,13 +4481,17 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                         <Text
                           accessibilityRole="text"
                           style={
-                            {
-                              "color": "#66676a",
-                              "fontFamily": "Geist-Regular",
-                              "fontSize": 14,
-                              "letterSpacing": 0,
-                              "lineHeight": 22,
-                            }
+                            [
+                              {
+                                "color": "#66676a",
+                                "fontFamily": "Geist-Regular",
+                                "fontSize": 14,
+                                "fontWeight": 400,
+                                "letterSpacing": 0,
+                                "lineHeight": 22,
+                              },
+                              undefined,
+                            ]
                           }
                         >
                           fiat_on_ramp.buying_via
@@ -4019,13 +4499,17 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                           <Text
                             accessibilityRole="text"
                             style={
-                              {
-                                "color": "#66676a",
-                                "fontFamily": "Geist-Regular",
-                                "fontSize": 14,
-                                "letterSpacing": 0,
-                                "lineHeight": 22,
-                              }
+                              [
+                                {
+                                  "color": "#66676a",
+                                  "fontFamily": "Geist-Regular",
+                                  "fontSize": 14,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 22,
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             fiat_on_ramp.change_provider

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/PaymentSelectionModal.test.tsx.snap
@@ -450,7 +450,7 @@ exports[`PaymentSelectionModal matches snapshot 1`] = `
                                     },
                                   ]
                                 }
-                                testID="button-icon"
+                                testID="payment-selection-modal-header-close"
                               >
                                 <SvgMock
                                   fill="currentColor"
@@ -1343,7 +1343,7 @@ exports[`PaymentSelectionModal matches snapshot when no payment methods are avai
                                     },
                                   ]
                                 }
-                                testID="button-icon"
+                                testID="payment-selection-modal-header-close"
                               >
                                 <SvgMock
                                   fill="currentColor"
@@ -1962,7 +1962,7 @@ exports[`PaymentSelectionModal matches snapshot when payment methods are loading
                                     },
                                   ]
                                 }
-                                testID="button-icon"
+                                testID="payment-selection-modal-header-close"
                               >
                                 <SvgMock
                                   fill="currentColor"
@@ -4361,7 +4361,7 @@ exports[`PaymentSelectionModal matches snapshot when payment methods fail to loa
                                     },
                                   ]
                                 }
-                                testID="button-icon"
+                                testID="payment-selection-modal-header-close"
                               >
                                 <SvgMock
                                   fill="currentColor"

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/QuoteDisplay.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/__snapshots__/QuoteDisplay.test.tsx.snap
@@ -56,13 +56,17 @@ exports[`QuoteDisplay matches snapshot when quote is unavailable 1`] = `
   <Text
     accessibilityRole="text"
     style={
-      {
-        "color": "#66676a",
-        "fontFamily": "Geist-Regular",
-        "fontSize": 14,
-        "letterSpacing": 0,
-        "lineHeight": 22,
-      }
+      [
+        {
+          "color": "#66676a",
+          "fontFamily": "Geist-Regular",
+          "fontSize": 14,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 22,
+        },
+        undefined,
+      ]
     }
   >
     Quote unavailable.
@@ -85,13 +89,17 @@ exports[`QuoteDisplay matches snapshot with crypto and fiat 1`] = `
   <Text
     accessibilityRole="text"
     style={
-      {
-        "color": "#131416",
-        "fontFamily": "Geist-Medium",
-        "fontSize": 16,
-        "letterSpacing": 0,
-        "lineHeight": 24,
-      }
+      [
+        {
+          "color": "#131416",
+          "fontFamily": "Geist-Medium",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
+        },
+        undefined,
+      ]
     }
   >
     0.05 ETH
@@ -99,13 +107,17 @@ exports[`QuoteDisplay matches snapshot with crypto and fiat 1`] = `
   <Text
     accessibilityRole="text"
     style={
-      {
-        "color": "#66676a",
-        "fontFamily": "Geist-Regular",
-        "fontSize": 14,
-        "letterSpacing": 0,
-        "lineHeight": 22,
-      }
+      [
+        {
+          "color": "#66676a",
+          "fontFamily": "Geist-Regular",
+          "fontSize": 14,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 22,
+        },
+        undefined,
+      ]
     }
   >
     $100.00
@@ -128,13 +140,17 @@ exports[`QuoteDisplay matches snapshot with crypto only 1`] = `
   <Text
     accessibilityRole="text"
     style={
-      {
-        "color": "#131416",
-        "fontFamily": "Geist-Medium",
-        "fontSize": 16,
-        "letterSpacing": 0,
-        "lineHeight": 24,
-      }
+      [
+        {
+          "color": "#131416",
+          "fontFamily": "Geist-Medium",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "letterSpacing": 0,
+          "lineHeight": 24,
+        },
+        undefined,
+      ]
     }
   >
     1.5 USDC

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { fireEvent, waitFor, screen } from '@testing-library/react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
-import ProcessingInfoModal from './ProcessingInfoModal';
+import ProcessingInfoModal, {
+  type ProcessingInfoModalParams,
+} from './ProcessingInfoModal';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
@@ -59,12 +61,14 @@ jest.mock('react-native-inappbrowser-reborn', () => ({
   open: jest.fn(),
 }));
 
-const mockUseParams = jest.fn(() => ({
-  providerName: 'Transak',
-  providerSupportUrl: 'https://transak.com/support',
-  statusDescription:
-    'Card purchases typically take a few minutes. You can contact support if you have questions.',
-}));
+const mockUseParams = jest.fn(
+  (): ProcessingInfoModalParams => ({
+    providerName: 'Transak',
+    providerSupportUrl: 'https://transak.com/support',
+    statusDescription:
+      'Card purchases typically take a few minutes. You can contact support if you have questions.',
+  }),
+);
 
 jest.mock('../../../../../../util/navigation/navUtils', () => ({
   ...jest.requireActual('../../../../../../util/navigation/navUtils'),

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.test.tsx
@@ -1,12 +1,44 @@
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { fireEvent, waitFor, screen } from '@testing-library/react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
 import ProcessingInfoModal from './ProcessingInfoModal';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 
+const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => {
+  callback?.();
+});
+
+jest.mock(
+  '../../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    return ReactActual.forwardRef(
+      (
+        {
+          children,
+          testID,
+        }: {
+          children: React.ReactNode;
+          testID?: string;
+        },
+        ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+      ) => {
+        ReactActual.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: mockOnCloseBottomSheet,
+        }));
+        return <View testID={testID}>{children}</View>;
+      },
+    );
+  },
+);
+
+const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+  useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
 }));
 
 jest.mock('react-native-safe-area-context', () => {
@@ -27,17 +59,36 @@ jest.mock('react-native-inappbrowser-reborn', () => ({
   open: jest.fn(),
 }));
 
-jest.mock('../../../../../../util/navigation/navUtils', () => ({
-  ...jest.requireActual('../../../../../../util/navigation/navUtils'),
-  useParams: () => ({
-    providerName: 'Transak',
-    providerSupportUrl: 'https://transak.com/support',
-    statusDescription:
-      'Card purchases typically take a few minutes. You can contact support if you have questions.',
-  }),
+const mockUseParams = jest.fn(() => ({
+  providerName: 'Transak',
+  providerSupportUrl: 'https://transak.com/support',
+  statusDescription:
+    'Card purchases typically take a few minutes. You can contact support if you have questions.',
 }));
 
-function render() {
+jest.mock('../../../../../../util/navigation/navUtils', () => ({
+  ...jest.requireActual('../../../../../../util/navigation/navUtils'),
+  useParams: () => mockUseParams(),
+}));
+
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn();
+const mockAddProperties = jest.fn();
+const mockBuild = jest.fn();
+
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(() => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  })),
+}));
+
+function renderModal() {
+  mockCreateEventBuilder.mockReturnValue({
+    addProperties: mockAddProperties,
+    build: mockBuild,
+  });
+  mockAddProperties.mockReturnValue({ build: mockBuild });
   return renderWithProvider(<ProcessingInfoModal />, {
     state: { engine: { backgroundState } },
   });
@@ -46,23 +97,29 @@ function render() {
 describe('ProcessingInfoModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseParams.mockReturnValue({
+      providerName: 'Transak',
+      providerSupportUrl: 'https://transak.com/support',
+      statusDescription:
+        'Card purchases typically take a few minutes. You can contact support if you have questions.',
+    });
   });
 
   it('renders correctly', () => {
-    render();
+    renderModal();
     expect(screen.getByTestId('processing-info-modal')).toBeOnTheScreen();
     expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders the close button', () => {
-    render();
+    renderModal();
     expect(
       screen.getByTestId('processing-info-modal-close-button'),
     ).toBeOnTheScreen();
   });
 
   it('renders description text', () => {
-    render();
+    renderModal();
     expect(
       screen.getByText(
         'Card purchases typically take a few minutes. You can contact support if you have questions.',
@@ -71,7 +128,111 @@ describe('ProcessingInfoModal', () => {
   });
 
   it('renders support button with provider name', () => {
-    render();
+    renderModal();
     expect(screen.getByText('Go to Transak support page')).toBeOnTheScreen();
+  });
+
+  it('opens InAppBrowser and closes sheet when support is pressed and browser is available', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(true);
+    (InAppBrowser.open as jest.Mock).mockResolvedValue(undefined);
+
+    renderModal();
+
+    fireEvent.press(screen.getByText('Go to Transak support page'));
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalled();
+    });
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.RAMPS_EXTERNAL_LINK_CLICKED,
+    );
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: 'Order Details',
+        external_link_description: 'Provider Support',
+        url_domain: 'transak.com',
+        ramp_type: 'UNIFIED_BUY_2',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockOnCloseBottomSheet).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(InAppBrowser.open).toHaveBeenCalledWith(
+        'https://transak.com/support',
+      );
+    });
+  });
+
+  it('navigates to SimpleWebview when InAppBrowser is not available', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(false);
+
+    renderModal();
+
+    fireEvent.press(screen.getByText('Go to Transak support page'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://transak.com/support',
+          title: 'Transak',
+        },
+      });
+    });
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+  });
+
+  it('uses raw support URL as url_domain when URL parsing fails', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(true);
+    mockUseParams.mockReturnValue({
+      providerName: 'P',
+      providerSupportUrl: 'not-a-valid-url',
+      statusDescription: 'Status',
+    });
+
+    renderModal();
+
+    fireEvent.press(screen.getByText('Go to P support page'));
+
+    await waitFor(() => {
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url_domain: 'not-a-valid-url',
+        }),
+      );
+    });
+  });
+
+  it('renders without description when statusDescription is absent', () => {
+    mockUseParams.mockReturnValue({
+      providerName: 'MoonPay',
+      providerSupportUrl: 'https://moonpay.com/help',
+    });
+
+    renderModal();
+
+    expect(
+      screen.queryByText(
+        'Card purchases typically take a few minutes. You can contact support if you have questions.',
+      ),
+    ).toBeNull();
+    expect(screen.getByText('Go to MoonPay support page')).toBeOnTheScreen();
+  });
+
+  it('does not open browser when providerSupportUrl is missing', () => {
+    mockUseParams.mockReturnValue({
+      providerName: 'Transak',
+      statusDescription: 'Waiting',
+    });
+
+    renderModal();
+
+    fireEvent.press(screen.getByText('Go to Transak support page'));
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(InAppBrowser.open).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
@@ -4,17 +4,16 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Text, {
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
-import { Box } from '@metamask/design-system-react-native';
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+  Box,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import {
   createNavigationDetails,
@@ -104,7 +103,7 @@ function ProcessingInfoModal() {
       isInteractable={false}
       testID={PROCESSING_INFO_MODAL_TEST_IDS.MODAL}
     >
-      <BottomSheetHeader
+      <HeaderCompactStandard
         onClose={handleClose}
         closeButtonProps={{
           testID: PROCESSING_INFO_MODAL_TEST_IDS.CLOSE_BUTTON,
@@ -114,8 +113,8 @@ function ProcessingInfoModal() {
       {statusDescription && (
         <Box twClassName="px-6 pb-4">
           <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
             style={styles.centeredText}
           >
             {statusDescription}
@@ -125,14 +124,15 @@ function ProcessingInfoModal() {
 
       <Box twClassName="px-6 pb-6">
         <Button
-          size={ButtonSize.Lg}
+          size={ButtonBaseSize.Lg}
           onPress={handleGoToSupport}
-          label={strings('ramps_order_details.go_to_provider_support', {
+          variant={ButtonVariant.Secondary}
+          isFullWidth
+        >
+          {strings('ramps_order_details.go_to_provider_support', {
             provider: providerName,
           })}
-          variant={ButtonVariants.Secondary}
-          width={ButtonWidthTypes.Full}
-        />
+        </Button>
       </Box>
     </BottomSheet>
   );

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/__snapshots__/ProcessingInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/__snapshots__/ProcessingInfoModal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProcessingInfoModal renders correctly 1`] = `
 <View
@@ -107,11 +107,11 @@ exports[`ProcessingInfoModal renders correctly 1`] = `
               "flexDirection": "row",
               "gap": 16,
               "minHeight": 56,
+              "paddingLeft": 8,
+              "paddingRight": 8,
             },
             false,
-            {
-              "paddingHorizontal": 16,
-            },
+            undefined,
           ]
         }
         testID="header"
@@ -139,39 +139,74 @@ exports[`ProcessingInfoModal renders correctly 1`] = `
           <View
             onLayout={[Function]}
           >
-            <TouchableOpacity
-              accessible={true}
-              activeOpacity={1}
-              disabled={false}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+            <View
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "borderRadius": 8,
-                  "height": 32,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 32,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "transparent",
+                    "borderRadius": 8,
+                    "height": 32,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "width": 32,
+                  },
+                  undefined,
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
               testID="processing-info-modal-close-button"
             >
               <SvgMock
-                color="#131416"
                 fill="currentColor"
-                height={24}
                 name="Close"
                 style={
-                  {
-                    "height": 24,
-                    "width": 24,
-                  }
+                  [
+                    {
+                      "color": "#131416",
+                      "height": 24,
+                      "width": 24,
+                    },
+                    undefined,
+                  ]
                 }
-                width={24}
               />
-            </TouchableOpacity>
+            </View>
           </View>
         </View>
       </View>
@@ -191,14 +226,19 @@ exports[`ProcessingInfoModal renders correctly 1`] = `
         <Text
           accessibilityRole="text"
           style={
-            {
-              "color": "#66676a",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-              "textAlign": "center",
-            }
+            [
+              {
+                "color": "#66676a",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "fontWeight": 400,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              },
+              {
+                "textAlign": "center",
+              },
+            ]
           }
         >
           Card purchases typically take a few minutes. You can contact support if you have questions.
@@ -217,44 +257,92 @@ exports[`ProcessingInfoModal renders correctly 1`] = `
           ]
         }
       >
-        <TouchableOpacity
+        <View
+          accessibilityLabel="Go to Transak support page"
           accessibilityRole="button"
-          accessible={true}
-          activeOpacity={1}
-          onPress={[Function]}
-          onPressIn={[Function]}
-          onPressOut={[Function]}
-          style={
+          accessibilityState={
             {
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "backgroundColor": "#b4b4b528",
-              "borderColor": "transparent",
-              "borderRadius": 12,
-              "borderWidth": 1,
-              "flexDirection": "row",
-              "height": 48,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "paddingHorizontal": 16,
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": false,
+              "expanded": undefined,
+              "selected": undefined,
             }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "alignItems": "center",
+                "backgroundColor": "#b4b4b528",
+                "borderColor": "transparent",
+                "borderRadius": 12,
+                "borderWidth": 1,
+                "columnGap": 8,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "minWidth": 80,
+                "opacity": 1,
+                "overflow": "hidden",
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "width": "100%",
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
           }
         >
           <Text
             accessibilityRole="text"
+            ellipsizeMode="clip"
+            numberOfLines={1}
             style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Medium",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
+              [
+                {
+                  "color": "#131416",
+                  "flexGrow": 0,
+                  "flexShrink": 1,
+                  "flexWrap": "wrap",
+                  "fontFamily": "Geist-Medium",
+                  "fontSize": 16,
+                  "fontWeight": 400,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "textAlign": "center",
+                },
+                undefined,
+              ]
             }
           >
             Go to Transak support page
           </Text>
-        </TouchableOpacity>
+        </View>
       </View>
     </View>
   </View>

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/__snapshots__/ProcessingInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/__snapshots__/ProcessingInfoModal.test.tsx.snap
@@ -2,264 +2,49 @@
 
 exports[`ProcessingInfoModal renders correctly 1`] = `
 <View
-  onLayout={[Function]}
-  style={
-    [
-      {
-        "bottom": 0,
-        "justifyContent": "flex-end",
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      {
-        "paddingBottom": 0,
-      },
-    ]
-  }
   testID="processing-info-modal"
 >
   <View
     style={
       [
         {
-          "backgroundColor": "#0a0d135c",
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 16,
+          "minHeight": 56,
+          "paddingLeft": 8,
+          "paddingRight": 8,
         },
-        {
-          "opacity": 0,
-        },
+        false,
+        undefined,
       ]
     }
+    testID="header"
   >
-    <TouchableOpacity
-      onPress={[Function]}
-      style={
-        {
-          "flex": 1,
-        }
-      }
-    />
-  </View>
-  <View
-    onLayout={[Function]}
-    style={
-      [
-        {
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-        },
-        {
-          "paddingBottom": 0,
-        },
-      ]
-    }
-  >
+    <View>
+      <View
+        onLayout={[Function]}
+      />
+    </View>
     <View
-      collapsable={false}
-      enabled={false}
-      handlerTag={-1}
-      handlerType="PanGestureHandler"
-      onGestureHandlerEvent={[Function]}
-      onGestureHandlerStateChange={[Function]}
-      onLayout={[Function]}
       style={
         [
           {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#b4b4b566",
-            "borderTopLeftRadius": 24,
-            "borderTopRightRadius": 24,
-            "borderWidth": 1,
-            "maxHeight": 5,
-            "overflow": "hidden",
-            "paddingBottom": 3,
-            "shadowColor": "#0000001a",
-            "shadowOffset": {
-              "height": 2,
-              "width": 0,
-            },
-            "shadowOpacity": 1,
-            "shadowRadius": 40,
+            "alignItems": "center",
+            "display": "flex",
+            "flexBasis": "0%",
+            "flexGrow": 1,
+            "flexShrink": 1,
           },
-          {
-            "transform": [
-              {
-                "translateY": 6,
-              },
-            ],
-          },
+          undefined,
         ]
       }
-    >
+    />
+    <View>
       <View
-        style={
-          [
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 16,
-              "minHeight": 56,
-              "paddingLeft": 8,
-              "paddingRight": 8,
-            },
-            false,
-            undefined,
-          ]
-        }
-        testID="header"
-      >
-        <View>
-          <View
-            onLayout={[Function]}
-          />
-        </View>
-        <View
-          style={
-            [
-              {
-                "alignItems": "center",
-                "display": "flex",
-                "flexBasis": "0%",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              undefined,
-            ]
-          }
-        />
-        <View>
-          <View
-            onLayout={[Function]}
-          >
-            <View
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": false,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                [
-                  {
-                    "alignItems": "center",
-                    "backgroundColor": "transparent",
-                    "borderRadius": 8,
-                    "height": 32,
-                    "justifyContent": "center",
-                    "opacity": 1,
-                    "width": 32,
-                  },
-                  undefined,
-                  {
-                    "transform": [
-                      {
-                        "scale": 1,
-                      },
-                    ],
-                  },
-                ]
-              }
-              testID="processing-info-modal-close-button"
-            >
-              <SvgMock
-                fill="currentColor"
-                name="Close"
-                style={
-                  [
-                    {
-                      "color": "#131416",
-                      "height": 24,
-                      "width": 24,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
-        style={
-          [
-            {
-              "display": "flex",
-              "paddingBottom": 16,
-              "paddingLeft": 24,
-              "paddingRight": 24,
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            [
-              {
-                "color": "#66676a",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "fontWeight": 400,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              },
-              {
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          Card purchases typically take a few minutes. You can contact support if you have questions.
-        </Text>
-      </View>
-      <View
-        style={
-          [
-            {
-              "display": "flex",
-              "paddingBottom": 24,
-              "paddingLeft": 24,
-              "paddingRight": 24,
-            },
-            undefined,
-          ]
-        }
+        onLayout={[Function]}
       >
         <View
-          accessibilityLabel="Go to Transak support page"
-          accessibilityRole="button"
           accessibilityState={
             {
               "busy": undefined,
@@ -293,21 +78,14 @@ exports[`ProcessingInfoModal renders correctly 1`] = `
             [
               {
                 "alignItems": "center",
-                "backgroundColor": "#b4b4b528",
-                "borderColor": "transparent",
-                "borderRadius": 12,
-                "borderWidth": 1,
-                "columnGap": 8,
-                "flexDirection": "row",
-                "height": 48,
+                "backgroundColor": "transparent",
+                "borderRadius": 8,
+                "height": 32,
                 "justifyContent": "center",
-                "minWidth": 80,
                 "opacity": 1,
-                "overflow": "hidden",
-                "paddingLeft": 16,
-                "paddingRight": 16,
-                "width": "100%",
+                "width": 32,
               },
+              undefined,
               {
                 "transform": [
                   {
@@ -317,33 +95,158 @@ exports[`ProcessingInfoModal renders correctly 1`] = `
               },
             ]
           }
+          testID="processing-info-modal-close-button"
         >
-          <Text
-            accessibilityRole="text"
-            ellipsizeMode="clip"
-            numberOfLines={1}
+          <SvgMock
+            fill="currentColor"
+            name="Close"
             style={
               [
                 {
                   "color": "#131416",
-                  "flexGrow": 0,
-                  "flexShrink": 1,
-                  "flexWrap": "wrap",
-                  "fontFamily": "Geist-Medium",
-                  "fontSize": 16,
-                  "fontWeight": 400,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                  "textAlign": "center",
+                  "height": 24,
+                  "width": 24,
                 },
                 undefined,
               ]
             }
-          >
-            Go to Transak support page
-          </Text>
+          />
         </View>
       </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "display": "flex",
+          "paddingBottom": 16,
+          "paddingLeft": 24,
+          "paddingRight": 24,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      style={
+        [
+          {
+            "color": "#66676a",
+            "fontFamily": "Geist-Regular",
+            "fontSize": 16,
+            "fontWeight": 400,
+            "letterSpacing": 0,
+            "lineHeight": 24,
+          },
+          {
+            "textAlign": "center",
+          },
+        ]
+      }
+    >
+      Card purchases typically take a few minutes. You can contact support if you have questions.
+    </Text>
+  </View>
+  <View
+    style={
+      [
+        {
+          "display": "flex",
+          "paddingBottom": 24,
+          "paddingLeft": 24,
+          "paddingRight": 24,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Go to Transak support page"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "width": "100%",
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
+      }
+    >
+      <Text
+        accessibilityRole="text"
+        ellipsizeMode="clip"
+        numberOfLines={1}
+        style={
+          [
+            {
+              "color": "#131416",
+              "flexGrow": 0,
+              "flexShrink": 1,
+              "flexWrap": "wrap",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 16,
+              "fontWeight": 400,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+              "textAlign": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        Go to Transak support page
+      </Text>
     </View>
   </View>
 </View>

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.test.tsx
@@ -107,6 +107,21 @@ function createMockQuote(
 
 const mockOnBack = jest.fn();
 
+const moonpayProvider: Provider = {
+  id: '/providers/moonpay',
+  name: 'MoonPay',
+  environmentType: 'PRODUCTION',
+  description: 'MoonPay',
+  hqAddress: 'MP',
+  links: [],
+  logos: {
+    light: '',
+    dark: '',
+    height: 24,
+    width: 90,
+  },
+};
+
 interface RenderOptions {
   providers?: Provider[];
   selectedProvider?: Provider | null;
@@ -114,6 +129,7 @@ interface RenderOptions {
   quotesLoading?: boolean;
   quotesError?: string | null;
   showQuotes?: boolean;
+  ordersProviders?: string[];
 }
 
 function renderWithProvider(
@@ -126,6 +142,7 @@ function renderWithProvider(
     quotesLoading = false,
     quotesError = null,
     showQuotes,
+    ordersProviders,
   } = options;
 
   jest.mocked(useRampsController).mockReturnValue({
@@ -142,6 +159,7 @@ function renderWithProvider(
         onProviderSelect={jest.fn()}
         onBack={mockOnBack}
         {...(showQuotes !== undefined && { showQuotes })}
+        {...(ordersProviders !== undefined && { ordersProviders })}
       />
     ),
     {
@@ -319,5 +337,101 @@ describe('ProviderSelection', () => {
       expect(getByText('Transak')).toBeTruthy();
     });
     expect(queryByText('Stripe')).toBeNull();
+  });
+
+  it('renders empty state when there are no providers', () => {
+    const { getByText } = renderWithProvider([], null, {
+      showQuotes: true,
+      quotes: {
+        success: [],
+        sorted: [],
+        error: [],
+        customActions: [],
+      },
+    });
+
+    expect(getByText('No providers available.')).toBeOnTheScreen();
+  });
+
+  it('renders Other options separator between quoted and non-quoted providers', async () => {
+    jest.mocked(useRampsController).mockReturnValue({
+      ...defaultMockController,
+      userRegion: mockUserRegion,
+      selectedToken: mockSelectedToken,
+      providers: [transakProvider, moonpayProvider],
+      selectedProvider: transakProvider,
+    });
+
+    const transakQuote = createMockQuote('/providers/transak', 'Transak');
+
+    const { getByText } = renderWithProvider(
+      [transakProvider, moonpayProvider],
+      transakProvider,
+      {
+        quotes: {
+          success: [transakQuote],
+          sorted: [{ sortBy: 'reliability', ids: ['/providers/transak'] }],
+          error: [],
+          customActions: [],
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(getByText('Other options')).toBeOnTheScreen();
+    });
+    expect(getByText('MoonPay')).toBeOnTheScreen();
+  });
+
+  it('shows Best rate tag when quote metadata has isBestRate', async () => {
+    jest.mocked(useRampsController).mockReturnValue({
+      ...defaultMockController,
+      userRegion: mockUserRegion,
+      selectedToken: mockSelectedToken,
+      providers: mockProviders,
+      selectedProvider: null,
+    });
+
+    const bestRateQuote = {
+      ...createMockQuote('/providers/transak', 'Transak'),
+      metadata: { tags: { isBestRate: true } },
+    };
+
+    const { getByText } = renderWithProvider(mockProviders, null, {
+      quotes: {
+        success: [bestRateQuote],
+        sorted: [],
+        error: [],
+        customActions: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(getByText('Best rate')).toBeOnTheScreen();
+    });
+  });
+
+  it('shows Previously used tag when provider is in ordersProviders', async () => {
+    jest.mocked(useRampsController).mockReturnValue({
+      ...defaultMockController,
+      userRegion: mockUserRegion,
+      selectedToken: mockSelectedToken,
+      providers: mockProviders,
+      selectedProvider: null,
+    });
+
+    const { getByText } = renderWithProvider(mockProviders, null, {
+      ordersProviders: ['/providers/transak'],
+      quotes: {
+        success: [createMockQuote('/providers/transak', 'Transak')],
+        sorted: [],
+        error: [],
+        customActions: [],
+      },
+    });
+
+    await waitFor(() => {
+      expect(getByText('Previously used')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx
@@ -274,7 +274,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
           accessible
         >
           <ListItemColumn widthType={WidthType.Fill}>
-            <Text variant={TextVariant.BodyLg} fontWeight={FontWeight.Medium}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {provider.name}
             </Text>
             {tag ? (

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelection.test.tsx.snap
@@ -615,13 +615,17 @@ exports[`ProviderSelection filters out custom-action quotes when displaying prov
                                       <Text
                                         accessibilityRole="text"
                                         style={
-                                          {
-                                            "color": "#66676a",
-                                            "fontFamily": "Geist-Regular",
-                                            "fontSize": 14,
-                                            "letterSpacing": 0,
-                                            "lineHeight": 22,
-                                          }
+                                          [
+                                            {
+                                              "color": "#66676a",
+                                              "fontFamily": "Geist-Regular",
+                                              "fontSize": 14,
+                                              "fontWeight": 400,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 22,
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
                                         $98.00
@@ -3076,13 +3080,17 @@ exports[`ProviderSelection matches snapshot when quotes fail to load 1`] = `
                             <Text
                               accessibilityRole="text"
                               style={
-                                {
-                                  "color": "#131416",
-                                  "fontFamily": "Geist-Regular",
-                                  "fontSize": 14,
-                                  "letterSpacing": 0,
-                                  "lineHeight": 22,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "fontFamily": "Geist-Regular",
+                                    "fontSize": 14,
+                                    "fontWeight": 400,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 22,
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
                               Failed to load quotes

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelection.test.tsx.snap
@@ -572,8 +572,8 @@ exports[`ProviderSelection filters out custom-action quotes when displaying prov
                                           {
                                             "color": "#131416",
                                             "fontFamily": "Geist-Medium",
-                                            "fontSize": 20,
-                                            "fontWeight": 500,
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
                                             "letterSpacing": 0,
                                             "lineHeight": 24,
                                           },
@@ -1234,8 +1234,8 @@ exports[`ProviderSelection matches snapshot when no quotes are available 1`] = `
                                           {
                                             "color": "#131416",
                                             "fontFamily": "Geist-Medium",
-                                            "fontSize": 20,
-                                            "fontWeight": 500,
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
                                             "letterSpacing": 0,
                                             "lineHeight": 24,
                                           },
@@ -3194,8 +3194,8 @@ exports[`ProviderSelection matches snapshot when quotes fail to load 1`] = `
                                           {
                                             "color": "#131416",
                                             "fontFamily": "Geist-Medium",
-                                            "fontSize": 20,
-                                            "fontWeight": 500,
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
                                             "letterSpacing": 0,
                                             "lineHeight": 24,
                                           },
@@ -3812,8 +3812,8 @@ exports[`ProviderSelection renders providers directly when quotes load but none 
                                           {
                                             "color": "#131416",
                                             "fontFamily": "Geist-Medium",
-                                            "fontSize": 20,
-                                            "fontWeight": 500,
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
                                             "letterSpacing": 0,
                                             "lineHeight": 24,
                                           },

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelectionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/__snapshots__/ProviderSelectionModal.test.tsx.snap
@@ -597,8 +597,8 @@ exports[`ProviderSelectionModal matches snapshot 1`] = `
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
-                                              "fontWeight": 500,
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             },
@@ -679,8 +679,8 @@ exports[`ProviderSelectionModal matches snapshot 1`] = `
                                             {
                                               "color": "#131416",
                                               "fontFamily": "Geist-Medium",
-                                              "fontSize": 20,
-                                              "fontWeight": 500,
+                                              "fontSize": 16,
+                                              "fontWeight": 400,
                                               "letterSpacing": 0,
                                               "lineHeight": 24,
                                             },

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -22,7 +22,7 @@ import {
   ToastVariants,
 } from '../../../../../../component-library/components/Toast';
 import Logger from '../../../../../../util/Logger';
-import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import MenuItem from '../../../components/MenuItem';
 import { useRampsController } from '../../../hooks/useRampsController';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
@@ -194,9 +194,10 @@ function SettingsModal() {
 
   return (
     <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={handleClosePress}>
-        {strings('fiat_on_ramp.build_quote_settings_modal.title')}
-      </BottomSheetHeader>
+      <HeaderCompactStandard
+        title={strings('fiat_on_ramp.build_quote_settings_modal.title')}
+        onClose={handleClosePress}
+      />
       <MenuItem
         iconName={IconName.Clock}
         title={strings(

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/__snapshots__/SettingsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/__snapshots__/SettingsModal.test.tsx.snap
@@ -437,11 +437,11 @@ exports[`SettingsModal render matches snapshot 1`] = `
                                   "flexDirection": "row",
                                   "gap": 16,
                                   "minHeight": 56,
+                                  "paddingLeft": 8,
+                                  "paddingRight": 8,
                                 },
                                 false,
-                                {
-                                  "paddingHorizontal": 16,
-                                },
+                                undefined,
                               ]
                             }
                             testID="header"
@@ -465,64 +465,109 @@ exports[`SettingsModal render matches snapshot 1`] = `
                                 ]
                               }
                             >
-                              <Text
-                                accessibilityRole="text"
+                              <View
                                 style={
                                   [
                                     {
-                                      "color": "#131416",
-                                      "fontFamily": "Geist-Bold",
-                                      "fontSize": 16,
-                                      "fontWeight": 700,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "alignItems": "center",
+                                      "display": "flex",
                                     },
-                                    {
-                                      "textAlign": "center",
-                                    },
+                                    undefined,
                                   ]
                                 }
-                                testID="header-title"
                               >
-                                Settings
-                              </Text>
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    [
+                                      {
+                                        "color": "#131416",
+                                        "fontFamily": "Geist-Bold",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  Settings
+                                </Text>
+                              </View>
                             </View>
                             <View>
                               <View
                                 onLayout={[Function]}
                               >
-                                <TouchableOpacity
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                <View
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "borderRadius": 8,
-                                      "height": 32,
-                                      "justifyContent": "center",
-                                      "opacity": 1,
-                                      "width": 32,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
                                   }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "transparent",
+                                        "borderRadius": 8,
+                                        "height": 32,
+                                        "justifyContent": "center",
+                                        "opacity": 1,
+                                        "width": 32,
+                                      },
+                                      undefined,
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
+                                  }
+                                  testID="button-icon"
                                 >
                                   <SvgMock
-                                    color="#131416"
                                     fill="currentColor"
-                                    height={24}
                                     name="Close"
                                     style={
-                                      {
-                                        "height": 24,
-                                        "width": 24,
-                                      }
+                                      [
+                                        {
+                                          "color": "#131416",
+                                          "height": 24,
+                                          "width": 24,
+                                        },
+                                        undefined,
+                                      ]
                                     }
-                                    width={24}
                                   />
-                                </TouchableOpacity>
+                                </View>
                               </View>
                             </View>
                           </View>

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
@@ -1,19 +1,18 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
+  Button,
+  ButtonVariant,
+  ButtonBaseSize,
+} from '@metamask/design-system-react-native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../../locales/i18n';
 import {
   createNavigationDetails,
@@ -134,19 +133,16 @@ function TokenNotAvailableModal() {
       onClose={handleDismiss}
       testID={TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS.MODAL}
     >
-      <BottomSheetHeader
+      <HeaderCompactStandard
+        title={strings('fiat_on_ramp.token_unavailable_modal.title')}
         onClose={handleClose}
         closeButtonProps={{
           testID: TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS.CLOSE_BUTTON,
         }}
-      >
-        <Text variant={TextVariant.HeadingMD}>
-          {strings('fiat_on_ramp.token_unavailable_modal.title')}
-        </Text>
-      </BottomSheetHeader>
+      />
 
       <View style={styles.content}>
-        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
           {strings('fiat_on_ramp.token_unavailable_modal.description', {
             token: tokenName,
             provider: providerName,
@@ -157,25 +153,25 @@ function TokenNotAvailableModal() {
       <View style={styles.footer}>
         <View style={styles.footerButton}>
           <Button
-            size={ButtonSize.Lg}
+            size={ButtonBaseSize.Lg}
             onPress={handleChangeToken}
-            label={strings('fiat_on_ramp.token_unavailable_modal.change_token')}
-            variant={ButtonVariants.Secondary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Secondary}
+            isFullWidth
             testID={TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS.CHANGE_TOKEN_BUTTON}
-          />
+          >
+            {strings('fiat_on_ramp.token_unavailable_modal.change_token')}
+          </Button>
         </View>
         <View style={styles.footerButton}>
           <Button
-            size={ButtonSize.Lg}
+            size={ButtonBaseSize.Lg}
             onPress={handleChangeProvider}
-            label={strings(
-              'fiat_on_ramp.token_unavailable_modal.change_provider',
-            )}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            isFullWidth
             testID={TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS.CHANGE_PROVIDER_BUTTON}
-          />
+          >
+            {strings('fiat_on_ramp.token_unavailable_modal.change_provider')}
+          </Button>
         </View>
       </View>
     </BottomSheet>

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/__snapshots__/TokenNotAvailableModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/__snapshots__/TokenNotAvailableModal.test.tsx.snap
@@ -320,11 +320,11 @@ exports[`TokenNotAvailableModal matches snapshot 1`] = `
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -348,58 +348,109 @@ exports[`TokenNotAvailableModal matches snapshot 1`] = `
                           ]
                         }
                       >
-                        <Text
-                          accessibilityRole="text"
+                        <View
                           style={
-                            {
-                              "color": "#131416",
-                              "fontFamily": "Geist-Bold",
-                              "fontSize": 20,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "alignItems": "center",
+                                "display": "flex",
+                              },
+                              undefined,
+                            ]
                           }
                         >
-                          Not available
-                        </Text>
+                          <Text
+                            accessibilityRole="text"
+                            style={
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
+                            }
+                          >
+                            Not available
+                          </Text>
+                        </View>
                       </View>
                       <View>
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="bottomsheetheader-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -414,13 +465,17 @@ exports[`TokenNotAvailableModal matches snapshot 1`] = `
                       <Text
                         accessibilityRole="text"
                         style={
-                          {
-                            "color": "#66676a",
-                            "fontFamily": "Geist-Regular",
-                            "fontSize": 16,
-                            "letterSpacing": 0,
-                            "lineHeight": 24,
-                          }
+                          [
+                            {
+                              "color": "#66676a",
+                              "fontFamily": "Geist-Regular",
+                              "fontSize": 16,
+                              "fontWeight": 400,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ]
                         }
                       >
                         USD Coin is not available with Transak in your region.
@@ -443,45 +498,93 @@ exports[`TokenNotAvailableModal matches snapshot 1`] = `
                           }
                         }
                       >
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Change token"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#b4b4b528",
+                                "borderColor": "transparent",
+                                "borderRadius": 12,
+                                "borderWidth": 1,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                           testID="token-unavailable-change-token-button"
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Change token
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                       </View>
                       <View
                         style={
@@ -490,43 +593,91 @@ exports[`TokenNotAvailableModal matches snapshot 1`] = `
                           }
                         }
                       >
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Change provider"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#131416",
-                              "borderRadius": 12,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#131416",
+                                "borderRadius": 12,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                           testID="token-unavailable-change-provider-button"
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#ffffff",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#ffffff",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Change provider
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                       </View>
                     </View>
                   </View>
@@ -861,11 +1012,11 @@ exports[`TokenNotAvailableModal matches snapshot with missing provider and token
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -889,58 +1040,109 @@ exports[`TokenNotAvailableModal matches snapshot with missing provider and token
                           ]
                         }
                       >
-                        <Text
-                          accessibilityRole="text"
+                        <View
                           style={
-                            {
-                              "color": "#131416",
-                              "fontFamily": "Geist-Bold",
-                              "fontSize": 20,
-                              "letterSpacing": 0,
-                              "lineHeight": 24,
-                            }
+                            [
+                              {
+                                "alignItems": "center",
+                                "display": "flex",
+                              },
+                              undefined,
+                            ]
                           }
                         >
-                          Not available
-                        </Text>
+                          <Text
+                            accessibilityRole="text"
+                            style={
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
+                            }
+                          >
+                            Not available
+                          </Text>
+                        </View>
                       </View>
                       <View>
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="bottomsheetheader-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -955,13 +1157,17 @@ exports[`TokenNotAvailableModal matches snapshot with missing provider and token
                       <Text
                         accessibilityRole="text"
                         style={
-                          {
-                            "color": "#66676a",
-                            "fontFamily": "Geist-Regular",
-                            "fontSize": 16,
-                            "letterSpacing": 0,
-                            "lineHeight": 24,
-                          }
+                          [
+                            {
+                              "color": "#66676a",
+                              "fontFamily": "Geist-Regular",
+                              "fontSize": 16,
+                              "fontWeight": 400,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ]
                         }
                       >
                          is not available with  in your region.
@@ -984,45 +1190,93 @@ exports[`TokenNotAvailableModal matches snapshot with missing provider and token
                           }
                         }
                       >
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Change token"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#b4b4b528",
+                                "borderColor": "transparent",
+                                "borderRadius": 12,
+                                "borderWidth": 1,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                           testID="token-unavailable-change-token-button"
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Change token
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                       </View>
                       <View
                         style={
@@ -1031,43 +1285,91 @@ exports[`TokenNotAvailableModal matches snapshot with missing provider and token
                           }
                         }
                       >
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Change provider"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#131416",
-                              "borderRadius": 12,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#131416",
+                                "borderRadius": 12,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                           testID="token-unavailable-change-provider-button"
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#ffffff",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#ffffff",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Change provider
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                       </View>
                     </View>
                   </View>

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
@@ -1,13 +1,11 @@
 import React, { useRef } from 'react';
 import { View } from 'react-native';
 
-import Text, {
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../../locales/i18n';
 import styleSheet from './UnsupportedTokenModal.styles';
 import { useStyles } from '../../../../../hooks/useStyles';
@@ -26,15 +24,14 @@ function UnsupportedTokenModal() {
 
   return (
     <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader
+      <HeaderCompactStandard
+        title={strings('deposit.token_modal.unsupported_token_title')}
         onClose={() => sheetRef.current?.onCloseBottomSheet()}
         closeButtonProps={{ testID: 'bottomsheetheader-close-button' }}
-      >
-        {strings('deposit.token_modal.unsupported_token_title')}
-      </BottomSheetHeader>
+      />
 
       <View style={styles.content}>
-        <Text variant={TextVariant.BodyMD}>
+        <Text variant={TextVariant.BodyMd}>
           {strings('deposit.token_modal.unsupported_token_description')}
         </Text>
       </View>

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/__snapshots__/UnsupportedTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/__snapshots__/UnsupportedTokenModal.test.tsx.snap
@@ -320,11 +320,11 @@ exports[`UnsupportedTokenModal renders the modal with correct title and descript
                             "flexDirection": "row",
                             "gap": 16,
                             "minHeight": 56,
+                            "paddingLeft": 8,
+                            "paddingRight": 8,
                           },
                           false,
-                          {
-                            "paddingHorizontal": 16,
-                          },
+                          undefined,
                         ]
                       }
                       testID="header"
@@ -348,65 +348,109 @@ exports[`UnsupportedTokenModal renders the modal with correct title and descript
                           ]
                         }
                       >
-                        <Text
-                          accessibilityRole="text"
+                        <View
                           style={
                             [
                               {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Bold",
-                                "fontSize": 16,
-                                "fontWeight": 700,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
+                                "alignItems": "center",
+                                "display": "flex",
                               },
-                              {
-                                "textAlign": "center",
-                              },
+                              undefined,
                             ]
                           }
-                          testID="header-title"
                         >
-                          Not available
-                        </Text>
+                          <Text
+                            accessibilityRole="text"
+                            style={
+                              [
+                                {
+                                  "color": "#131416",
+                                  "fontFamily": "Geist-Bold",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                },
+                                undefined,
+                              ]
+                            }
+                          >
+                            Not available
+                          </Text>
+                        </View>
                       </View>
                       <View>
                         <View
                           onLayout={[Function]}
                         >
-                          <TouchableOpacity
-                            accessible={true}
-                            activeOpacity={1}
-                            disabled={false}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                          <View
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "borderRadius": 8,
-                                "height": 32,
-                                "justifyContent": "center",
-                                "opacity": 1,
-                                "width": 32,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 8,
+                                  "height": 32,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 32,
+                                },
+                                undefined,
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                             testID="bottomsheetheader-close-button"
                           >
                             <SvgMock
-                              color="#131416"
                               fill="currentColor"
-                              height={24}
                               name="Close"
                               style={
-                                {
-                                  "height": 24,
-                                  "width": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
                               }
-                              width={24}
                             />
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </View>
@@ -421,13 +465,17 @@ exports[`UnsupportedTokenModal renders the modal with correct title and descript
                       <Text
                         accessibilityRole="text"
                         style={
-                          {
-                            "color": "#131416",
-                            "fontFamily": "Geist-Regular",
-                            "fontSize": 16,
-                            "letterSpacing": 0,
-                            "lineHeight": 24,
-                          }
+                          [
+                            {
+                              "color": "#131416",
+                              "fontFamily": "Geist-Regular",
+                              "fontSize": 16,
+                              "fontWeight": 400,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ]
                         }
                       >
                         This token may not be available in your region or supported by any local payment providers


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Aligns unified Ramp buy flow bottom sheets with **HeaderCompactStandard** (consistent with Settings and other compact headers). Replaces deprecated component-library **Text** and **Button** with **`@metamask/design-system-react-native`** equivalents in affected modals (payment/provider selection, error details, token unavailable, processing info, unsupported token, checkout sheet). List row typography for payment methods and quotes uses design-system **Text** variants. Unit test snapshots updated accordingly.

## **Changelog**

CHANGELOG entry: Updated Ramp buy flow modal headers and typography to use shared compact header and design system components

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramp unified buy modals

  Scenario: Open buy flow modals and verify layout
    Given the user is on unified Ramp buy with v2 UI enabled
    When the user opens provider selection, payment method selection, settings, checkout, error details, token unavailable, processing info, or unsupported token sheets
    Then headers use the compact standard layout and text/buttons match design system styling
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" src="https://github.com/user-attachments/assets/a59f030a-35a0-4155-aa8f-5e2419fd5d51" />
<img width="300" src="https://github.com/user-attachments/assets/758f43c0-45b3-4c34-855b-32f8d7e7cb9e" />
<img width="300" src="https://github.com/user-attachments/assets/3a0e8d55-156d-4f76-a36b-cfa946e64e8f" />
<img width="300" src="https://github.com/user-attachments/assets/0711ead9-4a06-475d-81cb-e5cf845caa5e" />


### **After**



https://github.com/user-attachments/assets/a43ec703-3722-4f05-85df-a6974e337ba3



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI refactors (header + typography/button migrations) but includes behavioral changes in `Checkout` WebView HTTP error handling/retry and `ProcessingInfoModal` support-link navigation/analytics that could affect the purchase flow if regressions occur.
> 
> **Overview**
> Updates Ramp unified buy bottom sheets to use `HeaderCompactStandard` for consistent compact headers, and migrates several modals/components from legacy component-library `Text`/`Button` to `@metamask/design-system-react-native` equivalents (including updated variants/colors/weights).
> 
> Adds coverage and behavior around error and navigation handling: `Checkout` now reacts to WebView `onHttpError` on the main checkout/callback URLs by showing an `ErrorView` with a retry that reloads the WebView, and tests add cases for missing `url` plus precreated-order registration. `ProcessingInfoModal` now tracks an external-link click event with parsed `url_domain` and conditionally opens `InAppBrowser` (closing the sheet first) or navigates to `SimpleWebview` when unavailable; corresponding unit tests were expanded.
> 
> Refactors `PaymentSelectionModal` header to `HeaderCompactStandard`, introduces `PAYMENT_SELECTION_MODAL_TEST_IDS` for the close button, adjusts list/quote typography, and updates/extends provider selection tests (e.g., empty state, “Other options”, “Best rate”, “Previously used”) with snapshot updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d11553c4f14b88dd06ac967925362f7500ec35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->