### PR TITLE
fix(ramps): Preserve user-entered amount during Transak navigation reset -> cp-7.71.0

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -760,7 +760,7 @@ describe('BuildQuote', () => {
         '/payments/debit-credit-card',
         '100',
       );
-      expect(mockRouteAfterAuth).toHaveBeenCalledWith(MOCK_TRANSAK_QUOTE);
+      expect(mockRouteAfterAuth).toHaveBeenCalledWith(MOCK_TRANSAK_QUOTE, 100);
     });
 
     it('navigates to VerifyIdentity when user has no token', async () => {

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -402,6 +402,41 @@ describe('BuildQuote', () => {
     });
   });
 
+  describe('amount param initialization', () => {
+    it('uses DEFAULT_AMOUNT (100) when no amount param is provided', () => {
+      mockUseParams.mockReturnValue({});
+
+      const { getByTestId } = renderWithProvider(<BuildQuote />, {
+        state: initialRootState,
+      });
+
+      const amountInput = getByTestId(BuildQuoteSelectors.AMOUNT_INPUT);
+      expect(amountInput.props.children).toContain('100');
+    });
+
+    it('uses amount param as initial value when provided via route params', () => {
+      mockUseParams.mockReturnValue({ amount: 30 });
+
+      const { getByTestId } = renderWithProvider(<BuildQuote />, {
+        state: initialRootState,
+      });
+
+      const amountInput = getByTestId(BuildQuoteSelectors.AMOUNT_INPUT);
+      expect(amountInput.props.children).toContain('30');
+    });
+
+    it('does not override amount with region default when amount param is provided', () => {
+      mockUseParams.mockReturnValue({ amount: 50 });
+
+      const { getByTestId } = renderWithProvider(<BuildQuote />, {
+        state: initialRootState,
+      });
+
+      const amountInput = getByTestId(BuildQuoteSelectors.AMOUNT_INPUT);
+      expect(amountInput.props.children).toContain('50');
+    });
+  });
+
   describe('navigateAfterExternalBrowser', () => {
     it('resets to BuildQuote when returnDestination is buildQuote (Android external browser path)', async () => {
       mockDeviceIsAndroid.mockReturnValue(true);

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -579,7 +579,7 @@ function BuildQuote() {
         if (!quote) {
           throw new Error(strings('deposit.buildQuote.unexpectedError'));
         }
-        await transakRouteAfterAuth(quote);
+        await transakRouteAfterAuth(quote, amountAsNumber);
       } else {
         navigation.navigate(
           ...createV2VerifyIdentityNavDetails({

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -109,6 +109,8 @@ export interface BuildQuoteParams {
   nativeFlowError?: string;
   /** Which flow the user used to enter the Buy screen. */
   buyFlowOrigin?: BuyFlowOrigin;
+  /** Pre-fill the amount input (e.g. when restoring state after a navigation reset). */
+  amount?: number;
 }
 
 /**
@@ -148,13 +150,17 @@ function BuildQuote() {
   const { formatCurrency } = useFormatters();
   const cursorOpacity = useBlinkingCursor();
 
-  const [amount, setAmount] = useState<string>(() => String(DEFAULT_AMOUNT));
-  const [amountAsNumber, setAmountAsNumber] = useState<number>(DEFAULT_AMOUNT);
-  const [userHasEnteredAmount, setUserHasEnteredAmount] = useState(false);
+  const params = useParams<BuildQuoteParams>();
+  const initialAmount = params?.amount ?? DEFAULT_AMOUNT;
+
+  const [amount, setAmount] = useState<string>(() => String(initialAmount));
+  const [amountAsNumber, setAmountAsNumber] = useState<number>(initialAmount);
+  const [userHasEnteredAmount, setUserHasEnteredAmount] = useState(
+    params?.amount != null,
+  );
   const [keyboardIsDirty, setKeyboardIsDirty] = useState(false);
   const [isContinueLoading, setIsContinueLoading] = useState(false);
   const [rampsError, setRampsError] = useState<string | null>(null);
-  const params = useParams<BuildQuoteParams>();
 
   useEffect(() => {
     if (params?.nativeFlowError) {

--- a/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx
@@ -71,6 +71,7 @@ describe('V2AdditionalVerification', () => {
 
     expect(mockNavigateToKycWebview).toHaveBeenCalledWith({
       kycUrl: 'https://kyc.example.com',
+      amount: 100,
     });
   });
 

--- a/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.tsx
@@ -27,7 +27,7 @@ interface V2AdditionalVerificationParams {
 
 const V2AdditionalVerification = () => {
   const navigation = useNavigation();
-  const { kycUrl } = useParams<V2AdditionalVerificationParams>();
+  const { kycUrl, quote } = useParams<V2AdditionalVerificationParams>();
 
   const { styles, theme } = useStyles(styleSheet, {});
 
@@ -46,8 +46,8 @@ const V2AdditionalVerification = () => {
   }, [navigation, theme]);
 
   const handleContinuePress = useCallback(() => {
-    navigateToKycWebview({ kycUrl });
-  }, [navigateToKycWebview, kycUrl]);
+    navigateToKycWebview({ kycUrl, amount: quote?.fiatAmount });
+  }, [navigateToKycWebview, kycUrl, quote?.fiatAmount]);
 
   return (
     <ScreenLayout>

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -223,7 +223,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockReset).toHaveBeenCalledWith(
@@ -270,7 +273,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockRequestOtt).toHaveBeenCalled();
@@ -334,7 +340,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockTransakCreateOrder).toHaveBeenCalledWith(
@@ -367,7 +376,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockReset).toHaveBeenCalledWith(
@@ -398,7 +410,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockLogoutFromProvider).toHaveBeenCalledWith(false);
@@ -432,7 +447,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockSubmitPurposeOfUsageForm).toHaveBeenCalledWith([
@@ -464,7 +482,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockReset).toHaveBeenCalledWith(
@@ -505,7 +526,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -527,7 +551,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -549,7 +576,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -572,7 +602,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockRequestOtt).toHaveBeenCalled();
@@ -598,7 +631,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockRequestOtt).toHaveBeenCalled();
@@ -618,7 +654,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -634,7 +673,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -655,7 +697,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockReset).toHaveBeenCalledWith(
@@ -685,7 +730,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -708,7 +756,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -732,7 +783,10 @@ describe('useTransakRouting', () => {
 
       await expect(
         act(async () => {
-          await result.current.routeAfterAuthentication(mockQuote as never);
+          await result.current.routeAfterAuthentication(
+            mockQuote as never,
+            mockQuote.fiatAmount,
+          );
         }),
       ).rejects.toThrow();
     });
@@ -755,7 +809,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       expect(mockRequestOtt).toHaveBeenCalled();
@@ -767,7 +824,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       act(() => {
-        result.current.navigateToVerifyIdentity({ quote: mockQuote as never });
+        result.current.navigateToVerifyIdentity({
+          quote: mockQuote as never,
+          amount: 30,
+        });
       });
 
       expect(mockReset).toHaveBeenCalledWith(
@@ -776,7 +836,7 @@ describe('useTransakRouting', () => {
           routes: [
             expect.objectContaining({
               name: 'RampAmountInput',
-              params: { amount: mockQuote.fiatAmount },
+              params: { amount: 30 },
             }),
             expect.objectContaining({
               name: 'RampVerifyIdentity',
@@ -844,7 +904,10 @@ describe('useTransakRouting', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       await act(async () => {
-        await result.current.routeAfterAuthentication(mockQuote as never);
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
       });
 
       return capturedHandleNavigationStateChange;

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -230,7 +230,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: mockQuote.fiatAmount },
+            }),
             expect.objectContaining({
               name: 'RampBasicInfo',
               params: expect.objectContaining({ quote: mockQuote }),
@@ -281,7 +284,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: mockQuote.fiatAmount },
+            }),
             expect.objectContaining({
               name: 'Checkout',
               params: expect.objectContaining({
@@ -368,7 +374,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: mockQuote.fiatAmount },
+            }),
             expect.objectContaining({
               name: 'RampKycProcessing',
               params: expect.objectContaining({ quote: mockQuote }),
@@ -462,7 +471,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: mockQuote.fiatAmount },
+            }),
             expect.objectContaining({
               name: 'RampAdditionalVerification',
               params: expect.objectContaining({
@@ -650,7 +662,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: mockQuote.fiatAmount },
+            }),
             expect.objectContaining({
               name: 'RampKycProcessing',
             }),
@@ -759,7 +774,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: mockQuote.fiatAmount },
+            }),
             expect.objectContaining({
               name: 'RampVerifyIdentity',
               params: expect.objectContaining({ quote: mockQuote }),
@@ -771,12 +789,13 @@ describe('useTransakRouting', () => {
   });
 
   describe('navigateToKycWebview', () => {
-    it('resets navigation stack to the KYC webview', () => {
+    it('resets navigation stack to the KYC webview with amount preserved', () => {
       const { result } = renderHook(() => useTransakRouting());
 
       act(() => {
         result.current.navigateToKycWebview({
           kycUrl: 'https://kyc.example.com',
+          amount: 30,
         });
       });
 
@@ -784,7 +803,10 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           index: 1,
           routes: [
-            expect.objectContaining({ name: 'RampAmountInput' }),
+            expect.objectContaining({
+              name: 'RampAmountInput',
+              params: { amount: 30 },
+            }),
             expect.objectContaining({
               name: 'Checkout',
               params: expect.objectContaining({

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -163,7 +163,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       navigation.reset({
         index: 1,
         routes: [
-          { name: Routes.RAMP.AMOUNT_INPUT },
+          {
+            name: Routes.RAMP.AMOUNT_INPUT,
+            params: { amount: quote.fiatAmount },
+          },
           { name: Routes.RAMP.VERIFY_IDENTITY, params: { quote } },
         ],
       });
@@ -182,7 +185,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       navigation.reset({
         index: 1,
         routes: [
-          { name: Routes.RAMP.AMOUNT_INPUT },
+          {
+            name: Routes.RAMP.AMOUNT_INPUT,
+            params: { amount: quote.fiatAmount },
+          },
           {
             name: Routes.RAMP.BASIC_INFO,
             params: { quote, previousFormData },
@@ -242,7 +248,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       navigation.reset({
         index: 1,
         routes: [
-          { name: Routes.RAMP.AMOUNT_INPUT },
+          {
+            name: Routes.RAMP.AMOUNT_INPUT,
+            params: { amount: quote.fiatAmount },
+          },
           {
             name: Routes.RAMP.ADDITIONAL_VERIFICATION,
             params: { quote, kycUrl, workFlowRunId },
@@ -341,7 +350,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
   );
 
   const navigateToWebviewModalCallback = useCallback(
-    ({ paymentUrl }: { paymentUrl: string }) => {
+    ({ paymentUrl, amount }: { paymentUrl: string; amount?: number }) => {
       const callbackKey = registerCheckoutCallback(handleNavigationStateChange);
       const [routeName, routeParams] = createCheckoutNavDetails({
         url: paymentUrl,
@@ -351,7 +360,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       navigation.reset({
         index: 1,
         routes: [
-          { name: Routes.RAMP.AMOUNT_INPUT },
+          {
+            name: Routes.RAMP.AMOUNT_INPUT,
+            params: { amount },
+          },
           { name: routeName, params: routeParams },
         ],
       });
@@ -364,7 +376,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       navigation.reset({
         index: 1,
         routes: [
-          { name: Routes.RAMP.AMOUNT_INPUT },
+          {
+            name: Routes.RAMP.AMOUNT_INPUT,
+            params: { amount: quote.fiatAmount },
+          },
           { name: Routes.RAMP.KYC_PROCESSING, params: { quote } },
         ],
       });
@@ -373,7 +388,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
   );
 
   const navigateToKycWebviewCallback = useCallback(
-    ({ kycUrl }: { kycUrl: string }) => {
+    ({ kycUrl, amount }: { kycUrl: string; amount?: number }) => {
       const [routeName, routeParams] = createCheckoutNavDetails({
         url: kycUrl,
         providerName: 'Transak',
@@ -381,7 +396,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       navigation.reset({
         index: 1,
         routes: [
-          { name: Routes.RAMP.AMOUNT_INPUT },
+          {
+            name: Routes.RAMP.AMOUNT_INPUT,
+            params: { amount },
+          },
           { name: routeName, params: routeParams },
         ],
       });
@@ -473,7 +491,10 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
                   throw new Error('Failed to generate payment URL');
                 }
 
-                navigateToWebviewModalCallback({ paymentUrl });
+                navigateToWebviewModalCallback({
+                  paymentUrl,
+                  amount: quote.fiatAmount,
+                });
               }
               return true;
             } catch (error) {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -159,13 +159,13 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
   );
 
   const navigateToVerifyIdentityCallback = useCallback(
-    ({ quote }: { quote: TransakBuyQuote }) => {
+    ({ quote, amount }: { quote: TransakBuyQuote; amount?: number }) => {
       navigation.reset({
         index: 1,
         routes: [
           {
             name: Routes.RAMP.AMOUNT_INPUT,
-            params: { amount: quote.fiatAmount },
+            params: { amount },
           },
           { name: Routes.RAMP.VERIFY_IDENTITY, params: { quote } },
         ],
@@ -178,16 +178,18 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
     ({
       quote,
       previousFormData,
+      amount,
     }: {
       quote: TransakBuyQuote;
       previousFormData?: BasicInfoFormData & AddressFormData;
+      amount?: number;
     }) => {
       navigation.reset({
         index: 1,
         routes: [
           {
             name: Routes.RAMP.AMOUNT_INPUT,
-            params: { amount: quote.fiatAmount },
+            params: { amount },
           },
           {
             name: Routes.RAMP.BASIC_INFO,
@@ -240,17 +242,19 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
       quote,
       kycUrl,
       workFlowRunId,
+      amount,
     }: {
       quote: TransakBuyQuote;
       kycUrl: string;
       workFlowRunId: string;
+      amount?: number;
     }) => {
       navigation.reset({
         index: 1,
         routes: [
           {
             name: Routes.RAMP.AMOUNT_INPUT,
-            params: { amount: quote.fiatAmount },
+            params: { amount },
           },
           {
             name: Routes.RAMP.ADDITIONAL_VERIFICATION,
@@ -372,13 +376,13 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
   );
 
   const navigateToKycProcessingCallback = useCallback(
-    ({ quote }: { quote: TransakBuyQuote }) => {
+    ({ quote, amount }: { quote: TransakBuyQuote; amount?: number }) => {
       navigation.reset({
         index: 1,
         routes: [
           {
             name: Routes.RAMP.AMOUNT_INPUT,
-            params: { amount: quote.fiatAmount },
+            params: { amount },
           },
           { name: Routes.RAMP.KYC_PROCESSING, params: { quote } },
         ],
@@ -408,7 +412,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
   );
 
   const routeAfterAuthentication = useCallback(
-    async (quote: TransakBuyQuote, depth = 0) => {
+    async (quote: TransakBuyQuote, amount?: number, depth = 0) => {
       try {
         const userDetails = await getUserDetails();
         const previousFormData = {
@@ -493,7 +497,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
 
                 navigateToWebviewModalCallback({
                   paymentUrl,
-                  amount: quote.fiatAmount,
+                  amount,
                 });
               }
               return true;
@@ -514,7 +518,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
               region: regionIsoCode,
             });
 
-            navigateToBasicInfoCallback({ quote, previousFormData });
+            navigateToBasicInfoCallback({ quote, previousFormData, amount });
             return;
 
           case 'ADDITIONAL_FORMS_REQUIRED': {
@@ -532,7 +536,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
                 await submitPurposeOfUsageForm([
                   'Buying/selling crypto for investments',
                 ]);
-                await routeAfterAuthentication(quote, depth + 1);
+                await routeAfterAuthentication(quote, amount, depth + 1);
               } else {
                 Logger.error(
                   new Error(`Submit of purpose depth exceeded: ${depth}`),
@@ -559,16 +563,17 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
                 quote,
                 kycUrl: metadata.kycUrl,
                 workFlowRunId: metadata.workFlowRunId,
+                amount,
               });
               return;
             }
 
-            navigateToKycProcessingCallback({ quote });
+            navigateToKycProcessingCallback({ quote, amount });
             return;
           }
 
           case 'SUBMITTED': {
-            navigateToKycProcessingCallback({ quote });
+            navigateToKycProcessingCallback({ quote, amount });
             return;
           }
 


### PR DESCRIPTION
## **Description**

Fixes the Buy flow amount reverting from the user-entered value back to the default $100 during the Transak native provider loading transition.

When a user enters a custom amount (e.g. $30) and taps Continue, the Transak routing callbacks use `navigation.reset()` to rebuild the navigation stack with a fresh `BuildQuote` screen as the base route. This fresh instance initialized with `DEFAULT_AMOUNT = 100`, causing a visible flash of $100 during the transition to the checkout/KYC screen.

The fix passes the current `quote.fiatAmount` as a route param (`amount`) to the `AMOUNT_INPUT` base route in every `navigation.reset()` call. `BuildQuote` now reads `params?.amount` as the initial state, preserving the user-entered amount through stack resets.

## **Changelog**

CHANGELOG entry: Fixed Buy flow amount input reverting to $100 during Transak native provider checkout transition.

## **Related issues**

Fixes: [TRAM-3348](https://consensyssoftware.atlassian.net/browse/TRAM-3348)

## **Manual testing steps**

```gherkin
Feature: Amount persists through Transak native provider checkout transition

  Scenario: Custom amount does not revert to default during Continue loading
    Given the user is on the Buy screen with Transak Native provider
    And the default amount is $100
    When the user changes the amount to $30
    And the user taps Continue
    Then the displayed amount remains $30 during the loading transition
    And the amount does not flash back to $100

  Scenario: Default amount is preserved when no custom amount is entered
    Given the user is on the Buy screen with Transak Native provider
    And the default amount is $100
    When the user taps Continue without changing the amount
    Then the displayed amount remains $100 throughout the flow

  Scenario: Amount persists when navigating back from KYC/checkout screens
    Given the user entered $50 and proceeded through Continue
    When the user navigates back to the Buy screen
    Then the amount input shows $50 (not $100)
```

## **Screenshots/Recordings**

### **Before**

<!-- Screenshot/video showing amount reverting from $30 to $100 during loading -->


https://github.com/user-attachments/assets/ba7fb42b-c43a-43f8-b438-0484090d7895



### **After**

<!-- Screenshot/video showing amount staying at $30 during loading transition -->


https://github.com/user-attachments/assets/6d60c1ae-f0eb-448b-b7f3-297efbce85df


https://github.com/user-attachments/assets/099ebf69-face-4bb0-8568-80357f59b35e

<img width="523" height="877" alt="Screenshot 2026-03-20 175035" src="https://github.com/user-attachments/assets/6bebcd4a-c04d-40c6-90d4-7e50ed683824" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Transak native-provider navigation/reset logic and initial screen state; mistakes could regress Buy/KYC routing or amount display during transitions, but changes are localized and covered by tests.
> 
> **Overview**
> Fixes the Transak native Buy flow so the user-entered fiat amount is preserved when the app uses `navigation.reset()` during KYC/checkout transitions.
> 
> `BuildQuote` now supports an `amount` route param to initialize the amount state (and to prevent region defaults from overriding it), and `useTransakRouting` propagates this amount through all reset-based navigation paths (KYC approved → checkout, KYC forms, additional verification, verify identity, and KYC webview). Tests are updated/added to assert the amount is passed through routing callbacks and used as the initial displayed value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8bdee0a10fab193fe58381e27316828206756ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->