### PR TITLE
refactor(card): remove cardGeolocation property and selectors

### DIFF
--- a/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
@@ -85,9 +85,25 @@ jest.mock('./OnboardingStep', () => {
 });
 
 // Create test store
-const createTestStore = (initialState = {}) =>
-  configureStore({
+// SignUp reads geoLocation from state.engine.backgroundState.GeolocationController.location
+// via selectGeolocationLocation. Pass { geoLocation: 'US' } etc. to control it.
+const createTestStore = (initialState: Record<string, unknown> = {}) => {
+  const { geoLocation, ...cardState } = initialState;
+  const engineState = {
+    backgroundState: {
+      GeolocationController:
+        typeof geoLocation === 'string' ? { location: geoLocation } : undefined,
+    },
+  };
+
+  return configureStore({
     reducer: {
+      engine: (state = engineState, action = { type: '', payload: null }) => {
+        switch (action.type) {
+          default:
+            return state;
+        }
+      },
       card: (
         state = {
           onboarding: {
@@ -97,8 +113,7 @@ const createTestStore = (initialState = {}) =>
             user: null,
           },
           userCardLocation: 'international',
-          geoLocation: 'UNKNOWN',
-          ...initialState,
+          ...cardState,
         },
         action = { type: '', payload: null },
       ) => {
@@ -114,6 +129,7 @@ const createTestStore = (initialState = {}) =>
       },
     },
   });
+};
 
 describe('SignUp Component', () => {
   let store: ReturnType<typeof createTestStore>;

--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -30,7 +30,6 @@ import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 import useEmailVerificationSend from '../../hooks/useEmailVerificationSend';
 import useRegions from '../../hooks/useRegions';
 import {
-  selectCardGeoLocation,
   setContactVerificationId,
   setUserCardLocation,
 } from '../../../../../core/redux/slices/card';
@@ -48,6 +47,7 @@ import {
 import SelectField from './SelectField';
 import { mapCountryToLocation } from '../../util/mapCountryToLocation';
 import type { Region } from '../../types';
+import { selectGeolocationLocation } from '../../../../../selectors/geolocationController';
 
 const SignUp = () => {
   const navigation = useNavigation();
@@ -61,7 +61,7 @@ const SignUp = () => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [selectedCountry, setSelectedCountry] = useState<Region | null>(null);
   const hasAutoSelectedCountry = useRef(false);
-  const geoLocation = useSelector(selectCardGeoLocation);
+  const geoLocation = useSelector(selectGeolocationLocation);
   const {
     signUpRegions,
     getRegionByCode,

--- a/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
+++ b/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
@@ -155,7 +155,7 @@ describe('useIsBaanxLoginEnabled', () => {
       expect(result.current).toBe(false);
     });
 
-    it('returns false when cardGeoLocation is empty string', () => {
+    it('returns false when geolocationLocation is empty string', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,

--- a/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
+++ b/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
@@ -11,20 +11,20 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 interface MockSelectorsParams {
   displayCardButtonFeatureFlag: boolean | null | undefined;
   alwaysShowCardButton: boolean | null | undefined;
-  cardGeoLocation: string;
+  geolocationLocation: string;
   cardSupportedCountries: Record<string, boolean> | null | undefined;
 }
 
 const mockSelectors = ({
   displayCardButtonFeatureFlag,
   alwaysShowCardButton,
-  cardGeoLocation,
+  geolocationLocation,
   cardSupportedCountries,
 }: MockSelectorsParams) => {
   mockUseSelector
     .mockReturnValueOnce(displayCardButtonFeatureFlag)
     .mockReturnValueOnce(alwaysShowCardButton)
-    .mockReturnValueOnce(cardGeoLocation)
+    .mockReturnValueOnce(geolocationLocation)
     .mockReturnValueOnce(cardSupportedCountries);
 };
 
@@ -38,7 +38,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: false,
         alwaysShowCardButton: true,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: { US: false },
       });
 
@@ -51,7 +51,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: true,
-        cardGeoLocation: 'XX',
+        geolocationLocation: 'XX',
         cardSupportedCountries: {},
       });
 
@@ -66,7 +66,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: { US: true },
       });
 
@@ -79,7 +79,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: false,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: { US: true },
       });
 
@@ -92,7 +92,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'XX',
+        geolocationLocation: 'XX',
         cardSupportedCountries: { US: true, GB: true },
       });
 
@@ -105,7 +105,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: { US: false },
       });
 
@@ -120,7 +120,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: null,
         alwaysShowCardButton: null,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: null,
       });
 
@@ -133,7 +133,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: undefined,
         alwaysShowCardButton: undefined,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: undefined,
       });
 
@@ -146,7 +146,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
         cardSupportedCountries: {},
       });
 
@@ -159,7 +159,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: '',
+        geolocationLocation: '',
         cardSupportedCountries: { US: true },
       });
 
@@ -174,7 +174,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'GB',
+        geolocationLocation: 'GB',
         cardSupportedCountries: { US: true, GB: true, CA: true },
       });
 
