### PR TITLE
fix: test multiple ios execution

### DIFF
--- a/.agents/skills/component-view-test/SKILL.md
+++ b/.agents/skills/component-view-test/SKILL.md
@@ -56,6 +56,7 @@ tests/component-view/
 ├── mocks.ts              ← Engine + native mocks (import this first, always)
 ├── render.tsx            ← renderComponentViewScreen, renderScreenWithRoutes
 ├── stateFixture.ts       ← StateFixtureBuilder (createStateFixture)
+├── platform.ts           ← describeForPlatforms, itForPlatforms (run per iOS/Android)
 ├── api-mocking/          ← HTTP API mocks (nock) — extensible, one file per feature
 ├── presets/              ← initialState<Feature>() builders — one file per feature area
 └── renderers/            ← render<Feature>View() functions — one file per feature area

--- a/.agents/skills/component-view-test/references/writing-tests.md
+++ b/.agents/skills/component-view-test/references/writing-tests.md
@@ -195,6 +195,38 @@ const defaultBridgeWithTokens = (overrides?: Record<string, unknown>) => {
 
 Then each test only specifies its delta from this baseline.
 
+### describe / it and platform (iOS + Android)
+
+Import from `tests/component-view/platform`. All helpers accept an optional **filter** (3rd arg): `'ios'` | `'android'` | `['ios','android']` | `{ only: 'ios' }` | `{ skip: ['android'] }`. Env: `TEST_OS=ios` or `TEST_OS=android` to run only one OS.
+
+| Helper                                                                  | Use                                                                                                           |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `describeForPlatforms(name, define, filter?)`                           | One describe per OS. Inside, `define({ os })`; use `it()` or `itForPlatforms()` — each runs once per that OS. |
+| `itForPlatforms(name, (ctx) => {}, filter?)`                            | One `it` per OS. Callback receives `{ os }`.                                                                  |
+| `itOnlyForPlatforms(name, fn, filter?)`                                 | Same as `itForPlatforms` but registers `it.only`.                                                             |
+| `itEach(table)(name, (row) => {}, filter?)`                             | One `it` per table row × per OS. Use `$key` in name to interpolate row fields.                                |
+| `describeEach(table)(name, (row) => { it('...', () => {}); }, filter?)` | One describe per row × per OS. Use `$key` in name.                                                            |
+| `getTargetPlatforms(filter?)`                                           | Returns `['ios','android']` (or filtered list) for custom loops.                                              |
+
+Example — `itEach` (each case runs on iOS and Android):
+
+```typescript
+import { itEach } from '../../../../../../tests/component-view/platform';
+
+const cases = [
+  { name: 'renders empty', amount: '0' },
+  { name: 'displays fiat', amount: '1' },
+];
+itEach(cases)('$name', ({ amount }) => {
+  const { findByDisplayValue } = renderDefault({
+    bridge: { sourceAmount: amount },
+  });
+  expect(findByDisplayValue(amount)).toBeOnTheScreen();
+});
+```
+
+Jest modifiers (`it.only`, `it.skip`, `describe.only`, `describe.skip`) work as usual inside these blocks.
+
 ### Minimal template
 
 ```typescript

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -9,7 +9,7 @@ import { renderScreenWithRoutes } from '../../../../../../tests/component-view/r
 import Routes from '../../../../../constants/navigation/Routes';
 import { initialStateBridge } from '../../../../../../tests/component-view/presets/bridge';
 import BridgeView from './index';
-import { describeForPlatforms } from '../../../../../util/test/platform';
+import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
 import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 import { BuildQuoteSelectors } from '../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
 import { CommonSelectorsIDs } from '../../../../../util/Common.testIds';

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/EarnMusdConversionEducationView.view.test.tsx
@@ -1,7 +1,7 @@
 import '../../../../../../tests/component-view/mocks';
 import { renderScreenWithRoutes } from '../../../../../../tests/component-view/render';
 import { initialStateWallet } from '../../../../../../tests/component-view/presets/wallet';
-import { describeForPlatforms } from '../../../../../util/test/platform';
+import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
 import React from 'react';
 import EarnMusdConversionEducationView from './index';
 import { strings } from '../../../../../../locales/i18n';

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.view.test.tsx
@@ -1,7 +1,7 @@
 import '../../../../../../../tests/component-view/mocks';
 import { renderComponentViewScreen } from '../../../../../../../tests/component-view/render';
 import { initialStateWallet } from '../../../../../../../tests/component-view/presets/wallet';
-import { describeForPlatforms } from '../../../../../../util/test/platform';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
 import React from 'react';
 import { View } from 'react-native';
 import MusdConversionAssetListCta from './index';

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.view.test.tsx
@@ -1,7 +1,7 @@
 import '../../../../../../../tests/component-view/mocks';
 import { renderComponentViewScreen } from '../../../../../../../tests/component-view/render';
 import { initialStateWallet } from '../../../../../../../tests/component-view/presets/wallet';
-import { describeForPlatforms } from '../../../../../../util/test/platform';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
 import React from 'react';
 import { View } from 'react-native';
 import MusdConversionAssetOverviewCta from './index';

--- a/app/components/Views/AssetDetails/AssetDetails.view.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetails.view.test.tsx
@@ -1,6 +1,6 @@
 import '../../../../tests/component-view/mocks';
 import { renderAssetDetailsView } from '../../../../tests/component-view/renderers/assetDetails';
-import { describeForPlatforms } from '../../../util/test/platform';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
 
 // addresses Regression: #25100 – Token Details page shows wrong network
 

--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -1,5 +1,5 @@
 import '../../../../tests/component-view/mocks';
-import { describeForPlatforms } from '../../../util/test/platform';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import { renderTrendingViewWithRoutes } from '../../../../tests/component-view/renderers/trending';
 import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
 import {

--- a/app/components/Views/Wallet/Wallet.view.test.tsx
+++ b/app/components/Views/Wallet/Wallet.view.test.tsx
@@ -4,7 +4,7 @@ import {
   renderWalletViewWithRoutes,
 } from '../../../../tests/component-view/renderers/wallet';
 import { WalletViewSelectorsIDs } from './WalletView.testIds';
-import { describeForPlatforms } from '../../../util/test/platform';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import { fireEvent } from '@testing-library/react-native';
 import Routes from '../../../constants/navigation/Routes';
 

--- a/app/components/Views/WalletActions/WalletActions.view.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.view.test.tsx
@@ -1,7 +1,7 @@
 import '../../../../tests/component-view/mocks';
 import { renderWalletActionsView } from '../../../../tests/component-view/renderers/walletActions';
 import { WalletActionsBottomSheetSelectorsIDs } from './WalletActionsBottomSheet.testIds';
-import { describeForPlatforms } from '../../../util/test/platform';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
 
 // Regression: #24972 – Perps missing from Trade menu when non-EVM network selected
 describeForPlatforms('WalletActions', () => {

--- a/app/components/Views/confirmations/components/send/send.view.test.tsx
+++ b/app/components/Views/confirmations/components/send/send.view.test.tsx
@@ -8,7 +8,7 @@ import {
   sendViewOverrides,
 } from '../../../../../../tests/component-view/presets/send';
 import { initialStateWallet } from '../../../../../../tests/component-view/presets/wallet';
-import { describeForPlatforms } from '../../../../../../app/util/test/platform';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
 import Routes from '../../../../../constants/navigation/Routes';
 import { TokenStandard } from '../../types/token';
 import {

--- a/app/components/Views/confirmations/components/send/send.view.test.tsx
+++ b/app/components/Views/confirmations/components/send/send.view.test.tsx
@@ -8,7 +8,7 @@ import {
   sendViewOverrides,
 } from '../../../../../../tests/component-view/presets/send';
 import { initialStateWallet } from '../../../../../../tests/component-view/presets/wallet';
-import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
+import { describeForPlatforms } from '../../../../../../tests/component-view/platform';
 import Routes from '../../../../../constants/navigation/Routes';
 import { TokenStandard } from '../../types/token';
 import {

--- a/docs/readme/component-view-testing.md
+++ b/docs/readme/component-view-testing.md
@@ -142,7 +142,10 @@ By default, you can execute tests for both platforms using the platform helpers.
 Import helpers and define tests parameterized by platform:
 
 ```ts
-import { itForPlatforms, describeForPlatforms } from '../../platform';
+import {
+  itForPlatforms,
+  describeForPlatforms,
+} from '../../tests/component-view/platform';
 import { renderBridgeView } from './renderers/bridge';
 
 describeForPlatforms('BridgeView', ({ os }) => {

--- a/tests/component-view/AGENTS.md
+++ b/tests/component-view/AGENTS.md
@@ -29,6 +29,7 @@ tests/component-view/
 ├── mocks.ts              ← Engine + native mocks (import this first, always)
 ├── render.tsx            ← renderComponentViewScreen, renderScreenWithRoutes
 ├── stateFixture.ts       ← StateFixtureBuilder, createStateFixture, deepMerge
+├── platform.ts           ← describeForPlatforms, itForPlatforms, itEach, describeEach (per OS + array tables)
 ├── api-mocking/          ← HTTP API mocks (nock) — one file per feature, extensible
 ├── presets/              ← initialState<Feature>() builders — one file per feature
 └── renderers/            ← render<Feature>View() functions — one file per feature
@@ -109,6 +110,7 @@ For run-by-name, watch mode, or other options, see the skill’s [references/ref
 - Presets: [presets/](presets/)
 - Renderers: [renderers/](renderers/)
 - State fixture: [stateFixture.ts](stateFixture.ts)
+- Platform + itEach/describeEach: [platform.ts](platform.ts)
 
 ## Before working
 

--- a/tests/component-view/platform.ts
+++ b/tests/component-view/platform.ts
@@ -119,9 +119,14 @@ export function describeForPlatforms(
       });
       // Set scope before define() so itForPlatforms/itOnlyForPlatforms inside define
       // see the current platform and register a single it per test (not duplicate per platform).
+      const previousScope = (globalThis as Record<string, unknown>)[SCOPE_KEY];
       (globalThis as Record<string, unknown>)[SCOPE_KEY] = os;
       define({ os });
-      delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
+      if (previousScope === undefined) {
+        delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
+      } else {
+        (globalThis as Record<string, unknown>)[SCOPE_KEY] = previousScope;
+      }
     });
   }
 }
