### PR TITLE
ci: split build artifacts and fix testflight upload for runway

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,29 +328,35 @@ jobs:
             SCRIPT_NAME="build:${{ matrix.platform }}:${BUILD_NAME//-/:}"
             yarn "$SCRIPT_NAME"
 
-      # Rename build artifacts (also zips simulator .app and writes ios_deploy_path / ios_archive_path outputs)
+      # Rename build artifacts (zips simulator .app and .xcarchive; writes ios_deploy_path / ios_archive_path / android_*_path outputs)
       - name: Rename ${{ matrix.platform }} artifacts
         if: success()
         id: rename
         run: node scripts/rename-artifacts.js ${{ matrix.platform }}
 
       # Upload build artifacts (only if build succeeded)
-      - name: Upload iOS simulator artifacts
+      - name: Upload iOS simulator app
         if: matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: ios-${{ inputs.build_name }}
+          name: ios-app-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_deploy_path }}
           if-no-files-found: error
 
-      - name: Upload iOS device artifacts
+      - name: Upload iOS IPA
         if: matrix.platform == 'ios' && env.IS_SIM_BUILD != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: ios-${{ inputs.build_name }}
-          path: |
-            ${{ steps.rename.outputs.ios_deploy_path }}
-            ${{ steps.rename.outputs.ios_archive_path }}
+          name: ios-ipa-${{ inputs.build_name }}
+          path: ${{ steps.rename.outputs.ios_deploy_path }}
+          if-no-files-found: error
+
+      - name: Upload iOS xcarchive
+        if: matrix.platform == 'ios' && env.IS_SIM_BUILD != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-xcarchive-${{ inputs.build_name }}
+          path: ${{ steps.rename.outputs.ios_archive_path }}
           if-no-files-found: error
 
       - name: Upload iOS sourcemap
@@ -361,27 +367,32 @@ jobs:
           path: ${{ steps.rename.outputs.ios_sourcemap_path }}
           if-no-files-found: warn
 
-      # Dev builds (CONFIGURATION=Debug): APK only — mirrors Bitrise IS_DEV_BUILD behavior
-      - name: Upload Android dev artifacts
+      # Dev builds (CONFIGURATION=Debug): APK only
+      - name: Upload Android APK (dev)
         if: matrix.platform == 'android' && env.CONFIGURATION == 'Debug'
         uses: actions/upload-artifact@v4
         with:
-          name: android-${{ inputs.build_name }}
+          name: android-apk-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_apk_path }}
           if-no-files-found: error
 
-      # Release builds: APK + AAB — mirrors Bitrise Deploy APK + Deploy AAB
-      - name: Upload Android release artifacts
+      # Release builds: APK and AAB as separate artifacts
+      - name: Upload Android APK (release)
         if: matrix.platform == 'android' && env.CONFIGURATION != 'Debug'
         uses: actions/upload-artifact@v4
         with:
-          name: android-${{ inputs.build_name }}
-          path: |
-            ${{ steps.rename.outputs.android_apk_path }}
-            ${{ steps.rename.outputs.android_aab_path }}
+          name: android-apk-${{ inputs.build_name }}
+          path: ${{ steps.rename.outputs.android_apk_path }}
           if-no-files-found: error
 
-      # Non-Debug builds (prod, RC, beta, test, e2e, exp): sourcemaps — mirrors Bitrise Deploy Android Sourcemaps step
+      - name: Upload Android AAB
+        if: matrix.platform == 'android' && env.CONFIGURATION != 'Debug'
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab-${{ inputs.build_name }}
+          path: ${{ steps.rename.outputs.android_aab_path }}
+          if-no-files-found: error
+
       - name: Upload Android sourcemaps
         if: matrix.platform == 'android' && env.CONFIGURATION != 'Debug'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -108,10 +108,10 @@ jobs:
           working-directory: ios
           bundler-cache: true
 
-      - name: Download iOS build artifact
+      - name: Download iOS IPA artifact
         uses: actions/download-artifact@v4
         with:
-          name: ios-main-exp
+          name: ios-ipa-main-exp
 
       - name: Find IPA path
         id: ipa
@@ -141,8 +141,7 @@ jobs:
             "github_actions_main-exp" \
             "${{ github.ref_name }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "MetaMask BETA & Release Candidates" \
-            "false"
+            "MetaMask BETA & Release Candidates"
 
       - name: Cleanup API Key
         if: always()
@@ -168,10 +167,10 @@ jobs:
           working-directory: ios
           bundler-cache: true
 
-      - name: Download iOS build artifact
+      - name: Download iOS IPA artifact
         uses: actions/download-artifact@v4
         with:
-          name: ios-main-rc
+          name: ios-ipa-main-rc
 
       - name: Find IPA path
         id: ipa
@@ -203,8 +202,7 @@ jobs:
             "github_actions_main-rc" \
             "${{ github.ref_name }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "MetaMask BETA & Release Candidates" \
-            "false"
+            "MetaMask BETA & Release Candidates"
 
       - name: Cleanup API Key
         if: always()

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -89,10 +89,10 @@ jobs:
           working-directory: ios
           bundler-cache: true
 
-      - name: Download iOS build artifact
+      - name: Download iOS IPA artifact
         uses: actions/download-artifact@v4
         with:
