### PR TITLE
ci: make TestFlight external distribution configurable

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -141,7 +141,8 @@ jobs:
             "github_actions_main-exp" \
             "${{ github.ref_name }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "MetaMask BETA & Release Candidates"
+            "MetaMask BETA & Release Candidates" \
+            "false"
 
       - name: Cleanup API Key
         if: always()
@@ -200,7 +201,8 @@ jobs:
             "github_actions_main-rc" \
             "${{ github.ref_name }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "MetaMask BETA & Release Candidates"
+            "MetaMask BETA & Release Candidates" \
+            "false"
 
       - name: Cleanup API Key
         if: always()

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -197,6 +197,8 @@ jobs:
 
       - name: Upload to TestFlight
         run: |
+          # Group arg is required as positional placeholder for the 5th arg (distribute_external=false).
+          # With distribute_external=false the build is uploaded but NOT distributed to external testers.
           bash scripts/upload-to-testflight.sh \
             "github_actions_main-rc" \
             "${{ github.ref_name }}" \

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -20,7 +20,8 @@ platform :ios do
     # Convert groups parameter to array (Fastlane CLI passes strings, not arrays)
     groups_param = options[:groups] || ['MetaMask BETA & Release Candidates']
     groups = groups_param.is_a?(Array) ? groups_param : [groups_param]
-    notify_external_testers = true
+    distribute_external = options[:distribute_external].nil? ? true : options[:distribute_external].to_s.downcase == 'true'
+    notify_external_testers = distribute_external
     
     if ipa_path.nil? || ipa_path.empty?
       UI.user_error!("You must provide an ipa_path using ipa_path: '/path/to/app.ipa'")
@@ -96,7 +97,7 @@ platform :ios do
     upload_to_testflight(
       api_key: api_key,
       ipa: ipa_path,
-      distribute_external: true,
+      distribute_external: distribute_external,
       groups: groups,
       notify_external_testers: notify_external_testers,
       changelog: changelog_message

--- a/scripts/upload-to-testflight.sh
+++ b/scripts/upload-to-testflight.sh
@@ -4,13 +4,14 @@
 # This script can be used in both Bitrise and GitHub Actions workflows
 #
 # Usage:
-#   ./scripts/upload-to-testflight.sh <pipeline_name> <branch> [ipa_path] [testflight_group]
+#   ./scripts/upload-to-testflight.sh <pipeline_name> <branch> [ipa_path] [testflight_group] [distribute_external]
 #
 # Arguments:
-#   pipeline_name    - Pipeline or workflow name (required)
-#   branch           - Git branch name (required)
-#   ipa_path         - Optional: Direct path to IPA file (if not provided, uses find-ipa-file.sh)
-#   testflight_group - Optional: TestFlight external testing group name (default: MetaMask BETA & Release Candidates)
+#   pipeline_name       - Pipeline or workflow name (required)
+#   branch              - Git branch name (required)
+#   ipa_path            - Optional: Direct path to IPA file (if not provided, uses find-ipa-file.sh)
+#   testflight_group    - Optional: TestFlight external testing group name (default: MetaMask BETA & Release Candidates)
+#   distribute_external - Optional: Whether to distribute to external testers (default: true)
 #
 # Environment variables:
 #   IPA_PATH - IPA path (set by find-ipa-file.sh if not provided as argument)
@@ -27,6 +28,7 @@ PIPELINE_NAME="$1"
 BRANCH="$2"
 LOCAL_IPA_PATH="$3"
 TESTFLIGHT_GROUP="${4:-MetaMask BETA & Release Candidates}"
+DISTRIBUTE_EXTERNAL="${5:-true}"
 
 # Get IPA path: use argument if provided, otherwise use find-ipa-file.sh
 if [ -n "$LOCAL_IPA_PATH" ]; then
@@ -74,5 +76,6 @@ cd ios
 bundle exec fastlane upload_to_testflight_only \
   ipa_path:"$IPA_PATH" \
   groups:"$TESTFLIGHT_GROUP" \
-  changelog:"$CHANGELOG"
+  changelog:"$CHANGELOG" \
+  distribute_external:"$DISTRIBUTE_EXTERNAL"
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The nightly build's TestFlight upload was failing with "This request is forbidden for security reasons - The API key in use does not allow this request" because the App Store Connect API key lacks permissions for external distribution (`distribute_external: true`).

This PR makes the `distribute_external` parameter configurable across the upload chain (Fastfile → shell script → workflow), defaulting to `true` to preserve existing behavior for all callers. The nightly build workflow now passes `false` to skip external distribution, unblocking uploads while the API key permissions are resolved.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: TestFlight upload with configurable external distribution

  Scenario: nightly build uploads without external distribution
    Given the nightly build workflow runs on the test/temp-nightly branch

    When the upload-to-testflight.sh script is invoked with distribute_external set to "false"
    Then fastlane should call upload_to_testflight with distribute_external: false
    And notify_external_testers should be false
    And the upload should succeed without requiring external distribution permissions

  Scenario: default invocation preserves external distribution
    Given a caller invokes upload-to-testflight.sh without the 5th argument

    When the script runs
    Then distribute_external should default to "true"
    And fastlane should call upload_to_testflight with distribute_external: true
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the TestFlight upload pipeline to optionally skip external distribution; misconfiguration could prevent builds from being distributed to intended testers.
> 
> **Overview**
> Makes TestFlight external distribution configurable end-to-end by adding a `distribute_external` parameter to `scripts/upload-to-testflight.sh` and plumbing it into the Fastlane `upload_to_testflight_only` lane.
> 
> Updates the nightly GitHub Actions workflow to pass `distribute_external=false` for exp/rc uploads so builds can be uploaded without distributing to external testers, while defaulting to `true` for existing callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aee4144eb51ea0b50e5a9dbe90afa220fd0840f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->