### PR TITLE
test(e2e): stabilize flaky wallet, perps, and predictions smoke flows

### DIFF
--- a/tests/page-objects/Perps/PerpsTabView.ts
+++ b/tests/page-objects/Perps/PerpsTabView.ts
@@ -1,5 +1,6 @@
 import Gestures from '../../framework/Gestures';
 import Matchers from '../../framework/Matchers';
+import Assertions from '../../framework/Assertions';
 import Utilities from '../../framework/Utilities';
 import {
   PerpsMarketBalanceActionsSelectorsIDs,
@@ -46,17 +47,27 @@ class PerpsTabView {
   }
 
   async tapAddFundsButton(): Promise<void> {
-    // Prefer new market add funds button; fallback to legacy id
-    const useMarketButton = await Utilities.isElementVisible(
-      this.marketAddFundsButton,
-      1500,
+    await Utilities.executeWithRetry(
+      async () => {
+        // Prefer new market add funds button; fallback to legacy id
+        const useMarketButton = await Utilities.isElementVisible(
+          this.marketAddFundsButton,
+          1000,
+        );
+        const target = useMarketButton
+          ? this.marketAddFundsButton
+          : this.addFundsButton;
+        await Gestures.waitAndTap(target, {
+          elemDescription: 'Perps Add Funds Button',
+          checkStability: true,
+          timeout: 2000,
+        });
+      },
+      {
+        timeout: 20000,
+        description: 'Tap Perps Add Funds Button',
+      },
     );
-    const target = useMarketButton
-      ? this.marketAddFundsButton
-      : this.addFundsButton;
-    await Gestures.waitAndTap(target, {
-      elemDescription: 'Perps Add Funds Button',
-    });
   }
 
   get marketAddFundsButton(): DetoxElement {
@@ -84,34 +95,53 @@ class PerpsTabView {
   }
 
   async getBalance(): Promise<number> {
-    // Prefer explicit value elements; fallback to balance button for accessibility labels
-    const isMarketValueVisible = await Utilities.isElementVisible(
-      this.marketBalanceValue,
-      1500,
+    let parsedBalance = 0;
+    await Utilities.executeWithRetry(
+      async () => {
+        // Prefer explicit value elements; fallback to balance button for accessibility labels
+        const isMarketValueVisible = await Utilities.isElementVisible(
+          this.marketBalanceValue,
+          1000,
+        );
+        const isLegacyValueVisible = await Utilities.isElementVisible(
+          this.balanceValue,
+          1000,
+        );
+
+        const targetElement: DetoxElement = isMarketValueVisible
+          ? this.marketBalanceValue
+          : isLegacyValueVisible
+            ? this.balanceValue
+            : this.balanceButton; // final fallback to button
+
+        await Assertions.expectElementToBeVisible(targetElement, {
+          timeout: 2000,
+          description: 'Perps balance value source should be visible',
+        });
+
+        const attributes = await (
+          (await targetElement) as IndexableNativeElement
+        ).getAttributes();
+        const balanceText =
+          (attributes as { text?: string; label?: string; value?: string })
+            .text ||
+          (attributes as { text?: string; label?: string; value?: string })
+            .label ||
+          (attributes as { text?: string; label?: string; value?: string })
+            .value ||
+          '0';
+
+        // Extract numeric value from balance text (remove currency symbols, commas, etc.)
+        const numericValue = balanceText.replace(/[^0-9.-]/g, '');
+        parsedBalance = parseFloat(numericValue) || 0;
+      },
+      {
+        timeout: 15000,
+        description: 'Read Perps balance',
+      },
     );
-    const isLegacyValueVisible = await Utilities.isElementVisible(
-      this.balanceValue,
-      1000,
-    );
 
-    const targetElement: DetoxElement = isMarketValueVisible
-      ? this.marketBalanceValue
-      : isLegacyValueVisible
-        ? this.balanceValue
-        : this.balanceButton; // final fallback to button
-
-    const attributes = await (
-      (await targetElement) as IndexableNativeElement
-    ).getAttributes();
-    const balanceText =
-      (attributes as { text?: string; label?: string; value?: string }).text ||
-      (attributes as { text?: string; label?: string; value?: string }).label ||
-      (attributes as { text?: string; label?: string; value?: string }).value ||
-      '0';
-
-    // Extract numeric value from balance text (remove currency symbols, commas, etc.)
-    const numericValue = balanceText.replace(/[^0-9.-]/g, '');
-    return parseFloat(numericValue) || 0;
+    return parsedBalance;
   }
 }
 

--- a/tests/page-objects/wallet/NetworkManager.ts
+++ b/tests/page-objects/wallet/NetworkManager.ts
@@ -191,19 +191,24 @@ class NetworkManager {
           return;
         }
 
-        await Assertions.expectElementToBeVisible(this.openNetworkManagerButton, {
-          timeout: 3000,
-          description: 'Open Network Manager Button should be visible',
-        });
+        await Assertions.expectElementToBeVisible(
+          this.openNetworkManagerButton,
+          {
+            timeout: 3000,
+            description: 'Open Network Manager Button should be visible',
+          },
+        );
         await Gestures.waitAndTap(this.openNetworkManagerButton, {
           elemDescription: 'Open Network Manager Button',
-          checkStability: true,
           timeout: 3000,
         });
-        await Assertions.expectElementToBeVisible(this.networkManagerBottomSheet, {
-          timeout: 3000,
-          description: 'Network Manager Bottom Sheet should appear',
-        });
+        await Assertions.expectElementToBeVisible(
+          this.networkManagerBottomSheet,
+          {
+            timeout: 3000,
+            description: 'Network Manager Bottom Sheet should appear',
+          },
+        );
       },
       {
         timeout: 30000,
@@ -355,10 +360,9 @@ class NetworkManager {
       elemDescription: 'Network Manager Bottom Sheet',
       timeout: 10000,
     });
-    await Utilities.waitForElementToStopMoving(this.networkManagerBottomSheet, {
-      timeout: 5000,
-      interval: 300,
-      stableCount: 4,
+    await Assertions.expectElementToBeVisible(this.popularNetworksTab, {
+      elemDescription: 'Popular Networks Tab',
+      timeout: 10000,
     });
   }
 

--- a/tests/page-objects/wallet/NetworkManager.ts
+++ b/tests/page-objects/wallet/NetworkManager.ts
@@ -7,7 +7,6 @@ import {
   NetworkManagerSelectorIDs,
   NetworkManagerSelectorText,
 } from '../../../app/components/UI/NetworkMultiSelector/NetworkManager.testIds';
-import TestHelpers from '../../helpers';
 import { WalletViewSelectorsIDs } from '../../../app/components/Views/Wallet/WalletView.testIds';
 
 class NetworkManager {
@@ -186,9 +185,32 @@ class NetworkManager {
    * Open the network manager
    */
   async openNetworkManager(): Promise<void> {
-    await Gestures.waitAndTap(this.openNetworkManagerButton, {
-      elemDescription: 'Open Network Manager Button',
-    });
+    await Utilities.executeWithRetry(
+      async () => {
+        if (await this.isNetworkManagerVisible()) {
+          return;
+        }
+
+        await Assertions.expectElementToBeVisible(this.openNetworkManagerButton, {
+          timeout: 3000,
+          description: 'Open Network Manager Button should be visible',
+        });
+        await Gestures.waitAndTap(this.openNetworkManagerButton, {
+          elemDescription: 'Open Network Manager Button',
+          checkStability: true,
+          timeout: 3000,
+        });
+        await Assertions.expectElementToBeVisible(this.networkManagerBottomSheet, {
+          timeout: 3000,
+          description: 'Network Manager Bottom Sheet should appear',
+        });
+      },
+      {
+        timeout: 30000,
+        description: 'Open network manager',
+      },
+    );
+
     await this.waitForNetworkManagerToLoad();
   }
 
@@ -333,9 +355,11 @@ class NetworkManager {
       elemDescription: 'Network Manager Bottom Sheet',
       timeout: 10000,
     });
-    // Wait for bottom sheet animation to complete
-    // eslint-disable-next-line no-restricted-syntax
-    await TestHelpers.delay(1000); // Allow for bottom sheet slide-up animation
+    await Utilities.waitForElementToStopMoving(this.networkManagerBottomSheet, {
+      timeout: 5000,
+      interval: 300,
+      stableCount: 4,
+    });
   }
 
   /**

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -222,18 +222,28 @@ class TabBarComponent {
   async tapActivity(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await UnifiedGestures.waitAndTap(this.tabBarActivityButton, {
-          timeout: 2000,
-        });
+        try {
+          await UnifiedGestures.waitAndTap(this.tabBarActivityButton, {
+            timeout: 2500,
+            description: 'Tab Bar - Activity Button',
+          });
+        } catch {
+          // Fallback to direct Detox matcher in case encapsulated tap misses transient tree updates.
+          await Gestures.waitAndTap(Matchers.getElementByID(TabBarSelectorIDs.ACTIVITY), {
+            timeout: 2500,
+            elemDescription: 'Tab Bar - Activity Button (fallback)',
+            checkStability: true,
+          });
+        }
         await Assertions.expectElementToBeVisible(ActivitiesView.title, {
           description: 'Activity View Title',
-          timeout: 500,
+          timeout: 1000,
         });
       },
       {
-        // Each attempt: ~2.5s (2s tap + 0.5s assertion). 15 retries ≈ ~37s total budget.
-        maxRetries: 15,
-        timeout: 45000,
+        // Keep a larger budget for slow post-confirmation transitions before tab bar is tappable.
+        maxRetries: 20,
+        timeout: 70000,
         description: 'Tap Activity Button',
       },
     );

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -229,11 +229,14 @@ class TabBarComponent {
           });
         } catch {
           // Fallback to direct Detox matcher in case encapsulated tap misses transient tree updates.
-          await Gestures.waitAndTap(Matchers.getElementByID(TabBarSelectorIDs.ACTIVITY), {
-            timeout: 2500,
-            elemDescription: 'Tab Bar - Activity Button (fallback)',
-            checkStability: true,
-          });
+          await Gestures.waitAndTap(
+            Matchers.getElementByID(TabBarSelectorIDs.ACTIVITY),
+            {
+              timeout: 2500,
+              elemDescription: 'Tab Bar - Activity Button (fallback)',
+              checkStability: true,
+            },
+          );
         }
         await Assertions.expectElementToBeVisible(ActivitiesView.title, {
           description: 'Activity View Title',

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -702,6 +702,14 @@ class WalletView {
     await this.scrollAndTapSection(
       this.perpsSectionHeader,
       'Perpetuals section',
+      'down',
+      {
+        // Keep the section header away from bottom navigation to reduce mistaps.
+        overshootSwipe: {
+          direction: 'up',
+          percentage: 0.15,
+        },
+      },
     );
   }
 
@@ -728,28 +736,66 @@ class WalletView {
     );
   }
 
-  async scrollAndTapPredictionsPosition(positionName: string): Promise<void> {
-    const target = Matchers.getElementByText(positionName);
-    try {
-      await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
-        direction: 'down',
-        scrollAmount: 220,
-        timeout: 12000,
-        elemDescription: `Scroll to prediction position: ${positionName}`,
-      });
-    } catch {
-      await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
-        direction: 'up',
-        scrollAmount: 220,
-        timeout: 12000,
-        elemDescription: `Scroll up fallback to prediction position: ${positionName}`,
-      });
-    }
+  private getPredictionPositionMatchers(positionName: string): DetoxElement[] {
+    const escapedName = positionName
+      .replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+      .replace(/\s+/gu, '\\s+');
 
-    await Gestures.waitAndTap(target, {
-      checkStability: true,
-      elemDescription: `Predictions Position: ${positionName}`,
-    });
+    return [
+      // Exact match keeps existing behaviour for stable layouts.
+      Matchers.getElementByText(positionName),
+      // Flexible match handles line wraps and spacing variance in CI.
+      Matchers.getElementByText(new RegExp(escapedName, 'u')),
+    ];
+  }
+
+  async scrollAndTapPredictionsPosition(positionName: string): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        for (const target of this.getPredictionPositionMatchers(positionName)) {
+          try {
+            await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
+              direction: 'down',
+              scrollAmount: 220,
+              timeout: 6000,
+              elemDescription: `Scroll to prediction position: ${positionName}`,
+            });
+            await Gestures.waitAndTap(target, {
+              checkStability: true,
+              elemDescription: `Predictions Position: ${positionName}`,
+            });
+            return;
+          } catch {
+            // Try opposite direction before giving up on this matcher.
+          }
+
+          try {
+            await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
+              direction: 'up',
+              scrollAmount: 220,
+              timeout: 6000,
+              elemDescription: `Scroll up fallback to prediction position: ${positionName}`,
+            });
+            await Gestures.waitAndTap(target, {
+              checkStability: true,
+              elemDescription: `Predictions Position: ${positionName}`,
+            });
+            return;
+          } catch {
+            // Continue to next matcher.
+          }
+        }
+
+        throw new Error(
+          `Could not scroll and tap prediction position "${positionName}"`,
+        );
+      },
+      {
+        timeout: 30000,
+        description: 'Scroll and tap prediction position',
+        elemDescription: positionName,
+      },
+    );
   }
 
   async scrollAndTapNftsSection(): Promise<void> {

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -754,12 +754,16 @@ class WalletView {
       async () => {
         for (const target of this.getPredictionPositionMatchers(positionName)) {
           try {
-            await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
-              direction: 'down',
-              scrollAmount: 220,
-              timeout: 6000,
-              elemDescription: `Scroll to prediction position: ${positionName}`,
-            });
+            await Gestures.scrollToElement(
+              target,
+              this.walletScrollViewIdentifier,
+              {
+                direction: 'down',
+                scrollAmount: 220,
+                timeout: 6000,
+                elemDescription: `Scroll to prediction position: ${positionName}`,
+              },
+            );
             await Gestures.waitAndTap(target, {
               checkStability: true,
               elemDescription: `Predictions Position: ${positionName}`,
@@ -770,12 +774,16 @@ class WalletView {
           }
 
           try {
-            await Gestures.scrollToElement(target, this.walletScrollViewIdentifier, {
-              direction: 'up',
-              scrollAmount: 220,
-              timeout: 6000,
-              elemDescription: `Scroll up fallback to prediction position: ${positionName}`,
-            });
+            await Gestures.scrollToElement(
+              target,
+              this.walletScrollViewIdentifier,
+              {
+                direction: 'up',
+                scrollAmount: 220,
+                timeout: 6000,
+                elemDescription: `Scroll up fallback to prediction position: ${positionName}`,
+              },
+            );
             await Gestures.waitAndTap(target, {
               checkStability: true,
               elemDescription: `Predictions Position: ${positionName}`,

--- a/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
+++ b/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
@@ -15,6 +15,7 @@ import { loginToApp } from '../../../flows/wallet.flow';
 import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import RowComponents from '../../../page-objects/Browser/Confirmations/RowComponents';
 import { AnvilManager, Hardfork } from '../../../seeder/anvil-manager';
+import ActivitiesView from '../../../page-objects/Transactions/ActivitiesView';
 import {
   setupMockRequest,
   setupMockPostRequest,
@@ -224,7 +225,21 @@ describe(
         },
         async () => {
           await performSendTransaction();
-          await Assertions.expectTextDisplayed('Confirmed');
+          await Assertions.expectElementToBeVisible(
+            ActivitiesView.transactionItem(0),
+            {
+              timeout: 60000,
+              description: 'Latest activity row should be visible',
+            },
+          );
+          await Assertions.expectElementToHaveText(
+            ActivitiesView.transactionStatus(0),
+            'Confirmed',
+            {
+              timeout: 60000,
+              description: 'Latest activity row should become Confirmed',
+            },
+          );
           await device.enableSynchronization();
         },
       );
@@ -251,7 +266,21 @@ describe(
         },
         async () => {
           await performSendTransaction();
-          await Assertions.expectTextDisplayed('Failed');
+          await Assertions.expectElementToBeVisible(
+            ActivitiesView.transactionItem(0),
+            {
+              timeout: 60000,
+              description: 'Latest activity row should be visible',
+            },
+          );
+          await Assertions.expectElementToHaveText(
+            ActivitiesView.transactionStatus(0),
+            'Failed',
+            {
+              timeout: 60000,
+              description: 'Latest activity row should become Failed',
+            },
+          );
           await device.enableSynchronization();
         },
       );

--- a/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
+++ b/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
@@ -15,7 +15,6 @@ import { loginToApp } from '../../../flows/wallet.flow';
 import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import RowComponents from '../../../page-objects/Browser/Confirmations/RowComponents';
 import { AnvilManager, Hardfork } from '../../../seeder/anvil-manager';
-import ActivitiesView from '../../../page-objects/Transactions/ActivitiesView';
 import {
   setupMockRequest,
   setupMockPostRequest,
@@ -225,21 +224,10 @@ describe(
         },
         async () => {
           await performSendTransaction();
-          await Assertions.expectElementToBeVisible(
-            ActivitiesView.transactionItem(0),
-            {
-              timeout: 60000,
-              description: 'Latest activity row should be visible',
-            },
-          );
-          await Assertions.expectElementToHaveText(
-            ActivitiesView.transactionStatus(0),
-            'Confirmed',
-            {
-              timeout: 60000,
-              description: 'Latest activity row should become Confirmed',
-            },
-          );
+          await Assertions.expectTextDisplayed('Confirmed', {
+            timeout: 60000,
+            allowDuplicates: true,
+          });
           await device.enableSynchronization();
         },
       );
@@ -266,21 +254,10 @@ describe(
         },
         async () => {
           await performSendTransaction();
-          await Assertions.expectElementToBeVisible(
-            ActivitiesView.transactionItem(0),
-            {
-              timeout: 60000,
-              description: 'Latest activity row should be visible',
-            },
-          );
-          await Assertions.expectElementToHaveText(
-            ActivitiesView.transactionStatus(0),
-            'Failed',
-            {
-              timeout: 60000,
-              description: 'Latest activity row should become Failed',
-            },
-          );
+          await Assertions.expectTextDisplayed('Failed', {
+            timeout: 60000,
+            allowDuplicates: true,
+          });
           await device.enableSynchronization();
         },
       );

--- a/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -30,6 +30,7 @@ import { RelayStatus } from '../../../../app/util/transactions/transaction-relay
 import TransactionConfirmView from '../../../page-objects/Send/TransactionConfirmView';
 import GasFeeTokenModal from '../../../page-objects/Confirmation/GasFeeTokenModal';
 import { AnvilPort } from '../../../framework/fixtures/FixtureUtils';
+import ActivitiesView from '../../../page-objects/Transactions/ActivitiesView';
 
 const TRANSACTION_UUID_MOCK = '1234-5678';
 const SENDER_ADDRESS_MOCK = '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3';
@@ -314,7 +315,21 @@ describe(
           await FooterActions.tapConfirmButton();
           await TabBarComponent.tapActivity();
 
-          await Assertions.expectTextDisplayed('Confirmed');
+          await Assertions.expectElementToBeVisible(
+            ActivitiesView.transactionItem(0),
+            {
+              timeout: 60000,
+              description: 'Latest activity row should be visible',
+            },
+          );
+          await Assertions.expectElementToHaveText(
+            ActivitiesView.transactionStatus(0),
+            'Confirmed',
+            {
+              timeout: 60000,
+              description: 'Latest activity row should become Confirmed',
+            },
+          );
           await device.enableSynchronization();
         },
       );

--- a/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -30,7 +30,6 @@ import { RelayStatus } from '../../../../app/util/transactions/transaction-relay
 import TransactionConfirmView from '../../../page-objects/Send/TransactionConfirmView';
 import GasFeeTokenModal from '../../../page-objects/Confirmation/GasFeeTokenModal';
 import { AnvilPort } from '../../../framework/fixtures/FixtureUtils';
-import ActivitiesView from '../../../page-objects/Transactions/ActivitiesView';
 
 const TRANSACTION_UUID_MOCK = '1234-5678';
 const SENDER_ADDRESS_MOCK = '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3';
@@ -315,21 +314,10 @@ describe(
           await FooterActions.tapConfirmButton();
           await TabBarComponent.tapActivity();
 
-          await Assertions.expectElementToBeVisible(
-            ActivitiesView.transactionItem(0),
-            {
-              timeout: 60000,
-              description: 'Latest activity row should be visible',
-            },
-          );
-          await Assertions.expectElementToHaveText(
-            ActivitiesView.transactionStatus(0),
-            'Confirmed',
-            {
-              timeout: 60000,
-              description: 'Latest activity row should become Confirmed',
-            },
-          );
+          await Assertions.expectTextDisplayed('Confirmed', {
+            timeout: 60000,
+            allowDuplicates: true,
+          });
           await device.enableSynchronization();
         },
       );

--- a/tests/smoke/perps/perps-add-funds.spec.ts
+++ b/tests/smoke/perps/perps-add-funds.spec.ts
@@ -101,7 +101,29 @@ describe(SmokePerps('Perps - Add funds (has funds, not first time)'), () => {
         );
 
         // Go to Perps tab
-        await WalletView.scrollAndTapPerpsSection();
+        await Utilities.executeWithRetry(
+          async () => {
+            await WalletView.scrollAndTapPerpsSection();
+            const marketAddFundsVisible = await Utilities.isElementVisible(
+              PerpsTabView.marketAddFundsButton,
+              1500,
+            );
+            const legacyAddFundsVisible = await Utilities.isElementVisible(
+              PerpsTabView.addFundsButton,
+              1500,
+            );
+
+            if (!marketAddFundsVisible && !legacyAddFundsVisible) {
+              throw new Error(
+                'Perps balance actions are not visible after opening Perps section',
+              );
+            }
+          },
+          {
+            timeout: 30000,
+            description: 'Open Perps section from wallet',
+          },
+        );
 
         // Read initial balance text for later comparison
         const initialBalance = await PerpsTabView.getBalance();
@@ -137,9 +159,12 @@ describe(SmokePerps('Perps - Add funds (has funds, not first time)'), () => {
         await Utilities.executeWithRetry(
           async () => {
             const current = await PerpsTabView.getBalance();
-            await Assertions.checkIfValueIsDefined(
-              current === initialBalance + 80,
-            );
+            const expectedBalance = initialBalance + 80;
+            if (Math.abs(current - expectedBalance) > 0.01) {
+              throw new Error(
+                `Perps balance mismatch. Expected ${expectedBalance}, received ${current}`,
+              );
+            }
           },
           { interval: 1000, timeout: 60000 },
         );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- hardened `WalletView.scrollAndTapPredictionsPosition` with flexible text matching (handles whitespace/line-wrap differences) and bidirectional scroll retries
- added overshoot swipe when opening the Perps section to reduce mis-taps near bottom navigation
- strengthened `TabBarComponent.tapActivity` with fallback tap strategy and larger retry budget for slow post-confirmation transitions
- made Perps add-funds navigation and balance reads more resilient to transient rendering states
- increased EIP-7702 activity status assertion timeout while using text-based status checks (`Confirmed`/`Failed`) to avoid brittle row-index assumptions in activity list rendering
- adjusted `NetworkManager.openNetworkManager` loading logic to avoid unstable element-stability waits that caused iOS network-manager smoke failures
- fixed formatting in touched page-object files to satisfy `format:check`

## Changelog
CHANGELOG entry: null

## Validation
- `yarn prettier --check tests/page-objects/wallet/NetworkManager.ts tests/page-objects/wallet/TabBarComponent.ts tests/page-objects/wallet/WalletView.ts tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts`
- `yarn eslint tests/page-objects/wallet/NetworkManager.ts tests/page-objects/wallet/TabBarComponent.ts tests/page-objects/wallet/WalletView.ts tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts tests/smoke/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53589fca-ecba-406c-b765-77a840510280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53589fca-ecba-406c-b765-77a840510280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