-          name: ios-main-${{ inputs.environment || 'rc' }}
+          name: ios-ipa-main-${{ inputs.environment || 'rc' }}
 
       - name: Find IPA path
         id: ipa

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -93,15 +93,28 @@ platform :ios do
       key_filepath: api_key_key_filepath,
     )
     
-    # Upload to TestFlight with API key from app_store_connect_api_key action
-    upload_to_testflight(
+    # Upload to TestFlight with API key from app_store_connect_api_key action.
+    # When distribute_external is false we skip_submission so the action only
+    # uploads the IPA binary. This avoids TestFlight management API calls that
+    # require an App Manager (or higher) role API key — a Developer role key
+    # can upload builds but cannot manage distribution.
+    testflight_options = {
       api_key: api_key,
       ipa: ipa_path,
       distribute_external: distribute_external,
       groups: groups,
       notify_external_testers: notify_external_testers,
       changelog: changelog_message
-    )
+    }
+
+    if distribute_external
+      testflight_options[:distribute_external] = true
+      testflight_options[:notify_external_testers] = true
+      testflight_options[:groups] = groups
+    else
+      testflight_options[:skip_submission] = true
+    end
+
+    upload_to_testflight(testflight_options)
   end
 end
-

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -247,17 +247,21 @@ function renameIos() {
     console.log(`✅ Sourcemap path: ${sourcemapPath}`);
   }
 
-  // Rename xcarchive (only for device builds)
+  // Zip xcarchive into a single file (only for device builds)
+  // .xcarchive is a directory; zipping it produces a clean single-file artifact
+  // that Runway and other tools can match by extension.
   if (!isSimBuild) {
     const oldArchive = path.join(__dirname, `../ios/build/${appName}.xcarchive`);
     if (fs.existsSync(oldArchive)) {
-      const newArchive = path.join(
+      const archiveZip = path.join(
         __dirname,
-        `../ios/build/${newBaseName}.xcarchive`,
+        `../ios/build/${newBaseName}.xcarchive.zip`,
       );
-      execSync(`cp -r "${oldArchive}" "${newArchive}"`);
-      console.log(`✅ Renamed archive: ${newArchive}`);
-      setGithubOutput('ios_archive_path', newArchive);
+      execSync(
+        `ditto -c -k --sequesterRsrc --keepParent "${oldArchive}" "${archiveZip}"`,
+      );
+      console.log(`✅ Zipped archive: ${archiveZip}`);
+      setGithubOutput('ios_archive_path', archiveZip);
     } else {
       console.log(`⚠️  Archive not found: ${oldArchive}`);
     }


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR makes two related CI improvements to support Runway and downstream artifact consumers:

**1. Split artifact uploads into separate named artifacts**

Previously, iOS device builds uploaded both the IPA and xcarchive under a single artifact name (`ios-<build_name>`), and Android release builds uploaded both APK and AAB under `android-<build_name>`. This made it impossible for tools like Runway to select a specific file type by artifact name.

Each file type now gets its own distinctly-named artifact:
- `ios-app-<build_name>` — iOS simulator `.app.zip`
- `ios-ipa-<build_name>` — iOS device `.ipa`
- `ios-xcarchive-<build_name>` — iOS `.xcarchive.zip`
- `android-apk-<build_name>` — Android APK
- `android-aab-<build_name>` — Android AAB

**2. Zip xcarchive into a single file**

`.xcarchive` is a directory, not a file. `rename-artifacts.js` now zips it with `ditto` into a `.xcarchive.zip` single-file artifact, which is what Runway and other upload tools expect.

**3. Fix TestFlight Fastlane upload for Developer role API keys**

When `distribute_external` is `false`, the Fastlane lane now sets `skip_submission: true`. Without this, `upload_to_testflight` makes TestFlight management API calls that require an App Manager (or higher) role — a Developer role API key (used for nightly builds) can upload binaries but cannot manage distribution. This fixes authentication failures on nightly uploads.

**4. Downstream workflow updates**

`nightly-build.yml` and `upload-to-testflight.yml` are updated to reference the new `ios-ipa-<build_name>` artifact name, and the redundant `"false"` positional argument for `distribute_external` is removed (now handled inside the Fastlane lane).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — these are CI/build pipeline and Fastlane changes only. Verification requires triggering a full build workflow and confirming:
1. GitHub Actions artifacts are uploaded under the new split names.
2. Nightly builds successfully upload to TestFlight without authentication errors.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes GitHub Actions artifact naming/packaging and TestFlight upload options, which can break downstream CI consumers and release uploads if misconfigured.
> 
> **Overview**
> **Build artifacts are now uploaded as separate, type-specific artifacts** instead of bundling multiple outputs under `ios-*` / `android-*`, enabling downstream tools to target `ios-app-*`, `ios-ipa-*`, `ios-xcarchive-*`, `android-apk-*`, and `android-aab-*` independently.
> 
> **iOS device builds now zip `.xcarchive` directories** in `scripts/rename-artifacts.js` (outputting a `.xcarchive.zip`) and workflows are updated to upload/download the new artifact names (notably for nightly and manual TestFlight uploads).
> 
> **TestFlight upload behavior is adjusted in `ios/fastlane/Fastfile`** so when `distribute_external` is false it sets `skip_submission: true`, avoiding App Store Connect management calls that require higher-privilege API keys; corresponding workflows remove the extra `
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e0abff6a979024d3700251581176ae8b0e0a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->