### PR TITLE
feat(card): Card Authentication migration from CardSDK to  CardController

### DIFF
--- a/app/components/UI/Card/hooks/useCardAuth.test.ts
+++ b/app/components/UI/Card/hooks/useCardAuth.test.ts
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import { cardQueries } from '../queries';
 import { useCardAuth } from './useCardAuth';
-import type { CardAuthSession } from '../../../../core/Engine/controllers/card-controller/provider-types';
 
 jest.mock('@tanstack/react-query', () => ({
   useMutation: jest.fn(),
@@ -15,7 +14,7 @@ jest.mock('../../../../core/Engine', () => ({
     CardController: {
       initiateAuth: jest.fn(),
       submitCredentials: jest.fn(),
-      sendOtp: jest.fn(),
+      executeStepAction: jest.fn(),
       logout: jest.fn(),
     },
   },
@@ -34,17 +33,6 @@ const mockController = Engine.context.CardController as jest.Mocked<
 const mockInvalidateQueries = jest.fn();
 const mockRemoveQueries = jest.fn();
 
-const mockSession: CardAuthSession = {
-  id: 'session-1',
-  currentStep: { type: 'email_password' },
-  _metadata: {
-    initiateToken: 'tok',
-    location: 'international',
-    state: 's',
-    codeVerifier: 'cv',
-  },
-};
-
 describe('useCardAuth', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -54,8 +42,6 @@ describe('useCardAuth', () => {
       removeQueries: mockRemoveQueries,
     });
 
-    // Simulate React Query: call mutationFn then onSuccess, so tests flow naturally
-    // through result.current.*.mutateAsync — same pattern as useCardPinToken.test.ts
     mockUseMutation.mockImplementation(
       (opts: {
         mutationFn: (...args: unknown[]) => Promise<unknown>;
@@ -73,15 +59,17 @@ describe('useCardAuth', () => {
     );
   });
 
-  it('session starts as null', () => {
+  it('currentStep starts as email_password', () => {
     const { result } = renderHook(() => useCardAuth());
 
-    expect(result.current.session).toBeNull();
+    expect(result.current.currentStep).toStrictEqual({
+      type: 'email_password',
+    });
   });
 
   describe('initiate', () => {
-    it('calls controller.initiateAuth and sets session on success', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
+    it('calls controller.initiateAuth', async () => {
+      mockController.initiateAuth.mockResolvedValue(undefined);
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
@@ -89,25 +77,11 @@ describe('useCardAuth', () => {
       });
 
       expect(mockController.initiateAuth).toHaveBeenCalledWith('US');
-      expect(result.current.session).toBe(mockSession);
     });
   });
 
   describe('submit', () => {
-    it('throws when session is null', async () => {
-      const { result } = renderHook(() => useCardAuth());
-
-      await expect(
-        result.current.submit.mutateAsync({
-          type: 'email_password',
-          email: 'a@b.com',
-          password: 'p',
-        }),
-      ).rejects.toThrow('No active auth session');
-    });
-
-    it('calls controller.submitCredentials with the active session', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
+    it('calls controller.submitCredentials with credentials', async () => {
       mockController.submitCredentials.mockResolvedValue({
         done: true,
         tokenSet: {} as never,
@@ -115,9 +89,6 @@ describe('useCardAuth', () => {
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
-        await result.current.initiate.mutateAsync('US');
-      });
-      await act(async () => {
         await result.current.submit.mutateAsync({
           type: 'email_password',
           email: 'a@b.com',
@@ -125,27 +96,18 @@ describe('useCardAuth', () => {
         });
       });
 
-      expect(mockController.submitCredentials).toHaveBeenCalledWith(
-        mockSession,
-        {
-          type: 'email_password',
-          email: 'a@b.com',
-          password: 'p',
-        },
-      );
+      expect(mockController.submitCredentials).toHaveBeenCalledWith({
+        type: 'email_password',
+        email: 'a@b.com',
+        password: 'p',
+      });
     });
 
-    it('clears session and invalidates queries on done:true', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
+    it('resets currentStep and invalidates queries on done:true', async () => {
       mockController.submitCredentials.mockResolvedValue({ done: true });
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
-        await result.current.initiate.mutateAsync('US');
-      });
-      expect(result.current.session).toBe(mockSession);
-
-      await act(async () => {
         await result.current.submit.mutateAsync({
           type: 'email_password',
           email: 'a@b.com',
@@ -153,14 +115,15 @@ describe('useCardAuth', () => {
         });
       });
 
-      expect(result.current.session).toBeNull();
+      expect(result.current.currentStep).toStrictEqual({
+        type: 'email_password',
+      });
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
         queryKey: cardQueries.keys.all(),
       });
     });
 
-    it('updates session.currentStep when nextStep is returned', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
+    it('updates currentStep when nextStep is returned', async () => {
       mockController.submitCredentials.mockResolvedValue({
         done: false,
         nextStep: { type: 'otp', destination: '+1555****90' },
@@ -168,9 +131,6 @@ describe('useCardAuth', () => {
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
-        await result.current.initiate.mutateAsync('US');
-      });
-      await act(async () => {
         await result.current.submit.mutateAsync({
           type: 'email_password',
           email: 'a@b.com',
@@ -178,14 +138,13 @@ describe('useCardAuth', () => {
         });
       });
 
-      expect(result.current.session?.currentStep).toStrictEqual({
+      expect(result.current.currentStep).toStrictEqual({
         type: 'otp',
         destination: '+1555****90',
       });
     });
 
-    it('clears session when onboardingRequired is returned', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
+    it('resets currentStep when onboardingRequired is returned', async () => {
       mockController.submitCredentials.mockResolvedValue({
         done: false,
         onboardingRequired: { sessionId: 'ob-1', phase: 'kyc' },
@@ -193,11 +152,6 @@ describe('useCardAuth', () => {
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
-        await result.current.initiate.mutateAsync('US');
-      });
-      expect(result.current.session).toBe(mockSession);
-
-      await act(async () => {
         await result.current.submit.mutateAsync({
           type: 'email_password',
           email: 'a@b.com',
@@ -205,32 +159,22 @@ describe('useCardAuth', () => {
         });
       });
 
-      expect(result.current.session).toBeNull();
+      expect(result.current.currentStep).toStrictEqual({
+        type: 'email_password',
+      });
     });
   });
 
-  describe('sendOtp', () => {
-    it('throws when session is null', async () => {
-      const { result } = renderHook(() => useCardAuth());
-
-      await expect(result.current.sendOtp.mutateAsync()).rejects.toThrow(
-        'No active auth session',
-      );
-    });
-
-    it('calls controller.sendOtp with the active session', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
-      mockController.sendOtp.mockResolvedValue(undefined);
+  describe('stepAction', () => {
+    it('calls controller.executeStepAction', async () => {
+      mockController.executeStepAction.mockResolvedValue(undefined);
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
-        await result.current.initiate.mutateAsync('US');
-      });
-      await act(async () => {
-        await result.current.sendOtp.mutateAsync();
+        await result.current.stepAction.mutateAsync();
       });
 
-      expect(mockController.sendOtp).toHaveBeenCalledWith(mockSession);
+      expect(mockController.executeStepAction).toHaveBeenCalled();
     });
   });
 
@@ -246,21 +190,33 @@ describe('useCardAuth', () => {
       expect(mockController.logout).toHaveBeenCalled();
     });
 
-    it('clears session and removes queries on success', async () => {
-      mockController.initiateAuth.mockResolvedValue(mockSession);
+    it('resets currentStep and removes queries on success', async () => {
+      mockController.submitCredentials.mockResolvedValue({
+        done: false,
+        nextStep: { type: 'otp', destination: '+1555****90' },
+      });
       mockController.logout.mockResolvedValue(undefined);
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {
-        await result.current.initiate.mutateAsync('US');
+        await result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        });
       });
-      expect(result.current.session).toBe(mockSession);
+      expect(result.current.currentStep).toStrictEqual({
+        type: 'otp',
+        destination: '+1555****90',
+      });
 
       await act(async () => {
         await result.current.logout.mutateAsync();
       });
 
-      expect(result.current.session).toBeNull();
+      expect(result.current.currentStep).toStrictEqual({
+        type: 'email_password',
+      });
       expect(mockRemoveQueries).toHaveBeenCalledWith({
         queryKey: cardQueries.keys.all(),
       });

--- a/app/components/UI/Card/hooks/useCardAuth.test.ts
+++ b/app/components/UI/Card/hooks/useCardAuth.test.ts
@@ -67,6 +67,13 @@ describe('useCardAuth', () => {
     });
   });
 
+  it('exposes getErrorMessage for displaying auth errors', () => {
+    const { result } = renderHook(() => useCardAuth());
+
+    expect(result.current.getErrorMessage).toBeDefined();
+    expect(typeof result.current.getErrorMessage).toBe('function');
+  });
+
   describe('initiate', () => {
     it('calls controller.initiateAuth', async () => {
       mockController.initiateAuth.mockResolvedValue(undefined);
@@ -149,6 +156,23 @@ describe('useCardAuth', () => {
         done: false,
         onboardingRequired: { sessionId: 'ob-1', phase: 'kyc' },
       });
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        });
+      });
+
+      expect(result.current.currentStep).toStrictEqual({
+        type: 'email_password',
+      });
+    });
+
+    it('resets currentStep when done:false without nextStep or onboardingRequired', async () => {
+      mockController.submitCredentials.mockResolvedValue({ done: false });
       const { result } = renderHook(() => useCardAuth());
 
       await act(async () => {

--- a/app/components/UI/Card/hooks/useCardAuth.test.ts
+++ b/app/components/UI/Card/hooks/useCardAuth.test.ts
@@ -1,0 +1,269 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import { cardQueries } from '../queries';
+import { useCardAuth } from './useCardAuth';
+import type { CardAuthSession } from '../../../../core/Engine/controllers/card-controller/provider-types';
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: jest.fn(),
+  useQueryClient: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    CardController: {
+      initiateAuth: jest.fn(),
+      submitCredentials: jest.fn(),
+      sendOtp: jest.fn(),
+      logout: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+const mockUseMutation = useMutation as jest.Mock;
+const mockUseQueryClient = useQueryClient as jest.Mock;
+const mockController = Engine.context.CardController as jest.Mocked<
+  typeof Engine.context.CardController
+>;
+
+const mockInvalidateQueries = jest.fn();
+const mockRemoveQueries = jest.fn();
+
+const mockSession: CardAuthSession = {
+  id: 'session-1',
+  currentStep: { type: 'email_password' },
+  _metadata: {
+    initiateToken: 'tok',
+    location: 'international',
+    state: 's',
+    codeVerifier: 'cv',
+  },
+};
+
+describe('useCardAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseQueryClient.mockReturnValue({
+      invalidateQueries: mockInvalidateQueries,
+      removeQueries: mockRemoveQueries,
+    });
+
+    // Simulate React Query: call mutationFn then onSuccess, so tests flow naturally
+    // through result.current.*.mutateAsync — same pattern as useCardPinToken.test.ts
+    mockUseMutation.mockImplementation(
+      (opts: {
+        mutationFn: (...args: unknown[]) => Promise<unknown>;
+        onSuccess?: (result: unknown) => void;
+      }) => ({
+        mutateAsync: jest.fn(async (...args: unknown[]) => {
+          const res = await opts.mutationFn(...args);
+          opts.onSuccess?.(res);
+          return res;
+        }),
+        isPending: false,
+        error: null,
+        data: null,
+      }),
+    );
+  });
+
+  it('session starts as null', () => {
+    const { result } = renderHook(() => useCardAuth());
+
+    expect(result.current.session).toBeNull();
+  });
+
+  describe('initiate', () => {
+    it('calls controller.initiateAuth and sets session on success', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+
+      expect(mockController.initiateAuth).toHaveBeenCalledWith('US');
+      expect(result.current.session).toBe(mockSession);
+    });
+  });
+
+  describe('submit', () => {
+    it('throws when session is null', async () => {
+      const { result } = renderHook(() => useCardAuth());
+
+      await expect(
+        result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        }),
+      ).rejects.toThrow('No active auth session');
+    });
+
+    it('calls controller.submitCredentials with the active session', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      mockController.submitCredentials.mockResolvedValue({
+        done: true,
+        tokenSet: {} as never,
+      });
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+      await act(async () => {
+        await result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        });
+      });
+
+      expect(mockController.submitCredentials).toHaveBeenCalledWith(
+        mockSession,
+        {
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        },
+      );
+    });
+
+    it('clears session and invalidates queries on done:true', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      mockController.submitCredentials.mockResolvedValue({ done: true });
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+      expect(result.current.session).toBe(mockSession);
+
+      await act(async () => {
+        await result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        });
+      });
+
+      expect(result.current.session).toBeNull();
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: cardQueries.keys.all(),
+      });
+    });
+
+    it('updates session.currentStep when nextStep is returned', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      mockController.submitCredentials.mockResolvedValue({
+        done: false,
+        nextStep: { type: 'otp', destination: '+1555****90' },
+      });
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+      await act(async () => {
+        await result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        });
+      });
+
+      expect(result.current.session?.currentStep).toStrictEqual({
+        type: 'otp',
+        destination: '+1555****90',
+      });
+    });
+
+    it('clears session when onboardingRequired is returned', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      mockController.submitCredentials.mockResolvedValue({
+        done: false,
+        onboardingRequired: { sessionId: 'ob-1', phase: 'kyc' },
+      });
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+      expect(result.current.session).toBe(mockSession);
+
+      await act(async () => {
+        await result.current.submit.mutateAsync({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'p',
+        });
+      });
+
+      expect(result.current.session).toBeNull();
+    });
+  });
+
+  describe('sendOtp', () => {
+    it('throws when session is null', async () => {
+      const { result } = renderHook(() => useCardAuth());
+
+      await expect(result.current.sendOtp.mutateAsync()).rejects.toThrow(
+        'No active auth session',
+      );
+    });
+
+    it('calls controller.sendOtp with the active session', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      mockController.sendOtp.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+      await act(async () => {
+        await result.current.sendOtp.mutateAsync();
+      });
+
+      expect(mockController.sendOtp).toHaveBeenCalledWith(mockSession);
+    });
+  });
+
+  describe('logout', () => {
+    it('calls controller.logout', async () => {
+      mockController.logout.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.logout.mutateAsync();
+      });
+
+      expect(mockController.logout).toHaveBeenCalled();
+    });
+
+    it('clears session and removes queries on success', async () => {
+      mockController.initiateAuth.mockResolvedValue(mockSession);
+      mockController.logout.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useCardAuth());
+
+      await act(async () => {
+        await result.current.initiate.mutateAsync('US');
+      });
+      expect(result.current.session).toBe(mockSession);
+
+      await act(async () => {
+        await result.current.logout.mutateAsync();
+      });
+
+      expect(result.current.session).toBeNull();
+      expect(mockRemoveQueries).toHaveBeenCalledWith({
+        queryKey: cardQueries.keys.all(),
+      });
+    });
+  });
+});

--- a/app/components/UI/Card/hooks/useCardAuth.ts
+++ b/app/components/UI/Card/hooks/useCardAuth.ts
@@ -6,6 +6,7 @@ import {
   CardAuthStep,
   CardCredentials,
 } from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { getCardProviderErrorMessage } from '../util/getCardProviderErrorMessage';
 
 function getController() {
   const controller = Engine.context?.CardController;
@@ -39,6 +40,9 @@ export const useCardAuth = () => {
         }
       } else if (result.nextStep) {
         setCurrentStep(result.nextStep);
+      } else {
+        // Controller cleared session (done:false without nextStep/onboardingRequired)
+        setCurrentStep(LOGIN_STEP);
       }
     },
     retry: false,
@@ -66,5 +70,6 @@ export const useCardAuth = () => {
     submit,
     stepAction,
     logout,
+    getErrorMessage: getCardProviderErrorMessage,
   };
 };

--- a/app/components/UI/Card/hooks/useCardAuth.ts
+++ b/app/components/UI/Card/hooks/useCardAuth.ts
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import { cardQueries } from '../queries';
+import {
+  CardAuthSession,
+  CardAuthStep,
+  CardCredentials,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+
+function getController() {
+  const controller = Engine.context?.CardController;
+  if (!controller) {
+    throw new Error('CardController not initialized');
+  }
+  return controller;
+}
+
+export const useCardAuth = () => {
+  const queryClient = useQueryClient();
+  const [session, setSession] = useState<CardAuthSession | null>(null);
+
+  const initiate = useMutation({
+    mutationKey: cardQueries.auth.keys.initiate(),
+    mutationFn: (country: string) => getController().initiateAuth(country),
+    onSuccess: (newSession) => setSession(newSession),
+    retry: false,
+  });
+
+  const submit = useMutation({
+    mutationKey: cardQueries.auth.keys.submit(),
+    mutationFn: (credentials: CardCredentials) => {
+      if (!session) {
+        throw new Error('No active auth session — call initiate first');
+      }
+      return getController().submitCredentials(session, credentials);
+    },
+    onSuccess: (result) => {
+      if (result.done) {
+        setSession(null);
+        queryClient.invalidateQueries({ queryKey: cardQueries.keys.all() });
+      } else if (result.nextStep) {
+        setSession((s) =>
+          s ? { ...s, currentStep: result?.nextStep as CardAuthStep } : null,
+        );
+      }
+      if (result.onboardingRequired) {
+        setSession(null);
+      }
+    },
+    retry: false,
+  });
+
+  const sendOtp = useMutation({
+    mutationKey: cardQueries.auth.keys.sendOtp(),
+    mutationFn: () => {
+      if (!session) {
+        throw new Error('No active auth session');
+      }
+      return getController().sendOtp(session);
+    },
+    retry: false,
+  });
+
+  const logout = useMutation({
+    mutationKey: cardQueries.auth.keys.logout(),
+    mutationFn: () => getController().logout(),
+    onSuccess: () => {
+      setSession(null);
+      queryClient.removeQueries({ queryKey: cardQueries.keys.all() });
+    },
+    retry: false,
+  });
+
+  return {
+    session,
+    initiate,
+    submit,
+    sendOtp,
+    logout,
+  };
+};

--- a/app/components/UI/Card/hooks/useCardAuth.ts
+++ b/app/components/UI/Card/hooks/useCardAuth.ts
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import { cardQueries } from '../queries';
 import {
-  CardAuthSession,
   CardAuthStep,
   CardCredentials,
 } from '../../../../core/Engine/controllers/card-controller/provider-types';
@@ -16,49 +15,38 @@ function getController() {
   return controller;
 }
 
+const LOGIN_STEP: CardAuthStep = { type: 'email_password' };
+
 export const useCardAuth = () => {
   const queryClient = useQueryClient();
-  const [session, setSession] = useState<CardAuthSession | null>(null);
+  const [currentStep, setCurrentStep] = useState<CardAuthStep>(LOGIN_STEP);
 
   const initiate = useMutation({
     mutationKey: cardQueries.auth.keys.initiate(),
     mutationFn: (country: string) => getController().initiateAuth(country),
-    onSuccess: (newSession) => setSession(newSession),
     retry: false,
   });
 
   const submit = useMutation({
     mutationKey: cardQueries.auth.keys.submit(),
-    mutationFn: (credentials: CardCredentials) => {
-      if (!session) {
-        throw new Error('No active auth session — call initiate first');
-      }
-      return getController().submitCredentials(session, credentials);
-    },
+    mutationFn: (credentials: CardCredentials) =>
+      getController().submitCredentials(credentials),
     onSuccess: (result) => {
-      if (result.done) {
-        setSession(null);
-        queryClient.invalidateQueries({ queryKey: cardQueries.keys.all() });
+      if (result.done || result.onboardingRequired) {
+        setCurrentStep(LOGIN_STEP);
+        if (result.done) {
+          queryClient.invalidateQueries({ queryKey: cardQueries.keys.all() });
+        }
       } else if (result.nextStep) {
-        setSession((s) =>
-          s ? { ...s, currentStep: result?.nextStep as CardAuthStep } : null,
-        );
-      }
-      if (result.onboardingRequired) {
-        setSession(null);
+        setCurrentStep(result.nextStep);
       }
     },
     retry: false,
   });
 
-  const sendOtp = useMutation({
-    mutationKey: cardQueries.auth.keys.sendOtp(),
-    mutationFn: () => {
-      if (!session) {
-        throw new Error('No active auth session');
-      }
-      return getController().sendOtp(session);
-    },
+  const stepAction = useMutation({
+    mutationKey: cardQueries.auth.keys.stepAction(),
+    mutationFn: () => getController().executeStepAction(),
     retry: false,
   });
 
@@ -66,17 +54,17 @@ export const useCardAuth = () => {
     mutationKey: cardQueries.auth.keys.logout(),
     mutationFn: () => getController().logout(),
     onSuccess: () => {
-      setSession(null);
+      setCurrentStep(LOGIN_STEP);
       queryClient.removeQueries({ queryKey: cardQueries.keys.all() });
     },
     retry: false,
   });
 
   return {
-    session,
+    currentStep,
     initiate,
     submit,
-    sendOtp,
+    stepAction,
     logout,
   };
 };

--- a/app/components/UI/Card/queries/auth.ts
+++ b/app/components/UI/Card/queries/auth.ts
@@ -2,6 +2,6 @@ export const authKeys = {
   all: () => ['card', 'auth'] as const,
   initiate: () => [...authKeys.all(), 'initiate'] as const,
   submit: () => [...authKeys.all(), 'submit'] as const,
-  sendOtp: () => [...authKeys.all(), 'otp'] as const,
+  stepAction: () => [...authKeys.all(), 'step-action'] as const,
   logout: () => [...authKeys.all(), 'logout'] as const,
 };

--- a/app/components/UI/Card/queries/auth.ts
+++ b/app/components/UI/Card/queries/auth.ts
@@ -1,0 +1,7 @@
+export const authKeys = {
+  all: () => ['card', 'auth'] as const,
+  initiate: () => [...authKeys.all(), 'initiate'] as const,
+  submit: () => [...authKeys.all(), 'submit'] as const,
+  sendOtp: () => [...authKeys.all(), 'otp'] as const,
+  logout: () => [...authKeys.all(), 'logout'] as const,
+};

--- a/app/components/UI/Card/queries/index.ts
+++ b/app/components/UI/Card/queries/index.ts
@@ -5,6 +5,7 @@ import {
   cashbackWithdrawEstimationOptions,
 } from './cashback';
 import { dashboardKeys } from './dashboard';
+import { authKeys } from './auth';
 
 export const cardQueries = {
   keys: {
@@ -21,5 +22,8 @@ export const cardQueries = {
     keys: cashbackKeys,
     walletOptions: cashbackWalletOptions,
     withdrawEstimationOptions: cashbackWithdrawEstimationOptions,
+  },
+  auth: {
+    keys: authKeys,
   },
 };

--- a/app/components/UI/Card/util/getCardProviderErrorMessage.test.ts
+++ b/app/components/UI/Card/util/getCardProviderErrorMessage.test.ts
@@ -1,0 +1,117 @@
+import { getCardProviderErrorMessage } from './getCardProviderErrorMessage';
+import {
+  CardProviderError,
+  CardProviderErrorCode,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { strings } from '../../../../../locales/i18n';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn(),
+}));
+
+const mockStrings = strings as jest.MockedFunction<typeof strings>;
+
+describe('getCardProviderErrorMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStrings.mockImplementation((key: string) => `mocked_${key}`);
+  });
+
+  describe('CardProviderError handling', () => {
+    const cardProviderErrorTestCases = [
+      {
+        code: CardProviderErrorCode.InvalidCredentials,
+        expectedStringKey:
+          'card.card_authentication.errors.invalid_credentials',
+        description: 'InvalidCredentials',
+      },
+      {
+        code: CardProviderErrorCode.InvalidOtp,
+        expectedStringKey: 'card.card_authentication.errors.invalid_otp_code',
+        description: 'InvalidOtp',
+      },
+      {
+        code: CardProviderErrorCode.Network,
+        expectedStringKey: 'card.card_authentication.errors.network_error',
+        description: 'Network',
+      },
+      {
+        code: CardProviderErrorCode.Timeout,
+        expectedStringKey: 'card.card_authentication.errors.timeout_error',
+        description: 'Timeout',
+      },
+      {
+        code: CardProviderErrorCode.ServerError,
+        expectedStringKey: 'card.card_authentication.errors.server_error',
+        description: 'ServerError',
+      },
+      {
+        code: CardProviderErrorCode.Unknown,
+        expectedStringKey: 'card.card_authentication.errors.unknown_error',
+        description: 'Unknown',
+      },
+    ] as const;
+
+    it.each(cardProviderErrorTestCases)(
+      'returns correct localized message for $description',
+      ({ code, expectedStringKey }) => {
+        const error = new CardProviderError(code, 'Test error message');
+
+        const result = getCardProviderErrorMessage(error);
+
+        expect(mockStrings).toHaveBeenCalledWith(expectedStringKey);
+        expect(result).toBe(`mocked_${expectedStringKey}`);
+      },
+    );
+
+    it('returns original message for AccountDisabled', () => {
+      const customMessage = 'Account has been disabled';
+      const error = new CardProviderError(
+        CardProviderErrorCode.AccountDisabled,
+        customMessage,
+      );
+
+      const result = getCardProviderErrorMessage(error);
+
+      expect(mockStrings).not.toHaveBeenCalled();
+      expect(result).toBe(customMessage);
+    });
+  });
+
+  describe('Non-CardProviderError handling', () => {
+    it('returns unknown error for generic Error', () => {
+      const error = new Error('Generic error');
+
+      const result = getCardProviderErrorMessage(error);
+
+      expect(mockStrings).toHaveBeenCalledWith(
+        'card.card_authentication.errors.unknown_error',
+      );
+      expect(result).toBe(
+        'mocked_card.card_authentication.errors.unknown_error',
+      );
+    });
+
+    it('returns unknown error for null', () => {
+      const result = getCardProviderErrorMessage(null);
+
+      expect(mockStrings).toHaveBeenCalledWith(
+        'card.card_authentication.errors.unknown_error',
+      );
+      expect(result).toBe(
+        'mocked_card.card_authentication.errors.unknown_error',
+      );
+    });
+
+    it('returns unknown error for undefined', () => {
+      const result = getCardProviderErrorMessage(undefined);
+
+      expect(mockStrings).toHaveBeenCalledWith(
+        'card.card_authentication.errors.unknown_error',
+      );
+      expect(result).toBe(
+        'mocked_card.card_authentication.errors.unknown_error',
+      );
+    });
+  });
+});

--- a/app/components/UI/Card/util/getCardProviderErrorMessage.ts
+++ b/app/components/UI/Card/util/getCardProviderErrorMessage.ts
@@ -1,0 +1,27 @@
+import { strings } from '../../../../../locales/i18n';
+import {
+  CardProviderError,
+  CardProviderErrorCode,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+
+export function getCardProviderErrorMessage(err: unknown): string {
+  if (err instanceof CardProviderError) {
+    switch (err.code) {
+      case CardProviderErrorCode.InvalidCredentials:
+        return strings('card.card_authentication.errors.invalid_credentials');
+      case CardProviderErrorCode.AccountDisabled:
+        return err.message;
+      case CardProviderErrorCode.InvalidOtp:
+        return strings('card.card_authentication.errors.invalid_otp_code');
+      case CardProviderErrorCode.Network:
+        return strings('card.card_authentication.errors.network_error');
+      case CardProviderErrorCode.Timeout:
+        return strings('card.card_authentication.errors.timeout_error');
+      case CardProviderErrorCode.ServerError:
+        return strings('card.card_authentication.errors.server_error');
+      default:
+        return strings('card.card_authentication.errors.unknown_error');
+    }
+  }
+  return strings('card.card_authentication.errors.unknown_error');
+}

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -31,7 +31,7 @@ function buildMockProvider(
     capabilities: {} as ICardProvider['capabilities'],
     initiateAuth: jest.fn(),
     submitCredentials: jest.fn(),
-    sendOtp: jest.fn(),
+    executeStepAction: jest.fn(),
     refreshTokens: jest.fn(),
     validateTokens: jest.fn(),
     logout: jest.fn(),
@@ -116,7 +116,7 @@ describe('CardController', () => {
     });
 
     expect(controller.state.selectedCountry).toBe('GB');
-    expect(controller.state.activeProviderId).toBeNull();
+    expect(controller.state.activeProviderId).toBe('baanx');
     expect(controller.state.isAuthenticated).toBe(false);
     expect(controller.state.cardholderAccounts).toStrictEqual([]);
     expect(controller.state.providerData).toStrictEqual({});
@@ -152,15 +152,17 @@ describe('CardController — auth methods', () => {
   });
 
   describe('initiateAuth', () => {
-    it('delegates to the active provider and returns the session', async () => {
+    it('delegates to the active provider and stores the session internally', async () => {
       const provider = buildMockProvider();
       provider.initiateAuth.mockResolvedValue(mockSession);
       const controller = buildController(provider);
 
-      const result = await controller.initiateAuth('US');
+      await controller.initiateAuth('US');
 
       expect(provider.initiateAuth).toHaveBeenCalledWith('US');
-      expect(result).toBe(mockSession);
+      expect(controller.getCurrentAuthStep()).toStrictEqual(
+        mockSession.currentStep,
+      );
     });
 
     it('throws CardProviderError when there is no active provider', async () => {
@@ -177,8 +179,22 @@ describe('CardController — auth methods', () => {
   });
 
   describe('submitCredentials', () => {
+    it('throws when no session has been initiated', async () => {
+      const provider = buildMockProvider();
+      const controller = buildController(provider);
+
+      await expect(
+        controller.submitCredentials({
+          type: 'email_password',
+          email: 'a@b.com',
+          password: 'pass',
+        }),
+      ).rejects.toMatchObject({ code: CardProviderErrorCode.Unknown });
+    });
+
     it('stores tokens, sets isAuthenticated and providerData on done:true', async () => {
       const provider = buildMockProvider();
+      provider.initiateAuth.mockResolvedValue(mockSession);
       provider.submitCredentials.mockResolvedValue({
         done: true,
         tokenSet: mockTokenSet,
@@ -186,7 +202,8 @@ describe('CardController — auth methods', () => {
       mockTokenStore.set.mockResolvedValue(true);
       const controller = buildController(provider);
 
-      const result = await controller.submitCredentials(mockSession, {
+      await controller.initiateAuth('US');
+      const result = await controller.submitCredentials({
         type: 'email_password',
         email: 'a@b.com',
         password: 'pass',
@@ -202,6 +219,7 @@ describe('CardController — auth methods', () => {
 
     it('still sets isAuthenticated when token store write fails', async () => {
       const provider = buildMockProvider();
+      provider.initiateAuth.mockResolvedValue(mockSession);
       provider.submitCredentials.mockResolvedValue({
         done: true,
         tokenSet: mockTokenSet,
@@ -209,7 +227,8 @@ describe('CardController — auth methods', () => {
       mockTokenStore.set.mockResolvedValue(false);
       const controller = buildController(provider);
 
-      await controller.submitCredentials(mockSession, {
+      await controller.initiateAuth('US');
+      await controller.submitCredentials({
         type: 'email_password',
         email: 'a@b.com',
         password: 'pass',
@@ -218,15 +237,17 @@ describe('CardController — auth methods', () => {
       expect(controller.state.isAuthenticated).toBe(true);
     });
 
-    it('does not set isAuthenticated when OTP step is required', async () => {
+    it('updates currentSession step when OTP step is required', async () => {
       const provider = buildMockProvider();
+      provider.initiateAuth.mockResolvedValue(mockSession);
       provider.submitCredentials.mockResolvedValue({
         done: false,
         nextStep: { type: 'otp', destination: '+1555****90' },
       });
       const controller = buildController(provider);
 
-      const result = await controller.submitCredentials(mockSession, {
+      await controller.initiateAuth('US');
+      const result = await controller.submitCredentials({
         type: 'email_password',
         email: 'a@b.com',
         password: 'pass',
@@ -234,17 +255,23 @@ describe('CardController — auth methods', () => {
 
       expect(controller.state.isAuthenticated).toBe(false);
       expect(result.done).toBe(false);
+      expect(controller.getCurrentAuthStep()).toStrictEqual({
+        type: 'otp',
+        destination: '+1555****90',
+      });
     });
 
-    it('does not set isAuthenticated when onboarding is required', async () => {
+    it('clears session when onboarding is required', async () => {
       const provider = buildMockProvider();
+      provider.initiateAuth.mockResolvedValue(mockSession);
       provider.submitCredentials.mockResolvedValue({
         done: false,
         onboardingRequired: { sessionId: 'ob-session', phase: 'kyc' },
       });
       const controller = buildController(provider);
 
-      const result = await controller.submitCredentials(mockSession, {
+      await controller.initiateAuth('US');
+      const result = await controller.submitCredentials({
         type: 'email_password',
         email: 'a@b.com',
         password: 'pass',
@@ -252,44 +279,39 @@ describe('CardController — auth methods', () => {
 
       expect(controller.state.isAuthenticated).toBe(false);
       expect(result.onboardingRequired?.phase).toBe('kyc');
+      expect(controller.getCurrentAuthStep()).toBeNull();
     });
   });
 
-  describe('sendOtp', () => {
-    it('delegates to the provider when session has otpUserId', async () => {
-      const provider = buildMockProvider();
-      (provider.sendOtp as jest.Mock).mockResolvedValue(undefined);
-      const sessionWithOtp: CardAuthSession = {
-        ...mockSession,
-        _metadata: { ...mockSession._metadata, otpUserId: 'user-42' },
-      };
-      const controller = buildController(provider);
-
-      await controller.sendOtp(sessionWithOtp);
-
-      expect(provider.sendOtp).toHaveBeenCalledWith(sessionWithOtp);
-    });
-
-    it('throws CardProviderError when session is missing otpUserId', async () => {
+  describe('executeStepAction', () => {
+    it('throws when no session has been initiated', async () => {
       const provider = buildMockProvider();
       const controller = buildController(provider);
 
-      await expect(controller.sendOtp(mockSession)).rejects.toMatchObject({
+      await expect(controller.executeStepAction()).rejects.toMatchObject({
         code: CardProviderErrorCode.Unknown,
       });
     });
 
-    it('throws CardProviderError when provider does not support OTP', async () => {
-      const provider = buildMockProvider({ sendOtp: undefined });
-      const sessionWithOtp: CardAuthSession = {
-        ...mockSession,
-        _metadata: { ...mockSession._metadata, otpUserId: 'user-42' },
-      };
+    it('delegates to the provider with the current session', async () => {
+      const provider = buildMockProvider();
+      provider.initiateAuth.mockResolvedValue(mockSession);
+      (provider.executeStepAction as jest.Mock).mockResolvedValue(undefined);
       const controller = buildController(provider);
 
-      await expect(controller.sendOtp(sessionWithOtp)).rejects.toMatchObject({
-        code: CardProviderErrorCode.Unknown,
-      });
+      await controller.initiateAuth('US');
+      await controller.executeStepAction();
+
+      expect(provider.executeStepAction).toHaveBeenCalledWith(mockSession);
+    });
+
+    it('is a no-op when the provider does not implement executeStepAction', async () => {
+      const provider = buildMockProvider({ executeStepAction: undefined });
+      provider.initiateAuth.mockResolvedValue(mockSession);
+      const controller = buildController(provider);
+
+      await controller.initiateAuth('US');
+      await expect(controller.executeStepAction()).resolves.toBeUndefined();
     });
   });
 

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -1,6 +1,19 @@
 import { Messenger } from '@metamask/messenger';
 import { CardController, defaultCardControllerState } from './CardController';
 import { type CardControllerActions, type CardControllerEvents } from './types';
+import {
+  CardProviderError,
+  CardProviderErrorCode,
+  type ICardProvider,
+  type CardAuthSession,
+  type CardAuthTokens,
+} from './provider-types';
+import { CardTokenStore } from './CardTokenStore';
+
+jest.mock('./CardTokenStore');
+jest.mock('../../../../util/Logger');
+
+const mockTokenStore = CardTokenStore as jest.Mocked<typeof CardTokenStore>;
 
 function buildMessenger() {
   return new Messenger<
@@ -10,10 +23,64 @@ function buildMessenger() {
   >({ namespace: 'CardController' });
 }
 
+function buildMockProvider(
+  overrides: Partial<ICardProvider> = {},
+): jest.Mocked<ICardProvider> {
+  return {
+    id: 'baanx',
+    capabilities: {} as ICardProvider['capabilities'],
+    initiateAuth: jest.fn(),
+    submitCredentials: jest.fn(),
+    sendOtp: jest.fn(),
+    refreshTokens: jest.fn(),
+    validateTokens: jest.fn(),
+    logout: jest.fn(),
+    getCardHomeData: jest.fn(),
+    getCardDetails: jest.fn(),
+    freezeCard: jest.fn(),
+    unfreezeCard: jest.fn(),
+    ...overrides,
+  } as jest.Mocked<ICardProvider>;
+}
+
+function buildController(
+  provider: ICardProvider,
+  stateOverrides: Partial<typeof defaultCardControllerState> = {},
+) {
+  return new CardController({
+    messenger: buildMessenger(),
+    providers: { baanx: provider },
+    state: {
+      activeProviderId: 'baanx',
+      ...stateOverrides,
+    },
+  });
+}
+
+const mockSession: CardAuthSession = {
+  id: 'session-1',
+  currentStep: { type: 'email_password' },
+  _metadata: {
+    initiateToken: 'tok',
+    location: 'international',
+    state: 's',
+    codeVerifier: 'cv',
+  },
+};
+
+const mockTokenSet: CardAuthTokens = {
+  accessToken: 'at',
+  refreshToken: 'rt',
+  accessTokenExpiresAt: Date.now() + 3_600_000,
+  refreshTokenExpiresAt: Date.now() + 86_400_000,
+  location: 'international',
+};
+
 describe('CardController', () => {
   it('initializes with default state when no state is provided', () => {
     const controller = new CardController({
       messenger: buildMessenger(),
+      providers: {},
     });
 
     expect(controller.state).toStrictEqual(defaultCardControllerState);
@@ -22,6 +89,7 @@ describe('CardController', () => {
   it('initializes with provided state merged over defaults', () => {
     const controller = new CardController({
       messenger: buildMessenger(),
+      providers: {},
       state: {
         selectedCountry: 'US',
         activeProviderId: 'baanx',
@@ -41,6 +109,7 @@ describe('CardController', () => {
   it('preserves default values for fields not in partial state', () => {
     const controller = new CardController({
       messenger: buildMessenger(),
+      providers: {},
       state: {
         selectedCountry: 'GB',
       },
@@ -56,6 +125,7 @@ describe('CardController', () => {
   it('initializes with full persisted state including providerData', () => {
     const controller = new CardController({
       messenger: buildMessenger(),
+      providers: {},
       state: {
         selectedCountry: 'US',
         activeProviderId: 'baanx',
@@ -72,6 +142,274 @@ describe('CardController', () => {
     ]);
     expect(controller.state.providerData).toStrictEqual({
       baanx: { location: 'us' },
+    });
+  });
+});
+
+describe('CardController — auth methods', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initiateAuth', () => {
+    it('delegates to the active provider and returns the session', async () => {
+      const provider = buildMockProvider();
+      provider.initiateAuth.mockResolvedValue(mockSession);
+      const controller = buildController(provider);
+
+      const result = await controller.initiateAuth('US');
+
+      expect(provider.initiateAuth).toHaveBeenCalledWith('US');
+      expect(result).toBe(mockSession);
+    });
+
+    it('throws CardProviderError when there is no active provider', async () => {
+      const controller = new CardController({
+        messenger: buildMessenger(),
+        providers: {},
+        state: { activeProviderId: null },
+      });
+
+      await expect(controller.initiateAuth('US')).rejects.toBeInstanceOf(
+        CardProviderError,
+      );
+    });
+  });
+
+  describe('submitCredentials', () => {
+    it('stores tokens, sets isAuthenticated and providerData on done:true', async () => {
+      const provider = buildMockProvider();
+      provider.submitCredentials.mockResolvedValue({
+        done: true,
+        tokenSet: mockTokenSet,
+      });
+      mockTokenStore.set.mockResolvedValue(true);
+      const controller = buildController(provider);
+
+      const result = await controller.submitCredentials(mockSession, {
+        type: 'email_password',
+        email: 'a@b.com',
+        password: 'pass',
+      });
+
+      expect(mockTokenStore.set).toHaveBeenCalledWith('baanx', mockTokenSet);
+      expect(controller.state.isAuthenticated).toBe(true);
+      expect(controller.state.providerData.baanx).toStrictEqual({
+        location: 'international',
+      });
+      expect(result.done).toBe(true);
+    });
+
+    it('still sets isAuthenticated when token store write fails', async () => {
+      const provider = buildMockProvider();
+      provider.submitCredentials.mockResolvedValue({
+        done: true,
+        tokenSet: mockTokenSet,
+      });
+      mockTokenStore.set.mockResolvedValue(false);
+      const controller = buildController(provider);
+
+      await controller.submitCredentials(mockSession, {
+        type: 'email_password',
+        email: 'a@b.com',
+        password: 'pass',
+      });
+
+      expect(controller.state.isAuthenticated).toBe(true);
+    });
+
+    it('does not set isAuthenticated when OTP step is required', async () => {
+      const provider = buildMockProvider();
+      provider.submitCredentials.mockResolvedValue({
+        done: false,
+        nextStep: { type: 'otp', destination: '+1555****90' },
+      });
+      const controller = buildController(provider);
+
+      const result = await controller.submitCredentials(mockSession, {
+        type: 'email_password',
+        email: 'a@b.com',
+        password: 'pass',
+      });
+
+      expect(controller.state.isAuthenticated).toBe(false);
+      expect(result.done).toBe(false);
+    });
+
+    it('does not set isAuthenticated when onboarding is required', async () => {
+      const provider = buildMockProvider();
+      provider.submitCredentials.mockResolvedValue({
+        done: false,
+        onboardingRequired: { sessionId: 'ob-session', phase: 'kyc' },
+      });
+      const controller = buildController(provider);
+
+      const result = await controller.submitCredentials(mockSession, {
+        type: 'email_password',
+        email: 'a@b.com',
+        password: 'pass',
+      });
+
+      expect(controller.state.isAuthenticated).toBe(false);
+      expect(result.onboardingRequired?.phase).toBe('kyc');
+    });
+  });
+
+  describe('sendOtp', () => {
+    it('delegates to the provider when session has otpUserId', async () => {
+      const provider = buildMockProvider();
+      (provider.sendOtp as jest.Mock).mockResolvedValue(undefined);
+      const sessionWithOtp: CardAuthSession = {
+        ...mockSession,
+        _metadata: { ...mockSession._metadata, otpUserId: 'user-42' },
+      };
+      const controller = buildController(provider);
+
+      await controller.sendOtp(sessionWithOtp);
+
+      expect(provider.sendOtp).toHaveBeenCalledWith(sessionWithOtp);
+    });
+
+    it('throws CardProviderError when session is missing otpUserId', async () => {
+      const provider = buildMockProvider();
+      const controller = buildController(provider);
+
+      await expect(controller.sendOtp(mockSession)).rejects.toMatchObject({
+        code: CardProviderErrorCode.Unknown,
+      });
+    });
+
+    it('throws CardProviderError when provider does not support OTP', async () => {
+      const provider = buildMockProvider({ sendOtp: undefined });
+      const sessionWithOtp: CardAuthSession = {
+        ...mockSession,
+        _metadata: { ...mockSession._metadata, otpUserId: 'user-42' },
+      };
+      const controller = buildController(provider);
+
+      await expect(controller.sendOtp(sessionWithOtp)).rejects.toMatchObject({
+        code: CardProviderErrorCode.Unknown,
+      });
+    });
+  });
+
+  describe('logout', () => {
+    it('calls provider.logout, removes tokens, sets isAuthenticated to false', async () => {
+      const provider = buildMockProvider();
+      provider.logout.mockResolvedValue(undefined);
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      const controller = buildController(provider, { isAuthenticated: true });
+
+      await controller.logout();
+
+      expect(provider.logout).toHaveBeenCalledWith(mockTokenSet);
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(controller.state.isAuthenticated).toBe(false);
+    });
+
+    it('still clears local state when provider.logout throws', async () => {
+      const provider = buildMockProvider();
+      provider.logout.mockRejectedValue(new Error('Server error'));
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      const controller = buildController(provider, { isAuthenticated: true });
+
+      await controller.logout();
+
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(controller.state.isAuthenticated).toBe(false);
+    });
+
+    it('skips provider.logout call when no tokens exist', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(null);
+      mockTokenStore.remove.mockResolvedValue(true);
+      const controller = buildController(provider);
+
+      await controller.logout();
+
+      expect(provider.logout).not.toHaveBeenCalled();
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+    });
+  });
+
+  describe('validateAndRefreshSession', () => {
+    it('returns isAuthenticated:false when no tokens exist', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(null);
+      const controller = buildController(provider);
+
+      const result = await controller.validateAndRefreshSession();
+
+      expect(result).toStrictEqual({ isAuthenticated: false });
+      expect(controller.state.isAuthenticated).toBe(false);
+    });
+
+    it('returns isAuthenticated:true with location when tokens are valid', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      provider.validateTokens.mockReturnValue('valid');
+      const controller = buildController(provider);
+
+      const result = await controller.validateAndRefreshSession();
+
+      expect(result).toStrictEqual({
+        isAuthenticated: true,
+        location: 'international',
+      });
+      expect(controller.state.isAuthenticated).toBe(true);
+    });
+
+    it('refreshes tokens and returns authenticated when needs_refresh', async () => {
+      const provider = buildMockProvider();
+      const refreshedTokens: CardAuthTokens = {
+        ...mockTokenSet,
+        accessToken: 'new-at',
+      };
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      provider.validateTokens.mockReturnValue('needs_refresh');
+      provider.refreshTokens.mockResolvedValue(refreshedTokens);
+      mockTokenStore.set.mockResolvedValue(true);
+      const controller = buildController(provider);
+
+      const result = await controller.validateAndRefreshSession();
+
+      expect(provider.refreshTokens).toHaveBeenCalledWith(mockTokenSet);
+      expect(mockTokenStore.set).toHaveBeenCalledWith('baanx', refreshedTokens);
+      expect(result).toStrictEqual({
+        isAuthenticated: true,
+        location: 'international',
+      });
+    });
+
+    it('clears tokens and returns unauthenticated when refresh fails', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      provider.validateTokens.mockReturnValue('needs_refresh');
+      provider.refreshTokens.mockRejectedValue(new Error('Refresh failed'));
+      mockTokenStore.remove.mockResolvedValue(true);
+      const controller = buildController(provider);
+
+      const result = await controller.validateAndRefreshSession();
+
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(result).toStrictEqual({ isAuthenticated: false });
+      expect(controller.state.isAuthenticated).toBe(false);
+    });
+
+    it('clears tokens and returns unauthenticated when tokens are expired', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      provider.validateTokens.mockReturnValue('expired');
+      mockTokenStore.remove.mockResolvedValue(true);
+      const controller = buildController(provider);
+
+      const result = await controller.validateAndRefreshSession();
+
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(result).toStrictEqual({ isAuthenticated: false });
+      expect(controller.state.isAuthenticated).toBe(false);
     });
   });
 });

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -142,8 +142,10 @@ export class CardController extends BaseController<
         'submitCredentials: no active auth session',
       );
     }
-    const pid = this.state.activeProviderId ?? '';
-    const result = await this.getActiveProvider().submitCredentials(
+
+    const provider = this.getActiveProvider();
+    const pid = this.state.activeProviderId as string;
+    const result = await provider.submitCredentials(
       this.currentSession,
       credentials,
     );
@@ -192,7 +194,8 @@ export class CardController extends BaseController<
   }
 
   async logout(): Promise<void> {
-    const pid = this.state.activeProviderId ?? '';
+    const pid = this.state.activeProviderId;
+    if (!pid) return;
     const tokens = await CardTokenStore.get(pid);
 
     if (tokens) {
@@ -220,7 +223,11 @@ export class CardController extends BaseController<
     isAuthenticated: boolean;
     location?: string;
   }> {
-    const pid = this.state.activeProviderId ?? '';
+    const pid = this.state.activeProviderId;
+    if (!pid) {
+      this.markUnauthenticated();
+      return { isAuthenticated: false };
+    }
     const tokens = await CardTokenStore.get(pid);
 
     if (!tokens) {

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -10,6 +10,7 @@ import {
   CardProviderErrorCode,
   type CardAuthSession,
   type CardAuthResult,
+  type CardAuthStep,
   type CardCredentials,
   type ICardProvider,
 } from './provider-types';
@@ -50,7 +51,7 @@ const metadata: StateMetadata<CardControllerState> = {
 
 export const defaultCardControllerState: CardControllerState = {
   selectedCountry: null,
-  activeProviderId: null,
+  activeProviderId: 'baanx',
   isAuthenticated: false,
   cardholderAccounts: [],
   providerData: {},
@@ -70,6 +71,7 @@ export class CardController extends BaseController<
   CardControllerMessenger
 > {
   private readonly providers: Record<string, ICardProvider>;
+  private currentSession: CardAuthSession | null = null;
 
   constructor({
     messenger,
@@ -123,19 +125,37 @@ export class CardController extends BaseController<
     }
   }
 
-  async initiateAuth(country: string): Promise<CardAuthSession> {
-    return this.getActiveProvider().initiateAuth(country);
+  async initiateAuth(country: string): Promise<void> {
+    this.currentSession = await this.getActiveProvider().initiateAuth(country);
+  }
+
+  getCurrentAuthStep(): CardAuthStep | null {
+    return this.currentSession?.currentStep ?? null;
   }
 
   async submitCredentials(
-    session: CardAuthSession,
     credentials: CardCredentials,
   ): Promise<CardAuthResult> {
+    if (!this.currentSession) {
+      throw new CardProviderError(
+        CardProviderErrorCode.Unknown,
+        'submitCredentials: no active auth session',
+      );
+    }
     const pid = this.state.activeProviderId ?? '';
     const result = await this.getActiveProvider().submitCredentials(
-      session,
+      this.currentSession,
       credentials,
     );
+
+    if (result.nextStep) {
+      this.currentSession = {
+        ...this.currentSession,
+        currentStep: result.nextStep,
+      };
+    } else {
+      this.currentSession = null;
+    }
 
     if (result.done && result.tokenSet) {
       const { tokenSet } = result;
@@ -160,25 +180,15 @@ export class CardController extends BaseController<
     return result;
   }
 
-  async sendOtp(session: CardAuthSession): Promise<void> {
-    const pid = this.state.activeProviderId ?? '';
+  async executeStepAction(): Promise<void> {
+    if (!this.currentSession) {
+      throw new CardProviderError(
+        CardProviderErrorCode.Unknown,
+        'executeStepAction: no active auth session',
+      );
+    }
     const provider = this.getActiveProvider();
-
-    if (typeof session._metadata.otpUserId !== 'string') {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'sendOtp: session missing otpUserId',
-      );
-    }
-
-    if (!provider.sendOtp) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        `Provider ${pid} does not support OTP`,
-      );
-    }
-
-    await provider.sendOtp(session);
+    await provider.executeStepAction?.(this.currentSession);
   }
 
   async logout(): Promise<void> {
@@ -196,6 +206,7 @@ export class CardController extends BaseController<
       }
     }
 
+    this.currentSession = null;
     await this.clearTokens();
     this.update((s) => {
       s.isAuthenticated = false;

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -1,9 +1,19 @@
 import { BaseController, type StateMetadata } from '@metamask/base-controller';
+import Logger from '../../../../util/Logger';
 import {
   CARD_CONTROLLER_NAME,
   type CardControllerMessenger,
   type CardControllerState,
 } from './types';
+import {
+  CardProviderError,
+  CardProviderErrorCode,
+  type CardAuthSession,
+  type CardAuthResult,
+  type CardCredentials,
+  type ICardProvider,
+} from './provider-types';
+import { CardTokenStore } from './CardTokenStore';
 
 const metadata: StateMetadata<CardControllerState> = {
   selectedCountry: {
@@ -59,12 +69,16 @@ export class CardController extends BaseController<
   CardControllerState,
   CardControllerMessenger
 > {
+  private readonly providers: Record<string, ICardProvider>;
+
   constructor({
     messenger,
     state,
+    providers,
   }: {
     messenger: CardControllerMessenger;
     state?: Partial<CardControllerState>;
+    providers: Record<string, ICardProvider>;
   }) {
     super({
       name: CARD_CONTROLLER_NAME,
@@ -75,5 +89,165 @@ export class CardController extends BaseController<
         ...state,
       },
     });
+    this.providers = providers;
+  }
+
+  private getActiveProvider(): ICardProvider {
+    const pid = this.state.activeProviderId;
+    const provider = pid ? this.providers[pid] : undefined;
+    if (!provider) {
+      throw new CardProviderError(
+        CardProviderErrorCode.Unknown,
+        `No active provider: ${pid}`,
+      );
+    }
+    return provider;
+  }
+
+  private markAuthenticated(): void {
+    this.update((s) => {
+      s.isAuthenticated = true;
+    });
+  }
+
+  private markUnauthenticated(): void {
+    this.update((s) => {
+      s.isAuthenticated = false;
+    });
+  }
+
+  private async clearTokens(): Promise<void> {
+    const pid = this.state.activeProviderId;
+    if (pid) {
+      await CardTokenStore.remove(pid);
+    }
+  }
+
+  async initiateAuth(country: string): Promise<CardAuthSession> {
+    return this.getActiveProvider().initiateAuth(country);
+  }
+
+  async submitCredentials(
+    session: CardAuthSession,
+    credentials: CardCredentials,
+  ): Promise<CardAuthResult> {
+    const pid = this.state.activeProviderId ?? '';
+    const result = await this.getActiveProvider().submitCredentials(
+      session,
+      credentials,
+    );
+
+    if (result.done && result.tokenSet) {
+      const { tokenSet } = result;
+      const stored = await CardTokenStore.set(pid, tokenSet);
+      if (!stored) {
+        Logger.error(new Error('Token store write failed after auth'), {
+          tags: { feature: 'card', provider: pid },
+          context: {
+            name: 'CardController',
+            data: { method: 'submitCredentials' },
+          },
+        });
+      }
+      this.update((s) => {
+        s.isAuthenticated = true;
+        (s.providerData as unknown as Record<string, Record<string, string>>)[
+          pid
+        ] = { location: tokenSet.location };
+      });
+    }
+
+    return result;
+  }
+
+  async sendOtp(session: CardAuthSession): Promise<void> {
+    const pid = this.state.activeProviderId ?? '';
+    const provider = this.getActiveProvider();
+
+    if (typeof session._metadata.otpUserId !== 'string') {
+      throw new CardProviderError(
+        CardProviderErrorCode.Unknown,
+        'sendOtp: session missing otpUserId',
+      );
+    }
+
+    if (!provider.sendOtp) {
+      throw new CardProviderError(
+        CardProviderErrorCode.Unknown,
+        `Provider ${pid} does not support OTP`,
+      );
+    }
+
+    await provider.sendOtp(session);
+  }
+
+  async logout(): Promise<void> {
+    const pid = this.state.activeProviderId ?? '';
+    const tokens = await CardTokenStore.get(pid);
+
+    if (tokens) {
+      try {
+        await this.getActiveProvider().logout(tokens);
+      } catch (error) {
+        Logger.error(error as Error, {
+          tags: { feature: 'card', provider: pid },
+          context: { name: 'CardController', data: { method: 'logout' } },
+        });
+      }
+    }
+
+    await this.clearTokens();
+    this.update((s) => {
+      s.isAuthenticated = false;
+      (s.providerData as unknown as Record<string, Record<string, string>>)[
+        pid
+      ] = {};
+    });
+  }
+
+  async validateAndRefreshSession(): Promise<{
+    isAuthenticated: boolean;
+    location?: string;
+  }> {
+    const pid = this.state.activeProviderId ?? '';
+    const tokens = await CardTokenStore.get(pid);
+
+    if (!tokens) {
+      this.markUnauthenticated();
+      return { isAuthenticated: false };
+    }
+
+    const provider = this.getActiveProvider();
+    const validity = provider.validateTokens(tokens);
+
+    if (validity === 'valid') {
+      this.markAuthenticated();
+      return { isAuthenticated: true, location: tokens.location };
+    }
+
+    if (validity === 'needs_refresh') {
+      try {
+        const newTokens = await provider.refreshTokens(tokens);
+        await CardTokenStore.set(pid, newTokens);
+        this.markAuthenticated();
+        return { isAuthenticated: true, location: newTokens.location };
+      } catch (error) {
+        Logger.error(error as Error, {
+          tags: { feature: 'card', provider: pid },
+          context: {
+            name: 'CardController',
+            data: { method: 'validateAndRefreshSession' },
+          },
+        });
+        await this.clearTokens();
+        this.markUnauthenticated();
+        return { isAuthenticated: false };
+      }
+    }
+
+    // expired
+    await this.clearTokens();
+    this.markUnauthenticated();
+    return { isAuthenticated: false };
   }
 }

--- a/app/core/Engine/controllers/card-controller/index.ts
+++ b/app/core/Engine/controllers/card-controller/index.ts
@@ -24,7 +24,10 @@ export const cardControllerInit: ControllerInitFunction<
 
   const controller = new CardController({
     messenger: controllerMessenger,
-    state: persistedState.CardController ?? defaultCardControllerState,
+    state: {
+      ...(persistedState.CardController ?? defaultCardControllerState),
+      activeProviderId: 'baanx',
+    },
     providers: { baanx: baanxProvider },
   });
 

--- a/app/core/Engine/controllers/card-controller/index.ts
+++ b/app/core/Engine/controllers/card-controller/index.ts
@@ -1,6 +1,9 @@
 import type { ControllerInitFunction } from '../../types';
 import { CardController, defaultCardControllerState } from './CardController';
 import type { CardControllerMessenger } from './types';
+import { BaanxService } from './services/BaanxService';
+import { BaanxProvider } from './providers/BaanxProvider';
+import { resolveBaanxConfig } from './services/baanx-config';
 
 /**
  * Initialize the CardController.
@@ -14,9 +17,15 @@ export const cardControllerInit: ControllerInitFunction<
 > = (request) => {
   const { controllerMessenger, persistedState } = request;
 
+  const baanxConfig = resolveBaanxConfig();
+  const baanxProvider = new BaanxProvider({
+    service: new BaanxService(baanxConfig),
+  });
+
   const controller = new CardController({
     messenger: controllerMessenger,
     state: persistedState.CardController ?? defaultCardControllerState,
+    providers: { baanx: baanxProvider },
   });
 
   return { controller };

--- a/app/core/Engine/controllers/card-controller/provider-types.ts
+++ b/app/core/Engine/controllers/card-controller/provider-types.ts
@@ -275,7 +275,7 @@ export interface ICardProvider {
     session: CardAuthSession,
     credentials: CardCredentials,
   ): Promise<CardAuthResult>;
-  sendOtp?(session: CardAuthSession): Promise<void>;
+  executeStepAction?(session: CardAuthSession): Promise<void>;
   refreshTokens(tokens: CardAuthTokens): Promise<CardAuthTokens>;
   validateTokens(tokens: CardAuthTokens): AuthTokenValidity;
   logout(tokens: CardAuthTokens): Promise<void>;

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -728,7 +728,7 @@ describe('BaanxProvider', () => {
     });
   });
 
-  describe('sendOtp', () => {
+  describe('executeStepAction', () => {
     it('posts userId to the OTP trigger endpoint', async () => {
       service.get.mockResolvedValue({ token: 'init-token', url: '' });
       const session = await provider.initiateAuth('US');
@@ -736,7 +736,7 @@ describe('BaanxProvider', () => {
       session._metadata.otpUserId = 'user-1';
       service.post.mockResolvedValue({});
 
-      await provider.sendOtp(session);
+      await provider.executeStepAction(session);
 
       expect(service.post).toHaveBeenCalledWith('/v1/auth/login/otp', {
         userId: 'user-1',
@@ -747,8 +747,8 @@ describe('BaanxProvider', () => {
       service.get.mockResolvedValue({ token: 'init-token', url: '' });
       const session = await provider.initiateAuth('US');
 
-      await expect(provider.sendOtp(session)).rejects.toThrow(
-        'No userId in session',
+      await expect(provider.executeStepAction(session)).rejects.toThrow(
+        'executeStepAction: session missing otpUserId',
       );
     });
   });

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -270,11 +270,12 @@ export class BaanxProvider implements ICardProvider {
     throw new Error(`Unsupported credential type: ${credentials.type}`);
   }
 
-  async sendOtp(session: CardAuthSession): Promise<void> {
+  async executeStepAction(session: CardAuthSession): Promise<void> {
     const userId = session._metadata.otpUserId as string | undefined;
     if (!userId) {
-      throw new Error(
-        'No userId in session — initiateAuth or login must be called first',
+      throw new CardProviderError(
+        CardProviderErrorCode.Unknown,
+        'executeStepAction: session missing otpUserId',
       );
     }
     await this.service.post('/v1/auth/login/otp', { userId });

--- a/app/core/Engine/controllers/card-controller/services/BaanxService.test.ts
+++ b/app/core/Engine/controllers/card-controller/services/BaanxService.test.ts
@@ -172,4 +172,74 @@ describe('BaanxService', () => {
       expect(service.location).toBe('us');
     });
   });
+
+  describe('per-request location override', () => {
+    it('uses x-us-env:true when location:us is passed to get(), regardless of currentLocation', async () => {
+      mockRequest.mockResolvedValue({ data: {} });
+      const service = createService();
+      // currentLocation is 'international' (default)
+
+      await service.get('/v1/test', undefined, 'us');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-us-env': 'true' }),
+        }),
+      );
+    });
+
+    it('uses x-us-env:false when location:international is passed to get(), even after setLocation(us)', async () => {
+      mockRequest.mockResolvedValue({ data: {} });
+      const service = createService();
+      service.setLocation('us');
+
+      await service.get('/v1/test', undefined, 'international');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-us-env': 'false' }),
+        }),
+      );
+    });
+
+    it('falls back to currentLocation when no per-request location is given', async () => {
+      mockRequest.mockResolvedValue({ data: {} });
+      const service = createService();
+      service.setLocation('us');
+
+      await service.get('/v1/test');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-us-env': 'true' }),
+        }),
+      );
+    });
+
+    it('post() threads per-request location through correctly', async () => {
+      mockRequest.mockResolvedValue({ data: {} });
+      const service = createService();
+
+      await service.post('/v1/test', {}, undefined, 'us');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-us-env': 'true' }),
+        }),
+      );
+    });
+
+    it('put() threads per-request location through correctly', async () => {
+      mockRequest.mockResolvedValue({ data: {} });
+      const service = createService();
+
+      await service.put('/v1/test', {}, undefined, 'us');
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-us-env': 'true' }),
+        }),
+      );
+    });
+  });
 });

--- a/app/core/Engine/controllers/card-controller/services/BaanxService.ts
+++ b/app/core/Engine/controllers/card-controller/services/BaanxService.ts
@@ -25,6 +25,7 @@ interface RequestOptions {
   tokenSet?: CardAuthTokens;
   timeout?: number;
   headers?: Record<string, string>;
+  location?: CardLocation;
 }
 
 export class BaanxService {
@@ -57,8 +58,9 @@ export class BaanxService {
   }
 
   async request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+    const effectiveLocation = opts.location ?? this.currentLocation;
     const headers: Record<string, string> = {
-      'x-us-env': String(this.currentLocation === 'us'),
+      'x-us-env': String(effectiveLocation === 'us'),
       ...opts.headers,
     };
 
@@ -108,23 +110,29 @@ export class BaanxService {
     }
   }
 
-  async get<T>(path: string, tokenSet?: CardAuthTokens): Promise<T> {
-    return this.request<T>(path, { tokenSet });
+  async get<T>(
+    path: string,
+    tokenSet?: CardAuthTokens,
+    location?: CardLocation,
+  ): Promise<T> {
+    return this.request<T>(path, { tokenSet, location });
   }
 
   async post<T>(
     path: string,
     body: unknown,
     tokenSet?: CardAuthTokens,
+    location?: CardLocation,
   ): Promise<T> {
-    return this.request<T>(path, { method: 'POST', body, tokenSet });
+    return this.request<T>(path, { method: 'POST', body, tokenSet, location });
   }
 
   async put<T>(
     path: string,
     body: unknown,
     tokenSet?: CardAuthTokens,
+    location?: CardLocation,
   ): Promise<T> {
-    return this.request<T>(path, { method: 'PUT', body, tokenSet });
+    return this.request<T>(path, { method: 'PUT', body, tokenSet, location });
   }
 }

--- a/app/core/Engine/controllers/card-controller/services/baanx-config.test.ts
+++ b/app/core/Engine/controllers/card-controller/services/baanx-config.test.ts
@@ -29,7 +29,17 @@ describe('resolveBaanxConfig', () => {
   });
 
   describe('baseUrl', () => {
-    it('delegates to getDefaultBaanxApiBaseUrlForMetaMaskEnv', () => {
+    it('uses BAANX_API_URL directly when set', () => {
+      process.env.BAANX_API_URL = 'https://override-url';
+
+      const config = resolveBaanxConfig();
+
+      expect(config.baseUrl).toBe('https://override-url');
+      expect(getDefaultBaanxApiBaseUrlForMetaMaskEnv).not.toHaveBeenCalled();
+    });
+
+    it('delegates to getDefaultBaanxApiBaseUrlForMetaMaskEnv when BAANX_API_URL is not set', () => {
+      delete process.env.BAANX_API_URL;
       process.env.METAMASK_ENVIRONMENT = 'dev';
 
       const config = resolveBaanxConfig();

--- a/app/core/Engine/controllers/card-controller/services/baanx-config.test.ts
+++ b/app/core/Engine/controllers/card-controller/services/baanx-config.test.ts
@@ -29,6 +29,10 @@ describe('resolveBaanxConfig', () => {
   });
 
   describe('baseUrl', () => {
+    beforeEach(() => {
+      (getDefaultBaanxApiBaseUrlForMetaMaskEnv as jest.Mock).mockClear();
+    });
+
     it('uses BAANX_API_URL directly when set', () => {
       process.env.BAANX_API_URL = 'https://override-url';
 

--- a/app/core/Engine/controllers/card-controller/services/baanx-config.ts
+++ b/app/core/Engine/controllers/card-controller/services/baanx-config.ts
@@ -13,8 +13,8 @@ import type { CardProviderConfig } from '../provider-config';
 export function resolveBaanxConfig(): CardProviderConfig {
   return {
     apiKey: process.env.MM_CARD_BAANX_API_CLIENT_KEY ?? '',
-    baseUrl: getDefaultBaanxApiBaseUrlForMetaMaskEnv(
-      process.env.METAMASK_ENVIRONMENT,
-    ),
+    baseUrl:
+      process.env.BAANX_API_URL ||
+      getDefaultBaanxApiBaseUrlForMetaMaskEnv(process.env.METAMASK_ENVIRONMENT),
   };
 }

--- a/app/util/logs/__snapshots__/index.test.ts.snap
+++ b/app/util/logs/__snapshots__/index.test.ts.snap
@@ -70,7 +70,7 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
         "txHistory": {},
       },
       "CardController": {
-        "activeProviderId": null,
+        "activeProviderId": "baanx",
         "cardholderAccounts": [],
         "isAuthenticated": false,
         "providerData": {},
@@ -935,7 +935,7 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
         "txHistory": {},
       },
       "CardController": {
-        "activeProviderId": null,
+        "activeProviderId": "baanx",
         "cardholderAccounts": [],
         "isAuthenticated": false,
         "providerData": {},

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -681,7 +681,7 @@
   },
   "CardController": {
     "selectedCountry": null,
-    "activeProviderId": null,
+    "activeProviderId": "baanx",
     "isAuthenticated": false,
     "cardholderAccounts": [],
     "providerData": {}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrates Card authentication to the CardController, introducing a controller-based auth flow that delegates to BaanxProvider and a new `useCardAuth` hook for UI consumption.

**Why**: Centralizing auth logic in the CardController aligns with the MetaMask controller architecture, provides a single source of truth for auth state, and enables future provider-agnostic auth flows. The new `useCardAuth` hook exposes mutations (initiate, submit, stepAction, logout) backed by the controller, with React Query for cache invalidation on success.

**What changed**:

- **CardController**: Added auth methods `initiateAuth`, `submitCredentials`, `executeStepAction`, and `logout` that delegate to the active provider (BaanxProvider). Manages `currentSession` for multi-step flows (email/password → OTP → complete).

- **BaanxProvider**: Implemented `executeStepAction` (generic OTP trigger) that posts `userId` to `/v1/auth/login/otp`. Renamed from provider-specific `sendOtp` to align with `ICardProvider` interface.

- **provider-types**: Added optional `executeStepAction?(session: CardAuthSession): Promise<void>` to `ICardProvider`.

- **useCardAuth hook**: New hook exposing `currentStep`, `initiate`, `submit`, `stepAction`, and `logout` mutations. Uses CardController for all auth operations; updates `currentStep` on submit results (OTP, onboarding required, done); invalidates card queries on login success; removes queries on logout.

- **auth queries**: Added `authKeys` (initiate, submit, step-action, logout) to `cardQueries.auth.keys`.

- **getCardProviderErrorMessage**: New utility mapping `CardProviderError` codes to localized strings for Card authentication UI.

- **BaanxService / baanx-config**: Minor adjustments for config resolution and service usage.

- **Tests**: Updated BaanxProvider tests (`sendOtp` → `executeStepAction`); fixed baanx-config test mock isolation with `beforeEach` mock clear; expanded CardController tests for auth methods; added `useCardAuth` unit tests.

## **Changelog**

CHANGELOG entry: Migrated Card authentication to CardController with new `useCardAuth` hook for controller-based auth flow.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card authentication via CardController

  Scenario: User logs in with email and password (no OTP)
    Given I am on the Card authentication screen
    And I have valid email and password credentials

    When I enter my email and password
    And I tap the login button
    Then I should be authenticated and see the Card home/dashboard

  Scenario: User logs in with email, password, and OTP
    Given I am on the Card authentication screen
    And I have credentials that require OTP verification

    When I enter my email and password
    And I tap the login button
    Then I should see the OTP input screen
    When I tap "Resend code" (or wait for cooldown)
    Then an OTP should be sent to my device/email
    When I enter the OTP code and submit
    Then I should be authenticated and see the Card home/dashboard

  Scenario: User logs out
    Given I am authenticated in the Card flow

    When I log out (or navigate away and return to auth)
    Then I should see the login screen again
    And card queries should be cleared
```

## **Screenshots/Recordings**

No visual design changes — authentication flow (email/password, OTP, logout) behaves the same; only the underlying implementation (CardController + useCardAuth vs SDK) changed.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a new controller-driven authentication/session lifecycle (multi-step auth, token storage, refresh, and logout) and changes default provider selection/state, which can impact login persistence and security-sensitive flows.
> 
> **Overview**
> Migrates card authentication off the UI/SDK path into `CardController`, adding controller-level methods for `initiateAuth`, `submitCredentials`, `executeStepAction`, `logout`, and `validateAndRefreshSession` with token persistence via `CardTokenStore`, provider delegation, and session/step tracking.
> 
> Adds a new UI hook `useCardAuth` backed by React Query mutations (with new `cardQueries.auth` keys) to drive the multi-step login flow and to invalidate/remove card queries on login/logout.
> 
> Standardizes provider step actions by renaming `ICardProvider.sendOtp` to `executeStepAction` and updating `BaanxProvider` accordingly, plus adds localized error mapping via `getCardProviderErrorMessage` and extends Baanx config/service behavior (env override for base URL; per-request location override for `x-us-env`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a91ba1934aece383d61a39eb9ab1c3cc0f50faa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->