### PR TITLE
fix: enhance removeAbortFilter to handle late async abort events in CI

### DIFF
--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -538,8 +538,14 @@ export default class MockServerE2E implements Resource {
   /**
    * Removes the lifecycle-wide abort filter. Call this AFTER all cleanup is
    * complete to ensure late async "Aborted" rejections are caught.
+   *
+   * This method is intentionally async: CI logs show abort events firing up to
+   * ~200ms AFTER all cleanup has completed and this method is called. We hold
+   * the filter active for an extra 500ms before restoring Jest's handlers so
+   * those stragglers are still suppressed rather than recorded as test failures.
    */
-  removeAbortFilter(): void {
+  async removeAbortFilter(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 500));
     this._removeAbortFilter();
   }
 

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -792,9 +792,12 @@ export async function withFixtures(
 
     // Remove the abort filter AFTER all cleanup is complete so late async
     // "Aborted" rejections from destroyed sockets are still caught.
+    // removeAbortFilter() is async — it holds the filter active for an extra
+    // 500ms before restoring Jest's handlers to cover abort events that fire
+    // after all cleanup has completed (observed up to ~200ms on loaded CI).
     if (mockServerInstance) {
       logger.info('Removing abort filter after full cleanup');
-      mockServerInstance.removeAbortFilter();
+      await mockServerInstance.removeAbortFilter();
     }
 
     // Handle error reporting: prioritize test error over cleanup errors

--- a/tests/framework/fixtures/FixtureUtils.ts
+++ b/tests/framework/fixtures/FixtureUtils.ts
@@ -143,78 +143,102 @@ async function setupAndroidPortForwarding(
   actualPort: number,
   instanceIndex?: number,
 ): Promise<void> {
-  try {
-    // Only set up port forwarding on Android
-    if (!(await PlatformDetector.isAndroid())) {
-      return;
-    }
+  // Only set up port forwarding on Android
+  if (!(await PlatformDetector.isAndroid())) {
+    return;
+  }
 
-    // Skip adb reverse on BrowserStack - BrowserStack Local tunnel handles port forwarding
-    if (isBrowserStack()) {
-      logger.info(
-        `BrowserStack mode: Skipping adb reverse for ${resourceType} (port ${actualPort} forwarded via tunnel)`,
+  // Skip adb reverse on BrowserStack - BrowserStack Local tunnel handles port forwarding
+  if (isBrowserStack()) {
+    logger.info(
+      `BrowserStack mode: Skipping adb reverse for ${resourceType} (port ${actualPort} forwarded via tunnel)`,
+    );
+    return;
+  }
+
+  // Forward all dynamically allocated ports that the app needs to access
+  // - LaunchArgs ports: Android doesn't support LaunchArgs, needs adb reverse
+  // - Dapp servers: Browser navigation bypasses MockServer, needs adb reverse
+  // - Ganache/Anvil: Even though fixture is updated, some code paths may use fallback ports
+  const forwardedResources = [
+    ResourceType.FIXTURE_SERVER,
+    ResourceType.COMMAND_QUEUE_SERVER,
+    ResourceType.MOCK_SERVER,
+    ResourceType.DAPP_SERVER,
+    ResourceType.GANACHE,
+    ResourceType.ANVIL,
+    ResourceType.ACCOUNT_ACTIVITY_WS,
+  ];
+
+  if (!forwardedResources.includes(resourceType)) {
+    return;
+  }
+
+  // Calculate the correct fallback port for multi-instance resources
+  let fallbackPort = getFallbackPort(resourceType);
+  if (
+    resourceType === ResourceType.DAPP_SERVER &&
+    instanceIndex !== undefined
+  ) {
+    fallbackPort += instanceIndex;
+  }
+
+  // Get device ID to target specific device (important for CI with multiple devices)
+  // In Detox: use device.id for multi-device support
+  // In Appium/Playwright: skip device flag (single emulator assumption)
+  let deviceFlag = '';
+  if (FrameworkDetector.isDetox()) {
+    const deviceId = device.id || '';
+    deviceFlag = deviceId ? `-s ${deviceId}` : '';
+  }
+
+  const command = `adb ${deviceFlag} reverse tcp:${fallbackPort} tcp:${actualPort}`;
+
+  // Retry on transient device-offline/not-found errors (common on CI when the
+  // emulator is still initialising between tests). Three attempts with 2 s gaps
+  // cover most boot-delay scenarios without adding significant wait time.
+  const maxAdbRetries = 3;
+  const adbRetryDelayMs = 2000;
+
+  for (let attempt = 1; attempt <= maxAdbRetries; attempt++) {
+    try {
+      logger.debug(`Executing port forward (attempt ${attempt}): ${command}`);
+      const { stdout, stderr } = await execAsync(command);
+
+      if (stderr && !stderr.includes('')) {
+        logger.warn(`adb reverse stderr: ${stderr}`);
+      }
+      if (stdout) {
+        logger.debug(`adb reverse stdout: ${stdout}`);
+      }
+
+      logger.debug(
+        `✓ Android port forwarding: ${fallbackPort} → ${actualPort} (${resourceType}${instanceIndex !== undefined ? `:${instanceIndex}` : ''})`,
       );
-      return;
+      return; // success
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      const isDeviceOffline =
+        errorMessage.includes('not found') ||
+        errorMessage.includes('device offline') ||
+        errorMessage.includes('unauthorized');
+
+      if (isDeviceOffline && attempt < maxAdbRetries) {
+        logger.warn(
+          `adb reverse failed (attempt ${attempt}/${maxAdbRetries}) — device not yet reachable: ${errorMessage}. Retrying in ${adbRetryDelayMs}ms…`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, adbRetryDelayMs));
+        continue;
+      }
+
+      logger.error(
+        `Failed to set up Android port forwarding for ${resourceType}: ${errorMessage}`,
+      );
+      logger.error('Error details:', error);
+      throw error;
     }
-
-    // Forward all dynamically allocated ports that the app needs to access
-    // - LaunchArgs ports: Android doesn't support LaunchArgs, needs adb reverse
-    // - Dapp servers: Browser navigation bypasses MockServer, needs adb reverse
-    // - Ganache/Anvil: Even though fixture is updated, some code paths may use fallback ports
-    const forwardedResources = [
-      ResourceType.FIXTURE_SERVER,
-      ResourceType.COMMAND_QUEUE_SERVER,
-      ResourceType.MOCK_SERVER,
-      ResourceType.DAPP_SERVER,
-      ResourceType.GANACHE,
-      ResourceType.ANVIL,
-      ResourceType.ACCOUNT_ACTIVITY_WS,
-    ];
-
-    if (!forwardedResources.includes(resourceType)) {
-      return;
-    }
-
-    // Calculate the correct fallback port for multi-instance resources
-    let fallbackPort = getFallbackPort(resourceType);
-    if (
-      resourceType === ResourceType.DAPP_SERVER &&
-      instanceIndex !== undefined
-    ) {
-      fallbackPort += instanceIndex;
-    }
-
-    // Get device ID to target specific device (important for CI with multiple devices)
-    // In Detox: use device.id for multi-device support
-    // In Appium/Playwright: skip device flag (single emulator assumption)
-    let deviceFlag = '';
-    if (FrameworkDetector.isDetox()) {
-      const deviceId = device.id || '';
-      deviceFlag = deviceId ? `-s ${deviceId}` : '';
-    }
-
-    const command = `adb ${deviceFlag} reverse tcp:${fallbackPort} tcp:${actualPort}`;
-
-    logger.debug(`Executing port forward: ${command}`);
-    const { stdout, stderr } = await execAsync(command);
-
-    if (stderr && !stderr.includes('')) {
-      logger.warn(`adb reverse stderr: ${stderr}`);
-    }
-    if (stdout) {
-      logger.debug(`adb reverse stdout: ${stdout}`);
-    }
-
-    logger.debug(
-      `✓ Android port forwarding: ${fallbackPort} → ${actualPort} (${resourceType}${instanceIndex !== undefined ? `:${instanceIndex}` : ''})`,
-    );
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.error(
-      `Failed to set up Android port forwarding for ${resourceType}: ${errorMessage}`,
-    );
-    logger.error('Error details:', error);
-    throw error;
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes two recurring CI failures affecting Android and iOS E2E smoke suites.                                                       
                                                                                                                                    
  ### Fix 1: Mockttp `Aborted` errors failing tests after filter removal                                                            
                                                            
  **Root cause:** CI logs showed abort events firing ~180ms *after* `removeAbortFilter()` was called and Jest's original handlers   
  were restored:                                            
                                                                                                                                    
  17:47:54.898  Abort filter removed — suppressed 0 mockttp "Aborted" error(s)                                                      
  17:47:55.082  Aborted at IncomingMessage.failWithAbortError  ← 184ms later
                                                                                                                                    
  The existing 500ms drain inside `stop()` did not help because it runs *before* `removeAbortFilter()`. On loaded CI runners (4 CPUs
   at 100%), the Node.js event loop delays abort events from destroyed sockets beyond the drain window. By the time                 
  `removeAbortFilter()` restored Jest's handlers, the queued events fired straight into Jest as test failures.
                                                                                                                                    
  **Fix:** `removeAbortFilter()` is now `async` and waits 500ms before restoring Jest's handlers (`MockServerE2E.ts`).              
  `withFixtures` now `await`s the call (`FixtureHelper.ts`). Abort events observed at up to ~200ms fire during the 500ms hold window
   and are suppressed by the still-active filter.                                                                                   
                                                            
  ### Fix 2: Android `adb: device 'emulator-XXXX' not found` crashing tests                                                         
  
  **Root cause:** On CI, emulators occasionally go offline between tests (still booting, brief crash-recovery).                     
  `setupAndroidPortForwarding` had no retry logic — any `adb reverse` failure was immediately rethrown, propagating through
  `startResourceWithRetry` → `handleLocalNodes` → `withFixtures` and killing the test before it started.                            
                                                            
  Failed to set up Android port forwarding for anvil:                                                                               
    adb: device 'emulator-10342' not found
  Failed to start anvil after 0 attempts                                                                                            
  Error in withFixtures: Command failed: adb -s emulator-10342 reverse tcp:8545 tcp:55324                                           
                                                                                                                                    
  **Fix:** `setupAndroidPortForwarding` now retries up to 3 times (2s apart) when the error indicates the device is transiently     
  unreachable (`not found`, `device offline`, `unauthorized`). Persistent failures still fail the test after exhausting retries.    
                                                            
  ## Files changed                                                                                                                  
                                                            
  | File | Change |                                                                                                                 
  |------|--------|                                         
  | `tests/api-mocking/MockServerE2E.ts` | `removeAbortFilter()` made async with 500ms pre-restore delay |
  | `tests/framework/fixtures/FixtureHelper.ts` | `await mockServerInstance.removeAbortFilter()` |                                  
  | `tests/framework/fixtures/FixtureUtils.ts` | Retry loop (3×, 2s) in `setupAndroidPortForwarding` for device-offline errors |  

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes E2E fixture cleanup timing (adds an awaited 500ms delay) and introduces retry behavior around `adb reverse`, which can mask persistent device issues if misclassified but is limited to specific error strings and test infrastructure.
> 
> **Overview**
> Reduces flaky E2E CI failures by making `MockServerE2E.removeAbortFilter()` async and delaying restoration of Jest handlers by 500ms, then updating `withFixtures` cleanup to `await` it so late `mockttp` "Aborted" events don’t fail tests.
> 
> Improves Android stability by adding a 3-attempt (2s backoff) retry loop around `adb reverse` in `setupAndroidPortForwarding` when devices are transiently unreachable (e.g., "not found"/"device offline"/"unauthorized"), while keeping non-transient failures fatal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e136696407c74b9d45dea9a2b5547cced0af2304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->