### PR TITLE
cherry-pick of #27690: feat: Add A/B test for bridge token selector balance layout

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.abTestConfig.ts
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.abTestConfig.ts
@@ -1,0 +1,26 @@
+export const TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY =
+  'swapsSWAPS4242AbtestTokenSelectorBalanceLayout';
+
+export enum TokenSelectorBalanceLayoutVariant {
+  Control = 'control',
+  Treatment = 'treatment',
+}
+
+interface TokenSelectorBalanceLayoutConfig {
+  showTokenBalanceFirst: boolean;
+  removeTickerFromTokenBalance: boolean;
+}
+
+export const TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS: Record<
+  TokenSelectorBalanceLayoutVariant,
+  TokenSelectorBalanceLayoutConfig
+> = {
+  [TokenSelectorBalanceLayoutVariant.Control]: {
+    showTokenBalanceFirst: false,
+    removeTickerFromTokenBalance: false,
+  },
+  [TokenSelectorBalanceLayoutVariant.Treatment]: {
+    showTokenBalanceFirst: true,
+    removeTickerFromTokenBalance: true,
+  },
+};

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { Text as RNText } from 'react-native';
 import { TokenSelectorItem } from './TokenSelectorItem';
 import { ethers } from 'ethers';
+import { useABTest } from '../../../../hooks';
 import { createMockTokenWithBalance } from '../testUtils/fixtures';
 import {
   TOKEN_BALANCE_LOADING,
@@ -11,6 +13,10 @@ import {
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => []),
+}));
+
+jest.mock('../../../../hooks', () => ({
+  useABTest: jest.fn(),
 }));
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -91,9 +97,18 @@ jest.mock('../../../../component-library/components/Tags/Tag', () => {
 
 describe('TokenSelectorItem', () => {
   const mockOnPress = jest.fn();
+  const mockUseABTest = jest.mocked(useABTest);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseABTest.mockReturnValue({
+      variant: {
+        showTokenBalanceFirst: false,
+        removeTickerFromTokenBalance: false,
+      },
+      variantName: 'control',
+      isActive: false,
+    });
   });
 
   describe('rendering', () => {
@@ -380,6 +395,58 @@ describe('TokenSelectorItem', () => {
       const fiatBalanceElement = getByText('$1,234.56');
 
       expect(fiatBalanceElement.props.numberOfLines).toBe(1);
+    });
+  });
+
+  describe('A/B variants', () => {
+    it('keeps fiat above token balance in the control layout', () => {
+      const token = createMockTokenWithBalance({
+        balance: '50.0',
+        balanceFiat: '$500',
+        symbol: 'USDC',
+      });
+
+      const controlRender = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+      expect(controlRender.getByText('50 USDC')).toBeOnTheScreen();
+
+      const controlTextOrder = controlRender
+        .UNSAFE_getAllByType(RNText)
+        .map((textNode) => String(textNode.props.children));
+      expect(controlTextOrder.indexOf('$500')).toBeLessThan(
+        controlTextOrder.indexOf('50 USDC'),
+      );
+    });
+
+    it('shows token balance first without the ticker in the treatment layout', () => {
+      mockUseABTest.mockReturnValue({
+        variant: {
+          showTokenBalanceFirst: true,
+          removeTickerFromTokenBalance: true,
+        },
+        variantName: 'treatment',
+        isActive: true,
+      });
+
+      const token = createMockTokenWithBalance({
+        balance: '50.0',
+        balanceFiat: '$500',
+        symbol: 'USDC',
+      });
+
+      const treatmentRender = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+      expect(treatmentRender.getByText('50')).toBeOnTheScreen();
+      expect(treatmentRender.queryByText('50 USDC')).not.toBeOnTheScreen();
+
+      const treatmentTextOrder = treatmentRender
+        .UNSAFE_getAllByType(RNText)
+        .map((textNode) => String(textNode.props.children));
+      expect(treatmentTextOrder.indexOf('50')).toBeLessThan(
+        treatmentTextOrder.indexOf('$500'),
+      );
     });
   });
 });

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -5,6 +5,8 @@ import {
   View,
   TouchableOpacity,
   Platform,
+  StyleProp,
+  TextStyle,
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
@@ -46,6 +48,12 @@ import { ACCOUNT_TYPE_LABELS } from '../../../../constants/account-type-labels';
 import parseAmount from '../../../../util/parseAmount';
 import { getTokenImageSource } from '../utils';
 import { useRWAToken } from '../hooks/useRWAToken';
+import { useABTest } from '../../../../hooks';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  TokenSelectorBalanceLayoutVariant,
+} from './TokenSelectorItem.abTestConfig';
 
 const createStyles = ({
   theme,
@@ -136,12 +144,22 @@ interface TokenSelectorItemProps {
   isNoFeeAsset?: boolean;
 }
 
+const isLoadingBalance = (balance?: string) =>
+  balance === TOKEN_BALANCE_LOADING ||
+  balance === TOKEN_BALANCE_LOADING_UPPERCASE;
+
 const FiatBalanceView = ({
   balance,
   isSelected,
+  textStyle,
+  textVariant,
+  textColor,
 }: {
   balance?: string;
   isSelected: boolean;
+  textStyle?: StyleProp<TextStyle>;
+  textVariant: TextVariant;
+  textColor: TextColor;
 }) => {
   const { styles } = useStyles(createStyles, { isSelected });
 
@@ -149,18 +167,51 @@ const FiatBalanceView = ({
     return null;
   }
 
-  if (
-    balance === TOKEN_BALANCE_LOADING ||
-    balance === TOKEN_BALANCE_LOADING_UPPERCASE
-  ) {
+  if (isLoadingBalance(balance)) {
     return <View style={styles.skeleton} />;
   }
 
   return (
     <Text
-      variant={TextVariant.BodySM}
-      color={TextColor.Alternative}
+      variant={textVariant}
+      color={textColor}
       numberOfLines={1}
+      style={textStyle}
+    >
+      {balance}
+    </Text>
+  );
+};
+
+const TokenBalanceView = ({
+  balance,
+  isSelected,
+  textStyle,
+  textVariant,
+  textColor,
+}: {
+  balance?: string;
+  isSelected: boolean;
+  textStyle?: StyleProp<TextStyle>;
+  textVariant: TextVariant;
+  textColor: TextColor;
+}) => {
+  const { styles } = useStyles(createStyles, { isSelected });
+
+  if (!balance) {
+    return null;
+  }
+
+  if (isLoadingBalance(balance)) {
+    return <View style={styles.skeleton} />;
+  }
+
+  return (
+    <Text
+      variant={textVariant}
+      color={textColor}
+      numberOfLines={1}
+      style={textStyle}
     >
       {balance}
     </Text>
@@ -178,6 +229,10 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   isNoFeeAsset = false,
 }) => {
   const { styles } = useStyles(createStyles, { isSelected });
+  const { variant } = useABTest(
+    TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  );
   const noFeeAssets = useSelector((state: RootState) =>
     selectNoFeeAssets(state, token.chainId),
   );
@@ -197,8 +252,18 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
     return parseAmount(balance, 5) || balance;
   };
 
-  const cryptoBalance = token.balance
-    ? `${formatTokenBalance(token.balance)} ${token.symbol}`
+  const selectedVariant =
+    variant ??
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+      TokenSelectorBalanceLayoutVariant.Control
+    ];
+  const formattedTokenBalance = token.balance
+    ? formatTokenBalance(token.balance)
+    : undefined;
+  const cryptoBalance = formattedTokenBalance
+    ? selectedVariant.removeTickerFromTokenBalance
+      ? formattedTokenBalance
+      : `${formattedTokenBalance} ${token.symbol}`
     : undefined;
 
   const isNative = token.address === ethers.constants.AddressZero;
@@ -206,8 +271,16 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   // to check if the token is a stock by checking if the name includes 'ondo' or 'stock'
   const { isStockToken } = useRWAToken();
 
-  const balance = shouldShowBalance ? fiatValue : undefined;
-  const secondaryBalance = shouldShowBalance ? cryptoBalance : undefined;
+  const fiatBalance = shouldShowBalance ? fiatValue : undefined;
+  const tokenBalance = shouldShowBalance ? cryptoBalance : undefined;
+  const topRowBalanceTextStyle = {
+    textVariant: TextVariant.BodyMDMedium,
+    textColor: TextColor.Default,
+  };
+  const bottomRowBalanceTextStyle = {
+    textVariant: TextVariant.BodyMD,
+    textColor: TextColor.Alternative,
+  };
 
   const label = token.accountType
     ? ACCOUNT_TYPE_LABELS[token.accountType]
@@ -291,21 +364,21 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                 )}
               </Box>
 
-              {secondaryBalance ? (
-                secondaryBalance === TOKEN_BALANCE_LOADING ||
-                secondaryBalance === TOKEN_BALANCE_LOADING_UPPERCASE ? (
-                  <View style={styles.skeleton} />
-                ) : (
-                  <Text
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Default}
-                    numberOfLines={1}
-                    style={styles.rightValue}
-                  >
-                    {secondaryBalance}
-                  </Text>
-                )
-              ) : null}
+              {selectedVariant.showTokenBalanceFirst ? (
+                <TokenBalanceView
+                  balance={tokenBalance}
+                  isSelected={isSelected}
+                  textStyle={styles.rightValue}
+                  {...topRowBalanceTextStyle}
+                />
+              ) : (
+                <FiatBalanceView
+                  balance={fiatBalance}
+                  isSelected={isSelected}
+                  textStyle={styles.rightValue}
+                  {...topRowBalanceTextStyle}
+                />
+              )}
             </Box>
 
             <Box
