### PR TITLE
feat: Add Perps Withdraw button into Developer Options, show new Perps Withdraw UI

### DIFF
--- a/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
@@ -849,6 +849,76 @@ exports[`DeveloperOptions renders correctly 1`] = `
                             Withdraw
                           </Text>
                         </TouchableOpacity>
+                        <Text
+                          accessibilityRole="text"
+                          style={
+                            {
+                              "color": "#131416",
+                              "fontFamily": "Geist-Bold",
+                              "fontSize": 24,
+                              "letterSpacing": 0,
+                              "lineHeight": 32,
+                              "marginTop": 16,
+                            }
+                          }
+                        >
+                          Perps Withdraw
+                        </Text>
+                        <Text
+                          accessibilityRole="text"
+                          style={
+                            {
+                              "color": "#66676a",
+                              "fontFamily": "Geist-Regular",
+                              "fontSize": 16,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                              "marginTop": 8,
+                            }
+                          }
+                        >
+                          Trigger a Perps withdraw confirmation.
+                        </Text>
+                        <TouchableOpacity
+                          accessibilityRole="button"
+                          accessible={true}
+                          activeOpacity={1}
+                          onPress={[Function]}
+                          onPressIn={[Function]}
+                          onPressOut={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "alignSelf": "stretch",
+                              "backgroundColor": "#b4b4b528",
+                              "borderColor": "transparent",
+                              "borderRadius": 12,
+                              "borderWidth": 1,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "marginTop": 16,
+                              "overflow": "hidden",
+                              "paddingHorizontal": 16,
+                            }
+                          }
+                          testID="confirmations-developer-options-perps-withdraw-button"
+                        >
+                          <Text
+                            accessibilityRole="text"
+                            style={
+                              {
+                                "color": "#131416",
+                                "fontFamily": "Geist-Medium",
+                                "fontSize": 16,
+                                "letterSpacing": 0,
+                                "lineHeight": 24,
+                              }
+                            }
+                          >
+                            Withdraw
+                          </Text>
+                        </TouchableOpacity>
                         <View
                           style={
                             [

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
@@ -1,0 +1,162 @@
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import {
+  CHAIN_IDS,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { fireEvent, act, render } from '@testing-library/react-native';
+import React from 'react';
+import { useTheme } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import { selectSelectedInternalAccountAddress } from '../../../../../../selectors/accountsController';
+import { selectDefaultEndpointByChainId } from '../../../../../../selectors/networkController';
+import { addTransactionBatch } from '../../../../../../util/transaction-controller';
+import { generateTransferData } from '../../../../../../util/transactions';
+import Routes from '../../../../../../constants/navigation/Routes';
+import { useStyles } from '../../../../../../component-library/hooks';
+import { useConfirmNavigation } from '../../../hooks/useConfirmNavigation';
+import { ConfirmationLoader } from '../../confirm/confirm-component';
+import { ConfirmationsDeveloperOptions } from './confirmations-developer-options';
+import { ConfirmationsDeveloperOptionsTestIds } from './confirmations-developer-options.testIds';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useTheme: jest.fn(),
+}));
+
+jest.mock('../../../../../../component-library/hooks', () => ({
+  useStyles: jest.fn(),
+}));
+
+jest.mock('../../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../../selectors/accountsController'),
+  selectSelectedInternalAccountAddress: jest.fn(),
+}));
+
+jest.mock('../../../../../../selectors/networkController', () => ({
+  ...jest.requireActual('../../../../../../selectors/networkController'),
+  selectDefaultEndpointByChainId: jest.fn(),
+}));
+
+jest.mock('../../../../../../util/transaction-controller', () => ({
+  addTransactionBatch: jest.fn(),
+}));
+
+jest.mock('../../../../../../util/transactions', () => ({
+  generateTransferData: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useConfirmNavigation', () => ({
+  useConfirmNavigation: jest.fn(),
+}));
+
+const MOCK_ACCOUNT = '0x1234567890123456789012345678901234567890' as Hex;
+const MOCK_TRANSFER_DATA = '0xabcdef' as Hex;
+const MOCK_ARBITRUM_USDC =
+  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex;
+const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
+const mockNavigateToConfirmation = jest.fn();
+
+describe('ConfirmationsDeveloperOptions', () => {
+  const mockUseSelector = jest.mocked(useSelector);
+  const mockUseTheme = jest.mocked(useTheme);
+  const mockUseStyles = jest.mocked(useStyles);
+  const mockSelectSelectedInternalAccountAddress = jest.mocked(
+    selectSelectedInternalAccountAddress,
+  );
+  const mockSelectDefaultEndpointByChainId = jest.mocked(
+    selectDefaultEndpointByChainId,
+  );
+  const mockAddTransactionBatch = jest.mocked(addTransactionBatch);
+  const mockGenerateTransferData = jest.mocked(generateTransferData);
+  const mockUseConfirmNavigation = jest.mocked(useConfirmNavigation);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseTheme.mockReturnValue({
+      colors: {},
+    } as never);
+
+    mockUseStyles.mockReturnValue({
+      styles: {
+        accessory: {},
+        desc: {},
+        heading: {},
+      },
+    } as never);
+
+    mockSelectSelectedInternalAccountAddress.mockReturnValue(MOCK_ACCOUNT);
+    mockSelectDefaultEndpointByChainId.mockReturnValue({
+      networkClientId: MOCK_NETWORK_CLIENT_ID,
+    } as never);
+    mockGenerateTransferData.mockReturnValue(MOCK_TRANSFER_DATA);
+    mockAddTransactionBatch.mockResolvedValue(undefined as never);
+    mockUseConfirmNavigation.mockReturnValue({
+      navigateToConfirmation: mockNavigateToConfirmation,
+    } as never);
+    mockUseSelector.mockImplementation(
+      ((selector: (state: object) => unknown) => selector({})) as typeof useSelector,
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the Perps Withdraw developer option', () => {
+    const { getByText, getByTestId } = render(<ConfirmationsDeveloperOptions />);
+
+    expect(getByText('Perps Withdraw')).toBeOnTheScreen();
+    expect(
+      getByText('Trigger a Perps withdraw confirmation.'),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(ConfirmationsDeveloperOptionsTestIds.PERPS_WITHDRAW_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('navigates to the Perps confirmation flow when the Perps Withdraw button is pressed', async () => {
+    const { getByTestId } = render(<ConfirmationsDeveloperOptions />);
+
+    await act(async () => {
+      fireEvent.press(
+        getByTestId(ConfirmationsDeveloperOptionsTestIds.PERPS_WITHDRAW_BUTTON),
+      );
+    });
+
+    expect(mockGenerateTransferData).toHaveBeenCalledWith('transfer', {
+      toAddress: MOCK_ARBITRUM_USDC,
+      amount: '0x0',
+    });
+    expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+      loader: ConfirmationLoader.CustomAmount,
+      stack: Routes.PERPS.ROOT,
+    });
+    expect(mockSelectDefaultEndpointByChainId).toHaveBeenCalledWith(
+      {},
+      CHAIN_IDS.ARBITRUM,
+    );
+    expect(mockAddTransactionBatch).toHaveBeenCalledWith({
+      from: MOCK_ACCOUNT,
+      origin: ORIGIN_METAMASK,
+      networkClientId: MOCK_NETWORK_CLIENT_ID,
+      disableHook: true,
+      disableSequential: true,
+      transactions: [
+        {
+          params: {
+            to: MOCK_ARBITRUM_USDC,
+            data: MOCK_TRANSFER_DATA,
+          },
+          type: TransactionType.perpsWithdraw,
+        },
+      ],
+    });
+  });
+});

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
@@ -1,8 +1,5 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
-import {
-  CHAIN_IDS,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { fireEvent, act, render } from '@testing-library/react-native';
 import React from 'react';
@@ -57,8 +54,7 @@ jest.mock('../../../hooks/useConfirmNavigation', () => ({
 
 const MOCK_ACCOUNT = '0x1234567890123456789012345678901234567890' as Hex;
 const MOCK_TRANSFER_DATA = '0xabcdef' as Hex;
-const MOCK_ARBITRUM_USDC =
-  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex;
+const MOCK_ARBITRUM_USDC = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex;
 const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
 const mockNavigateToConfirmation = jest.fn();
 
@@ -100,9 +96,9 @@ describe('ConfirmationsDeveloperOptions', () => {
     mockUseConfirmNavigation.mockReturnValue({
       navigateToConfirmation: mockNavigateToConfirmation,
     } as never);
-    mockUseSelector.mockImplementation(
-      ((selector: (state: object) => unknown) => selector({})) as typeof useSelector,
-    );
+    mockUseSelector.mockImplementation(((
+      selector: (state: object) => unknown,
+    ) => selector({})) as typeof useSelector);
   });
 
   afterEach(() => {
@@ -110,7 +106,9 @@ describe('ConfirmationsDeveloperOptions', () => {
   });
 
   it('renders the Perps Withdraw developer option', () => {
-    const { getByText, getByTestId } = render(<ConfirmationsDeveloperOptions />);
+    const { getByText, getByTestId } = render(
+      <ConfirmationsDeveloperOptions />,
+    );
 
     expect(getByText('Perps Withdraw')).toBeOnTheScreen();
     expect(

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.testIds.ts
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.testIds.ts
@@ -1,0 +1,4 @@
+export const ConfirmationsDeveloperOptionsTestIds = {
+  PERPS_WITHDRAW_BUTTON:
+    'confirmations-developer-options-perps-withdraw-button',
+} as const;

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -27,6 +27,9 @@ import { RootState } from '../../../../../../reducers';
 const POLYGON_USDCE_ADDRESS =
   '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174' as Hex;
 
+const ARBITRUM_USDC_ADDRESS =
+  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex;
+
 // Update as needed.
 const PROXY_ADDRESS = '0x13032833b30f3388208cda38971fdc839936b042' as Hex;
 
@@ -36,7 +39,28 @@ export function ConfirmationsDeveloperOptions() {
       <PredictDeposit />
       <PredictClaim />
       <PredictWithdraw />
+      <PerpsWithdraw />
     </>
+  );
+}
+
+function PerpsWithdraw() {
+  const { addTransactionBatchAndNavigate } = useAddPerpsTransactionBatch();
+
+  const handleWithdraw = useCallback(() => {
+    addTransactionBatchAndNavigate({
+      loader: ConfirmationLoader.CustomAmount,
+      transactionType: TransactionType.perpsWithdraw,
+    });
+  }, [addTransactionBatchAndNavigate]);
+
+  return (
+    <DeveloperButton
+      title="Perps Withdraw"
+      description="Trigger a Perps withdraw confirmation."
+      buttonLabel="Withdraw"
+      onPress={handleWithdraw}
+    />
   );
 }
 
@@ -154,6 +178,60 @@ function useAddTransactionBatch() {
         ],
       }).catch((e) => {
         console.error('Predict transaction error', e);
+      });
+    },
+    [navigateToConfirmation, networkClientId, selectedAccount, transferData],
+  );
+
+  return {
+    addTransactionBatchAndNavigate,
+  };
+}
+
+function useAddPerpsTransactionBatch() {
+  const selectedAccount = useSelector(selectSelectedInternalAccountAddress);
+  const { navigateToConfirmation } = useConfirmNavigation();
+
+  const { networkClientId } =
+    useSelector((state: RootState) =>
+      selectDefaultEndpointByChainId(state, CHAIN_IDS.ARBITRUM),
+    ) ?? {};
+
+  const transferData = generateTransferData('transfer', {
+    toAddress: ARBITRUM_USDC_ADDRESS,
+    amount: '0x0',
+  }) as Hex;
+
+  const addTransactionBatchAndNavigate = useCallback(
+    async ({
+      loader,
+      transactionType,
+    }: {
+      loader?: ConfirmationLoader;
+      transactionType: TransactionType;
+    }) => {
+      navigateToConfirmation({
+        loader,
+        stack: Routes.PERPS.ROOT,
+      });
+
+      addTransactionBatch({
+        from: selectedAccount as Hex,
+        origin: ORIGIN_METAMASK,
+        networkClientId,
+        disableHook: true,
+        disableSequential: true,
+        transactions: [
+          {
+            params: {
+              to: ARBITRUM_USDC_ADDRESS,
+              data: transferData,
+            },
+            type: transactionType,
+          },
+        ],
+      }).catch((e) => {
+        console.error('Perps transaction error', e);
       });
     },
     [navigateToConfirmation, networkClientId, selectedAccount, transferData],

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -24,12 +24,10 @@ import { useConfirmNavigation } from '../../../hooks/useConfirmNavigation';
 import { selectSelectedInternalAccountAddress } from '../../../../../../selectors/accountsController';
 import { RootState } from '../../../../../../reducers';
 import { ConfirmationsDeveloperOptionsTestIds } from './confirmations-developer-options.testIds';
+import { ARBITRUM_USDC } from '../../../constants/perps';
 
 const POLYGON_USDCE_ADDRESS =
   '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174' as Hex;
-
-const ARBITRUM_USDC_ADDRESS =
-  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex;
 
 // Update as needed.
 const PROXY_ADDRESS = '0x13032833b30f3388208cda38971fdc839936b042' as Hex;
@@ -200,7 +198,7 @@ function useAddPerpsTransactionBatch() {
     ) ?? {};
 
   const transferData = generateTransferData('transfer', {
-    toAddress: ARBITRUM_USDC_ADDRESS,
+    toAddress: ARBITRUM_USDC.address,
     amount: '0x0',
   }) as Hex;
 
@@ -226,7 +224,7 @@ function useAddPerpsTransactionBatch() {
         transactions: [
           {
             params: {
-              to: ARBITRUM_USDC_ADDRESS,
+              to: ARBITRUM_USDC.address,
               data: transferData,
             },
             type: transactionType,

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -23,6 +23,7 @@ import { generateTransferData } from '../../../../../../util/transactions';
 import { useConfirmNavigation } from '../../../hooks/useConfirmNavigation';
 import { selectSelectedInternalAccountAddress } from '../../../../../../selectors/accountsController';
 import { RootState } from '../../../../../../reducers';
+import { ConfirmationsDeveloperOptionsTestIds } from './confirmations-developer-options.testIds';
 
 const POLYGON_USDCE_ADDRESS =
   '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174' as Hex;
@@ -60,6 +61,7 @@ function PerpsWithdraw() {
       description="Trigger a Perps withdraw confirmation."
       buttonLabel="Withdraw"
       onPress={handleWithdraw}
+      testID={ConfirmationsDeveloperOptionsTestIds.PERPS_WITHDRAW_BUTTON}
     />
   );
 }
@@ -246,11 +248,13 @@ function DeveloperButton({
   buttonLabel,
   description,
   onPress,
+  testID,
   title,
 }: {
   buttonLabel: string;
   description: string;
   onPress: () => void;
+  testID?: string;
   title: string;
 }) {
   const theme = useTheme();
@@ -277,6 +281,7 @@ function DeveloperButton({
         size={ButtonSize.Lg}
         label={buttonLabel}
         onPress={onPress}
+        testID={testID}
         width={ButtonWidthTypes.Full}
         style={styles.accessory}
       />

--- a/app/components/Views/confirmations/components/info-root/info-root.test.tsx
+++ b/app/components/Views/confirmations/components/info-root/info-root.test.tsx
@@ -16,6 +16,10 @@ import { ConfirmationInfoComponentIDs } from '../../constants/info-ids';
 import Info from './info-root';
 import { contractDeploymentTransactionStateMock } from '../../__mocks__/contract-deployment-transaction-mock';
 import { useRefreshSmartTransactionsLiveness } from '../../../../hooks/useRefreshSmartTransactionsLiveness';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 jest.mock('../../../../hooks/AssetPolling/AssetPollingProvider', () => ({
   AssetPollingProvider: () => null,
@@ -137,6 +141,19 @@ jest.mock('../../../../../core/Engine', () => ({
 
 describe('Info', () => {
   const mockUseNetworkEnablement = jest.fn();
+  const perpsWithdrawConfirmation = {
+    chainId: '0xa4b1',
+    id: 'perps-withdraw-confirmation-id',
+    networkClientId: 'arbitrum',
+    origin: 'metamask',
+    txParams: {
+      from: '0x935e73edb9ff52e23bac7f7e043a1ecd06d05477',
+      to: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      value: '0x0',
+    },
+    type: TransactionType.perpsWithdraw,
+  } as unknown as TransactionMeta;
+
   mockUseNetworkEnablement.mockReturnValue({
     namespace: 'eip155',
     enabledNetworksByNamespace: {
@@ -209,6 +226,14 @@ describe('Info', () => {
     expect(
       getByTestId(ConfirmationInfoComponentIDs.CONTRACT_DEPLOYMENT),
     ).toBeDefined();
+  });
+
+  it('renders CustomAmountInfo for perps withdraw confirmations', () => {
+    const { getByTestId } = renderWithProvider(<Info />, {
+      state: getAppStateForConfirmation(perpsWithdrawConfirmation),
+    });
+
+    expect(getByTestId('custom-amount-info')).toBeOnTheScreen();
   });
 
   describe('useRefreshSmartTransactionsLiveness', () => {

--- a/app/components/Views/confirmations/components/info-root/info-root.tsx
+++ b/app/components/Views/confirmations/components/info-root/info-root.tsx
@@ -24,6 +24,7 @@ import { PredictDepositInfo } from '../info/predict-deposit-info';
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfo } from '../info/predict-claim-info';
 import { PredictWithdrawInfo } from '../info/predict-withdraw-info';
+import { PerpsWithdrawInfo } from '../info/perps-withdraw-info';
 import { MusdClaimInfo } from '../info/musd-claim-info';
 import { MusdConversionInfoRoot } from '../info/musd-conversion-info-root';
 import { useRefreshSmartTransactionsLiveness } from '../../../../hooks/useRefreshSmartTransactionsLiveness';
@@ -134,6 +135,13 @@ const Info = ({ route }: InfoProps) => {
     hasTransactionType(transactionMetadata, [TransactionType.predictWithdraw])
   ) {
     return <PredictWithdrawInfo />;
+  }
+
+  if (
+    transactionMetadata &&
+    hasTransactionType(transactionMetadata, [TransactionType.perpsWithdraw])
+  ) {
+    return <PerpsWithdrawInfo />;
   }
 
   const { requestData } = approvalRequest ?? {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -314,24 +314,28 @@ describe('CustomAmountInfo', () => {
     });
   });
 
-  it('renders alternate confirm label if predict withdraw', async () => {
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.predictWithdraw,
-      txParams: { from: '0x123' },
-    } as never);
+  it.each([
+    TransactionType.predictWithdraw,
+    TransactionType.perpsWithdraw,
+  ])(
+    'renders the withdraw confirm label for %s transactions',
+    async (transactionType) => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: transactionType,
+        txParams: { from: '0x123' },
+      } as never);
 
-    const { getByText, findByText } = render({
-      transactionType: TransactionType.predictWithdraw,
-    });
+      const { getByText, findByText } = render({ transactionType });
 
-    await act(async () => {
-      fireEvent.press(getByText(strings('confirm.edit_amount_done')));
-    });
+      await act(async () => {
+        fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+      });
 
-    expect(
-      await findByText(strings('confirm.deposit_edit_amount_predict_withdraw')),
-    ).toBeDefined();
-  });
+      expect(
+        await findByText(strings('confirm.deposit_edit_amount_predict_withdraw')),
+      ).toBeOnTheScreen();
+    },
+  );
 
   it('calls overrideContent with amountHuman and hides default content', () => {
     const mockOverrideContent = jest.fn().mockReturnValue(null);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -314,10 +314,7 @@ describe('CustomAmountInfo', () => {
     });
   });
 
-  it.each([
-    TransactionType.predictWithdraw,
-    TransactionType.perpsWithdraw,
-  ])(
+  it.each([TransactionType.predictWithdraw, TransactionType.perpsWithdraw])(
     'renders the withdraw confirm label for %s transactions',
     async (transactionType) => {
       useTransactionMetadataRequestMock.mockReturnValue({
@@ -332,7 +329,9 @@ describe('CustomAmountInfo', () => {
       });
 
       expect(
-        await findByText(strings('confirm.deposit_edit_amount_predict_withdraw')),
+        await findByText(
+          strings('confirm.deposit_edit_amount_predict_withdraw'),
+        ),
       ).toBeOnTheScreen();
     },
   );

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -315,7 +315,12 @@ function useIsResultReady({
 function useButtonLabel() {
   const transaction = useTransactionMetadataRequest();
 
-  if (hasTransactionType(transaction, [TransactionType.predictWithdraw])) {
+  if (
+    hasTransactionType(transaction, [
+      TransactionType.predictWithdraw,
+      TransactionType.perpsWithdraw,
+    ])
+  ) {
     return strings('confirm.deposit_edit_amount_predict_withdraw');
   }
 

--- a/app/components/Views/confirmations/components/info/perps-withdraw-info/index.ts
+++ b/app/components/Views/confirmations/components/info/perps-withdraw-info/index.ts
@@ -1,0 +1,1 @@
+export { PerpsWithdrawInfo } from './perps-withdraw-info';

--- a/app/components/Views/confirmations/components/info/perps-withdraw-info/perps-withdraw-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/perps-withdraw-info/perps-withdraw-info.test.tsx
@@ -1,0 +1,74 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { ARBITRUM_USDC, PERPS_CURRENCY } from '../../../constants/perps';
+import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
+import { useAddToken } from '../../../hooks/tokens/useAddToken';
+import useNavbar from '../../../hooks/ui/useNavbar';
+import { CustomAmountInfo } from '../custom-amount-info';
+import { PerpsWithdrawInfo } from './perps-withdraw-info';
+
+jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
+jest.mock('../../../hooks/ui/useNavbar');
+jest.mock('../../../hooks/tokens/useAddToken');
+jest.mock('../custom-amount-info', () => ({
+  CustomAmountInfo: jest.fn(() => null),
+}));
+jest.mock('../../perps-confirmations/perps-withdraw-balance', () => ({
+  PerpsWithdrawBalance: () => null,
+}));
+
+describe('PerpsWithdrawInfo', () => {
+  const mockUseTransactionPayWithdraw = jest.mocked(useTransactionPayWithdraw);
+  const mockUseAddToken = jest.mocked(useAddToken);
+  const mockUseNavbar = jest.mocked(useNavbar);
+  const mockCustomAmountInfo = jest.mocked(CustomAmountInfo);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseTransactionPayWithdraw.mockReturnValue({
+      isWithdraw: true,
+      canSelectWithdrawToken: true,
+    });
+  });
+
+  it.each([
+    { canSelectWithdrawToken: true, disablePay: false },
+    { canSelectWithdrawToken: false, disablePay: true },
+  ])(
+    'passes disablePay=$disablePay to CustomAmountInfo when canSelectWithdrawToken=$canSelectWithdrawToken',
+    ({ canSelectWithdrawToken, disablePay }) => {
+      mockUseTransactionPayWithdraw.mockReturnValue({
+        isWithdraw: true,
+        canSelectWithdrawToken,
+      });
+
+      render(<PerpsWithdrawInfo />);
+
+      expect(mockCustomAmountInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currency: PERPS_CURRENCY,
+          disablePay,
+        }),
+        expect.anything(),
+      );
+    },
+  );
+
+  it('registers Arbitrum USDC and sets the Perps withdraw title', () => {
+    render(<PerpsWithdrawInfo />);
+
+    expect(mockUseNavbar).toHaveBeenCalledWith(
+      strings('confirm.title.perps_withdraw'),
+    );
+    expect(mockUseAddToken).toHaveBeenCalledWith({
+      chainId: CHAIN_IDS.ARBITRUM,
+      decimals: ARBITRUM_USDC.decimals,
+      name: ARBITRUM_USDC.name,
+      symbol: ARBITRUM_USDC.symbol,
+      tokenAddress: ARBITRUM_USDC.address,
+    });
+  });
+});

--- a/app/components/Views/confirmations/components/info/perps-withdraw-info/perps-withdraw-info.tsx
+++ b/app/components/Views/confirmations/components/info/perps-withdraw-info/perps-withdraw-info.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import useNavbar from '../../../hooks/ui/useNavbar';
+import { CustomAmountInfo } from '../custom-amount-info';
+import { PerpsWithdrawBalance } from '../../perps-confirmations/perps-withdraw-balance';
+import { ARBITRUM_USDC, PERPS_CURRENCY } from '../../../constants/perps';
+import { useAddToken } from '../../../hooks/tokens/useAddToken';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
+
+export function PerpsWithdrawInfo() {
+  useNavbar(strings('confirm.title.perps_withdraw'));
+
+  const { canSelectWithdrawToken } = useTransactionPayWithdraw();
+
+  useAddToken({
+    chainId: CHAIN_IDS.ARBITRUM,
+    decimals: ARBITRUM_USDC.decimals,
+    name: ARBITRUM_USDC.name,
+    symbol: ARBITRUM_USDC.symbol,
+    tokenAddress: ARBITRUM_USDC.address,
+  });
+
+  return (
+    <CustomAmountInfo
+      currency={PERPS_CURRENCY}
+      disablePay={!canSelectWithdrawToken}
+    >
+      <PerpsWithdrawBalance />
+    </CustomAmountInfo>
+  );
+}

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/index.ts
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/index.ts
@@ -1,0 +1,1 @@
+export { PerpsWithdrawBalance } from './perps-withdraw-balance';

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.styles.ts
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../../util/theme/models';
+
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    container: {
+      marginBottom: 8,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.test.tsx
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { useStyles } from '../../../../../../component-library/hooks';
+import { usePerpsLiveAccount } from '../../../../../UI/Perps/hooks/stream/usePerpsLiveAccount';
+import { PerpsWithdrawBalance } from './perps-withdraw-balance';
+
+jest.mock('../../../../../../component-library/hooks', () => ({
+  useStyles: jest.fn(),
+}));
+jest.mock('../../../../../UI/Perps/hooks/stream/usePerpsLiveAccount');
+
+const mockUseStyles = jest.mocked(useStyles);
+const mockUsePerpsLiveAccount = jest.mocked(usePerpsLiveAccount);
+
+function renderComponent() {
+  return render(<PerpsWithdrawBalance />);
+}
+
+describe('PerpsWithdrawBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseStyles.mockReturnValue({
+      styles: {
+        container: {},
+      },
+    } as never);
+    mockUsePerpsLiveAccount.mockReturnValue({
+      account: {
+        availableBalance: '$1,232.39',
+      },
+      isInitialLoading: false,
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the formatted Perps balance', () => {
+    const { getByText } = renderComponent();
+
+    expect(
+      getByText(`${strings('confirm.available_perps_balance')}$1,232.39`),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders a zero balance when the live account has no available balance', () => {
+    mockUsePerpsLiveAccount.mockReturnValue({
+      account: null,
+      isInitialLoading: false,
+    } as never);
+
+    const { getByText } = renderComponent();
+
+    expect(
+      getByText(`${strings('confirm.available_perps_balance')}$0`),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../../component-library/hooks';
+import { Box } from '../../../../../UI/Box/Box';
+import { AlignItems } from '../../../../../UI/Box/box.types';
+import { usePerpsLiveAccount } from '../../../../../UI/Perps/hooks/stream/usePerpsLiveAccount';
+import {
+  formatPerpsFiat,
+  parseCurrencyString,
+} from '../../../../../UI/Perps/utils/formatUtils';
+import styleSheet from './perps-withdraw-balance.styles';
+
+export function PerpsWithdrawBalance() {
+  const { styles } = useStyles(styleSheet, {});
+  const { account } = usePerpsLiveAccount();
+
+  const balanceFormatted = useMemo(() => {
+    if (!account?.availableBalance) return formatPerpsFiat(0);
+    return formatPerpsFiat(parseCurrencyString(account.availableBalance));
+  }, [account?.availableBalance]);
+
+  return (
+    <Box alignItems={AlignItems.center} style={styles.container}>
+      <Text
+        variant={TextVariant.BodyMDMedium}
+        color={TextColor.Alternative}
+      >{`${strings('confirm.available_perps_balance')}${balanceFormatted}`}</Text>
+    </Box>
+  );
+}

--- a/app/components/Views/confirmations/constants/confirmations.test.ts
+++ b/app/components/Views/confirmations/constants/confirmations.test.ts
@@ -10,6 +10,8 @@ describe('confirmation constants', () => {
   });
 
   it('includes perps withdraw in post-quote transaction types', () => {
-    expect(POST_QUOTE_TRANSACTION_TYPES).toContain(TransactionType.perpsWithdraw);
+    expect(POST_QUOTE_TRANSACTION_TYPES).toContain(
+      TransactionType.perpsWithdraw,
+    );
   });
 });

--- a/app/components/Views/confirmations/constants/confirmations.test.ts
+++ b/app/components/Views/confirmations/constants/confirmations.test.ts
@@ -1,0 +1,15 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import {
+  FULL_SCREEN_CONFIRMATIONS,
+  POST_QUOTE_TRANSACTION_TYPES,
+} from './confirmations';
+
+describe('confirmation constants', () => {
+  it('includes perps withdraw in full-screen confirmations', () => {
+    expect(FULL_SCREEN_CONFIRMATIONS).toContain(TransactionType.perpsWithdraw);
+  });
+
+  it('includes perps withdraw in post-quote transaction types', () => {
+    expect(POST_QUOTE_TRANSACTION_TYPES).toContain(TransactionType.perpsWithdraw);
+  });
+});

--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -49,6 +49,7 @@ export const FULL_SCREEN_CONFIRMATIONS = [
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
@@ -78,7 +79,7 @@ export const HIDE_NETWORK_FILTER_TYPES = [TransactionType.perpsDepositAndOrder];
  */
 export const POST_QUOTE_TRANSACTION_TYPES = [
   TransactionType.predictWithdraw,
-  // TransactionType.perpsWithdraw, // Add when implementing for Perps
+  TransactionType.perpsWithdraw,
 ] as const;
 
 /**

--- a/app/components/Views/confirmations/utils/transaction.test.ts
+++ b/app/components/Views/confirmations/utils/transaction.test.ts
@@ -248,9 +248,12 @@ describe('hasGasFeeTokenSelected', () => {
 });
 
 describe('isTransactionPayWithdraw', () => {
-  it('returns true for predictWithdraw transaction type', () => {
+  it.each([
+    TransactionType.predictWithdraw,
+    TransactionType.perpsWithdraw,
+  ])('returns true for %s transaction type', (transactionType) => {
     const txMeta = {
-      type: TransactionType.predictWithdraw,
+      type: transactionType,
     } as TransactionMeta;
 
     expect(isTransactionPayWithdraw(txMeta)).toBe(true);
@@ -272,10 +275,13 @@ describe('isTransactionPayWithdraw', () => {
     expect(isTransactionPayWithdraw(txMeta)).toBe(false);
   });
 
-  it('returns true when nested transaction is a withdrawal type', () => {
+  it.each([
+    TransactionType.predictWithdraw,
+    TransactionType.perpsWithdraw,
+  ])('returns true when nested transaction is %s', (transactionType) => {
     const txMeta = {
       type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+      nestedTransactions: [{ type: transactionType }],
     } as TransactionMeta;
 
     expect(isTransactionPayWithdraw(txMeta)).toBe(true);

--- a/app/components/Views/confirmations/utils/transaction.test.ts
+++ b/app/components/Views/confirmations/utils/transaction.test.ts
@@ -248,16 +248,16 @@ describe('hasGasFeeTokenSelected', () => {
 });
 
 describe('isTransactionPayWithdraw', () => {
-  it.each([
-    TransactionType.predictWithdraw,
-    TransactionType.perpsWithdraw,
-  ])('returns true for %s transaction type', (transactionType) => {
-    const txMeta = {
-      type: transactionType,
-    } as TransactionMeta;
+  it.each([TransactionType.predictWithdraw, TransactionType.perpsWithdraw])(
+    'returns true for %s transaction type',
+    (transactionType) => {
+      const txMeta = {
+        type: transactionType,
+      } as TransactionMeta;
 
-    expect(isTransactionPayWithdraw(txMeta)).toBe(true);
-  });
+      expect(isTransactionPayWithdraw(txMeta)).toBe(true);
+    },
+  );
 
   it('returns false for non-withdrawal transaction types', () => {
     const txMeta = {
@@ -275,17 +275,17 @@ describe('isTransactionPayWithdraw', () => {
     expect(isTransactionPayWithdraw(txMeta)).toBe(false);
   });
 
-  it.each([
-    TransactionType.predictWithdraw,
-    TransactionType.perpsWithdraw,
-  ])('returns true when nested transaction is %s', (transactionType) => {
-    const txMeta = {
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: transactionType }],
-    } as TransactionMeta;
+  it.each([TransactionType.predictWithdraw, TransactionType.perpsWithdraw])(
+    'returns true when nested transaction is %s',
+    (transactionType) => {
+      const txMeta = {
+        type: TransactionType.batch,
+        nestedTransactions: [{ type: transactionType }],
+      } as TransactionMeta;
 
-    expect(isTransactionPayWithdraw(txMeta)).toBe(true);
-  });
+      expect(isTransactionPayWithdraw(txMeta)).toBe(true);
+    },
+  );
 
   it('returns false for undefined transaction', () => {
     expect(isTransactionPayWithdraw(undefined)).toBe(false);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6439,7 +6439,8 @@
       "approve": "Approve request",
       "perps_deposit": "Add funds",
       "predict_deposit": "Add Prediction funds",
-      "predict_withdraw": "Withdraw"
+      "predict_withdraw": "Withdraw",
+      "perps_withdraw": "Withdraw"
     },
     "sub_title": {
       "permit": "This site wants permission to spend your tokens.",
@@ -6565,6 +6566,7 @@
     "nested_transaction_heading": "Transaction {{index}}",
     "transaction": "Transaction",
     "available_balance": "Available balance: ",
+    "available_perps_balance": "Available Perps balance: ",
     "edit_amount_done": "Continue",
     "deposit_edit_amount_done": "Add funds",
     "deposit_edit_amount_predict_withdraw": "Withdraw",

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.10.0",
     "@metamask/bridge-controller": "^69.1.1",
-    "@metamask/bridge-status-controller": "^68.1.0",
+    "@metamask/bridge-status-controller": "^69.0.0",
     "@metamask/chain-agnostic-permission": "^1.3.0",
     "@metamask/compliance-controller": "^1.0.1",
     "@metamask/connectivity-controller": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@metamask/storage-service": "^1.0.0",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/transaction-controller": "^63.0.0",
+    "@metamask/transaction-controller": "^63.1.0",
     "@metamask/transaction-pay-controller": "^17.1.0",
     "@metamask/tron-wallet-snap": "1.24.0",
     "@metamask/utils": "^11.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10091,46 +10091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^63.0.0":
-  version: 63.0.0
-  resolution: "@metamask/transaction-controller@npm:63.0.0"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^37.0.0"
-    "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.19.0"
-    "@metamask/core-backend": "npm:^6.1.1"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/gas-fee-controller": "npm:^26.1.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^30.0.0"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/1e6c79a4b6714731880eeae3acf02d30814a54087a8ff66ddf95b1168d21434d81ce05bd0906f27a81f7c0b5de1a934bd5de879523449737b21dcbe9560d6787
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-controller@npm:^63.1.0":
+"@metamask/transaction-controller@npm:^63.0.0, @metamask/transaction-controller@npm:^63.1.0":
   version: 63.1.0
   resolution: "@metamask/transaction-controller@npm:63.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7890,7 +7890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^69.1.0, @metamask/bridge-controller@npm:^69.1.1":
+"@metamask/bridge-controller@npm:^69.1.1":
   version: 69.1.1
   resolution: "@metamask/bridge-controller@npm:69.1.1"
   dependencies:
@@ -7920,29 +7920,6 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/fac684a9caac65c336464affd8647d34ab0e4ccdddb3db95ffc741c454732df2eae52db6d9d6980ee04e38bd696d09e4c40fce30911bdea6c51fc5b91cf06320
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-status-controller@npm:^68.1.0":
-  version: 68.1.0
-  resolution: "@metamask/bridge-status-controller@npm:68.1.0"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^37.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/bridge-controller": "npm:^69.1.0"
-    "@metamask/controller-utils": "npm:^11.19.0"
-    "@metamask/gas-fee-controller": "npm:^26.0.3"
-    "@metamask/keyring-controller": "npm:^25.1.0"
-    "@metamask/network-controller": "npm:^30.0.0"
-    "@metamask/polling-controller": "npm:^16.0.3"
-    "@metamask/profile-sync-controller": "npm:^28.0.0"
-    "@metamask/snaps-controllers": "npm:^17.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^62.21.0"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    uuid: "npm:^8.3.2"
-  checksum: 10/62ada7df014c0b435a375d40e67987bdc477d04f659d1ad523a3915ab5b40f96ec29ed0a60dce601bd3bb5baa954dd4dede0a54b4fec96fb7a76300ce1afba9e
   languageName: node
   linkType: hard
 
@@ -10052,7 +10029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.20.0, @metamask/transaction-controller@npm:^62.21.0, @metamask/transaction-controller@npm:^62.22.0":
+"@metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.20.0, @metamask/transaction-controller@npm:^62.22.0":
   version: 62.22.0
   resolution: "@metamask/transaction-controller@npm:62.22.0"
   dependencies:
@@ -35525,7 +35502,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.10.0"
     "@metamask/bridge-controller": "npm:^69.1.1"
-    "@metamask/bridge-status-controller": "npm:^68.1.0"
+    "@metamask/bridge-status-controller": "npm:^69.0.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.3.0"
     "@metamask/build-utils": "npm:^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10130,6 +10130,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/transaction-controller@npm:^63.1.0":
+  version: 63.1.0
+  resolution: "@metamask/transaction-controller@npm:63.1.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^37.0.0"
+    "@metamask/approval-controller": "npm:^9.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/core-backend": "npm:^6.2.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/gas-fee-controller": "npm:^26.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/02aaf926d003c01f6844bc9c0f4cb18f34884e3badc393103beed3755ebcae52e522a52b2a16f40c0965be98c2f4125cf8ae60e3766b0f960ecc65c62f8a161f
+  languageName: node
+  linkType: hard
+
 "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.10.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.10.0-e1d24e7db5.patch":
   version: 62.10.0
   resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.10.0#~/.yarn/patches/@metamask-transaction-controller-npm-62.10.0-e1d24e7db5.patch::version=62.10.0&hash=dae606"
@@ -35628,7 +35667,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.5.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
-    "@metamask/transaction-controller": "npm:^63.0.0"
+    "@metamask/transaction-controller": "npm:^63.1.0"
     "@metamask/transaction-pay-controller": "npm:^17.1.0"
     "@metamask/tron-wallet-snap": "npm:1.24.0"
     "@metamask/utils": "npm:^11.8.1"


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the UI scaffolding for the Perps Withdraw confirmation flow. When triggered from Developer Options, the "Perps Withdraw" button navigates to a full-screen `CustomAmountInfo` confirmation page that displays the user's available Perps balance and uses the post-quote "Receive as" token picker pattern (same as Predict Withdraw).

This is the UI-only foundation — the end-to-end withdrawal execution (HyperLiquid signatures, Relay integration) will follow in a subsequent PR.

**Changes:**
- Added "Perps Withdraw" button and `useAddPerpsTransactionBatch` hook in Developer Options
- Created `PerpsWithdrawInfo` component that wires `CustomAmountInfo` with Perps balance display
- Created `PerpsWithdrawBalance` component showing available Perps balance from live account data
- Added `perpsWithdraw` to `FULL_SCREEN_CONFIRMATIONS` and `POST_QUOTE_TRANSACTION_TYPES`
- Added `perpsWithdraw` routing in `info-root.tsx`
- Updated `useButtonLabel` to show "Withdraw" for `perpsWithdraw` transactions
- Added locale strings for Perps Withdraw title and available balance

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add Perps Withdraw button into Developer Options, show new Perps Withdraw UI

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1072

## **Manual testing steps**

```gherkin
Feature: Perps Withdraw confirmation UI

  Background:
    Given I am logged into MetaMask Mobile
    And I have Developer Options enabled (export MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS="true" in .js.env)

  Scenario: user triggers Perps Withdraw from Developer Options
    Given I am on the Developer Options screen (Settings -> Developer options)
    And I scroll to the Perps Withdraw section

    When user taps the "Withdraw" button under "Perps Withdraw"
    Then the Perps Withdraw confirmation page should appear
    And the page title should show "Withdraw"
    And the available Perps balance should be displayed
    And the "Withdraw" action button should be visible at the bottom
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `perpsWithdraw` transaction type path through the confirmations UI (routing, labels, constants) and a developer-only trigger that creates batched transactions; changes are mostly UI scaffolding but touch confirmation flow selection logic and transaction batching.
> 
> **Overview**
> Introduces a **Perps Withdraw** confirmation flow scaffold: a new Developer Options button triggers a `perpsWithdraw` transaction batch on Arbitrum USDC and navigates into the Perps confirmation stack.
> 
> Adds a new `PerpsWithdrawInfo` full-screen `CustomAmountInfo` view that registers Arbitrum USDC, uses the post-quote *Receive as* pattern, and shows an *available Perps balance* via the new `PerpsWithdrawBalance` component.
> 
> Updates confirmations plumbing to recognize `TransactionType.perpsWithdraw` (info routing, full-screen + post-quote type lists, withdraw button labeling, locales) and adds targeted unit tests/snapshots. Also bumps `@metamask/bridge-status-controller` and `@metamask/transaction-controller` dependency versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d73fcc5c6cf65e8011aaca721022dc404e70ae6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->