### PR TITLE
fix(accounts): add migration to repair missing selectedAccount

### DIFF
--- a/app/store/migrations/126.test.ts
+++ b/app/store/migrations/126.test.ts
@@ -1,0 +1,286 @@
+import migrate from './126';
+import { captureException } from '@sentry/react-native';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+const mockedCaptureException = jest.mocked(captureException);
+
+const migrationVersion = 126;
+
+interface InternalAccounts {
+  accounts: Record<string, { id: string; address: string }>;
+  selectedAccount?: string;
+}
+
+const createValidState = (
+  internalAccounts?: InternalAccounts | unknown,
+  includeController = true,
+) => ({
+  engine: {
+    backgroundState: {
+      ...(includeController && {
+        AccountsController: {
+          ...(internalAccounts !== undefined && {
+            internalAccounts,
+          }),
+        },
+      }),
+    },
+  },
+});
+
+const ACCOUNT_1_ID = 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3';
+const ACCOUNT_2_ID = 'e9b38e2b-7d1e-4e5f-8c2a-1a5b3d7e9f01';
+
+const validAccounts = {
+  [ACCOUNT_1_ID]: { id: ACCOUNT_1_ID, address: '0xabc' },
+  [ACCOUNT_2_ID]: { id: ACCOUNT_2_ID, address: '0xdef' },
+};
+
+describe(`Migration ${migrationVersion}: Fix selectedAccount missing or undefined`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('invalid state structure', () => {
+    it('returns state if top-level state is invalid', () => {
+      const result = migrate('invalid');
+      expect(result).toBe('invalid');
+    });
+
+    it('captures exception and returns state if AccountsController is missing', () => {
+      const state = createValidState(undefined, false);
+      const result = migrate(state);
+
+      expect(result).toStrictEqual(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'AccountsController state is missing or invalid',
+          ),
+        }),
+      );
+    });
+
+    it('captures exception and returns state if AccountsController is not an object', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            AccountsController: 'invalid',
+          },
+        },
+      };
+      const result = migrate(state);
+
+      expect(result).toStrictEqual(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'AccountsController state is missing or invalid',
+          ),
+        }),
+      );
+    });
+
+    it('captures exception and returns state if internalAccounts is missing', () => {
+      const state = createValidState(undefined, true);
+      const result = migrate(state);
+
+      expect(result).toStrictEqual(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'internalAccounts is missing or invalid',
+          ),
+        }),
+      );
+    });
+  });
+
+  describe('valid selectedAccount (no-op)', () => {
+    it('does not modify state when selectedAccount is a valid string', () => {
+      const state = createValidState({
+        accounts: validAccounts,
+        selectedAccount: ACCOUNT_1_ID,
+      });
+      const result = migrate(state);
+
+      expect(result).toStrictEqual(state);
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('selectedAccount key is missing (JSON.stringify stripped it)', () => {
+    it('sets selectedAccount to first account ID when key is absent', () => {
+      const internalAccounts = {
+        accounts: validAccounts,
+      };
+      // Simulate JSON roundtrip: key was stripped
+      delete (internalAccounts as Record<string, unknown>).selectedAccount;
+
+      const state = createValidState(internalAccounts);
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe(ACCOUNT_1_ID);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('key_missing'),
+        }),
+      );
+    });
+
+    it('sets selectedAccount to empty string when key is absent and no accounts exist', () => {
+      const internalAccounts = {
+        accounts: {},
+      };
+      delete (internalAccounts as Record<string, unknown>).selectedAccount;
+
+      const state = createValidState(internalAccounts);
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe('');
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('key_missing'),
+        }),
+      );
+    });
+  });
+
+  describe('selectedAccount is explicitly undefined', () => {
+    it('sets selectedAccount to first account ID when value is undefined', () => {
+      const state = createValidState({
+        accounts: validAccounts,
+        selectedAccount: undefined,
+      });
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe(ACCOUNT_1_ID);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('selectedAccount is corrupt'),
+        }),
+      );
+    });
+  });
+
+  describe('selectedAccount is wrong type', () => {
+    it('sets selectedAccount to first account ID when value is a number', () => {
+      const state = createValidState({
+        accounts: validAccounts,
+        selectedAccount: 42,
+      });
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe(ACCOUNT_1_ID);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('wrong_type_number'),
+        }),
+      );
+    });
+
+    it('sets selectedAccount to first account ID when value is null', () => {
+      const state = createValidState({
+        accounts: validAccounts,
+        selectedAccount: null,
+      });
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe(ACCOUNT_1_ID);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('wrong_type_object'),
+        }),
+      );
+    });
+  });
+
+  describe('selectedAccount is empty string', () => {
+    it('does not modify state when selectedAccount is empty string (AccountsController handles this)', () => {
+      const state = createValidState({
+        accounts: validAccounts,
+        selectedAccount: '',
+      });
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe(ACCOUNT_1_ID);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('empty_string'),
+        }),
+      );
+    });
+  });
+
+  describe('fallback to empty string', () => {
+    it('sets selectedAccount to empty string when accounts have invalid structure', () => {
+      const state = createValidState({
+        accounts: { 'bad-id': { notAnId: true } },
+        selectedAccount: undefined,
+      });
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe('');
+    });
+
+    it('sets selectedAccount to empty string when first account id is empty', () => {
+      const state = createValidState({
+        accounts: { 'bad-id': { id: '' } },
+        selectedAccount: undefined,
+      });
+      const result = migrate(state) as ReturnType<typeof createValidState>;
+      const resultAccounts = result.engine.backgroundState
+        .AccountsController as Record<string, unknown>;
+      const resultInternal = resultAccounts.internalAccounts as Record<
+        string,
+        unknown
+      >;
+
+      expect(resultInternal.selectedAccount).toBe('');
+    });
+  });
+});