@@ -323,7 +396,21 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                 {token.name}
               </Text>
 
-              <FiatBalanceView balance={balance} isSelected={isSelected} />
+              {selectedVariant.showTokenBalanceFirst ? (
+                <FiatBalanceView
+                  balance={fiatBalance}
+                  isSelected={isSelected}
+                  textStyle={styles.rightValue}
+                  {...bottomRowBalanceTextStyle}
+                />
+              ) : (
+                <TokenBalanceView
+                  balance={tokenBalance}
+                  isSelected={isSelected}
+                  textStyle={styles.rightValue}
+                  {...bottomRowBalanceTextStyle}
+                />
+              )}
             </Box>
             {isStockToken(token as BridgeToken) && <StockBadge token={token} />}
           </Box>

--- a/app/components/UI/Bridge/hooks/useTrackSwapPageViewed/index.ts
+++ b/app/components/UI/Bridge/hooks/useTrackSwapPageViewed/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useABTest } from '../../../../../hooks';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
@@ -13,15 +13,46 @@ import {
   NUMPAD_QUICK_ACTIONS_AB_KEY,
   NUMPAD_QUICK_ACTIONS_VARIANTS,
 } from '../../components/GaslessQuickPickOptions/abTestConfig';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+} from '../../components/TokenSelectorItem.abTestConfig';
 
 export const useTrackSwapPageViewed = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const abTestContext = useSelector(selectAbTestContext);
