### PR TITLE
fix(perps): Can't create a TP/SL with 6 decimals for PUMP

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -261,6 +261,8 @@ export const PerpsTPSLViewSelectorsIDs = {
   BACK_BUTTON: 'back-button',
   BOTTOM_SHEET: 'perps-tpsl-bottomsheet',
   SET_BUTTON: 'bottomsheetfooter-button',
+  TAKE_PROFIT_PRICE_INPUT: 'perps-tpsl-take-profit-price-input',
+  STOP_LOSS_PRICE_INPUT: 'perps-tpsl-stop-loss-price-input',
 } as const;
 
 export const getPerpsTPSLViewSelector = {

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -571,6 +571,7 @@ const PerpsTPSLView: React.FC = () => {
                 </Text>
                 <TextInput
                   ref={takeProfitPriceRef}
+                  testID={PerpsTPSLViewSelectorsIDs.TAKE_PROFIT_PRICE_INPUT}
                   style={styles.input}
                   value={takeProfitPrice}
                   onChangeText={(text) => {
@@ -741,6 +742,7 @@ const PerpsTPSLView: React.FC = () => {
                 </Text>
                 <TextInput
                   ref={stopLossPriceRef}
+                  testID={PerpsTPSLViewSelectorsIDs.STOP_LOSS_PRICE_INPUT}
                   style={styles.input}
                   value={stopLossPrice}
                   onChangeText={(text) => {

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -21,6 +21,7 @@ import {
   HYPERLIQUID_MAINNET_CHAIN_ID,
   HYPERLIQUID_TESTNET_CHAIN_ID,
 } from '@metamask/perps-controller/constants/hyperLiquidConfig';
+import { DECIMAL_PRECISION_CONFIG } from '@metamask/perps-controller';
 
 export { HYPERLIQUID_MAINNET_CHAIN_ID, HYPERLIQUID_TESTNET_CHAIN_ID };
 
@@ -106,10 +107,10 @@ export const TP_SL_VIEW_CONFIG = {
 
   // Keypad configuration for price inputs
   // USD_PERPS is not a real currency - it's a custom configuration
-  // that allows 5 decimal places for crypto prices, overriding the
-  // default USD configuration which only allows 2 decimal places
+  // that allows up to MaxPriceDecimals decimal places for crypto prices,
+  // overriding the default USD configuration which only allows 2 decimal places
   KeypadCurrencyCode: 'USD_PERPS' as const,
-  KeypadDecimals: 5,
+  KeypadDecimals: DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
 } as const;
 
 /**

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -742,6 +742,17 @@ export function usePerpsTPSLForm(
       if (price && price !== '' && Number.parseFloat(price) > 0) {
         // Round to 5 significant figures to match input validation
         const roundedPrice = roundToSignificantFigures(price.toString());
+        // eslint-disable-next-line no-console
+        console.log(
+          '[PR-27773] BUG_MARKER: TP percentage button price rounded original=' +
+            price.toString() +
+            ' rounded=' +
+            roundedPrice +
+            ' asset=' +
+            asset +
+            ' currentPrice=' +
+            currentPrice,
+        );
         const formattedPriceString = formatPerpsFiat(roundedPrice, {
           ranges: PRICE_RANGES_UNIVERSAL,
         });

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -742,17 +742,6 @@ export function usePerpsTPSLForm(
       if (price && price !== '' && Number.parseFloat(price) > 0) {
         // Round to 5 significant figures to match input validation
         const roundedPrice = roundToSignificantFigures(price.toString());
-        // eslint-disable-next-line no-console
-        console.log(
-          '[PR-27773] BUG_MARKER: TP percentage button price rounded original=' +
-            price.toString() +
-            ' rounded=' +
-            roundedPrice +
-            ' asset=' +
-            asset +
-            ' currentPrice=' +
-            currentPrice,
-        );
         const formattedPriceString = formatPerpsFiat(roundedPrice, {
           ranges: PRICE_RANGES_UNIVERSAL,
         });

--- a/app/components/UI/Perps/utils/formatUtils.test.ts
+++ b/app/components/UI/Perps/utils/formatUtils.test.ts
@@ -1571,20 +1571,32 @@ describe('formatUtils', () => {
     });
 
     describe('leading zeros after decimal', () => {
-      it('counts all 6 decimal digits for 0.000123', () => {
+      it('counts only non-leading-zero decimal digits for 0.000123 (3 sig figs)', () => {
         const result = countSignificantFigures('0.000123');
 
-        expect(result).toBe(6);
+        expect(result).toBe(3);
       });
 
-      it('counts all 8 decimal digits for 0.00001234', () => {
+      it('counts only non-leading-zero decimal digits for 0.00001234 (4 sig figs)', () => {
         const result = countSignificantFigures('0.00001234');
 
-        expect(result).toBe(8);
+        expect(result).toBe(4);
       });
 
-      it('counts 4 decimal digits for 0.0001', () => {
+      it('counts 1 sig fig for 0.0001', () => {
         const result = countSignificantFigures('0.0001');
+
+        expect(result).toBe(1);
+      });
+
+      it('counts 4 sig figs for PUMP price 0.001234', () => {
+        const result = countSignificantFigures('0.001234');
+
+        expect(result).toBe(4);
+      });
+
+      it('counts 4 sig figs for PUMP price 0.001358', () => {
+        const result = countSignificantFigures('0.001358');
 
         expect(result).toBe(4);
       });
@@ -1603,10 +1615,10 @@ describe('formatUtils', () => {
         expect(result).toBe(3);
       });
 
-      it('returns 3 for 0.001000 after trimming trailing zeros', () => {
+      it('returns 1 for 0.001000 (JS normalizes to 0.001, which has 1 sig fig)', () => {
         const result = countSignificantFigures('0.001000');
 
-        expect(result).toBe(3);
+        expect(result).toBe(1);
       });
     });
 
@@ -1665,14 +1677,32 @@ describe('formatUtils', () => {
         expect(result).toBe(true);
       });
 
-      it('returns true for decimal with 6 digits including leading zeros', () => {
+      it('returns false for 0.000123 (3 actual sig figs, within limit of 5)', () => {
         const result = hasExceededSignificantFigures('0.000123');
 
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
 
-      it('returns true for 8 significant figures', () => {
+      it('returns false for 0.00001234 (4 actual sig figs, within limit of 5)', () => {
         const result = hasExceededSignificantFigures('0.00001234');
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false for PUMP price 0.001234 (4 actual sig figs, within limit of 5)', () => {
+        const result = hasExceededSignificantFigures('0.001234');
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false for PUMP price 0.0012345 (5 actual sig figs, at limit of 5)', () => {
+        const result = hasExceededSignificantFigures('0.0012345');
+
+        expect(result).toBe(false);
+      });
+
+      it('returns true for PUMP price 0.00123456 (6 actual sig figs, exceeds limit of 5)', () => {
+        const result = hasExceededSignificantFigures('0.00123456');
 
         expect(result).toBe(true);
       });
@@ -1883,16 +1913,34 @@ describe('formatUtils', () => {
         expect(result).toBe('1.2346');
       });
 
-      it('rounds decimal with leading zeros to 5 significant figures', () => {
+      it('returns unchanged for 0.065242 (5 actual sig figs, at limit)', () => {
         const result = roundToSignificantFigures('0.065242');
 
-        expect(result).toBe('0.06524');
+        expect(result).toBe('0.065242');
       });
 
-      it('rounds correctly with many leading zeros', () => {
+      it('rounds correctly with many leading zeros: 0.00123456 rounds to 5 sig figs (7 decimal places)', () => {
         const result = roundToSignificantFigures('0.00123456');
 
-        expect(result).toBe('0.00123');
+        expect(result).toBe('0.0012346');
+      });
+
+      it('returns unchanged for PUMP price 0.001234 (4 sig figs, within limit)', () => {
+        const result = roundToSignificantFigures('0.001234');
+
+        expect(result).toBe('0.001234');
+      });
+
+      it('returns unchanged for PUMP price 0.001358 (4 sig figs, within limit)', () => {
+        const result = roundToSignificantFigures('0.001358');
+
+        expect(result).toBe('0.001358');
+      });
+
+      it('returns unchanged for PUMP price 0.0012345 (5 sig figs, at limit)', () => {
+        const result = roundToSignificantFigures('0.0012345');
+
+        expect(result).toBe('0.0012345');
       });
     });
 

--- a/app/components/UI/Perps/utils/wait.test.ts
+++ b/app/components/UI/Perps/utils/wait.test.ts
@@ -13,14 +13,14 @@ describe('wait', () => {
     const promise = wait(100);
     jest.advanceTimersByTime(100);
     await promise;
-    expect(promise).resolves.toBeUndefined();
+    await expect(promise).resolves.toBeUndefined();
   });
 
   it('should handle zero duration', async () => {
     const promise = wait(0);
     jest.advanceTimersByTime(0);
     await promise;
-    expect(promise).resolves.toBeUndefined();
+    await expect(promise).resolves.toBeUndefined();
   });
 
   it('should return a Promise that resolves to undefined', async () => {

--- a/app/controllers/perps/utils/significantFigures.ts
+++ b/app/controllers/perps/utils/significantFigures.ts
@@ -27,7 +27,14 @@ export const countSignificantFigures = (priceString: string): number => {
     : trimmedInteger.replace(/0+$/u, '').length ||
       (trimmedInteger.length > 0 ? 1 : 0);
 
-  return effectiveIntegerLength + decimalPart.length;
+  // For numbers < 1 (e.g. 0.001234), leading zeros after the decimal are not
+  // significant figures. Strip them before counting.
+  const significantDecimalPart =
+    effectiveIntegerLength === 0
+      ? decimalPart.replace(/^0+/u, '')
+      : decimalPart;
+
+  return effectiveIntegerLength + significantDecimalPart.length;
 };
 
 /**
@@ -90,7 +97,13 @@ export const roundToSignificantFigures = (
     return normalized;
   }
 
-  const allowedDecimalDigits = maxSigFigs - integerSigFigs;
+  // For numbers < 1 (e.g. 0.001234), leading zeros after the decimal are not
+  // significant. Count them so we reserve enough decimal places for the actual
+  // significant digits that follow (e.g. 0.001234 needs 2 leading zeros + 4 sig figs = 6 decimals).
+  const leadingDecimalZeros =
+    integerSigFigs === 0 ? (decimalPart.match(/^0+/u)?.[0].length ?? 0) : 0;
+  const allowedDecimalDigits =
+    maxSigFigs - integerSigFigs + leadingDecimalZeros;
 
   if (allowedDecimalDigits <= 0) {
     return Math.round(number).toString();


### PR DESCRIPTION
## **Description**

The TP/SL trigger price input for PUMP (price ~$0.001234) was limited to 5 decimal places, making it impossible to enter a valid trigger price. Three root causes:

1. `countSignificantFigures` counted leading decimal zeros as significant figures, so `0.001234` returned 6 instead of 4 — causing the input to reject valid prices immediately.
2. `roundToSignificantFigures` used `maxSigFigs - integerSigFigs` as the decimal allowance, computing `5-0=5` for sub-unity prices and truncating `0.001234` to `0.00123`.
3. `TP_SL_VIEW_CONFIG.KeypadDecimals` was hardcoded to `5`, preventing 6-decimal keypad entry regardless of market.

**Fix:** Strip leading zeros before counting sig figs; offset the allowed decimal count by the number of leading zeros when rounding; replace the hardcoded `5` with `DECIMAL_PRECISION_CONFIG.MaxPriceDecimals`.

## **Changelog**

CHANGELOG entry: Fixed TP/SL trigger price input rejecting valid 6-decimal prices for low-value markets (e.g. PUMP)

## **Related issues**

Fixes: [TAT-2403](https://consensyssoftware.atlassian.net/browse/TAT-2403)

## **Manual testing steps**

```gherkin
Feature: TP/SL 6-decimal trigger price for PUMP
  Scenario: Set take profit with 6 decimal places for PUMP
    Given the user has opened the TP/SL screen for PUMP (price ~0.001234)
    When the user taps the +10% take profit preset button
    Then the trigger price input shows a value with 6 decimal places (e.g. 0.001911)
    And the "Set" button is enabled

  Scenario: BTC TP/SL unaffected
    Given the user has opened the TP/SL screen for BTC (price ~95000)
    When the user taps the +10% take profit preset button
    Then the trigger price shows a normal price
    And the "Set" button is enabled
```

## **Screenshots/Recordings**

### **Before**
See `.task/fix/tat-2403-0321-1541/artifacts/before.mp4` — PUMP TP/SL screen shows 5-decimal truncation

### **After**
See `.task/fix/tat-2403-0321-1541/artifacts/after.mp4` — PUMP TP/SL screen accepts 6-decimal price

## **Validation Recipe**

<details>
<summary>Automated validation recipe (validate-recipe.sh)</summary>

```json
{
  "pr": "27773",
  "title": "TP/SL trigger price accepts 6 decimal places for PUMP",
  "jira": "TAT-2403",
  "acceptance_criteria": [
    "TP/SL trigger price input for PUMP accepts up to 6 decimal places (e.g. 0.001234)",
    "Decimal precision is dynamically driven by market price magnitude (not hardcoded)",
    "A TP/SL with a 6-decimal trigger price for PUMP can be submitted without validation errors",
    "Other markets (BTC) continue to behave correctly",
    "No new TypeScript errors"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "runtime": {
      "pre_conditions": [
        "CDP connected",
        "Wallet unlocked on Wallet route",
        "PUMP market data available (sub-cent price, e.g. 0.001234)"
      ],
      "steps": [
        {
          "id": "nav_tpsl_pump",
          "description": "Navigate to TPSL view for PUMP at sub-cent price with leverage (needed for percentage button price computation)",
          "action": "navigate",
          "target": "PerpsTPSL",
          "params": {
            "asset": "PUMP",
            "currentPrice": 0.001234,
            "direction": "long",
            "szDecimals": 2,
            "leverage": 5,
            "onConfirm": "__noop__"
          }
        },
        {
          "id": "wait_render",
          "description": "Wait for TPSL view to render",
          "action": "wait",
          "ms": 1500
        },
        {
          "id": "press_tp_10_pct",
          "description": "Press +10% TP preset button to trigger price calculation for PUMP",
          "action": "press",
          "test_id": "perps-tpsl-take-profit-percentage-button-10"
        },
        {
          "id": "wait_price_set",
          "description": "Wait for price state to update after preset press",
          "action": "wait",
          "ms": 800
        },
        {
          "id": "read_tp_input_value",
          "description": "Read take profit price input value via React fiber tree walk by testID",
          "action": "eval_sync",
          "expression": "(function() { var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if (!hook) return 'no_hook'; var renderers = hook.renderers; if (!renderers) return 'no_renderers'; var getFiberRoots = hook.getFiberRoots; function findByTestId(fiber) { if (!fiber) return null; var props = fiber.memoizedProps; if (props && props.testID === 'perps-tpsl-take-profit-price-input') return fiber; return findByTestId(fiber.child) || findByTestId(fiber.sibling); } var found = null; renderers.forEach(function(renderer, id) { if (found) return; var roots = getFiberRoots ? getFiberRoots(id) : undefined; if (!roots) return; roots.forEach(function(r) { if (!found) found = findByTestId(r.current); }); }); if (!found) return 'not_found'; return found.memoizedProps.value || 'empty'; })()",
          "assert": { "operator": "not_null" }
        },
        {
          "id": "check_tp_decimal_count",
          "description": "Assert TP price has >= 6 decimal places — proves fix: old roundToSignificantFigures truncated PUMP prices to 5 decimals",
          "action": "eval_sync",
          "expression": "(function() { var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if (!hook) return 0; var renderers = hook.renderers; if (!renderers) return 0; var getFiberRoots = hook.getFiberRoots; function findByTestId(fiber) { if (!fiber) return null; var props = fiber.memoizedProps; if (props && props.testID === 'perps-tpsl-take-profit-price-input') return fiber; return findByTestId(fiber.child) || findByTestId(fiber.sibling); } var found = null; renderers.forEach(function(renderer, id) { if (found) return; var roots = getFiberRoots ? getFiberRoots(id) : undefined; if (!roots) return; roots.forEach(function(r) { if (!found) found = findByTestId(r.current); }); }); if (!found) return 0; var val = found.memoizedProps.value || ''; var parts = val.split('.'); return parts.length > 1 ? parts[1].length : 0; })()",
          "assert": { "operator": "gt", "value": 5 }
        },
        {
          "id": "screenshot_tpsl_pump",
          "description": "Screenshot PUMP TP/SL screen showing 6-decimal price",
          "action": "screenshot",
          "filename": "tpsl-pump-after-fix.png"
        },
        {
          "id": "nav_back",
          "description": "Navigate back before BTC test",
          "action": "navigate",
          "target": "Wallet"
        },
        {
          "id": "nav_tpsl_btc",
          "description": "Navigate to TPSL view for BTC to verify other markets unaffected",
          "action": "navigate",
          "target": "PerpsTPSL",
          "params": {
            "asset": "BTC",
            "currentPrice": 95000,
            "direction": "long",
            "szDecimals": 3,
            "leverage": 5,
            "onConfirm": "__noop__"
          }
        },
        {
          "id": "wait_btc_render",
          "description": "Wait for BTC TPSL view to render",
          "action": "wait",
          "ms": 1500
        },
        {
          "id": "press_btc_tp_10_pct",
          "description": "Press +10% TP preset button for BTC",
          "action": "press",
          "test_id": "perps-tpsl-take-profit-percentage-button-10"
        },
        {
          "id": "wait_btc_price",
          "description": "Wait for BTC price state to update",
          "action": "wait",
          "ms": 800
        },
        {
          "id": "check_btc_tp_value",
          "description": "Verify BTC TP price input is non-empty after pressing preset (other markets unaffected)",
          "action": "eval_sync",
          "expression": "(function() { var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if (!hook) return 'no_hook'; var renderers = hook.renderers; if (!renderers) return 'no_renderers'; var getFiberRoots = hook.getFiberRoots; function findByTestId(fiber) { if (!fiber) return null; var props = fiber.memoizedProps; if (props && props.testID === 'perps-tpsl-take-profit-price-input') return fiber; return findByTestId(fiber.child) || findByTestId(fiber.sibling); } var found = null; renderers.forEach(function(renderer, id) { if (found) return; var roots = getFiberRoots ? getFiberRoots(id) : undefined; if (!roots) return; roots.forEach(function(r) { if (!found) found = findByTestId(r.current); }); }); if (!found) return 'not_found'; return found.memoizedProps.value || 'empty'; })()",
          "assert": { "operator": "not_null" }
        },
        {
          "id": "screenshot_tpsl_btc",
          "description": "Screenshot BTC TP/SL screen to verify normal behavior",
          "action": "screenshot",
          "filename": "tpsl-btc-after-fix.png"
        },
        {
          "id": "check_no_errors",
          "description": "Verify no TPSL-specific errors in Metro logs after TPSL operations",
          "action": "log_watch",
          "window_seconds": 5,
          "must_not_appear": ["undefined is not an object", "is not a function", "TPSL_ERROR"]
        }
      ]
    }
  }
}
```
</details>

## **Pre-merge author checklist**
- [x] I've followed MetaMask Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches numeric precision/rounding used for TP/SL price validation and formatting; mistakes could cause incorrect trigger prices or input rejection across markets, though changes are localized and covered by updated tests.
> 
> **Overview**
> Fixes TP/SL trigger price handling for sub-$1 markets by updating `countSignificantFigures` and `roundToSignificantFigures` to *ignore* leading decimal zeros when counting sig figs while still reserving decimal places for them during rounding.
> 
> Updates the TP/SL keypad decimal limit to use `DECIMAL_PRECISION_CONFIG.MaxPriceDecimals` instead of a hardcoded `5`, adds `testID`s for the TP/SL price inputs, and adjusts/expands unit tests (including PUMP-like values) plus a small async expectation fix in `wait.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef0f23cc5db0f6410de566876699dc6dffec608a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->