### PR TITLE
chore: consolidate source_branch and ref in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,9 @@ on:
         type: boolean
         default: false
       source_branch:
-        description: 'Branch, tag, or SHA to build'
-        required: false
-        type: string
-        default: ''
-      ref:
-        description: 'Git ref to checkout when skip_version_bump is true. Defaults to the triggering event ref.'
+        description: >-
+          Branch, tag, or SHA. If skip_version_bump is false: base branch for the version bump (empty uses github.ref_name).
+          If skip_version_bump is true: ref for prepare, node-modules setup, and build checkout (empty uses the default triggering ref).
         required: false
         type: string
         default: ''
@@ -157,13 +154,13 @@ jobs:
           submodules: recursive
 
       - uses: actions/checkout@v4
-        if: ${{ inputs.skip_version_bump && inputs.ref != '' }}
+        if: ${{ inputs.skip_version_bump && inputs.source_branch != '' }}
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.source_branch }}
           submodules: recursive
 
       - uses: actions/checkout@v4
-        if: ${{ inputs.skip_version_bump && inputs.ref == '' }}
+        if: ${{ inputs.skip_version_bump && inputs.source_branch == '' }}
         with:
           submodules: recursive
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -76,7 +76,7 @@ jobs:
       build_name: main-exp
       platform: both
       skip_version_bump: true
-      ref: ${{ needs.bump-version-exp.outputs.commit-hash }}
+      source_branch: ${{ needs.bump-version-exp.outputs.commit-hash }}
     secrets: inherit
 
   build-rc:
@@ -87,7 +87,7 @@ jobs:
       build_name: main-rc
       platform: both
       skip_version_bump: true
-      ref: ${{ needs.bump-version-rc.outputs.commit-hash }}
+      source_branch: ${{ needs.bump-version-rc.outputs.commit-hash }}
     secrets: inherit
 
   upload-exp-testflight:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
source_branch and ref are doing the same thing in build.yml so we can consolidate them.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that primarily renames/rewires workflow inputs; risk is limited to mis-checkout of the intended commit/branch in GitHub Actions builds.
> 
> **Overview**
> Simplifies the reusable `build.yml` workflow by consolidating checkout control into a single `source_branch` input, and clarifies its semantics for version-bump vs. skip-version-bump runs.
> 
> Updates checkout conditionals to use `source_branch` wherever `ref` was previously used, and adjusts `nightly-build.yml` to pass the bumped commit hash via `source_branch` for both exp and RC builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30daf6c6def1baa4cc7abc660b6ecc806ae240d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->