-  const { variantName, isActive } = useABTest(
-    NUMPAD_QUICK_ACTIONS_AB_KEY,
-    NUMPAD_QUICK_ACTIONS_VARIANTS,
+  const { variantName: numpadVariantName, isActive: isNumpadAbActive } =
+    useABTest(NUMPAD_QUICK_ACTIONS_AB_KEY, NUMPAD_QUICK_ACTIONS_VARIANTS);
+  const {
+    variantName: tokenSelectorVariantName,
+    isActive: isTokenSelectorAbActive,
+  } = useABTest(
+    TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  );
+
+  const activeABTests = useMemo(
+    () => [
+      ...(isNumpadAbActive
+        ? [{ key: NUMPAD_QUICK_ACTIONS_AB_KEY, value: numpadVariantName }]
+        : []),
+      ...(isTokenSelectorAbActive
+        ? [
+            {
+              key: TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+              value: tokenSelectorVariantName,
+            },
+          ]
+        : []),
+    ],
+    [
+      isNumpadAbActive,
+      numpadVariantName,
+      isTokenSelectorAbActive,
+      tokenSelectorVariantName,
+    ],
   );
 
   const hasTrackedPageView = useRef(false);
@@ -44,13 +75,8 @@ export const useTrackSwapPageViewed = () => {
               abTestContext.assetsASSETS2493AbtestTokenDetailsLayout,
           },
         }),
