### PR TITLE
fix(wallet): resolve analytics and UX regressions

### DIFF
--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -343,7 +343,8 @@ const useTokenDetailsOpenedTracking = (params: TokenDetailsRouteParams) => {
 
       const isFromTokenList =
         source === TokenDetailsSource.MobileTokenList ||
-        source === TokenDetailsSource.MobileTokenListPage;
+        source === TokenDetailsSource.MobileTokenListPage ||
+        source === TokenDetailsSource.HomeSection;
 
       const eventProperties = {
         source,

--- a/app/components/UI/TokenDetails/constants/constants.ts
+++ b/app/components/UI/TokenDetails/constants/constants.ts
@@ -9,6 +9,8 @@ export enum TokenDetailsSource {
   MobileTokenList = 'mobile-token-list',
   /** Token list in full page view */
   MobileTokenListPage = 'mobile-token-list-page',
+  /** Homepage section entry point */
+  HomeSection = 'home_section',
   /** Trending tokens section */
   Trending = 'trending',
   /** Swap/Bridge token selector */

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
@@ -138,6 +138,7 @@ describe('CashGetMusdEmptyState', () => {
       expect.objectContaining({
         location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.HOME_CASH_SECTION,
         cta_type: MUSD_EVENTS_CONSTANTS.MUSD_CTA_TYPES.PRIMARY,
+        cta_click_target: 'cta_button',
         cta_text: 'Get mUSD',
       }),
     );
@@ -156,6 +157,7 @@ describe('CashGetMusdEmptyState', () => {
       expect.objectContaining({
         location: MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.MOBILE_TOKEN_LIST_PAGE,
         cta_type: MUSD_EVENTS_CONSTANTS.MUSD_CTA_TYPES.PRIMARY,
+        cta_click_target: 'cta_button',
         cta_text: 'Get mUSD',
       }),
     );

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -128,6 +128,7 @@ const CashGetMusdEmptyState = ({
             : EVENT_LOCATIONS.HOME_CASH_SECTION,
           redirects_to: getRedirectLocation(),
           cta_type: MUSD_CTA_TYPES.PRIMARY,
+          cta_click_target: 'cta_button',
           cta_text: strings('earn.musd_conversion.get_musd'),
           network_chain_id: MUSD_CONVERSION_DEFAULT_CHAIN_ID,
           network_name: networkName ?? undefined,

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -58,6 +58,16 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
+jest.mock('../../../../../core/NavigationService', () => {
+  const mockNavigate = jest.fn();
+  return {
+    __esModule: true,
+    default: {
+      navigation: { navigate: mockNavigate },
+    },
+  };
+});
+
 describe('MusdAggregatedRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -98,6 +108,20 @@ describe('MusdAggregatedRow', () => {
   it('has cash-section-musd-row testID', () => {
     renderWithProvider(<MusdAggregatedRow />);
     expect(screen.getByTestId('cash-section-musd-row')).toBeOnTheScreen();
+  });
+
+  it('navigates to Asset with home_section source when row is pressed', () => {
+    renderWithProvider(<MusdAggregatedRow />);
+
+    fireEvent.press(screen.getByTestId('cash-section-musd-row'));
+
+    const mockNavigate = jest.mocked(NavigationService.navigation.navigate);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'Asset',
+      expect.objectContaining({
+        source: 'home_section',
+      }),
+    );
   });
 
   it('shows Spinner when isClaiming is true', () => {

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -58,16 +58,6 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
-jest.mock('../../../../../core/NavigationService', () => {
-  const mockNavigate = jest.fn();
-  return {
-    __esModule: true,
-    default: {
-      navigation: { navigate: mockNavigate },
-    },
-  };
-});
-
 describe('MusdAggregatedRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -177,7 +167,7 @@ describe('MusdAggregatedRow', () => {
       expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
         'Asset',
         expect.objectContaining({
-          source: TokenDetailsSource.MobileTokenListPage,
+          source: TokenDetailsSource.HomeSection,
         }),
       );
     });

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -106,7 +106,7 @@ const MusdAggregatedRow = () => {
       'Asset' as never,
       {
         ...MUSD_MAINNET_ASSET_FOR_DETAILS,
-        source: TokenDetailsSource.MobileTokenListPage,
+        source: TokenDetailsSource.HomeSection,
       } as never,
     );
   }, [hasMusdBalanceOnAnyChain]);

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -70,7 +70,7 @@ export const AddressList = () => {
           networkName={item.networkName}
           address={item.account.address}
           copyParams={{
-            toastMessage: strings('multichain_accounts.address_list.copied'),
+            toastMessage: strings('notifications.address_copied_to_clipboard'),
             callback: copyAddressToClipboard,
             toastRef,
           }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR resolves three tickets in wallet/cash/multichain flows:
- TMCU-565: fixed `Token Details Opened` source for aggregated mUSD row to `home_section`.
- TMCU-556: added missing `cta_click_target: 'cta_button'` to `mUSD Conversion CTA Clicked`.
- TMCU-429: standardized multichain address-copy toast text to `Address copied to clipboard`.

## **Changelog**
CHANGELOG entry: Fixed several wallet regressions affecting mUSD analytics tracking and address copy messaging consistency

## **Related issues**
Refs: TMCU-565
Refs: TMCU-556
Refs: TMCU-429

## **Manual testing steps**
```gherkin
Feature: Wallet segment regressions

  Scenario: mUSD aggregated row tracks correct source
    Given user is on Wallet Home with Cash section visible
    When user taps the mUSD aggregated row
    Then token details opens
    And source is tracked as home_section

  Scenario: Get mUSD CTA includes click target
    Given user sees Get mUSD CTA in Cash section
    When user taps Get mUSD
    Then MUSD_CONVERSION_CTA_CLICKED is tracked
    And payload includes cta_click_target with value cta_button

  Scenario: Multichain address copy shows consistent toast
    Given user opens Multichain Address List
    When user copies an address
    Then toast shows Address copied to clipboard
```

## **Screenshots/Recordings**
### **Before**
<img width="396" height="839" alt="Screenshot 2026-03-20 at 10 45 36" src="https://github.com/user-attachments/assets/26c4f30a-6397-414f-8a74-ea98a072c3b8" />

### **After**
<img width="390" height="832" alt="Screenshot 2026-03-20 at 10 44 20" src="https://github.com/user-attachments/assets/b624da9b-a53d-4c5e-9d73-1a7ba66cff75" />

## **Pre-merge author checklist**
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics payload/source attribution and a toast string, with small navigation param updates covered by tests.
> 
> **Overview**
> Fixes wallet analytics regressions by introducing `TokenDetailsSource.HomeSection` and using it when navigating to Token Details from the homepage Cash mUSD aggregated row; Token Details open tracking now treats this source like token-list entry points for A/B attribution.
> 
> Adds missing `cta_click_target: 'cta_button'` to the `MUSD_CONVERSION_CTA_CLICKED` event from the Cash “Get mUSD” CTA (and updates tests accordingly). Standardizes the multichain address-copy toast message to `notifications.address_copied_to_clipboard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12a5ade1c9535e215eb832163a5e37e0695d6a57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->