### PR TITLE
fix(ramps): select BuildQuote quote with normalized provider id

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -447,10 +447,19 @@ function BuildQuote() {
   ]);
 
   const selectedQuote = useMemo(() => {
-    if (!quotesResponse?.success || !selectedProvider || !selectedPaymentMethod)
+    if (
+      !quotesResponse?.success ||
+      !selectedProvider ||
+      !selectedPaymentMethod
+    ) {
       return null;
-    const [quote] = quotesResponse.success;
-    return quote?.provider === selectedProvider.id ? quote : null;
+    }
+    const targetProvider = normalizeProviderCode(selectedProvider.id);
+    return (
+      quotesResponse.success.find(
+        (quote) => normalizeProviderCode(quote.provider) === targetProvider,
+      ) ?? null
+    );
   }, [quotesResponse, selectedProvider, selectedPaymentMethod]);
 
   const networkInfo = useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Unified Buy v2 **BuildQuote** (amount input) derives `selectedQuote` from the quotes API `success` array. The previous logic used only the **first** quote and required **`quote.provider === selectedProvider.id`**.

Quotes can still be **scoped to the selected provider** via request params while returning `provider` strings that **do not exactly match** controller state (for example `/providers/transak` vs `transak`). In that case `selectedQuote` was `null` even though a valid quote existed, which surfaced as **“We’ve encountered an error”** / no-quotes UI (`hasNoQuotes`) and looked intermittent when amounts refetched.

This change selects the quote with **`normalizeProviderCode`** on both sides and uses **`.find`** over `success` so the correct row is matched regardless of path vs short id formatting.

## **Changelog**

CHANGELOG entry: Fixed Buy amount screen sometimes showing a generic error when quotes returned for the selected provider but provider id strings differed in format.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Unified Buy v2 BuildQuote quote selection

  Scenario: Amount entry with Transak after provider selection
    Given Unified Buy v2 is enabled and Transak is the selected provider
    And a token and payment method are selected

    When the user opens the amount (BuildQuote) screen and enters or changes a fiat amount
    Then the Continue control enables when a quote is available
    And the generic “We’ve encountered an error” / no-quotes message does not appear solely because of provider id formatting
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
