### PR TITLE
fix(ramps): improve PayPal external-browser flow and Order Details UX

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/__snapshots__/OrdersList.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/__snapshots__/OrdersList.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
       {
         "account": "0xe64dD0AB5ad7e8C5F2bf6Ce75C34e187af8b920A",
         "createdAt": 0,
-        "cryptoAmount": 0,
+        "cryptoAmount": "—",
         "cryptoCurrencySymbol": "ETH",
         "fiatAmount": undefined,
         "fiatCurrencyCode": "USD",
@@ -1336,7 +1336,7 @@ exports[`OrdersList renders buy only correctly when pressing buy filter 1`] = `
                 }
                 testID="orders-list-crypto-amount-buy-6"
               >
-                0
+                —
                  
                 ETH
               </Text>
@@ -1505,7 +1505,7 @@ exports[`OrdersList renders correctly 1`] = `
       {
         "account": "0xe64dD0AB5ad7e8C5F2bf6Ce75C34e187af8b920A",
         "createdAt": 0,
-        "cryptoAmount": 0,
+        "cryptoAmount": "—",
         "cryptoCurrencySymbol": "ETH",
         "fiatAmount": undefined,
         "fiatCurrencyCode": "USD",
@@ -2864,7 +2864,7 @@ exports[`OrdersList renders correctly 1`] = `
                 }
                 testID="orders-list-crypto-amount-buy-7"
               >
-                0
+                —
                  
                 ETH
               </Text>
@@ -4979,7 +4979,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
       {
         "account": "0xe64dD0AB5ad7e8C5F2bf6Ce75C34e187af8b920A",
         "createdAt": 0,
-        "cryptoAmount": 0,
+        "cryptoAmount": "—",
         "cryptoCurrencySymbol": "ETH",
         "fiatAmount": undefined,
         "fiatCurrencyCode": "USD",
@@ -6338,7 +6338,7 @@ exports[`OrdersList resets filter to all after other filter was set 2`] = `
                 }
                 testID="orders-list-crypto-amount-buy-7"
               >
-                0
+                —
                  
                 ETH
               </Text>

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -430,12 +430,6 @@ describe('BuildQuote', () => {
         type: 'success',
         url: 'metamask://on-ramp/providers/moonpay?orderId=ord-123',
       });
-      mockGetOrderFromCallback.mockResolvedValue({
-        providerOrderId: 'ord-123',
-        status: 'Pending',
-        cryptoAmount: '0.05',
-        cryptoCurrency: { symbol: 'ETH' },
-      });
       mockGetBuyWidgetData.mockResolvedValue({
         url: 'https://widget.example.com/checkout',
         browser: 'IN_APP_OS_BROWSER',
@@ -451,14 +445,18 @@ describe('BuildQuote', () => {
       });
 
       await waitFor(() => {
-        expect(mockAddOrder).toHaveBeenCalled();
+        expect(mockAddOrder).not.toHaveBeenCalled();
+        expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
         expect(mockNavigationReset).toHaveBeenCalledWith({
           index: 0,
           routes: [
             {
               name: Routes.RAMP.RAMPS_ORDER_DETAILS,
               params: {
-                orderId: 'ord-123',
+                callbackUrl:
+                  'metamask://on-ramp/providers/moonpay?orderId=ord-123',
+                providerCode: 'moonpay',
+                walletAddress: '0x1234567890123456789012345678901234567890',
                 showCloseButton: true,
               },
             },

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -16,7 +16,6 @@ import {
   getWidgetRedirectConfig,
 } from '../../utils/buildQuoteWithRedirectUrl';
 import { computeAmountUpdate } from '../../utils/computeAmountUpdate';
-import { extractOrderCode } from '../../utils/extractOrderCode';
 import { getRampCallbackBaseUrl } from '../../utils/getRampCallbackBaseUrl';
 import { getNavigateAfterExternalBrowserRoutes } from '../../utils/rampsNavigation';
 import { reportRampsError } from '../../utils/reportRampsError';
@@ -80,6 +79,7 @@ import {
 import Device from '../../../../../util/device';
 import TruncatedError from '../../components/TruncatedError';
 import { PROVIDER_LINKS } from '../../Aggregator/types';
+
 const BAILED_ORDER_STATUSES = new Set<RampsOrderStatus>([
   RampsOrderStatus.Precreated,
   RampsOrderStatus.IdExpired,
@@ -154,8 +154,6 @@ function BuildQuote() {
     selectedToken,
     getBuyWidgetData,
     addPrecreatedOrder,
-    addOrder,
-    getOrderFromCallback,
     paymentMethodsLoading,
     selectedPaymentMethod,
   } = useRampsController();
@@ -588,36 +586,28 @@ function BuildQuote() {
             return;
           }
 
-          try {
-            const order = await getOrderFromCallback(
-              providerCode,
-              result.url,
-              effectiveWallet,
-            );
-
-            if (!order || isBailedOrderStatus(order.status)) {
-              navigateAfterExternalBrowser({ returnDestination: 'buildQuote' });
-              return;
-            }
-
-            addOrder(order);
-
-            const rawOrderId = order.providerOrderId ?? effectiveOrderId;
-            if (!rawOrderId) {
-              navigateAfterExternalBrowser({ returnDestination: 'buildQuote' });
-              return;
-            }
-
-            const orderCode = extractOrderCode(rawOrderId);
-            navigateAfterExternalBrowser({
-              returnDestination: 'order',
-              orderCode,
-              providerCode,
-              walletAddress: effectiveWallet || undefined,
-            });
-          } catch {
+          if (!effectiveWallet) {
             navigateAfterExternalBrowser({ returnDestination: 'buildQuote' });
+            return;
           }
+
+          let hasOrderIdInUrl = false;
+          try {
+            const url = new URL(result.url);
+            hasOrderIdInUrl = Boolean(url.searchParams.get('orderId')?.trim());
+          } catch {
+            hasOrderIdInUrl = false;
+          }
+          if (!hasOrderIdInUrl) {
+            navigateAfterExternalBrowser({ returnDestination: 'buildQuote' });
+            return;
+          }
+          navigateAfterExternalBrowser({
+            returnDestination: 'order',
+            callbackUrl: result.url,
+            providerCode,
+            walletAddress: effectiveWallet,
+          });
         } finally {
           InAppBrowser.closeAuth();
         }
@@ -662,8 +652,6 @@ function BuildQuote() {
     navigation,
     getBuyWidgetData,
     addPrecreatedOrder,
-    getOrderFromCallback,
-    addOrder,
     navigateAfterExternalBrowser,
   ]);
 

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -591,17 +591,6 @@ function BuildQuote() {
             return;
           }
 
-          let hasOrderIdInUrl = false;
-          try {
-            const url = new URL(result.url);
-            hasOrderIdInUrl = Boolean(url.searchParams.get('orderId')?.trim());
-          } catch {
-            hasOrderIdInUrl = false;
-          }
-          if (!hasOrderIdInUrl) {
-            navigateAfterExternalBrowser({ returnDestination: 'buildQuote' });
-            return;
-          }
           navigateAfterExternalBrowser({
             returnDestination: 'order',
             callbackUrl: result.url,

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -191,6 +191,7 @@ describe('Checkout', () => {
   const mockAddOrder = jest.fn();
   const mockGetOrderFromCallback = jest.fn();
   const mockAddPrecreatedOrder = jest.fn();
+  const mockRemoveOrder = jest.fn();
   const mockNavigation = {
     setOptions: jest.fn(),
     reset: jest.fn(),
@@ -210,6 +211,7 @@ describe('Checkout', () => {
       addOrder: mockAddOrder,
       getOrderFromCallback: mockGetOrderFromCallback,
       addPrecreatedOrder: mockAddPrecreatedOrder,
+      removeOrder: mockRemoveOrder,
     });
     mockUseRampsUnifiedV2Enabled.mockReturnValue(false);
     mockUseAnalytics.mockReturnValue({

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -90,7 +90,7 @@ const Checkout = () => {
   const params = useParams<CheckoutParams>();
   const theme = useTheme();
   const { styles } = useStyles(styleSheet, {});
-  const { addOrder, addPrecreatedOrder, getOrderFromCallback } =
+  const { addOrder, addPrecreatedOrder, getOrderFromCallback, removeOrder } =
     useRampsOrders();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const rampRoutingDecision = useSelector(getRampRoutingDecision);
@@ -233,6 +233,15 @@ const Checkout = () => {
           throw new Error('Order could not be retrieved from callback');
         }
 
+        const externalTransactionId = parsedUrl.query.externalTransactionId;
+        if (
+          typeof externalTransactionId === 'string' &&
+          externalTransactionId
+        ) {
+          removeOrder(`c-${externalTransactionId}`);
+          removeOrder(externalTransactionId);
+        }
+
         addOrder(rampsOrder);
         dispatch(protectWalletModalVisible());
 
@@ -272,6 +281,7 @@ const Checkout = () => {
       walletAddress,
       navigation,
       addOrder,
+      removeOrder,
       getOrderFromCallback,
       isV2Enabled,
       params?.cryptocurrency,

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
@@ -82,13 +82,14 @@ describe('OrderContent', () => {
     const pendingOrder: RampsOrder = {
       ...mockOrder,
       fiatAmount: 0,
+      cryptoAmount: 0,
       status: RampsOrderStatus.Pending,
     };
     renderOrder(pendingOrder);
     expect(screen.toJSON()).toMatchSnapshot();
   });
 
-  it('shows ellipsis for token amount when cryptoAmount is 0 or missing', () => {
+  it('shows placeholder for token amount when cryptoAmount is 0 or missing', () => {
     const orderWithZeroCrypto: RampsOrder = {
       ...mockOrder,
       cryptoAmount: 0,
@@ -199,24 +200,24 @@ describe('OrderContent', () => {
     expect(tokenAmount).toHaveTextContent('0.0₅614 ETH');
   });
 
-  it('shows "..." when cryptoAmount is missing', () => {
+  it('shows placeholder when cryptoAmount is missing', () => {
     const noAmountOrder: RampsOrder = {
       ...mockOrder,
       cryptoAmount: undefined as unknown as number,
     };
     renderOrder(noAmountOrder);
     const tokenAmount = screen.getByTestId('ramps-order-details-token-amount');
-    expect(tokenAmount).toHaveTextContent('... ETH');
+    expect(tokenAmount).toHaveTextContent('— ETH');
   });
 
-  it('renders "0" when cryptoAmount is zero', () => {
+  it('shows placeholder when cryptoAmount is zero', () => {
     const zeroAmountOrder: RampsOrder = {
       ...mockOrder,
       cryptoAmount: 0,
     };
     renderOrder(zeroAmountOrder);
     const tokenAmount = screen.getByTestId('ramps-order-details-token-amount');
-    expect(tokenAmount).toHaveTextContent('0 ETH');
+    expect(tokenAmount).toHaveTextContent('— ETH');
   });
 
   it('does not render info row when statusDescription is absent', () => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
@@ -41,6 +41,14 @@ import BankDetailRow from '../../Deposit/components/BankDetailRow/BankDetailRow'
 import Routes from '../../../../../constants/navigation/Routes';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
 
+const AMOUNT_PLACEHOLDER = '—';
+const TERMINAL_STATUSES = new Set([
+  RampsOrderStatus.Completed,
+  RampsOrderStatus.Failed,
+  RampsOrderStatus.Cancelled,
+  RampsOrderStatus.IdExpired,
+]);
+
 const localStyles = StyleSheet.create({
   badgeWrapperCenter: {
     alignSelf: 'center',
@@ -168,7 +176,12 @@ const OrderContent: React.FC<OrderContentProps> = ({
     }
   };
 
-  const isLoading = !order.fiatAmount;
+  const hasAmounts = Boolean(
+    (order.fiatAmount != null && Number(order.fiatAmount) > 0) ||
+      (order.cryptoAmount != null && Number(order.cryptoAmount) > 0),
+  );
+  const isTerminal = TERMINAL_STATUSES.has(order.status);
+  const isLoading = !hasAmounts && !isTerminal;
 
   const handleClose = useCallback(() => {
     trackEvent(
@@ -320,7 +333,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
           fontWeight={FontWeight.Bold}
           twClassName="mt-6 text-center"
         >
-          {order.cryptoAmount != null
+          {order.cryptoAmount != null && Number(order.cryptoAmount) > 0
             ? (formatSubscriptNotation(
                 parseFloat(String(order.cryptoAmount)),
               ) ??
@@ -333,7 +346,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
                   maximumFractionDigits: 5,
                 },
               ))
-            : '...'}{' '}
+            : AMOUNT_PLACEHOLDER}{' '}
           {cryptoSymbol}
         </Text>
       </Box>
@@ -463,12 +476,13 @@ const OrderContent: React.FC<OrderContentProps> = ({
           <Box twClassName="bg-muted rounded h-[18px] w-20" />
         ) : (
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-            {fiatDenomSymbol}
-            {renderFiat(
-              Number(order.totalFeesFiat ?? 0),
-              fiatCurrencyCode,
-              fiatDecimals,
-            )}
+            {hasAmounts
+              ? `${fiatDenomSymbol}${renderFiat(
+                  Number(order.totalFeesFiat ?? 0),
+                  fiatCurrencyCode,
+                  fiatDecimals,
+                )}`
+              : AMOUNT_PLACEHOLDER}
           </Text>
         )}
       </Box>
@@ -489,12 +503,13 @@ const OrderContent: React.FC<OrderContentProps> = ({
           <Box twClassName="bg-muted rounded h-[18px] w-24" />
         ) : (
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-            {fiatDenomSymbol}
-            {renderFiat(
-              Number(order.fiatAmount ?? 0),
-              fiatCurrencyCode,
-              fiatDecimals,
-            )}
+            {hasAmounts
+              ? `${fiatDenomSymbol}${renderFiat(
+                  Number(order.fiatAmount ?? 0),
+                  fiatCurrencyCode,
+                  fiatDecimals,
+                )}`
+              : AMOUNT_PLACEHOLDER}
           </Text>
         )}
       </Box>

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -60,7 +60,16 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
-const mockUseParams = jest.fn(() => ({ orderId: 'test-order-123' }));
+interface OrderDetailsParams {
+  orderId?: string;
+  callbackUrl?: string;
+  providerCode?: string;
+  walletAddress?: string;
+  showCloseButton?: boolean;
+}
+const mockUseParams = jest.fn<() => OrderDetailsParams>(() => ({
+  orderId: 'test-order-123',
+}));
 jest.mock('../../../../../util/navigation/navUtils', () => ({
   ...jest.requireActual('../../../../../util/navigation/navUtils'),
   useParams: () => mockUseParams(),

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -11,21 +11,29 @@ import { RampsOrderStatus } from '@metamask/ramps-controller';
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
+const mockSetParams = jest.fn();
+const mockReset = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     setOptions: mockSetOptions,
     navigate: mockNavigate,
     goBack: jest.fn(),
+    setParams: mockSetParams,
+    reset: mockReset,
   }),
 }));
 
 const mockGetOrderById = jest.fn();
 const mockRefreshOrder = jest.fn();
+const mockGetOrderFromCallback = jest.fn();
+const mockAddOrder = jest.fn();
 jest.mock('../../hooks/useRampsOrders', () => ({
   useRampsOrders: () => ({
     getOrderById: mockGetOrderById,
     refreshOrder: mockRefreshOrder,
+    getOrderFromCallback: mockGetOrderFromCallback,
+    addOrder: mockAddOrder,
   }),
 }));
 
@@ -186,5 +194,33 @@ describe('OrderDetails', () => {
   it('createRampsOrderDetailsNavDetails returns correct route', () => {
     const result = createRampsOrderDetailsNavDetails();
     expect(result[0]).toBe(Routes.RAMP.RAMPS_ORDER_DETAILS);
+  });
+
+  it('shows error state with retry when initial callback fetch fails', async () => {
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'metamask://on-ramp/providers/paypal?orderId=abc',
+      providerCode: 'paypal',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockRejectedValue(
+      new Error('Network request failed'),
+    );
+
+    const { getByText } = render();
+
+    await waitFor(() => {
+      expect(getByText('Network request failed')).toBeOnTheScreen();
+    });
+    expect(getByText('ramps_order_details.try_again')).toBeOnTheScreen();
+
+    fireEvent.press(getByText('ramps_order_details.try_again'));
+    expect(mockGetOrderFromCallback).toHaveBeenCalledTimes(2);
+    expect(mockGetOrderFromCallback).toHaveBeenNthCalledWith(
+      2,
+      'paypal',
+      'metamask://on-ramp/providers/paypal?orderId=abc',
+      '0x123',
+    );
   });
 });

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -15,6 +15,7 @@ import {
   normalizeProviderCode,
   RampsOrderStatus,
 } from '@metamask/ramps-controller';
+import { isBailedOrderStatus } from '../BuildQuote/BuildQuote';
 import { extractOrderCode } from '../../utils/extractOrderCode';
 import { getNavigateAfterExternalBrowserRoutes } from '../../utils/rampsNavigation';
 import Button, {
@@ -71,14 +72,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
-
-const isBailedOrderStatus = (status: RampsOrderStatus | undefined): boolean =>
-  status != null &&
-  [
-    RampsOrderStatus.Precreated,
-    RampsOrderStatus.IdExpired,
-    RampsOrderStatus.Unknown,
-  ].includes(status);
 
 const OrderDetails = () => {
   const params = useParams<RampsOrderDetailsParams>();

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -94,7 +94,7 @@ const OrderDetails = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const hasFetchedFromCallback = useRef(false);
 
-  const handleRetryCallbackFetch = useCallback(async () => {
+  const handleCallbackFetch = useCallback(async () => {
     if (!params.callbackUrl || !params.providerCode || !params.walletAddress) {
       return;
     }
@@ -124,8 +124,7 @@ const OrderDetails = () => {
       });
     } catch (fetchError) {
       Logger.error(fetchError as Error, {
-        message:
-          'RampsOrderDetails: error fetching order from callback URL (retry)',
+        message: 'RampsOrderDetails: error fetching order from callback URL',
         callbackUrl: params.callbackUrl,
       });
       setError(
@@ -217,71 +216,12 @@ const OrderDetails = () => {
   }, []);
 
   useEffect(() => {
-    if (
-      !hasCallbackParams ||
-      hasFetchedFromCallback.current ||
-      !params.callbackUrl ||
-      !params.providerCode ||
-      !params.walletAddress
-    ) {
+    if (!hasCallbackParams || hasFetchedFromCallback.current) {
       return;
     }
     hasFetchedFromCallback.current = true;
-
-    const providerCode = params.providerCode;
-    const callbackUrl = params.callbackUrl;
-    const walletAddress = params.walletAddress;
-    if (!providerCode || !callbackUrl || !walletAddress) return;
-
-    const fetchFromCallback = async () => {
-      try {
-        setError(null);
-        const fetchedOrder = await getOrderFromCallback(
-          providerCode,
-          callbackUrl,
-          walletAddress,
-        );
-        if (!fetchedOrder || isBailedOrderStatus(fetchedOrder.status)) {
-          navigation.reset({
-            index: 0,
-            routes: getNavigateAfterExternalBrowserRoutes({
-              returnDestination: 'buildQuote',
-            }),
-          });
-          return;
-        }
-        addOrder(fetchedOrder);
-        navigation.setParams({
-          orderId: fetchedOrder.providerOrderId,
-          callbackUrl: undefined,
-          providerCode: undefined,
-          walletAddress: undefined,
-        });
-      } catch (fetchError) {
-        Logger.error(fetchError as Error, {
-          message: 'RampsOrderDetails: error fetching order from callback URL',
-          callbackUrl,
-        });
-        setError(
-          fetchError instanceof Error && fetchError.message
-            ? fetchError.message
-            : strings('ramps_order_details.error_message'),
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchFromCallback();
-  }, [
-    hasCallbackParams,
-    params.callbackUrl,
-    params.providerCode,
-    params.walletAddress,
-    getOrderFromCallback,
-    addOrder,
-    navigation,
-  ]);
+    handleCallbackFetch();
+  }, [hasCallbackParams, handleCallbackFetch]);
 
   if (isLoading) {
     return (
@@ -296,9 +236,7 @@ const OrderDetails = () => {
   }
 
   if (error) {
-    const onRetry = hasCallbackParams
-      ? handleRetryCallbackFetch
-      : handleOnRefresh;
+    const onRetry = hasCallbackParams ? handleCallbackFetch : handleOnRefresh;
     return (
       <ScreenLayout>
         <ScreenLayout.Body>

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -262,13 +262,11 @@ const OrderDetails = () => {
           message: 'RampsOrderDetails: error fetching order from callback URL',
           callbackUrl,
         });
-        navigation.reset({
-          index: 0,
-          routes: getNavigateAfterExternalBrowserRoutes({
-            returnDestination: 'buildQuote',
-          }),
-        });
-        return;
+        setError(
+          fetchError instanceof Error && fetchError.message
+            ? fetchError.message
+            : strings('ramps_order_details.error_message'),
+        );
       } finally {
         setIsLoading(false);
       }

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -16,6 +16,7 @@ import {
   RampsOrderStatus,
 } from '@metamask/ramps-controller';
 import { extractOrderCode } from '../../utils/extractOrderCode';
+import { getNavigateAfterExternalBrowserRoutes } from '../../utils/rampsNavigation';
 import Button, {
   ButtonVariants,
   ButtonSize,
@@ -37,8 +38,12 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
 interface RampsOrderDetailsParams {
-  orderId: string;
+  orderId?: string;
   showCloseButton?: boolean;
+  /** When returning from external browser (e.g. PayPal), fetch order from callback URL. */
+  callbackUrl?: string;
+  providerCode?: string;
+  walletAddress?: string;
 }
 
 export const createRampsOrderDetailsNavDetails =
@@ -67,14 +72,26 @@ const styles = StyleSheet.create({
   },
 });
 
+const isBailedOrderStatus = (status: RampsOrderStatus | undefined): boolean =>
+  status != null &&
+  [
+    RampsOrderStatus.Precreated,
+    RampsOrderStatus.IdExpired,
+    RampsOrderStatus.Unknown,
+  ].includes(status);
+
 const OrderDetails = () => {
   const params = useParams<RampsOrderDetailsParams>();
-  const { getOrderById, refreshOrder } = useRampsOrders();
+  const { getOrderById, refreshOrder, getOrderFromCallback, addOrder } =
+    useRampsOrders();
   const orderCode = params.orderId ? extractOrderCode(params.orderId) : '';
   const order = getOrderById(orderCode);
   const isPending = order ? PENDING_STATUSES.has(order.status) : false;
+  const hasCallbackParams = Boolean(
+    params.callbackUrl && params.providerCode && params.walletAddress,
+  );
 
-  const [isLoading, setIsLoading] = useState(isPending);
+  const [isLoading, setIsLoading] = useState(isPending || hasCallbackParams);
   const [error, setError] = useState<string | null>(null);
   const theme = useTheme();
   const { colors } = theme;
@@ -82,6 +99,58 @@ const OrderDetails = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const hasFetchedFromCallback = useRef(false);
+
+  const handleRetryCallbackFetch = useCallback(async () => {
+    if (!params.callbackUrl || !params.providerCode || !params.walletAddress) {
+      return;
+    }
+    try {
+      setError(null);
+      setIsLoading(true);
+      const fetchedOrder = await getOrderFromCallback(
+        params.providerCode,
+        params.callbackUrl,
+        params.walletAddress,
+      );
+      if (!fetchedOrder || isBailedOrderStatus(fetchedOrder.status)) {
+        navigation.reset({
+          index: 0,
+          routes: getNavigateAfterExternalBrowserRoutes({
+            returnDestination: 'buildQuote',
+          }),
+        });
+        return;
+      }
+      addOrder(fetchedOrder);
+      navigation.setParams({
+        orderId: fetchedOrder.providerOrderId,
+        callbackUrl: undefined,
+        providerCode: undefined,
+        walletAddress: undefined,
+      });
+    } catch (fetchError) {
+      Logger.error(fetchError as Error, {
+        message:
+          'RampsOrderDetails: error fetching order from callback URL (retry)',
+        callbackUrl: params.callbackUrl,
+      });
+      setError(
+        fetchError instanceof Error && fetchError.message
+          ? fetchError.message
+          : strings('ramps_order_details.error_message'),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    params.callbackUrl,
+    params.providerCode,
+    params.walletAddress,
+    getOrderFromCallback,
+    addOrder,
+    navigation,
+  ]);
 
   useEffect(() => {
     navigation.setOptions(
@@ -148,11 +217,80 @@ const OrderDetails = () => {
   }, [order, refreshOrder]);
 
   useEffect(() => {
-    if (isPending) {
+    if (isPending && !hasCallbackParams) {
       handleOnRefresh();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (
+      !hasCallbackParams ||
+      hasFetchedFromCallback.current ||
+      !params.callbackUrl ||
+      !params.providerCode ||
+      !params.walletAddress
+    ) {
+      return;
+    }
+    hasFetchedFromCallback.current = true;
+
+    const providerCode = params.providerCode;
+    const callbackUrl = params.callbackUrl;
+    const walletAddress = params.walletAddress;
+    if (!providerCode || !callbackUrl || !walletAddress) return;
+
+    const fetchFromCallback = async () => {
+      try {
+        setError(null);
+        const fetchedOrder = await getOrderFromCallback(
+          providerCode,
+          callbackUrl,
+          walletAddress,
+        );
+        if (!fetchedOrder || isBailedOrderStatus(fetchedOrder.status)) {
+          navigation.reset({
+            index: 0,
+            routes: getNavigateAfterExternalBrowserRoutes({
+              returnDestination: 'buildQuote',
+            }),
+          });
+          return;
+        }
+        addOrder(fetchedOrder);
+        navigation.setParams({
+          orderId: fetchedOrder.providerOrderId,
+          callbackUrl: undefined,
+          providerCode: undefined,
+          walletAddress: undefined,
+        });
+      } catch (fetchError) {
+        Logger.error(fetchError as Error, {
+          message: 'RampsOrderDetails: error fetching order from callback URL',
+          callbackUrl,
+        });
+        navigation.reset({
+          index: 0,
+          routes: getNavigateAfterExternalBrowserRoutes({
+            returnDestination: 'buildQuote',
+          }),
+        });
+        return;
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFromCallback();
+  }, [
+    hasCallbackParams,
+    params.callbackUrl,
+    params.providerCode,
+    params.walletAddress,
+    getOrderFromCallback,
+    addOrder,
+    navigation,
+  ]);
 
   if (isLoading) {
     return (
@@ -166,11 +304,10 @@ const OrderDetails = () => {
     );
   }
 
-  if (!order) {
-    return <ScreenLayout />;
-  }
-
   if (error) {
+    const onRetry = hasCallbackParams
+      ? handleRetryCallbackFetch
+      : handleOnRefresh;
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
@@ -198,12 +335,16 @@ const OrderDetails = () => {
               size={ButtonSize.Lg}
               width={ButtonWidthTypes.Full}
               label={strings('ramps_order_details.try_again')}
-              onPress={handleOnRefresh}
+              onPress={onRetry}
             />
           </Box>
         </ScreenLayout.Body>
       </ScreenLayout>
     );
+  }
+
+  if (!order) {
+    return <ScreenLayout />;
   }
 
   return (

--- a/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderContent.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/OrderDetails/__snapshots__/OrderContent.test.tsx.snap
@@ -472,8 +472,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
         ]
       }
     >
-      $
-      2.5 USD
+      $2.5 USD
     </Text>
   </View>
   <View
@@ -524,8 +523,7 @@ exports[`OrderContent renders completed state correctly 1`] = `
         ]
       }
     >
-      $
-      100 USD
+      $100 USD
     </Text>
   </View>
   <View
@@ -771,7 +769,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
       }
       testID="ramps-order-details-token-amount"
     >
-      0.05
+      —
        
       ETH
     </Text>
@@ -1095,7 +1093,7 @@ exports[`OrderContent renders loading state when order has no amount 1`] = `
 </View>
 `;
 
-exports[`OrderContent shows ellipsis for token amount when cryptoAmount is 0 or missing 1`] = `
+exports[`OrderContent shows placeholder for token amount when cryptoAmount is 0 or missing 1`] = `
 <View
   style={
     [
@@ -1266,7 +1264,7 @@ exports[`OrderContent shows ellipsis for token amount when cryptoAmount is 0 or 
       }
       testID="ramps-order-details-token-amount"
     >
-      0
+      —
        
       ETH
     </Text>
@@ -1567,8 +1565,7 @@ exports[`OrderContent shows ellipsis for token amount when cryptoAmount is 0 or 
         ]
       }
     >
-      $
-      2.5 USD
+      $2.5 USD
     </Text>
   </View>
   <View
@@ -1619,8 +1616,7 @@ exports[`OrderContent shows ellipsis for token amount when cryptoAmount is 0 or 
         ]
       }
     >
-      $
-      100 USD
+      $100 USD
     </Text>
   </View>
   <View

--- a/app/components/UI/Ramp/utils/__snapshots__/displayOrder.test.ts.snap
+++ b/app/components/UI/Ramp/utils/__snapshots__/displayOrder.test.ts.snap
@@ -4,7 +4,7 @@ exports[`displayOrder fiatOrderToDisplayOrder converts a legacy FiatOrder to a D
 {
   "account": "0xabc",
   "createdAt": 1000,
-  "cryptoAmount": 0,
+  "cryptoAmount": "—",
   "cryptoCurrencySymbol": "ETH",
   "fiatAmount": "100",
   "fiatCurrencyCode": "USD",

--- a/app/components/UI/Ramp/utils/displayOrder.test.ts
+++ b/app/components/UI/Ramp/utils/displayOrder.test.ts
@@ -74,10 +74,16 @@ describe('displayOrder', () => {
       expect(result).toMatchSnapshot();
     });
 
-    it('defaults cryptoAmount to 0 when undefined', () => {
-      const fiatOrder = createMockFiatOrder({ cryptoAmount: undefined });
-      const result = fiatOrderToDisplayOrder(fiatOrder);
-      expect(result.cryptoAmount).toBe(0);
+    it('uses placeholder when cryptoAmount is undefined or zero', () => {
+      expect(
+        fiatOrderToDisplayOrder(
+          createMockFiatOrder({ cryptoAmount: undefined }),
+        ).cryptoAmount,
+      ).toBe('—');
+      expect(
+        fiatOrderToDisplayOrder(createMockFiatOrder({ cryptoAmount: 0 }))
+          .cryptoAmount,
+      ).toBe('—');
     });
   });
 
@@ -140,6 +146,23 @@ describe('displayOrder', () => {
       });
       const result = rampsOrderToDisplayOrder(order);
       expect(result.createdAt).toBe(0);
+    });
+
+    it('uses placeholder when cryptoAmount is 0 or missing (pending orders)', () => {
+      expect(
+        rampsOrderToDisplayOrder(createMockRampsOrder({ cryptoAmount: 0 }))
+          .cryptoAmount,
+      ).toBe('—');
+      expect(
+        rampsOrderToDisplayOrder(
+          createMockRampsOrder({ cryptoAmount: undefined }),
+        ).cryptoAmount,
+      ).toBe('—');
+      expect(
+        rampsOrderToDisplayOrder(
+          createMockRampsOrder({ cryptoAmount: null as unknown as string }),
+        ).cryptoAmount,
+      ).toBe('—');
     });
   });
 

--- a/app/components/UI/Ramp/utils/displayOrder.ts
+++ b/app/components/UI/Ramp/utils/displayOrder.ts
@@ -5,6 +5,9 @@ import {
 } from '../../../../reducers/fiatOrders';
 import { FIAT_ORDER_PROVIDERS } from '../../../../constants/on-ramp';
 
+/** Placeholder when crypto amount is unknown (pending) or zero. Matches OrderContent. */
+const AMOUNT_PLACEHOLDER = '—';
+
 export interface DisplayOrder {
   id: string;
   source: 'legacy' | 'v2';
@@ -30,6 +33,7 @@ function toEpochMs(value: unknown): number {
 }
 
 export function fiatOrderToDisplayOrder(order: FiatOrder): DisplayOrder {
+  const rawCrypto = order.cryptoAmount ?? 0;
   return {
     id: order.id,
     source: 'legacy',
@@ -37,7 +41,10 @@ export function fiatOrderToDisplayOrder(order: FiatOrder): DisplayOrder {
     createdAt: toEpochMs(order.createdAt),
     fiatAmount: order.amount,
     fiatCurrencyCode: order.currency,
-    cryptoAmount: order.cryptoAmount ?? 0,
+    cryptoAmount:
+      rawCrypto != null && Number(rawCrypto) > 0
+        ? rawCrypto
+        : AMOUNT_PLACEHOLDER,
     cryptoCurrencySymbol: order.cryptocurrency,
     network: order.network,
     status: order.state,
@@ -65,7 +72,10 @@ export function rampsOrderToDisplayOrder(order: RampsOrder): DisplayOrder {
     createdAt: toEpochMs(order.createdAt),
     fiatAmount: order.fiatAmount,
     fiatCurrencyCode: order.fiatCurrency?.symbol ?? '',
-    cryptoAmount: order.cryptoAmount,
+    cryptoAmount:
+      order.cryptoAmount != null && Number(order.cryptoAmount) > 0
+        ? order.cryptoAmount
+        : AMOUNT_PLACEHOLDER,
     cryptoCurrencySymbol: order.cryptoCurrency?.symbol ?? '',
     network: order.network?.chainId ?? '',
     status: RAMPS_STATUS_TO_DISPLAY[order.status] ?? 'PENDING',
@@ -98,6 +108,7 @@ export function mergeDisplayOrders(
     .map(fiatOrderToDisplayOrder);
 
   const v2 = visibleV2Orders.map(rampsOrderToDisplayOrder);
+  const merged = [...legacy, ...v2].sort((a, b) => b.createdAt - a.createdAt);
 
-  return [...legacy, ...v2].sort((a, b) => b.createdAt - a.createdAt);
+  return merged;
 }

--- a/app/components/UI/Ramp/utils/rampsNavigation.test.ts
+++ b/app/components/UI/Ramp/utils/rampsNavigation.test.ts
@@ -59,5 +59,25 @@ describe('rampsNavigation', () => {
         },
       });
     });
+
+    it('returns order details route with callbackUrl when returning from external browser', () => {
+      const routes = getNavigateAfterExternalBrowserRoutes({
+        returnDestination: 'order',
+        callbackUrl: 'metamask://on-ramp/providers/paypal?orderId=abc123',
+        providerCode: 'paypal-staging',
+        walletAddress: '0x1234',
+      });
+
+      expect(routes).toHaveLength(1);
+      expect(routes[0]).toEqual({
+        name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+        params: {
+          callbackUrl: 'metamask://on-ramp/providers/paypal?orderId=abc123',
+          providerCode: 'paypal-staging',
+          walletAddress: '0x1234',
+          showCloseButton: true,
+        },
+      });
+    });
   });
 });

--- a/app/components/UI/Ramp/utils/rampsNavigation.ts
+++ b/app/components/UI/Ramp/utils/rampsNavigation.ts
@@ -1,8 +1,12 @@
 import Routes from '../../../../constants/navigation/Routes';
 
 export interface RampsOrderDetailsParams {
-  orderId: string;
+  orderId?: string;
   showCloseButton?: boolean;
+  /** When returning from external browser (e.g. PayPal), pass callback URL to fetch order on Order Details screen. */
+  callbackUrl?: string;
+  providerCode?: string;
+  walletAddress?: string;
 }
 
 export function createRampsOrderDetailsRoute(params: RampsOrderDetailsParams): {
@@ -29,6 +33,12 @@ export type NavigateAfterExternalBrowserOpts =
       orderCode: string;
       providerCode: string;
       walletAddress?: string;
+    }
+  | {
+      returnDestination: 'order';
+      callbackUrl: string;
+      providerCode: string;
+      walletAddress: string;
     };
 
 /**
@@ -43,6 +53,16 @@ export function getNavigateAfterExternalBrowserRoutes(
   | ReturnType<typeof createRampsOrderDetailsRoute>
 )[] {
   if (opts.returnDestination === 'order') {
+    if ('callbackUrl' in opts) {
+      return [
+        createRampsOrderDetailsRoute({
+          callbackUrl: opts.callbackUrl,
+          providerCode: opts.providerCode,
+          walletAddress: opts.walletAddress,
+          showCloseButton: true,
+        }),
+      ];
+    }
     return [
       createRampsOrderDetailsRoute({
         orderId: opts.orderCode,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improves the unified on-ramp external-browser return flow, especially for PayPal-style redirects, and makes V2 order states clearer in Order Details and the orders list.

**What changed**

- **Build Quote -> Order Details callback handoff**  
  External-browser returns now navigate to Order Details with the full `callbackUrl`, `providerCode`, and `walletAddress` instead of trying to resolve the order inside Build Quote. This lets Order Details use the backend/controller callback-parsing flow directly.

- **Order Details – callback fetch and retry UX**  
  Order Details now supports loading an order from callback params on first render. If that callback fetch fails, the screen shows a retryable error state instead of immediately resetting away, so transient failures are recoverable.

- **Checkout – placeholder cleanup / deduplication**  
  When a callback flow finishes and the real provider order is fetched, temporary precreated/custom-ID placeholder orders are removed so the user does not see duplicate entries for the same purchase.

- **Order Content – amount display**  
  For pending or terminal orders with missing or zero amounts, the screen now shows `"—"` instead of misleading values like `"0 ETH"` or `"$0.00"` for crypto amount, fees, and total.

- **Order Content – loading state**  
  Skeleton loading UI is now limited to genuinely in-flight orders. Terminal statuses (Completed, Failed, Cancelled, IdExpired) no longer appear to be loading forever when amounts are unavailable.

- **Orders list display mapping**  
  Display-order formatting now matches the updated Order Details behavior so pending/missing crypto amounts also render as `"—"` in merged order lists.

- **Tests updated**  
  Tests were updated to reflect the callback-based navigation flow, retryable callback-fetch errors in Order Details, and the new placeholder/dedup behavior.

**What stays untouched**  
The core token selection, quote-building, and standard checkout flows are unchanged. The main behavior change is in how external-browser returns are routed and how incomplete/pending V2 orders are represented afterward.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-checkout navigation/fetch path for external-browser ramps flows and adjusts order rendering logic, which could affect whether users land on the correct Order Details state. Also adds order de-dup/removal on callback, impacting order list consistency if IDs are mishandled.
> 
> **Overview**
> Improves the external-browser (e.g. PayPal/MoonPay) return flow by **deferring order retrieval to `OrderDetails`**: `BuildQuote` no longer calls `getOrderFromCallback`/`addOrder` after `InAppBrowser.openAuth`, and instead resets navigation to Order Details with `callbackUrl`/`providerCode`/`walletAddress` params (new path supported in `rampsNavigation`).
> 
> `OrderDetails` now **auto-fetches the order from the callback URL** on first render (with a retry action), adds the order to controller state, and clears callback params once resolved; if the callback order is missing or in a bailed status it resets back to Build Quote.
> 
> Order UI is tightened by showing **`—` placeholders** (instead of `0`/`...`) when fiat/crypto amounts are missing/zero and by disabling the loading skeleton for terminal statuses. Checkout’s callback handler also removes any existing orders matching `externalTransactionId` before adding the fetched order to avoid duplicates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 701def2436d32e6915a9ca18563d05773aebe3dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->