@@ -185,9 +190,16 @@ export function describeEach<T extends Record<string, unknown>>(
             Platform.OS = originalOS;
             delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
           });
+          const previousScope = (globalThis as Record<string, unknown>)[
+            SCOPE_KEY
+          ];
           (globalThis as Record<string, unknown>)[SCOPE_KEY] = os;
           define(row);
-          delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
+          if (previousScope === undefined) {
+            delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
+          } else {
+            (globalThis as Record<string, unknown>)[SCOPE_KEY] = previousScope;
+          }
         });
       }
     }

--- a/tests/component-view/platform.ts
+++ b/tests/component-view/platform.ts
@@ -82,6 +82,7 @@ export function itOnlyForPlatforms(
 ) {
   const targets = resolveTargetPlatforms(filter);
   for (const os of targets) {
+    // eslint-disable-next-line jest/no-focused-tests -- itOnlyForPlatforms intentionally uses it.only
     it.only(`${name} [${os}]`, async () => {
       const originalOS = Platform.OS;
       Platform.OS = os;
@@ -96,6 +97,8 @@ export function itOnlyForPlatforms(
 
 /**
  * Group tests under a describe for each targeted platform.
+ * When define() calls itForPlatforms/itOnlyForPlatforms, those register only one test
+ * for the current describe's platform (so we get exactly two runs total: ios + android).
  */
 export function describeForPlatforms(
   name: string,
@@ -114,7 +117,11 @@ export function describeForPlatforms(
         Platform.OS = originalOS;
         delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
       });
+      // Set scope before define() so itForPlatforms/itOnlyForPlatforms inside define
+      // see the current platform and register a single it per test (not duplicate per platform).
+      (globalThis as Record<string, unknown>)[SCOPE_KEY] = os;
       define({ os });
+      delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
     });
   }
 }
@@ -124,4 +131,65 @@ export function describeForPlatforms(
  */
 export function getTargetPlatforms(filter?: PlatformFilter): RNPlatform[] {
   return resolveTargetPlatforms(filter);
+}
+
+function interpolateName(name: string, row: Record<string, unknown>): string {
+  return name.replace(/\$(\w+)/g, (_, key) => String(row[key] ?? ''));
+}
+
+/**
+ * Like Jest's it.each, but each test runs for each targeted platform (iOS/Android).
+ * Use $key in the name to interpolate row properties.
+ */
+export function itEach<T extends Record<string, unknown>>(table: readonly T[]) {
+  return (
+    name: string,
+    testFn: (row: T) => void | Promise<void>,
+    filter?: PlatformFilter,
+  ) => {
+    const targets = resolveTargetPlatforms(filter);
+    for (const row of table) {
+      for (const os of targets) {
+        it(`${interpolateName(name, row as Record<string, unknown>)} [${os}]`, async () => {
+          const originalOS = Platform.OS;
+          Platform.OS = os;
+          try {
+            await testFn(row);
+          } finally {
+            Platform.OS = originalOS;
+          }
+        });
+      }
+    }
+  };
+}
+
+/**
+ * Like Jest's describe.each, but each describe runs for each targeted platform (iOS/Android).
+ * Use $key in the name to interpolate row properties. Inside the callback, call it() to define tests.
+ */
+export function describeEach<T extends Record<string, unknown>>(
+  table: readonly T[],
+) {
+  return (name: string, define: (row: T) => void, filter?: PlatformFilter) => {
+    const targets = resolveTargetPlatforms(filter);
+    const originalOS = Platform.OS;
+    for (const row of table) {
+      for (const os of targets) {
+        describe(`${interpolateName(name, row as Record<string, unknown>)} [${os}]`, () => {
+          beforeAll(() => {
+            Platform.OS = os;
+            (globalThis as Record<string, unknown>)[SCOPE_KEY] = os;
+          });
+          afterAll(() => {
+            Platform.OS = originalOS;
+            delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
+          });
+          (globalThis as Record<string, unknown>)[SCOPE_KEY] = os;
+          define(row);
+          delete (globalThis as Record<string, unknown>)[SCOPE_KEY];
+        });
+      }
+    }
+  };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- **Platform helpers** in `tests/component-view/platform.ts`: `describeForPlatforms`, `itForPlatforms`, `itOnlyForPlatforms`, `itEach`, `describeEach`, `getTargetPlatforms`. Tests run per OS (iOS/Android); optional `filter` and `TEST_OS` supported.
- **Array-style tests**: `itEach(table)(name, fn)` and `describeEach(table)(name, define)` run each row for each OS (like Jest `it.each` / `describe.each` with platform dimension).
- **View tests** now import from `tests/component-view/platform` instead of `app/util/test/platform` (BridgeView, Wallet, WalletActions, AssetDetails, Trending, Send, Earn, etc.).
- **Docs**: `writing-tests.md` updated with a "describe / it and platform" section (helpers, filter, example). SKILL.md and AGENTS.md updated


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the component-view test harness behavior (platform scoping and test generation), which can alter how many tests run and expose new CI failures/flakiness across iOS/Android.
> 
> **Overview**
> **Improves component-view test execution across iOS/Android.** The PR updates `tests/component-view/platform.ts` to better scope `describeForPlatforms` (avoiding duplicate nested platform runs) and adds table-driven helpers `itEach`/`describeEach` for running each case across platforms.
> 
> It also migrates existing `*.view.test.tsx` files to import platform helpers from `tests/component-view/platform` instead of the older `app/util/test/platform`, and updates the testing docs/agent references to document the new helpers, filters, and `TEST_OS` environment targeting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 090d516c2f15b856b837e7b1ea1ec85276fe4994. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->