### PR TITLE
feat: fix incorrect styling of claimable bonus font weight and tooltip color cp-7.70.0

### DIFF
--- a/app/components/Views/confirmations/components/alerts/blocking-alert-message/blocking-alert-message.styles.ts
+++ b/app/components/Views/confirmations/components/alerts/blocking-alert-message/blocking-alert-message.styles.ts
@@ -5,6 +5,9 @@ const styleSheet = () =>
     container: {
       paddingTop: 32,
     },
+    message: {
+      textAlign: 'center',
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/confirmations/components/alerts/blocking-alert-message/blocking-alert-message.tsx
+++ b/app/components/Views/confirmations/components/alerts/blocking-alert-message/blocking-alert-message.tsx
@@ -26,7 +26,11 @@ export const BlockingAlertMessage: React.FC = React.memo(() => {
   return (
     <View style={styles.container}>
       {typeof blockingAlertMessage === 'string' ? (
-        <Text variant={TextVariant.BodyMD} color={TextColor.Error}>
+        <Text
+          variant={TextVariant.BodyMD}
+          color={TextColor.Error}
+          style={styles.message}
+        >
           {blockingAlertMessage}
         </Text>
       ) : (

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
@@ -7,7 +7,7 @@ import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
-import { InfoRowSkeleton } from '../../UI/info-row/info-row';
+import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
 import { strings } from '../../../../../../../locales/i18n';
 import { IconColor } from '../../../../../../component-library/components/Icons/Icon';
 import AppConstants from '../../../../../../core/AppConstants';
@@ -59,6 +59,8 @@ export function PercentageRow() {
   return (
     <InfoRow
       label={strings('earn.claimable_bonus')}
+      rowVariant={InfoRowVariant.Small}
+      tooltipColor={IconColor.Alternative}
       tooltip={
         <Text>
           {strings('earn.claimable_bonus_tooltip')}{' '}
@@ -67,7 +69,6 @@ export function PercentageRow() {
           </Text>
         </Text>
       }
-      tooltipColor={IconColor.Muted}
     >
       <Text variant={TextVariant.BodyMD} color={TextColor.Success}>
         {MUSD_CONVERSION_APY}%

--- a/app/components/Views/confirmations/components/rows/token-conversion-rate-row/token-conversion-rate-row.tsx
+++ b/app/components/Views/confirmations/components/rows/token-conversion-rate-row/token-conversion-rate-row.tsx
@@ -2,7 +2,10 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
-import InfoRow, { InfoRowSkeleton } from '../../UI/info-row/info-row';
+import InfoRow, {
+  InfoRowSkeleton,
+  InfoRowVariant,
+} from '../../UI/info-row/info-row';
 import Text, {
   TextColor,
   TextVariant,
@@ -74,6 +77,7 @@ export function TokenConversionRateRow() {
     <InfoRow
       label={strings('earn.musd_conversion.rate')}
       testID={TokenConversionRateRowTestIds.CONTAINER}
+      rowVariant={InfoRowVariant.Small}
     >
       <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
         {`1 ${inputTokenSymbol} = ${conversionRate} ${outputTokenSymbol}`}


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes some incorrect styling for the "Claimable bonus" row.

### Changes:
- `"Claimable Bonus"` font weight updated to match other rows
- `"Claimable Bonus"` tooltip color changed to `Alternative`
- Centered Quick Convert bottom sheet error messages
- `"Rate"` row text font weight updated to match other rows

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix percentage-row inconsistent styling

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: mUSD conversion confirmation styling

  Scenario: user views claimable bonus row with correct styling
    Given user is on the mUSD conversion confirmation screen

    When user views the "Claimable bonus" info row
    Then the label font weight matches other small-variant info rows
    And the tooltip icon color is Alternative, consistent with the transaction fee row

  Scenario: user views blocking alert message centered
    Given user triggers
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="500" height="477" alt="image" src="https://github.com/user-attachments/assets/11a97285-6b6d-4298-9733-d28e1bc71608" />

<img width="500" height="477" alt="image" src="https://github.com/user-attachments/assets/4b9e8999-66e2-41bf-bd84-3879a1b88727" />

### **After**

<!-- [screenshots/recordings] -->
<img width="500" height="477" alt="image" src="https://github.com/user-attachments/assets/287b1b56-2eee-46e1-8e03-c765a21db9d5" />

<img width="500" height="477" alt="image" src="https://github.com/user-attachments/assets/6e6bae89-f971-4f54-932c-722946784b66" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling adjustments to confirmation rows and blocking alert text; no business logic or data flow changes.
> 
> **Overview**
> Fixes styling inconsistencies in the mUSD conversion confirmation UI by rendering the "Claimable bonus" and conversion rate rows using the `InfoRowVariant.Small` variant (matching label font weight) and updating the claimable bonus tooltip icon color to `IconColor.Alternative`.
> 
> Also centers blocking alert error text in the quick convert bottom sheet by applying `textAlign: 'center'` to string-based blocking alert messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe91c3b35bbc7da4f180038d5065f5828c20096c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->