### PR TITLE
chore: market insights arrows updated

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsViewHeader.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsViewHeader.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import { Pressable } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   Text,
   TextVariant,
-  Icon,
   IconName,
-  IconSize,
-  IconColor,
+  ButtonIcon,
+  ButtonIconSize,
   BoxFlexDirection,
   BoxAlignItems,
   FontWeight,
@@ -22,31 +19,25 @@ interface MarketInsightsViewHeaderProps {
 
 const MarketInsightsViewHeader: React.FC<MarketInsightsViewHeaderProps> = ({
   onBackPress,
-}) => {
-  const tw = useTailwind();
-
-  return (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      twClassName="px-1 py-2"
-      testID={MarketInsightsSelectorsIDs.VIEW_HEADER}
-    >
-      <Pressable onPress={onBackPress} style={tw.style('p-2')} hitSlop={8}>
-        <Icon
-          name={IconName.ArrowLeft}
-          size={IconSize.Md}
-          color={IconColor.IconDefault}
-        />
-      </Pressable>
-      <Box twClassName="flex-1 items-center">
-        <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
-          {strings('market_insights.title')}
-        </Text>
-      </Box>
-      <Box twClassName="w-10" />
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="px-2 py-2"
+    testID={MarketInsightsSelectorsIDs.VIEW_HEADER}
+  >
+    <ButtonIcon
+      iconName={IconName.ArrowLeft}
+      size={ButtonIconSize.Md}
+      onPress={onBackPress}
+    />
+    <Box twClassName="flex-1 items-center">
+      <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
+        {strings('market_insights.title')}
+      </Text>
     </Box>
-  );
-};
+    <Box twClassName="w-10" />
+  </Box>
+);
 
 export default MarketInsightsViewHeader;

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Pressable } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -10,6 +10,8 @@ import {
   IconName,
   IconSize,
   IconColor,
+  ButtonIcon,
+  ButtonIconSize,
   BoxFlexDirection,
   BoxAlignItems,
 } from '@metamask/design-system-react-native';
@@ -63,11 +65,13 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
           <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
             {strings('market_insights.title')}
           </Text>
-          <Icon
-            name={IconName.ArrowRight}
-            size={IconSize.Sm}
-            color={IconColor.IconDefault}
-          />
+          <View pointerEvents="none" style={tw.style('ml-1')}>
+            <ButtonIcon
+              iconName={IconName.ArrowRight}
+              size={ButtonIconSize.Sm}
+              iconProps={{ color: IconColor.IconAlternative }}
+            />
+          </View>
         </Box>
 
         <Box gap={3}>

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "@metamask/account-tree-controller": "^5.0.0",
     "@metamask/accounts-controller": "^37.0.0",
     "@metamask/address-book-controller": "^7.1.0",
-    "@metamask/ai-controllers": "^0.4.0",
+    "@metamask/ai-controllers": "^0.5.0",
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7629,15 +7629,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@metamask/ai-controllers@npm:0.4.0"
+"@metamask/ai-controllers@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@metamask/ai-controllers@npm:0.5.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.9.0"
-  checksum: 10/b51e15821dd62c6b15dc2c1efe6da56f4467b81ee8e7ff7df5f38c429d8b47162ee918e94a5713fe55902390f75a4cb6672813f4e103e8b348fca624dd27c467
+  checksum: 10/a4806d4de47913e86117d825a395deb30bad8fccce1128592763b79bae245889796331de4bfba2dcf8d7aba334bf9b8b87c31d2255615492b34e26a09feb009d
   languageName: node
   linkType: hard
 
@@ -35470,7 +35470,7 @@ __metadata:
     "@metamask/account-tree-controller": "npm:^5.0.0"
     "@metamask/accounts-controller": "npm:^37.0.0"
     "@metamask/address-book-controller": "npm:^7.1.0"
-    "@metamask/ai-controllers": "npm:^0.4.0"
+    "@metamask/ai-controllers": "npm:^0.5.0"
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates both arrows to the correct sizes.
Updates ai ctrl package to latest version.

<img width="341" height="115" alt="Screenshot 2026-03-23 at 10 42 27" src="https://github.com/user-attachments/assets/ddef0cf0-b30b-435c-8e41-047f038903dc" />

<img width="361" height="104" alt="Screenshot 2026-03-23 at 10 42 38" src="https://github.com/user-attachments/assets/5ca7fb19-39bb-4b5a-b964-15ca894367c4" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps arrow icons to the design-system `ButtonIcon` for consistent sizing and styling, with minimal layout tweaks.
> 
> **Overview**
> Updates the Market Insights UI to use the design-system `ButtonIcon` for both the back arrow in `MarketInsightsViewHeader` and the trailing arrow in `MarketInsightsEntryCard`, aligning icon sizing/styling with the design system.
> 
> Includes small layout adjustments (e.g., header padding and spacing) and wraps the entry-card arrow in a non-interactive container (`pointerEvents="none"`) to preserve the card’s press behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e137b55495f63be372d2c8fbddc553afad24e9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->