### PR TITLE
fix: Ensure root messenger has required function for error reporting

### DIFF
--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -432,6 +432,7 @@ import {
   ComplianceServiceActions,
   ComplianceServiceEvents,
 } from '@metamask/compliance-controller';
+import { captureException } from '@sentry/react-native';
 
 /**
  * Controllers that area always instantiated
@@ -654,6 +655,7 @@ export type RootExtendedMessenger = ExtendedMessenger<
 export const getRootExtendedMessenger = (): RootExtendedMessenger =>
   new ExtendedMessenger<'Root', GlobalActions, GlobalEvents>({
     namespace: 'Root',
+    captureException,
   });
 
 /**
@@ -665,6 +667,7 @@ export type RootMessenger = Messenger<'Root', GlobalActions, GlobalEvents>;
 export const getRootMessenger = (): RootMessenger =>
   new Messenger<'Root', GlobalActions, GlobalEvents>({
     namespace: 'Root',
+    captureException,
   });
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The root messenger on mobile does not currently have a `captureException` function passed. This means that any controllers relying on `messenger.captureException` to record unhandled errors are having their errors swallowed. This PR fixes it by passing in the Sentry `captureException` function.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where certain error reporting would not work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: wires existing Sentry `captureException` into root `Messenger`/`ExtendedMessenger` construction; behavior change is limited to enabling error capture for controllers that opt into it.
> 
> **Overview**
> Fixes missing error reporting on mobile by importing Sentry’s `captureException` and passing it into both `getRootExtendedMessenger` and `getRootMessenger` in `app/core/Engine/types.ts`.
> 
> This ensures controllers using `messenger.captureException` can forward unhandled errors to Sentry instead of silently swallowing them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1617775a7a02ecbd07eb931aed7984b54d9ed735. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->