### PR TITLE
test(e2e): MMQA-1614: declarative MetaMetrics assertions via withFixtures

### DIFF
--- a/.agents/skills/e2e-test/SKILL.md
+++ b/.agents/skills/e2e-test/SKILL.md
@@ -3,7 +3,8 @@ name: e2e-test
 description:
   Add and fix Detox E2E tests (smoke and regression) for MetaMask Mobile using
   withFixtures, Page Objects, and tests/framework. Use when creating a new spec,
-  fixing a failing E2E test, or adding page objects and selectors.
+  fixing a failing E2E test, adding page objects and selectors, or adding
+  MetaMetrics analytics expectations (analyticsExpectations).
 ---
 
 # E2E Test Builder — Skill
@@ -43,6 +44,10 @@ Task → What do you need?
 ├─ Mock API or feature flags
 │  → Open references/mocking.md (testSpecificMock, setupRemoteFeatureFlagsMock, setupMockRequest)
 │  → When writing the spec: open references/writing-tests.md
+│
+├─ MetaMetrics / Segment analytics assertions (`analyticsExpectations` on `withFixtures`)
+│  → Open [tests/docs/analytics-e2e.md](../../../tests/docs/analytics-e2e.md) (config shape, teardown order, presets under `tests/helpers/analytics/expectations/`, `runAnalyticsExpectations`)
+│  → When wiring a spec: still follow references/writing-tests.md for `withFixtures` usage
 │
 └─ Run tests, debug failures, or self-review
    → Open references/running-tests.md (build check, detox commands, common failures, retry patterns)
@@ -89,4 +94,5 @@ Documentation is split by **action**. Open only the reference that matches what 
 | **Writing or updating a spec**                | [references/writing-tests.md](references/writing-tests.md) | New spec file, spec structure, FixtureBuilder patterns, smoke/regression templates.               |
 | **Page Objects and selectors**                | [references/page-objects.md](references/page-objects.md)   | Create or update POM classes, selector/testId conventions, Matchers/Gestures/Assertions API.      |
 | **API and feature flag mocking**              | [references/mocking.md](references/mocking.md)             | testSpecificMock, setupRemoteFeatureFlagsMock, setupMockRequest, shared mock files.               |
+| **MetaMetrics / analytics expectations**      | [tests/docs/analytics-e2e.md](../../../tests/docs/analytics-e2e.md) | `analyticsExpectations` on `withFixtures`, declarative checks, presets in `tests/helpers/analytics/expectations/`. |
 | **Running tests, debugging, fixing failures** | [references/running-tests.md](references/running-tests.md) | Build check, detox run commands, lint/tsc, common failures table, retry patterns, iteration loop. |

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -16,7 +16,7 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 
 ### E2E Tests (Detox smoke/regression)
 
-- [.agents/skills/e2e-test/SKILL.md](../.agents/skills/e2e-test/SKILL.md) — Canonical skill for adding or fixing E2E specs: workflow, decision tree, references (writing-tests, page-objects, mocking, running-tests).
+- [.agents/skills/e2e-test/SKILL.md](../.agents/skills/e2e-test/SKILL.md) — Canonical skill for adding or fixing E2E specs: workflow, decision tree, references (writing-tests, page-objects, mocking, analytics-e2e, running-tests).
 
 ## Canonical Sources (read these, do not duplicate)
 
@@ -24,6 +24,7 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 - [docs/readme/e2e-testing.md](../docs/readme/e2e-testing.md) — Setup, run commands, build types, Metro, Detox, Flask; legacy Appium; Appwright.
 - [tests/docs/README.md](docs/README.md) — Framework structure, withFixtures, FixtureBuilder, anti-patterns, checklist.
 - [tests/docs/MOCKING.md](docs/MOCKING.md) — API mocking, default and test-specific mocks.
+- [tests/docs/analytics-e2e.md](docs/analytics-e2e.md) — MetaMetrics E2E: `analyticsExpectations` on `withFixtures`, presets, `runAnalyticsExpectations`.
 - [tests/docs/CONTROLLER_MOCKING.md](docs/CONTROLLER_MOCKING.md) — Controller mocking.
 - [tests/docs/MODULE_MOCKING.md](docs/MODULE_MOCKING.md) — Module mocking.
 - [tests/framework/index.ts](framework/index.ts) — Assertions, Gestures, Matchers, Utilities, PlaywrightAdapter.

--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -22,6 +22,7 @@ import {
   FALLBACK_DAPP_SERVER_PORT,
 } from '../framework/Constants.ts';
 import { DEFAULT_ANVIL_PORT } from '../seeder/anvil-manager.ts';
