### PR TITLE
chore: bump `@metamask/smart-transactions-controller` to ^23.0.0

### DIFF
--- a/app/core/Engine/messengers/smart-transactions-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/smart-transactions-controller-messenger.test.ts
@@ -37,7 +37,6 @@ describe('getSmartTransactionsControllerMessenger', () => {
     expect(delegateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         actions: expect.arrayContaining([
-          'ErrorReportingService:captureException',
           'NetworkController:getNetworkClientById',
           'NetworkController:getState',
           'RemoteFeatureFlagController:getState',

--- a/app/core/Engine/messengers/smart-transactions-controller-messenger.ts
+++ b/app/core/Engine/messengers/smart-transactions-controller-messenger.ts
@@ -29,7 +29,6 @@ export function getSmartTransactionsControllerMessenger(
   });
   rootMessenger.delegate({
     actions: [
-      'ErrorReportingService:captureException',
       'NetworkController:getNetworkClientById',
       'NetworkController:getState',
       'RemoteFeatureFlagController:getState',

--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -134,7 +134,6 @@ function withRequest<ReturnValue>(
       'TransactionController:getTransactions',
       'TransactionController:updateTransaction',
       'RemoteFeatureFlagController:getState',
-      'ErrorReportingService:captureException',
     ],
     events: [
       'NetworkController:stateChange',

--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/signature-controller": "^39.1.0",
     "@metamask/slip44": "^4.2.0",
-    "@metamask/smart-transactions-controller": "^22.7.0",
+    "@metamask/smart-transactions-controller": "^23.0.0",
     "@metamask/snaps-controllers": "^18.0.4",
     "@metamask/snaps-execution-environments": "^11.0.1",
     "@metamask/snaps-rpc-methods": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9221,23 +9221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/polling-controller@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@metamask/polling-controller@npm:15.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.14.1"
-    "@metamask/utils": "npm:^11.8.1"
-    "@types/uuid": "npm:^8.3.0"
-    fast-json-stable-stringify: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@metamask/network-controller": ^25.0.0
-  checksum: 10/e1f5d45ce3b083d154ccacba54453bdeea6bbfafc461be559ce15ae435e0df500ebab8ffd06a5e7bc52e904c29d06c1a5ca0a29193f8778ca39dfd134a7f0794
-  languageName: node
-  linkType: hard
-
-"@metamask/polling-controller@npm:^16.0.3":
+"@metamask/polling-controller@npm:^16.0.0, @metamask/polling-controller@npm:^16.0.3":
   version: 16.0.3
   resolution: "@metamask/polling-controller@npm:16.0.3"
   dependencies:
@@ -9612,9 +9596,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^22.7.0":
-  version: 22.7.0
-  resolution: "@metamask/smart-transactions-controller@npm:22.7.0"
+"@metamask/smart-transactions-controller@npm:^23.0.0":
+  version: 23.0.0
+  resolution: "@metamask/smart-transactions-controller@npm:23.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -9627,18 +9611,16 @@ __metadata:
     "@metamask/eth-json-rpc-provider": "npm:^4.1.6"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/polling-controller": "npm:^15.0.0"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
     "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^63.0.0"
     "@metamask/utils": "npm:^11.0.0"
     bignumber.js: "npm:^9.0.1"
     fast-json-patch: "npm:^3.1.0"
     lodash: "npm:^4.17.21"
     reselect: "npm:^5.1.1"
-  peerDependencies:
-    "@metamask/error-reporting-service": ^3.0.0
-    "@metamask/network-controller": ^25.0.0
-    "@metamask/remote-feature-flag-controller": ^2.0.0
-    "@metamask/transaction-controller": ^61.0.0
   peerDependenciesMeta:
     "@metamask/accounts-controller":
       optional: true
@@ -9648,7 +9630,7 @@ __metadata:
       optional: true
     "@metamask/gas-fee-controller":
       optional: true
-  checksum: 10/49acf33fc852c109d2ce821a1a3a702068e8b9cd16b7a457838bb2ae0fce958ea1cc1eaf5395d876f77630939b0c8569b0032754554274bbc88e20d5d0f74de2
+  checksum: 10/5dc6e3fdc8ad93967da8e1a8ec9334b3fd82444793074689981ac56a38159a8c7f651d86ac2282463af424519ca5630d46f09d0833da149928974761f8fac7fe
   languageName: node
   linkType: hard
 
@@ -35617,7 +35599,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/signature-controller": "npm:^39.1.0"
     "@metamask/slip44": "npm:^4.2.0"
-    "@metamask/smart-transactions-controller": "npm:^22.7.0"
+    "@metamask/smart-transactions-controller": "npm:^23.0.0"
     "@metamask/snaps-controllers": "npm:^18.0.4"
     "@metamask/snaps-execution-environments": "npm:^11.0.1"
     "@metamask/snaps-rpc-methods": "npm:^15.0.0"


### PR DESCRIPTION
## **Description**

Bump `@metamask/smart-transactions-controller` from `^22.7.0` to `^23.0.0`.

Adapts to breaking changes per the [v23.0.0 changelog](https://github.com/MetaMask/smart-transactions-controller/blob/main/CHANGELOG.md#2300):
- Remove `ErrorReportingService:captureException` from messenger allowed actions and tests
- Controller deps moved from peer to direct (network-controller, transaction-controller, remote-feature-flag-controller, polling-controller)
- 
## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a major-version dependency bump that changes controller dependency wiring and allowed messenger actions; issues would surface at runtime in smart transaction flows.
> 
> **Overview**
> Updates `@metamask/smart-transactions-controller` from `^22.7.0` to `^23.0.0` (and lockfile), aligning with its breaking changes.
> 
> Removes `ErrorReportingService:captureException` from the Smart Transactions messenger allowed-actions list and updates related tests (`smart-transactions-controller-messenger*.ts` and `smart-publish-hook.test.ts`) to match the new permission surface. The lockfile reflects the controller moving several deps from peer to direct (notably newer `@metamask/polling-controller` plus direct `network`/`remote-feature-flag`/`transaction` controller deps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39fd5bbbbae414344e6901e6b3c8b011120ddcbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->