### PR TITLE
feat: render rich text from contentful

### DIFF
--- a/app/components/UI/Rewards/Views/CampaignMechanicsView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignMechanicsView.test.tsx
@@ -91,8 +91,16 @@ jest.mock('../components/Campaigns/CampaignHowItWorks', () => {
 jest.mock('../components/ContentfulRichText/ContentfulRichText', () => {
   const ReactActual = jest.requireActual('react');
   const { View, Text: RNText } = jest.requireActual('react-native');
+  const isDocumentFn = (value: unknown): boolean =>
+    value !== null &&
+    typeof value === 'object' &&
+    'nodeType' in (value as Record<string, unknown>) &&
+    (value as Record<string, unknown>).nodeType === 'document' &&
+    'content' in (value as Record<string, unknown>) &&
+    Array.isArray((value as Record<string, unknown>).content);
   return {
     __esModule: true,
+    isDocument: isDocumentFn,
     default: ({
       document: doc,
       testID,
@@ -296,6 +304,58 @@ describe('CampaignMechanicsView', () => {
                 title: 'How it works',
                 description: 'Earn rewards',
                 phases: [],
+              },
+            },
+          }),
+        ],
+      });
+      const { queryByTestId } = render(<CampaignMechanicsView />);
+      expect(
+        queryByTestId(CAMPAIGN_MECHANICS_TEST_IDS.NOTES_SECTION),
+      ).toBeNull();
+    });
+
+    it('does not render notes section when notes is a non-document object', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            details: {
+              image: {
+                lightModeUrl: 'https://example.com/light.png',
+                darkModeUrl: 'https://example.com/dark.png',
+              },
+              howItWorks: {
+                title: 'How it works',
+                description: 'Earn rewards',
+                phases: [],
+                notes: { title: 'Only title' },
+              },
+            },
+          }),
+        ],
+      });
+      const { queryByTestId } = render(<CampaignMechanicsView />);
+      expect(
+        queryByTestId(CAMPAIGN_MECHANICS_TEST_IDS.NOTES_SECTION),
+      ).toBeNull();
+    });
+
+    it('does not render notes section when notes is a string', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            details: {
+              image: {
+                lightModeUrl: 'https://example.com/light.png',
+                darkModeUrl: 'https://example.com/dark.png',
+              },
+              howItWorks: {
+                title: 'How it works',
+                description: 'Earn rewards',
+                phases: [],
+                notes: 'just a string',
               },
             },
           }),

--- a/app/components/UI/Rewards/Views/CampaignMechanicsView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignMechanicsView.test.tsx
@@ -88,6 +88,26 @@ jest.mock('../components/Campaigns/CampaignHowItWorks', () => {
   };
 });
 
+jest.mock('../components/ContentfulRichText/ContentfulRichText', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text: RNText } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      document: doc,
+      testID,
+    }: {
+      document: unknown;
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID },
+        ReactActual.createElement(RNText, null, JSON.stringify(doc)),
+      ),
+  };
+});
+
 jest.mock('../hooks/useRewardCampaigns');
 const mockUseRewardCampaigns = useRewardCampaigns as jest.MockedFunction<
   typeof useRewardCampaigns
@@ -196,7 +216,21 @@ describe('CampaignMechanicsView', () => {
   });
 
   describe('notes section', () => {
-    it('renders notes section when notes has valid shape', () => {
+    const richTextNotes = {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'paragraph',
+          data: {},
+          content: [
+            { nodeType: 'text', value: 'Important notes', marks: [], data: {} },
+          ],
+        },
+      ],
+    };
+
+    it('renders notes section with ContentfulRichText when notes is present', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -210,39 +244,16 @@ describe('CampaignMechanicsView', () => {
                 title: 'How it works',
                 description: 'Earn rewards',
                 phases: [],
-                notes: {
-                  title: 'Important notes',
-                  description: 'Please read carefully',
-                  items: [
-                    { title: 'Note 1', description: 'Detail 1' },
-                    { title: 'Note 2', description: 'Detail 2' },
-                  ],
-                },
+                notes: richTextNotes,
               },
             },
           }),
         ],
       });
-      const { getByTestId, getByText } = render(<CampaignMechanicsView />);
+      const { getByTestId } = render(<CampaignMechanicsView />);
       expect(
         getByTestId(CAMPAIGN_MECHANICS_TEST_IDS.NOTES_SECTION),
       ).toBeDefined();
