### PR TITLE
fix: prevent token full-view crash when switching networks

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenList.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenList.test.tsx
@@ -139,6 +139,7 @@ jest.mock('@metamask/design-system-react-native', () => ({
 
 // Mock FlashList
 const mockScrollToIndex = jest.fn();
+const mockRecomputeViewableItems = jest.fn();
 jest.mock('@shopify/flash-list', () => {
   const React = jest.requireActual('react');
   const { FlatList } = jest.requireActual('react-native');
@@ -146,7 +147,7 @@ jest.mock('@shopify/flash-list', () => {
     FlashList: React.forwardRef(
       (props: Record<string, unknown>, ref: React.Ref<unknown>) => {
         React.useImperativeHandle(ref, () => ({
-          recomputeViewableItems: jest.fn(),
+          recomputeViewableItems: mockRecomputeViewableItems,
           scrollToIndex: mockScrollToIndex,
         }));
         return React.createElement(FlatList, { ...props, ref });
@@ -409,6 +410,41 @@ describe('TokenList', () => {
     // This test ensures the component doesn't crash with different prop combinations
     expect(showRemoveMenu).not.toHaveBeenCalled();
     expect(setShowScamWarningModal).not.toHaveBeenCalled();
+  });
+
+  it('does not manually recompute viewable items when network filter changes', () => {
+    let isTokenNetworkFilterEqualCurrentNetwork = true;
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector.toString().includes('selectHomepageRedesignV1Enabled')) {
+        return false;
+      }
+      if (
+        selector
+          .toString()
+          .includes('selectIsTokenNetworkFilterEqualCurrentNetwork')
+      ) {
+        return isTokenNetworkFilterEqualCurrentNetwork;
+      }
+      return selector({});
+    });
+
+    const store = mockStore(initialState);
+    const { rerender } = render(
+      <Provider store={store}>
+        <TokenList {...defaultProps} isFullView />
+      </Provider>,
+    );
+
+    expect(mockRecomputeViewableItems).not.toHaveBeenCalled();
+
+    isTokenNetworkFilterEqualCurrentNetwork = false;
+    rerender(
+      <Provider store={store}>
+        <TokenList {...defaultProps} isFullView />
+      </Provider>,
+    );
+
+    expect(mockRecomputeViewableItems).not.toHaveBeenCalled();
   });
 
   describe('Homepage Redesign V1 Features', () => {

--- a/app/components/UI/Tokens/TokenList/TokenList.test.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenList.test.tsx
@@ -139,7 +139,6 @@ jest.mock('@metamask/design-system-react-native', () => ({
 
 // Mock FlashList
 const mockScrollToIndex = jest.fn();
-const mockRecomputeViewableItems = jest.fn();
 jest.mock('@shopify/flash-list', () => {
   const React = jest.requireActual('react');
   const { FlatList } = jest.requireActual('react-native');
@@ -147,7 +146,7 @@ jest.mock('@shopify/flash-list', () => {
     FlashList: React.forwardRef(
       (props: Record<string, unknown>, ref: React.Ref<unknown>) => {
         React.useImperativeHandle(ref, () => ({
-          recomputeViewableItems: mockRecomputeViewableItems,
+          recomputeViewableItems: jest.fn(),
           scrollToIndex: mockScrollToIndex,
         }));
         return React.createElement(FlatList, { ...props, ref });
@@ -410,41 +409,6 @@ describe('TokenList', () => {
     // This test ensures the component doesn't crash with different prop combinations
     expect(showRemoveMenu).not.toHaveBeenCalled();
     expect(setShowScamWarningModal).not.toHaveBeenCalled();
-  });
-
-  it('does not manually recompute viewable items when network filter changes', () => {
-    let isTokenNetworkFilterEqualCurrentNetwork = true;
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector.toString().includes('selectHomepageRedesignV1Enabled')) {
-        return false;
-      }
-      if (
-        selector
-          .toString()
-          .includes('selectIsTokenNetworkFilterEqualCurrentNetwork')
-      ) {
-        return isTokenNetworkFilterEqualCurrentNetwork;
-      }
-      return selector({});
-    });
-
-    const store = mockStore(initialState);
-    const { rerender } = render(
-      <Provider store={store}>
-        <TokenList {...defaultProps} isFullView />
-      </Provider>,
-    );
-
-    expect(mockRecomputeViewableItems).not.toHaveBeenCalled();
-
-    isTokenNetworkFilterEqualCurrentNetwork = false;
-    rerender(
-      <Provider store={store}>
-        <TokenList {...defaultProps} isFullView />
-      </Provider>,
-    );
-
-    expect(mockRecomputeViewableItems).not.toHaveBeenCalled();
   });
 
   describe('Homepage Redesign V1 Features', () => {

--- a/app/components/UI/Tokens/TokenList/TokenList.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenList.tsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useLayoutEffect,
   useRef,
   useMemo,
   useEffect,
@@ -83,10 +82,6 @@ const TokenListComponent = ({
 
   const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
-
-  useLayoutEffect(() => {
-    listRef.current?.recomputeViewableItems();
-  }, [isTokenNetworkFilterEqualCurrentNetwork]);
 
   // Apply maxItems limit if specified
   const displayTokenKeys = useMemo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What is this about?

Fixes the token full-view crash that occurs when switching networks (ASSETS-2950).

The `TokenList` FlashList already re-renders based on `extraData`, so manually forcing `recomputeViewableItems()` during network-filter changes was unnecessary and could trigger instability during network switches.

## Changelog

CHANGELOG entry: Fixed a crash when switching networks in the full tokens view

## What changed

- Removed `useLayoutEffect` that called `listRef.current?.recomputeViewableItems()` in `TokenList.tsx`.
- Kept FlashList updates driven by existing `extraData` (`isTokenNetworkFilterEqualCurrentNetwork`, `visibleKeys`).
- No new tests were added.

## Testing

- `yarn jest app/components/UI/Tokens/TokenList/TokenList.test.tsx --coverage=false` ✅

## References

- Jira: https://consensyssoftware.atlassian.net/browse/ASSETS-2950
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b85de33-543a-4aea-9ff9-6875557e1f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b85de33-543a-4aea-9ff9-6875557e1f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