@@ -187,7 +187,7 @@ describe('useIsBaanxLoginEnabled', () => {
       mockSelectors({
         displayCardButtonFeatureFlag: true,
         alwaysShowCardButton: false,
-        cardGeoLocation: 'DE',
+        geolocationLocation: 'DE',
         cardSupportedCountries: { US: true, GB: true, CA: true },
       });
 
@@ -201,7 +201,7 @@ describe('useIsBaanxLoginEnabled', () => {
     mockSelectors({
       displayCardButtonFeatureFlag: false,
       alwaysShowCardButton: false,
-      cardGeoLocation: 'US',
+      geolocationLocation: 'US',
       cardSupportedCountries: { US: true },
     });
     const { result, rerender } = renderHook(() => useIsBaanxLoginEnabled());
@@ -211,7 +211,7 @@ describe('useIsBaanxLoginEnabled', () => {
     mockSelectors({
       displayCardButtonFeatureFlag: false,
       alwaysShowCardButton: true,
-      cardGeoLocation: 'US',
+      geolocationLocation: 'US',
       cardSupportedCountries: { US: true },
     });
     rerender();

--- a/app/components/UI/Card/hooks/isBaanxLoginEnabled.ts
+++ b/app/components/UI/Card/hooks/isBaanxLoginEnabled.ts
@@ -3,19 +3,17 @@ import {
   selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
-import {
-  selectAlwaysShowCardButton,
-  selectCardGeoLocation,
-} from '../../../../core/redux/slices/card';
+import { selectAlwaysShowCardButton } from '../../../../core/redux/slices/card';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 
 export const isBaanxLoginEnabled = (params: {
   alwaysShowCardButton: boolean;
-  cardGeoLocation: string;
+  geolocationLocation: string;
   cardSupportedCountries: Record<string, boolean>;
   displayCardButtonFeatureFlag: boolean;
 }) =>
   params.alwaysShowCardButton ||
-  (params.cardSupportedCountries?.[params.cardGeoLocation] === true &&
+  (params.cardSupportedCountries?.[params.geolocationLocation] === true &&
     params.displayCardButtonFeatureFlag) ||
   false;
 
@@ -24,7 +22,7 @@ const useIsBaanxLoginEnabled = () => {
     selectDisplayCardButtonFeatureFlag,
   );
   const alwaysShowCardButton = useSelector(selectAlwaysShowCardButton);
-  const cardGeoLocation = useSelector(selectCardGeoLocation);
+  const geolocationLocation = useSelector(selectGeolocationLocation);
   const cardSupportedCountries = useSelector(selectCardSupportedCountries);
 
   // If user has explicitly enabled the experimental switch,
@@ -32,7 +30,7 @@ const useIsBaanxLoginEnabled = () => {
   // regardless of the progressive rollout flag state
   return isBaanxLoginEnabled({
     alwaysShowCardButton,
-    cardGeoLocation,
+    geolocationLocation,
     displayCardButtonFeatureFlag,
     cardSupportedCountries: cardSupportedCountries as Record<string, boolean>,
   });

--- a/app/components/UI/Card/hooks/useCardAuthenticationVerification.test.ts
+++ b/app/components/UI/Card/hooks/useCardAuthenticationVerification.test.ts
@@ -33,23 +33,23 @@ describe('useCardAuthenticationVerification', () => {
 
   /**
    * Sets up mocks for the hook's dependencies.
-   * useSelector is called 3 times in order: userLoggedIn, isAuthenticated, cardGeoLocation
+   * useSelector is called 3 times in order: userLoggedIn, isAuthenticated, geolocationLocation
    */
   const setupMocks = ({
     userLoggedIn,
     isBaanxLoginEnabled,
     isAuthenticated = false,
-    cardGeoLocation = 'UNKNOWN',
+    geolocationLocation = 'UNKNOWN',
   }: {
     userLoggedIn: boolean;
     isBaanxLoginEnabled: boolean;
     isAuthenticated?: boolean;
-    cardGeoLocation?: string;
+    geolocationLocation?: string;
   }) => {
     mockUseSelector
       .mockReturnValueOnce(userLoggedIn)
       .mockReturnValueOnce(isAuthenticated)
-      .mockReturnValueOnce(cardGeoLocation);
+      .mockReturnValueOnce(geolocationLocation);
     mockUseIsBaanxLoginEnabled.mockReturnValue(isBaanxLoginEnabled);
   };
 
@@ -69,7 +69,7 @@ describe('useCardAuthenticationVerification', () => {
     setupMocks({
       userLoggedIn: true,
       isBaanxLoginEnabled: false,
-      cardGeoLocation: 'UNKNOWN',
+      geolocationLocation: 'UNKNOWN',
     });
 
     renderHook(() => useCardAuthenticationVerification());
@@ -172,12 +172,12 @@ describe('useCardAuthenticationVerification', () => {
   });
 
   describe('session clearing when isBaanxLoginEnabled is false', () => {
-    it('does not reset auth when geoLocation is UNKNOWN (transient geo failure)', () => {
+    it('does not reset auth when geolocationLocation is UNKNOWN (transient geo failure)', () => {
       setupMocks({
         userLoggedIn: true,
         isBaanxLoginEnabled: false,
         isAuthenticated: true,
-        cardGeoLocation: 'UNKNOWN',
+        geolocationLocation: 'UNKNOWN',
       });
 
       renderHook(() => useCardAuthenticationVerification());
@@ -185,12 +185,25 @@ describe('useCardAuthenticationVerification', () => {
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
-    it('resets auth when geoLocation is resolved and feature is disabled for that region', () => {
+    it('does not reset auth when geolocationLocation is undefined (geo not loaded yet)', () => {
       setupMocks({
         userLoggedIn: true,
         isBaanxLoginEnabled: false,
         isAuthenticated: true,
-        cardGeoLocation: 'FR',
+        geolocationLocation: undefined,
+      });
+
+      renderHook(() => useCardAuthenticationVerification());
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('resets auth when geolocationLocation is resolved and feature is disabled for that region', () => {
+      setupMocks({
+        userLoggedIn: true,
+        isBaanxLoginEnabled: false,
+        isAuthenticated: true,
+        geolocationLocation: 'FR',
       });
 
       renderHook(() => useCardAuthenticationVerification());
@@ -203,7 +216,7 @@ describe('useCardAuthenticationVerification', () => {
         userLoggedIn: true,
         isBaanxLoginEnabled: false,
         isAuthenticated: false,
-        cardGeoLocation: 'FR',
+        geolocationLocation: 'FR',
       });
 
       renderHook(() => useCardAuthenticationVerification());
@@ -217,7 +230,7 @@ describe('useCardAuthenticationVerification', () => {
         userLoggedIn: true,
         isBaanxLoginEnabled: true,
         isAuthenticated: true,
-        cardGeoLocation: 'US',
+        geolocationLocation: 'US',
       });
       const { rerender } = renderHook(() =>
         useCardAuthenticationVerification(),
@@ -232,7 +245,7 @@ describe('useCardAuthenticationVerification', () => {
         userLoggedIn: true,
         isBaanxLoginEnabled: false,
         isAuthenticated: true,
-        cardGeoLocation: 'UNKNOWN',
+        geolocationLocation: 'UNKNOWN',
       });
       rerender();
 
@@ -245,7 +258,7 @@ describe('useCardAuthenticationVerification', () => {
         userLoggedIn: true,
         isBaanxLoginEnabled: false,
         isAuthenticated: true,
-        cardGeoLocation: 'UNKNOWN',
+        geolocationLocation: 'UNKNOWN',
       });
       const { rerender } = renderHook(() =>
         useCardAuthenticationVerification(),
@@ -258,7 +271,7 @@ describe('useCardAuthenticationVerification', () => {
         userLoggedIn: true,
         isBaanxLoginEnabled: false,
         isAuthenticated: true,
-        cardGeoLocation: 'FR',
+        geolocationLocation: 'FR',
       });
       rerender();
 

--- a/app/components/UI/Card/hooks/useCardAuthenticationVerification.ts
+++ b/app/components/UI/Card/hooks/useCardAuthenticationVerification.ts
@@ -42,7 +42,7 @@ export const useCardAuthenticationVerification = () => {
         );
       }
     } else if (userLoggedIn && !isBaanxLoginEnabled && isAuthenticated) {
-      if (geolocationLocation !== 'UNKNOWN') {
+      if (!!geolocationLocation && geolocationLocation !== 'UNKNOWN') {
         dispatch(resetAuthenticatedData());
       }
     }

--- a/app/components/UI/Card/hooks/useCardAuthenticationVerification.ts
+++ b/app/components/UI/Card/hooks/useCardAuthenticationVerification.ts
@@ -3,13 +3,13 @@ import { useSelector } from 'react-redux';
 import useThunkDispatch from '../../../hooks/useThunkDispatch';
 import {
   resetAuthenticatedData,
-  selectCardGeoLocation,
   selectIsAuthenticatedCard,
   verifyCardAuthentication,
 } from '../../../../core/redux/slices/card';
 import { selectUserLoggedIn } from '../../../../reducers/user';
 import Logger from '../../../../util/Logger';
 import useIsBaanxLoginEnabled from './isBaanxLoginEnabled';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 
 /**
  * Hook that automatically verifies card authentication status when the app loads.
@@ -21,7 +21,7 @@ export const useCardAuthenticationVerification = () => {
   const userLoggedIn = useSelector(selectUserLoggedIn);
   const isBaanxLoginEnabled = useIsBaanxLoginEnabled();
   const isAuthenticated = useSelector(selectIsAuthenticatedCard);
-  const cardGeoLocation = useSelector(selectCardGeoLocation);
+  const geolocationLocation = useSelector(selectGeolocationLocation);
 
   const checkAuthentication = useCallback(() => {
     dispatch(
@@ -42,7 +42,7 @@ export const useCardAuthenticationVerification = () => {
         );
       }
     } else if (userLoggedIn && !isBaanxLoginEnabled && isAuthenticated) {
-      if (cardGeoLocation !== 'UNKNOWN') {
+      if (geolocationLocation !== 'UNKNOWN') {
         dispatch(resetAuthenticatedData());
       }
     }
@@ -50,7 +50,7 @@ export const useCardAuthenticationVerification = () => {
     userLoggedIn,
     isBaanxLoginEnabled,
     isAuthenticated,
-    cardGeoLocation,
+    geolocationLocation,
     checkAuthentication,
     dispatch,
   ]);

--- a/app/components/UI/Card/util/getCardholder.test.ts
+++ b/app/components/UI/Card/util/getCardholder.test.ts
@@ -8,13 +8,6 @@ jest.mock('../sdk/CardSDK');
 jest.mock('../../../../util/Logger');
 jest.mock('../../../../util/address');
 
-const mockControllerMessengerCall = jest.fn();
-jest.mock('../../../../core/Engine', () => ({
-  controllerMessenger: {
-    call: (...args: unknown[]) => mockControllerMessengerCall(...args),
-  },
-}));
-
 const MockedCardSDK = CardSDK as jest.MockedClass<typeof CardSDK>;
 const mockedLogger = Logger as jest.Mocked<typeof Logger>;
 const mockedIsValidHexAddress = isValidHexAddress as jest.MockedFunction<
@@ -65,12 +58,10 @@ describe('getCardholder', () => {
     MockedCardSDK.mockImplementation(() => mockCardSDKInstance);
 
     mockedIsValidHexAddress.mockReturnValue(true);
-
-    mockControllerMessengerCall.mockResolvedValue('US');
   });
 
   describe('successful scenarios', () => {
-    it('should return cardholder addresses and geolocation when accounts are cardholders', async () => {
+    it('should return cardholder addresses when accounts are cardholders', async () => {
       const mockResult = [
         'eip155:59144:0x1234567890abcdef1234567890abcdef12345678',
         'eip155:59144:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
@@ -88,7 +79,6 @@ describe('getCardholder', () => {
           '0x1234567890abcdef1234567890abcdef12345678',
           '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
         ],
-        geoLocation: 'US',
       });
       expect(MockedCardSDK).toHaveBeenCalledWith({
         cardFeatureFlag: mockCardFeatureFlag,
@@ -103,7 +93,6 @@ describe('getCardholder', () => {
         'eip155:59144:0x1234567890abcdef1234567890abcdef12345678',
       ] as `${string}:${string}:${string}`[];
 
-      mockControllerMessengerCall.mockResolvedValue('GB');
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
 
       const result = await getCardholder({
@@ -113,12 +102,10 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
-        geoLocation: 'GB',
       });
     });
 
-    it('should return empty array and geolocation when no accounts are cardholders', async () => {
-      mockControllerMessengerCall.mockResolvedValue('CA');
+    it('should return empty array when no accounts are cardholders', async () => {
       mockCardSDKInstance.isCardHolder.mockResolvedValue([]);
 
       const result = await getCardholder({
@@ -128,13 +115,12 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'CA',
       });
     });
   });
 
   describe('early return scenarios', () => {
-    it('should return empty array and UNKNOWN geolocation when cardFeatureFlag is null', async () => {
+    it('should return empty array when cardFeatureFlag is null', async () => {
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: null as unknown as CardFeatureFlag,
@@ -142,13 +128,12 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array and UNKNOWN geolocation when cardFeatureFlag is undefined', async () => {
+    it('should return empty array when cardFeatureFlag is undefined', async () => {
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: undefined as unknown as CardFeatureFlag,
@@ -156,13 +141,12 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array and UNKNOWN geolocation when caipAccountIds is empty', async () => {
+    it('should return empty array when caipAccountIds is empty', async () => {
       const result = await getCardholder({
         caipAccountIds: [],
         cardFeatureFlag: mockCardFeatureFlag,
@@ -170,13 +154,12 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array and UNKNOWN geolocation when caipAccountIds is null', async () => {
+    it('should return empty array when caipAccountIds is null', async () => {
       const result = await getCardholder({
         caipAccountIds: null as unknown as `${string}:${string}:${string}`[],
         cardFeatureFlag: mockCardFeatureFlag,
@@ -184,13 +167,12 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array and UNKNOWN geolocation when caipAccountIds is undefined', async () => {
+    it('should return empty array when caipAccountIds is undefined', async () => {
       const result = await getCardholder({
         caipAccountIds:
           undefined as unknown as `${string}:${string}:${string}`[],
@@ -199,7 +181,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
@@ -220,7 +201,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         mockError,
@@ -239,7 +219,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         mockError,
@@ -258,7 +237,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         new Error(mockErrorString),
@@ -276,7 +254,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         new Error('null'),
@@ -294,7 +271,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         new Error('undefined'),
@@ -311,7 +287,6 @@ describe('getCardholder', () => {
         'eip155:59144:0x3333333333333333333333333333333333333333',
       ] as `${string}:${string}:${string}`[];
 
-      mockControllerMessengerCall.mockResolvedValue('DE');
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
 
       const result = await getCardholder({
@@ -325,7 +300,6 @@ describe('getCardholder', () => {
           '0x2222222222222222222222222222222222222222',
           '0x3333333333333333333333333333333333333333',
         ],
-        geoLocation: 'DE',
       });
     });
 
@@ -336,7 +310,6 @@ describe('getCardholder', () => {
         'also:invalid',
       ] as `${string}:${string}:${string}`[];
 
-      mockControllerMessengerCall.mockResolvedValue('FR');
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
 
       const result = await getCardholder({
@@ -346,7 +319,6 @@ describe('getCardholder', () => {
 
       expect(result).toEqual({
         cardholderAddresses: ['0x1111111111111111111111111111111111111111'],
-        geoLocation: 'FR',
       });
     });
 
@@ -357,7 +329,6 @@ describe('getCardholder', () => {
         'eip155:59144:0x2222222222222222222222222222222222222222',
       ] as `${string}:${string}:${string}`[];
 
-      mockControllerMessengerCall.mockResolvedValue('ES');
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
       mockedIsValidHexAddress
         .mockReturnValueOnce(true)
@@ -374,42 +345,8 @@ describe('getCardholder', () => {
           '0x1111111111111111111111111111111111111111',
           '0x2222222222222222222222222222222222222222',
         ],
-        geoLocation: 'ES',
       });
       expect(mockedIsValidHexAddress).toHaveBeenCalledTimes(3);
-    });
-  });
-
-  describe('geolocation from controller messenger', () => {
-    it('should await geolocation from GeolocationController:getGeolocation', async () => {
-      mockControllerMessengerCall.mockResolvedValue('JP');
-      mockCardSDKInstance.isCardHolder.mockResolvedValue([
-        'eip155:59144:0x1234567890abcdef1234567890abcdef12345678',
-      ] as `${string}:${string}:${string}`[]);
-
-      const result = await getCardholder({
-        caipAccountIds: mockFormattedAccounts,
-        cardFeatureFlag: mockCardFeatureFlag,
-      });
-
-      expect(result.geoLocation).toBe('JP');
-      expect(mockControllerMessengerCall).toHaveBeenCalledWith(
-        'GeolocationController:getGeolocation',
-      );
-    });
-
-    it('should return UNKNOWN when getGeolocation rejects', async () => {
-      mockControllerMessengerCall.mockRejectedValue(
-        new Error('Controller unavailable'),
-      );
-      mockCardSDKInstance.isCardHolder.mockResolvedValue([]);
-
-      const result = await getCardholder({
-        caipAccountIds: mockFormattedAccounts,
-        cardFeatureFlag: mockCardFeatureFlag,
-      });
-
-      expect(result.geoLocation).toBe('UNKNOWN');
     });
   });
 });

--- a/app/components/UI/Card/util/getCardholder.ts
+++ b/app/components/UI/Card/util/getCardholder.ts
@@ -3,7 +3,6 @@ import { CardSDK } from '../sdk/CardSDK';
 import Logger from '../../../../util/Logger';
 import { isValidHexAddress } from '../../../../util/address';
 import { isCaipAccountId, parseCaipAccountId } from '@metamask/utils';
-import Engine from '../../../../core/Engine';
 
 export const getCardholder = async ({
   caipAccountIds,
@@ -13,13 +12,11 @@ export const getCardholder = async ({
   cardFeatureFlag: CardFeatureFlag | null;
 }): Promise<{
   cardholderAddresses: string[];
-  geoLocation: string;
 }> => {
   try {
     if (!cardFeatureFlag || !caipAccountIds?.length) {
       return {
         cardholderAddresses: [],
-        geoLocation: 'UNKNOWN',
       };
     }
 
@@ -27,12 +24,7 @@ export const getCardholder = async ({
       cardFeatureFlag,
     });
 
-    const [cardCaipAccountIds, geoLocation] = await Promise.all([
-      cardSDK.isCardHolder(caipAccountIds),
-      Engine.controllerMessenger
-        .call('GeolocationController:getGeolocation')
-        .catch(() => 'UNKNOWN'),
-    ]);
+    const cardCaipAccountIds = await cardSDK.isCardHolder(caipAccountIds);
 
     const cardholderAddresses = cardCaipAccountIds.map((cardCaipAccountId) => {
       if (!isCaipAccountId(cardCaipAccountId)) return null;
@@ -46,7 +38,6 @@ export const getCardholder = async ({
 
     return {
       cardholderAddresses: cardholderAddresses.filter(Boolean) as string[],
-      geoLocation,
     };
   } catch (error) {
     Logger.error(
@@ -55,7 +46,6 @@ export const getCardholder = async ({
     );
     return {
       cardholderAddresses: [],
-      geoLocation: 'UNKNOWN',
     };
   }
 };

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardHome.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardHome.test.ts
@@ -8,7 +8,6 @@ import Logger from '../../../../../util/Logger';
 import {
   selectCardholderAccounts,
   selectIsAuthenticatedCard,
-  selectCardGeoLocation,
   setAlwaysShowCardButton,
 } from '../../../../redux/slices/card';
 import {
@@ -17,6 +16,7 @@ import {
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../../selectors/featureFlagController/card';
 import { selectInternalAccounts } from '../../../../../selectors/accountsController';
+import { selectGeolocationLocation } from '../../../../../selectors/geolocationController';
 
 jest.mock('../../../../redux', () => ({
   __esModule: true,
@@ -34,6 +34,7 @@ jest.mock('../../../../Engine', () => ({
 jest.mock('../../../../redux/slices/card');
 jest.mock('../../../../../selectors/featureFlagController/card');
 jest.mock('../../../../../selectors/accountsController');
+jest.mock('../../../../../selectors/geolocationController');
 jest.mock('../../../../SDKConnect/utils/DevLogger');
 jest.mock('../../../../../util/Logger');
 
@@ -62,7 +63,7 @@ describe('handleCardHome', () => {
 
     (selectCardholderAccounts as unknown as jest.Mock).mockReturnValue([]);
     (selectIsAuthenticatedCard as unknown as jest.Mock).mockReturnValue(false);
-    (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('US');
+    (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue('US');
     (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
       false,
     );
@@ -100,7 +101,7 @@ describe('handleCardHome', () => {
       });
 
       it('enables card regardless of geo location', () => {
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue(
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
           'UNSUPPORTED_COUNTRY',
         );
 
@@ -136,7 +137,9 @@ describe('handleCardHome', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'GB',
+        );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
           GB: true,
           DE: true,
@@ -170,7 +173,7 @@ describe('handleCardHome', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue(
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
           'UNSUPPORTED',
         );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
@@ -208,7 +211,9 @@ describe('handleCardHome', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(false);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'GB',
+        );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
           GB: true,
         });
@@ -230,7 +235,9 @@ describe('handleCardHome', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('XX');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'XX',
+        );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
           XX: false,
           GB: true,
@@ -279,7 +286,9 @@ describe('handleCardHome', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'GB',
+        );
       });
 
       it('does not enable card when cardSupportedCountries is undefined', () => {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardKycNotification.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardKycNotification.test.ts
@@ -7,7 +7,6 @@ import {
   selectIsAuthenticatedCard,
   selectOnboardingId,
   selectUserCardLocation,
-  selectCardGeoLocation,
   selectAlwaysShowCardButton,
 } from '../../../../redux/slices/card';
 import {
@@ -15,6 +14,7 @@ import {
   selectDisplayCardButtonFeatureFlag,
   selectCardFeatureFlag,
 } from '../../../../../selectors/featureFlagController/card';
+import { selectGeolocationLocation } from '../../../../../selectors/geolocationController';
 import { CardSDK } from '../../../../../components/UI/Card/sdk/CardSDK';
 
 jest.mock('../../../../redux', () => ({
@@ -28,6 +28,7 @@ jest.mock('../../../../redux', () => ({
 jest.mock('../../../../NavigationService');
 jest.mock('../../../../redux/slices/card');
 jest.mock('../../../../../selectors/featureFlagController/card');
+jest.mock('../../../../../selectors/geolocationController');
 jest.mock('../../../../../util/Logger');
 jest.mock('../../../../../components/UI/Card/sdk/CardSDK');
 jest.mock('../../../../../components/UI/Card/util/mapCountryToLocation');
@@ -71,7 +72,7 @@ describe('handleCardKycNotification', () => {
     (selectUserCardLocation as unknown as jest.Mock).mockReturnValue(
       'international',
     );
-    (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('US');
+    (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue('US');
     (selectAlwaysShowCardButton as unknown as jest.Mock).mockReturnValue(false);
     (
       selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
@@ -118,7 +119,7 @@ describe('handleCardKycNotification', () => {
       (
         selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
       ).mockReturnValue(true);
-      (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+      (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue('GB');
       (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
         GB: true,
       });

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardOnboarding.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleCardOnboarding.test.ts
@@ -8,7 +8,6 @@ import Logger from '../../../../../util/Logger';
 import {
   selectCardholderAccounts,
   selectIsAuthenticatedCard,
-  selectCardGeoLocation,
   setAlwaysShowCardButton,
 } from '../../../../redux/slices/card';
 import {
@@ -16,7 +15,9 @@ import {
   selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../../selectors/featureFlagController/card';
+import { selectGeolocationLocation } from '../../../../../selectors/geolocationController';
 
+jest.mock('../../../../../selectors/geolocationController');
 jest.mock('../../../../redux', () => ({
   __esModule: true,
   default: {
@@ -59,7 +60,7 @@ describe('handleCardOnboarding', () => {
     // Default mocks - onboarding disabled
     (selectCardholderAccounts as unknown as jest.Mock).mockReturnValue([]);
     (selectIsAuthenticatedCard as unknown as jest.Mock).mockReturnValue(false);
-    (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('US');
+    (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue('US');
     (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
       false,
     );
@@ -94,7 +95,7 @@ describe('handleCardOnboarding', () => {
       });
 
       it('enables onboarding regardless of geo location', () => {
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue(
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
           'UNSUPPORTED_COUNTRY',
         );
 
@@ -130,7 +131,9 @@ describe('handleCardOnboarding', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'GB',
+        );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
           GB: true,
           DE: true,
@@ -164,7 +167,7 @@ describe('handleCardOnboarding', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue(
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
           'UNSUPPORTED',
         );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
@@ -202,7 +205,9 @@ describe('handleCardOnboarding', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(false);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'GB',
+        );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
           GB: true,
         });
@@ -224,7 +229,9 @@ describe('handleCardOnboarding', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('XX');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'XX',
+        );
         (selectCardSupportedCountries as unknown as jest.Mock).mockReturnValue({
           XX: false,
           GB: true,
@@ -273,7 +280,9 @@ describe('handleCardOnboarding', () => {
         (
           selectDisplayCardButtonFeatureFlag as unknown as jest.Mock
         ).mockReturnValue(true);
-        (selectCardGeoLocation as unknown as jest.Mock).mockReturnValue('GB');
+        (selectGeolocationLocation as unknown as jest.Mock).mockReturnValue(
+          'GB',
+        );
       });
 
       it('does not enable onboarding when cardSupportedCountries is undefined', () => {

--- a/app/core/DeeplinkManager/handlers/legacy/handleCardHome.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleCardHome.ts
@@ -7,7 +7,6 @@ import Engine from '../../../Engine';
 import {
   selectCardholderAccounts,
   selectIsAuthenticatedCard,
-  selectCardGeoLocation,
   setAlwaysShowCardButton,
 } from '../../../redux/slices/card';
 import {
@@ -16,6 +15,7 @@ import {
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
 import { selectInternalAccounts } from '../../../../selectors/accountsController';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 
 /**
  * Card home deeplink handler
@@ -49,7 +49,7 @@ export const handleCardHome = () => {
     const cardholderAccounts = selectCardholderAccounts(state);
     const isAuthenticated = selectIsAuthenticatedCard(state);
     const hasCardLinkedAccount = cardholderAccounts.length > 0;
-    const cardGeoLocation = selectCardGeoLocation(state);
+    const geolocationLocation = selectGeolocationLocation(state);
     const isCardExperimentalSwitchEnabled = selectCardExperimentalSwitch(state);
     const displayCardButtonFeatureFlag =
       selectDisplayCardButtonFeatureFlag(state);
@@ -58,7 +58,7 @@ export const handleCardHome = () => {
     ) as Record<string, boolean>;
     const shouldCardBeEnabled =
       isCardExperimentalSwitchEnabled ||
-      (cardSupportedCountries?.[cardGeoLocation as string] === true &&
+      (cardSupportedCountries?.[geolocationLocation as string] === true &&
         displayCardButtonFeatureFlag);
 
     if (!shouldCardBeEnabled) {

--- a/app/core/DeeplinkManager/handlers/legacy/handleCardKycNotification.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleCardKycNotification.ts
@@ -6,7 +6,6 @@ import {
   selectIsAuthenticatedCard,
   selectOnboardingId,
   selectUserCardLocation,
-  selectCardGeoLocation,
   selectAlwaysShowCardButton,
 } from '../../../redux/slices/card';
 import {
@@ -15,6 +14,7 @@ import {
   selectCardFeatureFlag,
   CardFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 import { isBaanxLoginEnabled } from '../../../../components/UI/Card/hooks/isBaanxLoginEnabled';
 import { CardSDK } from '../../../../components/UI/Card/sdk/CardSDK';
 import { CardVerificationState } from '../../../../components/UI/Card/types';
@@ -54,7 +54,7 @@ export const handleCardKycNotification = async () => {
     // Check feature flags
     const shouldHandleKycNotification = isBaanxLoginEnabled({
       alwaysShowCardButton: selectAlwaysShowCardButton(state),
-      cardGeoLocation: selectCardGeoLocation(state) as string,
+      geolocationLocation: selectGeolocationLocation(state),
       cardSupportedCountries: selectCardSupportedCountries(state) as Record<
         string,
         boolean

--- a/app/core/DeeplinkManager/handlers/legacy/handleCardOnboarding.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleCardOnboarding.ts
@@ -7,7 +7,6 @@ import Engine from '../../../Engine';
 import {
   selectCardholderAccounts,
   selectIsAuthenticatedCard,
-  selectCardGeoLocation,
   setAlwaysShowCardButton,
 } from '../../../redux/slices/card';
 import {
@@ -15,6 +14,7 @@ import {
   selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 
 /**
  * Card onboarding deeplink handler
@@ -45,7 +45,7 @@ export const handleCardOnboarding = () => {
     const cardholderAccounts = selectCardholderAccounts(state);
     const isAuthenticated = selectIsAuthenticatedCard(state);
     const hasCardLinkedAccount = cardholderAccounts.length > 0;
-    const cardGeoLocation = selectCardGeoLocation(state);
+    const geolocationLocation = selectGeolocationLocation(state);
     const isCardExperimentalSwitchEnabled = selectCardExperimentalSwitch(state);
     const displayCardButtonFeatureFlag =
       selectDisplayCardButtonFeatureFlag(state);
@@ -54,7 +54,7 @@ export const handleCardOnboarding = () => {
     ) as Record<string, boolean>;
     const shouldOnboardingBeEnabled =
       isCardExperimentalSwitchEnabled ||
-      (cardSupportedCountries?.[cardGeoLocation as string] === true &&
+      (cardSupportedCountries?.[geolocationLocation as string] === true &&
         displayCardButtonFeatureFlag);
 
     if (!shouldOnboardingBeEnabled) {

--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -8,7 +8,6 @@ import cardReducer, {
   initialState,
   setHasViewedCardButton,
   selectHasViewedCardButton,
-  selectCardGeoLocation,
   selectCardIsLoaded,
   selectDisplayCardButton,
   selectAlwaysShowCardButton,
@@ -46,6 +45,10 @@ jest.mock('../../../../selectors/featureFlagController/card', () => ({
   selectDisplayCardButtonFeatureFlag: jest.fn(),
 }));
 
+jest.mock('../../../../selectors/geolocationController', () => ({
+  selectGeolocationLocation: jest.fn(),
+}));
+
 // Mock handleLocalAuthentication
 jest.mock(
   '../../../../components/UI/Card/util/handleLocalAuthentication',
@@ -61,6 +64,12 @@ import {
   selectCardSupportedCountries,
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
+
+const mockSelectGeolocationLocation =
+  selectGeolocationLocation as jest.MockedFunction<
+    typeof selectGeolocationLocation
+  >;
 
 const mockSelectSelectedInternalAccountByScope =
   selectSelectedInternalAccountByScope as jest.MockedFunction<
@@ -97,7 +106,6 @@ const CARD_STATE_MOCK: CardSliceState = {
   isLoaded: true,
   hasViewedCardButton: true,
   alwaysShowCardButton: false,
-  geoLocation: 'US',
   isAuthenticated: false,
   userCardLocation: 'international',
   onboarding: {
@@ -113,7 +121,6 @@ const EMPTY_CARD_STATE_MOCK: CardSliceState = {
   isLoaded: false,
   hasViewedCardButton: false,
   alwaysShowCardButton: false,
-  geoLocation: 'UNKNOWN',
   isAuthenticated: false,
   userCardLocation: 'international',
   onboarding: {
@@ -174,35 +181,6 @@ describe('Card Selectors', () => {
       };
       const mockRootState = { card: stateWithFlag } as unknown as RootState;
       expect(selectHasViewedCardButton(mockRootState)).toBe(true);
-    });
-  });
-
-  describe('selectCardGeoLocation', () => {
-    it('returns UNKNOWN by default from initial state', () => {
-      const mockRootState = { card: initialState } as unknown as RootState;
-      expect(selectCardGeoLocation(mockRootState)).toBe('UNKNOWN');
-    });
-
-    it('returns the geolocation from the card state', () => {
-      const mockRootState = {
-        card: CARD_STATE_MOCK,
-      } as unknown as RootState;
-      expect(selectCardGeoLocation(mockRootState)).toBe('US');
-    });
-
-    it('returns different geolocation values correctly', () => {
-      const geoLocations = ['US', 'GB', 'CA', 'DE', 'FR', 'UNKNOWN'];
-
-      geoLocations.forEach((geoLocation) => {
-        const stateWithGeoLocation: CardSliceState = {
-          ...initialState,
-          geoLocation,
-        };
-        const mockRootState = {
-          card: stateWithGeoLocation,
-        } as unknown as RootState;
-        expect(selectCardGeoLocation(mockRootState)).toBe(geoLocation);
-      });
     });
   });
 
@@ -381,10 +359,9 @@ describe('Card Selectors', () => {
 describe('Card Reducer', () => {
   describe('extraReducers', () => {
     describe('loadCardholderAccounts', () => {
-      it('should set cardholder accounts, geolocation, and update state when fulfilled', () => {
+      it('should set cardholder accounts and update state when fulfilled', () => {
         const mockPayload = {
           cardholderAddresses: ['0x123', '0x456'],
-          geoLocation: 'US',
         };
         const action = {
           type: loadCardholderAccounts.fulfilled.type,
@@ -393,14 +370,12 @@ describe('Card Reducer', () => {
         const state = cardReducer(initialState, action);
 
         expect(state.cardholderAccounts).toEqual(['0x123', '0x456']);
-        expect(state.geoLocation).toBe('US');
         expect(state.isLoaded).toBe(true);
       });
 
       it('should handle empty cardholderAddresses in payload when fulfilled', () => {
         const mockPayload = {
           cardholderAddresses: [],
-          geoLocation: 'GB',
         };
         const action = {
           type: loadCardholderAccounts.fulfilled.type,
@@ -409,14 +384,12 @@ describe('Card Reducer', () => {
         const state = cardReducer(initialState, action);
 
         expect(state.cardholderAccounts).toEqual([]);
-        expect(state.geoLocation).toBe('GB');
         expect(state.isLoaded).toBe(true);
       });
 
-      it('should handle null cardholderAddresses and fallback to UNKNOWN geolocation', () => {
+      it('should handle null cardholderAddresses in payload when fulfilled', () => {
         const mockPayload = {
           cardholderAddresses: null,
-          geoLocation: null,
         };
         const action = {
           type: loadCardholderAccounts.fulfilled.type,
@@ -425,7 +398,6 @@ describe('Card Reducer', () => {
         const state = cardReducer(initialState, action);
 
         expect(state.cardholderAccounts).toEqual([]);
-        expect(state.geoLocation).toBe('UNKNOWN');
         expect(state.isLoaded).toBe(true);
       });
 
@@ -441,25 +413,6 @@ describe('Card Reducer', () => {
 
         expect(state.isLoaded).toBe(true);
         expect(state.cardholderAccounts).toEqual([]); // Should remain empty on error
-        expect(state.geoLocation).toBe('UNKNOWN'); // Should remain UNKNOWN on error
-      });
-
-      it('should handle different geolocation values', () => {
-        const geoLocations = ['US', 'GB', 'CA', 'DE', 'FR', 'UNKNOWN'];
-
-        geoLocations.forEach((geoLocation) => {
-          const mockPayload = {
-            cardholderAddresses: ['0x123'],
-            geoLocation,
-          };
-          const action = {
-            type: loadCardholderAccounts.fulfilled.type,
-            payload: mockPayload,
-          };
-          const state = cardReducer(initialState, action);
-
-          expect(state.geoLocation).toBe(geoLocation);
-        });
       });
     });
   });
@@ -472,7 +425,6 @@ describe('Card Reducer', () => {
         isLoaded: true,
         hasViewedCardButton: true,
         alwaysShowCardButton: true,
-        geoLocation: 'US',
         isAuthenticated: false,
         userCardLocation: 'us',
         onboarding: {
@@ -485,7 +437,6 @@ describe('Card Reducer', () => {
       const state = cardReducer(currentState, resetCardState());
 
       expect(state).toEqual(initialState);
-      expect(state.geoLocation).toBe('UNKNOWN');
       expect(state.alwaysShowCardButton).toBe(false);
     });
 
@@ -650,7 +601,6 @@ describe('Card Reducer', () => {
           });
           // ensure other parts of state untouched
           expect(state.cardholderAccounts).toEqual(current.cardholderAccounts);
-          expect(state.geoLocation).toBe(current.geoLocation);
         });
 
         it('should reset onboarding state when already at initial values', () => {
@@ -693,7 +643,6 @@ describe('Card Reducer', () => {
         const currentState: CardSliceState = {
           ...initialState,
           cardholderAccounts: ['0x123'],
-          geoLocation: 'US',
           isLoaded: true,
           hasViewedCardButton: true,
           alwaysShowCardButton: true,
@@ -715,7 +664,6 @@ describe('Card Reducer', () => {
 
         // Other state properties remain unchanged
         expect(state.cardholderAccounts).toEqual(['0x123']);
-        expect(state.geoLocation).toBe('US');
         expect(state.isLoaded).toBe(true);
         expect(state.hasViewedCardButton).toBe(true);
         expect(state.alwaysShowCardButton).toBe(true);
@@ -739,80 +687,66 @@ describe('Card Reducer', () => {
 describe('Card Button Display Selectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSelectGeolocationLocation.mockReturnValue('US');
   });
 
   describe('selectIsUserInSupportedCardCountry', () => {
-    it('returns true when geoLocation is in supported countries', () => {
+    it('returns true when GeolocationController location is in supported countries', () => {
+      mockSelectGeolocationLocation.mockReturnValue('US');
       mockSelectCardSupportedCountries.mockReturnValue({
         US: true,
         GB: true,
       });
 
-      const stateWithUs: CardSliceState = {
-        ...initialState,
-        geoLocation: 'US',
-      };
       const mockRootState = {
-        card: stateWithUs,
+        card: initialState,
       } as unknown as RootState;
 
       expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(true);
     });
 
     it('returns false when geoLocation is not in supported countries', () => {
+      mockSelectGeolocationLocation.mockReturnValue('CN');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
 
-      const stateWithUnsupported: CardSliceState = {
-        ...initialState,
-        geoLocation: 'CN',
-      };
       const mockRootState = {
-        card: stateWithUnsupported,
+        card: initialState,
       } as unknown as RootState;
 
       expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
     });
 
     it('returns false when geoLocation is UNKNOWN', () => {
+      mockSelectGeolocationLocation.mockReturnValue('UNKNOWN');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
 
-      const stateWithUnknown: CardSliceState = {
-        ...initialState,
-        geoLocation: 'UNKNOWN',
-      };
       const mockRootState = {
-        card: stateWithUnknown,
+        card: initialState,
       } as unknown as RootState;
 
       expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
     });
 
     it('returns false when country is explicitly false in supported countries', () => {
+      mockSelectGeolocationLocation.mockReturnValue('DE');
       mockSelectCardSupportedCountries.mockReturnValue({
         US: true,
         DE: false,
       });
 
-      const stateWithDe: CardSliceState = {
-        ...initialState,
-        geoLocation: 'DE',
-      };
       const mockRootState = {
-        card: stateWithDe,
+        card: initialState,
       } as unknown as RootState;
 
       expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
     });
 
     it('returns false when cardSupportedCountries is empty or missing', () => {
+      mockSelectGeolocationLocation.mockReturnValue('US');
       mockSelectCardSupportedCountries.mockReturnValue({});
 
-      const stateWithUs: CardSliceState = {
-        ...initialState,
-        geoLocation: 'US',
-      };
       const mockRootState = {
-        card: stateWithUs,
+        card: initialState,
       } as unknown as RootState;
 
       expect(selectIsUserInSupportedCardCountry(mockRootState)).toBe(false);
@@ -895,7 +829,6 @@ describe('Card Button Display Selectors', () => {
     it('should not affect other state properties', () => {
       const state = cardReducer(initialState, setAlwaysShowCardButton(true));
       expect(state.cardholderAccounts).toEqual(initialState.cardholderAccounts);
-      expect(state.geoLocation).toEqual(initialState.geoLocation);
       expect(state.isLoaded).toEqual(initialState.isLoaded);
     });
   });
@@ -923,15 +856,16 @@ describe('Card Button Display Selectors', () => {
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(false);
       mockSelectSelectedInternalAccountByScope.mockReturnValue(() => undefined);
       mockIsEthAccount.mockReturnValue(false);
+      mockSelectGeolocationLocation.mockReturnValue('US');
     });
 
     it('should return true when alwaysShowCardButton is true', () => {
       mockSelectCardExperimentalSwitch.mockReturnValue(true);
+      mockSelectGeolocationLocation.mockReturnValue('XX');
 
       const stateWithAlwaysShow: CardSliceState = {
         ...initialState,
         alwaysShowCardButton: true,
-        geoLocation: 'XX', // Unsupported country
         cardholderAccounts: [], // Not a cardholder
       };
 
@@ -947,9 +881,9 @@ describe('Card Button Display Selectors', () => {
         ...initialState,
         cardholderAccounts: [mockAccountAddress.toLowerCase()],
         alwaysShowCardButton: false,
-        geoLocation: 'XX', // Unsupported country
       };
 
+      mockSelectGeolocationLocation.mockReturnValue('XX');
       mockSelectSelectedInternalAccountByScope.mockReturnValue(
         () => mockAccount,
       );
@@ -964,12 +898,12 @@ describe('Card Button Display Selectors', () => {
     });
 
     it('should return true when in supported country with feature flag enabled', () => {
+      mockSelectGeolocationLocation.mockReturnValue('US');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
 
       const stateWithGeoLocation: CardSliceState = {
         ...initialState,
-        geoLocation: 'US',
         cardholderAccounts: [],
         alwaysShowCardButton: false,
       };
@@ -982,12 +916,12 @@ describe('Card Button Display Selectors', () => {
     });
 
     it('should return false when in supported country but feature flag is disabled', () => {
+      mockSelectGeolocationLocation.mockReturnValue('US');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(false);
 
       const stateWithGeoLocation: CardSliceState = {
         ...initialState,
-        geoLocation: 'US',
         cardholderAccounts: [],
         alwaysShowCardButton: false,
       };
@@ -1000,12 +934,12 @@ describe('Card Button Display Selectors', () => {
     });
 
     it('should return false when feature flag is enabled but country is not supported', () => {
+      mockSelectGeolocationLocation.mockReturnValue('CN');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
 
       const stateWithUnsupportedGeoLocation: CardSliceState = {
         ...initialState,
-        geoLocation: 'CN', // Not in supported countries
         cardholderAccounts: [],
         alwaysShowCardButton: false,
       };
@@ -1034,28 +968,29 @@ describe('Card Button Display Selectors', () => {
       });
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
 
-      // Test US
-      let state: CardSliceState = {
+      const state: CardSliceState = {
         ...initialState,
-        geoLocation: 'US',
         cardholderAccounts: [],
         alwaysShowCardButton: false,
       };
+
+      // Test US
+      mockSelectGeolocationLocation.mockReturnValue('US');
       let mockRootState = { card: state } as unknown as RootState;
       expect(selectDisplayCardButton(mockRootState)).toBe(true);
 
       // Test GB
-      state = { ...state, geoLocation: 'GB' };
+      mockSelectGeolocationLocation.mockReturnValue('GB');
       mockRootState = { card: state } as unknown as RootState;
       expect(selectDisplayCardButton(mockRootState)).toBe(true);
 
       // Test CA
-      state = { ...state, geoLocation: 'CA' };
+      mockSelectGeolocationLocation.mockReturnValue('CA');
       mockRootState = { card: state } as unknown as RootState;
       expect(selectDisplayCardButton(mockRootState)).toBe(true);
 
       // Test DE (explicitly false)
-      state = { ...state, geoLocation: 'DE' };
+      mockSelectGeolocationLocation.mockReturnValue('DE');
       mockRootState = { card: state } as unknown as RootState;
       expect(selectDisplayCardButton(mockRootState)).toBe(false);
     });
@@ -1064,11 +999,11 @@ describe('Card Button Display Selectors', () => {
       mockSelectCardExperimentalSwitch.mockReturnValue(true);
       mockSelectCardSupportedCountries.mockReturnValue({});
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(false);
+      mockSelectGeolocationLocation.mockReturnValue('XX');
 
       const state: CardSliceState = {
         ...initialState,
         alwaysShowCardButton: true,
-        geoLocation: 'XX',
         cardholderAccounts: [],
       };
 
@@ -1078,12 +1013,12 @@ describe('Card Button Display Selectors', () => {
     });
 
     it('should handle UNKNOWN geolocation gracefully', () => {
+      mockSelectGeolocationLocation.mockReturnValue('UNKNOWN');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
 
       const state: CardSliceState = {
         ...initialState,
-        geoLocation: 'UNKNOWN',
         cardholderAccounts: [],
         alwaysShowCardButton: false,
       };
@@ -1095,6 +1030,7 @@ describe('Card Button Display Selectors', () => {
 
     it('should return true when all three conditions are true', () => {
       mockSelectCardExperimentalSwitch.mockReturnValue(true);
+      mockSelectGeolocationLocation.mockReturnValue('US');
       mockSelectCardSupportedCountries.mockReturnValue({ US: true });
       mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
       mockSelectSelectedInternalAccountByScope.mockReturnValue(
@@ -1105,7 +1041,6 @@ describe('Card Button Display Selectors', () => {
       const state: CardSliceState = {
         ...initialState,
         alwaysShowCardButton: true,
-        geoLocation: 'US',
         cardholderAccounts: [mockAccountAddress.toLowerCase()],
       };
 
@@ -1189,7 +1124,6 @@ describe('Authentication Selectors and Actions', () => {
     it('does not affect other state properties', () => {
       const state = cardReducer(initialState, setIsAuthenticatedCard(true));
       expect(state.cardholderAccounts).toEqual(initialState.cardholderAccounts);
-      expect(state.geoLocation).toEqual(initialState.geoLocation);
       expect(state.userCardLocation).toEqual(initialState.userCardLocation);
     });
   });
@@ -1347,7 +1281,6 @@ describe('verifyCardAuthentication Async Thunk', () => {
       const state = cardReducer(initialState, action);
 
       expect(state.cardholderAccounts).toEqual(initialState.cardholderAccounts);
-      expect(state.geoLocation).toEqual(initialState.geoLocation);
       expect(state.isLoaded).toEqual(initialState.isLoaded);
     });
   });
@@ -1390,7 +1323,6 @@ describe('verifyCardAuthentication Async Thunk', () => {
         ...initialState,
         isAuthenticated: true,
         cardholderAccounts: ['0x123'],
-        geoLocation: 'US',
         isLoaded: true,
       };
 
@@ -1403,7 +1335,6 @@ describe('verifyCardAuthentication Async Thunk', () => {
       const state = cardReducer(currentState, action);
 
       expect(state.cardholderAccounts).toEqual(['0x123']);
-      expect(state.geoLocation).toEqual('US');
       expect(state.isLoaded).toBe(true);
     });
   });

--- a/app/core/redux/slices/card/index.ts
+++ b/app/core/redux/slices/card/index.ts
@@ -12,6 +12,7 @@ import {
   selectDisplayCardButtonFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
 import { handleLocalAuthentication } from '../../../../components/UI/Card/util/handleLocalAuthentication';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 
 export interface OnboardingState {
   onboardingId: string | null;
@@ -24,7 +25,6 @@ export interface CardSliceState {
   hasViewedCardButton: boolean;
   isLoaded: boolean;
   alwaysShowCardButton: boolean;
-  geoLocation: string;
   isAuthenticated: boolean;
   userCardLocation: CardLocation;
   onboarding: OnboardingState;
@@ -36,7 +36,6 @@ export const initialState: CardSliceState = {
   hasViewedCardButton: false,
   isLoaded: false,
   alwaysShowCardButton: false,
-  geoLocation: 'UNKNOWN',
   isAuthenticated: false,
   userCardLocation: 'international',
   onboarding: {
@@ -108,7 +107,6 @@ const slice = createSlice({
     builder
       .addCase(loadCardholderAccounts.fulfilled, (state, action) => {
         state.cardholderAccounts = action.payload.cardholderAddresses ?? [];
-        state.geoLocation = action.payload.geoLocation ?? 'UNKNOWN';
         state.isLoaded = true;
       })
       .addCase(loadCardholderAccounts.rejected, (state, action) => {
@@ -166,11 +164,6 @@ export const selectAlwaysShowCardButton = createSelector(
   },
 );
 
-export const selectCardGeoLocation = createSelector(
-  selectCardState,
-  (card) => card.geoLocation,
-);
-
 export const selectCardIsLoaded = createSelector(
   selectCardState,
   (card) => card.isLoaded,
@@ -216,7 +209,7 @@ export const selectIsDaimoDemo = createSelector(
 );
 
 export const selectIsUserInSupportedCardCountry = createSelector(
-  selectCardGeoLocation,
+  selectGeolocationLocation,
   selectCardSupportedCountries,
   (geoLocation, cardSupportedCountries) =>
     (cardSupportedCountries as Record<string, boolean>)?.[geoLocation] === true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Refactors Card-related code so **geolocation is read only from `GeolocationController`** (`selectGeolocationLocation` → `engine.backgroundState.GeolocationController.location`) instead of a duplicated **`geoLocation` field on the card Redux slice** or from **`getCardholder`**.

**Why**: Geo was stored in multiple places (card slice, async `getCardholder` + controller messenger). That duplicated state, complicated the `loadCardholderAccounts` payload, and risked drift. The single source of truth should be the engine’s GeolocationController.

**What changed**:

- **Card slice (`card/index.ts`)**: Removed `geoLocation` from `CardSliceState` and initial state; removed writing geo on `loadCardholderAccounts.fulfilled`; removed **`selectCardGeoLocation`**. **`selectIsUserInSupportedCardCountry`** now uses **`selectGeolocationLocation`** instead of card-stored geo.
- **`getCardholder`**: Returns only **`{ cardholderAddresses }`**; removed parallel `GeolocationController:getGeolocation` call and **`geoLocation`** from the return type and error paths.
- **Consumers**: **`SignUp`**, **`isBaanxLoginEnabled`** (pure helper + hook), **`useCardAuthenticationVerification`**, and deeplink handlers (**`handleCardKycNotification`**, **`handleCardHome`**, **`handleCardOnboarding`**) now use **`selectGeolocationLocation`**. **`isBaanxLoginEnabled`** params use **`geolocationLocation`** (and **`handleCardKycNotification`** passes that key correctly).
- **Tests**: Updated **`SignUp.test.tsx`** (store includes `engine.backgroundState.GeolocationController` for selectors), **`card/index.test.ts`**, **`getCardholder.test.ts`**, deeplink handler tests, **`isBaanxLoginEnabled.test.ts`**, and **`handleCardKycNotification.test.ts`** (mocks **`geolocationController`**).

## **Changelog**

CHANGELOG entry: Card geolocation now comes from GeolocationController only; removed duplicated `geoLocation` from card state and from `getCardholder` results.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card flows use GeolocationController geo consistently

  Scenario: Card sign-up country prefill from geo
    Given GeolocationController has a supported country code (e.g. US)
    When I open Card sign-up
    Then the country field may prefill from geo and user card location updates as before

  Scenario: Card button / Baanx gating vs supported countries
    Given remote config maps supported countries for Card
    When my location from GeolocationController is in that map and flags allow
    Then Card entry / Baanx login gating behaves as before

  Scenario: Card KYC notification deeplink
    Given I receive a card KYC notification deeplink
    When the handler runs
    Then feature gating still uses geo + flags correctly and navigation still works

  Scenario: Cardholder load
    When cardholder accounts load completes
    Then card slice only updates cardholder list / loaded state (no separate geo field on card)
```

## **Screenshots/Recordings**

No intentional UI copy or layout changes; behavior should match main if geo from the controller matches previous values.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the source of truth for geo-based feature gating and session clearing across onboarding, deeplinks, and auth verification; incorrect selector wiring or missing engine state could disable/enable Card flows unexpectedly.
> 
> **Overview**
> **Geolocation is now sourced only from `GeolocationController`.** The Card slice no longer stores `geoLocation` (and `selectCardGeoLocation` is removed), and country gating (`selectIsUserInSupportedCardCountry`, `isBaanxLoginEnabled`, deeplink handlers, and `SignUp`) now reads `selectGeolocationLocation` instead.
> 
> `getCardholder` is simplified to return only `cardholderAddresses` (no parallel geolocation fetch), and `useCardAuthenticationVerification` tightens session-clearing to only reset auth once geolocation is *loaded* and not `UNKNOWN`. Tests are updated accordingly, including injecting `engine.backgroundState.GeolocationController.location` into the test store and updating mocks/expectations throughout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8730edbe58ea95c5aadc313973620a96f35a9e1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->