-      expect(
-        getByTestId(CAMPAIGN_MECHANICS_TEST_IDS.NOTES_TITLE),
-      ).toHaveTextContent('Important notes');
-      expect(
-        getByTestId(CAMPAIGN_MECHANICS_TEST_IDS.NOTES_DESCRIPTION),
-      ).toHaveTextContent('Please read carefully');
-      expect(
-        getByTestId(`${CAMPAIGN_MECHANICS_TEST_IDS.NOTE_ITEM}-0`),
-      ).toBeDefined();
-      expect(
-        getByTestId(`${CAMPAIGN_MECHANICS_TEST_IDS.NOTE_ITEM_TITLE}-0`),
-      ).toHaveTextContent('Note 1');
-      expect(
-        getByTestId(`${CAMPAIGN_MECHANICS_TEST_IDS.NOTE_ITEM_DESCRIPTION}-0`),
-      ).toHaveTextContent('Detail 1');
-      expect(getByText('Note 2')).toBeDefined();
     });
 
     it('does not render notes section when notes is null', () => {
@@ -271,7 +282,7 @@ describe('CampaignMechanicsView', () => {
       ).toBeNull();
     });
 
-    it('does not render notes section when notes has invalid shape', () => {
+    it('does not render notes section when howItWorks has no notes field', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -285,7 +296,6 @@ describe('CampaignMechanicsView', () => {
                 title: 'How it works',
                 description: 'Earn rewards',
                 phases: [],
-                notes: { title: 'Only title' }, // missing items
               },
             },
           }),

--- a/app/components/UI/Rewards/Views/CampaignMechanicsView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignMechanicsView.tsx
@@ -1,18 +1,13 @@
 import React, { useMemo } from 'react';
 import { ScrollView } from 'react-native';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import {
-  Box,
-  Text,
-  TextVariant,
-  TextColor,
-  FontWeight,
-} from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import CampaignHowItWorks from '../components/Campaigns/CampaignHowItWorks';
+import ContentfulRichText from '../components/ContentfulRichText/ContentfulRichText';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { strings } from '../../../../../locales/i18n';
 
@@ -22,41 +17,10 @@ type CampaignMechanicsRouteParams = {
   CampaignMechanics: { campaignId: string };
 };
 
-interface CampaignNoteItem {
-  title: string;
-  description: string;
-}
-
-interface CampaignNotes {
-  title: string;
-  description: string;
-  items: CampaignNoteItem[];
-}
-
-function parseCampaignNotes(notes: unknown): CampaignNotes | null {
-  if (
-    notes !== null &&
-    typeof notes === 'object' &&
-    !Array.isArray(notes) &&
-    'title' in notes &&
-    'description' in notes &&
-    'items' in notes &&
-    Array.isArray((notes as { items: unknown }).items)
-  ) {
-    return notes as CampaignNotes;
-  }
-  return null;
-}
-
 export const CAMPAIGN_MECHANICS_TEST_IDS = {
   CONTAINER: 'campaign-mechanics-container',
   HOW_IT_WORKS_SECTION: 'campaign-mechanics-how-it-works',
   NOTES_SECTION: 'campaign-mechanics-notes',
-  NOTES_TITLE: 'campaign-mechanics-notes-title',
-  NOTES_DESCRIPTION: 'campaign-mechanics-notes-description',
-  NOTE_ITEM: 'campaign-mechanics-note-item',
-  NOTE_ITEM_TITLE: 'campaign-mechanics-note-item-title',
-  NOTE_ITEM_DESCRIPTION: 'campaign-mechanics-note-item-description',
 } as const;
 
 const CampaignMechanicsView: React.FC = () => {
@@ -73,7 +37,7 @@ const CampaignMechanicsView: React.FC = () => {
   );
 
   const howItWorks = campaign?.details?.howItWorks ?? null;
-  const notes = parseCampaignNotes(howItWorks?.notes);
+  const notes = howItWorks?.notes ?? null;
 
   return (
     <ErrorBoundary navigation={navigation} view="CampaignMechanicsView">
@@ -103,45 +67,10 @@ const CampaignMechanicsView: React.FC = () => {
 
           {notes && (
             <Box
-              twClassName="px-4 py-4 gap-3"
+              twClassName="px-4 py-4"
               testID={CAMPAIGN_MECHANICS_TEST_IDS.NOTES_SECTION}
             >
-              <Text
-                variant={TextVariant.HeadingMd}
-                fontWeight={FontWeight.Bold}
-                testID={CAMPAIGN_MECHANICS_TEST_IDS.NOTES_TITLE}
-              >
-                {notes.title}
-              </Text>
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-                testID={CAMPAIGN_MECHANICS_TEST_IDS.NOTES_DESCRIPTION}
-              >
-                {notes.description}
-              </Text>
-              {notes.items.map((item, index) => (
-                <Box
-                  key={`note-item-${index}`}
-                  twClassName="gap-1"
-                  testID={`${CAMPAIGN_MECHANICS_TEST_IDS.NOTE_ITEM}-${index}`}
-                >
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    fontWeight={FontWeight.Bold}
-                    testID={`${CAMPAIGN_MECHANICS_TEST_IDS.NOTE_ITEM_TITLE}-${index}`}
-                  >
-                    {item.title}
-                  </Text>
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    color={TextColor.TextAlternative}
-                    testID={`${CAMPAIGN_MECHANICS_TEST_IDS.NOTE_ITEM_DESCRIPTION}-${index}`}
-                  >
-                    {item.description}
-                  </Text>
-                </Box>
-              ))}
+              <ContentfulRichText document={notes} />
             </Box>
           )}
         </ScrollView>

--- a/app/components/UI/Rewards/Views/CampaignMechanicsView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignMechanicsView.tsx
@@ -7,7 +7,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import CampaignHowItWorks from '../components/Campaigns/CampaignHowItWorks';
-import ContentfulRichText from '../components/ContentfulRichText/ContentfulRichText';
+import ContentfulRichText, {
+  isDocument,
+} from '../components/ContentfulRichText/ContentfulRichText';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { strings } from '../../../../../locales/i18n';
 
@@ -65,7 +67,7 @@ const CampaignMechanicsView: React.FC = () => {
             </Box>
           )}
 
-          {notes && (
+          {isDocument(notes) && (
             <Box
               twClassName="px-4 py-4"
               testID={CAMPAIGN_MECHANICS_TEST_IDS.NOTES_SECTION}

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import type { Json } from '@metamask/utils';
 import CampaignOptInSheet from './CampaignOptInSheet';
 import {
   type CampaignDto,
@@ -271,7 +272,7 @@ describe('CampaignOptInSheet', () => {
   });
 
   describe('termsAndConditions rich text', () => {
-    const richTextDoc = {
+    const richTextDoc: Json = {
       nodeType: 'document',
       data: {},
       content: [

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
@@ -71,8 +71,16 @@ jest.mock('../RewardsErrorBanner', () => {
 jest.mock('../ContentfulRichText/ContentfulRichText', () => {
   const ReactActual = jest.requireActual('react');
   const { View, Text: RNText } = jest.requireActual('react-native');
+  const isDocumentFn = (value: unknown): boolean =>
+    value !== null &&
+    typeof value === 'object' &&
+    'nodeType' in (value as Record<string, unknown>) &&
+    (value as Record<string, unknown>).nodeType === 'document' &&
+    'content' in (value as Record<string, unknown>) &&
+    Array.isArray((value as Record<string, unknown>).content);
   return {
     __esModule: true,
+    isDocument: isDocumentFn,
     default: ({
       document: doc,
       testID,
@@ -313,7 +321,29 @@ describe('CampaignOptInSheet', () => {
           campaign={createTestCampaign({ termsAndConditions: null })}
         />,
       );
-      expect(getByTestId('campaign-opt-in-sheet-terms-link')).toBeDefined();
+      expect(getByTestId('campaign-opt-in-sheet-terms-link')).toBeOnTheScreen();
+    });
+
+    it('renders the static fallback when termsAndConditions is malformed', () => {
+      const { getByTestId } = render(
+        <CampaignOptInSheet
+          campaign={createTestCampaign({
+            termsAndConditions: 'not a document',
+          })}
+        />,
+      );
+      expect(getByTestId('campaign-opt-in-sheet-terms-link')).toBeOnTheScreen();
+    });
+
+    it('renders the static fallback when termsAndConditions is a non-document object', () => {
+      const { getByTestId } = render(
+        <CampaignOptInSheet
+          campaign={createTestCampaign({
+            termsAndConditions: { foo: 'bar' },
+          })}
+        />,
+      );
+      expect(getByTestId('campaign-opt-in-sheet-terms-link')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Linking } from 'react-native';
 import CampaignOptInSheet from './CampaignOptInSheet';
 import {
   type CampaignDto,
   CampaignType,
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { useOptInToCampaign } from '../../hooks/useOptInToCampaign';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -63,6 +68,26 @@ jest.mock('../RewardsErrorBanner', () => {
   };
 });
 
+jest.mock('../ContentfulRichText/ContentfulRichText', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text: RNText } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      document: doc,
+      testID,
+    }: {
+      document: unknown;
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID },
+        ReactActual.createElement(RNText, null, JSON.stringify(doc)),
+      ),
+  };
+});
+
 jest.mock('../Onboarding/constants', () => ({
   REWARDS_ONBOARD_TERMS_URL: 'https://go.metamask.io/rewards-terms',
 }));
@@ -103,7 +128,6 @@ const mockOptInToCampaign = jest.fn();
 describe('CampaignOptInSheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
     mockUseOptInToCampaign.mockReturnValue({
       optInToCampaign: mockOptInToCampaign,
       isOptingIn: false,
@@ -137,14 +161,17 @@ describe('CampaignOptInSheet', () => {
     );
   });
 
-  it('opens the terms URL when terms link is pressed', () => {
+  it('opens the terms URL in in-app browser when terms link is pressed', () => {
     const { getByTestId } = render(
       <CampaignOptInSheet campaign={createTestCampaign()} />,
     );
     fireEvent.press(getByTestId('campaign-opt-in-sheet-terms-link'));
-    expect(Linking.openURL).toHaveBeenCalledWith(
-      'https://go.metamask.io/rewards-terms',
-    );
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
+      screen: Routes.BROWSER.VIEW,
+      params: expect.objectContaining({
+        newTabUrl: 'https://go.metamask.io/rewards-terms',
+      }),
+    });
   });
 
   it('renders the CTA button', () => {
@@ -233,5 +260,60 @@ describe('CampaignOptInSheet', () => {
     );
     // Button still renders while loading
     expect(getByTestId('campaign-opt-in-cta')).toBeDefined();
+  });
+
+  describe('termsAndConditions rich text', () => {
+    const richTextDoc = {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'paragraph',
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'By joining you agree to the ',
+              marks: [],
+              data: {},
+            },
+            {
+              nodeType: 'hyperlink',
+              data: { uri: 'https://example.com/terms' },
+              content: [
+                { nodeType: 'text', value: 'Terms', marks: [], data: {} },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    it('renders ContentfulRichText when termsAndConditions is present', () => {
+      const { getByTestId } = render(
+        <CampaignOptInSheet
+          campaign={createTestCampaign({ termsAndConditions: richTextDoc })}
+        />,
+      );
+      expect(getByTestId('campaign-opt-in-sheet-description')).toBeDefined();
+    });
+
+    it('does not render the static terms link when termsAndConditions is present', () => {
+      const { queryByTestId } = render(
+        <CampaignOptInSheet
+          campaign={createTestCampaign({ termsAndConditions: richTextDoc })}
+        />,
+      );
+      expect(queryByTestId('campaign-opt-in-sheet-terms-link')).toBeNull();
+    });
+
+    it('renders the static fallback when termsAndConditions is null', () => {
+      const { getByTestId } = render(
+        <CampaignOptInSheet
+          campaign={createTestCampaign({ termsAndConditions: null })}
+        />,
+      );
+      expect(getByTestId('campaign-opt-in-sheet-terms-link')).toBeDefined();
+    });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -20,7 +20,9 @@ import { useOptInToCampaign } from '../../hooks/useOptInToCampaign';
 import { strings } from '../../../../../../locales/i18n';
 import { REWARDS_ONBOARD_TERMS_URL } from '../Onboarding/constants';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import ContentfulRichText from '../ContentfulRichText/ContentfulRichText';
+import ContentfulRichText, {
+  isDocument,
+} from '../ContentfulRichText/ContentfulRichText';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 
@@ -92,7 +94,7 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
 
         {/* Legal disclaimer – rich text from Contentful or static fallback */}
         <Box twClassName="mb-6">
-          {campaign.termsAndConditions ? (
+          {isDocument(campaign.termsAndConditions) ? (
             <ContentfulRichText
               document={campaign.termsAndConditions}
               textVariant={TextVariant.BodySm}

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { Linking } from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -21,6 +20,9 @@ import { useOptInToCampaign } from '../../hooks/useOptInToCampaign';
 import { strings } from '../../../../../../locales/i18n';
 import { REWARDS_ONBOARD_TERMS_URL } from '../Onboarding/constants';
 import RewardsErrorBanner from '../RewardsErrorBanner';
+import ContentfulRichText from '../ContentfulRichText/ContentfulRichText';
+import { useNavigation } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
 
 interface CampaignOptInSheetProps {
   campaign: CampaignDto;
@@ -35,6 +37,7 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   campaign,
   onClose,
 }) => {
+  const navigation = useNavigation();
   const { optInToCampaign, isOptingIn, optInError } = useOptInToCampaign();
 
   const handleOptIn = useCallback(async () => {
@@ -47,8 +50,14 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   }, [optInToCampaign, campaign.id, onClose]);
 
   const handleTermsPress = useCallback(() => {
-    Linking.openURL(REWARDS_ONBOARD_TERMS_URL);
-  }, []);
+    navigation.navigate(Routes.BROWSER.HOME, {
+      screen: Routes.BROWSER.VIEW,
+      params: {
+        newTabUrl: REWARDS_ONBOARD_TERMS_URL,
+        timestamp: Date.now(),
+      },
+    });
+  }, [navigation]);
 
   return (
     <BottomSheet shouldNavigateBack={false} onClose={onClose}>
@@ -81,25 +90,34 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
           />
         </Box>
 
-        {/* Legal disclaimer with tappable link */}
+        {/* Legal disclaimer – rich text from Contentful or static fallback */}
         <Box twClassName="mb-6">
-          <Text
-            variant={TextVariant.BodyMd}
-            twClassName="text-alternative text-center"
-            testID="campaign-opt-in-sheet-description"
-          >
-            {strings('rewards.campaign.opt_in_sheet_description_pre_link')}{' '}
+          {campaign.termsAndConditions ? (
+            <ContentfulRichText
+              document={campaign.termsAndConditions}
+              textVariant={TextVariant.BodySm}
+              bodyClassName="text-center text-alternative"
+              testID="campaign-opt-in-sheet-description"
+            />
+          ) : (
             <Text
-              variant={TextVariant.BodyMd}
-              twClassName="text-primary-default"
-              onPress={handleTermsPress}
-              testID="campaign-opt-in-sheet-terms-link"
+              variant={TextVariant.BodySm}
+              twClassName="text-alternative text-center"
+              testID="campaign-opt-in-sheet-description"
             >
-              {strings('rewards.campaign.opt_in_sheet_link_text')}
+              {strings('rewards.campaign.opt_in_sheet_description_pre_link')}{' '}
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-primary-default"
+                onPress={handleTermsPress}
+                testID="campaign-opt-in-sheet-terms-link"
+              >
+                {strings('rewards.campaign.opt_in_sheet_link_text')}
+              </Text>
+              {'. '}
+              {strings('rewards.campaign.opt_in_sheet_description_post_link')}
             </Text>
-            {'. '}
-            {strings('rewards.campaign.opt_in_sheet_description_post_link')}
-          </Text>
+          )}
         </Box>
 
         {optInError && (

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.test.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import ContentfulRichText from './ContentfulRichText';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return { ...actual };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+interface RichTextNode {
+  nodeType: string;
+  data: Record<string, unknown>;
+  content?: RichTextNode[];
+  value?: string;
+  marks?: { type: string }[];
+}
+
+const makeDoc = (...content: RichTextNode[]) => ({
+  nodeType: 'document' as const,
+  data: {},
+  content,
+});
+
+const paragraph = (...children: RichTextNode[]) => ({
+  nodeType: 'paragraph' as const,
+  data: {},
+  content: children,
+});
+
+const text = (
+  value: string,
+  marks: { type: string }[] = [],
+): RichTextNode => ({
+  nodeType: 'text' as const,
+  value,
+  marks,
+  data: {},
+});
+
+const hyperlink = (uri: string, linkText: string): RichTextNode => ({
+  nodeType: 'hyperlink' as const,
+  data: { uri },
+  content: [text(linkText)],
+});
+
+describe('ContentfulRichText', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null for invalid document', () => {
+    const { toJSON } = render(
+      <ContentfulRichText document={null as unknown} testID="rt" />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null for a non-document object', () => {
+    const { toJSON } = render(
+      <ContentfulRichText document={{ foo: 'bar' }} testID="rt" />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders a simple paragraph with plain text', () => {
+    const doc = makeDoc(paragraph(text('Hello world')));
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('Hello world')).toBeDefined();
+  });
+
+  it('renders bold text', () => {
+    const doc = makeDoc(paragraph(text('bold text', [{ type: 'bold' }])));
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('bold text')).toBeDefined();
+  });
+
+  it('renders a hyperlink and opens in-app browser on press', () => {
+    const doc = makeDoc(
+      paragraph(
+        text('See '),
+        hyperlink('https://example.com', 'our terms'),
+        text(' for details.'),
+      ),
+    );
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    fireEvent.press(getByText('our terms'));
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
+      screen: Routes.BROWSER.VIEW,
+      params: expect.objectContaining({
+        newTabUrl: 'https://example.com',
+      }),
+    });
+  });
+
+  it('renders multiple paragraphs', () => {
+    const doc = makeDoc(
+      paragraph(text('First paragraph')),
+      paragraph(text('Second paragraph')),
+    );
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('First paragraph')).toBeDefined();
+    expect(getByText('Second paragraph')).toBeDefined();
+  });
+
+  it('renders an unordered list with bullets', () => {
+    const doc = makeDoc({
+      nodeType: 'unordered-list',
+      data: {},
+      content: [
+        {
+          nodeType: 'list-item',
+          data: {},
+          content: [paragraph(text('Item one'))],
+        },
+        {
+          nodeType: 'list-item',
+          data: {},
+          content: [paragraph(text('Item two'))],
+        },
+      ],
+    });
+    const { getByText, getAllByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('Item one')).toBeDefined();
+    expect(getByText('Item two')).toBeDefined();
+    expect(getAllByText('• ').length).toBe(2);
+  });
+
+  it('renders an ordered list with numbers', () => {
+    const doc = makeDoc({
+      nodeType: 'ordered-list',
+      data: {},
+      content: [
+        {
+          nodeType: 'list-item',
+          data: {},
+          content: [paragraph(text('First'))],
+        },
+        {
+          nodeType: 'list-item',
+          data: {},
+          content: [paragraph(text('Second'))],
+        },
+      ],
+    });
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('1. ')).toBeDefined();
+    expect(getByText('2. ')).toBeDefined();
+  });
+
+  it('renders a heading', () => {
+    const doc = makeDoc({
+      nodeType: 'heading-2',
+      data: {},
+      content: [text('Title')],
+    });
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('Title')).toBeDefined();
+  });
+
+  it('sets the testID on the container', () => {
+    const doc = makeDoc(paragraph(text('test')));
+    const { getByTestId } = render(
+      <ContentfulRichText document={doc} testID="my-rich-text" />,
+    );
+    expect(getByTestId('my-rich-text')).toBeDefined();
+  });
+});

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.test.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import type { Json } from '@metamask/utils';
 import ContentfulRichText from './ContentfulRichText';
 import Routes from '../../../../../constants/navigation/Routes';
 
@@ -17,38 +18,29 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: (...args: unknown[]) => args }),
 }));
 
-interface RichTextNode {
-  nodeType: string;
-  data: Record<string, unknown>;
-  content?: RichTextNode[];
-  value?: string;
-  marks?: { type: string }[];
-}
+type RichTextNode = Record<string, Json>;
 
-const makeDoc = (...content: RichTextNode[]) => ({
-  nodeType: 'document' as const,
+const makeDoc = (...content: RichTextNode[]): Json => ({
+  nodeType: 'document',
   data: {},
   content,
 });
 
-const paragraph = (...children: RichTextNode[]) => ({
-  nodeType: 'paragraph' as const,
+const paragraph = (...children: RichTextNode[]): RichTextNode => ({
+  nodeType: 'paragraph',
   data: {},
   content: children,
 });
 
-const text = (
-  value: string,
-  marks: { type: string }[] = [],
-): RichTextNode => ({
-  nodeType: 'text' as const,
+const text = (value: string, marks: { type: string }[] = []): RichTextNode => ({
+  nodeType: 'text',
   value,
-  marks,
+  marks: marks as Json[],
   data: {},
 });
 
 const hyperlink = (uri: string, linkText: string): RichTextNode => ({
-  nodeType: 'hyperlink' as const,
+  nodeType: 'hyperlink',
   data: { uri },
   content: [text(linkText)],
 });
@@ -60,7 +52,7 @@ describe('ContentfulRichText', () => {
 
   it('returns null for invalid document', () => {
     const { toJSON } = render(
-      <ContentfulRichText document={null as unknown} testID="rt" />,
+      <ContentfulRichText document={null as unknown as Json} testID="rt" />,
     );
     expect(toJSON()).toBeNull();
   });
@@ -77,7 +69,7 @@ describe('ContentfulRichText', () => {
     const { getByText } = render(
       <ContentfulRichText document={doc} testID="rt" />,
     );
-    expect(getByText('Hello world')).toBeDefined();
+    expect(getByText('Hello world')).toBeOnTheScreen();
   });
 
   it('renders bold text', () => {
@@ -85,7 +77,7 @@ describe('ContentfulRichText', () => {
     const { getByText } = render(
       <ContentfulRichText document={doc} testID="rt" />,
     );
-    expect(getByText('bold text')).toBeDefined();
+    expect(getByText('bold text')).toBeOnTheScreen();
   });
 
   it('renders a hyperlink and opens in-app browser on press', () => {
@@ -116,8 +108,8 @@ describe('ContentfulRichText', () => {
     const { getByText } = render(
       <ContentfulRichText document={doc} testID="rt" />,
     );
-    expect(getByText('First paragraph')).toBeDefined();
-    expect(getByText('Second paragraph')).toBeDefined();
+    expect(getByText('First paragraph')).toBeOnTheScreen();
+    expect(getByText('Second paragraph')).toBeOnTheScreen();
   });
 
   it('renders an unordered list with bullets', () => {
@@ -140,8 +132,8 @@ describe('ContentfulRichText', () => {
     const { getByText, getAllByText } = render(
       <ContentfulRichText document={doc} testID="rt" />,
     );
-    expect(getByText('Item one')).toBeDefined();
-    expect(getByText('Item two')).toBeDefined();
+    expect(getByText('Item one')).toBeOnTheScreen();
+    expect(getByText('Item two')).toBeOnTheScreen();
     expect(getAllByText('• ').length).toBe(2);
   });
 
@@ -165,8 +157,8 @@ describe('ContentfulRichText', () => {
     const { getByText } = render(
       <ContentfulRichText document={doc} testID="rt" />,
     );
-    expect(getByText('1. ')).toBeDefined();
-    expect(getByText('2. ')).toBeDefined();
+    expect(getByText('1. ')).toBeOnTheScreen();
+    expect(getByText('2. ')).toBeOnTheScreen();
   });
 
   it('renders a heading', () => {
@@ -178,7 +170,7 @@ describe('ContentfulRichText', () => {
     const { getByText } = render(
       <ContentfulRichText document={doc} testID="rt" />,
     );
-    expect(getByText('Title')).toBeDefined();
+    expect(getByText('Title')).toBeOnTheScreen();
   });
 
   it('sets the testID on the container', () => {
@@ -186,6 +178,20 @@ describe('ContentfulRichText', () => {
     const { getByTestId } = render(
       <ContentfulRichText document={doc} testID="my-rich-text" />,
     );
-    expect(getByTestId('my-rich-text')).toBeDefined();
+    expect(getByTestId('my-rich-text')).toBeOnTheScreen();
+  });
+
+  it('renders a text node that has no marks property', () => {
+    const doc = makeDoc(
+      paragraph({
+        nodeType: 'text',
+        value: 'no marks',
+        data: {},
+      }),
+    );
+    const { getByText } = render(
+      <ContentfulRichText document={doc} testID="rt" />,
+    );
+    expect(getByText('no marks')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
@@ -59,9 +59,7 @@ interface ContentfulRichTextProps {
   testID?: string;
 }
 
-function isDocument(
-  value: unknown,
-): value is {
+function isDocument(value: unknown): value is {
   nodeType: 'document';
   data: Record<string, unknown>;
   content: RichTextNode[];
@@ -79,7 +77,11 @@ function isDocument(
 function isTextNode(
   node: RichTextNode,
 ): node is RichTextNode & { value: string; marks: RichTextMark[] } {
-  return node.nodeType === 'text';
+  return (
+    node.nodeType === 'text' &&
+    typeof node.value === 'string' &&
+    Array.isArray(node.marks)
+  );
 }
 
 /**
@@ -148,6 +150,10 @@ const ContentfulRichText: React.FC<ContentfulRichTextProps> = ({
           return <Fragment key={childKey}>{child.value}</Fragment>;
         }
         return renderMarkedText(child.value, child.marks, childKey);
+      }
+
+      if (child.nodeType === 'text' && typeof child.value === 'string') {
+        return <Fragment key={childKey}>{child.value}</Fragment>;
       }
 
       if (child.nodeType === INLINE_TYPES.HYPERLINK) {

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
@@ -251,4 +251,5 @@ const ContentfulRichText: React.FC<ContentfulRichTextProps> = ({
   );
 };
 
+export { isDocument };
 export default ContentfulRichText;

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
@@ -1,0 +1,248 @@
+import React, { Fragment, useCallback } from 'react';
+import {
+  useNavigation,
+  type NavigationProp,
+  type ParamListBase,
+} from '@react-navigation/native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import type { Json } from '@metamask/utils';
+import Routes from '../../../../../constants/navigation/Routes';
+
+// Contentful rich text node-type constants (from @contentful/rich-text-types)
+const BLOCK_TYPES = {
+  DOCUMENT: 'document',
+  PARAGRAPH: 'paragraph',
+  HEADING_1: 'heading-1',
+  HEADING_2: 'heading-2',
+  HEADING_3: 'heading-3',
+  HEADING_4: 'heading-4',
+  HEADING_5: 'heading-5',
+  HEADING_6: 'heading-6',
+  OL_LIST: 'ordered-list',
+  UL_LIST: 'unordered-list',
+  LIST_ITEM: 'list-item',
+  HR: 'hr',
+} as const;
+
+const INLINE_TYPES = {
+  HYPERLINK: 'hyperlink',
+} as const;
+
+const MARK_TYPES = {
+  BOLD: 'bold',
+  ITALIC: 'italic',
+  UNDERLINE: 'underline',
+} as const;
+
+interface RichTextMark {
+  type: string;
+}
+
+interface RichTextNode {
+  nodeType: string;
+  data: Record<string, unknown>;
+  content?: RichTextNode[];
+  value?: string;
+  marks?: RichTextMark[];
+}
+
+interface ContentfulRichTextProps {
+  document: Json;
+  textVariant?: TextVariant;
+  headingClassName?: string;
+  bodyClassName?: string;
+  testID?: string;
+}
+
+function isDocument(
+  value: unknown,
+): value is {
+  nodeType: 'document';
+  data: Record<string, unknown>;
+  content: RichTextNode[];
+} {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'nodeType' in value &&
+    (value as { nodeType: unknown }).nodeType === BLOCK_TYPES.DOCUMENT &&
+    'content' in value &&
+    Array.isArray((value as { content: unknown }).content)
+  );
+}
+
+function isTextNode(
+  node: RichTextNode,
+): node is RichTextNode & { value: string; marks: RichTextMark[] } {
+  return node.nodeType === 'text';
+}
+
+/**
+ * Renders a Contentful rich text Document as React Native components
+ * using the MetaMask design system primitives.
+ *
+ * Supports paragraphs, headings, lists, hyperlinks, and text marks
+ * (bold, italic, underline).
+ */
+const ContentfulRichText: React.FC<ContentfulRichTextProps> = ({
+  document: doc,
+  textVariant = TextVariant.BodyMd,
+  headingClassName = 'text-default',
+  bodyClassName = 'text-alternative',
+  testID,
+}) => {
+  const navigation = useNavigation();
+
+  const handleLinkPress = useCallback(
+    (url: string) => {
+      navigation.navigate(Routes.BROWSER.HOME, {
+        screen: Routes.BROWSER.VIEW,
+        params: {
+          newTabUrl: url,
+          timestamp: Date.now(),
+        },
+      });
+    },
+    [navigation],
+  );
+
+  if (!isDocument(doc)) {
+    return null;
+  }
+
+  const renderMarkedText = (
+    text: string,
+    marks: RichTextMark[],
+    key: string,
+  ): React.ReactElement => {
+    const isBold = marks.some((m) => m.type === MARK_TYPES.BOLD);
+    const isItalic = marks.some((m) => m.type === MARK_TYPES.ITALIC);
+    const isUnderline = marks.some((m) => m.type === MARK_TYPES.UNDERLINE);
+
+    return (
+      <Text
+        key={key}
+        variant={textVariant}
+        twClassName={`${bodyClassName}${isItalic ? ' italic' : ''}${isUnderline ? ' underline' : ''}`}
+        fontWeight={isBold ? FontWeight.Bold : undefined}
+      >
+        {text}
+      </Text>
+    );
+  };
+
+  const renderInlineChildren = (
+    nodes: RichTextNode[],
+    keyPrefix: string,
+  ): React.ReactNode[] =>
+    nodes.map((child, i) => {
+      const childKey = `${keyPrefix}-${i}`;
+
+      if (isTextNode(child)) {
+        if (child.marks.length === 0) {
+          return <Fragment key={childKey}>{child.value}</Fragment>;
+        }
+        return renderMarkedText(child.value, child.marks, childKey);
+      }
+
+      if (child.nodeType === INLINE_TYPES.HYPERLINK) {
+        const uri = (child.data as { uri?: string }).uri ?? '';
+        return (
+          <Text
+            key={childKey}
+            variant={textVariant}
+            twClassName="text-primary-default"
+            onPress={() => handleLinkPress(uri)}
+          >
+            {renderInlineChildren(child.content ?? [], childKey)}
+          </Text>
+        );
+      }
+
+      return null;
+    });
+
+  const renderBlock = (
+    node: RichTextNode,
+    key: string,
+  ): React.ReactElement | null => {
+    switch (node.nodeType) {
+      case BLOCK_TYPES.PARAGRAPH:
+        return (
+          <Text key={key} variant={textVariant} twClassName={bodyClassName}>
+            {renderInlineChildren(node.content ?? [], key)}
+          </Text>
+        );
+
+      case BLOCK_TYPES.HEADING_1:
+      case BLOCK_TYPES.HEADING_2:
+      case BLOCK_TYPES.HEADING_3:
+      case BLOCK_TYPES.HEADING_4:
+      case BLOCK_TYPES.HEADING_5:
+      case BLOCK_TYPES.HEADING_6: {
+        const headingVariantMap: Record<string, TextVariant> = {
+          [BLOCK_TYPES.HEADING_1]: TextVariant.HeadingLg,
+          [BLOCK_TYPES.HEADING_2]: TextVariant.HeadingLg,
+          [BLOCK_TYPES.HEADING_3]: TextVariant.HeadingMd,
+          [BLOCK_TYPES.HEADING_4]: TextVariant.HeadingMd,
+          [BLOCK_TYPES.HEADING_5]: TextVariant.HeadingSm,
+          [BLOCK_TYPES.HEADING_6]: TextVariant.HeadingSm,
+        };
+        return (
+          <Text
+            key={key}
+            variant={headingVariantMap[node.nodeType]}
+            fontWeight={FontWeight.Bold}
+            twClassName={`my-3 ${headingClassName}`}
+          >
+            {renderInlineChildren(node.content ?? [], key)}
+          </Text>
+        );
+      }
+
+      case BLOCK_TYPES.UL_LIST:
+      case BLOCK_TYPES.OL_LIST:
+        return (
+          <Box key={key} twClassName="gap-1">
+            {(node.content ?? []).map((item, i) => {
+              const bullet =
+                node.nodeType === BLOCK_TYPES.OL_LIST ? `${i + 1}. ` : '• ';
+              return (
+                <Box key={`${key}-li-${i}`} twClassName="flex-row">
+                  <Text variant={textVariant} twClassName={bodyClassName}>
+                    {bullet}
+                  </Text>
+                  <Box twClassName="flex-1 flex-shrink">
+                    {(item.content ?? []).map((block, j) =>
+                      renderBlock(block, `${key}-li-${i}-${j}`),
+                    )}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      case BLOCK_TYPES.HR:
+        return (
+          <Box key={key} twClassName="border-b border-border-muted my-2" />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box testID={testID}>
+      {doc.content.map((block, i) => renderBlock(block, `rt-${i}`))}
+    </Box>
+  );
+};
+
+export default ContentfulRichText;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Render contentful rich text
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-03-18 at 17 27 27" src="https://github.com/user-attachments/assets/2082d21c-3ba2-4a0c-ae9e-c1f2b74c273e" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-03-18 at 17 27 20" src="https://github.com/user-attachments/assets/911e52e2-4404-476a-a7ac-3074776f92e5" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new rich-text renderer and switches rewards screens to render Contentful-provided documents and open links via in-app browser navigation, which may affect UI rendering and link handling for live campaign content.
> 
> **Overview**
> Enables Rewards UI to render **Contentful rich text documents** (paragraphs, headings, lists, text marks, and hyperlinks) via a new `ContentfulRichText` component, with hyperlinks opening in the in-app browser.
> 
> Updates `CampaignMechanicsView` to render `howItWorks.notes` only when it is a valid Contentful `document` (removing the previous structured-notes parsing and related testIDs), and updates `CampaignOptInSheet` to prefer `campaign.termsAndConditions` rich text with a static fallback.
> 
> Adds comprehensive unit tests for the new rich-text renderer and adjusts existing tests for the new rendering/navigation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a77608938aef1711996540a0295c99ead35763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->