### PR TITLE
docs(ButtonLink): clarify deprecation guidance (TextButton vs Tertiary Button)

### DIFF
--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
@@ -23,9 +23,17 @@ import {
 } from './ButtonLink.constants';
 
 /**
- * @deprecated Please update your code to use `TextButton` from `@metamask/design-system-react-native`.
- * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextButton/README.md}
+ * @deprecated ButtonLink has been replaced by design-system components.
+ *
+ * - Use `TextButton` for inline links within text flows.
+ * - Use `Button` with `variant={ButtonVariant.Tertiary}` for standalone link‑style buttons (e.g., CTAs, headers, separators).
+ *
+ * Examples:
+ * Inline: <Text>Forgot your password? <TextButton onPress={...}>Reset</TextButton></Text>
+ * Standalone: <Button variant={ButtonVariant.Tertiary} onPress={...}>Forgot password?</Button>
+ *
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextButton/README.md | TextButton}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md | Button}
  */
 const ButtonLink: React.FC<ButtonLinkProps> = ({
   style,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Clarify the `@deprecated` notice on `ButtonLink` so migration paths are explicit and unambiguous:
- Use `TextButton` for inline links within text flows
- Use `Button` with `variant={ButtonVariant.Tertiary}` for standalone link‑style buttons (CTAs, headers, separators)

Adds concise inline examples and links to design‑system docs. No runtime behavior changes (comment‑only).

Context: [Slack thread](https://consensys.slack.com/archives/C0354T27M5M/p1773898792873879?thread_ts=1773898792.873879&cid=C0354T27M5M)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A (documentation‑only change)

## **Screenshots/Recordings**

### **Before**
N/A

### **After**
N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1773898792873879?thread_ts=1773898792.873879&cid=C0354T27M5M)

<div><a href="https://cursor.com/agents/bc-25a23bc9-6961-5476-a358-35b83636d6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25a23bc9-6961-5476-a358-35b83636d6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