--- a/app/store/migrations/126.ts
+++ b/app/store/migrations/126.ts
@@ -1,0 +1,97 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+
+const migrationVersion = 126;
+
+/**
+ * Migration 126: Fix AccountsController selectedAccount that is missing or undefined.
+ *
+ * Migration 059 attempted to fix this but used `hasProperty` which returns false
+ * when the key is entirely absent (the common case after JSON.stringify/JSON.parse
+ * roundtrip strips undefined values). This migration covers both cases:
+ * - selectedAccount key is missing from internalAccounts
+ * - selectedAccount is explicitly undefined
+ * - selectedAccount is not a string
+ *
+ * @param state - The persisted Redux state.
+ * @returns The migrated Redux state.
+ */
+export default function migrate(state: unknown) {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  if (
+    !hasProperty(state.engine.backgroundState, 'AccountsController') ||
+    !isObject(state.engine.backgroundState.AccountsController)
+  ) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: AccountsController state is missing or invalid: '${typeof state.engine.backgroundState.AccountsController}'`,
+      ),
+    );
+    return state;
+  }
+
+  const accountsController = state.engine.backgroundState.AccountsController;
+
+  if (
+    !hasProperty(accountsController, 'internalAccounts') ||
+    !isObject(accountsController.internalAccounts)
+  ) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: internalAccounts is missing or invalid: '${typeof accountsController.internalAccounts}'`,
+      ),
+    );
+    return state;
+  }
+
+  const { internalAccounts } = accountsController;
+  const hasKey = hasProperty(internalAccounts, 'selectedAccount');
+  const currentValue = (internalAccounts as Record<string, unknown>)
+    .selectedAccount;
+
+  if (hasKey && typeof currentValue === 'string' && currentValue.length > 0) {
+    return state;
+  }
+
+  // Report the exact corruption type to Sentry for diagnostics
+  const corruptionType = !hasKey
+    ? 'key_missing'
+    : currentValue === undefined
+      ? 'value_undefined'
+      : typeof currentValue !== 'string'
+        ? `wrong_type_${typeof currentValue}`
+        : 'empty_string';
+
+  captureException(
+    new Error(
+      `Migration ${migrationVersion}: selectedAccount is corrupt (${corruptionType}). hasKey=${hasKey}, typeof=${typeof currentValue}, value=${String(currentValue)}`,
+    ),
+  );
+
+  // Try to recover: set to the first account ID if accounts exist
+  if (
+    hasProperty(internalAccounts, 'accounts') &&
+    isObject(internalAccounts.accounts)
+  ) {
+    const accountIds = Object.keys(internalAccounts.accounts);
+    if (accountIds.length > 0) {
+      const firstAccount = internalAccounts.accounts[accountIds[0]];
+      if (isObject(firstAccount) && hasProperty(firstAccount, 'id')) {
+        const accountId = firstAccount.id;
+        if (typeof accountId === 'string' && accountId.length > 0) {
+          (internalAccounts as Record<string, unknown>).selectedAccount =
+            accountId;
+          return state;
+        }
+      }
+    }
+  }
+
+  // Fallback: set to empty string so AccountsController auto-reconciles
+  (internalAccounts as Record<string, unknown>).selectedAccount = '';
+  return state;
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -126,6 +126,7 @@ import migration122 from './122';
 import migration123 from './123';
 import migration124 from './124';
 import migration125 from './125';
+import migration126 from './126';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -271,6 +272,7 @@ export const migrationList: MigrationsList = {
   123: migration123,
   124: migration124,
   125: migration125,
+  126: migration126,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sentry reports show users crashing on v7.66.0 with `Account Id "undefined" not found` during Engine initialization. The root cause is a corrupted `AccountsController.internalAccounts.selectedAccount` that is either missing or `undefined` in persisted state.

Migration 059 attempted to fix this but has a critical gap: it uses `hasProperty(internalAccounts, 'selectedAccount')` which returns `false` when the key is entirely absent (the common case after a `JSON.stringify`/`JSON.parse` roundtrip strips `undefined` values). This means migration 059 silently skips the most common form of this corruption.

**Migration 126** fixes this by:
- Detecting **both** a missing key and an explicit `undefined` value
- Reporting the exact corruption type (`key_missing`, `value_undefined`, `wrong_type_*`, `empty_string`) to Sentry for diagnostics
- Recovering by setting `selectedAccount` to the first account ID, or falling back to `''` (which `AccountsController` auto-reconciles)

Since this is migration 126 (> 107), it runs **after** `inflateFromControllers` pulls the per-controller filesystem data into `engine.backgroundState`, so it operates on the actual corrupted data regardless of its origin.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a crash caused by corrupted account selection state during app upgrade

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/11488

## **Manual testing steps**

```gherkin
Feature: Migration 126 repairs missing selectedAccount

  Scenario: user upgrades with corrupted AccountsController state
    Given the user has a persisted AccountsController state where selectedAccount key is missing from internalAccounts
    When the user upgrades to the new app version
    Then migration 126 detects the missing key and sets selectedAccount to the first account ID
    And the app starts successfully without crashing

  Scenario: user upgrades with valid AccountsController state
    Given the user has a persisted AccountsController state where selectedAccount is a valid account ID
    When the user upgrades to the new app version
    Then migration 126 is a no-op and the state is unchanged
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)