### PR TITLE
fix(perps): BRENTOIL shows up in the 'explore crypto' section

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsHomeData.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.test.ts
@@ -486,6 +486,102 @@ describe('usePerpsHomeData', () => {
     });
   });
 
+  describe('Market type filtering', () => {
+    it('excludes HIP-3 markets from crypto (perpsMarkets) section', () => {
+      const marketsWithHip3 = [
+        ...mockMarkets,
+        createMockMarket({
+          symbol: 'xyz:BRENTOIL',
+          name: 'Brent Oil',
+          isHip3: true,
+          isNewMarket: true,
+        }),
+        createMockMarket({
+          symbol: 'xyz:GOLD',
+          name: 'Gold',
+          marketType: 'commodity',
+          isHip3: true,
+        }),
+      ];
+
+      mockUsePerpsMarkets.mockReturnValue({
+        markets: marketsWithHip3,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        refresh: mockRefreshMarkets,
+      });
+
+      mockSortMarkets.mockImplementation(({ markets }) => markets);
+
+      const { result } = renderHook(() => usePerpsHomeData());
+
+      // Only non-HIP3 crypto markets should be in perpsMarkets
+      expect(result.current.perpsMarkets).toHaveLength(3);
+      expect(result.current.perpsMarkets.every((m) => !m.isHip3)).toBe(true);
+      // BRENTOIL (unmapped HIP-3) must not appear in crypto
+      expect(
+        result.current.perpsMarkets.find((m) => m.symbol === 'xyz:BRENTOIL'),
+      ).toBeUndefined();
+    });
+
+    it('includes HIP-3 commodity markets in commoditiesMarkets', () => {
+      const marketsWithCommodity = [
+        ...mockMarkets,
+        createMockMarket({
+          symbol: 'xyz:BRENTOIL',
+          name: 'Brent Oil',
+          marketType: 'commodity',
+          isHip3: true,
+        }),
+      ];
+
+      mockUsePerpsMarkets.mockReturnValue({
+        markets: marketsWithCommodity,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        refresh: mockRefreshMarkets,
+      });
+
+      mockSortMarkets.mockImplementation(({ markets }) => markets);
+
+      const { result } = renderHook(() => usePerpsHomeData());
+
+      expect(result.current.commoditiesMarkets).toHaveLength(1);
+      expect(result.current.commoditiesMarkets[0].symbol).toBe('xyz:BRENTOIL');
+    });
+
+    it('excludes unmapped HIP-3 markets from search crypto results', () => {
+      const marketsWithHip3 = [
+        ...mockMarkets,
+        createMockMarket({
+          symbol: 'xyz:BRENTOIL',
+          name: 'Brent Oil',
+          isHip3: true,
+          isNewMarket: true,
+        }),
+      ];
+
+      mockUsePerpsMarkets.mockReturnValue({
+        markets: marketsWithHip3,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        refresh: mockRefreshMarkets,
+      });
+
+      const { result } = renderHook(() =>
+        usePerpsHomeData({ searchQuery: 'BRENT' }),
+      );
+
+      // BRENTOIL should not appear in perpsMarkets (crypto) during search
+      expect(
+        result.current.perpsMarkets.find((m) => m.symbol === 'xyz:BRENTOIL'),
+      ).toBeUndefined();
+    });
+  });
+
   describe('Trending markets sorting', () => {
     it('sorts markets using saved sort preference', () => {
       renderHook(() => usePerpsHomeData());

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -18,7 +18,6 @@ import {
 import type { PerpsTransaction } from '../types/transactionHistory';
 import { transformFillsToTransactions } from '../utils/transactionTransforms';
 import Engine from '../../../../core/Engine';
-import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { HOME_SCREEN_CONFIG } from '../constants/perpsConfig';
 import { selectPerpsWatchlistMarkets } from '../selectors/perpsController';
 import { usePerpsConnection } from './usePerpsConnection';
@@ -181,21 +180,12 @@ export const usePerpsHomeData = ({
   // Filter and sort markets by type
   // Perps (crypto) - exclude all non-crypto markets
   const perpsMarkets = useMemo(
-    () => {
-      const cryptoFiltered = allMarkets.filter((m) => !m.marketType);
-      const miscategorized = cryptoFiltered.filter((m) => m.isHip3);
-      if (miscategorized.length > 0) {
-        DevLogger.log('[PR-27699] BUG_MARKER: HIP-3 markets in crypto section', {
-          symbols: miscategorized.map((m) => m.symbol),
-          count: miscategorized.length,
-        });
-      }
-      return sortMarkets({
-        markets: cryptoFiltered,
+    () =>
+      sortMarkets({
+        markets: allMarkets.filter((m) => !m.marketType && !m.isHip3),
         sortBy,
         direction,
-      }).slice(0, trendingLimit);
-    },
+      }).slice(0, trendingLimit),
     [allMarkets, sortBy, direction, trendingLimit],
   );
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -321,7 +321,7 @@ export const usePerpsHomeData = ({
     if (!searchQuery.trim()) {
       return perpsMarkets;
     }
-    return filteredData.markets.filter((m) => !m.marketType);
+    return filteredData.markets.filter((m) => !m.marketType && !m.isHip3);
   }, [searchQuery, perpsMarkets, filteredData.markets]);
 
   const searchedStocksMarkets = useMemo(() => {

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -18,6 +18,7 @@ import {
 import type { PerpsTransaction } from '../types/transactionHistory';
 import { transformFillsToTransactions } from '../utils/transactionTransforms';
 import Engine from '../../../../core/Engine';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { HOME_SCREEN_CONFIG } from '../constants/perpsConfig';
 import { selectPerpsWatchlistMarkets } from '../selectors/perpsController';
 import { usePerpsConnection } from './usePerpsConnection';
@@ -180,12 +181,21 @@ export const usePerpsHomeData = ({
   // Filter and sort markets by type
   // Perps (crypto) - exclude all non-crypto markets
   const perpsMarkets = useMemo(
-    () =>
-      sortMarkets({
-        markets: allMarkets.filter((m) => !m.marketType), // Crypto markets have no marketType
+    () => {
+      const cryptoFiltered = allMarkets.filter((m) => !m.marketType);
+      const miscategorized = cryptoFiltered.filter((m) => m.isHip3);
+      if (miscategorized.length > 0) {
+        DevLogger.log('[PR-27699] BUG_MARKER: HIP-3 markets in crypto section', {
+          symbols: miscategorized.map((m) => m.symbol),
+          count: miscategorized.length,
+        });
+      }
+      return sortMarkets({
+        markets: cryptoFiltered,
         sortBy,
         direction,
-      }).slice(0, trendingLimit),
+      }).slice(0, trendingLimit);
+    },
     [allMarkets, sortBy, direction, trendingLimit],
   );
 

--- a/app/controllers/perps/constants/hyperLiquidConfig.ts
+++ b/app/controllers/perps/constants/hyperLiquidConfig.ts
@@ -335,6 +335,19 @@ export const HIP3_ASSET_MARKET_TYPES: Record<
   'xyz:CRWV': 'equity',
   'xyz:SMSN': 'equity',
 
+  'xyz:GME': 'equity',
+  'xyz:SOFTBANK': 'equity',
+  'xyz:HYUNDAI': 'equity',
+  'xyz:KIOXIA': 'equity',
+  'xyz:HIMS': 'equity',
+  'xyz:URNM': 'equity',
+  'xyz:EWY': 'equity',
+  'xyz:EWJ': 'equity',
+  'xyz:SP500': 'equity',
+  'xyz:JP225': 'equity',
+  'xyz:KR200': 'equity',
+  'xyz:VIX': 'equity',
+
   // xyz DEX - Commodities
   'xyz:GOLD': 'commodity',
   'xyz:SILVER': 'commodity',
@@ -345,10 +358,13 @@ export const HIP3_ASSET_MARKET_TYPES: Record<
   'xyz:USAR': 'commodity',
   'xyz:NATGAS': 'commodity',
   'xyz:PLATINUM': 'commodity',
+  'xyz:PALLADIUM': 'commodity',
+  'xyz:BRENTOIL': 'commodity',
 
   // xyz DEX - Forex
   'xyz:EUR': 'forex',
   'xyz:JPY': 'forex',
+  'xyz:DXY': 'forex',
 } as const;
 
 /**


### PR DESCRIPTION
## **Description**
BRENTOIL (Brent Crude Oil) and 14 other recently added HIP-3 assets appeared in the "Explore Crypto" section because they were missing from the `HIP3_ASSET_MARKET_TYPES` mapping in `hyperLiquidConfig.ts`. Without a `marketType`, the crypto filter (`!m.marketType`) incorrectly captured them.

**Root cause:** `app/controllers/perps/constants/hyperLiquidConfig.ts:305` — 15 HIP-3 assets added to HyperLiquid's xyz DEX were not mapped in the app's asset classification config.

**Fix:** (1) Added all 15 missing assets to `HIP3_ASSET_MARKET_TYPES` with correct categories. (2) Added `&& !m.isHip3` guard to the crypto filter in `usePerpsHomeData` as defense-in-depth against future unmapped HIP-3 assets.

## **Changelog**
CHANGELOG entry: Fixed miscategorization of BRENTOIL and other non-crypto instruments appearing in the "Explore Crypto" section on Perps Home

## **Related issues**
Fixes: [TAT-2672](https://consensyssoftware.atlassian.net/browse/TAT-2672)

## **Manual testing steps**
```gherkin
Feature: Perps Home market categorization
  Scenario: BRENTOIL appears in Commodities, not Explore Crypto
    Given the user is on the Perps Home screen
    When the market data loads
    Then BRENTOIL should appear in the "Commodities" section
    And BRENTOIL should NOT appear in the "Explore Crypto" section
    And BTC, ETH, SOL remain in the "Explore Crypto" section
```

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/60b1f75c-823e-4788-8173-dd58629a323c


### **After**

https://github.com/user-attachments/assets/a2235b45-8a40-4f23-b0ca-aad8d12506aa


## **Validation Recipe**
<details>
<summary>Automated validation recipe (validate-recipe.sh)</summary>

```json
{
  "pr": "27699",
  "title": "BRENTOIL excluded from Explore Crypto section",
  "jira": "TAT-2672",
  "acceptance_criteria": [
    "BRENTOIL does not appear in the Explore Crypto section",
    "Other non-crypto instruments are excluded from Explore Crypto",
    "Filter logic enforced at data level, not manual exclusion",
    "BRENTOIL appears in Commodities section",
    "No crypto markets removed from Explore Crypto"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "runtime": {
      "pre_conditions": ["CDP connected", "Wallet unlocked on Wallet route"],
      "steps": [
        {
          "id": "nav_perps",
          "description": "Navigate to perps home",
          "action": "navigate",
          "target": "Perps"
        },
        {
          "id": "wait_load",
          "description": "Wait for market data to load",
          "action": "wait",
          "ms": 3000
        },
        {
          "id": "check_brentoil_not_in_crypto",
          "description": "BRENTOIL must not be in crypto markets (markets without marketType)",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(markets) { var cryptoMarkets = markets.filter(function(m) { return !m.marketType; }); var hasBrent = cryptoMarkets.some(function(m) { return (m.symbol || '').indexOf('BRENTOIL') >= 0; }); return JSON.stringify({hasBrentInCrypto: hasBrent, cryptoCount: cryptoMarkets.length}); })",
          "assert": { "operator": "eq", "field": "hasBrentInCrypto", "value": false }
        },
        {
          "id": "check_brentoil_in_commodities",
          "description": "BRENTOIL must be in commodities section",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(markets) { var commodities = markets.filter(function(m) { return m.marketType === 'commodity'; }); var hasBrent = commodities.some(function(m) { return (m.symbol || '').indexOf('BRENTOIL') >= 0; }); return JSON.stringify({hasBrentInCommodities: hasBrent, commodityCount: commodities.length}); })",
          "assert": { "operator": "eq", "field": "hasBrentInCommodities", "value": true }
        },
        {
          "id": "check_no_hip3_in_crypto",
          "description": "No HIP-3 markets should appear in crypto section",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(markets) { var hip3InCrypto = markets.filter(function(m) { return !m.marketType && m.isHip3; }); return JSON.stringify({hip3InCryptoCount: hip3InCrypto.length, symbols: hip3InCrypto.map(function(m) { return m.symbol; })}); })",
          "assert": { "operator": "eq", "field": "hip3InCryptoCount", "value": 0 }
        },
        {
          "id": "check_crypto_markets_exist",
          "description": "Crypto markets still exist in Explore Crypto",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(markets) { var crypto = markets.filter(function(m) { return !m.marketType && !m.isHip3; }); var hasBTC = crypto.some(function(m) { return m.symbol === 'BTC'; }); var hasETH = crypto.some(function(m) { return m.symbol === 'ETH'; }); return JSON.stringify({cryptoCount: crypto.length, hasBTC: hasBTC, hasETH: hasETH}); })",
          "assert": { "operator": "eq", "field": "hasBTC", "value": true }
        },
        {
          "id": "check_all_hip3_categorized",
          "description": "All HIP-3 markets have a marketType assigned",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(markets) { var uncategorized = markets.filter(function(m) { return m.isHip3 && !m.marketType; }); return JSON.stringify({uncategorizedCount: uncategorized.length, symbols: uncategorized.map(function(m) { return m.symbol; })}); })",
          "assert": { "operator": "eq", "field": "uncategorizedCount", "value": 0 }
        },
        {
          "id": "check_no_errors",
          "description": "No errors in Metro logs",
          "action": "log_watch",
          "window_seconds": 10,
          "must_not_appear": ["TypeError", "undefined is not an object"]
        }
      ]
    }
  }
}
```
</details>

## **Pre-merge author checklist**
- [x] I've followed MetaMask Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-filtering change that only affects how perps markets are categorized and displayed; behavior is covered by new unit tests guarding HIP-3 filtering in both trending and search results.
> 
> **Overview**
> Prevents HIP-3 xyz DEX instruments (e.g., `xyz:BRENTOIL`) from being treated as crypto on Perps Home by **excluding HIP-3 markets** from the crypto `perpsMarkets` list (including search results).
> 
> Expands `HIP3_ASSET_MARKET_TYPES` to classify newly added xyz assets across *equity/commodity/forex*, and adds unit tests to ensure HIP-3 markets don’t appear under **Explore Crypto** while correctly showing under their respective sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f35150df1172873fcaf4476723b8e45cd0e0f2cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->