### PR TITLE
feat(activity): Enhance incoming native transfer handling with poisoning protection

### DIFF
--- a/app/util/activity/index.test.ts
+++ b/app/util/activity/index.test.ts
@@ -1398,3 +1398,207 @@ describe('Activity utils :: filterByAddress - token poisoning protection', () =>
     expect(result).toEqual(true);
   });
 });
+
+describe('Activity utils :: filterByAddress - incoming native poisoning protection', () => {
+  const chainId = '0x1' as Hex;
+  const UNKNOWN_SENDER = '0x9999999999999999999999999999999999999999';
+
+  it('hides incoming native transfer from unknown address', () => {
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: UNKNOWN_SENDER,
+        to: TEST_ADDRESS_ONE,
+        value: '0x38d7ea4c68000', // 0.001 ETH
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    const result = filterByAddress(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE],
+    );
+    expect(result).toEqual(false);
+  });
+
+  it('shows incoming native from address in address book', () => {
+    const friendAddress = TEST_ADDRESS_TWO;
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: friendAddress,
+        to: TEST_ADDRESS_ONE,
+        value: '0x1',
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+    const addressBook = {
+      '0x1': {
+        [friendAddress]: {
+          address: friendAddress,
+          name: 'Friend',
+          chainId: '0x1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+
+    const result = filterByAddress(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      [],
+      {},
+      addressBook,
+      [TEST_ADDRESS_ONE],
+    );
+    expect(result).toEqual(true);
+  });
+
+  it('shows incoming native from user own account', () => {
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: TEST_ADDRESS_TWO,
+        to: TEST_ADDRESS_ONE,
+        value: '0x1',
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    const result = filterByAddress(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE, TEST_ADDRESS_TWO],
+    );
+    expect(result).toEqual(true);
+  });
+
+  it('always shows outgoing native to unknown address', () => {
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: TEST_ADDRESS_ONE,
+        to: UNKNOWN_SENDER,
+        value: '0x1',
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    const result = filterByAddress(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE],
+    );
+    expect(result).toEqual(true);
+  });
+
+  it('does not treat zero-value incoming as native transfer for poisoning rule', () => {
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: UNKNOWN_SENDER,
+        to: TEST_ADDRESS_ONE,
+        value: '0x0',
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    const result = filterByAddress(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE],
+    );
+    expect(result).toEqual(true);
+  });
+});
+
+describe('Activity utils :: filterByAddressAndNetwork - incoming native poisoning protection', () => {
+  const chainId = '0x1' as Hex;
+  const UNKNOWN_SENDER = '0x9999999999999999999999999999999999999999';
+
+  it('hides incoming native from unknown address', () => {
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: UNKNOWN_SENDER,
+        to: TEST_ADDRESS_ONE,
+        value: '0x1',
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+
+    const result = filterByAddressAndNetwork(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      { '0x1': true },
+      [],
+      {},
+      {},
+      [TEST_ADDRESS_ONE],
+    );
+    expect(result).toEqual(false);
+  });
+
+  it('shows incoming native from trusted address', () => {
+    const friendAddress = TEST_ADDRESS_TWO;
+    const transaction = {
+      chainId,
+      status: TX_SUBMITTED,
+      txParams: {
+        from: friendAddress,
+        to: TEST_ADDRESS_ONE,
+        value: '0x1',
+      },
+      isTransfer: false,
+    } as DeepPartial<TransactionMeta> as TransactionMeta;
+    const addressBook = {
+      '0x1': {
+        [friendAddress]: {
+          address: friendAddress,
+          name: 'Friend',
+          chainId: '0x1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    };
+
+    const result = filterByAddressAndNetwork(
+      transaction,
+      [],
+      TEST_ADDRESS_ONE,
+      { '0x1': true },
+      [],
+      {},
+      addressBook,
+      [TEST_ADDRESS_ONE],
+    );
+    expect(result).toEqual(true);
+  });
+});

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -120,6 +120,50 @@ function shouldShowTransferByAddress(
   return false;
 }
 
+function hasPositiveNativeValue(value: string | undefined): boolean {
+  if (value === undefined || value === null || value === '') {
+    return false;
+  }
+  try {
+    return BigInt(value) > 0n;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Incoming native coin (ETH, MATIC, etc.) to the selected account: not a token
+ * transfer, recipient is the user, sender is someone else, and non-zero `value`.
+ * Mirrors address-poisoning policy for ERC-20: show only if the sender is trusted
+ * (own account or address book); outgoing native is unaffected.
+ */
+function isIncomingNativeTransfer(
+  tx: TransactionMeta,
+  selectedAddress: string,
+): boolean {
+  if (tx.isTransfer) {
+    return false;
+  }
+  const { from, to, value } = tx.txParams;
+  if (!from || !to) {
+    return false;
+  }
+  if (!areAddressesEqual(to, selectedAddress)) {
+    return false;
+  }
+  if (areAddressesEqual(from, selectedAddress)) {
+    return false;
+  }
+  return hasPositiveNativeValue(value);
+}
+
+function shouldShowIncomingNativeByAddress(
+  from: string,
+  trustedAddresses: Set<string>,
+): boolean {
+  return isTrustedAddress(from, trustedAddresses);
+}
+
 /**
  * Determines if a transaction was executed in the current chain/network
  * @param tx - Transaction to evaluate
@@ -197,6 +241,10 @@ export const filterByAddressAndNetwork = (
     condition &&
     tx.status !== TX_UNAPPROVED
   ) {
+    if (isIncomingNativeTransfer(tx, selectedAddress)) {
+      return shouldShowIncomingNativeByAddress(from, trustedAddresses);
+    }
+
     const result = isTransfer
       ? shouldShowTransferByAddress(
           from,
@@ -235,6 +283,10 @@ export const filterByAddress = (
     isFromOrToSelectedAddress(from, to ?? '', selectedAddress) &&
     tx.status !== TX_UNAPPROVED
   ) {
+    if (isIncomingNativeTransfer(tx, selectedAddress)) {
+      return shouldShowIncomingNativeByAddress(from, trustedAddresses);
+    }
+
     const result = isTransfer
       ? shouldShowTransferByAddress(
           from,

--- a/tests/smoke/wallet/incoming-transactions.spec.ts
+++ b/tests/smoke/wallet/incoming-transactions.spec.ts
@@ -47,12 +47,6 @@ const EVM_ONLY_ACCOUNT_TREE = {
 const TOKEN_SYMBOL_MOCK = 'ABC';
 const TOKEN_ADDRESS_MOCK = '0x123';
 
-/**
- * Incoming native from an untrusted address is hidden. User-storage mocks return an empty remote
- * address book, which can wipe fixture contacts—so use Account 2 (same wallet) as sender; own
- * accounts are always trusted.
- */
-const SECOND_HD_ACCOUNT_ID = '5e8c6f1a-c372-5bed-9237-1f03c3d4e5b2';
 const TRUSTED_INCOMING_SENDER_CHECKSUM = toChecksumHexAddress(
   DEFAULT_FIXTURE_ACCOUNT_2,
 );
@@ -139,55 +133,32 @@ function createAccountsTestSpecificMock(
 }
 
 /**
- * Ensures Account 2 exists on the HD keyring + AccountsController so its address is in the trusted
- * set (same as address-book trust, without relying on contacts surviving user-storage sync mocks).
+ * Makes the sender address trusted via the address book so the incoming
+ * native transfer passes the poisoning filter.
+ *
+ * KeyringController / AccountsController merges don't work here because
+ * AccountsController reconciles against the vault on unlock (which only
+ * contains Account 1) and drops any extra accounts.  The address book is
+ * static persisted state that survives startup, and contact sync is
+ * disabled via UserStorageController flags.
  */
-function mergeSecondHdAccountForTrustedIncomingNative(fixture: Fixture): void {
-  merge(fixture.state.engine.backgroundState.KeyringController, {
-    keyrings: [
-      {
-        type: 'HD Key Tree',
-        accounts: [
-          toChecksumHexAddress(DEFAULT_FIXTURE_ACCOUNT),
-          TRUSTED_INCOMING_SENDER_CHECKSUM,
-        ],
-      },
-    ],
-  });
-
-  merge(fixture.state.engine.backgroundState.AccountsController, {
-    accountIdByAddress: {
-      [DEFAULT_FIXTURE_ACCOUNT_2]: SECOND_HD_ACCOUNT_ID,
-    },
-    internalAccounts: {
-      accounts: {
-        [SECOND_HD_ACCOUNT_ID]: {
-          address: TRUSTED_INCOMING_SENDER_CHECKSUM,
-          id: SECOND_HD_ACCOUNT_ID,
-          metadata: {
-            name: 'Account 2',
-            importTime: 1684232000457,
-            keyring: { type: 'HD Key Tree' },
-          },
-          options: {},
-          methods: [
-            'personal_sign',
-            'eth_signTransaction',
-            'eth_signTypedData_v1',
-            'eth_signTypedData_v3',
-            'eth_signTypedData_v4',
-          ],
-          type: 'eip155:eoa',
-          scopes: ['eip155:0'],
-        },
-      },
-    },
-  });
-
+function mergeTrustedSenderForIncomingNative(fixture: Fixture): void {
   merge(fixture.state.engine.backgroundState.UserStorageController, {
     isBackupAndSyncEnabled: false,
     isAccountSyncingEnabled: false,
     isContactSyncingEnabled: false,
+  });
+
+  merge(fixture.state.engine.backgroundState.AddressBookController, {
+    addressBook: {
+      '0x1': {
+        [TRUSTED_INCOMING_SENDER_CHECKSUM]: {
+          address: TRUSTED_INCOMING_SENDER_CHECKSUM,
+          name: 'Account 2',
+          chainId: '0x1',
+        },
+      },
+    },
   });
 }
 
@@ -204,7 +175,7 @@ describe(SmokeWalletPlatform('Incoming Transactions'), () => {
       .withNetworkEnabledMap({ eip155: { '0x1': true } })
       .withPrivacyModePreferences(false)
       .build();
-    mergeSecondHdAccountForTrustedIncomingNative(fixture);
+    mergeTrustedSenderForIncomingNative(fixture);
 
     await withFixtures(
       {

--- a/tests/smoke/wallet/incoming-transactions.spec.ts
+++ b/tests/smoke/wallet/incoming-transactions.spec.ts
@@ -103,7 +103,9 @@ function mockAccountsApi(
   transactions: Record<string, unknown>[] = [],
 ): MockApiEndpoint {
   return {
-    urlEndpoint: `https://accounts.api.cx.metamask.io/v1/accounts/${DEFAULT_FIXTURE_ACCOUNT}/transactions?networks=0x1,0x89,0x38,0xe708,0x2105,0xa,0xa4b1,0x82750,0x531&sortDirection=DESC`,
+    urlEndpoint: new RegExp(
+      `^https://accounts\\.api\\.cx\\.metamask\\.io/v1/accounts/${DEFAULT_FIXTURE_ACCOUNT}/transactions\\?.*sortDirection=DESC`,
+    ),
     response: {
       data:
         transactions.length > 0

--- a/tests/smoke/wallet/incoming-transactions.spec.ts
+++ b/tests/smoke/wallet/incoming-transactions.spec.ts
@@ -1,5 +1,6 @@
 import { TransactionType } from '@metamask/transaction-controller';
 import { Mockttp } from 'mockttp';
+import { merge } from 'lodash';
 
 import { SmokeWalletPlatform } from '../../tags';
 import { loginToApp } from '../../flows/wallet.flow';
@@ -9,7 +10,10 @@ import FixtureBuilder, {
   DEFAULT_FIXTURE_ACCOUNT,
   ENTROPY_WALLET_1_ID,
 } from '../../framework/fixtures/FixtureBuilder';
-import type { AccountTreeControllerState } from '../../framework/fixtures/types';
+import type {
+  AccountTreeControllerState,
+  Fixture,
+} from '../../framework/fixtures/types';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import ToastModal from '../../page-objects/wallet/ToastModal';
 import { MockApiEndpoint, TestSpecificMock } from '../../framework/types';
@@ -41,6 +45,9 @@ const EVM_ONLY_ACCOUNT_TREE = {
 const TOKEN_SYMBOL_MOCK = 'ABC';
 const TOKEN_ADDRESS_MOCK = '0x123';
 
+/** Sender for mocked incoming native txs; must be trusted (address book) to appear in activity. */
+const INCOMING_NATIVE_SENDER_ADDRESS = '0x2';
+
 const RESPONSE_STANDARD_MOCK = {
   hash: '0x123456',
   timestamp: new Date().toISOString(),
@@ -56,7 +63,7 @@ const RESPONSE_STANDARD_MOCK = {
   methodId: null,
   value: '1230000000000000000',
   to: DEFAULT_FIXTURE_ACCOUNT,
-  from: '0x2',
+  from: INCOMING_NATIVE_SENDER_ADDRESS,
   isError: false,
   valueTransfers: [],
 };
@@ -76,7 +83,7 @@ const RESPONSE_TOKEN_TRANSFER_MOCK = {
       contractAddress: TOKEN_ADDRESS_MOCK,
       decimal: 18,
       symbol: TOKEN_SYMBOL_MOCK,
-      from: '0x2',
+      from: INCOMING_NATIVE_SENDER_ADDRESS,
       to: DEFAULT_FIXTURE_ACCOUNT,
       amount: '4560000000000000000',
     },
@@ -85,7 +92,7 @@ const RESPONSE_TOKEN_TRANSFER_MOCK = {
 
 const RESPONSE_OUTGOING_TRANSACTION_MOCK = {
   ...RESPONSE_STANDARD_MOCK,
-  to: '0x2',
+  to: INCOMING_NATIVE_SENDER_ADDRESS,
   from: DEFAULT_FIXTURE_ACCOUNT,
 };
 
@@ -122,21 +129,49 @@ function createAccountsTestSpecificMock(
   };
 }
 
+/**
+ * Incoming native coin from non-trusted senders is hidden (address poisoning).
+ * Merge a contact for the mocked sender so the activity row still appears.
+ */
+function mergeTrustedSenderForIncomingNativeFixture(fixture: Fixture): void {
+  const addressBookController = (
+    fixture.state.engine.backgroundState as unknown as {
+      AddressBookController: Record<string, unknown>;
+    }
+  ).AddressBookController;
+  merge(addressBookController, {
+    addressBook: {
+      '0x1': {
+        [INCOMING_NATIVE_SENDER_ADDRESS]: {
+          address: INCOMING_NATIVE_SENDER_ADDRESS,
+          name: 'E2E trusted incoming sender',
+          chainId: '0x1',
+          memo: '',
+          isEns: false,
+        },
+      },
+    },
+  });
+}
+
 describe(SmokeWalletPlatform('Incoming Transactions'), () => {
   beforeAll(async () => {
     jest.setTimeout(2500000);
   });
 
-  it('displays standard incoming transaction', async () => {
+  it('displays incoming native transfer from trusted sender', async () => {
+    const fixture = new FixtureBuilder()
+      .withAccountTreeController(
+        EVM_ONLY_ACCOUNT_TREE as unknown as Partial<AccountTreeControllerState>,
+      )
+      .withNetworkEnabledMap({ eip155: { '0x1': true } })
+      .withPrivacyModePreferences(false)
+      .build();
+    mergeTrustedSenderForIncomingNativeFixture(fixture);
+
     await withFixtures(
       {
-        fixture: new FixtureBuilder()
-          .withAccountTreeController(
-            EVM_ONLY_ACCOUNT_TREE as unknown as Partial<AccountTreeControllerState>,
-          )
-          .withNetworkEnabledMap({ eip155: { '0x1': true } })
-          .withPrivacyModePreferences(false)
-          .build(),
+        fixture,
         restartDevice: true,
         testSpecificMock: createAccountsTestSpecificMock(),
       },

--- a/tests/smoke/wallet/incoming-transactions.spec.ts
+++ b/tests/smoke/wallet/incoming-transactions.spec.ts
@@ -1,3 +1,4 @@
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { TransactionType } from '@metamask/transaction-controller';
 import { Mockttp } from 'mockttp';
 import { merge } from 'lodash';
@@ -8,6 +9,7 @@ import Assertions from '../../framework/Assertions';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import FixtureBuilder, {
   DEFAULT_FIXTURE_ACCOUNT,
+  DEFAULT_FIXTURE_ACCOUNT_2,
   ENTROPY_WALLET_1_ID,
 } from '../../framework/fixtures/FixtureBuilder';
 import type {
@@ -45,8 +47,15 @@ const EVM_ONLY_ACCOUNT_TREE = {
 const TOKEN_SYMBOL_MOCK = 'ABC';
 const TOKEN_ADDRESS_MOCK = '0x123';
 
-/** Sender for mocked incoming native txs; must be trusted (address book) to appear in activity. */
-const INCOMING_NATIVE_SENDER_ADDRESS = '0x2';
+/**
+ * Incoming native from an untrusted address is hidden. User-storage mocks return an empty remote
+ * address book, which can wipe fixture contacts—so use Account 2 (same wallet) as sender; own
+ * accounts are always trusted.
+ */
+const SECOND_HD_ACCOUNT_ID = '5e8c6f1a-c372-5bed-9237-1f03c3d4e5b2';
+const TRUSTED_INCOMING_SENDER_CHECKSUM = toChecksumHexAddress(
+  DEFAULT_FIXTURE_ACCOUNT_2,
+);
 
 const RESPONSE_STANDARD_MOCK = {
   hash: '0x123456',
@@ -63,7 +72,7 @@ const RESPONSE_STANDARD_MOCK = {
   methodId: null,
   value: '1230000000000000000',
   to: DEFAULT_FIXTURE_ACCOUNT,
-  from: INCOMING_NATIVE_SENDER_ADDRESS,
+  from: TRUSTED_INCOMING_SENDER_CHECKSUM,
   isError: false,
   valueTransfers: [],
 };
@@ -77,13 +86,13 @@ const RESPONSE_STANDARD_2_MOCK = {
 
 const RESPONSE_TOKEN_TRANSFER_MOCK = {
   ...RESPONSE_STANDARD_MOCK,
-  to: '0x2',
+  to: DEFAULT_FIXTURE_ACCOUNT,
   valueTransfers: [
     {
       contractAddress: TOKEN_ADDRESS_MOCK,
       decimal: 18,
       symbol: TOKEN_SYMBOL_MOCK,
-      from: INCOMING_NATIVE_SENDER_ADDRESS,
+      from: TRUSTED_INCOMING_SENDER_CHECKSUM,
       to: DEFAULT_FIXTURE_ACCOUNT,
       amount: '4560000000000000000',
     },
@@ -92,7 +101,7 @@ const RESPONSE_TOKEN_TRANSFER_MOCK = {
 
 const RESPONSE_OUTGOING_TRANSACTION_MOCK = {
   ...RESPONSE_STANDARD_MOCK,
-  to: INCOMING_NATIVE_SENDER_ADDRESS,
+  to: TRUSTED_INCOMING_SENDER_CHECKSUM,
   from: DEFAULT_FIXTURE_ACCOUNT,
 };
 
@@ -130,27 +139,55 @@ function createAccountsTestSpecificMock(
 }
 
 /**
- * Incoming native coin from non-trusted senders is hidden (address poisoning).
- * Merge a contact for the mocked sender so the activity row still appears.
+ * Ensures Account 2 exists on the HD keyring + AccountsController so its address is in the trusted
+ * set (same as address-book trust, without relying on contacts surviving user-storage sync mocks).
  */
-function mergeTrustedSenderForIncomingNativeFixture(fixture: Fixture): void {
-  const addressBookController = (
-    fixture.state.engine.backgroundState as unknown as {
-      AddressBookController: Record<string, unknown>;
-    }
-  ).AddressBookController;
-  merge(addressBookController, {
-    addressBook: {
-      '0x1': {
-        [INCOMING_NATIVE_SENDER_ADDRESS]: {
-          address: INCOMING_NATIVE_SENDER_ADDRESS,
-          name: 'E2E trusted incoming sender',
-          chainId: '0x1',
-          memo: '',
-          isEns: false,
+function mergeSecondHdAccountForTrustedIncomingNative(fixture: Fixture): void {
+  merge(fixture.state.engine.backgroundState.KeyringController, {
+    keyrings: [
+      {
+        type: 'HD Key Tree',
+        accounts: [
+          toChecksumHexAddress(DEFAULT_FIXTURE_ACCOUNT),
+          TRUSTED_INCOMING_SENDER_CHECKSUM,
+        ],
+      },
+    ],
+  });
+
+  merge(fixture.state.engine.backgroundState.AccountsController, {
+    accountIdByAddress: {
+      [DEFAULT_FIXTURE_ACCOUNT_2]: SECOND_HD_ACCOUNT_ID,
+    },
+    internalAccounts: {
+      accounts: {
+        [SECOND_HD_ACCOUNT_ID]: {
+          address: TRUSTED_INCOMING_SENDER_CHECKSUM,
+          id: SECOND_HD_ACCOUNT_ID,
+          metadata: {
+            name: 'Account 2',
+            importTime: 1684232000457,
+            keyring: { type: 'HD Key Tree' },
+          },
+          options: {},
+          methods: [
+            'personal_sign',
+            'eth_signTransaction',
+            'eth_signTypedData_v1',
+            'eth_signTypedData_v3',
+            'eth_signTypedData_v4',
+          ],
+          type: 'eip155:eoa',
+          scopes: ['eip155:0'],
         },
       },
     },
+  });
+
+  merge(fixture.state.engine.backgroundState.UserStorageController, {
+    isBackupAndSyncEnabled: false,
+    isAccountSyncingEnabled: false,
+    isContactSyncingEnabled: false,
   });
 }
 
@@ -159,7 +196,7 @@ describe(SmokeWalletPlatform('Incoming Transactions'), () => {
     jest.setTimeout(2500000);
   });
 
-  it('displays incoming native transfer from trusted sender', async () => {
+  it('displays incoming native transfer from another own account', async () => {
     const fixture = new FixtureBuilder()
       .withAccountTreeController(
         EVM_ONLY_ACCOUNT_TREE as unknown as Partial<AccountTreeControllerState>,
@@ -167,7 +204,7 @@ describe(SmokeWalletPlatform('Incoming Transactions'), () => {
       .withNetworkEnabledMap({ eip155: { '0x1': true } })
       .withPrivacyModePreferences(false)
       .build();
-    mergeTrustedSenderForIncomingNativeFixture(fixture);
+    mergeSecondHdAccountForTrustedIncomingNative(fixture);
 
     await withFixtures(
       {

--- a/tests/smoke/wallet/incoming-transactions.spec.ts
+++ b/tests/smoke/wallet/incoming-transactions.spec.ts
@@ -250,15 +250,18 @@ describe(SmokeWalletPlatform('Incoming Transactions'), () => {
   });
 
   it('displays nothing if privacyMode is enabled', async () => {
+    const fixture = new FixtureBuilder()
+      .withAccountTreeController(
+        EVM_ONLY_ACCOUNT_TREE as unknown as Partial<AccountTreeControllerState>,
+      )
+      .withNetworkEnabledMap({ eip155: { '0x1': true } })
+      .withPrivacyModePreferences(true)
+      .build();
+    mergeTrustedSenderForIncomingNative(fixture);
+
     await withFixtures(
       {
-        fixture: new FixtureBuilder()
-          .withAccountTreeController(
-            EVM_ONLY_ACCOUNT_TREE as unknown as Partial<AccountTreeControllerState>,
-          )
-          .withNetworkEnabledMap({ eip155: { '0x1': true } })
-          .withPrivacyModePreferences(true)
-          .build(),
+        fixture,
         restartDevice: true,
         testSpecificMock: createAccountsTestSpecificMock(),
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Incoming native coin transfers (e.g. ETH, MATIC, BNB) were still shown in the Activity feed whenever isTransfer was false, because existing address-poisoning logic only applied to token transfers (shouldShowTransferByAddress). That left a gap for dust / spoof incoming native txs used in address-poisoning scams.

This change applies the same trust rule as incoming ERC-20 transfers when the user holds the token: incoming native transfers with non-zero value are shown only if the sender is trusted (any of the user’s own accounts or an entry in the address book). Outgoing native transfers are unchanged. Token transfers continue to use the existing isTransfer path. Zero-value incoming txs are not treated as this native case, so other activity rows are unaffected.

Implemented in app/util/activity/index.ts; covered by app/util/activity/index.test.ts.

## **Changelog**

CHANGELOG entry: Hid incoming native coin transfers from unknown senders in the Activity tab; transfers from your own accounts or address book contacts still appear.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-509

## **Manual testing steps**

```gherkin
Feature: Activity incoming native transfer filtering

  Scenario: Incoming native from an unknown address does not appear
    Given the user is on an EVM account with Activity (unified transactions) open
    And the account has previously received a non-zero native transfer from an address that is not in the address book and not another wallet account
    When the user views the Activity list
    Then that incoming native transfer is not shown

  Scenario: Incoming native from an address book contact still appears
    Given the user has a contact in the address book who sends a non-zero native transfer to the selected account
    When the user views the Activity list
    Then the incoming native transfer is shown

  Scenario: Outgoing native transfer still appears
    Given the user sends native currency to any recipient
    When the user views the Activity list
    Then the outgoing transfer is shown

  Scenario: Incoming ERC-20 behavior unchanged
    Given the user receives a token transfer from an unknown address for a token they hold
    When the user views the Activity list
    Then behavior matches existing token poisoning rules (hidden unless trusted sender)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="394" height="837" alt="Screenshot 2026-03-23 at 13 49 38" src="https://github.com/user-attachments/assets/d2700d52-41f2-426c-ad75-920ea9e8d0d6" />

<!-- [screenshots/recordings] -->

### **After**
<img width="389" height="837" alt="Screenshot 2026-03-23 at 13 49 48" src="https://github.com/user-attachments/assets/a19d2a46-e779-4e6b-b51a-1b564eabfa22" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core Activity feed filtering logic and could unintentionally hide legitimate incoming native transactions if trust/address-book state is incorrect; outgoing and zero-value cases are explicitly preserved.
> 
> **Overview**
> Adds **incoming native transfer poisoning protection**: `filterByAddress` and `filterByAddressAndNetwork` now treat non-token, non-zero native transfers *to* the selected account as suspicious unless the sender is in the trusted set (own accounts or address book).
> 
> Introduces helpers to detect positive native `txParams.value` and gate visibility accordingly, and adds unit + smoke test coverage to ensure unknown-sender incoming native transfers are hidden while trusted/own-account and outgoing/zero-value cases remain visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81789035d446164a5ee9c3ba455013983dac9abc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->