### PR TITLE
perf: Avoid full token catalog for non-withdraw flows

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useWithdrawTokenFilter.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useWithdrawTokenFilter.test.ts
@@ -111,6 +111,7 @@ function runHook({
 
 describe('useWithdrawTokenFilter', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockUseSendTokens.mockReturnValue(ALL_TOKENS_MOCK);
   });
 
@@ -292,7 +293,30 @@ describe('useWithdrawTokenFilter', () => {
     expect(filtered[0].address).toBe('0xccc');
   });
 
-  it('calls useSendTokens with includeNoBalance true', () => {
+  it('calls useSendTokens without full catalog options for non-withdraw transactions', () => {
+    runHook({ type: TransactionType.simpleSend });
+
+    expect(mockUseSendTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+      includeAllTokens: false,
+    });
+  });
+
+  it('calls useSendTokens without full catalog options when withdraw allowlist is missing', () => {
+    runHook({
+      type: TransactionType.predictWithdraw,
+      postQuoteFlags: {
+        default: { enabled: true },
+      },
+    });
+
+    expect(mockUseSendTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+      includeAllTokens: false,
+    });
+  });
+
+  it('calls useSendTokens with full catalog options when withdraw allowlist is present', () => {
     runHook({
       type: TransactionType.predictWithdraw,
       postQuoteFlags: {

--- a/app/components/Views/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/app/components/Views/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -27,19 +27,19 @@ export function useWithdrawTokenFilter(): (tokens: AssetType[]) => AssetType[] {
   const config = useSelector((state: RootState) =>
     selectPayQuoteConfig(state, transactionType),
   );
+  const allowlist = config.tokens;
+  const shouldLoadFullTokenCatalog = isWithdraw && Boolean(allowlist);
   const allTokens = useSendTokens({
-    includeNoBalance: true,
-    includeAllTokens: true,
+    includeNoBalance: shouldLoadFullTokenCatalog,
+    includeAllTokens: shouldLoadFullTokenCatalog,
   });
 
-  const allowlist = config.tokens;
-
   const filtered = useMemo(() => {
-    if (!allowlist) {
+    if (!shouldLoadFullTokenCatalog || !allowlist) {
       return undefined;
     }
     return allTokens.filter((token) => isAllowlisted(token, allowlist));
-  }, [allTokens, allowlist]);
+  }, [allTokens, allowlist, shouldLoadFullTokenCatalog]);
 
   return useCallback(
     (tokens: AssetType[]): AssetType[] => {


### PR DESCRIPTION
## **Description**
Avoids full token catalog for non-withdraw flows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1067

## **Manual testing steps**
1. Predict and Perps deposit pages load faster now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes when `useSendTokens` loads the full token catalog, and is gated to withdraw flows with an allowlist; main risk is missing allowlisted tokens if the gating condition is wrong.
> 
> **Overview**
> **Improves token list performance for non-withdraw flows** by avoiding loading the full token catalog via `useSendTokens` unless the current transaction is a pay-withdraw *and* a withdraw allowlist (`config.tokens`) is configured.
> 
> Updates `useWithdrawTokenFilter` to conditionally enable `includeNoBalance`/`includeAllTokens`, and extends tests to assert the new `useSendTokens` call behavior (including clearing mocks between cases).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82a19fc352410042e5208cb3f9e15b6153abb340. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->