### PR TITLE
test: add metametrics to collect qa stats

### DIFF
--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -20,8 +20,9 @@
  * Artifact names used below are coupled to `name:` fields in ci.yml and run-e2e-workflow.yml —
  * renaming either side silently drops that metric from the output.
  *
- * E2E MetaMetrics coverage: scans `tests/helpers/analytics/expectations/*.ts` plus
- * `LEGACY_INLINE_METAMETRICS_PATHS` for specs not yet using declarative expectations.
+ * MetaMetrics (top-level `metametrics` namespace): static scan of
+ * `tests/helpers/analytics/expectations/*.ts` plus `LEGACY_INLINE_METAMETRICS_PATHS`
+ * for specs not yet using declarative expectations.
  *
  * Example output:
  *   {
@@ -29,8 +30,8 @@
  *     "component_view":{ "total_tests_run": 94,    "total_tests_skipped": 0 },
  *     "e2e":           { "total_tests_run": 420,   "total_tests_skipped": 27,
  *                        "main_tests_run": 276, "main_android_tests_run": 276, "main_ios_tests_run": 276,
- *                        "flask_tests_run": 144, "confirmations_tests_run": 62,
- *                        "metametrics_events_checked_unique_count": 42,
+ *                        "flask_tests_run": 144, "confirmations_tests_run": 62 },
+ *     "metametrics":   { "metametrics_events_checked_unique_count": 42,
  *                        "metametrics_events_checked_names_json": "[\"Action Button Clicked\", ...]" },
  *     "performance":   { "total_tests_defined": 21, "total_tests_skipped": 1,
  *                        "login_tests_defined": 11, "onboarding_tests_defined": 4, "mm_connect_tests_defined": 6 }
@@ -617,7 +618,7 @@ async function collectE2EMetaMetricsEventCoverage() {
   const onboardingMap = await loadOnboardingEventsMap();
   const names = new Set();
   const entries = await gatherE2EMetaMetricsSourceFiles();
-  console.log(`[e2e] metametrics: scanning ${entries.length} file(s) for referenced event names`);
+  console.log(`[metametrics] scanning ${entries.length} file(s) for referenced event names`);
 
   for (const { path: filePath, mode } of entries) {
     const source = await readFile(filePath, 'utf8');
@@ -634,9 +635,23 @@ async function collectE2EMetaMetricsEventCoverage() {
     metametrics_events_checked_names_json: JSON.stringify(sorted),
   };
   console.log(
-    `[e2e] metametrics: ${sorted.length} unique event name(s) referenced in E2E sources`,
+    `[metametrics] ${sorted.length} unique event name(s) referenced in E2E sources`,
   );
   return payload;
+}
+
+/**
+ * Top-level `metametrics` namespace in qa-stats.json (static E2E event-name coverage).
+ *
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function collectMetametricsQaStats() {
+  try {
+    return await collectE2EMetaMetricsEventCoverage();
+  } catch (err) {
+    console.warn(`[metametrics] static scan failed, skipping namespace: ${err.message}`);
+    return {};
+  }
 }
 
 /**
@@ -841,13 +856,6 @@ function countExecutedTestsFromJUnitXml(rawXml) {
 
 // Collects all E2E test counts from JUnit artifacts.
 async function collectE2ECounts() {
-  let metametrics = {};
-  try {
-    metametrics = await collectE2EMetaMetricsEventCoverage();
-  } catch (err) {
-    console.warn(`[e2e] metametrics static scan failed, skipping those metrics: ${err.message}`);
-  }
-
   const artifacts = await getArtifactList();
 
   // Per-platform counts for health signalling
@@ -863,9 +871,9 @@ async function collectE2ECounts() {
 
   if (e2eArtifacts.length === 0) {
     console.log(
-      '[e2e] no JUnit artifacts found — skipping JUnit-based e2e counts (metametrics static scan still included when available)',
+      '[e2e] no JUnit artifacts found — skipping JUnit-based e2e counts (see `metametrics` namespace for static event coverage)',
     );
-    return metametrics;
+    return {};
   }
 
   for (const artifact of e2eArtifacts) {
@@ -923,7 +931,6 @@ async function collectE2ECounts() {
   result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
 
-  Object.assign(result, metametrics);
   return result;
 }
 
@@ -985,6 +992,7 @@ async function main() {
     { namespace: 'unit', collect: collectUnitTestCount },
     { namespace: 'component_view', collect: collectComponentViewTestCount },
     { namespace: 'e2e', collect: collectE2ECounts },
+    { namespace: 'metametrics', collect: collectMetametricsQaStats },
     { namespace: 'performance', collect: collectPerformanceTestCounts },
   ];
 

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -360,7 +360,7 @@ function collectFromDeclarativeExpectationsSource(source, onboardingMap, out) {
     const v = onboardingMap[m[1]];
     if (v) out.add(v);
   }
-  for (const m of source.matchAll(/^\s*name:\s*['"]([^'"]+)['"]/gm)) {
+  for (const m of source.matchAll(/\bname:\s*['"]([^'"]+)['"]/g)) {
     out.add(m[1]);
   }
   for (const m of source.matchAll(/\bname:\s*onboardingEvents\.(\w+)/g)) {

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -20,19 +20,25 @@
  * Artifact names used below are coupled to `name:` fields in ci.yml and run-e2e-workflow.yml —
  * renaming either side silently drops that metric from the output.
  *
+ * E2E MetaMetrics coverage: scans `tests/helpers/analytics/expectations/*.ts` plus
+ * `LEGACY_INLINE_METAMETRICS_PATHS` for specs not yet using declarative expectations.
+ *
  * Example output:
  *   {
  *     "unit":          { "total_tests_run": 41957, "total_tests_skipped": 17, "bridge_tests_run": 5000, "other_tests_run": 1000 },
  *     "component_view":{ "total_tests_run": 94,    "total_tests_skipped": 0 },
  *     "e2e":           { "total_tests_run": 420,   "total_tests_skipped": 27,
  *                        "main_tests_run": 276, "main_android_tests_run": 276, "main_ios_tests_run": 276,
- *                        "flask_tests_run": 144, "confirmations_tests_run": 62 },
+ *                        "flask_tests_run": 144, "confirmations_tests_run": 62,
+ *                        "metametrics_events_checked_unique_count": 42,
+ *                        "metametrics_events_checked_names_json": "[\"Action Button Clicked\", ...]" },
  *     "performance":   { "total_tests_defined": 21, "total_tests_skipped": 1,
  *                        "login_tests_defined": 11, "onboarding_tests_defined": 4, "mm_connect_tests_defined": 6 }
  *   }
  */
 
-import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, readdir, access } from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
@@ -49,6 +55,29 @@ if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 // ---------------------------------------------------------------------------
 const SCAN_APP_DIR        = 'app';
 const SCAN_E2E_SMOKE_DIRS = ['tests/smoke'];
+/** Declarative MetaMetrics expectations (`AnalyticsExpectations`) — primary source for QA event coverage. */
+const SCAN_ANALYTICS_EXPECTATIONS_DIR = 'tests/helpers/analytics/expectations';
+/**
+ * E2E sources that still assert MetaMetrics inline (not only via expectations/*.analytics.ts).
+ * Remove paths here when migrated to the expectations folder so the slim parser is enough.
+ */
+const LEGACY_INLINE_METAMETRICS_PATHS = [
+  'tests/smoke/card/card-button.spec.ts',
+  'tests/smoke/card/card-home-add-funds.spec.ts',
+  'tests/smoke/card/card-home-manage-card.spec.ts',
+  'tests/smoke/confirmations/send/metricsValidationHelper.ts',
+  'tests/smoke/predict/predict-claim-positions.spec.ts',
+  'tests/smoke/predict/predict-geo-restriction.spec.ts',
+  'tests/smoke/predict/predict-open-position.spec.ts',
+  'tests/smoke/ramps/onramp-unified-buy.spec.ts',
+  'tests/smoke/snaps/test-snap-preinstalled.spec.ts',
+  'tests/smoke/swap/bridge-action-smoke.spec.ts',
+  'tests/smoke/swap/swap-action-smoke.spec.ts',
+  'tests/smoke/wallet/analytics/new-wallet.spec.ts',
+  'tests/regression/ramps/onramp-parameters.spec.ts',
+  'tests/regression/wallet/analytics/opt-out.ts',
+];
+const PATH_ONBOARDING_EVENTS = 'tests/helpers/analytics/helpers.ts';
 const SCAN_PERFORMANCE_DIR = 'tests/performance';
 
 const PATTERN_CV_TEST_FILE   = /\.view(?:\..+)?\.test\.[jt]sx?$/;
@@ -270,6 +299,340 @@ async function walkFiles(dir, predicate) {
   return results;
 }
 
+// ---------------------------------------------------------------------------
+// E2E MetaMetrics event names (static scan)
+// Primary: tests/helpers/analytics/expectations/*.ts (AnalyticsExpectations).
+// Legacy: explicit paths that still use getEventsPayloads / inline comparisons.
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads onboarding event key → display name map from tests/helpers/analytics/helpers.ts.
+ *
+ * @returns {Promise<Record<string, string>>}
+ */
+async function loadOnboardingEventsMap() {
+  const raw = await readFile(PATH_ONBOARDING_EVENTS, 'utf8');
+  const marker = 'export const onboardingEvents = {';
+  const idx = raw.indexOf(marker);
+  if (idx === -1) return {};
+  const start = raw.indexOf('{', idx);
+  let depth = 0;
+  let i = start;
+  for (; i < raw.length; i += 1) {
+    const c = raw[i];
+    if (c === '{') depth += 1;
+    else if (c === '}') {
+      depth -= 1;
+      if (depth === 0) break;
+    }
+  }
+  const body = raw.slice(start + 1, i);
+  const map = {};
+  for (const m of body.matchAll(/(\w+)\s*:\s*(?:\r?\n\s*)?['"]([^'"]+)['"]\s*,?/g)) {
+    map[m[1]] = m[2];
+  }
+  return map;
+}
+
+/**
+ * @param {string} source
+ * @returns {Record<string, string>}
+ */
+function parseConstStringLiterals(source) {
+  const out = {};
+  for (const m of source.matchAll(/\bconst\s+(\w+)\s*=\s*['"]([^'"]+)['"]\s*;/g)) {
+    out[m[1]] = m[2];
+  }
+  return out;
+}
+
+/**
+ * Event names from declarative `*.analytics.ts` modules (onboarding refs, `name:` entries, event arrays).
+ *
+ * @param {string} source
+ * @param {Record<string, string>} onboardingMap
+ * @param {Set<string>} out
+ */
+function collectFromDeclarativeExpectationsSource(source, onboardingMap, out) {
+  const strConsts = parseConstStringLiterals(source);
+
+  for (const m of source.matchAll(/\bonboardingEvents\.(\w+)/g)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/^\s*name:\s*['"]([^'"]+)['"]/gm)) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(/\bname:\s*onboardingEvents\.(\w+)/g)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/\bname:\s*(\w+)\s*,/g)) {
+    const v = strConsts[m[1]];
+    if (v) out.add(v);
+  }
+
+  const reArrays = /\bconst\s+(\w+)\s*=\s*\[([\s\S]*?)\];/g;
+  let am;
+  while ((am = reArrays.exec(source)) !== null) {
+    const varName = am[1];
+    const inner = am[2];
+    const looksLikeEventList =
+      /(?:event|Event|Expected|expectation|analytics|Names)/.test(varName) ||
+      /\bonboardingEvents\b|\bexpectedEvents\b/.test(inner);
+    if (!looksLikeEventList) continue;
+    for (const part of inner.split(',')) {
+      const t = part.replace(/^\s+|\s+$/g, '');
+      if (!t) continue;
+      const lit = t.match(/^['"]([^'"]+)['"]$/);
+      if (lit) {
+        out.add(lit[1]);
+        continue;
+      }
+      const onb = t.match(/^onboardingEvents\.(\w+)$/);
+      if (onb && onboardingMap[onb[1]]) {
+        out.add(onboardingMap[onb[1]]);
+        continue;
+      }
+      if (strConsts[t]) out.add(strConsts[t]);
+    }
+  }
+}
+
+/**
+ * @param {string} source
+ * @returns {Record<string, Record<string, string>>} enumName -> (member -> string value)
+ */
+function parseEnumStringMembers(source) {
+  const enums = {};
+  const re = /\benum\s+(\w+)\s*\{/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const enumName = m[1];
+    const start = source.indexOf('{', m.index);
+    let depth = 0;
+    let i = start;
+    for (; i < source.length; i += 1) {
+      const c = source[i];
+      if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    const inner = source.slice(start + 1, i);
+    const members = {};
+    for (const em of inner.matchAll(/\b(\w+)\s*=\s*['"]([^'"]+)['"]\s*,?/g)) {
+      members[em[1]] = em[2];
+    }
+    if (Object.keys(members).length > 0) enums[enumName] = members;
+  }
+  return enums;
+}
+
+/**
+ * @param {string} source
+ * @returns {Record<string, Record<string, string>>}
+ */
+function parseConstObjectStringValues(source) {
+  const maps = {};
+  const re = /\bconst\s+(\w+)\s*=\s*\{/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const start = source.indexOf('{', m.index);
+    let depth = 0;
+    let i = start;
+    for (; i < source.length; i += 1) {
+      const c = source[i];
+      if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    const inner = source.slice(start + 1, i);
+    const props = {};
+    for (const km of inner.matchAll(/\b(\w+)\s*:\s*['"]([^'"]+)['"]\s*,?/g)) {
+      props[km[1]] = km[2];
+    }
+    const varName = m[1];
+    if (Object.keys(props).length > 0) maps[varName] = props;
+  }
+  return maps;
+}
+
+/**
+ * @param {string} token
+ * @param {Record<string, string>} onboardingMap
+ * @param {Record<string, Record<string, string>>} enums
+ * @param {Record<string, Record<string, string>>} objectMaps
+ * @param {Record<string, string>} strConsts
+ * @returns {string|null}
+ */
+function resolveLegacyMetaMetricsToken(token, onboardingMap, enums, objectMaps, strConsts) {
+  const t = token.replace(/^\s+|\s+$/g, '');
+  if (!t) return null;
+  const lit = t.match(/^['"]([^'"]+)['"]$/);
+  if (lit) return lit[1];
+  const onb = t.match(/^onboardingEvents\.(\w+)$/);
+  if (onb && onboardingMap[onb[1]]) return onboardingMap[onb[1]];
+  const qual = t.match(/^(\w+)\.(\w+)$/);
+  if (qual) {
+    const [, base, mem] = qual;
+    if (enums[base]?.[mem]) return enums[base][mem];
+    if (objectMaps[base]?.[mem]) return objectMaps[base][mem];
+  }
+  if (strConsts[t]) return strConsts[t];
+  return null;
+}
+
+/**
+ * Inline MetaMetrics checks in specs (getEventsPayloads, `event.event ===`, enums, etc.).
+ *
+ * @param {string} source
+ * @param {Record<string, string>} onboardingMap
+ * @param {Set<string>} out
+ */
+function collectFromLegacyInlineAnalyticsSource(source, onboardingMap, out) {
+  const enums = parseEnumStringMembers(source);
+  const strConsts = parseConstStringLiterals(source);
+  const objectMaps = parseConstObjectStringValues(source);
+
+  for (const m of source.matchAll(/\bonboardingEvents\.(\w+)/g)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/event\.event\s*===\s*['"]([^'"]+)['"]/g)) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(/event\.event\s*===\s*(\w+)\.(\w+)/g)) {
+    const v = resolveLegacyMetaMetricsToken(
+      `${m[1]}.${m[2]}`,
+      onboardingMap,
+      enums,
+      objectMaps,
+      strConsts,
+    );
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/findEvent\([^,]+,\s*['"]([^'"]+)['"]/g)) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(/findEvent\([^,]+,\s*onboardingEvents\.(\w+)/g)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/filterEvents\(\s*[^,]+,\s*['"]([^'"]+)['"]/g)) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(/filterEvents\(\s*[^,]+,\s*onboardingEvents\.(\w+)/g)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/\bevent:\s*([A-Za-z_]\w*)\s*[,}]/g)) {
+    const v = strConsts[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/getEventsPayloads\s*\(\s*[^,]+,\s*\[([\s\S]*?)\]\s*\)/g)) {
+    const inner = m[1];
+    for (const sm of inner.matchAll(/['"]([^'"]+)['"]/g)) {
+      out.add(sm[1]);
+    }
+    for (const sm of inner.matchAll(/\bonboardingEvents\.(\w+)/g)) {
+      const v = onboardingMap[sm[1]];
+      if (v) out.add(v);
+    }
+    for (const part of inner.split(',')) {
+      const v = resolveLegacyMetaMetricsToken(
+        part,
+        onboardingMap,
+        enums,
+        objectMaps,
+        strConsts,
+      );
+      if (v) out.add(v);
+    }
+  }
+
+  const reArrays = /\bconst\s+(\w+)\s*=\s*\[([\s\S]*?)\];/g;
+  let am;
+  while ((am = reArrays.exec(source)) !== null) {
+    const varName = am[1];
+    const inner = am[2];
+    const looksLikeEventList =
+      /(?:event|Event|Expected|expectation|analytics|Names)/.test(varName) ||
+      /\bonboardingEvents\b|\bexpectedEvents\b/.test(inner);
+    if (!looksLikeEventList) continue;
+    for (const part of inner.split(',')) {
+      const v = resolveLegacyMetaMetricsToken(
+        part,
+        onboardingMap,
+        enums,
+        objectMaps,
+        strConsts,
+      );
+      if (v) out.add(v);
+    }
+  }
+}
+
+/**
+ * @returns {Promise<Array<{ path: string, mode: 'expectations' | 'legacy' }>>}
+ */
+async function gatherE2EMetaMetricsSourceFiles() {
+  const out = [];
+
+  try {
+    for (const f of await walkFiles(SCAN_ANALYTICS_EXPECTATIONS_DIR, (n) => n.endsWith('.ts'))) {
+      out.push({ path: f, mode: 'expectations' });
+    }
+  } catch {
+    // Sparse checkout or missing path
+  }
+
+  for (const p of LEGACY_INLINE_METAMETRICS_PATHS) {
+    try {
+      await access(p, fsConstants.F_OK);
+      out.push({ path: p, mode: 'legacy' });
+    } catch {
+      // File removed or renamed — update LEGACY_INLINE_METAMETRICS_PATHS
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Static scan for distinct MetaMetrics event display names asserted in E2E.
+ *
+ * @returns {Promise<{ metametrics_events_checked_unique_count: number, metametrics_events_checked_names_json: string }>}
+ */
+async function collectE2EMetaMetricsEventCoverage() {
+  const onboardingMap = await loadOnboardingEventsMap();
+  const names = new Set();
+  const entries = await gatherE2EMetaMetricsSourceFiles();
+  console.log(`[e2e] metametrics: scanning ${entries.length} file(s) for referenced event names`);
+
+  for (const { path: filePath, mode } of entries) {
+    const source = await readFile(filePath, 'utf8');
+    if (mode === 'expectations') {
+      collectFromDeclarativeExpectationsSource(source, onboardingMap, names);
+    } else {
+      collectFromLegacyInlineAnalyticsSource(source, onboardingMap, names);
+    }
+  }
+
+  const sorted = [...names].sort((a, b) => a.localeCompare(b));
+  const payload = {
+    metametrics_events_checked_unique_count: sorted.length,
+    metametrics_events_checked_names_json: JSON.stringify(sorted),
+  };
+  console.log(
+    `[e2e] metametrics: ${sorted.length} unique event name(s) referenced in E2E sources`,
+  );
+  return payload;
+}
+
 /**
  * Extracts a feature folder name from a Jest test file path.
  *
@@ -472,6 +835,13 @@ function countExecutedTestsFromJUnitXml(rawXml) {
 
 // Collects all E2E test counts from JUnit artifacts.
 async function collectE2ECounts() {
+  let metametrics = {};
+  try {
+    metametrics = await collectE2EMetaMetricsEventCoverage();
+  } catch (err) {
+    console.warn(`[e2e] metametrics static scan failed, skipping those metrics: ${err.message}`);
+  }
+
   const artifacts = await getArtifactList();
 
   // Per-platform counts for health signalling
@@ -486,8 +856,10 @@ async function collectE2ECounts() {
   console.log(`[e2e] found ${e2eArtifacts.length} JUnit artifact(s)`);
 
   if (e2eArtifacts.length === 0) {
-    console.log('[e2e] no JUnit artifacts found — E2E tests did not run, skipping e2e metrics');
-    return {};
+    console.log(
+      '[e2e] no JUnit artifacts found — skipping JUnit-based e2e counts (metametrics static scan still included when available)',
+    );
+    return metametrics;
   }
 
   for (const artifact of e2eArtifacts) {
@@ -545,6 +917,7 @@ async function collectE2ECounts() {
   result.total_tests_defined = defined;
   result.total_tests_skipped = skips;
 
+  Object.assign(result, metametrics);
   return result;
 }
 

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -66,6 +66,8 @@ const LEGACY_INLINE_METAMETRICS_PATHS = [
   'tests/smoke/card/card-home-add-funds.spec.ts',
   'tests/smoke/card/card-home-manage-card.spec.ts',
   'tests/smoke/confirmations/send/metricsValidationHelper.ts',
+  'tests/smoke/confirmations/transactions/dapp-initiated-transfer.spec.ts',
+  'tests/smoke/predict/predict-cash-out.spec.ts',
   'tests/smoke/predict/predict-claim-positions.spec.ts',
   'tests/smoke/predict/predict-geo-restriction.spec.ts',
   'tests/smoke/predict/predict-open-position.spec.ts',
@@ -73,6 +75,7 @@ const LEGACY_INLINE_METAMETRICS_PATHS = [
   'tests/smoke/snaps/test-snap-preinstalled.spec.ts',
   'tests/smoke/swap/bridge-action-smoke.spec.ts',
   'tests/smoke/swap/swap-action-smoke.spec.ts',
+  'tests/smoke/wallet/analytics/import-wallet.spec.ts',
   'tests/smoke/wallet/analytics/new-wallet.spec.ts',
   'tests/regression/ramps/onramp-parameters.spec.ts',
   'tests/regression/wallet/analytics/opt-out.ts',
@@ -533,7 +536,10 @@ function collectFromLegacyInlineAnalyticsSource(source, onboardingMap, out) {
     const v = strConsts[m[1]];
     if (v) out.add(v);
   }
-  for (const m of source.matchAll(/getEventsPayloads\s*\(\s*[^,]+,\s*\[([\s\S]*?)\]\s*\)/g)) {
+  // Allow optional args after the event array (e.g. timeout): `], 5000)` not only `])`.
+  for (const m of source.matchAll(
+    /getEventsPayloads\s*\(\s*[^,]+,\s*\[([\s\S]*?)\]\s*(?:,\s*[^)]+)?\s*\)/g,
+  )) {
     const inner = m[1];
     for (const sm of inner.matchAll(/['"]([^'"]+)['"]/g)) {
       out.add(sm[1]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This updates [.github/scripts/collect-qa-stats.mjs](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/.github/scripts/collect-qa-stats.mjs) so QA stats include E2E MetaMetrics coverage in its own top-level metametrics namespace (alongside unit, component_view, e2e, and performance).

The script statically scans event display names that tests assert: it walks tests/helpers/analytics/expectations/*.ts and an explicit LEGACY_INLINE_METAMETRICS_PATHS list for specs/helpers that still use inline checks (getEventsPayloads, event.event ===, etc.). It resolves onboardingEvents.* using tests/helpers/analytics/helpers.ts. Emitted keys are metametrics_events_checked_unique_count and metametrics_events_checked_names_json (sorted JSON array of names).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the QA metrics pipeline by adding a new `metametrics` namespace and altering artifact sourcing (optional fixture mode), which could affect downstream dashboards/alerts if parsing or artifact naming assumptions break.
> 
> **Overview**
> Extends `.github/scripts/collect-qa-stats.mjs` to emit a new top-level `metametrics` namespace in `qa-stats.json`, populated by a static scan of E2E sources to count and list unique MetaMetrics event names asserted in tests.
> 
> Adds an optional local fixture mode (`QA_STATS_FIXTURE_ROOT`) that bypasses the GitHub API/token and reads artifacts from extracted directories, and tweaks E2E logging/output to better handle runs without JUnit artifacts and to print the JSON body after writing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b371f3602bac194f6b4f55a3355bea7a9c1a6f01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->