-        ...(isActive && {
-          active_ab_tests: [
-            {
-              key: NUMPAD_QUICK_ACTIONS_AB_KEY,
-              value: variantName,
-            },
-          ],
+        ...(activeABTests.length > 0 && {
+          active_ab_tests: activeABTests,
         }),
       };
       trackEvent(
@@ -64,8 +90,7 @@ export const useTrackSwapPageViewed = () => {
     destToken,
     trackEvent,
     createEventBuilder,
-    isActive,
-    variantName,
+    activeABTests,
     abTestContext,
   ]);
 };

--- a/app/util/bridge/hooks/useSubmitBridgeTx.test.tsx
+++ b/app/util/bridge/hooks/useSubmitBridgeTx.test.tsx
@@ -12,8 +12,14 @@ import { QuoteMetadata, QuoteResponse } from '@metamask/bridge-controller';
 import { backgroundState } from '../../test/initial-root-state';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { selectSourceWalletAddress } from '../../../selectors/bridge';
+import { useABTest } from '../../../hooks';
 
 type BridgeQuoteResponse = QuoteResponse & QuoteMetadata;
+interface MockABTestResult {
+  variant: unknown;
+  variantName: string;
+  isActive: boolean;
+}
 
 let mockSubmitTx: jest.Mock<
   Promise<TransactionMeta>,
@@ -97,11 +103,37 @@ jest.mock('../../../selectors/bridge', () => ({
   ),
 }));
 
+jest.mock('../../../hooks', () => ({
+  useABTest: jest.fn(),
+}));
+
 const mockStore = configureMockStore();
