### PR TITLE
feat(card): add selectIsUserInSupportedCardCountry

### DIFF
--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -25,6 +25,7 @@ import cardReducer, {
   selectContactVerificationId,
   selectConsentSetId,
   resetAuthenticatedData,
+  selectIsUserInSupportedCardCountry,
 } from '.';
 
 // Mock the multichain selectors
@@ -718,6 +719,84 @@ describe('Card Reducer', () => {
 describe('Card Button Display Selectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('selectIsUserInSupportedCardCountry', () => {
+    it('returns true when geoLocation is in supported countries', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({
+        US: true,
+        GB: true,
+      });
+
+      const stateWithUs: CardSliceState = {
+        ...initialState,
+        geoLocation: 'US',
+      };
+      const mockRootState = {
+        card: stateWithUs,
+      } as unknown as RootState;
+
+      expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(true);
+    });
+
+    it('returns false when geoLocation is not in supported countries', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+
+      const stateWithUnsupported: CardSliceState = {
+        ...initialState,
+        geoLocation: 'CN',
+      };
+      const mockRootState = {
+        card: stateWithUnsupported,
+      } as unknown as RootState;
+
+      expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
+    });
+
+    it('returns false when geoLocation is UNKNOWN', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+
+      const stateWithUnknown: CardSliceState = {
+        ...initialState,
+        geoLocation: 'UNKNOWN',
+      };
+      const mockRootState = {
+        card: stateWithUnknown,
+      } as unknown as RootState;
+
+      expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
+    });
+
+    it('returns false when country is explicitly false in supported countries', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({
+        US: true,
+        DE: false,
+      });
+
+      const stateWithDe: CardSliceState = {
+        ...initialState,
+        geoLocation: 'DE',
+      };
+      const mockRootState = {
+        card: stateWithDe,
+      } as unknown as RootState;
+
+      expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
+    });
+
+    it('returns false when cardSupportedCountries is empty or missing', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({});
+
+      const stateWithUs: CardSliceState = {
+        ...initialState,
+        geoLocation: 'US',
+      };
+      const mockRootState = {
+        card: stateWithUs,
+      } as unknown as RootState;
+
+      expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
+    });
   });
 
   describe('selectAlwaysShowCardButton', () => {

--- a/app/core/redux/slices/card/index.ts
+++ b/app/core/redux/slices/card/index.ts
@@ -210,28 +210,31 @@ export const selectIsDaimoDemo = createSelector(
   (card) => card.isDaimoDemo,
 );
 
+export const selectIsUserInSupportedCardCountry = createSelector(
+  selectCardGeoLocation,
+  selectCardSupportedCountries,
+  (geoLocation, cardSupportedCountries) =>
+    (cardSupportedCountries as Record<string, boolean>)?.[geoLocation] === true,
+);
+
 export const selectDisplayCardButton = createSelector(
   selectIsCardholder,
   selectAlwaysShowCardButton,
-  selectCardGeoLocation,
-  selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
   selectIsAuthenticatedCard,
+  selectIsUserInSupportedCardCountry,
   (
     isCardholder,
     alwaysShowCardButton,
-    geoLocation,
-    cardSupportedCountries,
     displayCardButtonFeatureFlag,
     isAuthenticated,
+    isUserInSupportedCardCountry,
   ) => {
     if (
       alwaysShowCardButton ||
       isCardholder ||
       isAuthenticated ||
-      ((cardSupportedCountries as Record<string, boolean>)?.[geoLocation] ===
-        true &&
-        displayCardButtonFeatureFlag)
+      (isUserInSupportedCardCountry && displayCardButtonFeatureFlag)
     ) {
       return true;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Extracts the Card supported-country check into a dedicated `selectIsUserInSupportedCardCountry` selector and refactors `selectDisplayCardButton` to use it.

**Why**: The geo-location vs supported-countries logic was inlined in `selectDisplayCardButton`. Extracting it into a named selector improves readability, enables reuse, and simplifies testing. The display logic becomes clearer: show the Card button when the user is in a supported country and the feature flag is on.

**What changed**:

- **`selectIsUserInSupportedCardCountry`**: New selector that returns whether the user's `geoLocation` is in the feature-flag `cardSupportedCountries` map with value `true`. Uses `selectCardGeoLocation` and `selectCardSupportedCountries`.

- **`selectDisplayCardButton`**: Refactored to use `selectIsUserInSupportedCardCountry` instead of inline geo/countries logic. The condition `(cardSupportedCountries)?.[geoLocation] === true && displayCardButtonFeatureFlag` is now `isUserInSupportedCardCountry && displayCardButtonFeatureFlag`.

- **Tests**: Added unit tests for `selectIsUserInSupportedCardCountry` covering supported country, unsupported country, UNKNOWN geoLocation, explicitly false country, and empty/missing supported countries.

## **Changelog**

CHANGELOG entry: Extracted Card supported-country check into `selectIsUserInSupportedCardCountry` selector.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card button display in supported vs unsupported countries

  Scenario: Card button shows in supported country with feature flag
    Given I am in a supported country (e.g. US, GB)
    And the Card display feature flag is enabled

    When I view the app home/tab bar
    Then the Card button should be visible

  Scenario: Card button hidden in unsupported country
    Given I am in an unsupported country (or geoLocation is UNKNOWN)
    And the Card display feature flag is enabled

    When I view the app home/tab bar
    Then the Card button should not be visible (unless cardholder/alwaysShow)
```

## **Screenshots/Recordings**

No visual design changes — Card button visibility logic is unchanged; only the selector structure was refactored.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that extracts existing geoLocation/supported-country logic into a dedicated selector and wires it into `selectDisplayCardButton`, with added unit coverage; behavior should remain the same aside from potential edge cases around missing/empty country maps.
> 
> **Overview**
> Introduces a new selector, `selectIsUserInSupportedCardCountry`, to centralize the "geoLocation is in `cardSupportedCountries` with value `true`" check.
> 
> Refactors `selectDisplayCardButton` to depend on this selector instead of inlining the supported-country lookup, and adds focused unit tests covering supported/unsupported/`UNKNOWN` geoLocation, explicitly disabled countries, and empty supported-country maps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d09eb3cdec0482e6327d38e256785575971bcf38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->