### PR TITLE
feat: migrate Button component (assets scope)

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.test.tsx
@@ -7,9 +7,7 @@ import {
   TokenPrice,
 } from '../../../../components/hooks/useTokenHistoricalPrices';
 import PriceChart from '../PriceChart/PriceChart';
-import Button, {
-  ButtonVariants,
-} from '../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 
 jest.mock('../PriceChart/PriceChart', () => ({
   ...jest.requireActual('../PriceChart/PriceChart'),
@@ -119,16 +117,15 @@ describe('Price Component', () => {
   });
 
   it('renders price at selected date', async () => {
-    jest
-      .mocked(PriceChart)
-      .mockImplementation(({ onChartIndexChange }) => (
-        <Button
-          testID="mock-price-chart"
-          variant={ButtonVariants.Primary}
-          label="TEST BUTTON"
-          onPress={() => onChartIndexChange(1)}
-        />
-      ));
+    jest.mocked(PriceChart).mockImplementation(({ onChartIndexChange }) => (
+      <Button
+        testID="mock-price-chart"
+        variant={ButtonVariant.Primary}
+        onPress={() => onChartIndexChange(1)}
+      >
+        TEST BUTTON
+      </Button>
+    ));
 
     const { getByTestId } = render(<Price {...{ ...mockProps }} />);
 

--- a/app/components/UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal.test.tsx
+++ b/app/components/UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal.test.tsx
@@ -50,22 +50,27 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => {
   };
 });
 
-jest.mock('../../../../../component-library/components/Buttons/Button', () => {
+jest.mock('@metamask/design-system-react-native', () => {
   /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
   const ReactMock = require('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
-    __esModule: true,
-    default: ({ label, onPress, testID }: Record<string, unknown>) =>
+    ...actual,
+    Button: ({ children, onPress }: Record<string, unknown>) =>
       ReactMock.createElement(
         'View',
         {
-          testID: testID ?? 'edit-network-button',
+          testID: 'edit-network-button',
           onPress,
+          accessibilityRole: 'button',
+          accessible: true,
         },
-        ReactMock.createElement('Text', {}, label),
+        ReactMock.createElement(
+          'Text',
+          { accessibilityRole: 'text' },
+          children,
+        ),
       ),
-    ButtonVariants: { Secondary: 'Secondary' },
-    ButtonSize: { Lg: 'Lg' },
   };
 });
 

--- a/app/components/UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal.tsx
+++ b/app/components/UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal.tsx
@@ -6,10 +6,11 @@ import { StyleSheet, View } from 'react-native';
 import SheetHeader from '../../../../../component-library/components/Sheet/SheetHeader';
 import { strings } from '../../../../../../locales/i18n';
 import Text from '../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -35,9 +36,6 @@ const createStyles = (colors: Colors) =>
       paddingBottom: 21,
       paddingTop: 0,
       borderWidth: 0,
-    },
-    editNetworkButton: {
-      width: '100%',
     },
     notch: {
       width: 40,
@@ -114,12 +112,13 @@ export const ScamWarningModal = ({
         </Box>
         <Box style={styles.boxContent}>
           <Button
-            variant={ButtonVariants.Secondary}
-            label={strings('networks.edit_network_details')}
+            variant={ButtonVariant.Secondary}
             onPress={goToNetworkEdit}
-            style={styles.editNetworkButton}
+            isFullWidth
             size={ButtonSize.Lg}
-          />
+          >
+            {strings('networks.edit_network_details')}
+          </Button>
         </Box>
       </Box>
     </Modal>

--- a/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.test.tsx
+++ b/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.test.tsx
@@ -149,7 +149,7 @@ describe('AddCustomToken', () => {
     const { getByTestId } = renderComponent();
 
     const nextButton = getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON);
-    expect(nextButton.props.disabled || nextButton.props.isDisabled).toBe(true);
+    expect(nextButton).toBeDisabled();
   });
 
   it('navigates to ConfirmAddAsset when form is valid and Next is pressed', async () => {

--- a/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx
+++ b/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx
@@ -9,7 +9,11 @@ import { TextInput, Platform, ActivityIndicator } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import { Box, Text, TextVariant ,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import type { Hex } from '@metamask/utils';
 import { useNavigation, type ParamListBase } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -32,11 +36,6 @@ import {
 } from '../../../../../util/networks';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { formatIconUrlWithProxy } from '@metamask/assets-controllers';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import Icon, {
   IconName,
   IconSize,
@@ -547,14 +546,15 @@ const AddCustomToken = ({
 
       <Box style={tw.style('pt-4 m-4', { paddingBottom: bottomInset })}>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('transaction.next')}
+          isFullWidth
           onPress={handleNext}
           isDisabled={isNextDisabled}
           testID={ImportTokenViewSelectorsIDs.NEXT_BUTTON}
-        />
+        >
+          {strings('transaction.next')}
+        </Button>
       </Box>
     </Box>
   );

--- a/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx
+++ b/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx
@@ -9,7 +9,10 @@ import { TextInput, Platform, ActivityIndicator } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box, Text, TextVariant ,
+import {
+  Box,
+  Text,
+  TextVariant,
   Button,
   ButtonVariant,
   ButtonSize,

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
@@ -307,7 +307,7 @@ describe('SearchTokenAutocomplete', () => {
   it('next button is disabled when no tokens are selected', () => {
     const { getByTestId } = renderComponent();
     const nextButton = getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON);
-    expect(nextButton).toHaveProp('disabled', true);
+    expect(nextButton).toBeDisabled();
   });
 
   it('enables Next button after selecting a token', () => {
@@ -320,7 +320,7 @@ describe('SearchTokenAutocomplete', () => {
     fireEvent.press(tokenResult);
 
     const nextButton = getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON);
-    expect(nextButton).toHaveProp('disabled', false);
+    expect(nextButton).toBeEnabled();
   });
 
   it('shows clear button when search has text and clears on press', () => {
@@ -354,16 +354,10 @@ describe('SearchTokenAutocomplete', () => {
     );
 
     fireEvent.press(tokenResult);
-    expect(getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON)).toHaveProp(
-      'disabled',
-      false,
-    );
+    expect(getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON)).toBeEnabled();
 
     fireEvent.press(tokenResult);
-    expect(getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON)).toHaveProp(
-      'disabled',
-      true,
-    );
+    expect(getByTestId(ImportTokenViewSelectorsIDs.NEXT_BUTTON)).toBeDisabled();
   });
 
   it('navigates to ConfirmAddAsset with correct params and tracks analytics', () => {

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -26,7 +26,6 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-
   Box,
   BoxFlexDirection,
   BoxAlignItems,
@@ -34,7 +33,8 @@ import {
   Icon,
   IconName,
   IconSize,
-  IconColor} from '@metamask/design-system-react-native';
+  IconColor,
+} from '@metamask/design-system-react-native';
 import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Logger from '../../../../../util/Logger';

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -22,13 +22,11 @@ import { getDecimalChainId } from '../../../../../util/networks';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import Routes from '../../../../../constants/navigation/Routes';
 import SearchTokenResults from '../SearchTokenResults/SearchTokenResults';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
-import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
 import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+
   Box,
   BoxFlexDirection,
   BoxAlignItems,
@@ -36,8 +34,8 @@ import {
   Icon,
   IconName,
   IconSize,
-  IconColor,
-} from '@metamask/design-system-react-native';
+  IconColor} from '@metamask/design-system-react-native';
+import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Logger from '../../../../../util/Logger';
 import { CaipAssetType, Hex } from '@metamask/utils';
@@ -451,14 +449,15 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
 
       <Box style={tw.style('px-4 pt-6', Platform.OS !== 'android' && 'pb-4')}>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('transaction.next')}
+          isFullWidth
           onPress={goToConfirmAddToken}
           isDisabled={selectedAssets.length < 1}
           testID={ImportTokenViewSelectorsIDs.NEXT_BUTTON}
-        />
+        >
+          {strings('transaction.next')}
+        </Button>
       </Box>
     </Box>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replace Button component with DSRN package.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/1cbd0d59-883c-440c-91bd-914b307a655a

### **After**

https://github.com/user-attachments/assets/6bc13f85-7f7b-4b64-a6b5-fcc47f4763b8

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it swaps the `Button` implementation and prop API in user-facing asset add flows and the scam warning modal, which could cause subtle layout/disabled-state regressions. Logic changes are minimal and covered by updated tests.
> 
> **Overview**
> Migrates several assets-scope screens and tests from the legacy component-library `Button` to `@metamask/design-system-react-native` `Button`, updating the prop API (e.g., `ButtonVariants`/`label`/`width` → `ButtonVariant` + children + `isFullWidth`).
> 
> Updates `ScamWarningModal`, `AddCustomToken`, and `SearchTokenAutocomplete` to use the new button props and removes now-unneeded styling, and adjusts related tests/mocks to assert disabled/enabled behavior via `toBeDisabled()`/`toBeEnabled()` and the new button shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0077d623a122ecfd7dad128a58b33df37e9a7bf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->