+const inactiveABTestResult: MockABTestResult = {
+  variant: undefined,
+  variantName: 'control',
+  isActive: false,
+};
 
 describe('useSubmitBridgeTx', () => {
+  const mockABTests = ({
+    first = inactiveABTestResult,
+    second = inactiveABTestResult,
+  }: {
+    first?: MockABTestResult;
+    second?: MockABTestResult;
+  } = {}) => {
+    jest
+      .mocked(useABTest)
+      .mockReset()
+      .mockReturnValue(inactiveABTestResult)
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second);
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default every test to the non-experiment path unless it opts in.
+    mockABTests();
   });
 
   const createWrapper = (mockState = {}) => {
@@ -179,6 +211,7 @@ describe('useSubmitBridgeTx', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
     expect(txResult).toEqual({
       chainId: '0x1',
@@ -190,6 +223,46 @@ describe('useSubmitBridgeTx', () => {
         from: '0x1234567890123456789012345678901234567890',
       },
     });
+
+    // Re-render with an active assignment to verify submitTx forwards activeAbTests.
+    mockABTests({
+      second: {
+        variant: {},
+        variantName: 'treatment',
+        isActive: true,
+      },
+    });
+    mockSubmitTx.mockResolvedValueOnce({
+      chainId: '0x1',
+      id: '2',
+      networkClientId: '1',
+      status: 'submitted',
+      time: Date.now(),
+      txParams: {
+        from: '0x1234567890123456789012345678901234567890',
+      },
+    } as TransactionMeta);
+
+    const { result: activeResult } = renderHook(() => useSubmitBridgeTx(), {
+      wrapper: createWrapper(),
+    });
+
+    await activeResult.current.submitBridgeTx({
+      quoteResponse: mockQuoteResponse as BridgeQuoteResponse,
+    });
+
+    expect(mockSubmitTx).toHaveBeenLastCalledWith(
+      '0x1234567890123456789012345678901234567890',
+      {
+        ...mockQuoteResponse,
+        approval: undefined,
+      },
+      true,
+      undefined,
+      undefined,
+      undefined,
+      [{ key: expect.any(String), value: 'treatment' }],
+    );
   });
 
   it('should handle bridge transaction with approval', async () => {
@@ -224,6 +297,7 @@ describe('useSubmitBridgeTx', () => {
         approval: mockQuoteResponse.approval ?? undefined,
       },
       true,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -427,6 +501,33 @@ describe('useSubmitBridgeTx', () => {
       accountAddress: '0x1234567890123456789012345678901234567890',
       location: undefined,
       abTests: undefined,
+      activeAbTests: undefined,
+    });
+
+    // Re-render with an active assignment to verify submitIntent forwards activeAbTests.
+    mockABTests({
+      second: {
+        variant: {},
+        variantName: 'treatment',
+        isActive: true,
+      },
+    });
+    mockSubmitIntent.mockResolvedValueOnce(mockIntentResult);
+
+    const { result: activeResult } = renderHook(() => useSubmitBridgeTx(), {
+      wrapper: createWrapper(),
+    });
+
+    await activeResult.current.submitBridgeTx({
+      quoteResponse: mockQuoteResponse,
+    });
+
+    expect(mockSubmitIntent).toHaveBeenLastCalledWith({
+      quoteResponse: mockQuoteResponse,
+      accountAddress: '0x1234567890123456789012345678901234567890',
+      location: undefined,
+      abTests: undefined,
+      activeAbTests: [{ key: expect.any(String), value: 'treatment' }],
     });
     expect(mockSubmitTx).not.toHaveBeenCalled();
     expect(txResult).toEqual(mockIntentResult);

--- a/app/util/bridge/hooks/useSubmitBridgeTx.ts
+++ b/app/util/bridge/hooks/useSubmitBridgeTx.ts
@@ -8,11 +8,30 @@ import { useSelector } from 'react-redux';
 import { selectShouldUseSmartTransaction } from '../../../selectors/smartTransactionsController';
 import { selectSourceWalletAddress } from '../../../selectors/bridge';
 import { selectAbTestContext } from '../../../core/redux/slices/bridge';
+import { useABTest } from '../../../hooks';
+import {
+  NUMPAD_QUICK_ACTIONS_AB_KEY,
+  NUMPAD_QUICK_ACTIONS_VARIANTS,
+} from '../../../components/UI/Bridge/components/GaslessQuickPickOptions/abTestConfig';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+} from '../../../components/UI/Bridge/components/TokenSelectorItem.abTestConfig';
+import { useMemo } from 'react';
 
 export default function useSubmitBridgeTx() {
   const stxEnabled = useSelector(selectShouldUseSmartTransaction);
   const walletAddress = useSelector(selectSourceWalletAddress);
   const abTestContext = useSelector(selectAbTestContext);
+  const { variantName: numpadVariantName, isActive: isNumpadAbActive } =
+    useABTest(NUMPAD_QUICK_ACTIONS_AB_KEY, NUMPAD_QUICK_ACTIONS_VARIANTS);
+  const {
+    variantName: tokenSelectorVariantName,
+    isActive: isTokenSelectorAbActive,
+  } = useABTest(
+    TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  );
 
   const abTests = abTestContext?.assetsASSETS2493AbtestTokenDetailsLayout
     ? {
@@ -20,6 +39,30 @@ export default function useSubmitBridgeTx() {
           abTestContext.assetsASSETS2493AbtestTokenDetailsLayout,
       }
     : undefined;
+  const activeAbTests = useMemo(() => {
+    const tests: { key: string; value: string }[] = [];
+
+    if (isNumpadAbActive) {
+      tests.push({
+        key: NUMPAD_QUICK_ACTIONS_AB_KEY,
+        value: numpadVariantName,
+      });
+    }
+
+    if (isTokenSelectorAbActive) {
+      tests.push({
+        key: TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+        value: tokenSelectorVariantName,
+      });
+    }
+
+    return tests.length > 0 ? tests : undefined;
+  }, [
+    isNumpadAbActive,
+    numpadVariantName,
+    isTokenSelectorAbActive,
+    tokenSelectorVariantName,
+  ]);
 
   const submitBridgeTx = async ({
     quoteResponse,
@@ -40,6 +83,7 @@ export default function useSubmitBridgeTx() {
         accountAddress: walletAddress,
         location,
         abTests,
+        activeAbTests,
       });
     }
     return Engine.context.BridgeStatusController.submitTx(
@@ -52,6 +96,7 @@ export default function useSubmitBridgeTx() {
       undefined, // quotesReceivedContext
       location,
       abTests,
+      activeAbTests,
     );
   };
 


### PR DESCRIPTION
## **Description**

Cherry pick swaps a/b test that barely missed RC cutoff.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

This PR adds an A/B test for the bridge token selector balance layout.

Control keeps the current presentation by showing fiat balance on the top row and keeping the ticker in the token balance text. Treatment moves the token balance to the top row, removes the duplicate ticker from the token balance text, and keeps the top and bottom rows aligned with the intended size and color hierarchy.

The PR also passes the active experiment through the bridge page-view and submit analytics paths using `active_ab_tests` so the treatment can be evaluated against downstream conversion metrics.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs` `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added an experiment for the bridge token selector balance layout.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Bridge token selector balance layout experiment

  Scenario: User sees the control layout in the bridge token selector
    Given the token selector balance layout experiment is in the control variant
    And the user opens the Bridge flow
    When the token selector list is shown
    Then the fiat balance is shown on the top row
    And the token balance is shown on the bottom row with the ticker included

  Scenario: User sees the treatment layout in the bridge token selector
    Given the token selector balance layout experiment is in the treatment variant
    And the user opens the Bridge flow
    When the token selector list is shown
    Then the token balance is shown on the top row without the duplicate ticker
    And the fiat balance is shown on the bottom row

  Scenario: Analytics include the active experiment
    Given the token selector balance layout experiment is active
    When the user opens the Bridge flow
    And submits a bridge quote
    Then the relevant page-view and submit analytics payloads include active_ab_tests for the active experiment
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Control variant:
<img width="322" height="683" alt="Screenshot 2026-03-18 at 19 11 16" src="https://github.com/user-attachments/assets/572bffbe-8ab3-446c-8da8-564cd0ded31d" />


### **After**

Treatment variant:
<img width="317" height="690" alt="Screenshot 2026-03-19 at 18 24 35" src="https://github.com/user-attachments/assets/46b6241d-dd00-4ee1-8de6-7097a7533d14" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes bridge token list balance rendering and threads new `activeAbTests` metadata through bridge submission/page-view analytics, which could affect UI correctness and controller call signatures if mismatched.
> 
> **Overview**
> Adds a new A/B experiment (`swapsSWAPS4242AbtestTokenSelectorBalanceLayout`) that toggles the bridge token selector’s balance layout: *control* keeps fiat-on-top with token balance including ticker, while *treatment* shows token balance first and can omit the ticker.
> 
> Updates bridge analytics and submission paths to include an `active_ab_tests`/`activeAbTests` array when experiments are active (now aggregating both the existing numpad quick actions test and the new token selector test), with new/updated unit tests covering the variant-driven UI ordering and the forwarded experiment metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb210460eafefd04d0684425d031b24bc996c31c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
