### PR TITLE
feat: MUSD-531 updated mUSD aggregated balance row to redirect to cash list when user has mUSD on any network

### DIFF
--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MusdAggregatedRow from './MusdAggregatedRow';
+import Routes from '../../../../../constants/navigation/Routes';
+import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
+import NavigationService from '../../../../../core/NavigationService';
 
 const mockClaimRewards = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -9,12 +12,22 @@ const mockCreateEventBuilder = jest.fn(() => ({
   addProperties: jest.fn().mockReturnThis(),
   build: jest.fn(),
 }));
+jest.mock('../../../../../core/NavigationService', () => ({
+  __esModule: true,
+  default: {
+    navigation: {
+      navigate: jest.fn(),
+    },
+  },
+}));
 
+const mockUseMusdBalance = jest.fn(() => ({
+  tokenBalanceAggregated: '1800.5',
+  fiatBalanceAggregatedFormatted: '$1,800.50',
+  hasMusdBalanceOnAnyChain: false,
+}));
 jest.mock('../../../../UI/Earn/hooks/useMusdBalance', () => ({
-  useMusdBalance: () => ({
-    tokenBalanceAggregated: '1800.5',
-    fiatBalanceAggregatedFormatted: '$1,800.50',
-  }),
+  useMusdBalance: () => mockUseMusdBalance(),
 }));
 
 const mockUseMerklBonusClaim = jest.fn(() => ({
@@ -48,6 +61,11 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
 describe('MusdAggregatedRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseMusdBalance.mockReturnValue({
+      tokenBalanceAggregated: '1800.5',
+      fiatBalanceAggregatedFormatted: '$1,800.50',
+      hasMusdBalanceOnAnyChain: false,
+    });
     mockUseMerklBonusClaim.mockReturnValue({
       claimableReward: '10',
       hasPendingClaim: false,
@@ -108,6 +126,37 @@ describe('MusdAggregatedRow', () => {
 
     expect(screen.queryByText('Claim bonus')).toBeNull();
     expect(screen.getByText('3% bonus')).toBeOnTheScreen();
+  });
+
+  describe('handleTokenRowPress', () => {
+    it('navigates to CASH_TOKENS_FULL_VIEW when user has mUSD balance on any chain', () => {
+      mockUseMusdBalance.mockReturnValueOnce({
+        tokenBalanceAggregated: '1800.5',
+        fiatBalanceAggregatedFormatted: '$1,800.50',
+        hasMusdBalanceOnAnyChain: true,
+      });
+
+      renderWithProvider(<MusdAggregatedRow />);
+
+      fireEvent.press(screen.getByTestId('cash-section-musd-row'));
+
+      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+        Routes.WALLET.CASH_TOKENS_FULL_VIEW,
+      );
+    });
+
+    it('navigates to mUSD mainnet Asset details when user has no mUSD balance on any chain', () => {
+      renderWithProvider(<MusdAggregatedRow />);
+
+      fireEvent.press(screen.getByTestId('cash-section-musd-row'));
+
+      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+        'Asset',
+        expect.objectContaining({
+          source: TokenDetailsSource.MobileTokenListPage,
+        }),
+      );
+    });
   });
 
   describe('claimable bonus threshold (min $0.01)', () => {

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -42,6 +42,7 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { MUSD_MAINNET_ASSET_FOR_DETAILS } from './CashGetMusdEmptyState.constants';
 import NavigationService from '../../../../../core/NavigationService';
 import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
+import Routes from '../../../../../constants/navigation/Routes';
 
 /**
  * Minimal mUSD asset for useMerklBonusClaim (claim runs on Linea).
@@ -62,8 +63,11 @@ const LINEA_MUSD_ASSET: TokenI = {
 const MusdAggregatedRow = () => {
   const tw = useTailwind();
   const privacyMode = useSelector(selectPrivacyMode);
-  const { tokenBalanceAggregated, fiatBalanceAggregatedFormatted } =
-    useMusdBalance();
+  const {
+    tokenBalanceAggregated,
+    fiatBalanceAggregatedFormatted,
+    hasMusdBalanceOnAnyChain,
+  } = useMusdBalance();
   const { claimableReward, hasPendingClaim, claimRewards, isClaiming } =
     useMerklBonusClaim(
       LINEA_MUSD_ASSET,
@@ -91,6 +95,13 @@ const MusdAggregatedRow = () => {
   }, [trackEvent, createEventBuilder, networkName, claimRewards]);
 
   const handleTokenRowPress = useCallback(() => {
+    if (hasMusdBalanceOnAnyChain) {
+      NavigationService.navigation.navigate(
+        Routes.WALLET.CASH_TOKENS_FULL_VIEW as never,
+      );
+      return;
+    }
+
     NavigationService.navigation.navigate(
       'Asset' as never,
       {
@@ -98,7 +109,7 @@ const MusdAggregatedRow = () => {
         source: TokenDetailsSource.MobileTokenListPage,
       } as never,
     );
-  }, []);
+  }, [hasMusdBalanceOnAnyChain]);
 
   const tokenBalanceDisplay = `${getIntlNumberFormatter(I18n.locale, {
     minimumFractionDigits: 0,


### PR DESCRIPTION

## **Description**

The mUSD aggregated balance row on the home screen now redirects users to the correct destination based on whether they hold mUSD on any network. Users with mUSD on mainnet or Linea are taken to the Cash tokens list view; users with no mUSD balance are redirected to the mainnet mUSD asset details screen.

## **Changelog**

CHANGELOG entry: Updated mUSD aggregated balance row to redirect to the Cash tokens list when the user holds mUSD on any network

## **Related issues**

Fixes:
- [MUSD-531: Improve navigation for aggregated mUSD balance on home screen](https://consensyssoftware.atlassian.net/browse/MUSD-531)

## **Manual testing steps**

```gherkin
Feature: mUSD aggregated balance row navigation on home screen

  Scenario: user with mUSD balance taps the aggregated mUSD row
    Given the user holds mUSD on mainnet or Linea
    And the user is on the home screen

    When user taps the mUSD aggregated balance row
    Then the Cash tokens list view opens

  Scenario: user with no mUSD balance taps the aggregated mUSD row
    Given the user has no mUSD balance on any network
    And the user is on the home screen

    When user taps the mUSD aggregated balance row
    Then the mainnet mUSD asset details screen opens
```

## **Screenshots/Recordings**

### **Before**

Clicking the aggregated mUSD balance row always redirected to mainnet mUSD asset details.

### **After**


https://github.com/user-attachments/assets/74bc7179-7a92-472e-97cf-c6f64a43825a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation change gated by a balance flag; main risk is misrouting users if `hasMusdBalanceOnAnyChain` is incorrect.
> 
> **Overview**
> Updates the home screen `MusdAggregatedRow` press behavior to **conditionally navigate**: if the user holds mUSD on any supported chain it opens the Cash tokens list (`Routes.WALLET.CASH_TOKENS_FULL_VIEW`), otherwise it continues to open the mainnet mUSD Asset details view.
> 
> Extends the unit tests to mock `NavigationService` and `useMusdBalance`’s new `hasMusdBalanceOnAnyChain` output, and adds coverage for both navigation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81109c035b5425312adaadde3a329020b90fb2ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->