### PR TITLE
fix(perps): Can't create a TP/SL with 6 decimals for PUMP

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -27,7 +27,6 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import Keypad from '../../../../../components/Base/Keypad';
 import { useTheme } from '../../../../../util/theme';
-
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   PERPS_EVENT_PROPERTY,
@@ -75,6 +74,15 @@ const PerpsTPSLView: React.FC = () => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const scrollViewRef = useRef<ScrollView>(null);
+
+  // BUG_MARKER [PR-27774]: Keypad hardcoded to 5 decimals but pxDecimals for asset may be higher
+  // eslint-disable-next-line no-console
+  console.log('[PR-27774] BUG_MARKER: PerpsTPSL render', {
+    asset,
+    szDecimals,
+    keypadDecimals: TP_SL_VIEW_CONFIG.KeypadDecimals,
+    pxDecimalsNeeded: szDecimals !== undefined ? 6 - szDecimals : 'unknown',
+  });
 
   // Keypad state management
   const [focusedInput, setFocusedInput] = useState<string | null>(null);

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -75,15 +75,6 @@ const PerpsTPSLView: React.FC = () => {
   const styles = createStyles(colors);
   const scrollViewRef = useRef<ScrollView>(null);
 
-  // BUG_MARKER [PR-27774]: Keypad hardcoded to 5 decimals but pxDecimals for asset may be higher
-  // eslint-disable-next-line no-console
-  console.log('[PR-27774] BUG_MARKER: PerpsTPSL render', {
-    asset,
-    szDecimals,
-    keypadDecimals: TP_SL_VIEW_CONFIG.KeypadDecimals,
-    pxDecimalsNeeded: szDecimals !== undefined ? 6 - szDecimals : 'unknown',
-  });
-
   // Keypad state management
   const [focusedInput, setFocusedInput] = useState<string | null>(null);
 


### PR DESCRIPTION
## **Description**

The TP/SL trigger price keypad was hardcoded to 5 decimal places via `TP_SL_VIEW_CONFIG.KeypadDecimals = 5`, blocking users from entering 6-decimal prices required for PUMP (`szDecimals=0`, `pxDecimals = 6 - 0 = 6`). The fix derives the keypad decimal limit dynamically from `szDecimals` using HyperLiquid's formula: `pxDecimals = MaxPriceDecimals - szDecimals`. The same per-market limit is now used in `usePerpsTPSLForm` for decimal and significant-figure validation, and `PerpsMarketDetailsView` now passes `szDecimals` when navigating to the TP/SL screen from existing positions.

## **Changelog**

CHANGELOG entry: Fixed TP/SL trigger price keypad decimal limit to use per-market precision instead of a hardcoded global value, enabling 6-decimal price entry for PUMP and other high-precision markets.

## **Related issues**

Fixes: [TAT-2403](https://consensyssoftware.atlassian.net/browse/TAT-2403)

## **Manual testing steps**

```gherkin
Feature: TP/SL trigger price decimal precision

  Scenario: User can enter a 6-decimal TP price for PUMP
    Given I am on the PUMP TP/SL screen
    When I tap the Take Profit price input
    And I enter "0.001234" using the keypad
    Then the price input shows "0.001234"
    And the TP/SL can be submitted without validation errors

  Scenario: BTC TP/SL is unaffected
    Given I have an open BTC position
    When I navigate to the BTC TP/SL screen
    And I tap the Take Profit price input
    Then the keypad allows at most 1 decimal place (pxDecimals = 6 - 5 = 1)
```

## **Screenshots/Recordings**

### **Before**
See `.task/fix/tat-2403-0321-1939/artifacts/before.mp4`
(Recipe fails on `check_keypad_decimals` step: decimals=5, expected 6)

### **After**
See `.task/fix/tat-2403-0321-1939/artifacts/after.mp4`
(All 9 recipe steps pass: keypad decimals=6 for PUMP)

## **Validation Recipe**

<details>
<summary>Automated validation recipe (validate-recipe.sh)</summary>

```json
{
  "pr": "27774",
  "title": "TP/SL Keypad accepts 6 decimal places for PUMP (szDecimals=0)",
  "jira": "TAT-2403",
  "acceptance_criteria": [
    "PUMP TP/SL trigger price keypad allows up to 6 decimal places (pxDecimals = MaxPriceDecimals - szDecimals = 6 - 0 = 6)",
    "Keypad decimals are driven by per-market szDecimals, not a hardcoded global value",
    "No TypeScript errors introduced"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "runtime": {
      "pre_conditions": ["CDP connected", "Wallet unlocked on Wallet route"],
      "steps": [
        {
          "id": "nav_perps",
          "description": "Mount Perps navigator stack",
          "action": "navigate",
          "target": "PerpsMarketListView"
        },
        {
          "id": "wait_mount",
          "description": "Wait for Perps navigator to settle",
          "action": "wait",
          "ms": 1500
        },
        {
          "id": "nav_tpsl_pump",
          "description": "Navigate to TP/SL screen for PUMP with szDecimals=0",
          "action": "eval_sync",
          "expression": "globalThis.__AGENTIC__.navigate('Perps', {screen: 'PerpsTPSL', params: {asset: 'PUMP', currentPrice: '0.001872', szDecimals: 0, onConfirm: function(tp, sl) { return Promise.resolve(); }}})"
        },
        {
          "id": "wait_tpsl",
          "description": "Wait for TP/SL screen to render",
          "action": "wait",
          "ms": 1500
        },
        {
          "id": "focus_tp_input",
          "description": "Focus TP price input to render the Keypad",
          "action": "eval_sync",
          "expression": "(function() { var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__; var roots = hook.getFiberRoots(1); var result = 'not-found'; roots.forEach(function(root) { if (result !== 'not-found') return; function walk(fiber) { if (!fiber || result !== 'not-found') return; var props = fiber.memoizedProps || fiber.pendingProps; if (props && props.showSoftInputOnFocus === false && props.onFocus) { props.onFocus(); result = 'focused'; return; } walk(fiber.child); walk(fiber.sibling); } walk(root.current); }); return result; })()",
          "assert": { "operator": "eq", "value": "focused" }
        },
        {
          "id": "wait_keypad",
          "description": "Wait for Keypad to render",
          "action": "wait",
          "ms": 500
        },
        {
          "id": "check_keypad_decimals",
          "description": "Assert Keypad decimals = 6 (pxDecimals = 6-0 for PUMP szDecimals=0)",
          "action": "eval_sync",
          "expression": "(function() { var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__; var roots = hook.getFiberRoots(1); var result = null; roots.forEach(function(root) { if (result !== null) return; function walk(fiber) { if (!fiber || result !== null) return; var fnName = fiber.type && (fiber.type.displayName || fiber.type.name || ''); if (fnName === 'KeypadComponent') { var props = fiber.memoizedProps || fiber.pendingProps; if (props && props.decimals !== undefined) { result = props.decimals; return; } } walk(fiber.child); walk(fiber.sibling); } walk(root.current); }); return result; })()",
          "assert": { "operator": "eq", "value": 6 }
        },
        {
          "id": "check_no_errors",
          "description": "No TP/SL render errors in Metro logs",
          "action": "log_watch",
          "window_seconds": 5,
          "must_not_appear": ["PerpsTPSLView render error", "undefined is not an object"]
        },
        {
          "id": "screenshot_result",
          "description": "Capture TP/SL screen with PUMP",
          "action": "screenshot",
          "filename": "tpsl-pump-keypad.png"
        }
      ]
    }
  }
}
```

</details>

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
