### PR TITLE
feat: instant transaction support with confirmation render optimizations

### DIFF
--- a/app/components/Base/TokenIcon/index.tsx
+++ b/app/components/Base/TokenIcon/index.tsx
@@ -170,7 +170,6 @@ function TokenIcon({
       <RemoteImage
         key={icon || `symbol-${symbol}`}
         testID={testID}
-        fadeIn
         source={getSource()}
         onError={() => setShowFallback(true)}
         style={[
@@ -222,4 +221,4 @@ TokenIcon.propTypes = {
   testID: PropTypes.string,
 };
 
-export default TokenIcon;
+export default React.memo(TokenIcon);

--- a/app/components/UI/Earn/hooks/useMusdConfirmNavigation.ts
+++ b/app/components/UI/Earn/hooks/useMusdConfirmNavigation.ts
@@ -6,7 +6,9 @@ import { selectMusdQuickConvertEnabledFlag } from '../selectors/featureFlags';
 import { useMusdConversionTokens } from './useMusdConversionTokens';
 import { useTransactionPayIsMaxAmount } from '../../../Views/confirmations/hooks/pay/useTransactionPayData';
 
-export const useMusdConfirmNavigation = () => {
+export const useMusdConfirmNavigation = ({
+  enabled = true,
+}: { enabled?: boolean } = {}) => {
   const navigation = useNavigation();
   const isMusdQuickConvertEnabled = useSelector(
     selectMusdQuickConvertEnabledFlag,
@@ -14,7 +16,7 @@ export const useMusdConfirmNavigation = () => {
 
   const isMaxAmount = useTransactionPayIsMaxAmount();
 
-  const { tokens: conversionTokens } = useMusdConversionTokens();
+  const { tokens: conversionTokens } = useMusdConversionTokens({ enabled });
 
   const isLastConvertibleToken = conversionTokens.length <= 1;
 

--- a/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionTokens.ts
@@ -25,7 +25,9 @@ import { safeFormatChainIdToHex } from '../../Card/util/safeFormatChainIdToHex';
  * - hasConvertibleTokensByChainId(chainId: Hex): boolean - Checks if there are convertible tokens on a given chain.
  * - tokens: AssetType[] - The tokens that are eligible for mUSD conversion.
  */
-export const useMusdConversionTokens = () => {
+export const useMusdConversionTokens = ({
+  enabled = true,
+}: { enabled?: boolean } = {}) => {
   const musdConversionPaymentTokensAllowlist = useSelector(
     selectMusdConversionPaymentTokensAllowlist,
   );
@@ -38,7 +40,10 @@ export const useMusdConversionTokens = () => {
     selectMusdConversionMinAssetBalanceRequired,
   );
 
-  const allTokens = useAccountTokens({ includeNoBalance: false });
+  const allTokens = useAccountTokens({
+    includeNoBalance: false,
+    skip: !enabled,
+  });
 
   const filterTokensWithMinBalance = useCallback(
     (token: AssetType) => {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -97,11 +97,7 @@ const ConfirmWrapped = ({
   return (
     <ConfirmationContextProvider>
       <ConfirmationAssetPollingProvider>
-        {isReady ? (
-          <ConfirmationAlerts>{content}</ConfirmationAlerts>
-        ) : (
-          <AlertsContextProvider alerts={[]}>{content}</AlertsContextProvider>
-        )}
+        <ConfirmationAlerts>{content}</ConfirmationAlerts>
       </ConfirmationAssetPollingProvider>
     </ConfirmationContextProvider>
   );

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -67,33 +67,41 @@ const ConfirmWrapped = ({
   route?: UnstakeConfirmationViewProps['route'];
 }) => {
   const isScrollDisabled = useDisableScroll();
+  const transactionMeta = useTransactionMetadataRequest();
+  const isReady = transactionMeta?.ready !== false;
+
+  const content = (
+    <QRHardwareContextProvider>
+      <LedgerContextProvider>
+        <Title />
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollViewContent}
+          nestedScrollEnabled
+          scrollEnabled={!isScrollDisabled}
+        >
+          <TouchableWithoutFeedback>
+            <>
+              <AlertBanner
+                ignoreTypes={TRANSACTION_TYPES_DISABLE_ALERT_BANNER}
+              />
+              <Info route={route} />
+            </>
+          </TouchableWithoutFeedback>
+        </ScrollView>
+        <Footer />
+      </LedgerContextProvider>
+    </QRHardwareContextProvider>
+  );
 
   return (
     <ConfirmationContextProvider>
       <ConfirmationAssetPollingProvider>
-        <ConfirmationAlerts>
-          <QRHardwareContextProvider>
-            <LedgerContextProvider>
-              <Title />
-              <ScrollView
-                style={styles.scrollView}
-                contentContainerStyle={styles.scrollViewContent}
-                nestedScrollEnabled
-                scrollEnabled={!isScrollDisabled}
-              >
-                <TouchableWithoutFeedback>
-                  <>
-                    <AlertBanner
-                      ignoreTypes={TRANSACTION_TYPES_DISABLE_ALERT_BANNER}
-                    />
-                    <Info route={route} />
-                  </>
-                </TouchableWithoutFeedback>
-              </ScrollView>
-              <Footer />
-            </LedgerContextProvider>
-          </QRHardwareContextProvider>
-        </ConfirmationAlerts>
+        {isReady ? (
+          <ConfirmationAlerts>{content}</ConfirmationAlerts>
+        ) : (
+          <AlertsContextProvider alerts={[]}>{content}</AlertsContextProvider>
+        )}
       </ConfirmationAssetPollingProvider>
     </ConfirmationContextProvider>
   );
@@ -125,12 +133,10 @@ export const Confirm = ({
     if (approvalRequest) {
       const options = {
         headerShown: false,
-        // If there is an approvalRequest, we need to allow the user to swipe to reject the confirmation
         gestureEnabled: true,
       };
 
       if (isFullScreenConfirmation) {
-        // If the confirmation is full screen, we need to show the header
         options.headerShown = true;
       }
       navigation.setOptions(options);
@@ -151,7 +157,6 @@ export const Confirm = ({
     }
   }, [approvalRequest]);
 
-  // Show spinner if there is no approvalRequest
   if (!approvalRequest) {
     return <Loader />;
   }

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -12,7 +12,10 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
 import { useTheme } from '@react-navigation/native';
-import { addTransactionBatch } from '../../../../../../util/transaction-controller';
+import {
+  addTransactionBatch,
+  addTransactionBatchInstant,
+} from '../../../../../../util/transaction-controller';
 import { useSelector } from 'react-redux';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import Routes from '../../../../../../constants/navigation/Routes';
@@ -82,7 +85,10 @@ function PredictClaim() {
 }
 
 function PredictDeposit() {
-  const { addTransactionBatchAndNavigate } = useAddTransactionBatch();
+  const {
+    addTransactionBatchAndNavigate,
+    addTransactionBatchInstantAndNavigate,
+  } = useAddTransactionBatch();
 
   const handleDeposit = useCallback(async () => {
     addTransactionBatchAndNavigate({
@@ -91,13 +97,27 @@ function PredictDeposit() {
     });
   }, [addTransactionBatchAndNavigate]);
 
+  const handleDepositInstant = useCallback(() => {
+    addTransactionBatchInstantAndNavigate({
+      transactionType: TransactionType.predictDeposit,
+    });
+  }, [addTransactionBatchInstantAndNavigate]);
+
   return (
-    <DeveloperButton
-      title="Predict Deposit"
-      description="Trigger a Predict deposit confirmation."
-      buttonLabel="Deposit"
-      onPress={handleDeposit}
-    />
+    <>
+      <DeveloperButton
+        title="Predict Deposit"
+        description="Trigger a Predict deposit confirmation."
+        buttonLabel="Deposit"
+        onPress={handleDeposit}
+      />
+      <DeveloperButton
+        title="Predict Deposit (Instant)"
+        description="Trigger an instant Predict deposit confirmation."
+        buttonLabel="Deposit Instant"
+        onPress={handleDepositInstant}
+      />
+    </>
   );
 }
 
@@ -159,8 +179,42 @@ function useAddTransactionBatch() {
     [navigateToConfirmation, networkClientId, selectedAccount, transferData],
   );
 
+  const addTransactionBatchInstantAndNavigate = useCallback(
+    ({ transactionType }: { transactionType: TransactionType }) => {
+      addTransactionBatchInstant({
+        from: selectedAccount as Hex,
+        origin: ORIGIN_METAMASK,
+        networkClientId,
+        disableHook: true,
+        disableSequential: true,
+        instant: true,
+        transactions: [
+          {
+            params: {
+              to: PROXY_ADDRESS,
+              value: '0x1',
+            },
+          },
+          {
+            params: {
+              to: POLYGON_USDCE_ADDRESS,
+              data: transferData,
+            },
+            type: transactionType,
+          },
+        ],
+      });
+
+      navigateToConfirmation({
+        stack: Routes.PREDICT.ROOT,
+      });
+    },
+    [navigateToConfirmation, networkClientId, selectedAccount, transferData],
+  );
+
   return {
     addTransactionBatchAndNavigate,
+    addTransactionBatchInstantAndNavigate,
   };
 }
 

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -181,6 +181,11 @@ function useAddTransactionBatch() {
 
   const addTransactionBatchInstantAndNavigate = useCallback(
     ({ transactionType }: { transactionType: TransactionType }) => {
+      navigateToConfirmation({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PREDICT.ROOT,
+      });
+
       addTransactionBatchInstant({
         from: selectedAccount as Hex,
         origin: ORIGIN_METAMASK,
@@ -203,10 +208,6 @@ function useAddTransactionBatch() {
             type: transactionType,
           },
         ],
-      });
-
-      navigateToConfirmation({
-        stack: Routes.PREDICT.ROOT,
       });
     },
     [navigateToConfirmation, networkClientId, selectedAccount, transferData],

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -81,7 +81,14 @@ export function PayWithRow() {
       return payToken ?? defaultWithdrawToken ?? null;
     }
     return payToken ?? null;
-  }, [isWithdraw, payToken, defaultWithdrawToken]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isWithdraw,
+    payToken?.address,
+    payToken?.chainId,
+    defaultWithdrawToken?.address,
+    defaultWithdrawToken?.chainId,
+  ]);
 
   // For deposits, show the user's balance of the selected pay token
   const balanceUsdFormatted = useMemo(

--- a/app/components/Views/confirmations/components/token-icon/token-icon.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Hex } from '@metamask/utils';
 import BaseTokenIcon from '../../../../Base/TokenIcon';
 import styleSheet from './token-icon.styles';
@@ -25,44 +25,82 @@ export enum TokenIconVariant {
   Hero = 'hero',
 }
 
+interface TokenIconVisualProps {
+  chainId: Hex;
+  showNetwork: boolean;
+  variant: TokenIconVariant;
+  image?: string;
+  symbol?: string;
+}
+
+const TokenIconVisual = React.memo(({
+  chainId,
+  showNetwork,
+  variant,
+  image,
+  symbol,
+}: TokenIconVisualProps) => {
+  const { styles } = useStyles(styleSheet, { variant });
+
+  const networkImageSource = useMemo(
+    () => getNetworkImageSource({ chainId }),
+    [chainId],
+  );
+
+  const badgeElement = useMemo(
+    () =>
+      showNetwork ? (
+        <Badge
+          variant={BadgeVariant.Network}
+          imageSource={networkImageSource}
+          style={styles.badge}
+        />
+      ) : undefined,
+    [showNetwork, networkImageSource, styles.badge],
+  );
+
+  return (
+    <BadgeWrapper
+      style={styles.container}
+      badgePosition={BadgePosition.BottomRight}
+      badgeElement={badgeElement}
+    >
+      <BaseTokenIcon
+        testID="token-icon"
+        icon={image}
+        symbol={symbol}
+        style={styles.tokenIcon}
+      />
+    </BadgeWrapper>
+  );
+});
+
 export const TokenIcon: React.FC<TokenIconProps> = ({
   address,
   chainId,
   showNetwork = true,
   variant = TokenIconVariant.Default,
 }) => {
-  const { styles } = useStyles(styleSheet, { variant });
-
   const token = useTokenWithBalance(address, chainId);
+  const lastTokenRef = useRef(token);
 
-  if (!token) {
+  if (token) {
+    lastTokenRef.current = token;
+  }
+
+  const displayToken = token ?? lastTokenRef.current;
+
+  if (!displayToken) {
     return null;
   }
 
-  const networkImageSource = getNetworkImageSource({
-    chainId,
-  });
-
   return (
-    <BadgeWrapper
-      style={styles.container}
-      badgePosition={BadgePosition.BottomRight}
-      badgeElement={
-        showNetwork && (
-          <Badge
-            variant={BadgeVariant.Network}
-            imageSource={networkImageSource}
-            style={styles.badge}
-          />
-        )
-      }
-    >
-      <BaseTokenIcon
-        testID="token-icon"
-        icon={token?.image}
-        symbol={token?.symbol}
-        style={styles.tokenIcon}
-      />
-    </BadgeWrapper>
+    <TokenIconVisual
+      chainId={chainId}
+      showNetwork={showNetwork}
+      variant={variant}
+      image={displayToken.image}
+      symbol={displayToken.symbol}
+    />
   );
 };

--- a/app/components/Views/confirmations/hooks/gas/useGasFeeToken.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeToken.ts
@@ -156,11 +156,14 @@ function useFiatTokenValue(
 ) {
   const { decimals, rateWei } = gasFeeToken ?? { decimals: 0, rateWei: '0x0' };
 
-  const nativeWei = new BigNumber(tokenValue ?? '0x0')
-    .shiftedBy(-decimals)
-    .multipliedBy(new BigNumber(rateWei));
-
-  const nativeEth = nativeWei.shiftedBy(-18);
+  const nativeEth = useMemo(
+    () =>
+      new BigNumber(tokenValue ?? '0x0')
+        .shiftedBy(-decimals)
+        .multipliedBy(new BigNumber(rateWei))
+        .shiftedBy(-18),
+    [tokenValue, decimals, rateWei],
+  );
 
   const fiatValue = useEthFiatAmount(
     nativeEth,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -29,7 +29,9 @@ export function useTransactionPayMetrics() {
   const transactionMeta = useTransactionMetadataRequest();
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
-  const highestBalanceChainId = useHighestBalanceCaipChainId();
+  const highestBalanceChainId = useHighestBalanceCaipChainId({
+    skip: !payToken,
+  });
   const automaticPayToken = useRef<BridgeToken>();
   const hasLoadedQuoteRef = useRef(false);
   const quotes = useTransactionPayQuotes();
@@ -159,8 +161,10 @@ export function useTransactionPayMetrics() {
   }, [dispatch, transactionId, params]);
 }
 
-function useHighestBalanceCaipChainId(): string | undefined {
-  const tokens = useAccountTokens();
+function useHighestBalanceCaipChainId({
+  skip = false,
+}: { skip?: boolean } = {}): string | undefined {
+  const tokens = useAccountTokens({ skip });
 
   return useMemo(() => {
     // Aggregate fiat balances by chainId

--- a/app/components/Views/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/app/components/Views/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -28,8 +28,8 @@ export function useWithdrawTokenFilter(): (tokens: AssetType[]) => AssetType[] {
     selectPayQuoteConfig(state, transactionType),
   );
   const allTokens = useSendTokens({
-    includeNoBalance: true,
-    includeAllTokens: true,
+    includeNoBalance: isWithdraw,
+    includeAllTokens: isWithdraw,
   });
 
   const allowlist = config.tokens;

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -15,13 +15,16 @@ import { selectERC20TokensByChain } from '../../../../../selectors/tokenListCont
 
 const EMPTY_CACHE = {} as ReturnType<typeof selectERC20TokensByChain>;
 const selectEmptyCache = () => EMPTY_CACHE;
+const EMPTY_TOKENS: AssetType[] = [];
 
 export function useAccountTokens({
   includeNoBalance = false,
   includeAllTokens = false,
+  skip = false,
 }: {
   includeNoBalance?: boolean;
   includeAllTokens?: boolean;
+  skip?: boolean;
 } = {}): AssetType[] {
   const assets = useSelector(selectAssetsBySelectedAccountGroup);
   const fiatCurrency = useSelector(selectCurrentCurrency);
@@ -30,6 +33,10 @@ export function useAccountTokens({
   );
 
   return useMemo(() => {
+    if (skip) {
+      return EMPTY_TOKENS;
+    }
+
     const flatAssets = Object.values(assets).flat();
 
     const assetsWithBalance = flatAssets.filter((asset) => {
@@ -119,6 +126,7 @@ export function useAccountTokens({
     includeAllTokens,
     fiatCurrency,
     tokensChainsCache,
+    skip,
   ]) as unknown as AssetType[];
 }
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -35,8 +35,11 @@ export function useTransactionConfirm() {
     transactionMetadata ?? {};
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const quotes = useTransactionPayQuotes();
+
   const { navigateOnConfirm: musdConversionNavigateOnConfirm } =
-    useMusdConfirmNavigation();
+    useMusdConfirmNavigation({
+      enabled: type === TransactionType.musdConversion,
+    });
 
   const { tryEnableEvmNetwork } = useNetworkEnablement();
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionMetadataRequest.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionMetadataRequest.ts
@@ -4,19 +4,33 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectTransactionMetadataById } from '../../../../../selectors/transactionController';
 import { RootState } from '../../../../UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
 import useApprovalRequest from '../useApprovalRequest';
 import { EMPTY_ADDRESS } from '../../../../../constants/transaction';
+import Engine from '../../../../../core/Engine';
 
 export function useTransactionMetadataRequest() {
   const { approvalRequest } = useApprovalRequest();
 
-  const transactionMetadata = useSelector((state: RootState) =>
+  const reduxMetadata = useSelector((state: RootState) =>
     selectTransactionMetadataById(state, approvalRequest?.id as string),
   );
+
+  const controllerMetadata = useMemo(() => {
+    if (!approvalRequest?.id) {
+      return undefined;
+    }
+
+    return Engine.context.TransactionController.state.transactions.find(
+      (tx: TransactionMeta) => tx.id === approvalRequest.id,
+    );
+  }, [approvalRequest?.id]);
+
+  const transactionMetadata = reduxMetadata ?? controllerMetadata;
 
   if (
     approvalRequest?.type === ApprovalType.Transaction &&

--- a/app/components/Views/confirmations/hooks/useApprovalRequest.ts
+++ b/app/components/Views/confirmations/hooks/useApprovalRequest.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { providerErrors } from '@metamask/rpc-errors';
 import Engine from '../../../../core/Engine';
@@ -10,8 +10,26 @@ import { selectPendingApprovals } from '../../../../selectors/approvalController
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ApprovalRequestType = ApprovalRequest<any>;
 
+function getControllerPendingApprovals():
+  | Record<string, ApprovalRequestType>
+  | undefined {
+  const pending = Engine.context.ApprovalController?.state?.pendingApprovals;
+
+  if (pending && Object.keys(pending).length > 0) {
+    return pending as Record<string, ApprovalRequestType>;
+  }
+
+  return undefined;
+}
+
 const useApprovalRequest = () => {
-  const pendingApprovals = useSelector(selectPendingApprovals, isEqual);
+  const reduxApprovals = useSelector(selectPendingApprovals);
+
+  const pendingApprovals =
+    (reduxApprovals && Object.keys(reduxApprovals).length > 0
+      ? reduxApprovals
+      : undefined) ?? getControllerPendingApprovals();
+
   const pendingApprovalList = Object.values(pendingApprovals ?? {});
 
   const firstPendingApproval = pendingApprovalList[0] as

--- a/app/components/Views/confirmations/hooks/useConfirmNavigation.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmNavigation.ts
@@ -22,6 +22,7 @@ const ROUTE_NO_HEADER = Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER;
 
 export type ConfirmNavigateOptions = {
   amount?: string;
+  animationEnabled?: boolean;
   headerShown?: boolean;
   stack?: string;
 } & ConfirmationParams;
@@ -42,7 +43,7 @@ export function useConfirmNavigation() {
 
   const navigateToConfirmation = useCallback(
     (options: ConfirmNavigateOptions) => {
-      const { headerShown, stack, ...params } = options;
+      const { headerShown, stack, animationEnabled, ...params } = options;
       const { loader } = params;
 
       if (!loader && stack === Routes.PERPS.ROOT) {
@@ -68,6 +69,11 @@ export function useConfirmNavigation() {
 
       if (stack) {
         navigate(stack, { screen: route, params });
+        return;
+      }
+
+      if (animationEnabled === false) {
+        navigate(route, { ...params, animationEnabled: false });
         return;
       }
 

--- a/app/components/Views/confirmations/hooks/useEthFiatAmount.tsx
+++ b/app/components/Views/confirmations/hooks/useEthFiatAmount.tsx
@@ -41,38 +41,44 @@ export function useEthFiatAmount(
     [conversionRate, currentCurrency, ethAmount],
   );
 
-  if (
-    !conversionRate ||
-    !showFiat ||
-    currentCurrency.toUpperCase() === 'ETH' ||
-    conversionRate <= 0 ||
-    ethAmount === undefined
-  ) {
-    return undefined;
-  }
+  const result = useMemo(() => {
+    if (
+      !conversionRate ||
+      !showFiat ||
+      currentCurrency.toUpperCase() === 'ETH' ||
+      conversionRate <= 0 ||
+      ethAmount === undefined
+    ) {
+      return undefined;
+    }
 
-  // Calculate the fiat amount
-  const fiatAmount = new BigNumber(ethAmount.toString()).times(conversionRate);
+    const fiatAmount = new BigNumber(ethAmount.toString()).times(
+      conversionRate,
+    );
 
-  // Handle small fiat amounts
-  if (
-    ethAmount &&
-    fiatAmount.lt(new BigNumber(0.01)) &&
-    fiatAmount.isGreaterThan(new BigNumber(0))
-  ) {
+    if (ethAmount && fiatAmount.lt(0.01) && fiatAmount.isGreaterThan(0)) {
+      return hideCurrencySymbol
+        ? `< ${formatCurrency(0.01, currentCurrency)}`
+        : `< ${formatCurrency(
+            0.01,
+            currentCurrency,
+          )} ${currentCurrency.toUpperCase()}`;
+    }
+
     return hideCurrencySymbol
-      ? `< ${formatCurrency(0.01, currentCurrency)}`
-      : `< ${formatCurrency(
-          0.01,
+      ? formatCurrency(formattedFiat, currentCurrency)
+      : `${formatCurrency(
+          formattedFiat,
           currentCurrency,
         )} ${currentCurrency.toUpperCase()}`;
-  }
+  }, [
+    conversionRate,
+    currentCurrency,
+    ethAmount,
+    formattedFiat,
+    hideCurrencySymbol,
+    showFiat,
+  ]);
 
-  // Return the formatted fiat amount
-  return hideCurrencySymbol
-    ? formatCurrency(formattedFiat, currentCurrency)
-    : `${formatCurrency(
-        formattedFiat,
-        currentCurrency,
-      )} ${currentCurrency.toUpperCase()}`;
+  return result;
 }

--- a/app/components/Views/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/app/components/Views/confirmations/hooks/useHasInsufficientBalance.ts
@@ -1,5 +1,6 @@
 import { add0x, Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
+import { useMemo } from 'react';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
 import { useSelector } from 'react-redux';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
@@ -28,19 +29,20 @@ export function useHasInsufficientBalance(): {
   const { nativeCurrency } =
     networkConfigurations[transactionMetadata?.chainId as Hex] ?? {};
 
-  const maxFeeNativeInHex = multiplyHexes(
-    maxFeePerGas ? (decimalToHex(maxFeePerGas) as Hex) : (gasPrice as Hex),
-    gas as Hex,
-  );
+  const hasInsufficientBalance = useMemo(() => {
+    const maxFeeNativeInHex = multiplyHexes(
+      maxFeePerGas ? (decimalToHex(maxFeePerGas) as Hex) : (gasPrice as Hex),
+      gas as Hex,
+    );
 
-  const transactionValue = txParams?.value || HEX_ZERO;
-  const totalTransactionValue = addHexes(maxFeeNativeInHex, transactionValue);
-  const totalTransactionInHex = add0x(totalTransactionValue as string);
+    const transactionValue = txParams?.value || HEX_ZERO;
+    const totalTransactionValue = addHexes(maxFeeNativeInHex, transactionValue);
+    const totalTransactionInHex = add0x(totalTransactionValue as string);
 
-  const balanceWeiInHexBN = new BigNumber(balanceWeiInHex ?? '0x0');
-  const totalTransactionValueBN = new BigNumber(totalTransactionInHex ?? '0x0');
-
-  const hasInsufficientBalance = balanceWeiInHexBN.lt(totalTransactionValueBN);
+    return new BigNumber(balanceWeiInHex ?? '0x0').lt(
+      new BigNumber(totalTransactionInHex ?? '0x0'),
+    );
+  }, [balanceWeiInHex, maxFeePerGas, gas, gasPrice, txParams?.value]);
 
   return { hasInsufficientBalance, nativeCurrency };
 }

--- a/app/util/transaction-controller/index.ts
+++ b/app/util/transaction-controller/index.ts
@@ -40,6 +40,14 @@ export async function addTransactionBatch(
   return await TransactionController.addTransactionBatch(...args);
 }
 
+export function addTransactionBatchInstant(
+  ...args: Parameters<BaseTransactionController['addTransactionBatchInstant']>
+) {
+  const { TransactionController } = Engine.context;
+
+  return TransactionController.addTransactionBatchInstant(...args);
+}
+
 // Keeping this export as function to put more logic in the future
 export async function estimateGas(
   transaction: TransactionParams,

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
-    "@metamask/transaction-controller": "^63.0.0",
+    "@metamask/transaction-controller": "file:.yalc/@metamask/transaction-controller",
     "@metamask/transaction-pay-controller": "^17.1.0",
     "@metamask/tron-wallet-snap": "1.24.0",
     "@metamask/utils": "^11.8.1",


### PR DESCRIPTION
## **Description**

Optimize the confirmation render path for instant transactions. Navigate to the confirmation screen before controller work completes, cache token icon state to prevent flicker during data hydration, and reduce unnecessary re-renders across the confirmation flow.

Depends on core PR for `startTransaction` support: https://github.com/MetaMask/core/pull/8248

## **Changelog**

CHANGELOG entry: Improved confirmation screen load performance for transactions

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open dev options in confirmations and trigger an instant transaction
2. Confirmation screen should appear immediately without blank/loading state
3. Token icons should not flicker as transaction data hydrates
4. Standard (non-instant) transaction flow should be unaffected

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.