### PR TITLE
feat: enhance TransactionsFooter to dynamically display block explorer names

### DIFF
--- a/app/components/UI/Transactions/TransactionsFooter.test.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.test.tsx
@@ -105,6 +105,7 @@ describe('TransactionsFooter', () => {
   describe('EVM Chain Block Explorer', () => {
     it('renders Etherscan button for mainnet', () => {
       mockIsMainnetByChainId.mockReturnValue(true);
+      mockGetBlockExplorerName.mockReturnValue('Etherscan');
 
       const { getByText } = render(
         <TransactionsFooter
@@ -120,6 +121,7 @@ describe('TransactionsFooter', () => {
 
     it('renders Etherscan button for non-RPC networks', () => {
       mockIsMainnetByChainId.mockReturnValue(false);
+      mockGetBlockExplorerName.mockReturnValue('Etherscan');
 
       const { getByText } = render(
         <TransactionsFooter
@@ -147,6 +149,22 @@ describe('TransactionsFooter', () => {
       );
 
       expect(getByText('View full history on Custom Explorer')).toBeTruthy();
+    });
+
+    it('uses explorer URL for label when chainId does not match global providerType', () => {
+      mockIsMainnetByChainId.mockReturnValue(false);
+      mockGetBlockExplorerName.mockReturnValue('Gnosisscan');
+
+      const { getByText } = render(
+        <TransactionsFooter
+          chainId="0x64"
+          providerType="mainnet"
+          rpcBlockExplorer="https://gnosisscan.io"
+          onViewBlockExplorer={mockOnViewBlockExplorer}
+        />,
+      );
+
+      expect(getByText('View full history on Gnosisscan')).toBeTruthy();
     });
 
     it('hides button for RPC networks without block explorer', () => {
@@ -180,6 +198,7 @@ describe('TransactionsFooter', () => {
 
     it('calls onViewBlockExplorer when button is pressed', () => {
       mockIsMainnetByChainId.mockReturnValue(true);
+      mockGetBlockExplorerName.mockReturnValue('Etherscan');
 
       const { getByText } = render(
         <TransactionsFooter
@@ -314,6 +333,7 @@ describe('TransactionsFooter', () => {
 
     it('renders both button and disclaimer when both conditions are met', () => {
       mockIsMainnetByChainId.mockReturnValue(true);
+      mockGetBlockExplorerName.mockReturnValue('Etherscan');
 
       const { getByText } = render(
         <TransactionsFooter
@@ -404,6 +424,7 @@ describe('TransactionsFooter', () => {
   describe('Component Structure', () => {
     it('renders with correct structure when both elements are present', () => {
       mockIsMainnetByChainId.mockReturnValue(true);
+      mockGetBlockExplorerName.mockReturnValue('Etherscan');
 
       const { getByText } = render(
         <TransactionsFooter

--- a/app/components/UI/Transactions/TransactionsFooter.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.tsx
@@ -93,14 +93,20 @@ const TransactionsFooter = ({
       return null;
     }
 
-    if (isMainnetByChainId(chainId) || (providerType && providerType !== RPC)) {
-      return strings('transactions.view_full_history_on_etherscan');
+    // Prefer deriving the label from the explorer URL when present. Unified
+    // activity can pass chainId for one enabled network while providerType
+    // reflects the globally selected network — the URL matches the list we show.
+    if (rpcBlockExplorer && rpcBlockExplorer !== NO_RPC_BLOCK_EXPLORER) {
+      const explorerName = getBlockExplorerName(rpcBlockExplorer);
+      if (explorerName) {
+        return `${strings(
+          'transactions.view_full_history_on',
+        )} ${explorerName}`;
+      }
     }
 
-    if (rpcBlockExplorer && rpcBlockExplorer !== NO_RPC_BLOCK_EXPLORER) {
-      return `${strings(
-        'transactions.view_full_history_on',
-      )} ${getBlockExplorerName(rpcBlockExplorer)}`;
+    if (isMainnetByChainId(chainId) || (providerType && providerType !== RPC)) {
+      return strings('transactions.view_full_history_on_etherscan');
     }
 
     return null;

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -10,6 +10,7 @@ import { RefreshControl, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
+import { RPC } from '../../../constants/network';
 import {
   selectSelectedInternalAccount,
   selectInternalAccounts,
@@ -423,7 +424,7 @@ const UnifiedTransactionsView = ({
     let title;
     if (configBlockExplorerUrl) {
       const result = getBlockExplorerAddressUrl(
-        providerType,
+        RPC,
         selectedAccountGroupEvmAddress,
         blockExplorerUrl,
       );
@@ -449,7 +450,6 @@ const UnifiedTransactionsView = ({
     });
   }, [
     navigation,
-    providerType,
     blockExplorerUrl,
     selectedAccountGroupEvmAddress,
     popularListBlockExplorer,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On the activity (unified transactions) view, the “View full history on …” footer could show the wrong explorer name for custom or non-selected networks: `TransactionsFooter` preferred the hardcoded Etherscan string using **global** `providerType` before using the explorer URL, while `chainId` / `rpcBlockExplorer` reflected the **enabled** network for the list—so the label could say Etherscan even when the configured explorer was e.g. Gnosisscan.

Separately, “View full history” navigation used `getBlockExplorerAddressUrl(providerType, …)` when a network config block explorer existed. That helper only applies the configured base URL when `networkType === RPC`; otherwise it builds an Etherscan URL from `providerType`. If the wallet’s selected network did not match the activity list’s chain, the link opened the wrong explorer.

**Solution:** Derive the footer label from `rpcBlockExplorer` when present (before the Etherscan shortcut). For unified activity, build the address URL with `getBlockExplorerAddressUrl(RPC, address, blockExplorerUrl)` whenever the explorer comes from `networkConfigurationsByChainId`, so the opened URL always matches the configured explorer for that chain.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed incorrect block explorer name and link on the activity “View full history” action for custom networks when the selected wallet network did not match the activity chain

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19233

## **Manual testing steps**

```gherkin
Feature: Activity view block explorer footer

  Scenario: Custom network shows correct explorer name and opens matching URL
    Given a custom EVM network is added with a non-Etherscan block explorer URL (e.g. Gnosis Chain with gnosisscan.io)
    And that network is enabled for the account and its activity is visible on the Activity tab
    And a different EVM network is selected in the network picker (e.g. Ethereum mainnet)

    When user opens the Activity tab and scrolls to the “View full history on …” link at the bottom

    Then the link text uses the explorer derived from the activity chain’s block explorer (not “Etherscan” unless appropriate)

    When user taps the link

    Then the in-app webview opens the account page on that chain’s block explorer base URL (same host as configured), not Ethereum Etherscan
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="399" height="832" alt="Screenshot 2026-03-20 at 13 41 58" src="https://github.com/user-attachments/assets/d578df27-3c3b-407e-b8c4-17ae8bdf1943" />
<img width="393" height="841" alt="Screenshot 2026-03-20 at 13 42 03" src="https://github.com/user-attachments/assets/6fa4a56a-ff8f-45b3-bd95-08bf629a7b3c" />

<!-- [screenshots/recordings] -->

### **After**
<img width="394" height="839" alt="Screenshot 2026-03-20 at 13 40 29" src="https://github.com/user-attachments/assets/fc6298c8-2ce8-4c8a-a992-d566372c5e2c" />
<img width="395" height="842" alt="Screenshot 2026-03-20 at 13 40 34" src="https://github.com/user-attachments/assets/f1f51bac-ff77-472b-a42b-c01967ed75b2" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation tweak that only changes how the block explorer label and destination URL are derived; main potential regression is incorrect/missing explorer link text if `rpcBlockExplorer` parsing fails.
> 
> **Overview**
> Fixes the Activity/Unified Transactions footer to **derive the “View full history on …” label from the provided `rpcBlockExplorer` URL first**, instead of prematurely falling back to the hardcoded Etherscan string when `providerType` reflects a different globally-selected network.
> 
> Updates unified activity’s “view block explorer” navigation to build address links via `getBlockExplorerAddressUrl(RPC, ...)` when a per-chain configured explorer exists, ensuring the opened webview matches the enabled chain’s configured explorer. Adds/updates unit tests to cover the mismatched `chainId` vs global `providerType` label case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99228cfd413407d1ef786dad3bdfaeec37f61f79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->