### PR TITLE
fix(25760): prevent Ledger connect image from being cut off on iOS af…

### DIFF
--- a/app/components/Views/LedgerConnect/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/LedgerConnect/__snapshots__/index.test.tsx.snap
@@ -132,7 +132,6 @@ exports[`LedgerConnect render matches latest snapshot 1`] = `
         style={
           {
             "height": 64,
-            "overflow": "visible",
             "resizeMode": "contain",
             "width": 30,
           }

--- a/app/components/Views/LedgerConnect/index.styles.ts
+++ b/app/components/Views/LedgerConnect/index.styles.ts
@@ -41,7 +41,6 @@ const createStyles = (colors: Colors, insets: EdgeInsets) =>
       resizeMode: 'contain',
       width: Device.getDeviceWidth() * 0.6,
       height: 64,
-      overflow: 'visible',
     },
     connectLedgerText: {
       ...(fontStyles.normal as TextStyle),

--- a/app/components/Views/LedgerSelectAccount/index.styles.ts
+++ b/app/components/Views/LedgerSelectAccount/index.styles.ts
@@ -22,7 +22,6 @@ const createStyles = (colors: Colors) =>
       alignItems: 'center',
     },
     selectorContainer: {
-      flex: 1,
       flexDirection: 'column',
     },
     mainTitle: {


### PR DESCRIPTION
## **Description**

Cherry pick from: https://github.com/MetaMask/metamask-mobile/pull/26783

On iOS, the Ledger connect illustration was cut off when opening the Ledger flow after the keyboard had been shown (e.g. search in Explore, then back). Removed overflow: 'visible' from the cover image style so the layout no longer gets clipped. Also fixed a typo in LedgerSelectAccount: style-= → style= so the selector container gets its 
styles.

This PR also fixes an issue where the spacing on the hardware wallet account selector screen was wonky.

This PR increases the polish for the app and even though not sev1 issues, improve the experience for the users. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Ledger connect screen image being cut off on iOS after using the keyboard.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25760
Fixes https://github.com/MetaMask/metamask-mobile/issues/27534

Manual testing steps
Feature: Ledger connect screen

Scenario: user opens Ledger connect after using keyboard
Given the app is open and user has been to Explore and opened the search keyboard then navigated back

When user starts connecting a Ledger device
Then the Ledger connect illustration is fully visible (not cut off)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/83f5238d-8c62-4c8e-a922-e0c65ed7456d" />


<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/7395a5af-3092-48ab-96ca-f92fd2652156" />


### **After**

<img width="300" height="700" alt="Screenshot_20260318-200328" src="https://github.com/user-attachments/assets/de9b7758-b630-4934-85fb-12ad03576e87" />


https://github.com/user-attachments/assets/c433295e-5151-4083-bb4c-5548c99d9aa6



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
