### PR TITLE
refactor: simplify rampsUnifiedBuyV2 feature flag to single selector cp-7.71.0

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.test.ts
@@ -6,11 +6,11 @@ import useRampsUnifiedV2Enabled from './useRampsUnifiedV2Enabled';
 import { getVersion } from 'react-native-device-info';
 
 function mockInitialState({
-  rampsUnifiedBuyV2ActiveFlag = true,
-  rampsUnifiedBuyV2MinimumVersionFlag,
+  enabled = true,
+  minimumVersion,
 }: {
-  rampsUnifiedBuyV2ActiveFlag?: boolean;
-  rampsUnifiedBuyV2MinimumVersionFlag?: string | null;
+  enabled?: boolean;
+  minimumVersion?: string | null;
 } = {}) {
   return {
     ...initialRootState,
@@ -20,9 +20,9 @@ function mockInitialState({
         RemoteFeatureFlagController: {
           remoteFeatureFlags: {
             rampsUnifiedBuyV2: {
-              active: rampsUnifiedBuyV2ActiveFlag,
-              ...(rampsUnifiedBuyV2MinimumVersionFlag !== undefined && {
-                minimumVersion: rampsUnifiedBuyV2MinimumVersionFlag,
+              enabled,
+              ...(minimumVersion !== undefined && {
+                minimumVersion,
               }),
             },
           },
@@ -59,8 +59,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: false,
-            rampsUnifiedBuyV2MinimumVersionFlag: '2.0.0',
+            enabled: false,
+            minimumVersion: '2.0.0',
           }),
         },
       );
@@ -76,8 +76,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: '1.0.0',
+            enabled: true,
+            minimumVersion: '1.0.0',
           }),
         },
       );
@@ -93,8 +93,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: '2.0.0',
+            enabled: true,
+            minimumVersion: '2.0.0',
           }),
         },
       );
@@ -111,8 +111,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+            enabled: true,
+            minimumVersion: '7.63.0',
           }),
         },
       );
@@ -127,8 +127,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: false,
-            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+            enabled: false,
+            minimumVersion: '7.63.0',
           }),
         },
       );
@@ -143,8 +143,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+            enabled: true,
+            minimumVersion: '7.63.0',
           }),
         },
       );
@@ -159,8 +159,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: null,
+            enabled: true,
+            minimumVersion: null,
           }),
         },
       );
@@ -175,8 +175,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: undefined,
+            enabled: true,
+            minimumVersion: undefined,
           }),
         },
       );
@@ -191,8 +191,8 @@ describe('useRampsUnifiedV2Enabled', () => {
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: true,
-            rampsUnifiedBuyV2MinimumVersionFlag: '7.63.0',
+            enabled: true,
+            minimumVersion: '7.63.0',
           }),
         },
       );
@@ -200,15 +200,15 @@ describe('useRampsUnifiedV2Enabled', () => {
       expect(result.current).toBe(true);
     });
 
