### PR TITLE
feat(i18n): Update language display names to native forms

### DIFF
--- a/locales/i18n.js
+++ b/locales/i18n.js
@@ -102,24 +102,29 @@ export async function setLocale(locale) {
   I18nEvents.emit('localeChanged', locale);
 }
 
-// Get languages
+/**
+ * Human-readable language names for the settings language selector only.
+ * Labels use each language's native form (endonyms); keys are unchanged locale codes.
+ *
+ * @returns {Record<string, string>} locale code → display label
+ */
 export function getLanguages() {
   return {
-    de: 'German',
-    el: 'Greek',
+    de: 'Deutsch',
+    el: 'Ελληνικά',
     en: 'English',
-    es: 'Spanish',
-    fr: 'French',
-    hi: 'Hindi',
-    id: 'Bahasa Indonesian',
-    ja: 'Japanese',
-    ko: 'Korean',
-    pt: 'Portuguese - Brazil',
-    ru: 'Russian',
+    es: 'Español',
+    fr: 'Français',
+    hi: 'हिन्दी',
+    id: 'Bahasa Indonesia',
+    ja: '日本語',
+    ko: '한국어',
+    pt: 'Português (Brasil)',
+    ru: 'Русский',
     tl: 'Filipino',
-    tr: 'Turkish',
-    vi: 'Vietnamese',
-    zh: 'Chinese - China',
+    tr: 'Türkçe',
+    vi: 'Tiếng Việt',
+    zh: '简体中文',
   };
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Language options in Settings → General → Current language were labeled in English (e.g. “Spanish”, “Chinese - China”), which is awkward for users who don’t read English well.

This PR updates display labels only in getLanguages() (locales/i18n.js): each option uses that language’s endonym (e.g. Español, 简体中文). Locale keys and persistence (setLocale, storage, supportedTranslations) are unchanged.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the General settings language picker to show each language in its native name.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-454

## **Manual testing steps**

```gherkin
Feature: Language selector display in General settings

  Scenario: User sees native language names in the picker
    Given the user has opened MetaMask and is logged in
    And the user navigates to Settings > General

    When the user views the "Current language" section
    Then the closed selector shows the current locale using its native label where applicable (e.g. English stays "English")
    And opening the language selector lists options with native names (e.g. Español, 简体中文, Deutsch)

  Scenario: Changing language still works
    Given the user is on Settings > General
    When the user selects a different language from the list and confirms if prompted
    Then the app locale updates as before
    And returning to General settings shows the newly selected language label correctly
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="269" height="573" alt="Screenshot 2026-03-23 at 11 30 48" src="https://github.com/user-attachments/assets/6439354b-358e-4434-9051-248a9415ee78" />

<!-- [screenshots/recordings] -->

### **After**
<img width="265" height="571" alt="Screenshot 2026-03-23 at 11 29 29" src="https://github.com/user-attachments/assets/6a08eea8-0206-419f-8ac6-dacb80c36340" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that updates display strings in `getLanguages()` without altering locale codes, storage, or translation loading logic.
> 
> **Overview**
> Updates `getLanguages()` in `locales/i18n.js` so the Settings language selector displays **native language names (endonyms)** (e.g., `Deutsch`, `Español`, `简体中文`) instead of English labels.
> 
> Adds a short JSDoc comment clarifying this mapping is *display-only* and does not change locale keys or persistence behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bfd5f36c9061f385328e357781a19b69096f87d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->