### PR TITLE
ci(nightly): fetch Apple API keys from AWS Secrets Manager

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -94,12 +94,56 @@ jobs:
     name: Upload exp to TestFlight
     needs: [build-exp]
     runs-on: ghcr.io/cirruslabs/macos-runner:sequoia-xl
-    environment: apple
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_APPLE_TESTFLIGHT }}
+          aws-region: 'us-east-2'
+
+      - name: Fetch Apple API keys from AWS Secrets Manager
+        run: |
+          echo "🔐 Fetching App Store Connect API keys from Secrets Manager..."
+          secret_id="metamask-mobile-main-apple-api-keys"
+          secret_json=$(aws secretsmanager get-secret-value \
+            --region 'us-east-2' \
+            --secret-id "$secret_id" \
+            --query SecretString \
+            --output text)
+
+          for key in APP_STORE_CONNECT_API_KEY_ISSUER_ID APP_STORE_CONNECT_API_KEY_KEY_ID; do
+            value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k] // empty')
+            if [ -z "$value" ]; then
+              echo "::error::Missing key in secret: $key"
+              exit 1
+            fi
+            echo "::add-mask::$value"
+            echo "${key}=${value}" >> "$GITHUB_ENV"
+          done
+
+          key=APP_STORE_CONNECT_API_KEY_KEY_CONTENT
+          value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k] // empty')
+          if [ -z "$value" ]; then
+            echo "::error::Missing key in secret: $key"
+            exit 1
+          fi
+          while IFS= read -r line || [ -n "$line" ]; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$(printf '%s\n' "$value")"
+
+          delim="APPLEP8$(openssl rand -hex 16)"
+          {
+            printf '%s<<%s\n' "$key" "$delim"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_ENV"
+
+          echo "✅ Apple API keys loaded from AWS"
 
       - name: Setup Ruby (iOS)
         uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb #v1
@@ -130,10 +174,6 @@ jobs:
             "$APP_STORE_CONNECT_API_KEY_ISSUER_ID" \
             "$APP_STORE_CONNECT_API_KEY_KEY_ID" \
             "$APP_STORE_CONNECT_API_KEY_KEY_CONTENT"
-        env:
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CONTENT }}
 
       - name: Upload to TestFlight
         run: |
@@ -141,8 +181,7 @@ jobs:
             "github_actions_main-exp" \
             "${{ github.ref_name }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "MetaMask BETA & Release Candidates" \
-            "false"
+            "MetaMask BETA & Release Candidates"
 
       - name: Cleanup API Key
         if: always()
@@ -154,12 +193,56 @@ jobs:
     name: Upload RC to TestFlight
     needs: [build-rc]
     runs-on: ghcr.io/cirruslabs/macos-runner:sequoia-xl
-    environment: apple
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_APPLE_TESTFLIGHT }}
+          aws-region: 'us-east-2'
+
+      - name: Fetch Apple API keys from AWS Secrets Manager
+        run: |
+          echo "🔐 Fetching App Store Connect API keys from Secrets Manager..."
+          secret_id="metamask-mobile-main-apple-api-keys"
+          secret_json=$(aws secretsmanager get-secret-value \
+            --region 'us-east-2' \
+            --secret-id "$secret_id" \
+            --query SecretString \
+            --output text)
+
+          for key in APP_STORE_CONNECT_API_KEY_ISSUER_ID APP_STORE_CONNECT_API_KEY_KEY_ID; do
+            value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k] // empty')
+            if [ -z "$value" ]; then
+              echo "::error::Missing key in secret: $key"
+              exit 1
+            fi
+            echo "::add-mask::$value"
+            echo "${key}=${value}" >> "$GITHUB_ENV"
+          done
+
+          key=APP_STORE_CONNECT_API_KEY_KEY_CONTENT
+          value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k] // empty')
+          if [ -z "$value" ]; then
+            echo "::error::Missing key in secret: $key"
+            exit 1
+          fi
+          while IFS= read -r line || [ -n "$line" ]; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$(printf '%s\n' "$value")"
+
+          delim="APPLEP8$(openssl rand -hex 16)"
+          {
+            printf '%s<<%s\n' "$key" "$delim"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_ENV"
+
+          echo "✅ Apple API keys loaded from AWS"
 
       - name: Setup Ruby (iOS)
         uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb #v1
@@ -190,21 +273,14 @@ jobs:
             "$APP_STORE_CONNECT_API_KEY_ISSUER_ID" \
             "$APP_STORE_CONNECT_API_KEY_KEY_ID" \
             "$APP_STORE_CONNECT_API_KEY_KEY_CONTENT"
-        env:
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CONTENT }}
 
       - name: Upload to TestFlight
         run: |
-          # Group arg is required as positional placeholder for the 5th arg (distribute_external=false).
-          # With distribute_external=false the build is uploaded but NOT distributed to external testers.
           bash scripts/upload-to-testflight.sh \
             "github_actions_main-rc" \
             "${{ github.ref_name }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "MetaMask BETA & Release Candidates" \
-            "false"
+            "MetaMask BETA & Release Candidates"
 
       - name: Cleanup API Key
         if: always()


### PR DESCRIPTION

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The nightly build workflow previously relied on the `apple` GitHub Environment to access Apple App Store Connect API credentials as repository secrets. This approach required a manual approval gate on the environment and did not support group-managed permissions.

This PR replaces the `environment: apple` block in both `upload-exp-testflight` and `upload-rc-testflight` jobs with an AWS-based key retrieval pattern:

1. An OIDC-backed `aws-actions/configure-aws-credentials` step assumes the `AWS_ROLE_APPLE_TESTFLIGHT` IAM role.
2. A new "Fetch Apple API keys from AWS Secrets Manager" step retrieves all three App Store Connect API key values (`ISSUER_ID`, `KEY_ID`, `KEY_CONTENT`) from the `metamask-mobile-main-apple-api-keys` secret in AWS Secrets Manager, masks each value, and writes them to `$GITHUB_ENV` for subsequent steps.
3. The `env:` block referencing `secrets.APP_STORE_CONNECT_API_KEY_*` is removed from the "Setup App Store Connect API Key" step — the variables are now available from the previous step via `$GITHUB_ENV`.
4. The hardcoded `"false"` for `distribute_external` is removed from both `upload-to-testflight.sh` calls, allowing the script's default (`true`) to apply, which enables full external distribution (submit for Beta App Review + notify external testers).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the nightly TestFlight upload jobs to assume an AWS role and pull signing credentials at runtime, which can break releases if IAM/secret formatting is wrong. Also changes TestFlight upload behavior by relying on the script default for external distribution, potentially expanding who receives nightly builds.
> 
> **Overview**
> Nightly `upload-exp-testflight` and `upload-rc-testflight` jobs now **assume an AWS role via OIDC** and **pull App Store Connect API key values from AWS Secrets Manager**, masking them and exporting into `$GITHUB_ENV` instead of using the `apple` GitHub Environment secrets.
> 
> The TestFlight upload invocation drops the explicit `distribute_external=false` argument, so `scripts/upload-to-testflight.sh` uses its default (`true`) for external distribution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17a5613c3acd5597aa575169a1c6417449311332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->