-    it('returns false when both active flag and minimum version are not set', () => {
+    it('returns false when both enabled flag and minimum version are not set', () => {
       mockGetVersion.mockReturnValue('8.0.0');
 
       const { result } = renderHookWithProvider(
         () => useRampsUnifiedV2Enabled(),
         {
           state: mockInitialState({
-            rampsUnifiedBuyV2ActiveFlag: false,
-            rampsUnifiedBuyV2MinimumVersionFlag: null,
+            enabled: false,
+            minimumVersion: null,
           }),
         },
       );

--- a/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.ts
+++ b/app/components/UI/Ramp/hooks/useRampsUnifiedV2Enabled.ts
@@ -1,33 +1,13 @@
 import { useSelector } from 'react-redux';
-import {
-  selectRampsUnifiedBuyV2ActiveFlag,
-  selectRampsUnifiedBuyV2MinimumVersionFlag,
-} from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
-import { hasMinimumRequiredVersion } from '../utils/hasMinimumRequiredVersion';
+import { selectRampsUnifiedBuyV2Enabled } from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
 
 export default function useRampsUnifiedV2Enabled() {
-  const rampsUnifiedBuyV2MinimumVersionFlag = useSelector(
-    selectRampsUnifiedBuyV2MinimumVersionFlag,
-  );
-  const rampsUnifiedBuyV2ActiveFlag = useSelector(
-    selectRampsUnifiedBuyV2ActiveFlag,
-  );
+  const isEnabled = useSelector(selectRampsUnifiedBuyV2Enabled);
 
-  const rampsUnifiedBuyV2BuildFlag =
-    process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED;
-
-  // if build flag is defined, it takes precedence over remote feature flag
-  if (
-    rampsUnifiedBuyV2BuildFlag === 'true' ||
-    rampsUnifiedBuyV2BuildFlag === 'false'
-  ) {
-    return rampsUnifiedBuyV2BuildFlag === 'true';
+  const buildFlag = process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED;
+  if (buildFlag === 'true' || buildFlag === 'false') {
+    return buildFlag === 'true';
   }
 
-  const isRampsUnifiedV2Enabled = hasMinimumRequiredVersion(
-    rampsUnifiedBuyV2MinimumVersionFlag,
-    rampsUnifiedBuyV2ActiveFlag,
-  );
-
-  return isRampsUnifiedV2Enabled;
+  return isEnabled;
 }

--- a/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.test.ts
+++ b/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.test.ts
@@ -9,10 +9,10 @@ jest.mock('react-native-device-info', () => ({
 }));
 
 function buildState({
-  active = true,
+  enabled = true,
   minimumVersion,
 }: {
-  active?: boolean;
+  enabled?: boolean;
   minimumVersion?: string | null;
 } = {}) {
   return {
@@ -24,7 +24,7 @@ function buildState({
           ...backgroundState.RemoteFeatureFlagController,
           remoteFeatureFlags: {
             rampsUnifiedBuyV2: {
-              active,
+              enabled,
               ...(minimumVersion !== undefined && { minimumVersion }),
             },
           },
@@ -53,7 +53,7 @@ describe('isRampsUnifiedV2Enabled', () => {
       process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'true';
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: false, minimumVersion: '99.0.0' }),
+        buildState({ enabled: false, minimumVersion: '99.0.0' }),
       );
 
       expect(result).toBe(true);
@@ -63,7 +63,7 @@ describe('isRampsUnifiedV2Enabled', () => {
       process.env.MM_RAMPS_UNIFIED_BUY_V2_ENABLED = 'false';
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: true, minimumVersion: '1.0.0' }),
+        buildState({ enabled: true, minimumVersion: '1.0.0' }),
       );
 
       expect(result).toBe(false);
@@ -71,21 +71,21 @@ describe('isRampsUnifiedV2Enabled', () => {
   });
 
   describe('remote feature flag behavior when build flag is not set', () => {
-    it('returns true when active and version meets minimum requirement', () => {
+    it('returns true when enabled and version meets minimum requirement', () => {
       mockGetVersion.mockReturnValue('8.0.0');
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: true, minimumVersion: '7.63.0' }),
+        buildState({ enabled: true, minimumVersion: '7.63.0' }),
       );
 
       expect(result).toBe(true);
     });
 
-    it('returns false when active flag is false', () => {
+    it('returns false when enabled flag is false', () => {
       mockGetVersion.mockReturnValue('8.0.0');
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: false, minimumVersion: '7.63.0' }),
+        buildState({ enabled: false, minimumVersion: '7.63.0' }),
       );
 
       expect(result).toBe(false);
@@ -95,7 +95,7 @@ describe('isRampsUnifiedV2Enabled', () => {
       mockGetVersion.mockReturnValue('7.0.0');
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: true, minimumVersion: '7.63.0' }),
+        buildState({ enabled: true, minimumVersion: '7.63.0' }),
       );
 
       expect(result).toBe(false);
@@ -105,7 +105,7 @@ describe('isRampsUnifiedV2Enabled', () => {
       mockGetVersion.mockReturnValue('8.0.0');
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: true, minimumVersion: null }),
+        buildState({ enabled: true, minimumVersion: null }),
       );
 
       expect(result).toBe(false);
@@ -115,7 +115,7 @@ describe('isRampsUnifiedV2Enabled', () => {
       mockGetVersion.mockReturnValue('7.63.0');
 
       const result = isRampsUnifiedV2Enabled(
-        buildState({ active: true, minimumVersion: '7.63.0' }),
+        buildState({ enabled: true, minimumVersion: '7.63.0' }),
       );
 
       expect(result).toBe(true);

--- a/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.ts
+++ b/app/components/UI/Ramp/utils/isRampsUnifiedV2Enabled.ts
@@ -1,8 +1,4 @@
-import {
-  selectRampsUnifiedBuyV2ActiveFlag,
-  selectRampsUnifiedBuyV2MinimumVersionFlag,
-} from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
-import { hasMinimumRequiredVersion } from './hasMinimumRequiredVersion';
+import { selectRampsUnifiedBuyV2Enabled } from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
 import { RootState } from '../../../../reducers';
 
 /**
@@ -16,7 +12,5 @@ export function isRampsUnifiedV2Enabled(state: RootState): boolean {
     return buildFlag === 'true';
   }
 
-  const activeFlag = selectRampsUnifiedBuyV2ActiveFlag(state);
-  const minimumVersion = selectRampsUnifiedBuyV2MinimumVersionFlag(state);
-  return hasMinimumRequiredVersion(minimumVersion, activeFlag);
+  return selectRampsUnifiedBuyV2Enabled(state);
 }

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
@@ -67,17 +67,17 @@ jest.mock('react-native-device-info', () => ({
 
 const createMockInitMessenger = (
   overrides: {
-    active?: boolean;
+    enabled?: boolean;
     minimumVersion?: string | null;
   } = {},
 ): RampsControllerInitMessenger => {
-  const { active = false, minimumVersion = null } = overrides;
+  const { enabled = false, minimumVersion = null } = overrides;
 
   return {
     call: jest.fn().mockReturnValue({
       remoteFeatureFlags: {
         rampsUnifiedBuyV2: {
-          active,
+          enabled,
           minimumVersion,
         },
       },
@@ -196,7 +196,7 @@ describe('ramps controller init', () => {
   describe('when V2 feature flag is enabled', () => {
     it('calls init at startup', async () => {
       initRequestMock.initMessenger = createMockInitMessenger({
-        active: true,
+        enabled: true,
         minimumVersion: '1.0.0',
       });
 
@@ -209,7 +209,7 @@ describe('ramps controller init', () => {
 
     it('handles init failure gracefully', async () => {
       initRequestMock.initMessenger = createMockInitMessenger({
-        active: true,
+        enabled: true,
         minimumVersion: '1.0.0',
       });
       mockInit.mockRejectedValue(new Error('Network error'));
@@ -225,7 +225,7 @@ describe('ramps controller init', () => {
   describe('when V2 feature flag is disabled', () => {
     it('does not call init at startup', async () => {
       initRequestMock.initMessenger = createMockInitMessenger({
-        active: false,
+        enabled: false,
       });
 
       rampsControllerInit(initRequestMock);
@@ -235,9 +235,9 @@ describe('ramps controller init', () => {
       });
     });
 
-    it('does not call init when active is true but minimumVersion is missing', async () => {
+    it('does not call init when enabled is true but minimumVersion is missing', async () => {
       initRequestMock.initMessenger = createMockInitMessenger({
-        active: true,
+        enabled: true,
         minimumVersion: null,
       });
 
@@ -265,7 +265,7 @@ describe('ramps controller init', () => {
 
   it('always returns the controller instance regardless of flag state', () => {
     initRequestMock.initMessenger = createMockInitMessenger({
-      active: false,
+      enabled: false,
     });
 
     const result = rampsControllerInit(initRequestMock);

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -5,16 +5,10 @@ import {
   getDefaultRampsControllerState,
 } from '@metamask/ramps-controller';
 import type { RampsControllerInitMessenger } from '../../messengers/ramps-controller-messenger';
-import { hasMinimumRequiredVersion } from '../../../../components/UI/Ramp/utils/hasMinimumRequiredVersion';
+import { validatedVersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
+import { RAMPS_UNIFIED_BUY_V2_FLAG_KEY } from '../../../../selectors/featureFlagController/ramps/rampsUnifiedBuyV2';
 import { handleOrderStatusChangedForNotifications } from './event-handlers/notification';
 import { handleOrderStatusChangedForMetrics } from './event-handlers/analytics';
-
-interface RampsUnifiedBuyV2Config {
-  active?: boolean;
-  minimumVersion?: string;
-}
-
-const RAMPS_UNIFIED_BUY_V2_FLAG_KEY = 'rampsUnifiedBuyV2';
 
 /**
  * Determines whether the ramps unified buy V2 feature is enabled
@@ -30,14 +24,9 @@ function getIsRampsUnifiedBuyV2Enabled(
     const remoteState = initMessenger.call(
       'RemoteFeatureFlagController:getState',
     );
-    const config = (remoteState?.remoteFeatureFlags?.[
-      RAMPS_UNIFIED_BUY_V2_FLAG_KEY
-    ] ?? {}) as RampsUnifiedBuyV2Config;
-
-    return hasMinimumRequiredVersion(
-      config.minimumVersion,
-      config.active ?? false,
-    );
+    const remoteFlag =
+      remoteState?.remoteFeatureFlags?.[RAMPS_UNIFIED_BUY_V2_FLAG_KEY];
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   } catch {
     return false;
   }

--- a/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.test.ts
+++ b/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.test.ts
@@ -1,165 +1,77 @@
-import {
-  RampsUnifiedBuyV2Config,
-  selectRampsUnifiedBuyV2Config,
-  selectRampsUnifiedBuyV2ActiveFlag,
-  selectRampsUnifiedBuyV2MinimumVersionFlag,
-} from './rampsUnifiedBuyV2';
-import { selectRemoteFeatureFlags } from '..';
-import { FeatureFlags } from '@metamask/remote-feature-flag-controller';
+import { selectRampsUnifiedBuyV2Enabled } from './rampsUnifiedBuyV2';
+// eslint-disable-next-line import-x/no-namespace
+import * as remoteFeatureFlagModule from '../../../util/remoteFeatureFlag';
 
-describe('RampsUnifiedBuyV2 selectors', () => {
-  const mockRemoteFeatureFlags: ReturnType<typeof selectRemoteFeatureFlags> & {
-    rampsUnifiedBuyV2: RampsUnifiedBuyV2Config;
-  } = {
-    rampsUnifiedBuyV2: {
-      active: true,
-      minimumVersion: '7.63.0',
-    },
-  };
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
 
-  const mockEmptyRemoteFeatureFlags = {};
+describe('selectRampsUnifiedBuyV2Enabled', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
 
-  describe('selectRampsUnifiedBuyV2Config', () => {
-    it('returns the rampsUnifiedBuyV2Config when it exists', () => {
-      const result = selectRampsUnifiedBuyV2Config.resultFunc(
-        mockRemoteFeatureFlags,
-      );
-
-      expect(result).toEqual(mockRemoteFeatureFlags.rampsUnifiedBuyV2);
-    });
-
-    it('returns an empty object when rampsUnifiedBuyV2Config does not exist', () => {
-      const result = selectRampsUnifiedBuyV2Config.resultFunc(
-        mockEmptyRemoteFeatureFlags,
-      );
-
-      expect(result).toEqual({});
-    });
-
-    it('returns an empty object when remoteFeatureFlags is null', () => {
-      const result = selectRampsUnifiedBuyV2Config.resultFunc(
-        null as unknown as FeatureFlags,
-      );
-
-      expect(result).toEqual({});
-    });
-
-    it('returns an empty object when remoteFeatureFlags is undefined', () => {
-      const result = selectRampsUnifiedBuyV2Config.resultFunc(
-        undefined as unknown as FeatureFlags,
-      );
-
-      expect(result).toEqual({});
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
   });
 
-  describe('selectRampsUnifiedBuyV2ActiveFlag', () => {
-    it('returns true when active is set to true', () => {
-      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
-        mockRemoteFeatureFlags.rampsUnifiedBuyV2,
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when active is set to false', () => {
-      const mockConfigWithActiveFalse: RampsUnifiedBuyV2Config = {
-        active: false,
-        minimumVersion: '7.63.0',
-      };
-
-      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
-        mockConfigWithActiveFalse,
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when active is not set', () => {
-      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc({});
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when active is null', () => {
-      const mockConfigWithActiveNull: RampsUnifiedBuyV2Config = {
-        active: null as unknown as boolean,
-        minimumVersion: '7.63.0',
-      };
-
-      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
-        mockConfigWithActiveNull,
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when active is undefined', () => {
-      const mockConfigWithActiveUndefined: RampsUnifiedBuyV2Config = {
-        active: undefined as unknown as boolean,
-        minimumVersion: '7.63.0',
-      };
-
-      const result = selectRampsUnifiedBuyV2ActiveFlag.resultFunc(
-        mockConfigWithActiveUndefined,
-      );
-
-      expect(result).toBe(false);
-    });
+  afterEach(() => {
+    mockHasMinimumRequiredVersion?.mockRestore();
   });
 
-  describe('selectRampsUnifiedBuyV2MinimumVersionFlag', () => {
-    it('returns the minimumVersion when it exists', () => {
-      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
-        mockRemoteFeatureFlags.rampsUnifiedBuyV2,
-      );
-
-      expect(result).toBe('7.63.0');
+  it('returns true when remote flag is valid and enabled', () => {
+    const result = selectRampsUnifiedBuyV2Enabled.resultFunc({
+      rampsUnifiedBuyV2: {
+        enabled: true,
+        minimumVersion: '1.0.0',
+      },
     });
+    expect(result).toBe(true);
+  });
 
-    it('returns null when minimumVersion is not set', () => {
-      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc({});
-
-      expect(result).toBeNull();
+  it('returns false when remote flag is valid but disabled', () => {
+    const result = selectRampsUnifiedBuyV2Enabled.resultFunc({
+      rampsUnifiedBuyV2: {
+        enabled: false,
+        minimumVersion: '1.0.0',
+      },
     });
+    expect(result).toBe(false);
+  });
 
-    it('returns null when minimumVersion is null', () => {
-      const mockConfigWithVersionNull: RampsUnifiedBuyV2Config = {
-        active: true,
-        minimumVersion: null as unknown as string,
-      };
-
-      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
-        mockConfigWithVersionNull,
-      );
-
-      expect(result).toBeNull();
+  it('returns false when version check fails', () => {
+    mockHasMinimumRequiredVersion.mockReturnValue(false);
+    const result = selectRampsUnifiedBuyV2Enabled.resultFunc({
+      rampsUnifiedBuyV2: {
+        enabled: true,
+        minimumVersion: '99.0.0',
+      },
     });
+    expect(result).toBe(false);
+  });
 
-    it('returns null when minimumVersion is undefined', () => {
-      const mockConfigWithVersionUndefined: RampsUnifiedBuyV2Config = {
-        active: true,
-        minimumVersion: undefined,
-      };
-
-      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
-        mockConfigWithVersionUndefined,
-      );
-
-      expect(result).toBeNull();
+  it('returns false when remote flag is invalid', () => {
+    const result = selectRampsUnifiedBuyV2Enabled.resultFunc({
+      rampsUnifiedBuyV2: {
+        enabled: 'invalid',
+        minimumVersion: 123,
+      },
     });
+    expect(result).toBe(false);
+  });
 
-    it('returns the minimumVersion when it is an empty string', () => {
-      const mockConfigWithEmptyVersion: RampsUnifiedBuyV2Config = {
-        active: true,
-        minimumVersion: '',
-      };
+  it('returns false when remote feature flags are empty', () => {
+    const result = selectRampsUnifiedBuyV2Enabled.resultFunc({});
+    expect(result).toBe(false);
+  });
 
-      const result = selectRampsUnifiedBuyV2MinimumVersionFlag.resultFunc(
-        mockConfigWithEmptyVersion,
-      );
-
-      expect(result).toBe('');
+  it('returns false when rampsUnifiedBuyV2 is null', () => {
+    const result = selectRampsUnifiedBuyV2Enabled.resultFunc({
+      rampsUnifiedBuyV2: null,
     });
+    expect(result).toBe(false);
   });
 });

--- a/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.ts
+++ b/app/selectors/featureFlagController/ramps/rampsUnifiedBuyV2.ts
@@ -1,34 +1,18 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
+import {
+  validatedVersionGatedFeatureFlag,
+  VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
 
-export interface RampsUnifiedBuyV2Config {
-  active?: boolean;
-  minimumVersion?: string;
-}
+export const RAMPS_UNIFIED_BUY_V2_FLAG_KEY = 'rampsUnifiedBuyV2';
 
-const FLAG_KEY = 'rampsUnifiedBuyV2';
-
-export const selectRampsUnifiedBuyV2Config = createSelector(
+export const selectRampsUnifiedBuyV2Enabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    const rampsUnifiedBuyV2Config = remoteFeatureFlags?.[FLAG_KEY];
-    return (rampsUnifiedBuyV2Config ?? {}) as RampsUnifiedBuyV2Config;
-  },
-);
-
-export const selectRampsUnifiedBuyV2ActiveFlag = createSelector(
-  selectRampsUnifiedBuyV2Config,
-  (rampsUnifiedBuyV2Config) => {
-    const rampsUnifiedBuyV2ActiveFlag = rampsUnifiedBuyV2Config?.active;
-    return rampsUnifiedBuyV2ActiveFlag ?? false;
-  },
-);
-
-export const selectRampsUnifiedBuyV2MinimumVersionFlag = createSelector(
-  selectRampsUnifiedBuyV2Config,
-  (rampsUnifiedBuyV2Config) => {
-    const rampsUnifiedBuyV2MinimumVersion =
-      rampsUnifiedBuyV2Config?.minimumVersion;
-    return rampsUnifiedBuyV2MinimumVersion ?? null;
+    const remoteFlag = remoteFeatureFlags[
+      RAMPS_UNIFIED_BUY_V2_FLAG_KEY
+    ] as unknown as VersionGatedFeatureFlag;
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );

--- a/tests/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/tests/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -135,9 +135,9 @@ export const remoteFeatureFlagRampsUnifiedV1Enabled = (active = true) => ({
   },
 });
 
-export const remoteFeatureFlagRampsUnifiedV2Enabled = (active = true) => ({
+export const remoteFeatureFlagRampsUnifiedV2Enabled = (enabled = true) => ({
   rampsUnifiedBuyV2: {
-    active,
+    enabled,
     minimumVersion: '7.63.0',
   },
 });
@@ -157,14 +157,14 @@ export const remoteFeatureFlagRampsUnifiedEnabled = (active = true) => ({
  */
 export const remoteFeatureFlagRampsUnifiedMatrixForE2E = (
   rampsUnifiedBuyV1Active: boolean,
-  rampsUnifiedBuyV2Active: boolean,
+  rampsUnifiedBuyV2Enabled: boolean,
 ) => ({
   rampsUnifiedBuyV1: {
     active: rampsUnifiedBuyV1Active,
     minimumVersion: '0.0.0',
   },
   rampsUnifiedBuyV2: {
-    active: rampsUnifiedBuyV2Active,
+    enabled: rampsUnifiedBuyV2Enabled,
     minimumVersion: '0.0.0',
   },
 });

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3240,7 +3240,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      active: false,
+      enabled: false,
       minimumVersion: '7.61.0',
     },
     status: FeatureFlagStatus.Active,

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -517,7 +517,7 @@ class FixtureBuilder {
             minimumVersion: '0.0.0',
           },
           rampsUnifiedBuyV2: {
-            active: rampsUnifiedBuyV2,
+            enabled: rampsUnifiedBuyV2,
             minimumVersion: '0.0.0',
           },
         },


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `rampsUnifiedBuyV2` feature flag previously used three chained selectors (`selectRampsUnifiedBuyV2Config` → `selectRampsUnifiedBuyV2ActiveFlag` / `selectRampsUnifiedBuyV2MinimumVersionFlag`) and a custom 2-arg `hasMinimumRequiredVersion` utility. This was inconsistent with how other feature flags (e.g. homepage redesign) are handled in the codebase.

This PR consolidates the three selectors into a single `selectRampsUnifiedBuyV2Enabled` selector that uses the shared `validatedVersionGatedFeatureFlag` utility from `app/util/remoteFeatureFlag`. The remote flag shape is updated from `{ active, minimumVersion }` to `{ enabled, minimumVersion }` to match the standard `VersionGatedFeatureFlag` type.

**Key changes:**
- **Selector file** (`rampsUnifiedBuyV2.ts`): Replaced 3 selectors + `RampsUnifiedBuyV2Config` interface with a single `selectRampsUnifiedBuyV2Enabled` selector
- **Hook** (`useRampsUnifiedV2Enabled.ts`): Simplified from two `useSelector` calls + `hasMinimumRequiredVersion` to a single `useSelector`
- **Utility** (`isRampsUnifiedV2Enabled.ts`): Simplified to delegate directly to the selector
- **Controller init** (`ramps-controller-init.ts`): Replaced local interface + `hasMinimumRequiredVersion` with `validatedVersionGatedFeatureFlag`; imports shared flag key constant
- **Flag key constant**: Exported `RAMPS_UNIFIED_BUY_V2_FLAG_KEY` from the selector file as single source of truth
- **E2E mocks/fixtures**: Updated flag shape from `active` to `enabled` in `FixtureBuilder`, `feature-flags-mocks`, and `feature-flag-registry`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — this is a pure refactor of internal selector structure. Behavior is unchanged. All unit tests have been updated and pass.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**


https://github.com/user-attachments/assets/13ab83a0-f3b1-4862-95cc-ec02fc5b89b5



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches feature-flag gating that controls whether the ramps V2 flow and controller initialization run, and changes the expected remote flag shape from `active` to `enabled`. Main risk is misconfigured/older flag payloads causing the feature to be incorrectly disabled.
> 
> **Overview**
> Simplifies `rampsUnifiedBuyV2` enablement checks by replacing the chained config/active/min-version selectors and custom gating logic with a single `selectRampsUnifiedBuyV2Enabled` that delegates to `validatedVersionGatedFeatureFlag`.
> 
> Updates the Ramp hook/utility and `ramps-controller-init` to consume this unified version-gated flag (keeping the build-flag override), and standardizes the remote flag payload from `{ active, minimumVersion }` to `{ enabled, minimumVersion }` across unit tests, E2E mocks/fixtures, and the feature-flag registry defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3edd562babe66c83b700fbbac49c57cb1ea522fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->