### PR TITLE
fix: cash and token rows have different bold

### DIFF
--- a/app/components/UI/Earn/hooks/useMusdBalance.ts
+++ b/app/components/UI/Earn/hooks/useMusdBalance.ts
@@ -16,7 +16,7 @@ import { selectNetworkConfigurations } from '../../../../selectors/networkContro
 import { fromTokenMinimalUnitString } from '../../../../util/number';
 import BigNumber from 'bignumber.js';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import I18n from '../../../../../locales/i18n';
+import { getLocaleLanguageCode } from '../../../hooks/useFormatters';
 import { formatWithThreshold } from '../../../../util/assets';
 
 const SUPPORTED_MUSD_CHAIN_IDS = [
@@ -127,7 +127,7 @@ export const useMusdBalance = () => {
       fiatBalanceFormattedResult[chainId] = formatWithThreshold(
         fiatValue.toNumber(),
         0.01,
-        I18n.locale,
+        getLocaleLanguageCode(),
         {
           style: 'currency',
           currency: currentCurrency,
@@ -142,11 +142,16 @@ export const useMusdBalance = () => {
     const fiatBalanceAggregatedString = fiatBalanceTotal?.toFixed();
     const fiatBalanceAggregatedFormattedString =
       fiatBalanceTotal && currentCurrency
-        ? formatWithThreshold(fiatBalanceTotal.toNumber(), 0.01, I18n.locale, {
-            style: 'currency',
-            currency: currentCurrency,
-          })
-        : formatWithThreshold(0, 0.01, I18n.locale, {
+        ? formatWithThreshold(
+            fiatBalanceTotal.toNumber(),
+            0.01,
+            getLocaleLanguageCode(),
+            {
+              style: 'currency',
+              currency: currentCurrency,
+            },
+          )
+        : formatWithThreshold(0, 0.01, getLocaleLanguageCode(), {
             style: 'currency',
             currency: (currentCurrency ?? 'USD').toUpperCase(),
           });

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -116,18 +116,19 @@ const MusdAggregatedRow = () => {
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
-        twClassName="flex-1 gap-5"
+        twClassName="flex-1"
       >
         <AvatarToken
           name={MUSD_TOKEN.symbol}
           src={MUSD_TOKEN.imageSource as number}
           size={AvatarTokenSize.Lg}
         />
-        <Box twClassName="flex-1 gap-0.5">
+        {/* Same two-line layout / typography as TokenListItemV2 (flex-1 ml-5, BodyMDMedium fiat). */}
+        <Box twClassName="flex-1 ml-5">
           <Box
             flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
             justifyContent={BoxJustifyContent.Between}
+            twClassName="gap-2.5"
           >
             <Text
               variant={TextVariant.BodyMd}
@@ -137,7 +138,7 @@ const MusdAggregatedRow = () => {
               {MUSD_TOKEN.name}
             </Text>
             <SensitiveText
-              variant={CLTextVariant.BodyMDBold}
+              variant={CLTextVariant.BodyMDMedium}
               isHidden={privacyMode}
               length={SensitiveTextLength.Medium}
             >
@@ -146,35 +147,40 @@ const MusdAggregatedRow = () => {
           </Box>
           <Box
             flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
             justifyContent={BoxJustifyContent.Between}
+            twClassName="gap-2.5"
           >
-            {isClaiming ? (
-              <AnimatedSpinner size={SpinnerSize.SM} />
-            ) : hasClaimableBonus ? (
-              <Pressable
-                onPress={handleClaimBonus}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+            >
+              {isClaiming ? (
+                <AnimatedSpinner size={SpinnerSize.SM} />
+              ) : hasClaimableBonus ? (
+                <Pressable
+                  onPress={handleClaimBonus}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
+                  <Text
+                    variant={TextVariant.BodySm}
+                    fontWeight={FontWeight.Medium}
+                    color={TextColor.PrimaryDefault}
+                  >
+                    {strings('earn.claim_bonus')}
+                  </Text>
+                </Pressable>
+              ) : (
                 <Text
                   variant={TextVariant.BodySm}
                   fontWeight={FontWeight.Medium}
-                  color={TextColor.PrimaryDefault}
+                  color={TextColor.SuccessDefault}
                 >
-                  {strings('earn.claim_bonus')}
+                  {strings('earn.musd_conversion.percentage_bonus', {
+                    percentage: MUSD_CONVERSION_APY,
+                  })}
                 </Text>
-              </Pressable>
-            ) : (
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.SuccessDefault}
-              >
-                {strings('earn.musd_conversion.percentage_bonus', {
-                  percentage: MUSD_CONVERSION_APY,
-                })}
-              </Text>
-            )}
+              )}
+            </Box>
             <SensitiveText
               variant={CLTextVariant.BodySMMedium}
               color={CLTextColor.Alternative}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. **Typography:** The homepage Cash section mUSD row showed the aggregated fiat value in bold (`BodyMDBold`), while token list rows (`TokenListItemV2`) use medium weight for primary fiat (`BodyMDMedium`), so Cash looked heavier than the rest of the wallet.
2. **Layout:** Spacing and structure (`gap-5` vs avatar, `gap-0.5` between lines) did not match the two-line token row pattern (`flex-1 ml-5`, `gap-2.5` on each row).
3. **Fiat strings:** `useMusdBalance` formatted currency with `I18n.locale` (e.g. `en-US`). Token `balanceFiat` uses `formatWithThreshold` with `getLocaleLanguageCode()` elsewhere in the assets flow. That mismatch could produce inconsistent currency symbols (e.g. `US$` vs `$`) between Cash and token rows.

**Solution**

- **`MusdAggregatedRow`:** Match `TokenListItemV2`’s text column: `flex-1 ml-5`, two rows with `justifyContent={Between}` and `twClassName="gap-2.5"`; primary fiat uses `BodyMDMedium`; the second row wraps claim / spinner / APY in an inner `Box` so the token amount stays right-aligned like the list.
- **`useMusdBalance`:** Replace `I18n.locale` with `getLocaleLanguageCode()` for all `formatWithThreshold` fiat formatting (per-chain and aggregated) so Cash uses the same locale strategy as token fiat balances.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Cash (mUSD) row typography and layout to match the token list and aligned aggregated mUSD fiat formatting with token balance locale handling.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-579

## **Manual testing steps**

```gherkin
Feature: Cash mUSD row matches token list

  Scenario: Primary fiat weight matches token rows
    Given the user sees the Cash section with mUSD balance (Homepage sections enabled, eligible for Cash)
    When they view the mUSD row
    Then the aggregated fiat amount uses medium weight (same as token list fiat), not bold

  Scenario: Layout and spacing align with token list rows
    Given the same Cash mUSD row is visible
    When comparing to any token row in the token list
    Then the two-line layout (title + fiat on first row; secondary info + token amount on second) and spacing feel consistent

  Scenario: Fiat symbol matches token list formatting
    Given primary currency is USD and device locale is set (e.g. en-US)
    When viewing Cash aggregated fiat and a token’s fiat balance on the same screen
    Then both use the same currency symbol style (e.g. $ consistently, not US$ on Cash only)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="393" height="837" alt="Screenshot 2026-03-20 at 13 14 17" src="https://github.com/user-attachments/assets/9fe95f9c-1eb0-4066-a011-85c897a27f63" />

<!-- [screenshots/recordings] -->

### **After**
<img width="395" height="835" alt="Screenshot 2026-03-20 at 13 10 50" src="https://github.com/user-attachments/assets/e402979c-87f8-4e82-aeaa-4f60c0e014ff" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/formatting changes: adjusts Cash mUSD row layout/typography and switches fiat formatting locale helper; no business logic or data flows are changed beyond display formatting.
> 
> **Overview**
> Updates the Homepage Cash section’s mUSD aggregated row to visually match `TokenListItemV2`, including spacing, two-line structure, and changing the primary fiat amount from bold to medium weight while keeping the right-side token amount aligned.
> 
> Standardizes mUSD fiat formatting in `useMusdBalance` by replacing `I18n.locale` with `getLocaleLanguageCode()` for per-chain and aggregated `formatWithThreshold` calls, aligning currency symbol/locale behavior with token list fiat displays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8305a4431345e59d1755f7ec851a3d825a869fb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->