+import { logLiveMetaMetricsPostIfDebug } from '../helpers/analytics/analyticsDebug.ts';
 
 const logger = createLogger({
   name: 'MockServer',
@@ -304,6 +305,10 @@ export default class MockServerE2E implements Resource {
             } catch (e) {
               requestBodyText = undefined;
             }
+          }
+
+          if (method === 'POST') {
+            logLiveMetaMetricsPostIfDebug(urlEndpoint, requestBodyJson);
           }
 
           const methodEvents = this._events[method] || [];

--- a/tests/docs/analytics-e2e.md
+++ b/tests/docs/analytics-e2e.md
@@ -1,0 +1,80 @@
+# MetaMetrics / Segment analytics in E2E
+
+MetaMetrics events are proxied through the E2E **Mockttp** server. Helpers in `tests/helpers/analytics/helpers.ts` read captured request bodies.
+
+## `withFixtures` — `analyticsExpectations`
+
+Optional **`analyticsExpectations`** on `withFixtures` options runs **after** your test body and **`endTestfn`**, and **before** the mock server enters drain mode—so captured events are still available (see `FixtureHelper.ts` teardown order).
+
+Validation logic lives in **`tests/helpers/analytics/runAnalyticsExpectations.ts`** (single code path for all tests). Specs typically **import a preset object** from `tests/helpers/analytics/expectations/*.analytics.ts` and pass it to `analyticsExpectations`.
+
+### Configuration (`AnalyticsExpectations`)
+
+| Field | Purpose |
+| ----- | -------- |
+| `eventNames` | Subset of event names passed to `getEventsPayloads` (faster, less noise). If omitted and no `events[]` entries, **all** captured MetaMetrics payloads are loaded. |
+| `expectedTotalCount` | Assert exact length of that filtered list. |
+| `events` | Declarative per-event rules (see below). |
+| `validate` | Optional escape hatch; runs **after** declarative checks succeed. Receives `{ events, mockServer }`. |
+
+### Per-event rules (`AnalyticsEventExpectation`)
+
+| Field | Purpose |
+| ----- | -------- |
+| `name` | MetaMetrics event name. |
+| `minCount` | Minimum payloads with this name (@default 1). |
+| `matchEventIndex` | Which occurrence to use for single-payload checks (@default 0). |
+| `requiredProperties` | Type/shape map for **every** payload with this name (`Assertions.checkIfObjectHasKeysAndValidValues`). |
+| `matchProperties` | Exact property object for payload at `matchEventIndex` (`Assertions.checkIfObjectsMatch`). |
+| `containProperties` | Subset match for payload at `matchEventIndex` (`Assertions.checkIfObjectContains`). |
+| `requiredDefinedPropertyKeys` | Keys that must be defined on payload at `matchEventIndex`. |
+
+### Preset expectations (data-only, reusable)
+
+Place shared configs under **`tests/helpers/analytics/expectations/`** (e.g. `import-wallet.analytics.ts`). Import the preset from that file directly (same pattern as other test helpers—no barrel `index.ts`).
+
+```typescript
+import { importWalletWithMetricsOptInExpectations } from '../../../helpers/analytics/expectations/import-wallet.analytics';
+
+await withFixtures(
+  {
+    fixture: ...,
+    analyticsExpectations: importWalletWithMetricsOptInExpectations,
+  },
+  async () => {
+    /* UI only */
+  },
+);
+```
+
+Imports:
+
+```typescript
+import { withFixtures } from '../framework/fixtures/FixtureHelper';
+import type { AnalyticsExpectations } from '../framework';
+```
+
+Example (inline declarative, no `validate`):
+
+```typescript
+analyticsExpectations: {
+  eventNames: ['Wallet Imported'],
+  expectedTotalCount: 1,
+  events: [
+    {
+      name: 'Wallet Imported',
+      matchProperties: { biometrics_enabled: false },
+    },
+  ],
+},
+```
+
+Example (no events expected):
+
+```typescript
+analyticsExpectations: {
+  expectedTotalCount: 0,
+},
+```
+
+Programmatic use: `runAnalyticsExpectations` and `assertCapturedMetaMetricsEvents` are exported from `tests/framework/index.ts`.

--- a/tests/docs/analytics-e2e.md
+++ b/tests/docs/analytics-e2e.md
@@ -10,24 +10,26 @@ Validation logic lives in **`tests/helpers/analytics/runAnalyticsExpectations.ts
 
 ### Configuration (`AnalyticsExpectations`)
 
-| Field | Purpose |
-| ----- | -------- |
-| `eventNames` | Subset of event names passed to `getEventsPayloads` (faster, less noise). If omitted and no `events[]` entries, **all** captured MetaMetrics payloads are loaded. |
-| `expectedTotalCount` | Assert exact length of that filtered list. |
-| `events` | Declarative per-event rules (see below). |
-| `validate` | Optional escape hatch; runs **after** declarative checks succeed. Receives `{ events, mockServer }`. |
+| Field                | Purpose                                                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eventNames`         | Subset of event names passed to `getEventsPayloads` (faster, less noise). If omitted and no `events[]` entries, **all** captured MetaMetrics payloads are loaded. |
+| `expectedTotalCount` | Assert exact length of that filtered list.                                                                                                                        |
+| `events`             | Declarative per-event rules (see below).                                                                                                                          |
+| `validate`           | Optional escape hatch; runs **after** declarative checks succeed. Receives `{ events, mockServer }`.                                                              |
+
+All declarative rules and the optional `validate` callback are evaluated with **`SoftAssert`**: every configured expected event is checked and **all** failures are reported in one thrown error (not stop-on-first). Property checks for an event are skipped if that event did not meet `minCount`, so you get a clear “missing event” line without extra property noise.
 
 ### Per-event rules (`AnalyticsEventExpectation`)
 
-| Field | Purpose |
-| ----- | -------- |
-| `name` | MetaMetrics event name. |
-| `minCount` | Minimum payloads with this name (@default 1). |
-| `matchEventIndex` | Which occurrence to use for single-payload checks (@default 0). |
-| `requiredProperties` | Type/shape map for **every** payload with this name (`Assertions.checkIfObjectHasKeysAndValidValues`). |
-| `matchProperties` | Exact property object for payload at `matchEventIndex` (`Assertions.checkIfObjectsMatch`). |
-| `containProperties` | Subset match for payload at `matchEventIndex` (`Assertions.checkIfObjectContains`). |
-| `requiredDefinedPropertyKeys` | Keys that must be defined on payload at `matchEventIndex`. |
+| Field                         | Purpose                                                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `name`                        | MetaMetrics event name.                                                                                |
+| `minCount`                    | Minimum payloads with this name (@default 1).                                                          |
+| `matchEventIndex`             | Which occurrence to use for single-payload checks (@default 0).                                        |
+| `requiredProperties`          | Type/shape map for **every** payload with this name (`Assertions.checkIfObjectHasKeysAndValidValues`). |
+| `matchProperties`             | Exact property object for payload at `matchEventIndex` (`Assertions.checkIfObjectsMatch`).             |
+| `containProperties`           | Subset match for payload at `matchEventIndex` (`Assertions.checkIfObjectContains`).                    |
+| `requiredDefinedPropertyKeys` | Keys that must be defined on payload at `matchEventIndex`.                                             |
 
 ### Preset expectations (data-only, reusable)
 
@@ -78,3 +80,12 @@ analyticsExpectations: {
 ```
 
 Programmatic use: `runAnalyticsExpectations` and `assertCapturedMetaMetricsEvents` are exported from `tests/framework/index.ts`.
+
+## Debug logging (`E2E_ANALYTICS_DEBUG`)
+
+Set **`E2E_ANALYTICS_DEBUG=1`** (also accepts `true`, `yes`, `on`) when running E2E to log MetaMetrics traffic:
+
+1. **Live (as requests hit the mock)** — When the app POSTs through `/proxy` to the MetaMetrics track URL, the mock server logs a line like `Event sent (live): "<name>"` (see `logLiveMetaMetricsPostIfDebug` in `tests/helpers/analytics/analyticsDebug.ts` and `MockServerE2E.ts`).
+2. **Batch (when payloads are read)** — Whenever `getEventsPayloads` runs, it logs each captured event as `Captured event: "<name>"` plus debug-level property JSON (truncated). This runs at the end of the flow when analytics assertions (or custom code) fetch captured events.
+
+Properties are logged at **debug** level to limit noise; event names are **info** level. Adjust log level if your harness filters debug output.

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -46,6 +46,10 @@ import ContractAddressRegistry from '../../../app/util/test/contract-address-reg
 import FixtureBuilder from './FixtureBuilder';
 import { createLogger } from '../logger';
 import { mockNotificationServices } from '../../smoke/notifications/utils/mocks';
+import {
+  runAnalyticsExpectations,
+  shouldRunAnalyticsExpectations,
+} from '../../helpers/analytics/runAnalyticsExpectations';
 import PortManager, { ResourceType } from '../PortManager';
 import { DEFAULT_MOCKS } from '../../api-mocking/mock-responses/defaults';
 import type { Fixture } from './types';
@@ -512,6 +516,7 @@ export async function withFixtures(
     endTestfn,
     skipReactNativeReload = false,
     useCommandQueueServer = false,
+    analyticsExpectations,
   } = options;
 
   // Clean up any stale port forwarding from previous failed tests
@@ -672,7 +677,22 @@ export async function withFixtures(
       }
     }
 
-    // Enter drain mode AFTER endTestfn so analytics events are still captured,
+    if (
+      mockServerInstance &&
+      shouldRunAnalyticsExpectations(analyticsExpectations)
+    ) {
+      try {
+        await runAnalyticsExpectations(
+          mockServerInstance.server,
+          analyticsExpectations,
+        );
+      } catch (analyticsError) {
+        logger.error('Error in analyticsExpectations:', analyticsError);
+        cleanupErrors.push(analyticsError as Error);
+      }
+    }
+
+    // Enter drain mode AFTER endTestfn / analyticsExpectations so analytics events are still captured,
     // but BEFORE stopping backends — prevents forwarding to dead Anvil/Ganache.
     if (mockServerInstance) {
       mockServerInstance.startDraining();

--- a/tests/framework/fixtures/README.md
+++ b/tests/framework/fixtures/README.md
@@ -42,6 +42,7 @@ describe('My Test Suite', () => {
 | `languageAndLocale`     | `LanguageAndLocale`                                     | `false`  | -       | Set the device Language and Locale of the device                                                      |
 | `permissions`           | `object`                                                | `false`  | -       | Allows setting specific device permissions                                                            |
 | `endTestfn`             | `fn()`                                                  | `false`  | -       | Allows providing a function that is executed at the end of the test before the cleanup                |
+| `analyticsExpectations` | `AnalyticsExpectations`                                 | `false`  | -       | Optional MetaMetrics checks after `endTestfn`, before mock drain; see `tests/docs/analytics-e2e.md`      |
 | `skipReactNativeReload` | `boolean`                                               | `false`  | `false` | Skip React Native reload during cleanup to preserve app state between tests                           |
 | `useCommandQueueServer` | `boolean`                                               | `false`  | `false` | Launches an instance of CommandQueueServer to create a queue of items the app consumes on E2E context |
 

--- a/tests/framework/index.ts
+++ b/tests/framework/index.ts
@@ -6,6 +6,12 @@ export { default as Utilities, BASE_DEFAULTS, sleep } from './Utilities.ts';
 export { Logger, createLogger, LogLevel, logger } from './logger.ts';
 export { default as PortManager, ResourceType } from './PortManager.ts';
 export * from './types.ts';
+export {
+  runAnalyticsExpectations,
+  assertCapturedMetaMetricsEvents,
+  deriveEventNamesForFetch,
+  shouldRunAnalyticsExpectations,
+} from '../helpers/analytics/runAnalyticsExpectations.ts';
 export { boxedStep, getDriver } from './PlaywrightUtilities.ts';
 
 // Mock server utilities

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -366,8 +366,9 @@ export interface AnalyticsExpectations {
   /** Declarative per-event count and property checks. */
   events?: AnalyticsEventExpectation[];
   /**
-   * Custom validation after declarative checks succeed (or when no declarative checks are configured).
-   * Receives the same `events` array returned from `getEventsPayloads` for this test.
+   * Custom validation after declarative rules are evaluated. Runs in the same `SoftAssert` pass as
+   * declarative checks, so failures are merged: all expected events are still checked even when
+   * some already failed (unless you throw before returning from `validate`).
    */
   validate?: (ctx: {
     events: EventPayload[];

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -330,10 +330,7 @@ export interface AnalyticsEventExpectation {
    * `Assertions.checkIfObjectHasKeysAndValidValues` (e.g. `'string'`, `'number'`, `'array'`).
    * Applied to **every** captured payload with this event name.
    */
-  requiredProperties?: Record<
-    string,
-    string | ((value: unknown) => boolean)
-  >;
+  requiredProperties?: Record<string, string | ((value: unknown) => boolean)>;
   /**
    * Exact property match on the payload at `matchEventIndex` via
    * `Assertions.checkIfObjectsMatch`.

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -6,6 +6,7 @@ import { AnvilManager, Hardfork } from '../seeder/anvil-manager.ts';
 import ContractAddressRegistry from '../../app/util/test/contract-address-registry';
 import Ganache from '../../app/util/test/ganache';
 import { Mockttp } from 'mockttp';
+import type { EventPayload } from '../helpers/analytics/helpers.ts';
 import FixtureBuilder from './fixtures/FixtureBuilder.ts';
 import type { Fixture } from './fixtures/types.ts';
 import CommandQueueServer from './fixtures/CommandQueueServer.ts';
@@ -312,6 +313,72 @@ export interface MockApiEndpoint {
 export type TestSpecificMock = (mockServer: Mockttp) => Promise<void>;
 
 /**
+ * Declarative expectation for a single MetaMetrics event name captured during E2E.
+ */
+export interface AnalyticsEventExpectation {
+  /** MetaMetrics event name (e.g. `'Wallet Imported'`). */
+  name: string;
+  /** Minimum number of payloads with this event name. @default 1 */
+  minCount?: number;
+  /**
+   * Which captured occurrence to use for `matchProperties`, `containProperties`, and
+   * `requiredDefinedPropertyKeys`. @default 0
+   */
+  matchEventIndex?: number;
+  /**
+   * Property shape checks using the same value contract as
+   * `Assertions.checkIfObjectHasKeysAndValidValues` (e.g. `'string'`, `'number'`, `'array'`).
+   * Applied to **every** captured payload with this event name.
+   */
+  requiredProperties?: Record<
+    string,
+    string | ((value: unknown) => boolean)
+  >;
+  /**
+   * Exact property match on the payload at `matchEventIndex` via
+   * `Assertions.checkIfObjectsMatch`.
+   */
+  matchProperties?: Record<string, unknown>;
+  /**
+   * Subset property match on the payload at `matchEventIndex` via
+   * `Assertions.checkIfObjectContains`.
+   */
+  containProperties?: Record<string, unknown>;
+  /**
+   * Keys on the payload at `matchEventIndex` that must be defined (via
+   * `Assertions.checkIfValueIsDefined`).
+   */
+  requiredDefinedPropertyKeys?: string[];
+}
+
+/**
+ * Optional MetaMetrics validation for `withFixtures`.
+ * Executed after `testSuite` and `endTestfn`, before the mock server enters drain mode,
+ * so captured Segment/MetaMetrics requests are still available on `mockServer`.
+ */
+export interface AnalyticsExpectations {
+  /**
+   * Subset of event names to pass to `getEventsPayloads`.
+   * When omitted and no `events` entries exist, all captured MetaMetrics payloads are loaded.
+   */
+  eventNames?: string[];
+  /**
+   * When set, asserts the filtered payload list length equals this value (after `getEventsPayloads`).
+   */
+  expectedTotalCount?: number;
+  /** Declarative per-event count and property checks. */
+  events?: AnalyticsEventExpectation[];
+  /**
+   * Custom validation after declarative checks succeed (or when no declarative checks are configured).
+   * Receives the same `events` array returned from `getEventsPayloads` for this test.
+   */
+  validate?: (ctx: {
+    events: EventPayload[];
+    mockServer: Mockttp;
+  }) => Promise<void>;
+}
+
+/**
  * The options for the withFixtures function.
  * @param {FixtureBuilder | ((ctx: { localNodes?: LocalNode[] }) => FixtureBuilder | Promise<FixtureBuilder>)} fixture - The state of the fixture to load or a function that returns a fixture builder.
  * @param {boolean} [restartDevice=false] - If true, restarts the app to apply the loaded fixture.
@@ -324,6 +391,7 @@ export type TestSpecificMock = (mockServer: Mockttp) => Promise<void>;
  * @param {LanguageAndLocale} [languageAndLocale] - The language and locale to use for the test.
  * @param {Record<string, unknown>} [permissions] - The permissions to set for the device.
  * @param {() => Promise<void>} [endTestfn] - The function to execute after the test is finished.
+ * @param {AnalyticsExpectations} [analyticsExpectations] - Optional MetaMetrics assertions run after `endTestfn`, before mock drain.
  */
 export interface WithFixturesOptions {
   fixture:
@@ -350,4 +418,5 @@ export interface WithFixturesOptions {
    */
   skipReactNativeReload?: boolean;
   useCommandQueueServer?: boolean;
+  analyticsExpectations?: AnalyticsExpectations;
 }

--- a/tests/helpers/analytics/analyticsDebug.ts
+++ b/tests/helpers/analytics/analyticsDebug.ts
@@ -1,0 +1,93 @@
+import { E2E_METAMETRICS_TRACK_URL } from '../../../app/util/test/utils';
+import { createLogger } from '../../framework/logger';
+
+/** Same shape as `EventPayload` in `helpers.ts` (kept local to avoid circular imports). */
+export interface MetaMetricsEventPayload {
+  event: string;
+  properties: Record<string, unknown>;
+}
+
+const logger = createLogger({
+  name: 'E2EAnalyticsDebug',
+});
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+/**
+ * When enabled (`E2E_ANALYTICS_DEBUG=1`), logs MetaMetrics payloads when they are
+ * captured and optionally when each POST hits the E2E mock proxy.
+ *
+ * @see tests/docs/analytics-e2e.md
+ */
+export function isE2EAnalyticsDebugEnabled(): boolean {
+  const raw = process.env.E2E_ANALYTICS_DEBUG;
+  if (raw === undefined || raw === '') {
+    return false;
+  }
+  return TRUTHY.has(raw.toLowerCase().trim());
+}
+
+const MAX_PROPERTIES_JSON_LENGTH = 2000;
+
+/**
+ * Logs each captured event after `getEventsPayloads` (batch read, end of flow or whenever fetch runs).
+ */
+export function logCapturedMetaMetricsPayloads(
+  events: readonly MetaMetricsEventPayload[],
+  context: string,
+): void {
+  if (!isE2EAnalyticsDebugEnabled()) {
+    return;
+  }
+  if (events.length === 0) {
+    logger.info(`[E2E Analytics] ${context}: 0 MetaMetrics payloads`);
+    return;
+  }
+  logger.info(
+    `[E2E Analytics] ${context}: ${String(events.length)} MetaMetrics payload(s)`,
+  );
+  events.forEach((payload, index) => {
+    logger.info(
+      `[E2E Analytics]   [${String(index + 1)}/${String(events.length)}] Captured event: "${payload.event}"`,
+    );
+    const serialized = JSON.stringify(payload.properties);
+    const preview =
+      serialized.length > MAX_PROPERTIES_JSON_LENGTH
+        ? `${serialized.slice(0, MAX_PROPERTIES_JSON_LENGTH)}…`
+        : serialized;
+    logger.debug(`[E2E Analytics]   Properties: ${preview}`);
+  });
+}
+
+/**
+ * Logs as soon as a MetaMetrics track POST is handled by the mock `/proxy` handler
+ * (real-time relative to the test run, not only at teardown).
+ */
+export function logLiveMetaMetricsPostIfDebug(
+  proxiedTargetUrl: string,
+  requestBodyJson: unknown,
+): void {
+  if (!isE2EAnalyticsDebugEnabled()) {
+    return;
+  }
+  if (!proxiedTargetUrl.includes(E2E_METAMETRICS_TRACK_URL)) {
+    return;
+  }
+  const body = requestBodyJson as Record<string, unknown> | null | undefined;
+  if (body && typeof body.event === 'string') {
+    logger.info(`[E2E Analytics] Event sent (live): "${body.event}"`);
+    const props = body.properties;
+    if (props !== undefined && props !== null) {
+      const serialized = JSON.stringify(props);
+      const preview =
+        serialized.length > MAX_PROPERTIES_JSON_LENGTH
+          ? `${serialized.slice(0, MAX_PROPERTIES_JSON_LENGTH)}…`
+          : serialized;
+      logger.debug(`[E2E Analytics]   Properties: ${preview}`);
+    }
+    return;
+  }
+  logger.debug(
+    `[E2E Analytics] MetaMetrics POST (unparsed or batch shape): ${JSON.stringify(requestBodyJson)?.slice(0, 500)}`,
+  );
+}

--- a/tests/helpers/analytics/expectations/dapp-initiated-transfer.analytics.ts
+++ b/tests/helpers/analytics/expectations/dapp-initiated-transfer.analytics.ts
@@ -1,0 +1,66 @@
+import type { AnalyticsExpectations } from '../../../framework';
+import { commonTransactionPropertiesAndTypes } from '../common-transaction-properties';
+
+const TRANSACTION_ADDED = 'Transaction Added';
+const TRANSACTION_SUBMITTED = 'Transaction Submitted';
+const TRANSACTION_APPROVED = 'Transaction Approved';
+const TRANSACTION_FINALIZED = 'Transaction Finalized';
+
+const transactionEventNames = [
+  TRANSACTION_ADDED,
+  TRANSACTION_SUBMITTED,
+  TRANSACTION_APPROVED,
+  TRANSACTION_FINALIZED,
+];
+
+const simulationLifecycleProperties: Record<
+  string,
+  string | ((value: unknown) => boolean)
+> = {
+  ...commonTransactionPropertiesAndTypes,
+  simulation_response: 'string',
+  simulation_latency: 'number',
+  simulation_receiving_assets_quantity: 'number',
+  simulation_receiving_assets_type: 'array',
+  simulation_receiving_assets_value: 'array',
+  simulation_sending_assets_quantity: 'number',
+  simulation_sending_assets_type: 'array',
+  simulation_sending_assets_value: 'array',
+  asset_type: 'string',
+  simulation_receiving_assets_total_value: 'number',
+  simulation_sending_assets_total_value: 'number',
+};
+
+const transactionFinalizedProperties: Record<
+  string,
+  string | ((value: unknown) => boolean)
+> = {
+  ...simulationLifecycleProperties,
+  rpc_domain: 'string',
+};
+
+/**
+ * Expected MetaMetrics payloads after confirming a dapp-initiated native transfer (local Anvil).
+ */
+export const dappInitiatedTransferAnalyticsExpectations: AnalyticsExpectations = {
+  eventNames: [...transactionEventNames],
+  expectedTotalCount: transactionEventNames.length,
+  events: [
+    {
+      name: TRANSACTION_ADDED,
+      requiredProperties: { ...commonTransactionPropertiesAndTypes },
+    },
+    {
+      name: TRANSACTION_SUBMITTED,
+      requiredProperties: { ...simulationLifecycleProperties },
+    },
+    {
+      name: TRANSACTION_APPROVED,
+      requiredProperties: { ...simulationLifecycleProperties },
+    },
+    {
+      name: TRANSACTION_FINALIZED,
+      requiredProperties: { ...transactionFinalizedProperties },
+    },
+  ],
+};

--- a/tests/helpers/analytics/expectations/dapp-initiated-transfer.analytics.ts
+++ b/tests/helpers/analytics/expectations/dapp-initiated-transfer.analytics.ts
@@ -42,25 +42,26 @@ const transactionFinalizedProperties: Record<
 /**
  * Expected MetaMetrics payloads after confirming a dapp-initiated native transfer (local Anvil).
  */
-export const dappInitiatedTransferAnalyticsExpectations: AnalyticsExpectations = {
-  eventNames: [...transactionEventNames],
-  expectedTotalCount: transactionEventNames.length,
-  events: [
-    {
-      name: TRANSACTION_ADDED,
-      requiredProperties: { ...commonTransactionPropertiesAndTypes },
-    },
-    {
-      name: TRANSACTION_SUBMITTED,
-      requiredProperties: { ...simulationLifecycleProperties },
-    },
-    {
-      name: TRANSACTION_APPROVED,
-      requiredProperties: { ...simulationLifecycleProperties },
-    },
-    {
-      name: TRANSACTION_FINALIZED,
-      requiredProperties: { ...transactionFinalizedProperties },
-    },
-  ],
-};
+export const dappInitiatedTransferAnalyticsExpectations: AnalyticsExpectations =
+  {
+    eventNames: [...transactionEventNames],
+    expectedTotalCount: transactionEventNames.length,
+    events: [
+      {
+        name: TRANSACTION_ADDED,
+        requiredProperties: { ...commonTransactionPropertiesAndTypes },
+      },
+      {
+        name: TRANSACTION_SUBMITTED,
+        requiredProperties: { ...simulationLifecycleProperties },
+      },
+      {
+        name: TRANSACTION_APPROVED,
+        requiredProperties: { ...simulationLifecycleProperties },
+      },
+      {
+        name: TRANSACTION_FINALIZED,
+        requiredProperties: { ...transactionFinalizedProperties },
+      },
+    ],
+  };

--- a/tests/helpers/analytics/expectations/import-wallet.analytics.ts
+++ b/tests/helpers/analytics/expectations/import-wallet.analytics.ts
@@ -1,0 +1,61 @@
+import type { AnalyticsExpectations } from '../../../framework';
+import { onboardingEvents } from '../helpers';
+
+const importWalletFlowExpectedEventNames = [
+  onboardingEvents.ANALYTICS_PREFERENCE_SELECTED,
+  onboardingEvents.WALLET_IMPORTED,
+  onboardingEvents.WALLET_SETUP_COMPLETED,
+  onboardingEvents.WALLET_IMPORT_STARTED,
+  onboardingEvents.WALLET_IMPORT_ATTEMPTED,
+];
+
+/**
+ * Expected MetaMetrics payloads after importing a wallet with metrics opt-in.
+ */
+export const importWalletWithMetricsOptInExpectations: AnalyticsExpectations = {
+  eventNames: importWalletFlowExpectedEventNames,
+  expectedTotalCount: importWalletFlowExpectedEventNames.length,
+  events: [
+    {
+      name: onboardingEvents.ANALYTICS_PREFERENCE_SELECTED,
+      matchProperties: {
+        has_marketing_consent: false,
+        is_metrics_opted_in: true,
+        location: 'onboarding_metametrics',
+        updated_after_onboarding: false,
+        account_type: 'imported',
+      },
+    },
+    {
+      name: onboardingEvents.WALLET_IMPORT_STARTED,
+      matchProperties: {
+        account_type: 'imported',
+      },
+    },
+    {
+      name: onboardingEvents.WALLET_IMPORT_ATTEMPTED,
+      matchProperties: {},
+    },
+    {
+      name: onboardingEvents.WALLET_IMPORTED,
+      matchProperties: {
+        biometrics_enabled: false,
+      },
+    },
+    {
+      name: onboardingEvents.WALLET_SETUP_COMPLETED,
+      matchProperties: {
+        wallet_setup_type: 'import',
+        new_wallet: false,
+        account_type: 'imported',
+      },
+    },
+  ],
+};
+
+/**
+ * No MetaMetrics payloads when the user opts out during onboarding import.
+ */
+export const importWalletMetricsOptOutExpectations: AnalyticsExpectations = {
+  expectedTotalCount: 0,
+};

--- a/tests/helpers/analytics/expectations/predict-cash-out.analytics.ts
+++ b/tests/helpers/analytics/expectations/predict-cash-out.analytics.ts
@@ -1,0 +1,28 @@
+import type { AnalyticsExpectations } from '../../../framework';
+
+const MARKET_DETAILS_OPENED = 'Predict Market Details Opened';
+const POSITION_VIEWED = 'Predict Position Viewed';
+const ACTIVITY_VIEWED = 'Predict Activity Viewed';
+
+/**
+ * Expected MetaMetrics payloads after the predictions cash-out flow (Spurs vs. Pelicans scenario).
+ */
+export const predictCashOutFlowAnalyticsExpectations: AnalyticsExpectations = {
+  eventNames: [MARKET_DETAILS_OPENED, POSITION_VIEWED, ACTIVITY_VIEWED],
+  events: [
+    {
+      name: MARKET_DETAILS_OPENED,
+      requiredDefinedPropertyKeys: ['entry_point', 'market_details_viewed'],
+    },
+    {
+      name: POSITION_VIEWED,
+      requiredDefinedPropertyKeys: ['open_positions_count'],
+    },
+    {
+      name: ACTIVITY_VIEWED,
+      containProperties: {
+        activity_type: 'activity_list',
+      },
+    },
+  ],
+};

--- a/tests/helpers/analytics/expectations/predict-cash-out.analytics.ts
+++ b/tests/helpers/analytics/expectations/predict-cash-out.analytics.ts
@@ -1,22 +1,22 @@
 import type { AnalyticsExpectations } from '../../../framework';
 
 const MARKET_DETAILS_OPENED = 'Predict Market Details Opened';
-const POSITION_VIEWED = 'Predict Position Viewed';
 const ACTIVITY_VIEWED = 'Predict Activity Viewed';
 
 /**
  * Expected MetaMetrics payloads after the predictions cash-out flow (Spurs vs. Pelicans scenario).
+ *
+ * Note: "Predict Position Viewed" is not asserted here. It is only emitted from legacy
+ * `PredictHomePositions` inside `PredictTabView` when the wallet Predict tab is visible.
+ * With homepage sections v1 (`remoteFeatureFlagHomepageSectionsV1Enabled`), the wallet uses
+ * `Homepage` + `PredictionsSection` instead — that path does not call `trackPositionViewed`.
  */
 export const predictCashOutFlowAnalyticsExpectations: AnalyticsExpectations = {
-  eventNames: [MARKET_DETAILS_OPENED, POSITION_VIEWED, ACTIVITY_VIEWED],
+  eventNames: [MARKET_DETAILS_OPENED, ACTIVITY_VIEWED],
   events: [
     {
       name: MARKET_DETAILS_OPENED,
       requiredDefinedPropertyKeys: ['entry_point', 'market_details_viewed'],
-    },
-    {
-      name: POSITION_VIEWED,
-      requiredDefinedPropertyKeys: ['open_positions_count'],
     },
     {
       name: ACTIVITY_VIEWED,

--- a/tests/helpers/analytics/helpers.ts
+++ b/tests/helpers/analytics/helpers.ts
@@ -1,6 +1,7 @@
 import { MockedEndpoint, Mockttp, MockttpServer } from 'mockttp';
 import { E2E_METAMETRICS_TRACK_URL } from '../../../app/util/test/utils';
 import { createLogger } from '../../framework/logger';
+import { logCapturedMetaMetricsPayloads } from './analyticsDebug';
 
 const logger = createLogger({
   name: 'AnalyticsHelpers',
@@ -85,9 +86,18 @@ export const getEventsPayloads = async (
     await Promise.all(matchingRequests.map((req) => req.body?.getJson()))
   ).filter(Boolean);
 
-  return (payloads as EventPayload[])
+  const result = (payloads as EventPayload[])
     .filter((payload) => events.length === 0 || events.includes(payload.event))
     .map(({ event, properties }) => ({ event, properties }));
+
+  logCapturedMetaMetricsPayloads(
+    result,
+    events.length > 0
+      ? `getEventsPayloads (filtered to ${String(events.length)} name(s))`
+      : 'getEventsPayloads (all MetaMetrics)',
+  );
+
+  return result;
 };
 
 /**

--- a/tests/helpers/analytics/runAnalyticsExpectations.test.ts
+++ b/tests/helpers/analytics/runAnalyticsExpectations.test.ts
@@ -60,19 +60,15 @@ describe('deriveEventNamesForFetch', () => {
 
   it('uses unique names from events when eventNames missing', () => {
     const expectations: AnalyticsExpectations = {
-      events: [
-        { name: 'Dup' },
-        { name: 'Dup' },
-        { name: 'Other' },
-      ],
+      events: [{ name: 'Dup' }, { name: 'Dup' }, { name: 'Other' }],
     };
     expect(deriveEventNamesForFetch(expectations)).toEqual(['Dup', 'Other']);
   });
 
   it('returns empty array when no names source', () => {
-    expect(deriveEventNamesForFetch({ validate: async () => undefined })).toEqual(
-      [],
-    );
+    expect(
+      deriveEventNamesForFetch({ validate: async () => undefined }),
+    ).toEqual([]);
   });
 });
 

--- a/tests/helpers/analytics/runAnalyticsExpectations.test.ts
+++ b/tests/helpers/analytics/runAnalyticsExpectations.test.ts
@@ -1,0 +1,234 @@
+import type { Mockttp } from 'mockttp';
+import {
+  assertCapturedMetaMetricsEvents,
+  deriveEventNamesForFetch,
+  shouldRunAnalyticsExpectations,
+} from './runAnalyticsExpectations';
+import type { AnalyticsExpectations } from '../../framework';
+import type { EventPayload } from './helpers';
+
+const mockServer = {} as Mockttp;
+
+describe('shouldRunAnalyticsExpectations', () => {
+  it('returns false for undefined', () => {
+    expect(shouldRunAnalyticsExpectations(undefined)).toBe(false);
+  });
+
+  it('returns false for empty object', () => {
+    expect(shouldRunAnalyticsExpectations({})).toBe(false);
+  });
+
+  it('returns true when validate is set', () => {
+    expect(
+      shouldRunAnalyticsExpectations({
+        validate: async () => undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when expectedTotalCount is set including zero', () => {
+    expect(shouldRunAnalyticsExpectations({ expectedTotalCount: 0 })).toBe(
+      true,
+    );
+  });
+
+  it('returns true when events array is non-empty', () => {
+    expect(
+      shouldRunAnalyticsExpectations({
+        events: [{ name: 'Test Event' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when eventNames is non-empty', () => {
+    expect(
+      shouldRunAnalyticsExpectations({
+        eventNames: ['A'],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('deriveEventNamesForFetch', () => {
+  it('prefers explicit eventNames', () => {
+    const expectations: AnalyticsExpectations = {
+      eventNames: ['One', 'Two'],
+      events: [{ name: 'Three' }],
+    };
+    expect(deriveEventNamesForFetch(expectations)).toEqual(['One', 'Two']);
+  });
+
+  it('uses unique names from events when eventNames missing', () => {
+    const expectations: AnalyticsExpectations = {
+      events: [
+        { name: 'Dup' },
+        { name: 'Dup' },
+        { name: 'Other' },
+      ],
+    };
+    expect(deriveEventNamesForFetch(expectations)).toEqual(['Dup', 'Other']);
+  });
+
+  it('returns empty array when no names source', () => {
+    expect(deriveEventNamesForFetch({ validate: async () => undefined })).toEqual(
+      [],
+    );
+  });
+});
+
+describe('assertCapturedMetaMetricsEvents', () => {
+  const sample: EventPayload[] = [
+    { event: 'Alpha', properties: { x: 'a' } },
+    { event: 'Alpha', properties: { x: 'b' } },
+  ];
+
+  it('throws when expectedTotalCount does not match', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        sample,
+        { expectedTotalCount: 99 },
+        mockServer,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('passes when expectedTotalCount matches', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        sample,
+        { expectedTotalCount: 2 },
+        mockServer,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when minCount not met for an event', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        sample,
+        {
+          events: [{ name: 'Missing', minCount: 1 }],
+        },
+        mockServer,
+      ),
+    ).rejects.toThrow(/Missing/);
+  });
+
+  it('validates requiredProperties on each matching payload', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        sample,
+        {
+          events: [
+            {
+              name: 'Alpha',
+              minCount: 2,
+              requiredProperties: { x: 'string' },
+            },
+          ],
+        },
+        mockServer,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('runs validate after declarative checks', async () => {
+    let ran = false;
+    await assertCapturedMetaMetricsEvents(
+      [{ event: 'Z', properties: {} }],
+      {
+        expectedTotalCount: 1,
+        validate: async () => {
+          ran = true;
+        },
+      },
+      mockServer,
+    );
+    expect(ran).toBe(true);
+  });
+
+  it('validates matchProperties on target payload', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        [{ event: 'E', properties: { id: 1, name: 'ok' } }],
+        {
+          events: [
+            {
+              name: 'E',
+              matchProperties: { id: 1, name: 'ok' },
+            },
+          ],
+        },
+        mockServer,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails matchProperties when values differ', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        [{ event: 'E', properties: { id: 2 } }],
+        {
+          events: [
+            {
+              name: 'E',
+              matchProperties: { id: 1 },
+            },
+          ],
+        },
+        mockServer,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('validates containProperties', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        [{ event: 'E', properties: { a: 1, b: 2 } }],
+        {
+          events: [
+            {
+              name: 'E',
+              containProperties: { b: 2 },
+            },
+          ],
+        },
+        mockServer,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('validates requiredDefinedPropertyKeys', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        [{ event: 'E', properties: { x: 'set' } }],
+        {
+          events: [
+            {
+              name: 'E',
+              requiredDefinedPropertyKeys: ['x'],
+            },
+          ],
+        },
+        mockServer,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails requiredDefinedPropertyKeys when key missing', async () => {
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        [{ event: 'E', properties: {} }],
+        {
+          events: [
+            {
+              name: 'E',
+              requiredDefinedPropertyKeys: ['missing'],
+            },
+          ],
+        },
+        mockServer,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/helpers/analytics/runAnalyticsExpectations.test.ts
+++ b/tests/helpers/analytics/runAnalyticsExpectations.test.ts
@@ -128,7 +128,7 @@ describe('assertCapturedMetaMetricsEvents', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('runs validate after declarative checks', async () => {
+  it('runs validate in the same SoftAssert pass as declarative checks', async () => {
     let ran = false;
     await assertCapturedMetaMetricsEvents(
       [{ event: 'Z', properties: {} }],
@@ -141,6 +141,49 @@ describe('assertCapturedMetaMetricsEvents', () => {
       mockServer,
     );
     expect(ran).toBe(true);
+  });
+
+  it('still runs validate when declarative checks failed and aggregates errors', async () => {
+    let ran = false;
+    await expect(
+      assertCapturedMetaMetricsEvents(
+        [{ event: 'Z', properties: {} }],
+        {
+          expectedTotalCount: 99,
+          validate: async () => {
+            ran = true;
+            throw new Error('validate failed');
+          },
+        },
+        mockServer,
+      ),
+    ).rejects.toThrow(/validate failed/);
+    expect(ran).toBe(true);
+  });
+
+  it('evaluates every expected event and reports all failures together', async () => {
+    let caught: Error | undefined;
+    try {
+      await assertCapturedMetaMetricsEvents(
+        [{ event: 'OnlyThis', properties: {} }],
+        {
+          events: [
+            { name: 'MissingOne', minCount: 1 },
+            {
+              name: 'OnlyThis',
+              matchProperties: { wrong: true },
+            },
+          ],
+        },
+        mockServer,
+      );
+    } catch (error) {
+      caught = error as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message).toContain('MissingOne');
+    expect(caught?.message).toContain('OnlyThis');
+    expect(caught?.message).toContain('match expected object');
   });
 
   it('validates matchProperties on target payload', async () => {

--- a/tests/helpers/analytics/runAnalyticsExpectations.ts
+++ b/tests/helpers/analytics/runAnalyticsExpectations.ts
@@ -1,0 +1,152 @@
+import { Mockttp, MockttpServer } from 'mockttp';
+import Assertions from '../../framework/Assertions';
+import SoftAssert from '../../framework/SoftAssert';
+import type { AnalyticsExpectations } from '../../framework/types';
+import {
+  EventPayload,
+  filterEvents,
+  getEventsPayloads,
+} from './helpers';
+
+/**
+ * Returns true when `analyticsExpectations` should run (non-empty configuration).
+ */
+export function shouldRunAnalyticsExpectations(
+  config: AnalyticsExpectations | undefined,
+): config is AnalyticsExpectations {
+  if (!config) {
+    return false;
+  }
+  return (
+    config.validate !== undefined ||
+    config.expectedTotalCount !== undefined ||
+    (config.events !== undefined && config.events.length > 0) ||
+    (config.eventNames !== undefined && config.eventNames.length > 0)
+  );
+}
+
+/**
+ * Derives the event-name filter passed to `getEventsPayloads`.
+ * Prefers explicit `eventNames`; otherwise uses unique names from `events`; otherwise all payloads.
+ */
+export function deriveEventNamesForFetch(
+  expectations: AnalyticsExpectations,
+): string[] {
+  if (expectations.eventNames && expectations.eventNames.length > 0) {
+    return expectations.eventNames;
+  }
+  if (expectations.events && expectations.events.length > 0) {
+    return [...new Set(expectations.events.map((entry) => entry.name))];
+  }
+  return [];
+}
+
+/**
+ * Runs declarative MetaMetrics checks, then optional `validate`.
+ * Declarative failures are aggregated; `validate` runs only if declarative checks pass.
+ */
+export async function assertCapturedMetaMetricsEvents(
+  events: EventPayload[],
+  expectations: AnalyticsExpectations,
+  mockServer: Mockttp | MockttpServer,
+): Promise<void> {
+  const softAssert = new SoftAssert();
+
+  const expectedTotalCount = expectations.expectedTotalCount;
+  if (expectedTotalCount !== undefined) {
+    await softAssert.checkAndCollect(
+      async () =>
+        Assertions.checkIfArrayHasLength(events, expectedTotalCount),
+      `Expected ${String(expectedTotalCount)} MetaMetrics events, got ${events.length}`,
+    );
+  }
+
+  if (expectations.events && expectations.events.length > 0) {
+    for (const eventExpectation of expectations.events) {
+      const minCount = eventExpectation.minCount ?? 1;
+      const matching = filterEvents(events, eventExpectation.name);
+
+      await softAssert.checkAndCollect(async () => {
+        if (matching.length < minCount) {
+          throw new Error(
+            `Expected at least ${String(minCount)} "${eventExpectation.name}" events, got ${String(matching.length)}`,
+          );
+        }
+      }, `MetaMetrics event count for "${eventExpectation.name}"`);
+
+      const requiredProperties = eventExpectation.requiredProperties;
+      if (requiredProperties) {
+        for (let i = 0; i < matching.length; i += 1) {
+          const payload = matching[i];
+          await softAssert.checkAndCollect(
+            async () =>
+              Assertions.checkIfObjectHasKeysAndValidValues(
+                payload.properties,
+                requiredProperties,
+              ),
+            `"${eventExpectation.name}" event[${String(i)}] property shape`,
+          );
+        }
+      }
+
+      const targetIndex = Math.min(
+        eventExpectation.matchEventIndex ?? 0,
+        Math.max(matching.length - 1, 0),
+      );
+      const targetPayload = matching[targetIndex];
+
+      const definedKeys = eventExpectation.requiredDefinedPropertyKeys;
+      if (definedKeys && definedKeys.length > 0) {
+        for (const key of definedKeys) {
+          await softAssert.checkAndCollect(
+            async () =>
+              Assertions.checkIfValueIsDefined(targetPayload.properties[key]),
+            `"${eventExpectation.name}" property "${key}" should be defined`,
+          );
+        }
+      }
+
+      const matchProperties = eventExpectation.matchProperties;
+      if (matchProperties !== undefined) {
+        await softAssert.checkAndCollect(
+          async () =>
+            Assertions.checkIfObjectsMatch(
+              targetPayload.properties as object,
+              matchProperties as object,
+            ),
+          `"${eventExpectation.name}" properties should match expected object`,
+        );
+      }
+
+      const containProperties = eventExpectation.containProperties;
+      if (containProperties !== undefined) {
+        await softAssert.checkAndCollect(
+          async () =>
+            Assertions.checkIfObjectContains(
+              targetPayload.properties,
+              containProperties,
+            ),
+          `"${eventExpectation.name}" properties should contain expected subset`,
+        );
+      }
+    }
+  }
+
+  softAssert.throwIfErrors();
+
+  if (expectations.validate) {
+    await expectations.validate({ events, mockServer });
+  }
+}
+
+/**
+ * Fetches MetaMetrics payloads from the mock server and runs `assertCapturedMetaMetricsEvents`.
+ */
+export async function runAnalyticsExpectations(
+  mockServer: Mockttp | MockttpServer,
+  expectations: AnalyticsExpectations,
+): Promise<void> {
+  const names = deriveEventNamesForFetch(expectations);
+  const events = await getEventsPayloads(mockServer, names);
+  await assertCapturedMetaMetricsEvents(events, expectations, mockServer);
+}

--- a/tests/helpers/analytics/runAnalyticsExpectations.ts
+++ b/tests/helpers/analytics/runAnalyticsExpectations.ts
@@ -2,11 +2,7 @@ import { Mockttp, MockttpServer } from 'mockttp';
 import Assertions from '../../framework/Assertions';
 import SoftAssert from '../../framework/SoftAssert';
 import type { AnalyticsExpectations } from '../../framework/types';
-import {
-  EventPayload,
-  filterEvents,
-  getEventsPayloads,
-} from './helpers';
+import { EventPayload, filterEvents, getEventsPayloads } from './helpers';
 
 /**
  * Returns true when `analyticsExpectations` should run (non-empty configuration).
@@ -55,8 +51,7 @@ export async function assertCapturedMetaMetricsEvents(
   const expectedTotalCount = expectations.expectedTotalCount;
   if (expectedTotalCount !== undefined) {
     await softAssert.checkAndCollect(
-      async () =>
-        Assertions.checkIfArrayHasLength(events, expectedTotalCount),
+      async () => Assertions.checkIfArrayHasLength(events, expectedTotalCount),
       `Expected ${String(expectedTotalCount)} MetaMetrics events, got ${events.length}`,
     );
   }

--- a/tests/helpers/analytics/runAnalyticsExpectations.ts
+++ b/tests/helpers/analytics/runAnalyticsExpectations.ts
@@ -38,8 +38,10 @@ export function deriveEventNamesForFetch(
 }
 
 /**
- * Runs declarative MetaMetrics checks, then optional `validate`.
- * Declarative failures are aggregated; `validate` runs only if declarative checks pass.
+ * Runs declarative MetaMetrics checks, then optional `validate`, aggregating **all**
+ * failures via `SoftAssert` so every expected event / rule is evaluated (not stop-on-first).
+ * Property checks for an event are skipped when that event did not meet `minCount`, to avoid
+ * noisy follow-on errors; other expected events are still fully checked.
  */
 export async function assertCapturedMetaMetricsEvents(
   events: EventPayload[],
@@ -69,8 +71,16 @@ export async function assertCapturedMetaMetricsEvents(
         }
       }, `MetaMetrics event count for "${eventExpectation.name}"`);
 
+      const targetIndex = Math.min(
+        eventExpectation.matchEventIndex ?? 0,
+        Math.max(matching.length - 1, 0),
+      );
+      const targetPayload = matching[targetIndex];
+      const canInspectPayload =
+        matching.length >= minCount && targetPayload !== undefined;
+
       const requiredProperties = eventExpectation.requiredProperties;
-      if (requiredProperties) {
+      if (requiredProperties && canInspectPayload) {
         for (let i = 0; i < matching.length; i += 1) {
           const payload = matching[i];
           await softAssert.checkAndCollect(
@@ -84,11 +94,9 @@ export async function assertCapturedMetaMetricsEvents(
         }
       }
 
-      const targetIndex = Math.min(
-        eventExpectation.matchEventIndex ?? 0,
-        Math.max(matching.length - 1, 0),
-      );
-      const targetPayload = matching[targetIndex];
+      if (!canInspectPayload) {
+        continue;
+      }
 
       const definedKeys = eventExpectation.requiredDefinedPropertyKeys;
       if (definedKeys && definedKeys.length > 0) {
@@ -127,11 +135,15 @@ export async function assertCapturedMetaMetricsEvents(
     }
   }
 
-  softAssert.throwIfErrors();
-
-  if (expectations.validate) {
-    await expectations.validate({ events, mockServer });
+  const customValidate = expectations.validate;
+  if (customValidate) {
+    await softAssert.checkAndCollect(
+      async () => customValidate({ events, mockServer }),
+      'analyticsExpectations.validate',
+    );
   }
+
+  softAssert.throwIfErrors();
 }
 
 /**

--- a/tests/smoke/confirmations/transactions/dapp-initiated-transfer.spec.ts
+++ b/tests/smoke/confirmations/transactions/dapp-initiated-transfer.spec.ts
@@ -16,11 +16,6 @@ import {
 } from '../../../api-mocking/mock-responses/simulations';
 import TestDApp from '../../../page-objects/Browser/TestDApp';
 import { DappVariants } from '../../../framework/Constants';
-import {
-  EventPayload,
-  getEventsPayloads,
-} from '../../../helpers/analytics/helpers';
-import SoftAssert from '../../../framework/SoftAssert';
 import { Mockttp } from 'mockttp';
 import {
   setupMockRequest,
@@ -35,21 +30,7 @@ import {
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { confirmationFeatureFlags } from '../../../api-mocking/mock-responses/feature-flags-mocks';
 import { DEFAULT_ANVIL_PORT } from '../../../seeder/anvil-manager';
-import { commonTransactionPropertiesAndTypes } from '../../../helpers/analytics/common-transaction-properties';
-
-const expectedEvents = {
-  TRANSACTION_ADDED: 'Transaction Added',
-  TRANSACTION_SUBMITTED: 'Transaction Submitted',
-  TRANSACTION_APPROVED: 'Transaction Approved',
-  TRANSACTION_FINALIZED: 'Transaction Finalized',
-};
-
-const expectedEventNames = [
-  expectedEvents.TRANSACTION_ADDED,
-  expectedEvents.TRANSACTION_SUBMITTED,
-  expectedEvents.TRANSACTION_APPROVED,
-  expectedEvents.TRANSACTION_FINALIZED,
-];
+import { dappInitiatedTransferAnalyticsExpectations } from '../../../helpers/analytics/expectations/dapp-initiated-transfer.analytics';
 
 describe(SmokeConfirmations('DApp Initiated Transfer'), () => {
   const testSpecificMock = async (mockServer: Mockttp) => {
@@ -101,13 +82,12 @@ describe(SmokeConfirmations('DApp Initiated Transfer'), () => {
       Object.assign({}, ...confirmationFeatureFlags),
     );
   };
-  let eventsToCheck: EventPayload[];
 
   beforeAll(async () => {
     jest.setTimeout(2500000);
   });
 
-  it('sends native asset', async () => {
+  it('sends native asset and validates MetaMetrics transaction events', async () => {
     await withFixtures(
       {
         dapps: [
@@ -133,12 +113,7 @@ describe(SmokeConfirmations('DApp Initiated Transfer'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock,
-        endTestfn: async ({ mockServer }) => {
-          eventsToCheck = await getEventsPayloads(
-            mockServer,
-            expectedEventNames,
-          );
-        },
+        analyticsExpectations: dappInitiatedTransferAnalyticsExpectations,
       },
       async () => {
         await loginToApp();
@@ -153,7 +128,6 @@ describe(SmokeConfirmations('DApp Initiated Transfer'), () => {
         });
         await TestDApp.tapSendEIP1559Button();
 
-        // Check all expected elements are visible
         await Assertions.expectElementToBeVisible(
           ConfirmationUITypes.ModalConfirmationContainer,
           {
@@ -169,14 +143,12 @@ describe(SmokeConfirmations('DApp Initiated Transfer'), () => {
           RowComponents.SimulationDetails,
         );
 
-        // Scroll to reveal GasFeesDetails on Android due to taller From/To row
         if (device.getPlatform() === 'android') {
           await Gestures.swipe(RowComponents.SimulationDetails, 'up');
         }
 
         await Assertions.expectElementToBeVisible(RowComponents.GasFeesDetails);
 
-        // Scroll to Advanced Details section on Android
         if (device.getPlatform() === 'android') {
           await Gestures.swipe(
             ConfirmationUITypes.ModalConfirmationContainer,
@@ -208,134 +180,12 @@ describe(SmokeConfirmations('DApp Initiated Transfer'), () => {
           },
         );
 
-        // Accept confirmation
         await FooterActions.tapConfirmButton();
 
-        // Close browser to reveal app tab bar, then check activity
         await Browser.tapCloseBrowserButton();
         await TabBarComponent.tapActivity();
         await Assertions.expectTextDisplayed('Confirmed');
       },
     );
-  });
-
-  it('validates the segment events from the dapp initiated transfer', async () => {
-    if (!eventsToCheck) {
-      throw new Error('Events to check are not defined');
-    }
-
-    const softAssert = new SoftAssert();
-
-    // Transaction Added
-    const transactionAddedEvent = eventsToCheck.find(
-      (event) => event.event === expectedEvents.TRANSACTION_ADDED,
-    );
-    await softAssert.checkAndCollect(
-      () => Assertions.checkIfValueIsDefined(transactionAddedEvent),
-      'Transaction Added: Should be defined',
-    );
-    await softAssert.checkAndCollect(
-      () =>
-        Assertions.checkIfObjectHasKeysAndValidValues(
-          transactionAddedEvent?.properties ?? {},
-          {
-            ...commonTransactionPropertiesAndTypes,
-          },
-        ),
-      'Transaction Added: Should have the correct properties',
-    );
-
-    // Transaction Submitted
-    const transactionSubmittedEvent = eventsToCheck.find(
-      (event) => event.event === expectedEvents.TRANSACTION_SUBMITTED,
-    );
-    await softAssert.checkAndCollect(
-      () => Assertions.checkIfValueIsDefined(transactionSubmittedEvent),
-      'Transaction Submitted: Should be defined',
-    );
-    await softAssert.checkAndCollect(
-      () =>
-        Assertions.checkIfObjectHasKeysAndValidValues(
-          transactionSubmittedEvent?.properties ?? {},
-          {
-            ...commonTransactionPropertiesAndTypes,
-            simulation_response: 'string',
-            simulation_latency: 'number',
-            simulation_receiving_assets_quantity: 'number',
-            simulation_receiving_assets_type: 'array',
-            simulation_receiving_assets_value: 'array',
-            simulation_sending_assets_quantity: 'number',
-            simulation_sending_assets_type: 'array',
-            simulation_sending_assets_value: 'array',
-            asset_type: 'string',
-            simulation_receiving_assets_total_value: 'number',
-            simulation_sending_assets_total_value: 'number',
-          },
-        ),
-      'Transaction Submitted: Should have the correct properties',
-    );
-
-    // Transaction Approved
-    const transactionApprovedEvent = eventsToCheck.find(
-      (event) => event.event === expectedEvents.TRANSACTION_APPROVED,
-    );
-    await softAssert.checkAndCollect(
-      () => Assertions.checkIfValueIsDefined(transactionApprovedEvent),
-      'Transaction Approved: Should be defined',
-    );
-    await softAssert.checkAndCollect(
-      () =>
-        Assertions.checkIfObjectHasKeysAndValidValues(
-          transactionApprovedEvent?.properties ?? {},
-          {
-            ...commonTransactionPropertiesAndTypes,
-            simulation_response: 'string',
-            simulation_latency: 'number',
-            simulation_receiving_assets_quantity: 'number',
-            simulation_receiving_assets_type: 'array',
-            simulation_receiving_assets_value: 'array',
-            simulation_sending_assets_quantity: 'number',
-            simulation_sending_assets_type: 'array',
-            simulation_sending_assets_value: 'array',
-            asset_type: 'string',
-            simulation_receiving_assets_total_value: 'number',
-            simulation_sending_assets_total_value: 'number',
-          },
-        ),
-      'Transaction Approved: Should have the correct properties',
-    );
-
-    // Transaction Finalized
-    const transactionFinalizedEvent = eventsToCheck.find(
-      (event) => event.event === expectedEvents.TRANSACTION_FINALIZED,
-    );
-    await softAssert.checkAndCollect(
-      () => Assertions.checkIfValueIsDefined(transactionFinalizedEvent),
-      'Transaction Finalized: Should be defined',
-    );
-    await softAssert.checkAndCollect(
-      () =>
-        Assertions.checkIfObjectHasKeysAndValidValues(
-          transactionFinalizedEvent?.properties ?? {},
-          {
-            ...commonTransactionPropertiesAndTypes,
-            simulation_response: 'string',
-            simulation_latency: 'number',
-            simulation_receiving_assets_quantity: 'number',
-            simulation_receiving_assets_type: 'array',
-            simulation_receiving_assets_value: 'array',
-            simulation_sending_assets_quantity: 'number',
-            simulation_sending_assets_type: 'array',
-            simulation_sending_assets_value: 'array',
-            asset_type: 'string',
-            rpc_domain: 'string',
-            simulation_receiving_assets_total_value: 'number',
-            simulation_sending_assets_total_value: 'number',
-          },
-        ),
-      'Transaction Finalized: Should have the correct properties',
-    );
-
-    softAssert.throwIfErrors();
   });
 });

--- a/tests/smoke/predict/predict-cash-out.spec.ts
+++ b/tests/smoke/predict/predict-cash-out.spec.ts
@@ -27,11 +27,10 @@ import { predictCashOutFlowAnalyticsExpectations } from '../../helpers/analytics
 
 /*
 Test Scenario: Cash out on open position - Spurs vs. Pelicans
-  Verifies the cash out flow for a predictions position:
-  1. Navigate to Predictions tab and verify balance is $28.16
-  2. Open Spurs vs. Pelicans position details
-  3. Cash out the position with updated mocks
-  4. Verify cash out appears in Activities tab
+  Verifies the cash out flow for a predictions position (homepage sections v1 — no wallet tabs):
+  1. From wallet homepage Predictions section, open Spurs vs. Pelicans position details
+  2. Cash out the position with updated mocks
+  3. Verify balance and cash out in Activities tab
   */
 const positionDetails = {
   name: 'Spurs vs. Pelicans',

--- a/tests/smoke/predict/predict-cash-out.spec.ts
+++ b/tests/smoke/predict/predict-cash-out.spec.ts
@@ -23,8 +23,7 @@ import PredictCashOutPage from '../../page-objects/Predict/PredictCashOutPage';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
 import PredictActivityDetails from '../../page-objects/Transactions/predictionsActivityDetails';
-import { getEventsPayloads } from '../../helpers/analytics/helpers';
-import SoftAssert from '../../framework/SoftAssert';
+import { predictCashOutFlowAnalyticsExpectations } from '../../helpers/analytics/expectations/predict-cash-out.analytics';
 
 /*
 Test Scenario: Cash out on open position - Spurs vs. Pelicans
@@ -52,7 +51,7 @@ const PredictionMarketFeature = async (mockServer: Mockttp) => {
 };
 
 describe(SmokePredictions('Predictions'), () => {
-  it('should cash out on open position: Spurs vs. Pelicans', async () => {
+  it('cashes out on open position: Spurs vs. Pelicans', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -61,6 +60,7 @@ describe(SmokePredictions('Predictions'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: PredictionMarketFeature,
+        analyticsExpectations: predictCashOutFlowAnalyticsExpectations,
       },
       async ({ mockServer }) => {
         await loginToApp();
@@ -103,63 +103,6 @@ describe(SmokePredictions('Predictions'), () => {
           PredictActivityDetails.container,
         );
         await Assertions.expectTextDisplayed(positionDetails.cashOutValue);
-
-        // Verify analytics events
-        const events = await getEventsPayloads(mockServer);
-        const softAssert = new SoftAssert();
-
-        const expectedEvents = {
-          MARKET_DETAILS_OPENED: 'Predict Market Details Opened',
-          POSITION_VIEWED: 'Predict Position Viewed',
-          ACTIVITY_VIEWED: 'Predict Activity Viewed',
-        };
-
-        // Event 1: PREDICT_MARKET_DETAILS_OPENED
-        await softAssert.checkAndCollect(async () => {
-          const marketDetailsOpened = events.filter(
-            (event) => event.event === expectedEvents.MARKET_DETAILS_OPENED,
-          );
-          await Assertions.checkIfValueIsDefined(marketDetailsOpened);
-          if (marketDetailsOpened.length > 0) {
-            await Assertions.checkIfValueIsDefined(
-              marketDetailsOpened[0].properties.entry_point,
-            );
-            await Assertions.checkIfValueIsDefined(
-              marketDetailsOpened[0].properties.market_details_viewed,
-            );
-          }
-        }, 'Market Details Opened event should be tracked');
-
-        // Event 2: PREDICT_POSITION_VIEWED
-        await softAssert.checkAndCollect(async () => {
-          const positionViewed = events.filter(
-            (event) => event.event === expectedEvents.POSITION_VIEWED,
-          );
-          await Assertions.checkIfValueIsDefined(positionViewed);
-          if (positionViewed.length > 0) {
-            await Assertions.checkIfValueIsDefined(
-              positionViewed[0].properties.open_positions_count,
-            );
-          }
-        }, 'Position Viewed event should be tracked');
-
-        // Event 3: PREDICT_ACTIVITY_VIEWED
-        await softAssert.checkAndCollect(async () => {
-          const activityViewed = events.filter(
-            (event) => event.event === expectedEvents.ACTIVITY_VIEWED,
-          );
-          await Assertions.checkIfValueIsDefined(activityViewed);
-          if (activityViewed.length > 0) {
-            await Assertions.checkIfObjectContains(
-              activityViewed[0].properties,
-              {
-                activity_type: 'activity_list',
-              },
-            );
-          }
-        }, 'Activity Viewed event should be tracked');
-
-        softAssert.throwIfErrors();
       },
     );
   });

--- a/tests/smoke/wallet/analytics/import-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/import-wallet.spec.ts
@@ -2,30 +2,26 @@
 import { SmokeWalletPlatform } from '../../../tags';
 import { importWalletWithRecoveryPhrase } from '../../../flows/wallet.flow';
 import TestHelpers from '../../../helpers';
-import Assertions from '../../../framework/Assertions';
-import {
-  EventPayload,
-  findEvent,
-  getEventsPayloads,
-  onboardingEvents,
-} from '../../../helpers/analytics/helpers';
-import {
-  IDENTITY_TEAM_PASSWORD,
-  IDENTITY_TEAM_SEED_PHRASE,
-} from '../../identity/utils/constants';
-import SoftAssert from '../../../framework/SoftAssert';
 import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { remoteFeatureMultichainAccountsAccountDetails } from '../../../api-mocking/mock-responses/feature-flags-mocks';
+import {
+  importWalletMetricsOptOutExpectations,
+  importWalletWithMetricsOptInExpectations,
+} from '../../../helpers/analytics/expectations/import-wallet.analytics';
+import {
+  IDENTITY_TEAM_PASSWORD,
+  IDENTITY_TEAM_SEED_PHRASE,
+} from '../../identity/utils/constants';
 
 describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
   });
 
-  it('should track analytics events during wallet import flow', async () => {
+  it('tracks analytics events during wallet import flow', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),
@@ -36,122 +32,7 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
             remoteFeatureMultichainAccountsAccountDetails(),
           );
         },
-        endTestfn: async ({ mockServer }) => {
-          const expectedEvents = [
-            onboardingEvents.ANALYTICS_PREFERENCE_SELECTED,
-            onboardingEvents.WALLET_IMPORTED,
-            onboardingEvents.WALLET_SETUP_COMPLETED,
-            onboardingEvents.WALLET_IMPORT_STARTED,
-            onboardingEvents.WALLET_IMPORT_ATTEMPTED,
-          ];
-          const events = await getEventsPayloads(mockServer, expectedEvents);
-
-          const softAssert = new SoftAssert();
-
-          const checkEventCount = softAssert.checkAndCollect(
-            () =>
-              Assertions.checkIfArrayHasLength(events, expectedEvents.length),
-            `Expected ${expectedEvents.length} events to be tracked, but found ${events.length}`,
-          );
-
-          // ANALYTICS_PREFERENCE_SELECTED
-          const analyticsPreferenceSelectedEvent = findEvent(
-            events,
-            onboardingEvents.ANALYTICS_PREFERENCE_SELECTED,
-          ) as EventPayload;
-
-          const checkAnalyticsPreference = softAssert.checkAndCollect(
-            async () => {
-              Assertions.checkIfObjectsMatch(
-                analyticsPreferenceSelectedEvent?.properties,
-                {
-                  has_marketing_consent: false,
-                  is_metrics_opted_in: true,
-                  location: 'onboarding_metametrics',
-                  updated_after_onboarding: false,
-                  account_type: 'imported',
-                },
-              );
-            },
-            'Analytics Preference Selected event properties do not match expected values',
-          );
-
-          // WALLET IMPORTED STARTED
-          const walletImportStartedEvent = findEvent(
-            events,
-            onboardingEvents.WALLET_IMPORT_STARTED,
-          ) as EventPayload;
-
-          const checkWalletImportStarted = softAssert.checkAndCollect(
-            () =>
-              Assertions.checkIfObjectsMatch(
-                walletImportStartedEvent.properties,
-                {
-                  account_type: 'imported',
-                },
-              ),
-            'Wallet Import Started event properties do not match expected values',
-          );
-
-          // WALLET IMPORTED ATTEMPTED
-          const walletImportAttemptedEvent = findEvent(
-            events,
-            onboardingEvents.WALLET_IMPORT_ATTEMPTED,
-          ) as EventPayload;
-
-          const checkWalletImportAttempted = softAssert.checkAndCollect(
-            () =>
-              Assertions.checkIfObjectsMatch(
-                walletImportAttemptedEvent.properties,
-                {},
-              ),
-            'Wallet Import Attempted event properties do not match expected values',
-          );
-
-          // WALLET IMPORTED
-          const walletImportedEvent = findEvent(
-            events,
-            onboardingEvents.WALLET_IMPORTED,
-          ) as EventPayload;
-
-          const checkWalletImported = softAssert.checkAndCollect(
-            () =>
-              Assertions.checkIfObjectsMatch(walletImportedEvent.properties, {
-                biometrics_enabled: false,
-              }),
-            'Wallet Imported event properties do not match expected values',
-          );
-
-          // WALLET SETUP COMPLETED
-          const walletSetupCompletedEvent = findEvent(
-            events,
-            onboardingEvents.WALLET_SETUP_COMPLETED,
-          ) as EventPayload;
-
-          const checkWalletSetupCompleted = softAssert.checkAndCollect(
-            () =>
-              Assertions.checkIfObjectsMatch(
-                walletSetupCompletedEvent.properties,
-                {
-                  wallet_setup_type: 'import',
-                  new_wallet: false,
-                  account_type: 'imported',
-                },
-              ),
-            'Wallet Setup Completed event properties do not match expected values',
-          );
-
-          await Promise.all([
-            checkEventCount,
-            checkAnalyticsPreference,
-            checkWalletImportStarted,
-            checkWalletImportAttempted,
-            checkWalletImported,
-            checkWalletSetupCompleted,
-          ]);
-
-          softAssert.throwIfErrors();
-        },
+        analyticsExpectations: importWalletWithMetricsOptInExpectations,
       },
       async () => {
         await importWalletWithRecoveryPhrase({
@@ -162,7 +43,8 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
       },
     );
   });
-  it('should not track analytics events when opt-in to metrics is off', async () => {
+
+  it('does not track analytics events when opt-in to metrics is off', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),
@@ -173,10 +55,7 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
             remoteFeatureMultichainAccountsAccountDetails(),
           );
         },
-        endTestfn: async ({ mockServer }) => {
-          const events = await getEventsPayloads(mockServer);
-          await Assertions.checkIfArrayHasLength(events, 0);
-        },
+        analyticsExpectations: importWalletMetricsOptOutExpectations,
       },
       async () => {
         await importWalletWithRecoveryPhrase({


### PR DESCRIPTION
## Context
E2E runs proxy MetaMetrics/Segment through Mockttp. We lacked a **shared, declarative** way to assert captured events after a flow—easy to miss analytics regressions or duplicate ad-hoc checks.

## What changed
- **`analyticsExpectations`** on `withFixtures` (runs after the test body, before mock drain).
- **`runAnalyticsExpectations` / `assertCapturedMetaMetricsEvents`** — declarative rules (counts, per-event shape, match/contain properties) + unit tests.
- **Flow presets** in `tests/helpers/analytics/expectations/*.analytics.ts`**; wired in **import-wallet**, **dapp-initiated-transfer**, and **predict-cash-out** smoke specs.
- **Docs**: `tests/docs/analytics-e2e.md`; **e2e-test** skill + `tests/AGENTS.md` pointers.

## Commits
1. `feat(e2e): add analyticsExpectations to withFixtures`
2. `feat(e2e): add MetaMetrics analytics assertion runner`
3. `test(e2e): wire analyticsExpectations in smoke flows`
4. `docs(e2e): MetaMetrics E2E guide and agent skill pointers`

## Testing
- `yarn jest tests/helpers/analytics/runAnalyticsExpectations.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new E2E teardown-time assertion logic and additional Mockttp logging that can cause previously passing tests to fail if analytics payloads change or timing differs. Scope is limited to the test framework and smoke specs (no production runtime paths).
> 
> **Overview**
> Adds first-class **declarative MetaMetrics/Segment assertions** to Detox E2E by introducing `analyticsExpectations` on `withFixtures`, executed after the test (and optional `endTestfn`) but before the mock server drains.
> 
> Implements `runAnalyticsExpectations`/`assertCapturedMetaMetricsEvents` with `SoftAssert` aggregation, exports the helpers via `tests/framework/index.ts`, and extends framework types with `AnalyticsExpectations`/`AnalyticsEventExpectation`.
> 
> Refactors existing smoke specs (import-wallet, dapp-initiated transfer, predict cash-out) to use reusable expectation presets under `tests/helpers/analytics/expectations/` instead of bespoke in-test analytics checks, and adds optional analytics debug logging (`E2E_ANALYTICS_DEBUG`) plus new documentation and agent-skill pointers (`tests/docs/analytics-e2e.md`, SKILL/AGENTS updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a86f153a9dd909f053b091f5fd0d0d9d21916956. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->