### PR TITLE
feat: extend smart E2E selection to release branch PRs and skip drafts

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -30,9 +30,13 @@ inputs:
     required: false
     default: 'false'
   base-ref:
-    description: 'Base branch ref (must be main for analysis to run)'
+    description: 'Base branch ref (must be main or release/* for analysis to run)'
     required: false
     default: ''
+  is-draft:
+    description: 'Whether the PR is a draft'
+    required: false
+    default: 'false'
 
 outputs:
   ai_e2e_test_tags:
@@ -131,6 +135,7 @@ runs:
         GITHUB_REPOSITORY: ${{ inputs.repository }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         BASE_REF: ${{ inputs.base-ref }}
+        IS_DRAFT: ${{ inputs.is-draft }}
       run: |
         echo "ai_e2e_test_tags=[\"ALL\"]" >> "$GITHUB_OUTPUT"
         echo "ai_confidence=0" >> "$GITHUB_OUTPUT"
@@ -142,9 +147,12 @@ runs:
         if [[ "$EVENT_NAME" != "pull_request" ]]; then
           SHOULD_SKIP=true
           SKIP_REASON="only runs on PRs"
-        elif [[ "$BASE_REF" != "main" ]]; then
+        elif [[ "$IS_DRAFT" == "true" ]]; then
           SHOULD_SKIP=true
-          SKIP_REASON="base branch is not main (base: $BASE_REF)"
+          SKIP_REASON="draft PR"
+        elif [[ "$BASE_REF" != "main" && "$BASE_REF" != release/* ]]; then
+          SHOULD_SKIP=true
+          SKIP_REASON="base branch is not main or a release branch (base: $BASE_REF)"
         elif [[ -n "${{ steps.check-skip-label.outputs.SKIP }}" ]] && [[ "${{ steps.check-skip-label.outputs.SKIP }}" == "true" ]]; then
           SHOULD_SKIP=true
           SKIP_REASON="skip-smart-e2e-selection label found"
@@ -245,7 +253,7 @@ runs:
         fi
 
     - name: Apply risk label to PR
-      if: inputs.pr-number != '' && inputs.github-token != ''
+      if: inputs.pr-number != '' && inputs.github-token != '' && inputs.is-draft != 'true' && (inputs.base-ref == 'main' || startsWith(inputs.base-ref, 'release/'))
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -147,17 +147,17 @@ runs:
         if [[ "$EVENT_NAME" != "pull_request" ]]; then
           SHOULD_SKIP=true
           SKIP_REASON="only runs on PRs"
+        elif [[ -n "${{ steps.check-skip-label.outputs.SKIP }}" ]] && [[ "${{ steps.check-skip-label.outputs.SKIP }}" == "true" ]]; then
+          SHOULD_SKIP=true
+          SKIP_REASON="skip-smart-e2e-selection label found"
+          FORCE_RUN=true
+          echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
         elif [[ "$IS_DRAFT" == "true" ]]; then
           SHOULD_SKIP=true
           SKIP_REASON="draft PR"
         elif [[ "$BASE_REF" != "main" && "$BASE_REF" != release/* ]]; then
           SHOULD_SKIP=true
           SKIP_REASON="base branch is not main or a release branch (base: $BASE_REF)"
-        elif [[ -n "${{ steps.check-skip-label.outputs.SKIP }}" ]] && [[ "${{ steps.check-skip-label.outputs.SKIP }}" == "true" ]]; then
-          SHOULD_SKIP=true
-          SKIP_REASON="skip-smart-e2e-selection label found"
-          FORCE_RUN=true
-          echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
         fi
 
         # Export skip status, reason, and force run flag for downstream jobs

--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -84,14 +84,14 @@ runs:
         git sparse-checkout disable
         git checkout HEAD -- .
 
-    - name: Fetch main branch for comparison
+    - name: Fetch base branch for comparison
       if: steps.check-skip-label.outputs.SKIP != 'true'
       shell: bash
       run: |
         # Unshallow the repository first (if it's shallow)
         git fetch --unshallow 2>/dev/null || true
-        # Fetch main branch for diff comparison
-        git fetch origin main 2>/dev/null || true
+        # Fetch the base branch for diff comparison (main or release/*)
+        git fetch origin "${{ inputs.base-ref || 'main' }}" 2>/dev/null || true
 
     - name: Setup Node.js
       if: steps.check-skip-label.outputs.SKIP != 'true'

--- a/.github/scripts/e2e-smart-selection.mjs
+++ b/.github/scripts/e2e-smart-selection.mjs
@@ -11,6 +11,7 @@ const env = {
   PR_NUMBER: process.env.PR_NUMBER || '',
   GITHUB_OUTPUT: process.env.GITHUB_OUTPUT || '',
   GITHUB_STEP_SUMMARY: process.env.GITHUB_STEP_SUMMARY || '',
+  BASE_REF: process.env.BASE_REF || 'main',
 };
 
 const PR_COMMENT_FILE = 'pr_comment.md';
@@ -77,9 +78,11 @@ async function main() {
       return;
     }
 
-    // Build command - always uses origin/main as base (job only runs on PRs targeting main)
-    const baseCmd = `node -r esbuild-register tests/tools/e2e-ai-analyzer --mode select-tags --pr ${env.PR_NUMBER}`;
-    console.log(`🎯 Analyzing PR against origin/main`);
+    // Build command - uses GitHub API (PR number) for changed files list; -b ensures
+    // file diffs are computed against the correct base branch (main or release/*)
+    const baseBranch = `origin/${env.BASE_REF}`;
+    const baseCmd = `node -r esbuild-register tests/tools/e2e-ai-analyzer --mode select-tags --pr ${env.PR_NUMBER} -b ${baseBranch}`;
+    console.log(`🎯 Analyzing PR #${env.PR_NUMBER} against base branch: ${baseBranch}`);
 
     try {
       execSync(baseCmd, {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,7 @@ jobs:
           repository: ${{ github.repository }}
           post-comment: 'true'
           base-ref: ${{ github.event.pull_request.base.ref }}
+          is-draft: ${{ github.event.pull_request.draft }}
 
   # Main E2E tests
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

  ## Summary

  - Enables AI-powered E2E test selection on PRs targeting `release/*` branches (previously only ran on PRs targeting `main`)
  - Skips smart E2E analysis on draft PRs, falling back to the full suite
  - Restricts risk label application to non-draft PRs targeting `main` or `release/*` only

  ## Changes

  - `action.yml`: Added `is-draft` input; updated base-ref guard to allow `main` or `release/*`; added draft check before analysis;
  scoped risk label step with matching guards
  - `ci.yml`: Passes `github.event.pull_request.draft` to the action as `is-draft`

  ## Behaviour matrix

  | PR type | Analysis runs | Risk label applied |
  |---|---|---|
  | Non-draft → `main` | Yes (if confidence ≥ 80%) | Yes |
  | Non-draft → `release/*` | Yes (if confidence ≥ 80%) | Yes |
  | Draft → `main` | No (falls back to ALL) | No |
  | Draft → `release/*` | No (falls back to ALL) | No |
  | Any → other branch | No (falls back to ALL) | No |
  | Push to `main` / schedule | No (falls back to ALL) | No |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

   ## **Manual testing steps**

   ```gherkin
   Feature: Smart E2E selection on draft and open PRs

     Scenario: Draft PR targeting a release branch skips analysis
       Given a PR targeting a release/* branch is in draft state
       When CI runs the Smart E2E Selection job
       Then the AI analysis is skipped with reason "draft PR"
       And selected_tags falls back to ["ALL"]
       And no risk label is applied to the PR

     Scenario: Open PR targeting a release branch runs analysis
       Given a PR targeting a release/* branch is marked ready for review
       When CI runs the Smart E2E Selection job
       Then the AI analysis runs against the release branch diff
       And selected_tags reflects the AI-selected tags (or ["ALL"] if confidence < 80%)
       And the risk label is applied to the PR
   ```

## **Testing**
Draft PR
<img width="939" height="496" alt="Screenshot 2026-03-19 at 13 00 48" src="https://github.com/user-attachments/assets/2bd6c397-e174-484b-a42b-a6a1b783e520" />

Open PR
<img width="864" height="574" alt="Screenshot 2026-03-19 at 13 12 17" src="https://github.com/user-attachments/assets/6c8057a2-dd80-4ad6-bdc6-24e3354172cc" />


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating for AI-driven E2E selection and risk labeling, which can alter what tests run on PRs and potentially impact coverage if misconfigured. Limited in scope to GitHub Action/workflow logic.
> 
> **Overview**
> **Smart E2E selection now supports PRs targeting `release/*` branches** (in addition to `main`) by fetching the PR’s base ref and passing it through to the analyzer via `-b origin/<base-ref>`.
> 
> **Draft PRs now skip AI analysis** (falling back to `['ALL']`) and **risk labeling is suppressed** unless the PR is non-draft and targeting `main` or `release/*`. The CI workflow now passes the PR draft status into the composite action via the new `is-draft` input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e569a2dfa38631e35e760708330a4ea9e2a73b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->