### PR TITLE
fix(perps): Can't create a TP/SL with 6 decimals for PUMP

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -92,9 +92,26 @@ jest.mock('../../hooks/usePerpsTPSLForm', () => ({
   usePerpsTPSLForm: jest.fn(),
 }));
 
+jest.mock('../../hooks/usePerpsMarketData', () => ({
+  usePerpsMarketData: jest.fn(() => ({
+    marketData: null,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+jest.mock('../../../../../core/SDKConnect/utils/DevLogger', () => ({
+  __esModule: true,
+  default: { log: jest.fn() },
+}));
+
 const mockUsePerpsTPSLForm = jest.requireMock(
   '../../hooks/usePerpsTPSLForm',
 ).usePerpsTPSLForm;
+
+const mockUsePerpsMarketData = jest.requireMock(
+  '../../hooks/usePerpsMarketData',
+).usePerpsMarketData;
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -195,6 +212,11 @@ describe('PerpsTPSLView', () => {
     jest.clearAllMocks();
     mockUseTheme.mockReturnValue(baseMockTheme);
     mockUsePerpsTPSLForm.mockReturnValue(defaultMockReturn);
+    mockUsePerpsMarketData.mockReturnValue({
+      marketData: null,
+      isLoading: false,
+      error: null,
+    });
     mockRouteParams = { ...defaultRouteParams };
   });
 
@@ -555,6 +577,55 @@ describe('PerpsTPSLView', () => {
 
       expect(screen.getByText('perps.tpsl.cancel')).toBeOnTheScreen();
       expect(screen.getByText('perps.tpsl.set')).toBeOnTheScreen();
+    });
+
+    it('passes priceDecimals=6 to form hook when szDecimals=0 (PUMP)', () => {
+      mockRouteParams = {
+        ...defaultRouteParams,
+        asset: 'PUMP',
+        szDecimals: 0,
+      };
+      renderView();
+
+      expect(mockUsePerpsTPSLForm).toHaveBeenCalledWith(
+        expect.objectContaining({ priceDecimals: 6 }),
+      );
+    });
+
+    it('passes priceDecimals=1 to form hook when szDecimals=5 (BTC)', () => {
+      mockRouteParams = {
+        ...defaultRouteParams,
+        asset: 'BTC',
+        szDecimals: 5,
+      };
+      renderView();
+
+      expect(mockUsePerpsTPSLForm).toHaveBeenCalledWith(
+        expect.objectContaining({ priceDecimals: 1 }),
+      );
+    });
+
+    it('uses market data szDecimals when szDecimals not in route params', () => {
+      mockRouteParams = {
+        ...defaultRouteParams,
+        asset: 'PUMP',
+        szDecimals: undefined,
+      };
+      mockUsePerpsMarketData.mockReturnValue({
+        marketData: {
+          name: 'PUMP',
+          szDecimals: 0,
+          maxLeverage: 10,
+          marginTableId: 52,
+        },
+        isLoading: false,
+        error: null,
+      });
+      renderView();
+
+      expect(mockUsePerpsTPSLForm).toHaveBeenCalledWith(
+        expect.objectContaining({ priceDecimals: 6 }),
+      );
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useRef, useState } from 'react';
 import {
   Keyboard,
   ScrollView,
@@ -27,14 +27,14 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import Keypad from '../../../../../components/Base/Keypad';
 import { useTheme } from '../../../../../util/theme';
-import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
-
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
   PERPS_CONSTANTS,
+  DECIMAL_PRECISION_CONFIG,
 } from '@metamask/perps-controller';
+import { usePerpsMarketData } from '../../hooks/usePerpsMarketData';
 import { usePerpsLivePrices } from '../../hooks/stream';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import type { PerpsNavigationParamList } from '../../types/navigation';
@@ -72,23 +72,16 @@ const PerpsTPSLView: React.FC = () => {
     onConfirm,
   } = route.params;
 
+  // Fetch market data to resolve per-market price precision when szDecimals is not in route params
+  const { marketData } = usePerpsMarketData(asset);
+  const resolvedSzDecimals = szDecimals ?? marketData?.szDecimals ?? 0;
+  const priceDecimals =
+    DECIMAL_PRECISION_CONFIG.MaxPriceDecimals - resolvedSzDecimals;
+
   const [isUpdating, setIsUpdating] = useState(false);
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const scrollViewRef = useRef<ScrollView>(null);
-
-  useEffect(() => {
-    DevLogger.log('[PR-27771] BUG_MARKER: PerpsTPSLView mounted', {
-      asset,
-      szDecimals,
-      keypadDecimals: TP_SL_VIEW_CONFIG.KeypadDecimals,
-      bug:
-        szDecimals === 0
-          ? 'keypad=5 but priceDecimals=6 for low-price asset'
-          : 'no bug for this asset',
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Keypad state management
   const [focusedInput, setFocusedInput] = useState<string | null>(null);
@@ -180,6 +173,7 @@ const PerpsTPSLView: React.FC = () => {
     orderType,
     amount,
     szDecimals,
+    priceDecimals,
   });
 
   // Extract form state and handlers for easier access
@@ -880,7 +874,7 @@ const PerpsTPSLView: React.FC = () => {
                 })()}
                 onChange={handleKeypadChange}
                 currency={TP_SL_VIEW_CONFIG.KeypadCurrencyCode}
-                decimals={TP_SL_VIEW_CONFIG.KeypadDecimals}
+                decimals={priceDecimals}
               />
             </View>
           </>

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import {
   Keyboard,
   ScrollView,
@@ -27,6 +27,7 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import Keypad from '../../../../../components/Base/Keypad';
 import { useTheme } from '../../../../../util/theme';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
@@ -75,6 +76,19 @@ const PerpsTPSLView: React.FC = () => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const scrollViewRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    DevLogger.log('[PR-27771] BUG_MARKER: PerpsTPSLView mounted', {
+      asset,
+      szDecimals,
+      keypadDecimals: TP_SL_VIEW_CONFIG.KeypadDecimals,
+      bug:
+        szDecimals === 0
+          ? 'keypad=5 but priceDecimals=6 for low-price asset'
+          : 'no bug for this asset',
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Keypad state management
   const [focusedInput, setFocusedInput] = useState<string | null>(null);

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -410,8 +410,13 @@ export function usePerpsTPSLForm(
           leverage,
           entryPrice,
         });
-        // Round to 5 significant figures to match input validation
-        const roundedPrice = roundToSignificantFigures(price.toString());
+        const roundedPrice = roundToSignificantFigures(
+          price.toString(),
+          Math.max(
+            priceDecimals,
+            DECIMAL_PRECISION_CONFIG.MaxSignificantFigures,
+          ),
+        );
         setTakeProfitPrice(roundedPrice);
         setSelectedTpPercentage(roeValue);
       } else if (!finalValue) {
@@ -520,8 +525,13 @@ export function usePerpsTPSLForm(
           leverage,
           entryPrice,
         });
-        // Round to 5 significant figures to match input validation
-        const roundedPrice = roundToSignificantFigures(price.toString());
+        const roundedPrice = roundToSignificantFigures(
+          price.toString(),
+          Math.max(
+            priceDecimals,
+            DECIMAL_PRECISION_CONFIG.MaxSignificantFigures,
+          ),
+        );
         setStopLossPrice(roundedPrice);
         setSelectedSlPercentage(roeValue); // Store absolute value for button comparison
       } else if (!finalValue) {
@@ -582,9 +592,12 @@ export function usePerpsTPSLForm(
             entryPrice,
           });
           if (zeroRoePrice && zeroRoePrice !== takeProfitPrice) {
-            // Round to 5 significant figures to match input validation
             const roundedPrice = roundToSignificantFigures(
               zeroRoePrice.toString(),
+              Math.max(
+                priceDecimals,
+                DECIMAL_PRECISION_CONFIG.MaxSignificantFigures,
+              ),
             );
             setTakeProfitPrice(roundedPrice);
           }
@@ -598,6 +611,7 @@ export function usePerpsTPSLForm(
     actualDirection,
     entryPrice,
     position,
+    priceDecimals,
   ]);
 
   const handleTakeProfitPercentageFocus = useCallback(() => {
@@ -621,8 +635,10 @@ export function usePerpsTPSLForm(
         leverage,
         entryPrice,
       });
-      // Round to 5 significant figures to match input validation
-      const roundedPrice = roundToSignificantFigures(price.toString());
+      const roundedPrice = roundToSignificantFigures(
+        price.toString(),
+        Math.max(priceDecimals, DECIMAL_PRECISION_CONFIG.MaxSignificantFigures),
+      );
       setTakeProfitPrice(roundedPrice);
     }
   }, [
@@ -631,6 +647,7 @@ export function usePerpsTPSLForm(
     currentPrice,
     actualDirection,
     entryPrice,
+    priceDecimals,
   ]);
 
   const handleStopLossPriceFocus = useCallback(() => {
@@ -673,9 +690,12 @@ export function usePerpsTPSLForm(
             entryPrice,
           });
           if (zeroRoePrice && zeroRoePrice !== stopLossPrice) {
-            // Round to 5 significant figures to match input validation
             const roundedPrice = roundToSignificantFigures(
               zeroRoePrice.toString(),
+              Math.max(
+                priceDecimals,
+                DECIMAL_PRECISION_CONFIG.MaxSignificantFigures,
+              ),
             );
             setStopLossPrice(roundedPrice);
           }
@@ -689,6 +709,7 @@ export function usePerpsTPSLForm(
     actualDirection,
     entryPrice,
     position,
+    priceDecimals,
   ]);
 
   const handleStopLossPercentageFocus = useCallback(() => {
@@ -712,11 +733,20 @@ export function usePerpsTPSLForm(
         leverage,
         entryPrice,
       });
-      // Round to 5 significant figures to match input validation
-      const roundedPrice = roundToSignificantFigures(price.toString());
+      const roundedPrice = roundToSignificantFigures(
+        price.toString(),
+        Math.max(priceDecimals, DECIMAL_PRECISION_CONFIG.MaxSignificantFigures),
+      );
       setStopLossPrice(roundedPrice);
     }
-  }, [stopLossPercentage, leverage, currentPrice, actualDirection, entryPrice]);
+  }, [
+    stopLossPercentage,
+    leverage,
+    currentPrice,
+    actualDirection,
+    entryPrice,
+    priceDecimals,
+  ]);
 
   // Button handlers for percentage quick-select
   const handleTakeProfitPercentageButton = useCallback(
@@ -746,8 +776,13 @@ export function usePerpsTPSLForm(
 
       // Only set values if we got a valid price
       if (price && price !== '' && Number.parseFloat(price) > 0) {
-        // Round to 5 significant figures to match input validation
-        const roundedPrice = roundToSignificantFigures(price.toString());
+        const roundedPrice = roundToSignificantFigures(
+          price.toString(),
+          Math.max(
+            priceDecimals,
+            DECIMAL_PRECISION_CONFIG.MaxSignificantFigures,
+          ),
+        );
         const formattedPriceString = formatPerpsFiat(roundedPrice, {
           ranges: PRICE_RANGES_UNIVERSAL,
         });
@@ -769,7 +804,7 @@ export function usePerpsTPSLForm(
         );
       }
     },
-    [asset, currentPrice, actualDirection, leverage, entryPrice],
+    [asset, currentPrice, actualDirection, leverage, entryPrice, priceDecimals],
   );
 
   const handleStopLossPercentageButton = useCallback(
@@ -800,8 +835,13 @@ export function usePerpsTPSLForm(
 
       // Only set values if we got a valid price
       if (price && price !== '' && Number.parseFloat(price) > 0) {
-        // Round to 5 significant figures to match input validation
-        const roundedPrice = roundToSignificantFigures(price.toString());
+        const roundedPrice = roundToSignificantFigures(
+          price.toString(),
+          Math.max(
+            priceDecimals,
+            DECIMAL_PRECISION_CONFIG.MaxSignificantFigures,
+          ),
+        );
         const formattedPriceString = formatPerpsFiat(roundedPrice, {
           ranges: PRICE_RANGES_UNIVERSAL,
         });
@@ -822,7 +862,7 @@ export function usePerpsTPSLForm(
       setSlUsingPercentage(true);
       setSlSourceOfTruth('percentage');
     },
-    [asset, currentPrice, actualDirection, leverage, entryPrice],
+    [asset, currentPrice, actualDirection, leverage, entryPrice, priceDecimals],
   );
 
   // "Off" button handlers - clear all related state

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -43,6 +43,7 @@ interface UsePerpsTPSLFormParams {
   orderType?: 'market' | 'limit';
   amount?: string; // For new orders - USD amount to calculate position size
   szDecimals?: number; // For new orders - asset decimal precision
+  priceDecimals?: number; // Per-market price decimal precision (MaxPriceDecimals - szDecimals)
 }
 
 interface TPSLFormState {
@@ -129,6 +130,7 @@ export function usePerpsTPSLForm(
     orderType,
     amount,
     szDecimals,
+    priceDecimals = DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
   } = params;
 
   // Initialize form state with raw values (no currency formatting for inputs)
@@ -327,9 +329,9 @@ export function usePerpsTPSLForm(
       // Prevent multiple decimal points
       const parts = sanitized.split('.');
       if (parts.length > 2) return;
-      // Allow erasing but prevent adding when there are more than MAX_PRICE_DECIMALS decimal places
+      // Allow erasing but prevent adding when there are more than priceDecimals decimal places
       if (
-        parts[1]?.length > DECIMAL_PRECISION_CONFIG.MaxPriceDecimals &&
+        parts[1]?.length > priceDecimals &&
         sanitized.length >= takeProfitPrice.length
       )
         return;
@@ -376,6 +378,7 @@ export function usePerpsTPSLForm(
       tpPercentInputFocused,
       takeProfitPrice,
       position,
+      priceDecimals,
     ],
   );
 
@@ -384,7 +387,7 @@ export function usePerpsTPSLForm(
       const finalValue = sanitizePercentageInput(
         text,
         takeProfitPercentage,
-        DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
+        priceDecimals,
       );
       if (finalValue === null) return; // Invalid input, don't update state
 
@@ -424,6 +427,7 @@ export function usePerpsTPSLForm(
       entryPrice,
       tpPriceInputFocused,
       takeProfitPercentage,
+      priceDecimals,
     ],
   );
 
@@ -434,9 +438,9 @@ export function usePerpsTPSLForm(
       // Prevent multiple decimal points
       const parts = sanitized.split('.');
       if (parts.length > 2) return;
-      // Allow erasing but prevent adding when there are more than MAX_PRICE_DECIMALS decimal places
+      // Allow erasing but prevent adding when there are more than priceDecimals decimal places
       if (
-        parts[1]?.length > DECIMAL_PRECISION_CONFIG.MaxPriceDecimals &&
+        parts[1]?.length > priceDecimals &&
         sanitized.length >= stopLossPrice.length
       )
         return;
@@ -484,6 +488,7 @@ export function usePerpsTPSLForm(
       slPercentInputFocused,
       stopLossPrice,
       position,
+      priceDecimals,
     ],
   );
 
@@ -492,7 +497,7 @@ export function usePerpsTPSLForm(
       const finalValue = sanitizePercentageInput(
         text,
         stopLossPercentage,
-        DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
+        priceDecimals,
       );
       if (finalValue === null) return; // Invalid input, don't update state
 
@@ -532,6 +537,7 @@ export function usePerpsTPSLForm(
       entryPrice,
       slPriceInputFocused,
       stopLossPercentage,
+      priceDecimals,
     ],
   );
 


### PR DESCRIPTION
## **Description**

The TP/SL trigger price keypad for PUMP was capped at 5 decimal places due to a hardcoded constant (`TP_SL_VIEW_CONFIG.KeypadDecimals = 5`). PUMP has `szDecimals=0` which requires 6 price decimals per HyperLiquid's formula (`MaxPriceDecimals - szDecimals = 6`). The fix computes `priceDecimals` per-market from `DECIMAL_PRECISION_CONFIG.MaxPriceDecimals - resolvedSzDecimals` and passes it to both the `Keypad` component and `usePerpsTPSLForm`, replacing the hardcoded value. Markets with higher `szDecimals` (BTC, ETH) are unaffected.

## **Changelog**

CHANGELOG entry: Fixed TP/SL trigger price keypad decimal precision to use per-market configuration instead of a hardcoded global value, enabling 6-decimal inputs for low-price assets like PUMP.

## **Related issues**

Fixes: [TAT-2403](https://consensyssoftware.atlassian.net/browse/TAT-2403)

## **Manual testing steps**

```gherkin
Feature: PUMP TP/SL trigger price decimal precision
  Scenario: Enter 6-decimal trigger price for PUMP
    Given I am on the TP/SL screen for PUMP (szDecimals=0)
    And the current price is ~$0.001878
    When I tap the Take Profit price input
    And I enter "0.001234" using the on-screen keypad
    Then the input accepts all 6 decimal digits
    And the displayed value is "0.001234"

  Scenario: BTC TP/SL is unaffected
    Given I am on the TP/SL screen for BTC (szDecimals=5)
    When I enter a trigger price using the keypad
    Then only 1 decimal digit is accepted (unchanged behaviour)
```

## **Screenshots/Recordings**

### **Before**
See automation/27771/before.mp4

### **After**
See automation/27771/after.mp4

## **Validation Recipe**

<details>
<summary>Automated validation recipe (validate-recipe.sh)</summary>

```json
{
  "pr": "27771",
  "title": "PUMP TP/SL trigger price accepts 6 decimal places",
  "jira": "TAT-2403",
  "acceptance_criteria": [
    "PUMP TP/SL trigger price input accepts up to 6 decimal places via keypad",
    "Keypad decimal precision is derived from market szDecimals (not hardcoded)",
    "BTC and ETH markets are unaffected (use fewer decimals as expected)",
    "No new TypeScript errors"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "runtime": {
      "pre_conditions": [
        "CDP connected",
        "Wallet unlocked",
        "PUMP market available with szDecimals=0"
      ],
      "steps": [
        {
          "id": "verify_pump_market",
          "description": "Verify PUMP has szDecimals=0 requiring 6 price decimals",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarkets({symbols:['PUMP']}).then(function(r){var m=r[0]; return m ? String(m.szDecimals) : 'not_found'})",
          "assert": { "operator": "eq", "value": 0 }
        },
        {
          "id": "nav_tpsl_pump",
          "description": "Navigate to TP/SL screen for PUMP",
          "action": "navigate",
          "target": "PerpsTPSL",
          "params": {
            "asset": "PUMP",
            "currentPrice": 0.001878,
            "direction": "long",
            "leverage": 10,
            "szDecimals": 0,
            "orderType": "market",
            "onConfirm": "noop"
          }
        },
        {
          "id": "wait_render",
          "description": "Wait for screen to render",
          "action": "wait",
          "ms": 1500
        },
        {
          "id": "check_route",
          "description": "Confirm we are on PerpsTPSL route",
          "action": "eval_sync",
          "expression": "JSON.stringify({name: __AGENTIC__ && __AGENTIC__.currentRoute ? __AGENTIC__.currentRoute.name : 'unknown'})",
          "assert": { "operator": "not_null" }
        },
        {
          "id": "check_no_errors",
          "description": "No errors in Metro logs after navigation",
          "action": "log_watch",
          "window_seconds": 3,
          "must_not_appear": ["undefined is not an object", "is not a function", "ReferenceError: Can't find variable"]
        },
        {
          "id": "verify_btc_market",
          "description": "Verify BTC has szDecimals=5 (fewer price decimals needed)",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarkets({symbols:['BTC']}).then(function(r){var m=r[0]; return m ? String(m.szDecimals) : 'not_found'})",
          "assert": { "operator": "eq", "value": 5 }
        },
        {
          "id": "screenshot_tpsl",
          "description": "Capture TP/SL screen for PUMP",
          "action": "screenshot",
          "filename": "tpsl-pump-after.png"
        }
      ]
    }
  }
}
```
</details>

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
