### PR TITLE
refactor: extract full-view sort reset effect hook

### DIFF
--- a/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
@@ -38,30 +38,13 @@ const mockUseNavigation = useNavigation as jest.MockedFunction<
 
 describe('DeFiFullView', () => {
   const mockGoBack = jest.fn();
-  let useFullViewSortResetEffectSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useFullViewSortResetEffectSpy = jest
-      .spyOn(
-        jest.requireMock(
-          '../TokensFullView/useFullViewSortResetEffect',
-        ) as typeof import('../TokensFullView/useFullViewSortResetEffect'),
-        'useFullViewSortResetEffect',
-      )
-      .mockImplementation(jest.fn());
 
     mockUseNavigation.mockReturnValue({
       goBack: mockGoBack,
     } as unknown as ReturnType<typeof useNavigation>);
-  });
-
-  it('invokes the full view sort reset effect hook', () => {
-    renderScreen(DeFiFullView, {
-      name: 'DeFiFullView',
-    });
-
-    expect(useFullViewSortResetEffectSpy).toHaveBeenCalledTimes(1);
   });
 
   it('renders header with title and back button', () => {

--- a/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
@@ -1,6 +1,7 @@
 import { renderScreen } from '../../../util/test/renderWithProvider';
 import DeFiFullView from './DeFiFullView';
 import { useNavigation } from '@react-navigation/native';
+import { useFullViewSortResetEffect } from '../TokensFullView/useFullViewSortResetEffect';
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => {
@@ -13,6 +14,10 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: jest.fn(),
+}));
+
+jest.mock('../TokensFullView/useFullViewSortResetEffect', () => ({
+  useFullViewSortResetEffect: jest.fn(),
 }));
 
 jest.mock('../../UI/DeFiPositions/DeFiPositionsList', () => {
@@ -31,6 +36,10 @@ jest.mock('../../UI/DeFiPositions/DeFiPositionsList', () => {
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
+const mockUseFullViewSortResetEffect =
+  useFullViewSortResetEffect as jest.MockedFunction<
+    typeof useFullViewSortResetEffect
+  >;
 
 describe('DeFiFullView', () => {
   const mockGoBack = jest.fn();
@@ -41,6 +50,14 @@ describe('DeFiFullView', () => {
     mockUseNavigation.mockReturnValue({
       goBack: mockGoBack,
     } as unknown as ReturnType<typeof useNavigation>);
+  });
+
+  it('invokes the full view sort reset effect hook', () => {
+    renderScreen(DeFiFullView, {
+      name: 'DeFiFullView',
+    });
+
+    expect(mockUseFullViewSortResetEffect).toHaveBeenCalledTimes(1);
   });
 
   it('renders header with title and back button', () => {

--- a/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
@@ -1,7 +1,6 @@
 import { renderScreen } from '../../../util/test/renderWithProvider';
 import DeFiFullView from './DeFiFullView';
 import { useNavigation } from '@react-navigation/native';
-import { useFullViewSortResetEffect } from '../TokensFullView/useFullViewSortResetEffect';
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => {
@@ -36,16 +35,21 @@ jest.mock('../../UI/DeFiPositions/DeFiPositionsList', () => {
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
-const mockUseFullViewSortResetEffect =
-  useFullViewSortResetEffect as jest.MockedFunction<
-    typeof useFullViewSortResetEffect
-  >;
 
 describe('DeFiFullView', () => {
   const mockGoBack = jest.fn();
+  let useFullViewSortResetEffectSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    useFullViewSortResetEffectSpy = jest
+      .spyOn(
+        jest.requireMock(
+          '../TokensFullView/useFullViewSortResetEffect',
+        ) as typeof import('../TokensFullView/useFullViewSortResetEffect'),
+        'useFullViewSortResetEffect',
+      )
+      .mockImplementation(jest.fn());
 
     mockUseNavigation.mockReturnValue({
       goBack: mockGoBack,
@@ -57,7 +61,7 @@ describe('DeFiFullView', () => {
       name: 'DeFiFullView',
     });
 
-    expect(mockUseFullViewSortResetEffect).toHaveBeenCalledTimes(1);
+    expect(useFullViewSortResetEffectSpy).toHaveBeenCalledTimes(1);
   });
 
   it('renders header with title and back button', () => {

--- a/app/components/Views/DeFiFullView/DeFiFullView.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -11,29 +10,12 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
 import { Box } from '@metamask/design-system-react-native';
 import DeFiPositionsList from '../../UI/DeFiPositions/DeFiPositionsList';
-import Engine from '../../../core/Engine';
-import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
+import { useFullViewSortResetEffect } from '../TokensFullView/useFullViewSortResetEffect';
 
 const DeFiFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
-
-  useFocusEffect(
-    useCallback(
-      () => () => {
-        if (isHomepageSectionsV1Enabled) {
-          Engine.context.PreferencesController.setTokenSortConfig(
-            DEFAULT_TOKEN_SORT_CONFIG,
-          );
-        }
-      },
-      [isHomepageSectionsV1Enabled],
-    ),
-  );
+  useFullViewSortResetEffect();
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();

--- a/app/components/Views/DeFiFullView/DeFiFullView.view.test.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.view.test.tsx
@@ -1,0 +1,50 @@
+import '../../../../tests/component-view/mocks';
+import { waitFor } from '@testing-library/react-native';
+import type { DeepPartial } from '../../../util/test/renderWithProvider';
+import type { RootState } from '../../../reducers';
+import { describeForPlatforms } from '../../../util/test/platform';
+import Engine from '../../../core/Engine';
+import { renderDeFiFullView } from '../../../../tests/component-view/renderers/defiFullView';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
+
+const homepageSectionsV1EnabledOverrides = {
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          homepageSectionsV1: {
+            enabled: true,
+            featureVersion: '1.0.0',
+            minimumVersion: '0.0.1',
+          },
+        },
+      },
+    },
+  },
+} as unknown as DeepPartial<RootState>;
+
+describeForPlatforms('DeFiFullView - Component Tests', () => {
+  it('resets token sort config when DeFi Full View unmounts', async () => {
+    const setTokenSortConfigSpy = jest.spyOn(
+      Engine.context.PreferencesController,
+      'setTokenSortConfig',
+    );
+    setTokenSortConfigSpy.mockClear();
+
+    const { findByText, unmount } = renderDeFiFullView({
+      overrides: homepageSectionsV1EnabledOverrides,
+    });
+
+    await findByText('DeFi');
+
+    unmount();
+
+    await waitFor(() => {
+      expect(setTokenSortConfigSpy).toHaveBeenCalledWith(
+        DEFAULT_TOKEN_SORT_CONFIG,
+      );
+    });
+
+    setTokenSortConfigSpy.mockRestore();
+  });
+});

--- a/app/components/Views/TokensFullView/TokensFullView.test.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.test.tsx
@@ -1,7 +1,6 @@
 import { renderScreen } from '../../../util/test/renderWithProvider';
 import TokensFullView from './TokensFullView';
 import { useNavigation } from '@react-navigation/native';
-import { useFullViewSortResetEffect } from './useFullViewSortResetEffect';
 
 // Mock external dependencies that are not under test
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
@@ -48,16 +47,21 @@ jest.mock('../../UI/Tokens', () => {
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
-const mockUseFullViewSortResetEffect =
-  useFullViewSortResetEffect as jest.MockedFunction<
-    typeof useFullViewSortResetEffect
-  >;
 
 describe('TokensFullView', () => {
   const mockGoBack = jest.fn();
+  let useFullViewSortResetEffectSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    useFullViewSortResetEffectSpy = jest
+      .spyOn(
+        jest.requireMock(
+          './useFullViewSortResetEffect',
+        ) as typeof import('./useFullViewSortResetEffect'),
+        'useFullViewSortResetEffect',
+      )
+      .mockImplementation(jest.fn());
 
     // Setup default mocks
     mockUseNavigation.mockReturnValue({
@@ -70,7 +74,7 @@ describe('TokensFullView', () => {
       name: 'TokensFullView',
     });
 
-    expect(mockUseFullViewSortResetEffect).toHaveBeenCalledTimes(1);
+    expect(useFullViewSortResetEffectSpy).toHaveBeenCalledTimes(1);
   });
 
   it('renders header with title and back button', () => {

--- a/app/components/Views/TokensFullView/TokensFullView.test.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.test.tsx
@@ -1,6 +1,7 @@
 import { renderScreen } from '../../../util/test/renderWithProvider';
 import TokensFullView from './TokensFullView';
 import { useNavigation } from '@react-navigation/native';
+import { useFullViewSortResetEffect } from './useFullViewSortResetEffect';
 
 // Mock external dependencies that are not under test
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
@@ -14,6 +15,10 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: jest.fn(),
+}));
+
+jest.mock('./useFullViewSortResetEffect', () => ({
+  useFullViewSortResetEffect: jest.fn(),
 }));
 
 // Mock AssetPollingProvider to avoid Engine/controller polling setup
@@ -43,6 +48,10 @@ jest.mock('../../UI/Tokens', () => {
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
+const mockUseFullViewSortResetEffect =
+  useFullViewSortResetEffect as jest.MockedFunction<
+    typeof useFullViewSortResetEffect
+  >;
 
 describe('TokensFullView', () => {
   const mockGoBack = jest.fn();
@@ -54,6 +63,14 @@ describe('TokensFullView', () => {
     mockUseNavigation.mockReturnValue({
       goBack: mockGoBack,
     } as unknown as ReturnType<typeof useNavigation>);
+  });
+
+  it('invokes the full view sort reset effect hook', () => {
+    renderScreen(TokensFullView, {
+      name: 'TokensFullView',
+    });
+
+    expect(mockUseFullViewSortResetEffect).toHaveBeenCalledTimes(1);
   });
 
   it('renders header with title and back button', () => {

--- a/app/components/Views/TokensFullView/TokensFullView.test.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.test.tsx
@@ -50,31 +50,14 @@ const mockUseNavigation = useNavigation as jest.MockedFunction<
 
 describe('TokensFullView', () => {
   const mockGoBack = jest.fn();
-  let useFullViewSortResetEffectSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useFullViewSortResetEffectSpy = jest
-      .spyOn(
-        jest.requireMock(
-          './useFullViewSortResetEffect',
-        ) as typeof import('./useFullViewSortResetEffect'),
-        'useFullViewSortResetEffect',
-      )
-      .mockImplementation(jest.fn());
 
     // Setup default mocks
     mockUseNavigation.mockReturnValue({
       goBack: mockGoBack,
     } as unknown as ReturnType<typeof useNavigation>);
-  });
-
-  it('invokes the full view sort reset effect hook', () => {
-    renderScreen(TokensFullView, {
-      name: 'TokensFullView',
-    });
-
-    expect(useFullViewSortResetEffectSpy).toHaveBeenCalledTimes(1);
   });
 
   it('renders header with title and back button', () => {

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -11,29 +10,12 @@ import { IconName } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
 import Tokens from '../../UI/Tokens';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
-import Engine from '../../../core/Engine';
-import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
+import { useFullViewSortResetEffect } from './useFullViewSortResetEffect';
 
 const TokensFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
-
-  useFocusEffect(
-    useCallback(
-      () => () => {
-        if (isHomepageSectionsV1Enabled) {
-          Engine.context.PreferencesController.setTokenSortConfig(
-            DEFAULT_TOKEN_SORT_CONFIG,
-          );
-        }
-      },
-      [isHomepageSectionsV1Enabled],
-    ),
-  );
+  useFullViewSortResetEffect();
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();

--- a/app/components/Views/TokensFullView/TokensFullView.view.test.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.view.test.tsx
@@ -1,0 +1,50 @@
+import '../../../../tests/component-view/mocks';
+import { waitFor } from '@testing-library/react-native';
+import type { DeepPartial } from '../../../util/test/renderWithProvider';
+import type { RootState } from '../../../reducers';
+import { describeForPlatforms } from '../../../util/test/platform';
+import Engine from '../../../core/Engine';
+import { renderTokensFullView } from '../../../../tests/component-view/renderers/tokensFullView';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
+
+const homepageSectionsV1EnabledOverrides = {
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          homepageSectionsV1: {
+            enabled: true,
+            featureVersion: '1.0.0',
+            minimumVersion: '0.0.1',
+          },
+        },
+      },
+    },
+  },
+} as unknown as DeepPartial<RootState>;
+
+describeForPlatforms('TokensFullView - Component Tests', () => {
+  it('resets token sort config when Tokens Full View unmounts', async () => {
+    const setTokenSortConfigSpy = jest.spyOn(
+      Engine.context.PreferencesController,
+      'setTokenSortConfig',
+    );
+    setTokenSortConfigSpy.mockClear();
+
+    const { findByText, unmount } = renderTokensFullView({
+      overrides: homepageSectionsV1EnabledOverrides,
+    });
+
+    await findByText('Tokens');
+
+    unmount();
+
+    await waitFor(() => {
+      expect(setTokenSortConfigSpy).toHaveBeenCalledWith(
+        DEFAULT_TOKEN_SORT_CONFIG,
+      );
+    });
+
+    setTokenSortConfigSpy.mockRestore();
+  });
+});

--- a/app/components/Views/TokensFullView/useFullViewSortResetEffect.test.ts
+++ b/app/components/Views/TokensFullView/useFullViewSortResetEffect.test.ts
@@ -28,12 +28,13 @@ describe('useFullViewSortResetEffect', () => {
   const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
     typeof useFocusEffect
   >;
-  const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-  const mockSetTokenSortConfig =
-    Engine.context.PreferencesController
-      .setTokenSortConfig as jest.MockedFunction<
-      typeof Engine.context.PreferencesController.setTokenSortConfig
-    >;
+  const mockUseSelector = useSelector as jest.MockedFunction<
+    typeof useSelector
+  >;
+  const mockSetTokenSortConfig = Engine.context.PreferencesController
+    .setTokenSortConfig as jest.MockedFunction<
+    typeof Engine.context.PreferencesController.setTokenSortConfig
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/app/components/Views/TokensFullView/useFullViewSortResetEffect.test.ts
+++ b/app/components/Views/TokensFullView/useFullViewSortResetEffect.test.ts
@@ -1,13 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useFocusEffect } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import Engine from '../../../core/Engine';
 import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
 import { useFullViewSortResetEffect } from './useFullViewSortResetEffect';
-
-jest.mock('@react-navigation/native', () => ({
-  useFocusEffect: jest.fn(),
-}));
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -25,9 +20,6 @@ jest.mock('../../../core/Engine', () => ({
 }));
 
 describe('useFullViewSortResetEffect', () => {
-  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
-    typeof useFocusEffect
-  >;
   const mockUseSelector = useSelector as jest.MockedFunction<
     typeof useSelector
   >;
@@ -40,43 +32,39 @@ describe('useFullViewSortResetEffect', () => {
     jest.clearAllMocks();
   });
 
-  it('registers a focus effect callback', () => {
-    mockUseSelector.mockReturnValue(false);
-
-    renderHook(() => useFullViewSortResetEffect());
-
-    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
-  });
-
-  it('resets token sort config when homepage sections v1 is enabled', () => {
+  it('resets token sort config when hook unmounts with homepage sections v1 enabled', () => {
     mockUseSelector.mockReturnValue(true);
 
-    renderHook(() => useFullViewSortResetEffect());
+    const { unmount } = renderHook(() => useFullViewSortResetEffect());
 
-    const onFocusEffect = mockUseFocusEffect.mock.calls[0][0];
-    const onCleanup = onFocusEffect();
-
-    if (typeof onCleanup === 'function') {
-      onCleanup();
-    }
+    unmount();
 
     expect(mockSetTokenSortConfig).toHaveBeenCalledWith(
       DEFAULT_TOKEN_SORT_CONFIG,
     );
   });
 
-  it('does not reset token sort config when homepage sections v1 is disabled', () => {
+  it('does not reset token sort config when hook unmounts with homepage sections v1 disabled', () => {
     mockUseSelector.mockReturnValue(false);
 
-    renderHook(() => useFullViewSortResetEffect());
-
-    const onFocusEffect = mockUseFocusEffect.mock.calls[0][0];
-    const onCleanup = onFocusEffect();
-
-    if (typeof onCleanup === 'function') {
-      onCleanup();
-    }
+    const { unmount } = renderHook(() => useFullViewSortResetEffect());
+    unmount();
 
     expect(mockSetTokenSortConfig).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest homepage sections v1 value on unmount', () => {
+    mockUseSelector.mockReturnValue(false);
+    const { rerender, unmount } = renderHook(() =>
+      useFullViewSortResetEffect(),
+    );
+
+    mockUseSelector.mockReturnValue(true);
+    rerender();
+    unmount();
+
+    expect(mockSetTokenSortConfig).toHaveBeenCalledWith(
+      DEFAULT_TOKEN_SORT_CONFIG,
+    );
   });
 });

--- a/app/components/Views/TokensFullView/useFullViewSortResetEffect.test.ts
+++ b/app/components/Views/TokensFullView/useFullViewSortResetEffect.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useFocusEffect } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import Engine from '../../../core/Engine';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
+import { useFullViewSortResetEffect } from './useFullViewSortResetEffect';
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      PreferencesController: {
+        setTokenSortConfig: jest.fn(),
+      },
+    },
+  },
+}));
+
+describe('useFullViewSortResetEffect', () => {
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
+  const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+  const mockSetTokenSortConfig =
+    Engine.context.PreferencesController
+      .setTokenSortConfig as jest.MockedFunction<
+      typeof Engine.context.PreferencesController.setTokenSortConfig
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers a focus effect callback', () => {
+    mockUseSelector.mockReturnValue(false);
+
+    renderHook(() => useFullViewSortResetEffect());
+
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('resets token sort config when homepage sections v1 is enabled', () => {
+    mockUseSelector.mockReturnValue(true);
+
+    renderHook(() => useFullViewSortResetEffect());
+
+    const onFocusEffect = mockUseFocusEffect.mock.calls[0][0];
+    const onCleanup = onFocusEffect();
+
+    if (typeof onCleanup === 'function') {
+      onCleanup();
+    }
+
+    expect(mockSetTokenSortConfig).toHaveBeenCalledWith(
+      DEFAULT_TOKEN_SORT_CONFIG,
+    );
+  });
+
+  it('does not reset token sort config when homepage sections v1 is disabled', () => {
+    mockUseSelector.mockReturnValue(false);
+
+    renderHook(() => useFullViewSortResetEffect());
+
+    const onFocusEffect = mockUseFocusEffect.mock.calls[0][0];
+    const onCleanup = onFocusEffect();
+
+    if (typeof onCleanup === 'function') {
+      onCleanup();
+    }
+
+    expect(mockSetTokenSortConfig).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/TokensFullView/useFullViewSortResetEffect.ts
+++ b/app/components/Views/TokensFullView/useFullViewSortResetEffect.ts
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { useFocusEffect } from '@react-navigation/native';
+import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../../core/Engine';
 import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
@@ -12,17 +11,20 @@ export const useFullViewSortResetEffect = () => {
   const isHomepageSectionsV1Enabled = useSelector(
     selectHomepageSectionsV1Enabled,
   );
+  const shouldResetTokenSortConfigRef = useRef(isHomepageSectionsV1Enabled);
 
-  useFocusEffect(
-    useCallback(
-      () => () => {
-        if (isHomepageSectionsV1Enabled) {
-          Engine.context.PreferencesController.setTokenSortConfig(
-            DEFAULT_TOKEN_SORT_CONFIG,
-          );
-        }
-      },
-      [isHomepageSectionsV1Enabled],
-    ),
+  useEffect(() => {
+    shouldResetTokenSortConfigRef.current = isHomepageSectionsV1Enabled;
+  }, [isHomepageSectionsV1Enabled]);
+
+  useEffect(
+    () => () => {
+      if (shouldResetTokenSortConfigRef.current) {
+        Engine.context.PreferencesController.setTokenSortConfig(
+          DEFAULT_TOKEN_SORT_CONFIG,
+        );
+      }
+    },
+    [],
   );
 };

--- a/app/components/Views/TokensFullView/useFullViewSortResetEffect.ts
+++ b/app/components/Views/TokensFullView/useFullViewSortResetEffect.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import Engine from '../../../core/Engine';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
+import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
+
+/**
+ * Resets full-view token sort config when leaving a full-view screen.
+ */
+export const useFullViewSortResetEffect = () => {
+  const isHomepageSectionsV1Enabled = useSelector(
+    selectHomepageSectionsV1Enabled,
+  );
+
+  useFocusEffect(
+    useCallback(
+      () => () => {
+        if (isHomepageSectionsV1Enabled) {
+          Engine.context.PreferencesController.setTokenSortConfig(
+            DEFAULT_TOKEN_SORT_CONFIG,
+          );
+        }
+      },
+      [isHomepageSectionsV1Enabled],
+    ),
+  );
+};

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -32,6 +32,7 @@ jest.mock('../../app/core/Engine', () => {
         state: {
           securityAlertsEnabled: true,
         },
+        setTokenSortConfig: jest.fn(),
         setTokenNetworkFilter() {
           return undefined;
         },

--- a/tests/component-view/renderers/defiFullView.ts
+++ b/tests/component-view/renderers/defiFullView.ts
@@ -1,0 +1,32 @@
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
+import { renderComponentViewScreen } from '../render';
+import Routes from '../../../app/constants/navigation/Routes';
+import DeFiFullView from '../../../app/components/Views/DeFiFullView';
+import { initialStateWallet } from '../presets/wallet';
+
+interface RenderDeFiFullViewOptions {
+  overrides?: DeepPartial<RootState>;
+  deterministicFiat?: boolean;
+}
+
+export function renderDeFiFullView(
+  options: RenderDeFiFullViewOptions = {},
+): ReturnType<typeof renderComponentViewScreen> {
+  const { overrides, deterministicFiat } = options;
+  const builder = initialStateWallet({ deterministicFiat });
+
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+
+  const state = builder.build();
+
+  return renderComponentViewScreen(
+    DeFiFullView as unknown as React.ComponentType,
+    { name: Routes.WALLET.DEFI_FULL_VIEW },
+    { state },
+  );
+}

--- a/tests/component-view/renderers/tokensFullView.ts
+++ b/tests/component-view/renderers/tokensFullView.ts
@@ -1,0 +1,49 @@
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
+import { renderComponentViewScreen } from '../render';
+import Routes from '../../../app/constants/navigation/Routes';
+import TokensFullView from '../../../app/components/Views/TokensFullView';
+import { initialStateWallet } from '../presets/wallet';
+import { DEFAULT_TOKEN_SORT_CONFIG } from '../../../app/components/UI/Tokens/util/sortAssets';
+
+interface RenderTokensFullViewOptions {
+  overrides?: DeepPartial<RootState>;
+  deterministicFiat?: boolean;
+}
+
+export function renderTokensFullView(
+  options: RenderTokensFullViewOptions = {},
+): ReturnType<typeof renderComponentViewScreen> {
+  const { overrides, deterministicFiat } = options;
+  const builder = initialStateWallet({ deterministicFiat })
+    .withPreferences({
+      tokenSortConfig: DEFAULT_TOKEN_SORT_CONFIG,
+    })
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          NetworkEnablementController: {
+            enabledNetworkMap: {
+              eip155: {
+                '0x1': true,
+              },
+            },
+          },
+        },
+      },
+    } as unknown as DeepPartial<RootState>);
+
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+
+  const state = builder.build();
+
+  return renderComponentViewScreen(
+    TokensFullView as unknown as React.ComponentType,
+    { name: Routes.WALLET.TOKENS_FULL_VIEW },
+    { state },
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## **Description**

Extracted the full-view token sort reset cleanup logic into a shared `useFullViewSortResetEffect` hook and reused it in both `TokensFullView` and `DeFiFullView`.

Follow-up commits:
- fixed Prettier formatting in the new hook unit test to satisfy `scripts (format:check)` CI.
- switched the shared hook from `useFocusEffect` to unmount-based `useEffect` cleanup so sort reset only occurs when the full-view screen unmounts (not when temporary overlays/bottom sheets blur focus).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: full view token sort reset cleanup

  Scenario: leaving tokens and defi full views keeps shared sort-reset behavior
    Given homepage sections v1 is enabled and the user opens Tokens Full View or DeFi Full View
    When the user navigates away from the full view screen
    Then the token sort config is reset to the default config via shared hook cleanup
```

## **Screenshots/Recordings**

### **Before**

N/A (no visual UI change)

### **After**

N/A (no visual UI change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<div><a href="https://cursor.com/agents/bc-094856ad-39f2-4994-98bc-9cd7c33b0bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-094856ad-39f2-4994-98bc-9cd7c33b0bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-094856ad-39f2-4994-98bc-9cd7c33b0bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-094856ad-39f2-4994-98bc-9cd7c33b0bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

