### PR TITLE
feat: migrate Button (card scope)

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
@@ -412,7 +412,8 @@ describe('CardAuthentication Component', () => {
       fireEvent.press(loginButton);
 
       await waitFor(() => {
-        expect(loginButton).toHaveProp('loading', true);
+        expect(loginButton).toBeDisabled();
+        expect(loginButton.props.accessibilityState.busy).toBe(true);
       });
 
       if (resolveLogin) {
@@ -420,7 +421,7 @@ describe('CardAuthentication Component', () => {
       }
 
       await waitFor(() => {
-        expect(loginButton).toHaveProp('loading', false);
+        expect(loginButton.props.accessibilityState.busy).toBeFalsy();
       });
     });
   });

--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -10,14 +10,11 @@ import {
   Icon,
   IconName,
   IconSize,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
-
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import { useTheme } from '../../../../../util/theme';
 import useCardProviderAuthentication from '../../hooks/useCardProviderAuthentication';
 import { CardAuthenticationSelectors } from './CardAuthentication.testIds';
@@ -472,17 +469,18 @@ const CardAuthentication = () => {
       step === 'otp' ? (
         <>
           <Button
-            variant={ButtonVariants.Primary}
-            label={strings('card.card_otp_authentication.confirm_button')}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             onPress={() => performLogin(confirmCode)}
-            loading={loading}
+            isLoading={loading}
             isDisabled={
               loading || !confirmCode || confirmCode.length < CODE_LENGTH
             }
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             testID="otp-confirm-button"
-          />
+          >
+            {strings('card.card_otp_authentication.confirm_button')}
+          </Button>
           <TouchableOpacity
             onPress={handleBackToLogin}
             testID="otp-back-to-login-button"
@@ -509,15 +507,16 @@ const CardAuthentication = () => {
           )}
           <Box>
             <Button
-              variant={ButtonVariants.Primary}
-              label={strings('card.card_authentication.login_button')}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               testID={CardAuthenticationSelectors.VERIFY_ACCOUNT_BUTTON}
               onPress={() => performLogin()}
-              loading={loading}
-              width={ButtonWidthTypes.Full}
+              isLoading={loading}
+              isFullWidth
               isDisabled={isLoginDisabled || loading}
-            />
+            >
+              {strings('card.card_authentication.login_button')}
+            </Button>
             <TouchableOpacity
               onPress={() => navigation.navigate(Routes.CARD.ONBOARDING.ROOT)}
             >

--- a/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
@@ -910,46 +910,91 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                     ]
                                   }
                                 >
-                                  <TouchableOpacity
+                                  <View
+                                    accessibilityLabel="Log in"
                                     accessibilityRole="button"
-                                    accessible={true}
-                                    activeOpacity={1}
-                                    disabled={true}
-                                    loading={false}
-                                    onPress={[Function]}
-                                    onPressIn={[Function]}
-                                    onPressOut={[Function]}
-                                    style={
+                                    accessibilityState={
                                       {
-                                        "alignItems": "center",
-                                        "alignSelf": "stretch",
-                                        "backgroundColor": "#131416",
-                                        "borderRadius": 12,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "opacity": 0.5,
-                                        "overflow": "hidden",
-                                        "paddingHorizontal": 16,
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": true,
+                                        "expanded": undefined,
+                                        "selected": undefined,
                                       }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#131416",
+                                          "borderRadius": 12,
+                                          "columnGap": 8,
+                                          "flexDirection": "row",
+                                          "height": 48,
+                                          "justifyContent": "center",
+                                          "minWidth": 80,
+                                          "opacity": 0.5,
+                                          "overflow": "hidden",
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "width": "100%",
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                        },
+                                      ]
                                     }
                                     testID="verify-account-button"
                                   >
                                     <Text
                                       accessibilityRole="text"
