### PR TITLE
feat(perps): add initial_conditions block and setup flows

### DIFF
--- a/docs/perps/perps-agentic-feedback-loop.md
+++ b/docs/perps/perps-agentic-feedback-loop.md
@@ -375,6 +375,74 @@ scripts/perps/agentic/app-state.sh recipe --list
 
 **Adding recipes for your team:** Create `recipes/<team>.json` — see `recipes/README.md` for the format. Each recipe has a description, a JS expression, and an `async` flag.
 
+### Pre-conditions & Setup
+
+Recipes can declare required app state in a top-level `initial_conditions` block. `validate-recipe.sh` reads this block and applies the state before running any steps — no manual setup needed between sessions.
+
+**`initial_conditions` fields:**
+
+| Field      | Type      | Description                                                                    |
+| ---------- | --------- | ------------------------------------------------------------------------------ |
+| `account`  | `string`  | Ethereum address to switch to before the recipe runs                           |
+| `testnet`  | `boolean` | Set testnet mode (`true`/`false`). No-op if already in the desired state       |
+| `provider` | `string`  | Active provider to switch to. Valid values: `hyperliquid`, `myx`, `aggregated` |
+
+**Example recipe with `initial_conditions`:**
+
+```json
+{
+  "title": "Verify position flow on testnet",
+  "initial_conditions": {
+    "testnet": true,
+    "provider": "hyperliquid",
+    "account": "0xabc123..."
+  },
+  "validate": {
+    "runtime": {
+      "steps": [...]
+    }
+  }
+}
+```
+
+**CLI overrides** (useful for ad-hoc runs without editing the recipe):
+
+```bash
+# Force testnet mode
+bash scripts/perps/agentic/validate-recipe.sh flows/my-flow.json --testnet
+
+# Switch to a specific account
+bash scripts/perps/agentic/validate-recipe.sh flows/my-flow.json --account 0xabc123...
+
+# Combine
+bash scripts/perps/agentic/validate-recipe.sh flows/my-flow.json --testnet --account 0xabc123...
+```
+
+**Setup step actions** (use inside `steps[]` for in-flow state changes):
+
+| Action            | Key param                        | Description                                                 |
+| ----------------- | -------------------------------- | ----------------------------------------------------------- |
+| `select_account`  | `address`                        | Switch to account by Ethereum address                       |
+| `toggle_testnet`  | `enabled` (bool, default `true`) | Enable or disable testnet mode; no-op if already correct    |
+| `switch_provider` | `provider`                       | Switch active provider (`hyperliquid`, `myx`, `aggregated`) |
+
+**Setup flows** (`flows/setup-*.json`) wrap these actions for reuse via `flow_ref`:
+
+```json
+{ "id": "go-testnet", "action": "flow_ref", "ref": "setup-testnet" }
+{ "id": "switch-acct", "action": "flow_ref", "ref": "setup-account", "params": { "address": "0xabc..." } }
+```
+
+**Setup recipes** (`recipes/perps/setup.json`) provide quick state reads:
+
+```bash
+# Check current testnet mode
+scripts/perps/agentic/app-state.sh recipe perps/setup/testnet-mode
+
+# Check active provider
+scripts/perps/agentic/app-state.sh recipe perps/setup/current-provider
+```
+
 ---
 
 ## 5. State Paths & Routes

