### PR TITLE
chore: revert Stable sync release 7.70.0 (#27672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.69.1]
-
-### Fixed
-
-- Fixed root pages scrollable behavior with SafeAreaView, standardizing safe area and header inset handling across main tab views (#27446)
-- Fixed token prices in the wallet list displaying without thousand-separator commas and with too many decimal places (#27485)
-
 ## [7.69.0]
 
 ### Added
@@ -10931,10 +10924,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/MetaMask/metamask-mobile/pull/957): fix timeouts (#957)
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
-[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.1...HEAD
-[7.69.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.0...v7.69.1
-[7.69.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.3...v7.69.0
+[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.0...HEAD
 [7.68.3]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.2...v7.68.3
+[7.69.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.2...v7.69.0
 [7.68.2]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.1...v7.68.2
 [7.68.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.0...v7.68.1
 [7.68.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.67.3...v7.68.0


### PR DESCRIPTION
## Description

Reverts PR #27672 which was incorrectly merged with **squash** instead of "Create a merge commit".

Per release-changelog guidelines: Squash merges destroy Git ancestry and cause phantom conflicts when merging the release PR into stable.

## What this does

- Reverts the squash merge commit 5b70fff
- Restores release/7.70.0 to pre-sync state

## Next steps

After this revert is merged, re-create the stable sync:
1. Create branch `stable-sync-release-7.70.0` from `release/7.70.0`
2. Merge `stable` into it (resolve conflicts)
3. Open PR into `release/7.70.0`
4. **Merge with "Create a merge commit"** — do NOT squash

## Changelog

CHANGELOG entry: null

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only edits: removes the `7.69.1` section and updates version compare links, with no runtime code impact.
> 
> **Overview**
> Removes the `7.69.1` release notes from `CHANGELOG.md` and updates the footer compare links so `[Unreleased]` now compares from `v7.69.0` and the `7.69.0` link points to `v7.68.2...v7.69.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb1fb7c578a36c235d55d828f1ea00a7ed32cc57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->