+                                      ellipsizeMode="clip"
+                                      numberOfLines={1}
                                       style={
-                                        {
-                                          "color": "#ffffff",
-                                          "fontFamily": "Geist-Medium",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {
+                                            "color": "#ffffff",
+                                            "flexGrow": 0,
+                                            "flexShrink": 1,
+                                            "flexWrap": "wrap",
+                                            "fontFamily": "Geist-Medium",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       Log in
                                     </Text>
-                                  </TouchableOpacity>
+                                  </View>
                                   <TouchableOpacity
                                     onPress={[Function]}
                                   >

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -1805,7 +1805,7 @@ describe('CardHome Component', () => {
       );
       expect(addFundsButton).toBeTruthy();
       // Button should have disabled styling applied
-      expect(addFundsButton.props.disabled).toBe(true);
+      expect(addFundsButton).toBeDisabled();
     });
 
     it('enables add funds button when swap is enabled for priority token', () => {
@@ -1820,7 +1820,7 @@ describe('CardHome Component', () => {
         CardHomeSelectors.ADD_FUNDS_BUTTON,
       );
       expect(addFundsButton).toBeTruthy();
-      expect(addFundsButton.props.disabled).toBe(false);
+      expect(addFundsButton).toBeEnabled();
     });
 
     it('applies disabled styling when swap is not enabled', () => {
@@ -1837,7 +1837,7 @@ describe('CardHome Component', () => {
         CardHomeSelectors.ADD_FUNDS_BUTTON,
       );
       expect(addFundsButton).toBeTruthy();
-      expect(addFundsButton.props.disabled).toBe(true);
+      expect(addFundsButton).toBeDisabled();
     });
 
     it('does not disable button when swap is enabled for priority token', async () => {
@@ -1851,7 +1851,7 @@ describe('CardHome Component', () => {
       const addFundsButton = screen.getByTestId(
         CardHomeSelectors.ADD_FUNDS_BUTTON,
       );
-      expect(addFundsButton.props.disabled).toBe(false);
+      expect(addFundsButton).toBeEnabled();
 
       mockTrackEvent.mockClear();
       fireEvent.press(addFundsButton);

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -17,7 +17,14 @@ import {
   Switch,
   TouchableOpacity,
 } from 'react-native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Icon, {
   IconName,
@@ -40,11 +47,6 @@ import { TextVariant as ComponentTextVariant } from '../../../../../component-li
 import Engine from '../../../../../core/Engine';
 import { useTheme } from '../../../../../util/theme';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import { strings } from '../../../../../../locales/i18n';
 import { useNavigateToCardPage } from '../../hooks/useNavigateToCardPage';
 import {
@@ -1017,13 +1019,14 @@ const CardHome = () => {
     if (!isBaanxLoginEnabled) {
       return (
         <Button
-          variant={ButtonVariants.Primary}
-          label={strings('card.card_home.add_funds')}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           onPress={addFundsAction}
-          width={ButtonWidthTypes.Full}
+          isFullWidth
           testID={CardHomeSelectors.ADD_FUNDS_BUTTON}
-        />
+        >
+          {strings('card.card_home.add_funds')}
+        </Button>
       );
     }
 
@@ -1038,44 +1041,47 @@ const CardHome = () => {
 
       return (
         <Button
-          variant={ButtonVariants.Primary}
-          label={strings('card.card_home.enable_card_button_label')}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           onPress={
             shouldRedirectToChooseCard
               ? navigateToChooseYourCard
               : openOnboardingDelegationAction
           }
-          width={ButtonWidthTypes.Full}
+          isFullWidth
           testID={cardSetupState.setupTestId}
-        />
+        >
+          {strings('card.card_home.enable_card_button_label')}
+        </Button>
       );
     }
 
     return (
       <Box twClassName="w-full gap-2 flex-row justify-between items-center">
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           style={tw.style(
             'w-1/2',
             !isSwapEnabledForPriorityToken && 'opacity-50',
           )}
-          label={strings('card.card_home.add_funds')}
           size={ButtonSize.Lg}
           onPress={addFundsAction}
-          width={ButtonWidthTypes.Full}
-          disabled={!isSwapEnabledForPriorityToken}
+          isFullWidth
+          isDisabled={!isSwapEnabledForPriorityToken}
           testID={CardHomeSelectors.ADD_FUNDS_BUTTON}
-        />
+        >
+          {strings('card.card_home.add_funds')}
+        </Button>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           style={tw.style('w-1/2')}
-          label={strings('card.card_home.change_asset')}
           size={ButtonSize.Lg}
           onPress={changeAssetAction}
-          width={ButtonWidthTypes.Full}
+          isFullWidth
           testID={CardHomeSelectors.CHANGE_ASSET_BUTTON}
-        />
+        >
+          {strings('card.card_home.change_asset')}
+        </Button>
       </Box>
     );
   }, [
@@ -1277,15 +1283,16 @@ const CardHome = () => {
         {retries < 3 && !isAuthenticationError(cardError) && (
           <Box twClassName="pt-2">
             <Button
-              variant={ButtonVariants.Primary}
-              label={strings('card.card_home.try_again')}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Md}
               onPress={() => {
                 setRetries((prevState) => prevState + 1);
                 fetchAllData();
               }}
               testID={CardHomeSelectors.TRY_AGAIN_BUTTON}
-            />
+            >
+              {strings('card.card_home.try_again')}
+            </Button>
           </Box>
         )}
       </Box>

--- a/app/components/UI/Card/Views/CardHome/__snapshots__/CardHome.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardHome/__snapshots__/CardHome.test.tsx.snap
@@ -944,83 +944,182 @@ exports[`CardHome Component renders correctly and matches snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Add funds"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                    "width": "50%",
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "width": "50%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="add-funds-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Add funds
                                 </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
+                              </View>
+                              <View
+                                accessibilityLabel="card.card_home.change_asset"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                    "width": "50%",
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "width": "50%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="change-asset-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   card.card_home.change_asset
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>
@@ -2309,83 +2408,182 @@ exports[`CardHome Component renders correctly with privacy mode enabled 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Add funds"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                    "width": "50%",
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "width": "50%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="add-funds-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Add funds
                                 </Text>
-                              </TouchableOpacity>
-                              <TouchableOpacity
+                              </View>
+                              <View
+                                accessibilityLabel="card.card_home.change_asset"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                    "width": "50%",
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "width": "50%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="change-asset-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   card.card_home.change_asset
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>

--- a/app/components/UI/Card/Views/Cashback/Cashback.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.tsx
@@ -6,16 +6,14 @@ import {
   TextVariant,
   TextColor,
   Skeleton,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import {
   ToastContext,
   ToastVariants,
@@ -253,15 +251,16 @@ const Cashback: React.FC = () => {
 
       <Box twClassName="px-4 pb-4">
         <Button
-          variant={ButtonVariants.Primary}
-          label={buttonLabel}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           onPress={handleWithdraw}
-          width={ButtonWidthTypes.Full}
+          isFullWidth
           isDisabled={isButtonDisabled}
-          loading={isProcessing}
+          isLoading={isProcessing}
           testID={CashbackSelectors.WITHDRAW_BUTTON}
-        />
+        >
+          {buttonLabel}
+        </Button>
       </Box>
     </SafeAreaView>
   );

--- a/app/components/UI/Card/Views/ChooseYourCard/ChooseYourCard.test.tsx
+++ b/app/components/UI/Card/Views/ChooseYourCard/ChooseYourCard.test.tsx
@@ -132,6 +132,8 @@ jest.mock('@metamask/design-system-react-native', () => {
   const React = jest.requireActual('react');
   const { View, Text: RNText } = jest.requireActual('react-native');
 
+  const { TouchableOpacity } = jest.requireActual('react-native');
+
   return {
     Box: ({
       children,
@@ -143,6 +145,19 @@ jest.mock('@metamask/design-system-react-native', () => {
       ...props
     }: React.PropsWithChildren<Record<string, unknown>>) =>
       React.createElement(RNText, props, children),
+    Button: ({
+      children,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(
+        TouchableOpacity,
+        { onPress, disabled: disabled || isDisabled, ...props },
+        React.createElement(RNText, {}, children || label),
+      ),
     TextVariant: {
       HeadingLg: 'HeadingLg',
       HeadingMd: 'HeadingMd',
@@ -153,6 +168,16 @@ jest.mock('@metamask/design-system-react-native', () => {
       Regular: 'Regular',
       Medium: 'Medium',
       Bold: 'Bold',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
   };
 });

--- a/app/components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx
+++ b/app/components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx
@@ -24,13 +24,11 @@ import {
   Text,
   TextVariant,
   FontWeight,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import Icon, {
   IconName,
   IconSize,
@@ -528,17 +526,16 @@ const ChooseYourCard = () => {
 
         <Box twClassName="px-4 pb-4 gap-2">
           <Button
-            variant={ButtonVariants.Primary}
-            label={
-              selectedCard.id === CardType.METAL
-                ? strings('card.choose_your_card.upgrade_title')
-                : strings('card.choose_your_card.continue_button')
-            }
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             onPress={handleContinue}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             testID={ChooseYourCardSelectors.CONTINUE_BUTTON}
-          />
+          >
+            {selectedCard.id === CardType.METAL
+              ? strings('card.choose_your_card.upgrade_title')
+              : strings('card.choose_your_card.continue_button')}
+          </Button>
           {activeIndex === 0 && !isUpgradeFlow && (
             <TouchableOpacity
               onPress={handleScrollToMetal}

--- a/app/components/UI/Card/Views/OrderCompleted/OrderCompleted.test.tsx
+++ b/app/components/UI/Card/Views/OrderCompleted/OrderCompleted.test.tsx
@@ -91,6 +91,8 @@ jest.mock('@metamask/design-system-react-native', () => {
   const React = jest.requireActual('react');
   const { View, Text: RNText } = jest.requireActual('react-native');
 
+  const { TouchableOpacity } = jest.requireActual('react-native');
+
   return {
     Box: ({
       children,
@@ -102,12 +104,35 @@ jest.mock('@metamask/design-system-react-native', () => {
       ...props
     }: React.PropsWithChildren<Record<string, unknown>>) =>
       React.createElement(RNText, props, children),
+    Button: ({
+      children,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(
+        TouchableOpacity,
+        { onPress, disabled: disabled || isDisabled, ...props },
+        React.createElement(RNText, {}, children || label),
+      ),
     TextVariant: {
       HeadingLg: 'HeadingLg',
       BodyMd: 'BodyMd',
     },
     FontWeight: {
       Regular: 'Regular',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
   };
 });

--- a/app/components/UI/Card/Views/OrderCompleted/OrderCompleted.tsx
+++ b/app/components/UI/Card/Views/OrderCompleted/OrderCompleted.tsx
@@ -8,13 +8,11 @@ import {
   Text,
   TextVariant,
   FontWeight,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -120,13 +118,14 @@ const OrderCompleted: React.FC = () => {
 
         <Box twClassName="pb-4">
           <Button
-            variant={ButtonVariants.Primary}
-            label={buttonLabel}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             onPress={handleSetUpCard}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             testID={OrderCompletedSelectors.SET_UP_CARD_BUTTON}
-          />
+          >
+            {buttonLabel}
+          </Button>
         </Box>
       </Box>
     </SafeAreaView>

--- a/app/components/UI/Card/Views/ReviewOrder/ReviewOrder.test.tsx
+++ b/app/components/UI/Card/Views/ReviewOrder/ReviewOrder.test.tsx
@@ -107,6 +107,8 @@ jest.mock('@metamask/design-system-react-native', () => {
   const React = jest.requireActual('react');
   const { View, Text: RNText } = jest.requireActual('react-native');
 
+  const { TouchableOpacity } = jest.requireActual('react-native');
+
   return {
     Box: ({
       children,
@@ -118,6 +120,19 @@ jest.mock('@metamask/design-system-react-native', () => {
       ...props
     }: React.PropsWithChildren<Record<string, unknown>>) =>
       React.createElement(RNText, props, children),
+    Button: ({
+      children,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(
+        TouchableOpacity,
+        { onPress, disabled: disabled || isDisabled, ...props },
+        React.createElement(RNText, {}, children || label),
+      ),
     TextVariant: {
       HeadingLg: 'HeadingLg',
       HeadingSm: 'HeadingSm',
@@ -128,6 +143,16 @@ jest.mock('@metamask/design-system-react-native', () => {
       Regular: 'Regular',
       Medium: 'Medium',
       Bold: 'Bold',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
   };
 });

--- a/app/components/UI/Card/Views/ReviewOrder/ReviewOrder.tsx
+++ b/app/components/UI/Card/Views/ReviewOrder/ReviewOrder.tsx
@@ -8,13 +8,11 @@ import {
   Text,
   TextVariant,
   FontWeight,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -295,14 +293,15 @@ const ReviewOrder = () => {
             </Text>
           )}
           <Button
-            variant={ButtonVariants.Primary}
-            label={strings('card.review_order.pay')}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             onPress={handlePay}
-            width={ButtonWidthTypes.Full}
-            loading={isCreatingPayment}
+            isFullWidth
+            isLoading={isCreatingPayment}
             testID={ReviewOrderSelectors.PAY_BUTTON}
-          />
+          >
+            {strings('card.review_order.pay')}
+          </Button>
         </Box>
       </Box>
     </SafeAreaView>

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
@@ -184,6 +184,49 @@ jest.mock('../../components/AssetSelectionBottomSheet', () => ({
   ]),
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const {
+    View,
+    Text,
+    TouchableOpacity,
+    ActivityIndicator: RNActivityIndicator,
+  } = jest.requireActual('react-native');
+
+  return {
+    ...actual,
+    Box: ({
+      children,
+      testID,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      ReactActual.createElement(View, { testID, ...props }, children),
+    Text: ({
+      children,
+      testID,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      ReactActual.createElement(Text, { testID, ...props }, children),
+    Button: ({
+      children,
+      testID,
+      onPress,
+      label,
+      isDisabled,
+      isLoading,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: isDisabled || isLoading, ...props },
+        isLoading
+          ? ReactActual.createElement(RNActivityIndicator, {})
+          : ReactActual.createElement(Text, {}, children || label),
+      ),
+  };
+});
+
 import React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { fireEvent, screen, waitFor } from '@testing-library/react-native';

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -12,15 +12,13 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import {
   CardTokenAllowance,
   DelegationSettingsResponse,
@@ -207,19 +205,21 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
           </Text>
           <Box twClassName="w-full gap-3">
             <Button
-              variant={ButtonVariants.Primary}
-              label={strings('card.card_spending_limit.retry')}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Md}
               onPress={fetchHookData}
-              width={ButtonWidthTypes.Full}
-            />
+              isFullWidth
+            >
+              {strings('card.card_spending_limit.retry')}
+            </Button>
             <Button
-              variant={ButtonVariants.Secondary}
-              label={strings('card.card_spending_limit.skip')}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
               onPress={skip}
-              width={ButtonWidthTypes.Full}
-            />
+              isFullWidth
+            >
+              {strings('card.card_spending_limit.skip')}
+            </Button>
           </Box>
         </Box>
       </SafeAreaView>
@@ -330,24 +330,26 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
           <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
             <Box twClassName="flex-1">
               <Button
-                variant={ButtonVariants.Secondary}
-                label={strings('card.card_spending_limit.cancel')}
+                variant={ButtonVariant.Secondary}
                 size={ButtonSize.Lg}
                 onPress={isOnboardingFlow ? skip : cancel}
-                width={ButtonWidthTypes.Full}
+                isFullWidth
                 isDisabled={isLoading}
-              />
+              >
+                {strings('card.card_spending_limit.cancel')}
+              </Button>
             </Box>
             <Box twClassName="flex-1">
               <Button
-                variant={ButtonVariants.Primary}
-                label={strings('card.card_spending_limit.confirm_new_limit')}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
                 onPress={submit}
-                width={ButtonWidthTypes.Full}
+                isFullWidth
                 isDisabled={!isValid || isLoading}
-                loading={isLoading}
-              />
+                isLoading={isLoading}
+              >
+                {strings('card.card_spending_limit.confirm_new_limit')}
+              </Button>
             </Box>
           </Box>
         </Box>

--- a/app/components/UI/Card/components/CardDeveloperOptionsSection/CardDeveloperOptionsSection.tsx
+++ b/app/components/UI/Card/components/CardDeveloperOptionsSection/CardDeveloperOptionsSection.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import { resetOnboardingState } from '../../../../../core/redux/slices/card';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import { strings } from '../../../../../../locales/i18n';
 
 const CardDeveloperOptionsSection = () => {
@@ -41,15 +41,14 @@ const CardDeveloperOptionsSection = () => {
         )}
       </Text>
       <Button
-        variant={ButtonVariants.Secondary}
+        variant={ButtonVariant.Secondary}
         size={ButtonSize.Lg}
-        label={strings(
-          'app_settings.developer_options.card.reset_onboarding_button',
-        )}
         onPress={handleResetOnboardingState}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         style={tw.style('mt-4')}
-      />
+      >
+        {strings('app_settings.developer_options.card.reset_onboarding_button')}
+      </Button>
     </Box>
   );
 };

--- a/app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx
+++ b/app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx
@@ -5,7 +5,7 @@ import {
   TextVariant,
   Text,
   Button,
-  ButtonVariant
+  ButtonVariant,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,

--- a/app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx
+++ b/app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
-import Button, {
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
 import {
   FontWeight,
-  Text,
   TextVariant,
+  Text,
+  Button,
+  ButtonVariant
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
@@ -107,20 +106,22 @@ const CardMessageBox = ({
         >
           {onDismiss && (
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               onPress={onDismiss}
-              label={strings('card.card_spending_limit.dismiss')}
               testID="dismiss-button"
-            />
+            >
+              {strings('card.card_spending_limit.dismiss')}
+            </Button>
           )}
           {config.confirmButtonLabel && onConfirm ? (
             <Button
-              variant={ButtonVariants.Primary}
+              variant={ButtonVariant.Primary}
               onPress={onConfirm}
-              loading={onConfirmLoading}
-              label={config.confirmButtonLabel}
+              isLoading={onConfirmLoading}
               testID="confirm-button"
-            />
+            >
+              {config.confirmButtonLabel}
+            </Button>
           ) : null}
         </View>
       </View>

--- a/app/components/UI/Card/components/Onboarding/Complete.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/Complete.test.tsx
@@ -115,6 +115,30 @@ jest.mock('@metamask/design-system-react-native', () => {
       Medium: '500',
       Bold: '700',
     },
+    Button: ({
+      children,
+      testID,
+      onPress,
+      isDisabled,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => {
+      const { TouchableOpacity } = jest.requireActual('react-native');
+      return React.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: isDisabled, ...props },
+        React.createElement(Text, {}, children),
+      );
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
+    },
   };
 });
 
@@ -286,9 +310,8 @@ describe('Complete Component', () => {
     });
 
     it('displays the correct button text', () => {
-      const { getByTestId } = render(<Complete />);
-      const buttonLabel = getByTestId('button-label');
-      expect(buttonLabel.props.children).toBe('Continue');
+      const { getByText } = render(<Complete />);
+      expect(getByText('Continue')).toBeTruthy();
     });
 
     it('is not disabled', () => {
@@ -447,10 +470,9 @@ describe('Complete Component', () => {
     });
 
     it('renders translated button label', () => {
-      const { getByTestId } = render(<Complete />);
+      const { getByText } = render(<Complete />);
 
-      const buttonLabel = getByTestId('button-label');
-      expect(buttonLabel.props.children).toBe('Continue');
+      expect(getByText('Continue')).toBeTruthy();
     });
   });
 
@@ -480,10 +502,9 @@ describe('Complete Component', () => {
     });
 
     it('renders button with correct label', () => {
-      const { getByTestId } = render(<Complete />);
+      const { getByText } = render(<Complete />);
 
-      const buttonLabel = getByTestId('button-label');
-      expect(buttonLabel.props.children).toBe('Continue');
+      expect(getByText('Continue')).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Card/components/Onboarding/Complete.tsx
+++ b/app/components/UI/Card/components/Onboarding/Complete.tsx
@@ -8,11 +8,6 @@ import {
 } from '@react-navigation/native';
 import OnboardingStep from './OnboardingStep';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../constants/navigation/Routes';
 import { resetOnboardingState } from '../../../../../core/redux/slices/card';
 import { useDispatch } from 'react-redux';
@@ -28,6 +23,9 @@ import {
   FontWeight,
   Text,
   TextVariant,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
@@ -140,15 +138,16 @@ const Complete = () => {
 
   const renderActions = () => (
     <Button
-      variant={ButtonVariants.Primary}
-      label={strings('card.card_onboarding.complete.confirm_button')}
+      variant={ButtonVariant.Primary}
       size={ButtonSize.Lg}
       onPress={handleContinue}
-      disabled={isLoading}
-      loading={isLoading}
-      width={ButtonWidthTypes.Full}
+      isDisabled={isLoading}
+      isLoading={isLoading}
+      isFullWidth
       testID="complete-confirm-button"
-    />
+    >
+      {strings('card.card_onboarding.complete.confirm_button')}
+    </Button>
   );
 
   return (

--- a/app/components/UI/Card/components/Onboarding/ConfirmEmail.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmEmail.test.tsx
@@ -117,7 +117,11 @@ jest.mock('@metamask/design-system-react-native', () => {
       return React.createElement(
         TouchableOpacity,
         { testID, onPress, disabled: disabled || isDisabled, ...props },
-        React.createElement(Text, {}, children || label),
+        React.createElement(
+          Text,
+          { testID: 'button-label' },
+          children || label,
+        ),
       );
     },
     TextVariant: {

--- a/app/components/UI/Card/components/Onboarding/ConfirmEmail.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmEmail.test.tsx
@@ -96,8 +96,42 @@ jest.mock('@metamask/design-system-react-native', () => {
         },
         children,
       ),
+    Button: ({
+      children,
+      testID,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      onPress?: () => void;
+      label?: string;
+      isDisabled?: boolean;
+      disabled?: boolean;
+      [key: string]: unknown;
+    }) => {
+      const { TouchableOpacity } = jest.requireActual('react-native');
+      return React.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: disabled || isDisabled, ...props },
+        React.createElement(Text, {}, children || label),
+      );
+    },
     TextVariant: {
       BodyLg: 'BodyLg',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
   };
 });

--- a/app/components/UI/Card/components/Onboarding/ConfirmEmail.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmEmail.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
-import Button, {
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -320,15 +322,16 @@ const ConfirmEmail = () => {
   const renderActions = () => (
     <Box twClassName="flex flex-col items-center justify-center gap-2">
       <Button
-        variant={ButtonVariants.Primary}
-        label={strings('card.card_onboarding.continue_button')}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
         onPress={handleContinue}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         isDisabled={isDisabled}
-        loading={verifyLoading}
+        isLoading={verifyLoading}
         testID="confirm-email-continue-button"
-      />
+      >
+        {strings('card.card_onboarding.continue_button')}
+      </Button>
       <Text
         variant={TextVariant.BodySm}
         testID="confirm-email-legal-terms"

--- a/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.test.tsx
@@ -98,6 +98,36 @@ jest.mock('@metamask/design-system-react-native', () => {
     TextVariant: {
       BodyLg: 'BodyLg',
     },
+    Button: ({
+      children,
+      testID,
+      onPress,
+      isDisabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      onPress?: () => void;
+      isDisabled?: boolean;
+      [key: string]: unknown;
+    }) => {
+      const { TouchableOpacity } = jest.requireActual('react-native');
+      return React.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: isDisabled, ...props },
+        React.createElement(Text, {}, children),
+      );
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
+    },
   };
 });
 
@@ -443,7 +473,7 @@ describe('ConfirmPhoneNumber Component', () => {
   describe('Continue Button', () => {
     it('should render continue button', () => {
       const store = createTestStore();
-      const { getByTestId } = render(
+      const { getByTestId, getByText } = render(
         <Provider store={store}>
           <ConfirmPhoneNumber />
         </Provider>,
@@ -451,7 +481,7 @@ describe('ConfirmPhoneNumber Component', () => {
 
       const button = getByTestId('confirm-phone-number-continue-button');
       expect(button).toBeTruthy();
-      expect(getByTestId('button-label')).toHaveTextContent('Continue');
+      expect(getByText('Continue')).toBeTruthy();
     });
 
     it('should be disabled when confirmation code is empty', () => {

--- a/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { Platform, TextInputProps } from 'react-native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
-import Button, {
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -308,15 +310,16 @@ const ConfirmPhoneNumber = () => {
 
   const renderActions = () => (
     <Button
-      variant={ButtonVariants.Primary}
-      label={strings('card.card_onboarding.continue_button')}
+      variant={ButtonVariant.Primary}
       size={ButtonSize.Lg}
       onPress={handleContinue}
-      width={ButtonWidthTypes.Full}
+      isFullWidth
       isDisabled={isDisabled}
-      loading={verifyLoading}
+      isLoading={verifyLoading}
       testID="confirm-phone-number-continue-button"
-    />
+    >
+      {strings('card.card_onboarding.continue_button')}
+    </Button>
   );
 
   return (

--- a/app/components/UI/Card/components/Onboarding/KYCFailed.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCFailed.test.tsx
@@ -56,9 +56,42 @@ jest.mock('@metamask/design-system-react-native', () => {
       children?: React.ReactNode;
       testID?: string;
     }) => ReactActual.createElement(Text, { testID, ...props }, children),
+    Button: ({
+      children,
+      testID,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      onPress?: () => void;
+      label?: string;
+      isDisabled?: boolean;
+      disabled?: boolean;
+    }) => {
+      const { TouchableOpacity } = jest.requireActual('react-native');
+      return ReactActual.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: disabled || isDisabled, ...props },
+        ReactActual.createElement(Text, {}, children || label),
+      );
+    },
     TextVariant: {
       HeadingLg: 'HeadingLg',
       BodyMd: 'BodyMd',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
   };
 });

--- a/app/components/UI/Card/components/Onboarding/KYCFailed.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCFailed.test.tsx
@@ -323,12 +323,11 @@ describe('KYCFailed Component', () => {
     });
 
     it('displays the correct button label', () => {
-      const { getByTestId } = render(<KYCFailed />);
+      const { getByTestId, getByText } = render(<KYCFailed />);
 
-      const buttonLabel = getByTestId('kyc-failed-close-button-label');
-
-      expect(buttonLabel).toBeTruthy();
-      expect(buttonLabel.props.children).toBe('Back to home');
+      const button = getByTestId('kyc-failed-close-button');
+      expect(button).toBeTruthy();
+      expect(getByText('Back to home')).toBeTruthy();
     });
 
     it('navigates to wallet home when close button is pressed', () => {
@@ -440,11 +439,9 @@ describe('KYCFailed Component', () => {
     });
 
     it('uses correct i18n key for close button', () => {
-      const { getByTestId } = render(<KYCFailed />);
+      const { getByText } = render(<KYCFailed />);
 
-      const buttonLabel = getByTestId('kyc-failed-close-button-label');
-
-      expect(buttonLabel.props.children).toBe('Back to home');
+      expect(getByText('Back to home')).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Card/components/Onboarding/KYCFailed.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCFailed.tsx
@@ -12,11 +12,6 @@ import { useDispatch } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -26,7 +21,14 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { CardScreens } from '../../util/metrics';
 import MM_CARD_ONBOARDING_FAILED from '../../../../../images/mm-card-onboarding-failed.png';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import { brandColor } from '@metamask/design-tokens';
 import { colors as importedColors } from '../../../../../styles/common';
 import { resetOnboardingState } from '../../../../../core/redux/slices/card';
@@ -154,13 +156,14 @@ const KYCFailed = () => {
       >
         <Box twClassName="pt-2 pb-4">
           <Button
-            variant={ButtonVariants.Primary}
-            label={strings('card.card_onboarding.kyc_failed.close_button')}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             onPress={navigateToHome}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             testID="kyc-failed-close-button"
-          />
+          >
+            {strings('card.card_onboarding.kyc_failed.close_button')}
+          </Button>
         </Box>
       </SafeAreaView>
     </Box>

--- a/app/components/UI/Card/components/Onboarding/KYCPending.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCPending.test.tsx
@@ -318,12 +318,11 @@ describe('KYCPending Component', () => {
     });
 
     it('displays the correct button label', () => {
-      const { getByTestId } = render(<KYCPending />);
+      const { getByTestId, getByText } = render(<KYCPending />);
 
-      const buttonLabel = getByTestId('kyc-pending-got-it-button-label');
-
-      expect(buttonLabel).toBeTruthy();
-      expect(buttonLabel.props.children).toBe('Got it');
+      const button = getByTestId('kyc-pending-got-it-button');
+      expect(button).toBeTruthy();
+      expect(getByText('Got it')).toBeTruthy();
     });
 
     it('navigates to wallet home when Got it button is pressed', () => {
@@ -421,11 +420,9 @@ describe('KYCPending Component', () => {
     });
 
     it('uses correct i18n key for Got it button', () => {
-      const { getByTestId } = render(<KYCPending />);
+      const { getByText } = render(<KYCPending />);
 
-      const buttonLabel = getByTestId('kyc-pending-got-it-button-label');
-
-      expect(buttonLabel.props.children).toBe('Got it');
+      expect(getByText('Got it')).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Card/components/Onboarding/KYCPending.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCPending.test.tsx
@@ -42,9 +42,42 @@ jest.mock('@metamask/design-system-react-native', () => {
       children?: React.ReactNode;
       testID?: string;
     }) => ReactActual.createElement(Text, { testID, ...props }, children),
+    Button: ({
+      children,
+      testID,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      onPress?: () => void;
+      label?: string;
+      isDisabled?: boolean;
+      disabled?: boolean;
+    }) => {
+      const { TouchableOpacity } = jest.requireActual('react-native');
+      return ReactActual.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: disabled || isDisabled, ...props },
+        ReactActual.createElement(Text, {}, children || label),
+      );
+    },
     TextVariant: {
       HeadingLg: 'HeadingLg',
       BodyMd: 'BodyMd',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
   };
 });

--- a/app/components/UI/Card/components/Onboarding/KYCPending.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCPending.tsx
@@ -4,11 +4,6 @@ import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -18,7 +13,14 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { CardScreens } from '../../util/metrics';
 import WaitingKYCImage from '../../../../../images/waiting-kyc-card.png';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import { colors as importedColors } from '../../../../../styles/common';
 
 // Threshold for small screen adjustments
@@ -115,13 +117,14 @@ const KYCPending = () => {
               {strings('card.card_onboarding.kyc_pending.footer_text')}
             </Text>
             <Button
-              variant={ButtonVariants.Primary}
-              label={strings('card.card_onboarding.kyc_pending.got_it_button')}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onPress={navigateToHome}
-              width={ButtonWidthTypes.Full}
+              isFullWidth
               testID="kyc-pending-got-it-button"
-            />
+            >
+              {strings('card.card_onboarding.kyc_pending.got_it_button')}
+            </Button>
           </Box>
         </SafeAreaView>
       </Box>

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
@@ -56,6 +56,20 @@ jest.mock('@metamask/design-system-react-native', () => {
     Lg: 'lg',
   };
 
+  const { TouchableOpacity } = jest.requireActual('react-native');
+
+  const ButtonVariant = {
+    Primary: 'Primary',
+    Secondary: 'Secondary',
+    Link: 'Link',
+  };
+
+  const ButtonSize = {
+    Sm: 'Sm',
+    Md: 'Md',
+    Lg: 'Lg',
+  };
+
   return {
     Box: ({
       children,
@@ -83,9 +97,32 @@ jest.mock('@metamask/design-system-react-native', () => {
       children: React.ReactNode;
       testID?: string;
     }) => React.createElement(Text, { testID, ...props }, children),
+    Button: ({
+      children,
+      testID,
+      onPress,
+      label,
+      isDisabled,
+      disabled,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      onPress?: () => void;
+      label?: string;
+      isDisabled?: boolean;
+      disabled?: boolean;
+    }) =>
+      React.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: disabled || isDisabled, ...props },
+        React.createElement(Text, {}, children || label),
+      ),
     TextVariant,
     IconName,
     IconSize,
+    ButtonVariant,
+    ButtonSize,
   };
 });
 

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -5,12 +5,10 @@ import {
   Label,
   Text,
   TextVariant,
-} from '@metamask/design-system-react-native';
-import Button, {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -448,15 +446,16 @@ const PersonalDetails = () => {
         </Text>
       )}
       <Button
-        variant={ButtonVariants.Primary}
-        label={strings('card.card_onboarding.continue_button')}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
         onPress={handleContinue}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         isDisabled={isDisabled}
-        loading={registerLoading}
+        isLoading={registerLoading}
         testID="personal-details-continue-button"
-      />
+      >
+        {strings('card.card_onboarding.continue_button')}
+      </Button>
     </Box>
   );
 

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
@@ -155,14 +155,40 @@ jest.mock('@metamask/design-system-react-native', () => {
   }: React.PropsWithChildren<Record<string, unknown>>) =>
     React.createElement(RNText, props, children);
 
+  const { TouchableOpacity } = jest.requireActual('react-native');
+
+  const Button = ({
+    children,
+    testID,
+    onPress,
+    isDisabled,
+    ...props
+  }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement(
+      TouchableOpacity,
+      { testID, onPress, disabled: isDisabled, ...props },
+      React.createElement(RNText, {}, children),
+    );
+
   return {
     Box,
     Label,
     Text,
     Icon,
+    Button,
     TextVariant: {
       BodySm: 'BodySm',
       BodyMd: 'BodyMd',
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
     },
     IconName: {
       ArrowDown: 'arrow-down',
@@ -1786,7 +1812,7 @@ describe('PhysicalAddress Component', () => {
     });
 
     it('displays translated text correctly', () => {
-      const { getByTestId } = render(
+      const { getByTestId, getByText } = render(
         <Provider store={store}>
           <PhysicalAddress />
         </Provider>,
@@ -1794,13 +1820,12 @@ describe('PhysicalAddress Component', () => {
 
       const title = getByTestId('onboarding-step-title');
       const description = getByTestId('onboarding-step-description');
-      const buttonText = getByTestId('button-text');
 
       expect(title.props.children).toBe('Physical Address');
       expect(description.props.children).toBe(
         'Enter your physical address information',
       );
-      expect(buttonText.props.children).toBe('Continue');
+      expect(getByText('Continue')).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -11,12 +11,10 @@ import {
   Label,
   Text,
   TextVariant,
-} from '@metamask/design-system-react-native';
-import Button, {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -804,15 +802,16 @@ const PhysicalAddress = () => {
         </Text>
       ) : null}
       <Button
-        variant={ButtonVariants.Primary}
-        label={strings('card.card_onboarding.continue_button')}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
         onPress={handleContinue}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         isDisabled={isDisabled}
-        loading={registerLoading || isPollingVerification}
+        isLoading={registerLoading || isPollingVerification}
         testID="physical-address-continue-button"
-      />
+      >
+        {strings('card.card_onboarding.continue_button')}
+      </Button>
     </Box>
   );
 

--- a/app/components/UI/Card/components/Onboarding/SetPhoneNumber.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SetPhoneNumber.test.tsx
@@ -109,6 +109,11 @@ jest.mock('@metamask/design-system-react-native', () => {
       Sm: 'sm',
       Md: 'md',
     },
+    Label: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(Text, props, children),
   };
 });
 

--- a/app/components/UI/Card/components/Onboarding/SetPhoneNumber.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SetPhoneNumber.test.tsx
@@ -55,6 +55,63 @@ jest.mock('./RegionSelectorModal', () => ({
 
 import { useCardSDK } from '../../sdk';
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const React = jest.requireActual('react');
+  const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+
+  return {
+    Box: ({
+      children,
+      testID,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(View, { testID, ...props }, children),
+    Text: ({
+      children,
+      testID,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(Text, { testID, ...props }, children),
+    Button: ({
+      children,
+      testID,
+      onPress,
+      label,
+      isDisabled,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement(
+        TouchableOpacity,
+        { testID, onPress, disabled: isDisabled, ...props },
+        React.createElement(Text, {}, children || label),
+      ),
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+      Link: 'Link',
+    },
+    ButtonSize: {
+      Sm: 'Sm',
+      Md: 'Md',
+      Lg: 'Lg',
+    },
+    TextVariant: {
+      BodySm: 'BodySm',
+      BodyMd: 'BodyMd',
+      HeadingMd: 'HeadingMd',
+    },
+    Icon: ({ ...props }: Record<string, unknown>) =>
+      React.createElement(View, props),
+    IconName: {
+      ArrowDown: 'arrow-down',
+    },
+    IconSize: {
+      Sm: 'sm',
+      Md: 'md',
+    },
+  };
+});
+
 // Mock OnboardingStep
 jest.mock('./OnboardingStep', () => {
   const React = jest.requireActual('react');

--- a/app/components/UI/Card/components/Onboarding/SetPhoneNumber.tsx
+++ b/app/components/UI/Card/components/Onboarding/SetPhoneNumber.tsx
@@ -11,12 +11,10 @@ import {
   Label,
   Text,
   TextVariant,
-} from '@metamask/design-system-react-native';
-import Button, {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -297,15 +295,16 @@ const SetPhoneNumber = () => {
   const renderActions = () => (
     <Box twClassName="flex flex-col items-center justify-center gap-2">
       <Button
-        variant={ButtonVariants.Primary}
-        label={strings('card.card_onboarding.continue_button')}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
         onPress={handleContinue}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         isDisabled={isDisabled}
-        loading={phoneVerificationIsLoading}
+        isLoading={phoneVerificationIsLoading}
         testID="set-phone-number-continue-button"
-      />
+      >
+        {strings('card.card_onboarding.continue_button')}
+      </Button>
       <Text
         variant={TextVariant.BodySm}
         testID="set-phone-number-legal-terms"

--- a/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
@@ -181,7 +181,7 @@ describe('SignUp Component', () => {
       );
 
       const continueButton = getByTestId('signup-continue-button');
-      expect(continueButton.props.disabled).toBe(true);
+      expect(continueButton).toBeDisabled();
     });
 
     it('does not show error messages initially', () => {
@@ -460,7 +460,7 @@ describe('SignUp Component', () => {
 
       expect(queryByText('United Kingdom')).toBeNull();
       // Continue button must remain disabled — no eligible country was selected
-      expect(getByTestId('signup-continue-button').props.disabled).toBe(true);
+      expect(getByTestId('signup-continue-button')).toBeDisabled();
       expect(storeWithGB.getState().card.userCardLocation).toBe(
         'international',
       );
@@ -533,7 +533,7 @@ describe('SignUp Component', () => {
       // Now check if the continue button is enabled
       await waitFor(
         () => {
-          expect(continueButton.props.disabled).toBe(false);
+          expect(continueButton).toBeEnabled();
         },
         { timeout: 3000 },
       );
@@ -559,7 +559,7 @@ describe('SignUp Component', () => {
       });
 
       await waitFor(() => {
-        expect(continueButton.props.disabled).toBe(true);
+        expect(continueButton).toBeDisabled();
       });
     });
 
@@ -590,7 +590,7 @@ describe('SignUp Component', () => {
       });
 
       await waitFor(() => {
-        expect(continueButton.props.disabled).toBe(true);
+        expect(continueButton).toBeDisabled();
       });
     });
 
@@ -612,7 +612,7 @@ describe('SignUp Component', () => {
       });
 
       await waitFor(() => {
-        expect(continueButton.props.disabled).toBe(true);
+        expect(continueButton).toBeDisabled();
       });
     });
   });
@@ -637,7 +637,7 @@ describe('SignUp Component', () => {
       });
 
       await waitFor(() => {
-        expect(continueButton.props.disabled).toBe(false);
+        expect(continueButton).toBeEnabled();
       });
 
       await act(async () => {
@@ -666,7 +666,7 @@ describe('SignUp Component', () => {
       });
 
       await waitFor(() => {
-        expect(continueButton.props.disabled).toBe(false);
+        expect(continueButton).toBeEnabled();
       });
 
       await act(async () => {

--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -15,12 +15,10 @@ import {
   IconSize,
   IconName,
   Label,
-} from '@metamask/design-system-react-native';
-import Button, {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -350,15 +348,16 @@ const SignUp = () => {
   const renderActions = () => (
     <>
       <Button
-        variant={ButtonVariants.Primary}
-        label={strings('card.card_onboarding.continue_button')}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
         onPress={handleContinue}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         isDisabled={isDisabled}
-        loading={emailVerificationIsLoading}
+        isLoading={emailVerificationIsLoading}
         testID="signup-continue-button"
-      />
+      >
+        {strings('card.card_onboarding.continue_button')}
+      </Button>
       <TouchableOpacity
         onPress={() => navigation.navigate(Routes.CARD.AUTHENTICATION)}
       >

--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.test.tsx
@@ -144,6 +144,33 @@ jest.mock('@metamask/design-system-react-native', () => {
     IconColor: {
       IconAlternative: 'IconAlternative',
     },
+    Button: ({
+      children,
+      label,
+      onPress,
+      isDisabled,
+      isFullWidth,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => {
+      const { TouchableOpacity, Text: RNText } =
+        jest.requireActual('react-native');
+      return React.createElement(
+        TouchableOpacity,
+        {
+          ...props,
+          testID: 'verify-identity-continue-button',
+          onPress,
+          disabled: isDisabled,
+        },
+        React.createElement(RNText, null, label || children),
+      );
+    },
+    ButtonVariant: {
+      Primary: 'Primary',
+    },
+    ButtonSize: {
+      Lg: 'Lg',
+    },
   };
 });
 

--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
@@ -12,12 +12,10 @@ import {
   IconSize,
   Text,
   TextVariant,
-} from '@metamask/design-system-react-native';
-import Button, {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 import useStartVerification from '../../hooks/useStartVerification';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
@@ -191,15 +189,16 @@ const VerifyIdentity = () => {
 
   const renderActions = () => (
     <Button
-      variant={ButtonVariants.Primary}
-      label={strings('card.card_onboarding.continue_button')}
+      variant={ButtonVariant.Primary}
       size={ButtonSize.Lg}
       onPress={handleContinue}
-      width={ButtonWidthTypes.Full}
+      isFullWidth
       isDisabled={!sessionUrl || isLaunchingVeriff}
-      loading={isLaunchingVeriff}
+      isLoading={isLaunchingVeriff}
       testID="verify-identity-continue-button"
-    />
+    >
+      {strings('card.card_onboarding.continue_button')}
+    </Button>
   );
   return (
     <OnboardingStep

--- a/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
@@ -961,45 +961,95 @@ exports[`DeveloperOptions renders correctly 1`] = `
                           >
                             Reset Card onboarding state to start the onboarding flow from the beginning.
                           </Text>
-                          <TouchableOpacity
+                          <View
+                            accessibilityLabel="Reset Onboarding State"
                             accessibilityRole="button"
-                            accessible={true}
-                            activeOpacity={1}
-                            onPress={[Function]}
-                            onPressIn={[Function]}
-                            onPressOut={[Function]}
-                            style={
+                            accessibilityState={
                               {
-                                "alignItems": "center",
-                                "alignSelf": "stretch",
-                                "backgroundColor": "#b4b4b528",
-                                "borderColor": "transparent",
-                                "borderRadius": 12,
-                                "borderWidth": 1,
-                                "flexDirection": "row",
-                                "height": 48,
-                                "justifyContent": "center",
-                                "marginTop": 16,
-                                "overflow": "hidden",
-                                "paddingHorizontal": 16,
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
                               }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "#b4b4b528",
+                                  "borderColor": "transparent",
+                                  "borderRadius": 12,
+                                  "borderWidth": 1,
+                                  "columnGap": 8,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "minWidth": 80,
+                                  "opacity": 1,
+                                  "overflow": "hidden",
+                                  "paddingLeft": 16,
+                                  "paddingRight": 16,
+                                  "width": "100%",
+                                },
+                                {
+                                  "marginTop": 16,
+                                },
+                                {
+                                  "transform": [
+                                    {
+                                      "scale": 1,
+                                    },
+                                  ],
+                                },
+                              ]
                             }
                           >
                             <Text
                               accessibilityRole="text"
+                              ellipsizeMode="clip"
+                              numberOfLines={1}
                               style={
-                                {
-                                  "color": "#131416",
-                                  "fontFamily": "Geist-Medium",
-                                  "fontSize": 16,
-                                  "letterSpacing": 0,
-                                  "lineHeight": 24,
-                                }
+                                [
+                                  {
+                                    "color": "#131416",
+                                    "flexGrow": 0,
+                                    "flexShrink": 1,
+                                    "flexWrap": "wrap",
+                                    "fontFamily": "Geist-Medium",
+                                    "fontSize": 16,
+                                    "fontWeight": 400,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                    "textAlign": "center",
+                                  },
+                                  undefined,
+                                ]
                               }
                             >
                               Reset Onboarding State
                             </Text>
-                          </TouchableOpacity>
+                          </View>
                         </View>
                       </View>
                     </RCTScrollView>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replace deprecated `Button` usage with DSRN package.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/8597813f-5f65-4225-9660-c8b939a8675d

### **After**

https://github.com/user-attachments/assets/37d71232-f8d1-497a-8a5c-3effed6338c7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many card/onboarding screens to swap a core UI component; while mostly prop/markup changes, subtle differences in disabled/loading/accessibility behavior could affect user flows and tests.
> 
> **Overview**
> Migrates card-related screens/components from the deprecated component-library `Button` to the design-system `@metamask/design-system-react-native` `Button` (e.g., auth, home, cashback, checkout/onboarding, spending limit, message box, and dev options).
> 
> Updates callsites to the new API (`variant` enums, `isLoading`, `isDisabled`, `isFullWidth`, and children-based labels) and adjusts tests/snapshots accordingly (including assertions using `toBeDisabled`/`toBeEnabled` and checking `accessibilityState.busy`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e6d97df12417d2c3044b3d4cec65cb6f509b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->