### PR TITLE
chore: Exempt `metamaskbotv2` from CLA check cp-7.71.0

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,7 +6,7 @@ on:
     types: [opened,closed,synchronize]
   merge_group:
     types: [checks_requested]
-    
+
 jobs:
   CLABot:
     if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
@@ -24,6 +24,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,crowdin-bot,runway-github[bot],cursorbot,cursoragent'
+          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursorbot,cursoragent'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
## **Description**

The CLABot workflow has been updated to exempt `metamaskv2` (i.e. commits created by Patroll tokens) from the CLA check.

We saw the CLA check fail recently on a release branch due to some commits appearing for the first time from Patroll (see https://github.com/MetaMask/metamask-mobile/pull/27708#issuecomment-4092630720). This change will fix that CI failure.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change limited to expanding the CLA bot allowlist; main impact is potentially skipping CLA enforcement for this additional bot account.
> 
> **Overview**
> Updates the `CLA Signature Bot` GitHub Actions workflow to add `metamaskbotv2[bot]` to the CLA exemption allowlist, preventing CLA check failures on PRs/merge groups created by that bot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1f4342f672c3170241c1afa8ad69771b3182c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->