### PR TITLE
fix: start Ramps V2 init when remote feature flags hydrate cp-7.71.0

### DIFF
--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
@@ -207,6 +207,40 @@ describe('ramps controller init', () => {
       });
     });
 
+    it('calls init when remote flags were off at startup then V2 enables on RemoteFeatureFlagController:stateChange', async () => {
+      let remoteEnabled = false;
+      const subscribeMock = jest.fn();
+      const initMessenger = {
+        call: jest.fn(() => ({
+          remoteFeatureFlags: {
+            rampsUnifiedBuyV2: remoteEnabled
+              ? { enabled: true, minimumVersion: '1.0.0' }
+              : { enabled: false },
+          },
+        })),
+        subscribe: subscribeMock,
+      } as unknown as RampsControllerInitMessenger;
+
+      initRequestMock.initMessenger = initMessenger;
+
+      rampsControllerInit(initRequestMock);
+
+      expect(mockInit).not.toHaveBeenCalled();
+
+      const stateChangeHandler = subscribeMock.mock.calls.find(
+        (call) => call[0] === 'RemoteFeatureFlagController:stateChange',
+      )?.[1] as () => void;
+
+      expect(stateChangeHandler).toBeDefined();
+
+      remoteEnabled = true;
+      stateChangeHandler();
+
+      await waitFor(() => {
+        expect(mockInit).toHaveBeenCalledTimes(1);
+      });
+    });
+
     it('handles init failure gracefully', async () => {
       initRequestMock.initMessenger = createMockInitMessenger({
         enabled: true,
@@ -253,6 +287,7 @@ describe('ramps controller init', () => {
         call: jest.fn().mockImplementation(() => {
           throw new Error('Controller not ready');
         }),
+        subscribe: jest.fn(),
       } as unknown as RampsControllerInitMessenger;
 
       rampsControllerInit(initRequestMock);

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -11,8 +11,7 @@ import { handleOrderStatusChangedForNotifications } from './event-handlers/notif
 import { handleOrderStatusChangedForMetrics } from './event-handlers/analytics';
 
 /**
- * Determines whether the ramps unified buy V2 feature is enabled
- * by reading the remote feature flag state.
+ * Whether Unified Buy V2 is enabled per RemoteFeatureFlagController state.
  *
  * @param initMessenger - The init messenger to read RemoteFeatureFlagController state.
  * @returns Whether V2 is enabled.
@@ -54,21 +53,28 @@ export const rampsControllerInit: ControllerInitFunction<
     state: rampsControllerState,
   });
 
-  const isV2Enabled = getIsRampsUnifiedBuyV2Enabled(initMessenger);
+  let orderSubscriptionsRegistered = false;
 
-  if (isV2Enabled) {
+  const registerUnifiedBuyV2OrderSubscriptions = (): void => {
+    if (orderSubscriptionsRegistered) {
+      return;
+    }
+    orderSubscriptionsRegistered = true;
     initMessenger.subscribe(
       'RampsController:orderStatusChanged',
       handleOrderStatusChangedForNotifications,
     );
-
     initMessenger.subscribe(
       'RampsController:orderStatusChanged',
       handleOrderStatusChangedForMetrics,
     );
+  };
 
-    // Start init immediately so tokens (and providers) load on app start.
-    // init() is async and does not block controller creation.
+  const startUnifiedBuyV2IfEnabled = (): void => {
+    if (!getIsRampsUnifiedBuyV2Enabled(initMessenger)) {
+      return;
+    }
+    registerUnifiedBuyV2OrderSubscriptions();
     controller
       .init()
       .then(() => {
@@ -77,7 +83,15 @@ export const rampsControllerInit: ControllerInitFunction<
       .catch(() => {
         // Initialization failed - error state will be available via selectors
       });
-  }
+  };
+
+  startUnifiedBuyV2IfEnabled();
+
+  // Remote flags can be empty on first Engine init and fill in once the
+  // controller has fetched; re-check so RampsController.init() runs then.
+  initMessenger.subscribe('RemoteFeatureFlagController:stateChange', () => {
+    startUnifiedBuyV2IfEnabled();
+  });
 
   return {
     controller,

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -89,6 +89,11 @@ export const rampsControllerInit: ControllerInitFunction<
 
   // Remote flags can be empty on first Engine init and fill in once the
   // controller has fetched; re-check so RampsController.init() runs then.
+  //
+  // This event fires for any RemoteFeatureFlagController state update — not
+  // only rampsUnifiedBuyV2. When V2 is off, startUnifiedBuyV2IfEnabled returns
+  // immediately. When V2 is on, order subscriptions register once; init() and
+  // startOrderPolling() are idempotent, so repeat invocations are safe.
   initMessenger.subscribe('RemoteFeatureFlagController:stateChange', () => {
     startUnifiedBuyV2IfEnabled();
   });


### PR DESCRIPTION
## **Description**

On a fresh install, `RemoteFeatureFlagController` loads flags asynchronously while Engine builds controllers. `rampsControllerInit` previously read the unified buy V2 flag only once; if flags were not in state yet, `RampsController.init()` never ran, so buy token lists stayed empty until a full app restart.

This change subscribes to `RemoteFeatureFlagController:stateChange` (already delegated on `RampsControllerInitMessenger`) and re-runs the same V2 startup path when remote flag state updates. Order-status subscriptions are registered at most once. `RampsController.init()` remains idempotent for repeated calls.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3350

## **Manual testing steps**

```gherkin
Feature: Unified buy V2 after fresh install

  Scenario: Buy token list loads without restarting the app
    Given a dev build with unified buy V2 enabled via remote flags
    And the app is installed fresh (or remote flag cache cleared)

    When the user completes onboarding and opens Buy / token selection
    Then tokens and providers load without requiring an app restart
```

## **Screenshots/Recordings**

<div>
    <a href="https://www.loom.com/share/e80a3794612d4030aa963834e5a8d7bf">
      <p>Fix Ramps controller not initializing on fresh install - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/e80a3794612d4030aa963834e5a8d7bf">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/e80a3794612d4030aa963834e5a8d7bf-13202ae1a2494608-full-play.gif#t=0.1">
    </a>
  </div>

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new subscription-driven initialization path triggered by `RemoteFeatureFlagController:stateChange`, which can change startup behavior and potentially cause repeated init/polling if underlying idempotency assumptions are wrong.
> 
> **Overview**
> Ensures Unified Buy V2 startup runs even when remote feature flags hydrate *after* Engine/controller initialization by subscribing to `RemoteFeatureFlagController:stateChange` and re-checking the V2 flag.
> 
> Refactors V2 startup into a helper that conditionally calls `RampsController.init()`/`startOrderPolling()` and registers order-status subscriptions only once. Updates tests to cover the “flag off at startup then enabled on stateChange” scenario and to include `subscribe` in the thrown-state mock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78ff8000147e10ce2325b2dfa563dd0dd16b878c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->