### PR TITLE
ci: add expo dev build GitHub Actions workflow

### DIFF
--- a/.github/workflows/expo-dev-build.yml
+++ b/.github/workflows/expo-dev-build.yml
@@ -1,0 +1,34 @@
+##############################################################################################
+#
+# Expo Dev Build — replaces the Bitrise expo_dev_pipeline.
+#
+# Triggered on every push to main. Builds the main-dev configuration (Debug, simulator)
+# for both iOS and Android using the reusable build.yml workflow.
+#
+# No version bump or TestFlight upload — this is a dev/simulator build only.
+# Artifacts (iOS .app zip + Android APK) are uploaded as GitHub Actions artifacts.
+#
+# [skip ci] commits (e.g. version bumps) are automatically skipped by GitHub Actions.
+#
+##############################################################################################
+name: Expo Dev Build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-dev:
+    name: Expo dev build (main-dev)
+    uses: ./.github/workflows/build.yml
+    with:
+      build_name: main-dev
+      platform: both
+      skip_version_bump: true
+    secrets: inherit


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a new GitHub Actions workflow (`expo-dev-build.yml`) that replaces the Bitrise `expo_dev_pipeline` triggered on pushes to `main`.

The workflow calls the reusable `build.yml` with `build_name: main-dev` and `platform: both`, which builds:
- **iOS**: simulator `.app` (zipped) — Debug configuration
- **Android**: debug APK

No version bump or TestFlight upload is needed since this is a dev/simulator build. Build artifacts are uploaded as GitHub Actions artifacts (`ios-main-dev` and `android-main-dev`).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — CI-only change. Verify by pushing to `main` and confirming the "Expo Dev Build" workflow runs successfully in the Actions tab, producing `ios-main-dev` and `android-main-dev` artifacts.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a new workflow without modifying app code or release/versioning logic; main impact is additional CI load on `main` pushes.
> 
> **Overview**
> Adds a new `Expo Dev Build` GitHub Actions workflow triggered on pushes to `main` (and manually) to replace the prior Bitrise dev pipeline.
> 
> The workflow invokes the reusable `build.yml` with `build_name: main-dev`, `platform: both`, and `skip_version_bump: true` to produce and upload iOS simulator and Android debug artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e766b129e643b2c9d19cf81446989b7383a632fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->