### PR TITLE
fix(ci): only pass groups to upload_to_testflight when distributing externally

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -93,15 +93,20 @@ platform :ios do
       key_filepath: api_key_key_filepath,
     )
     
-    # Upload to TestFlight with API key from app_store_connect_api_key action
-    upload_to_testflight(
+    # Upload to TestFlight with API key from app_store_connect_api_key action.
+    # Only include groups when distributing externally -- passing groups with
+    # distribute_external=false still triggers the groups API, which fails if
+    # the API key lacks external-distribution permissions.
+    testflight_options = {
       api_key: api_key,
       ipa: ipa_path,
       distribute_external: distribute_external,
-      groups: groups,
       notify_external_testers: notify_external_testers,
       changelog: changelog_message
-    )
+    }
+    testflight_options[:groups] = groups if distribute_external
+
+    upload_to_testflight(testflight_options)
   end
 end
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `upload_to_testflight` Fastlane action was always receiving the `groups` parameter, even when `distribute_external` was set to `false`. Fastlane still calls the App Store Connect groups API when `groups` is present regardless of the `distribute_external` flag, causing a "This request is forbidden for security reasons" error when the API key lacks external-distribution permissions.

This fix conditionally includes `groups` in the options hash only when `distribute_external` is `true`, so the groups API call is skipped entirely for internal-only uploads.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — CI-only change. Verify by triggering a nightly build and confirming the TestFlight upload succeeds without the "forbidden" error.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)