### PR TITLE
chore: upgrade design-system-react-native to 0.11.0 and deprecate replaced components

### DIFF
--- a/app/component-library/components-temp/ButtonFilter/ButtonFilter.tsx
+++ b/app/component-library/components-temp/ButtonFilter/ButtonFilter.tsx
@@ -5,6 +5,12 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 import { ButtonFilterProps } from './ButtonFilter.types';
 
+/**
+ * @deprecated Please update your code to use `ButtonFilter` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonFilter/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const ButtonFilter = ({
   children,
   isActive = false,

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
@@ -13,6 +13,12 @@ import { useAnimatedPressable, useStyles } from '../../hooks';
 import { MainActionButtonProps } from './MainActionButton.types';
 import styleSheet from './MainActionButton.styles';
 
+/**
+ * @deprecated Please update your code to use `MainActionButton` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/MainActionButton/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const MainActionButton = ({
   iconName,
   label,

--- a/app/component-library/components-temp/TabEmptyState/TabEmptyState.tsx
+++ b/app/component-library/components-temp/TabEmptyState/TabEmptyState.tsx
@@ -14,6 +14,12 @@ import {
 
 import type { TabEmptyStateProps } from './TabEmptyState.types';
 
+/**
+ * @deprecated Please update your code to use `TabEmptyState` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TabEmptyState/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 export const TabEmptyState: React.FC<TabEmptyStateProps> = ({
   icon,
   description,

--- a/app/component-library/components/Banners/Banner/Banner.tsx
+++ b/app/component-library/components/Banners/Banner/Banner.tsx
@@ -7,6 +7,14 @@ import BannerTip from './variants/BannerTip';
 // Internal dependencies.
 import { BannerProps, BannerVariant } from './Banner.types';
 
+/**
+ * @deprecated Please update your code to use `BannerAlert` from `@metamask/design-system-react-native`.
+ * The `BannerVariant.Tip` variant is unused and will be removed.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BannerAlert/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md Migration docs}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const Banner = (bannerProps: BannerProps) => {
   switch (bannerProps.variant) {
     case BannerVariant.Alert:

--- a/app/component-library/components/Banners/Banner/foundation/BannerBase/BannerBase.tsx
+++ b/app/component-library/components/Banners/Banner/foundation/BannerBase/BannerBase.tsx
@@ -24,6 +24,12 @@ import {
   TESTID_BANNER_CLOSE_BUTTON_ICON,
 } from './BannerBase.constants';
 
+/**
+ * @deprecated Please update your code to use `BannerBase` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BannerBase/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const BannerBase: React.FC<BannerBaseProps> = ({
   style,
   startAccessory,

--- a/app/component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.tsx
+++ b/app/component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.tsx
@@ -18,6 +18,13 @@ import {
   BANNERALERT_TEST_ID,
 } from './BannerAlert.constants';
 
+/**
+ * @deprecated Please update your code to use `BannerAlert` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BannerAlert/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md Migration docs}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const BannerAlert: React.FC<BannerAlertProps> = ({
   style,
   severity = DEFAULT_BANNERALERT_SEVERITY,

--- a/app/component-library/components/Banners/Banner/variants/BannerTip/BannerTip.tsx
+++ b/app/component-library/components/Banners/Banner/variants/BannerTip/BannerTip.tsx
@@ -17,6 +17,12 @@ import {
   BANNERTIP_TEST_ID,
 } from './BannerTip.constants';
 
+/**
+ * @deprecated This component is unused and will be removed.
+ * Please use `BannerBase` from `@metamask/design-system-react-native` instead.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BannerBase/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const BannerTip: React.FC<BannerTipProps> = ({
   style,
   logoType = DEFAULT_BANNERTIP_LOGOTYPE,

--- a/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.tsx
@@ -31,6 +31,12 @@ import BottomSheetDialog, {
   BottomSheetDialogRef,
 } from './foundation/BottomSheetDialog';
 
+/**
+ * @deprecated Please update your code to use `BottomSheet` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BottomSheet/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const BottomSheet = forwardRef<BottomSheetRef, BottomSheetProps>(
   (
     {

--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
@@ -47,6 +47,12 @@ import {
   BottomSheetDialogProps,
 } from './BottomSheetDialog.types';
 
+/**
+ * @deprecated Please update your code to use `BottomSheetDialog` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BottomSheetDialog/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const BottomSheetDialog = forwardRef<
   BottomSheetDialogRef,
   BottomSheetDialogProps

--- a/app/component-library/components/Icons/Icon/Icon.tsx
+++ b/app/component-library/components/Icons/Icon/Icon.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_ICON_SIZE, DEFAULT_ICON_COLOR } from './Icon.constants';
  * @deprecated Please update your code to use `Icon` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Icon/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md Migration docs}
  */
 const Icon = ({
   size = DEFAULT_ICON_SIZE,

--- a/app/component-library/components/List/ListItem/ListItem.tsx
+++ b/app/component-library/components/List/ListItem/ListItem.tsx
@@ -16,6 +16,12 @@ import {
   TESTID_LISTITEM_GAP,
 } from './ListItem.constants';
 
+/**
+ * @deprecated Please update your code to use `ListItem` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ListItem/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ */
 const ListItem: React.FC<ListItemProps> = ({
   style,
   children,

--- a/app/component-library/components/Texts/Text/Text.tsx
+++ b/app/component-library/components/Texts/Text/Text.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_TEXT_COLOR, DEFAULT_TEXT_VARIANT } from './Text.constants';
  * @deprecated Please update your code to use `Text` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Text/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md Migration docs}
  */
 const Text: React.FC<TextProps> = ({
   variant = DEFAULT_TEXT_VARIANT,

--- a/app/components/UI/Bridge/components/InputStepper/index.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/index.tsx
@@ -4,6 +4,7 @@ import Input from '../../../../../component-library/components/Form/TextField/fo
 import {
   ButtonIcon,
   ButtonIconSize,
+  ButtonIconVariant,
   IconColor,
   IconName,
   Text,
@@ -42,7 +43,7 @@ export const InputStepper = ({
         <ButtonIcon
           size={ButtonIconSize.Lg}
           iconName={IconName.Minus}
-          isFloating
+          variant={ButtonIconVariant.Floating}
           style={tw.style(minusPressed ? 'bg-muted-pressed' : 'bg-muted')}
           iconProps={{ color: IconColor.IconDefault }}
           onPressIn={() => setMinusPressed(true)}
@@ -72,7 +73,7 @@ export const InputStepper = ({
         <ButtonIcon
           size={ButtonIconSize.Lg}
           iconName={IconName.Add}
-          isFloating
+          variant={ButtonIconVariant.Floating}
           style={tw.style(plusPressed ? 'bg-muted-pressed' : 'bg-muted')}
           iconProps={{ color: IconColor.IconDefault }}
           onPressIn={() => setPlusPressed(true)}

--- a/app/components/UI/Bridge/components/InputStepper/index.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/index.tsx
@@ -4,7 +4,6 @@ import Input from '../../../../../component-library/components/Form/TextField/fo
 import {
   ButtonIcon,
   ButtonIconSize,
-  ButtonIconVariant,
   IconColor,
   IconName,
   Text,
@@ -43,7 +42,7 @@ export const InputStepper = ({
         <ButtonIcon
           size={ButtonIconSize.Lg}
           iconName={IconName.Minus}
-          variant={ButtonIconVariant.Floating}
+          isFloating
           style={tw.style(minusPressed ? 'bg-muted-pressed' : 'bg-muted')}
           iconProps={{ color: IconColor.IconDefault }}
           onPressIn={() => setMinusPressed(true)}
@@ -73,7 +72,7 @@ export const InputStepper = ({
         <ButtonIcon
           size={ButtonIconSize.Lg}
           iconName={IconName.Add}
-          variant={ButtonIconVariant.Floating}
+          isFloating
           style={tw.style(plusPressed ? 'bg-muted-pressed' : 'bg-muted')}
           iconProps={{ color: IconColor.IconDefault }}
           onPressIn={() => setPlusPressed(true)}

--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -154,6 +154,9 @@ exports[`Login renders matching snapshot 1`] = `
                   "lineHeight": 24,
                 },
                 {
+                  "lineHeight": 0,
+                },
+                {
                   "textAlignVertical": "center",
                 },
               ]

--- a/app/components/Views/ManualBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ManualBackupStep1/__snapshots__/index.test.tsx.snap
@@ -539,7 +539,7 @@ exports[`ManualBackupStep1 matches snapshot 1`] = `
                   "text-body-md",
                   "font-default-medium",
                   "text-default",
-                  "shrink grow-0 flex-wrap text-center  text-primary-inverse",
+                  "shrink grow-0 flex-wrap text-center  text-primary-inverse ",
                 ],
                 undefined,
               ]
@@ -1094,7 +1094,7 @@ exports[`ManualBackupStep1 theme appearance renders with dark theme 1`] = `
                   "text-body-md",
                   "font-default-medium",
                   "text-default",
-                  "shrink grow-0 flex-wrap text-center  text-primary-inverse",
+                  "shrink grow-0 flex-wrap text-center  text-primary-inverse ",
                 ],
                 undefined,
               ]
@@ -1649,7 +1649,7 @@ exports[`ManualBackupStep1 theme appearance renders with light theme on Android 
                   "text-body-md",
                   "font-default-medium",
                   "text-default",
-                  "shrink grow-0 flex-wrap text-center  text-primary-inverse",
+                  "shrink grow-0 flex-wrap text-center  text-primary-inverse ",
                 ],
                 undefined,
               ]

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -83,7 +83,7 @@ const ManualBackupStep1 = () => {
   );
 
   const [seedPhraseHidden, setSeedPhraseHidden] = useState(true);
-  const [password, setPassword] = useState<string | undefined>(undefined);
+  const [password, setPassword] = useState('');
   const [warningIncorrectPassword, setWarningIncorrectPassword] = useState<
     string | undefined
   >(undefined);

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -335,6 +335,7 @@ const RevealPrivateCredential = ({
         ) : (
           <Box twClassName="p-5 pb-0">
             <PasswordEntry
+              password={password}
               onPasswordChange={setPassword}
               onSubmit={tryUnlock}
               warningMessage={warningIncorrectPassword}

--- a/app/components/Views/RevealPrivateCredential/components/PasswordEntry.tsx
+++ b/app/components/Views/RevealPrivateCredential/components/PasswordEntry.tsx
@@ -16,6 +16,7 @@ import { PasswordEntryProps } from '../types';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 const PasswordEntry = ({
+  password,
   onPasswordChange,
   onSubmit,
   warningMessage,
@@ -36,6 +37,7 @@ const PasswordEntry = ({
         {strings('reveal_credential.enter_password')}
       </Text>
       <TextField
+        value={password}
         placeholder={'Password'}
         placeholderTextColor={colors.text.muted}
         onChangeText={onPasswordChange}

--- a/app/components/Views/RevealPrivateCredential/types.ts
+++ b/app/components/Views/RevealPrivateCredential/types.ts
@@ -49,6 +49,7 @@ export interface SeedPhraseConcealerProps {
 }
 
 export interface PasswordEntryProps {
+  password: string;
   onPasswordChange: (password: string) => void;
   onSubmit: () => void;
   warningMessage: string;

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@metamask/core-backend": "^6.2.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^0.15.0",
-    "@metamask/design-system-react-native": "^0.10.0",
+    "@metamask/design-system-react-native": "^0.11.0",
     "@metamask/design-system-twrnc-preset": "^0.3.0",
     "@metamask/design-tokens": "^8.2.2",
     "@metamask/earn-controller": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8135,11 +8135,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "@metamask/design-system-react-native@npm:0.10.0"
+"@metamask/design-system-react-native@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@metamask/design-system-react-native@npm:0.11.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.3.0"
+    "@metamask/design-system-shared": "npm:^0.4.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8152,16 +8152,16 @@ __metadata:
     react-native-gesture-handler: ">=1.10.3"
     react-native-reanimated: ">=3.3.0"
     react-native-safe-area-context: ">=4.0.0"
-  checksum: 10/4b105db890392d9f363ad5a573249980a621a3edb6e6d371cef8e78f8ade378d98c24a1f4d814c815a4f8e30e2978a8c69571f61e9b0983289d1c08e28f02da2
+  checksum: 10/d30aa86379138b689a821af25f7c56a8a4dbaaa3378ce4daf668122babfd0c254b8ea319a9b2e9202f2c58d86caca2eb6b888f13e063e83100da4136bad0b378
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@metamask/design-system-shared@npm:0.3.0"
+"@metamask/design-system-shared@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@metamask/design-system-shared@npm:0.4.0"
   dependencies:
     "@metamask/utils": "npm:^11.10.0"
-  checksum: 10/2be032b91b10d03ca4e02ba9ff5afc9db763fb865161add83a7e28ef83f165cc3c3edba03f5d600ec95e3014afd0077abcadd75e613792e77c709760813ff749
+  checksum: 10/e7799c011360295b6ae1cb458cd069e2df2ce27e836a6c604c3f2488ef7b76d00709afadc5c9462e47cb81a379751fd9da8684dcc704244e180870aa293cdd2b
   languageName: node
   linkType: hard
 
@@ -35536,7 +35536,7 @@ __metadata:
     "@metamask/core-backend": "npm:^6.2.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^0.15.0"
-    "@metamask/design-system-react-native": "npm:^0.10.0"
+    "@metamask/design-system-react-native": "npm:^0.11.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.3.0"
     "@metamask/design-tokens": "npm:^8.2.2"
     "@metamask/earn-controller": "npm:^10.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Upgrades `@metamask/design-system-react-native` from `^0.10.0` to `^0.11.0` and deprecates local component-library components that now have design system replacements.

https://github.com/MetaMask/metamask-design-system/releases/tag/v25.0.0

**Why:** The design system monorepo v25.0.0 release (`@metamask/design-system-react-native@0.11.0`) shipped several new components that duplicate functionality currently in `app/component-library/`. Upgrading and marking local equivalents as `@deprecated` guides developers toward the canonical design system implementations and prevents further adoption of the local versions.

**What changed:**

1. **Package upgrade** — `@metamask/design-system-react-native` bumped from `^0.10.0` to `^0.11.0`
2. **Breaking change migration** — `ButtonIcon` `isFloating` boolean prop replaced by `variant` enum in 0.11.0; migrated `InputStepper` to use `ButtonIconVariant.Floating`
3. **10 components deprecated** with `@deprecated` JSDoc following the existing codebase pattern, linking to component READMEs and [migration docs](https://github.com/MetaMask/metamask-design-system/releases):
   - `MainActionButton` (components-temp)
   - `TabEmptyState` (components-temp)
   - `ButtonFilter` (components-temp)
   - `BannerBase` (foundation)
   - `Banner` (union — use `BannerAlert` from DS directly)
   - `BannerAlert` (variant)
   - `BannerTip` (variant — unused, will be removed)
   - `BottomSheet`
   - `BottomSheetDialog` (foundation)
   - `ListItem`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — deprecation annotations are documentation-only changes. The `ButtonIcon` prop migration in `InputStepper` can be verified by navigating to the Bridge input stepper UI.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a shared UI dependency and migrates to a changed `ButtonIcon` API, which could cause subtle UI/regression issues if other call sites rely on previous props or styles. Password handling was also adjusted to be controlled in a couple of sensitive SRP/password-entry screens, so review for unintended behavior changes.
> 
> **Overview**
> Upgrades `@metamask/design-system-react-native` to `0.11.0` (and `@metamask/design-system-shared` to `0.4.0` via lockfile), and updates the Bridge `InputStepper` to the new `ButtonIcon` API by replacing `isFloating` with `variant={ButtonIconVariant.Floating}`.
> 
> Marks multiple in-repo component-library equivalents as **deprecated** via JSDoc (e.g. `Banner`, `BannerBase`, `BottomSheet`, `ListItem`, and several `components-temp` components), pointing developers to the design-system replacements and noting `BannerVariant.Tip`/`BannerTip` as unused and slated for removal.
> 
> Tightens password input control by initializing `ManualBackupStep1` password state to `''` and wiring `RevealPrivateCredential`’s `PasswordEntry` to a new required `password` prop, with corresponding snapshot updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5987809be8b40736c8f5485b08958fdd3b3dce13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->