--- a/scripts/perps/agentic/flows/setup-account.json
+++ b/scripts/perps/agentic/flows/setup-account.json
@@ -1,0 +1,33 @@
+{
+  "title": "Setup — switch to account {{address}} and verify",
+  "validate": {
+    "runtime": {
+      "pre_conditions": ["Wallet unlocked"],
+      "steps": [
+        {
+          "id": "switch-account",
+          "description": "Switch to account {{address}}",
+          "action": "select_account",
+          "address": "{{address}}"
+        },
+        {
+          "id": "wait-switch",
+          "description": "Wait for account switch to apply",
+          "action": "wait",
+          "ms": 1000
+        },
+        {
+          "id": "verify-account",
+          "description": "Assert selected account address matches {{address}}",
+          "action": "eval_sync",
+          "expression": "JSON.stringify({address:Engine.context.AccountsController.state.internalAccounts.accounts[Engine.context.AccountsController.state.internalAccounts.selectedAccount].address})",
+          "assert": {
+            "operator": "eq",
+            "field": "address",
+            "value": "{{address}}"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/perps/agentic/flows/setup-testnet.json
+++ b/scripts/perps/agentic/flows/setup-testnet.json
@@ -1,0 +1,44 @@
+{
+  "title": "Setup — enable testnet and verify market data loads",
+  "validate": {
+    "runtime": {
+      "pre_conditions": ["Wallet unlocked", "Perps feature enabled"],
+      "steps": [
+        {
+          "id": "enable-testnet",
+          "description": "Enable testnet mode (no-op if already enabled)",
+          "action": "toggle_testnet",
+          "enabled": true
+        },
+        {
+          "id": "wait-reload",
+          "description": "Wait for market data to reload after testnet toggle",
+          "action": "wait",
+          "ms": 2000
+        },
+        {
+          "id": "verify-testnet",
+          "description": "Assert testnet is enabled in controller state",
+          "action": "eval_sync",
+          "expression": "JSON.stringify({isTestnet:Engine.context.PerpsController.state.isTestnet})",
+          "assert": {
+            "operator": "eq",
+            "field": "isTestnet",
+            "value": true
+          }
+        },
+        {
+          "id": "verify-markets",
+          "description": "Assert market list is non-empty after testnet switch",
+          "action": "recipe_ref",
+          "ref": "markets",
+          "assert": {
+            "operator": "not_null",
+            "field": null,
+            "value": null
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/perps/agentic/recipes/perps/setup.json
+++ b/scripts/perps/agentic/recipes/perps/setup.json
@@ -1,0 +1,17 @@
+{
+  "testnet-mode": {
+    "description": "Current testnet mode (isTestnet boolean)",
+    "expression": "Engine.context.PerpsController.state.isTestnet",
+    "async": false
+  },
+  "current-provider": {
+    "description": "Currently active provider",
+    "expression": "Engine.context.PerpsController.state.activeProvider",
+    "async": false
+  },
+  "account-balance": {
+    "description": "Perps account balance",
+    "expression": "Engine.context.PerpsController.getBalance().then(function(r){return JSON.stringify(r)})",
+    "async": true
+  }
+}

--- a/scripts/perps/agentic/validate-recipe.sh
+++ b/scripts/perps/agentic/validate-recipe.sh
@@ -50,18 +50,20 @@ export WATCHER_PORT="${WATCHER_PORT:-8081}"
 SD="scripts/perps/agentic"
 
 # ── Args ──────────────────────────────────────────────────────────────
-RECIPE="" DRY=false SKIP_MANUAL=false SINGLE=""
+RECIPE="" DRY=false SKIP_MANUAL=false SINGLE="" OVERRIDE_ACCOUNT="" OVERRIDE_TESTNET=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)     DRY=true; shift ;;
     --skip-manual) SKIP_MANUAL=true; shift ;;
     --step)        SINGLE="$2"; shift 2 ;;
+    --account)     OVERRIDE_ACCOUNT="$2"; shift 2 ;;
+    --testnet)     OVERRIDE_TESTNET=true; shift ;;
     -*)            echo "Unknown flag: $1"; exit 1 ;;
     *)             RECIPE="$1"; shift ;;
   esac
 done
 
-[ -z "$RECIPE" ] && { echo "Usage: validate-recipe.sh <recipe-folder-or-json> [--dry-run] [--step <id>] [--skip-manual]"; exit 1; }
+[ -z "$RECIPE" ] && { echo "Usage: validate-recipe.sh <recipe-folder-or-json> [--dry-run] [--step <id>] [--skip-manual] [--account <addr>] [--testnet]"; exit 1; }
 
 # Resolve folder → recipe.json; track RECIPE_DIR for artifact output
 RECIPE_DIR=""
@@ -93,6 +95,33 @@ PRECOND=$(node -p "const d=JSON.parse(require('fs').readFileSync(process.argv[1]
 echo "Running recipe: $TITLE (PR #$PR)"
 echo "Pre-conditions: $PRECOND"
 echo ""
+
+# ── Initial conditions ────────────────────────────────────────────────
+IC_ACCOUNT=$(node -p "const c=(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).initial_conditions||{});c.account||''" "$RECIPE")
+IC_TESTNET=$(node -p "const c=(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).initial_conditions||{});c.testnet!==undefined?String(c.testnet):''" "$RECIPE")
+IC_PROVIDER=$(node -p "const c=(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).initial_conditions||{});c.provider||''" "$RECIPE")
+
+# CLI overrides
+[ -n "$OVERRIDE_ACCOUNT" ]       && IC_ACCOUNT="$OVERRIDE_ACCOUNT"
+[ "$OVERRIDE_TESTNET" = true ]   && IC_TESTNET="true"
+
+if [ "$DRY" = false ]; then
+  if [ -n "$IC_ACCOUNT" ]; then
+    echo "[setup] switch-account $IC_ACCOUNT"
+    bash "$SD/app-state.sh" switch-account "$IC_ACCOUNT" >/dev/null 2>&1
+  fi
+  if [ -n "$IC_TESTNET" ]; then
+    CURR_TESTNET=$(node "$SD/cdp-bridge.js" eval "Engine.context.PerpsController.state.isTestnet" 2>/dev/null)
+    if [ "$CURR_TESTNET" != "$IC_TESTNET" ]; then
+      echo "[setup] toggle_testnet (current: $CURR_TESTNET → desired: $IC_TESTNET)"
+      node "$SD/cdp-bridge.js" eval-async "Engine.context.PerpsController.toggleTestnet().then(function(r){return JSON.stringify(r)})" >/dev/null 2>&1
+    fi
+  fi
+  if [ -n "$IC_PROVIDER" ]; then
+    echo "[setup] switch_provider $IC_PROVIDER"
+    node "$SD/cdp-bridge.js" eval-async "Engine.context.PerpsController.switchProvider('$IC_PROVIDER').then(function(r){return JSON.stringify(r)})" >/dev/null 2>&1
+  fi
+fi
 
 # ── Counters ──────────────────────────────────────────────────────────
 TOTAL=0 PASSED=0 FAILED=0 SKIPPED=0
@@ -273,6 +302,28 @@ while IFS= read -r sj; do
           RESULT=$(node "$SD/cdp-bridge.js" set-input "$SI_TID" "$SI_VAL" 2>/dev/null) || RESULT='{"ok":false,"error":"set-input failed"}'
         fi
       fi
+      ;;
+    select_account)
+      ADDR=$(node -p "JSON.parse(process.argv[1]).address||''" "$sj")
+      echo "  -> switch-account $ADDR"
+      [ "$DRY" = false ] && RESULT=$(bash "$SD/app-state.sh" switch-account "$ADDR" 2>&1)
+      ;;
+    toggle_testnet)
+      DESIRED=$(node -p "var s=JSON.parse(process.argv[1]);s.enabled!==undefined?String(s.enabled):'true'" "$sj")
+      echo "  -> toggle_testnet (desired: $DESIRED)"
+      if [ "$DRY" = false ]; then
+        CURR=$(node "$SD/cdp-bridge.js" eval "Engine.context.PerpsController.state.isTestnet" 2>/dev/null)
+        if [ "$CURR" != "$DESIRED" ]; then
+          RESULT=$(node "$SD/cdp-bridge.js" eval-async "Engine.context.PerpsController.toggleTestnet().then(function(r){return JSON.stringify(r)})" 2>/dev/null)
+        else
+          RESULT='{"ok":true,"already":true}'
+        fi
+      fi
+      ;;
+    switch_provider)
+      PROV=$(node -p "JSON.parse(process.argv[1]).provider||''" "$sj")
+      echo "  -> switch_provider $PROV"
+      [ "$DRY" = false ] && RESULT=$(node "$SD/cdp-bridge.js" eval-async "Engine.context.PerpsController.switchProvider('$PROV').then(function(r){return JSON.stringify(r)})" 2>/dev/null)
       ;;
     *)
       echo "  ❌ FAIL: unknown action '$ACT'"


### PR DESCRIPTION
Recipes can now declare required app state in a top-level `initial_conditions` block. `validate-recipe.sh` applies it automatically before steps run, making flows reproducible across sessions without manual setup.

**Changes:**
- `validate-recipe.sh`: `initial_conditions` block (account/testnet/provider), `--account`/`--testnet` CLI overrides, three new step actions (`select_account`, `toggle_testnet`, `switch_provider`)
- `flows/setup-testnet.json`: toggle testnet on and verify market data loads
- `flows/setup-account.json`: switch to account by address and verify
- `recipes/perps/setup.json`: quick state reads (testnet-mode, current-provider, account-balance)
- `docs/perps/perps-agentic-feedback-loop.md`: Pre-conditions & Setup section