### PR TITLE
refactor: normalize networkClientId handling in useGasFeeEstimates hook

### DIFF
--- a/app/components/Views/confirmations/hooks/gas/useGasFeeEstimates.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeEstimates.ts
@@ -13,11 +13,21 @@ import Engine from '../../../../../core/Engine';
  * GasFeeController that it is done requiring new gas estimates. Also checks
  * the returned gas estimate for validity on the current network.
  *
+ * Normalizes falsy networkClientId (e.g. '' from networkClientId ?? '') to
+ * undefined so NetworkController.getNetworkClientById is never called with
+ * a falsy value (which throws "No network client ID was provided").
+ *
  * @param _networkClientId - The optional network client ID to get gas fee estimates for. Defaults to the currently selected network.
  * @returns {GasEstimates} GasEstimates object
  */
-export function useGasFeeEstimates(networkClientId: string) {
+export function useGasFeeEstimates(networkClientId: string | undefined) {
   const [chainId, setChainId] = useState('');
+
+  // Avoid passing '' or other falsy values to NetworkController/GasFeeController;
+  // getNetworkClientById(undefined) is never called, getNetworkClientById('') throws.
+  const effectiveNetworkClientId = networkClientId?.trim()
+    ? networkClientId
+    : undefined;
 
   const gasFeeEstimates = useSelector(
     (state: RootState) => selectGasFeeEstimatesByChainId(state, chainId),
@@ -26,10 +36,13 @@ export function useGasFeeEstimates(networkClientId: string) {
   const { NetworkController } = Engine.context;
 
   useEffect(() => {
+    if (!effectiveNetworkClientId) {
+      return;
+    }
     let isMounted = true;
     const networkConfig =
       NetworkController.getNetworkConfigurationByNetworkClientId(
-        networkClientId,
+        effectiveNetworkClientId,
       );
 
     if (networkConfig && isMounted) {
@@ -39,7 +52,7 @@ export function useGasFeeEstimates(networkClientId: string) {
     return () => {
       isMounted = false;
     };
-  }, [networkClientId, NetworkController]);
+  }, [effectiveNetworkClientId, NetworkController]);
 
   usePolling({
     startPolling: Engine.context.GasFeeController.startPolling.bind(
@@ -49,7 +62,11 @@ export function useGasFeeEstimates(networkClientId: string) {
       Engine.context.GasFeeController.stopPollingByPollingToken.bind(
         Engine.context.GasFeeController,
       ),
-    input: [{ networkClientId }],
+    // GasFeeController.startPolling requires networkClientId: string; never pass
+    // undefined/'' (see hook JSDoc). When missing, skip polling until we have an id.
+    input: effectiveNetworkClientId
+      ? [{ networkClientId: effectiveNetworkClientId }]
+      : [],
   });
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**TMCU-582** — Sentry was reporting `No network client ID was provided` (thrown by `NetworkController.getNetworkClientById` when given a falsy id). That surfaced in flows tied to the Cash / homepage area because shared hooks (e.g. `useGasFeeEstimates` via confirmations gas UI) could run with `transactionMeta.networkClientId` missing or with `''` from patterns like `networkClientId ?? ''`.

**Solution:** `useGasFeeEstimates` now accepts `string | undefined`, derives `effectiveNetworkClientId` only when the value is non-empty after trim, skips `getNetworkConfigurationByNetworkClientId` when absent, and passes **no** polling input to `GasFeeController.startPolling` until a valid `networkClientId` exists. `GasFeeController` only skips `getNetworkClientById` for `undefined`, not for `''`, so empty string previously caused the throw; we never pass `''` into that path anymore.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-582

## **Manual testing steps**

```gherkin
Feature: Gas fee estimates hook with valid network client

  Scenario: Confirmation flow still receives gas estimates when network client id is set
    Given the user has opened a transaction confirmation that includes a valid networkClientId
    When the gas fee UI loads
    Then gas fee estimates should populate as before (no regression)

  Scenario: No crash or Sentry noise when network client id is temporarily missing
    Given a code path passes undefined or empty string into useGasFeeEstimates
    When the hook runs
    Then the app should not throw "No network client ID was provided" and polling should not start until a valid id exists
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes when gas fee polling/config lookup runs, which could impact gas estimate availability if callers pass an empty/whitespace ID, but it primarily prevents a known runtime throw.
> 
> **Overview**
> Prevents `useGasFeeEstimates` from calling into `NetworkController`/`GasFeeController` with falsy `networkClientId` values (notably `''`), which previously triggered the "No network client ID was provided" error.
> 
> The hook now accepts `string | undefined`, normalizes empty/whitespace IDs to `undefined`, skips the network config lookup when missing, and avoids starting gas fee polling until a valid ID is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e6fc5398365560cc7ba20d47cad2bf002ccf184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->