### PR TITLE
fix(ci): assign unique build versions for nightly exp and rc builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -7,6 +7,11 @@ name: Nightly Build
 # [skip ci] commits (e.g. version bumps pushed via update-latest-build-version.yml)
 # are automatically skipped by GitHub Actions, so this workflow will NOT
 # double-trigger on those commits.
+#
+# Version strategy: exp and rc builds share the same bundle ID (MetaMask) so
+# TestFlight requires unique CFBundleVersion per upload. We call the external
+# version generator once (→ version N for exp), then locally increment to N+1
+# for the rc build. Both builds run in parallel after their respective bumps.
 
 on:
   push:
@@ -20,8 +25,8 @@ permissions:
   id-token: write
 
 jobs:
-  bump-version:
-    name: Bump build version
+  bump-version-exp:
+    name: Bump build version (exp)
     uses: ./.github/workflows/update-latest-build-version.yml
     permissions:
       contents: write
@@ -30,26 +35,59 @@ jobs:
       base-branch: ${{ github.ref_name }}
     secrets: inherit
 
+  bump-version-rc:
+    name: Bump build version (rc)
+    needs: [bump-version-exp]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      commit-hash: ${{ steps.bump.outputs.commit-hash }}
+      build-version: ${{ steps.bump.outputs.build-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version-exp.outputs.commit-hash }}
+          fetch-depth: 0
+          token: ${{ secrets.PR_TOKEN || github.token }}
+
+      - name: Increment version for RC build
+        id: bump
+        env:
+          EXP_VERSION: ${{ needs.bump-version-exp.outputs.build-version }}
+          HEAD_REF: ${{ github.ref_name }}
+        run: |
+          RC_VERSION=$((EXP_VERSION + 1))
+          echo "Exp version: $EXP_VERSION → RC version: $RC_VERSION"
+          ./scripts/set-build-version.sh "$RC_VERSION"
+          git config user.name metamaskbot
+          git config user.email metamaskbot@users.noreply.github.com
+          git add bitrise.yml package.json ios/MetaMask.xcodeproj/project.pbxproj android/app/build.gradle
+          git commit -m "[skip ci] Bump version number to ${RC_VERSION} (nightly rc)"
+          git push origin HEAD:"$HEAD_REF" --force-with-lease
+          echo "commit-hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "build-version=$RC_VERSION" >> "$GITHUB_OUTPUT"
+
   build-exp:
     name: Nightly exp build (main-exp)
-    needs: [bump-version]
+    needs: [bump-version-exp]
     uses: ./.github/workflows/build.yml
     with:
       build_name: main-exp
       platform: both
       skip_version_bump: true
-      ref: ${{ needs.bump-version.outputs.commit-hash }}
+      ref: ${{ needs.bump-version-exp.outputs.commit-hash }}
     secrets: inherit
 
   build-rc:
     name: Nightly RC build (main-rc)
-    needs: [bump-version]
+    needs: [bump-version-rc]
     uses: ./.github/workflows/build.yml
     with:
       build_name: main-rc
       platform: both
       skip_version_bump: true
-      ref: ${{ needs.bump-version.outputs.commit-hash }}
+      ref: ${{ needs.bump-version-rc.outputs.commit-hash }}
     secrets: inherit
 
   upload-exp-testflight:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The nightly build workflow bumped the version only once and then built both `main-exp` and `main-rc` from the same commit. Since both share the same iOS bundle ID (`io.metamask.MetaMask` — both are `METAMASK_BUILD_TYPE: main`), TestFlight requires a unique `CFBundleVersion` per upload. The second upload would be rejected with a duplicate build number error.

This fix introduces a two-step version bump strategy:
1. Call the external version generator once → version **N** (for exp)
2. Locally increment to **N+1** and commit (for rc)

Both builds still run in parallel after their respective bumps, so no meaningful latency is added.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — CI-only workflow change. Verify by triggering the nightly build workflow and confirming both exp and rc builds upload to TestFlight successfully with distinct build numbers.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the nightly GitHub Actions workflow to perform an additional version-bump commit and force-push before the RC build, which could disrupt nightly builds if the bump/push sequence fails or races.
> 
> **Overview**
> Updates `nightly-build.yml` to **split the single version bump into two jobs**: an exp bump via `update-latest-build-version.yml`, followed by an RC-only bump that increments the exp build number (N→N+1), commits the versioned files, and force-pushes to the nightly branch.
> 
> The exp and rc build jobs are rewired to build from their respective bump commits (so TestFlight uploads no longer collide on `CFBundleVersion`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f223098062832813eb56faad03cc9a84732cefbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->