### PR TITLE
fix: unwrap rampsUnifiedBuyV2 threshold remote flag shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ramps unified buy v2 remote feature flag so LaunchDarkly threshold variations apply correctly
+
 ## [7.69.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed ramps unified buy v2 remote feature flag so LaunchDarkly threshold variations apply correctly
+- Fixed ramps unified buy v2 remote feature flag so LaunchDarkly threshold variations apply correctly (#27757)
 
 ## [7.69.0]
 

--- a/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.test.ts
+++ b/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.test.ts
@@ -1,5 +1,6 @@
 import {
   RampsUnifiedBuyV2Config,
+  resolveRampsUnifiedBuyV2Config,
   selectRampsUnifiedBuyV2Config,
   selectRampsUnifiedBuyV2ActiveFlag,
   selectRampsUnifiedBuyV2MinimumVersionFlag,
@@ -19,6 +20,35 @@ describe('RampsUnifiedBuyV2 selectors', () => {
 
   const mockEmptyRemoteFeatureFlags = {};
 
+  describe('resolveRampsUnifiedBuyV2Config', () => {
+    it('returns inner config when RemoteFeatureFlagController threshold shape is used', () => {
+      const wrapped = {
+        name: 'gradual rollout',
+        value: { active: true, minimumVersion: '7.71.0' },
+      };
+
+      const result = resolveRampsUnifiedBuyV2Config(wrapped);
+
+      expect(result).toEqual({ active: true, minimumVersion: '7.71.0' });
+    });
+
+    it('returns flat config when payload is not wrapped', () => {
+      const flat = { active: true, minimumVersion: '7.63.0' };
+
+      const result = resolveRampsUnifiedBuyV2Config(flat);
+
+      expect(result).toEqual(flat);
+    });
+
+    it('returns empty object when raw is null', () => {
+      expect(resolveRampsUnifiedBuyV2Config(null)).toEqual({});
+    });
+
+    it('returns empty object when raw is not an object', () => {
+      expect(resolveRampsUnifiedBuyV2Config('true')).toEqual({});
+    });
+  });
+
   describe('selectRampsUnifiedBuyV2Config', () => {
     it('returns the rampsUnifiedBuyV2Config when it exists', () => {
       const result = selectRampsUnifiedBuyV2Config.resultFunc(
@@ -26,6 +56,33 @@ describe('RampsUnifiedBuyV2 selectors', () => {
       );
 
       expect(result).toEqual(mockRemoteFeatureFlags.rampsUnifiedBuyV2);
+    });
+
+    it('unwraps threshold-resolved flag shape from RemoteFeatureFlagController', () => {
+      const flagsWithWrapped = {
+        rampsUnifiedBuyV2: {
+          name: 'on',
+          value: { active: true, minimumVersion: '7.71.0' },
+        },
+      };
+
+      const result = selectRampsUnifiedBuyV2Config.resultFunc(flagsWithWrapped);
+
+      expect(result).toEqual({ active: true, minimumVersion: '7.71.0' });
+    });
+
+    it('feeds active and minimum version selectors when flag is threshold-wrapped', () => {
+      const flagsWithWrapped = {
+        rampsUnifiedBuyV2: {
+          value: { active: true, minimumVersion: '7.71.0' },
+        },
+      };
+      const config = selectRampsUnifiedBuyV2Config.resultFunc(flagsWithWrapped);
+
+      expect(selectRampsUnifiedBuyV2ActiveFlag.resultFunc(config)).toBe(true);
+      expect(selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(config)).toBe(
+        '7.71.0',
+      );
     });
 
     it('returns an empty object when rampsUnifiedBuyV2Config does not exist', () => {

--- a/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.ts
+++ b/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.ts
@@ -8,11 +8,38 @@ export interface RampsUnifiedBuyV2Config {
 
 const FLAG_KEY = 'rampsUnifiedBuyV2';
 
+/**
+ * Normalizes `rampsUnifiedBuyV2` from RemoteFeatureFlagController state.
+ * Threshold-based LaunchDarkly flags are resolved to `{ name?, value }` where
+ * `value` holds `{ active, minimumVersion }`. Non-threshold payloads and local
+ * overrides use the flat `{ active, minimumVersion }` shape.
+ */
+export function resolveRampsUnifiedBuyV2Config(
+  raw: unknown,
+): RampsUnifiedBuyV2Config {
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+  const record = raw as Record<string, unknown>;
+  if (
+    'value' in record &&
+    typeof record.value === 'object' &&
+    record.value !== null &&
+    !Array.isArray(record.value)
+  ) {
+    return record.value as RampsUnifiedBuyV2Config;
+  }
+  return raw as RampsUnifiedBuyV2Config;
+}
+
 export const selectRampsUnifiedBuyV2Config = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    const rampsUnifiedBuyV2Config = remoteFeatureFlags?.[FLAG_KEY];
-    return (rampsUnifiedBuyV2Config ?? {}) as RampsUnifiedBuyV2Config;
+    const raw = remoteFeatureFlags?.[FLAG_KEY];
+    return resolveRampsUnifiedBuyV2Config(raw);
   },
 );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`RemoteFeatureFlagController` resolves LaunchDarkly **threshold** flag payloads to `{ name?, value }`, where `value` contains the variation JSON (e.g. `{ active, minimumVersion }`). The `rampsUnifiedBuyV2` selectors read `active` and `minimumVersion` only at the top level, so threshold-based rollouts were effectively ignored and the feature stayed off.

This change adds `resolveRampsUnifiedBuyV2Config` to normalize both the threshold-resolved shape and the existing flat shape (non-threshold API payloads, local overrides, E2E fixtures). Behavior is backward compatible for older flat configs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed ramps unified buy v2 remote feature flag so LaunchDarkly threshold variations apply correctly

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramps unified buy v2 remote flag

  Scenario: Threshold-wrapped remote flag is honored
    Given the app is on a version that satisfies rampsUnifiedBuyV2 minimumVersion
    And remote flags return rampsUnifiedBuyV2 as a threshold-resolved { value: { active: true, minimumVersion } } shape
    When the user opens a buy / fund entry point that uses unified buy v2
    Then the unified buy v2 flow is available according to active and version gates
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
