### PR TITLE
fix(homepage): hide Predictions section on API connection errors cp-7.70.0

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -310,7 +310,7 @@ describe('PredictionsSection', () => {
   });
 
   describe('error state', () => {
-    it('renders error state when markets fail to load', () => {
+    it('returns null when markets fail to load', () => {
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: false,
@@ -318,12 +318,11 @@ describe('PredictionsSection', () => {
         refetch: jest.fn(),
       });
 
-      renderWithProvider(
+      const { toJSON } = renderWithProvider(
         <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
-      expect(screen.getByText('Unable to load predictions')).toBeOnTheScreen();
-      expect(screen.getByText('Retry')).toBeOnTheScreen();
+      expect(toJSON()).toBeNull();
     });
 
     it('does not render error state while still loading', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -325,7 +325,7 @@ describe('PredictionsSection', () => {
       expect(toJSON()).toBeNull();
     });
 
-    it('does not render error state while still loading', () => {
+    it('renders loading state instead of returning null while data is still loading', () => {
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: [],
         isLoading: true,
@@ -333,13 +333,11 @@ describe('PredictionsSection', () => {
         refetch: jest.fn(),
       });
 
-      renderWithProvider(
+      const { toJSON } = renderWithProvider(
         <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
-      expect(
-        screen.queryByText('Unable to load predictions'),
-      ).not.toBeOnTheScreen();
+      expect(toJSON()).not.toBeNull();
     });
   });
 

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -113,7 +113,7 @@ const PredictionsSection = forwardRef<
   // !isLoading is required: isEmpty is false during loading (its formula starts
   // with !isLoading), so without this guard the hook would fire with stale
   // itemCount/isEmpty values before data arrives.
-  const willRender = isPredictEnabled && !isLoading && !isEmpty;
+  const willRender = isPredictEnabled && !isLoading && !isEmpty && !hasError;
 
   const { onLayout } = useHomeViewedEvent({
     sectionRef: willRender ? sectionViewRef : null,

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -10,7 +10,6 @@ import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
-import ErrorState from '../../components/ErrorState';
 import Routes from '../../../../../constants/navigation/Routes';
 import { WalletViewSelectorsIDs } from '../../../../Views/Wallet/WalletView.testIds';
 import { SectionRefreshHandle } from '../../types';
@@ -158,26 +157,9 @@ const PredictionsSection = forwardRef<
     return null;
   }
 
+  // Don't render if there is a connection error
   if (hasError) {
-    return (
-      <View ref={sectionViewRef} onLayout={onLayout}>
-        <Box gap={3}>
-          <SectionHeader
-            title={title}
-            onPress={handleViewAllPredictions}
-            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
-              'predictions',
-            )}
-          />
-          <ErrorState
-            title={strings('homepage.error.unable_to_load', {
-              section: title.toLowerCase(),
-            })}
-            onRetry={refresh}
-          />
-        </Box>
-      </View>
-    );
+    return null;
   }
 
   // Render positions if user has any


### PR DESCRIPTION
## **Description**

Some users' ISPs block access to Polymarket APIs, causing the Predictions homepage section to display an error state with a retry button that will never succeed. This change hides the Predictions section entirely when API connection errors occur, instead of showing a broken error UI.

**What changed:**
- `PredictionsSection` now returns `null` when `hasError` is true (previously rendered `ErrorState` component)
- Removed unused `ErrorState` import
- Updated unit test to assert `null` output on error instead of checking for error UI elements

## **Changelog**

CHANGELOG entry: Fixed Predictions section showing an error state for users whose ISP blocks Polymarket API access — the section is now hidden instead

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27629

## **Manual testing steps**

```gherkin
Feature: Predictions section error handling

  Scenario: user with blocked Polymarket API access views Homepage
    Given the user's ISP blocks access to Polymarket APIs
    And the user is on the Homepage

    When the Predictions section fails to fetch market data
    Then the Predictions section is not displayed
    And no error UI or retry button is shown

  Scenario: user with working API access views Homepage
    Given the user has normal access to Polymarket APIs
    And the user is on the Homepage

    When the Predictions section loads successfully
    Then the Predictions section displays normally with markets or positions
```

## **Screenshots/Recordings**

### **Before**

<img width="430" height="873" alt="Screenshot 2026-03-18 at 10 59 25 AM" src="https://github.com/user-attachments/assets/69190f59-8825-48e1-b5c2-b5856d700a8b" />




### **After**

<img width="433" height="872" alt="Screenshot 2026-03-18 at 10 59 50 AM" src="https://github.com/user-attachments/assets/bb5d4f9d-1d55-4d78-849b-4584193c573f" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the homepage Predictions section: it now hides itself on connection errors instead of showing an error UI. Main risk is reduced visibility into failures, but no sensitive logic or data handling changes.
> 
> **Overview**
> **Homepage Predictions section no longer renders an error state on API failures.** When `usePredictMarketsForHomepage`/`usePredictPositionsForHomepage` report a connection error (and there’s no content to show), `PredictionsSection` now returns `null` and excludes error cases from `willRender` (so view-tracking/layout isn’t treated as visible content).
> 
> Tests were updated to assert `null` output on error and to ensure the section still renders a loading state while fetches are in progress.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 621359218d8acc5df4e10fc2d246b005af8fde61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->