### PR TITLE
feat(rewards): update campaigns feature flag behavior on dashboard

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -1,23 +1,19 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import { useDispatch, useSelector } from 'react-redux';
-import { Alert } from 'react-native';
+import { useSelector } from 'react-redux';
 import RewardsDashboard from './RewardsDashboard';
 import Routes from '../../../../constants/navigation/Routes';
 import { REWARDS_VIEW_SELECTORS } from './RewardsView.constants';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
   useSelector: jest.fn(),
 }));
 
-const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 // Mock navigation
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -26,10 +22,7 @@ jest.mock('@react-navigation/native', () => {
     ...actual,
     useNavigation: () => ({
       navigate: mockNavigate,
-      setOptions: mockSetOptions,
     }),
-    // Run focus effects as a normal effect during tests
-    // This simulates the screen coming into focus
     useFocusEffect: (effect: () => void | (() => void)) => {
       ReactActual.useEffect(() => {
         const cleanup = effect();
@@ -42,18 +35,12 @@ jest.mock('@react-navigation/native', () => {
 // Mock selectors
 jest.mock('../../../../reducers/rewards/selectors', () => ({
   selectActiveTab: jest.fn(),
-  selectSeasonId: jest.fn(),
-  selectOptinAllowedForGeo: jest.fn(),
   selectHideCurrentAccountNotOptedInBannerArray: jest.fn(),
   selectHideUnlinkedAccountsBanner: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
-}));
-
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectCampaignsRewardsEnabledFlag: jest.fn(),
 }));
 
 jest.mock(
@@ -65,14 +52,11 @@ jest.mock(
 
 import {
   selectActiveTab,
-  selectSeasonId,
-  selectOptinAllowedForGeo,
   selectHideUnlinkedAccountsBanner,
   selectHideCurrentAccountNotOptedInBannerArray,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { selectSelectedAccountGroup } from '../../../../selectors/multichainAccounts/accountTreeController';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 
 const mockSelectActiveTab = selectActiveTab as jest.MockedFunction<
   typeof selectActiveTab
@@ -80,13 +64,6 @@ const mockSelectActiveTab = selectActiveTab as jest.MockedFunction<
 const mockSelectRewardsSubscriptionId =
   selectRewardsSubscriptionId as jest.MockedFunction<
     typeof selectRewardsSubscriptionId
-  >;
-const mockSelectSeasonId = selectSeasonId as jest.MockedFunction<
-  typeof selectSeasonId
->;
-const mockSelectOptinAllowedForGeo =
-  selectOptinAllowedForGeo as jest.MockedFunction<
-    typeof selectOptinAllowedForGeo
   >;
 const mockSelectHideUnlinkedAccountsBanner =
   selectHideUnlinkedAccountsBanner as jest.MockedFunction<
@@ -100,18 +77,6 @@ const mockSelectSelectedAccountGroup =
   selectSelectedAccountGroup as jest.MockedFunction<
     typeof selectSelectedAccountGroup
   >;
-const mockSelectCampaignsRewardsEnabledFlag =
-  selectCampaignsRewardsEnabledFlag as jest.MockedFunction<
-    typeof selectCampaignsRewardsEnabledFlag
-  >;
-
-// Mock theme
-jest.mock('../../../../util/theme', () => {
-  const { mockTheme } = jest.requireActual('../../../../util/theme');
-  return {
-    useTheme: () => mockTheme,
-  };
-});
 
 // Mock react-native-safe-area-context
 jest.mock('react-native-safe-area-context', () => {
@@ -186,10 +151,6 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
       'rewards.main_title': 'Rewards',
-      'rewards.tab_overview_title': 'Overview',
-      'rewards.tab_snapshots_title': 'Snapshots',
-      'rewards.tab_activity_title': 'Activity',
-      'rewards.not_implemented': 'Not implemented yet',
     };
     return translations[key] || key;
   }),
@@ -234,164 +195,9 @@ jest.mock('../components/Campaigns/CampaignsPreview', () => ({
   },
 }));
 
-jest.mock('../components/PreviousSeason/PreviousSeasonSummary', () => ({
-  __esModule: true,
-  default: function MockPreviousSeasonSummary() {
-    const ReactActual = jest.requireActual('react');
-    const { View, Text } = jest.requireActual('react-native');
-    return ReactActual.createElement(
-      View,
-      { testID: 'rewards-view-previous-season-summary' },
-      ReactActual.createElement(Text, null, 'Previous Season Summary'),
-    );
-  },
-}));
-
-// Mock tab components
-jest.mock('../components/Tabs/RewardsOverview', () => ({
-  __esModule: true,
-  default: function MockRewardsOverview({ tabLabel }: { tabLabel: string }) {
-    const ReactActual = jest.requireActual('react');
-    const { View, Text } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      { testID: 'rewards-overview-tab' },
-      ReactActual.createElement(Text, null, tabLabel || 'Overview'),
-    );
-  },
-}));
-
-jest.mock('../Views/CampaignsView', () => {
-  const ReactActual = jest.requireActual('react');
-  const RN = jest.requireActual('react-native');
-  const MockCampaignsView = ({ tabLabel }: { tabLabel?: string }) =>
-    ReactActual.createElement(
-      RN.View,
-      { testID: 'rewards-campaigns-tab' },
-      ReactActual.createElement(RN.Text, null, tabLabel || 'Campaigns'),
-    );
-  return { __esModule: true, default: MockCampaignsView };
-});
-
-jest.mock('../components/Tabs/RewardsActivity', () => ({
-  __esModule: true,
-  default: function MockRewardsActivity({ tabLabel }: { tabLabel: string }) {
-    const ReactActual = jest.requireActual('react');
-    const { View, Text } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      { testID: 'rewards-activity-tab' },
-      ReactActual.createElement(Text, null, tabLabel || 'Activity'),
-    );
-  },
-}));
-
-jest.mock('../components/Tabs/MusdCalculatorTab/MusdCalculatorTab', () => ({
-  __esModule: true,
-  default: function MockMusdCalculatorTab() {
-    const ReactActual = jest.requireActual('react');
-    const { View, Text } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      { testID: 'musd-calculator-tab' },
-      ReactActual.createElement(Text, null, 'mUSD Calculator'),
-    );
-  },
-}));
-
-// Mock RewardsInfoBanner
-jest.mock('../components/RewardsInfoBanner', () => ({
-  __esModule: true,
-  default: function MockRewardsInfoBanner({
-    title,
-    description,
-    onConfirm,
-    onDismiss,
-    confirmButtonLabel,
-    onConfirmLoading,
-    testID,
-  }: {
-    title: string | React.ReactNode;
-    description: string;
-    onConfirm?: () => void;
-    onDismiss?: () => void;
-    confirmButtonLabel?: string;
-    onConfirmLoading?: boolean;
-    testID?: string;
-  }) {
-    const ReactActual = jest.requireActual('react');
-    const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      { testID: testID || 'rewards-info-banner' },
-      ReactActual.createElement(
-        Text,
-        { testID: 'banner-title' },
-        typeof title === 'string' ? title : 'Custom Title',
-      ),
-      ReactActual.createElement(
-        Text,
-        { testID: 'banner-description' },
-        description,
-      ),
-      onConfirm &&
-        ReactActual.createElement(
-          TouchableOpacity,
-          {
-            testID: 'banner-confirm-button',
-            onPress: onConfirm,
-            disabled: onConfirmLoading,
-          },
-          ReactActual.createElement(
-            Text,
-            null,
-            onConfirmLoading ? 'Loading...' : confirmButtonLabel || 'Confirm',
-          ),
-        ),
-      onDismiss &&
-        ReactActual.createElement(
-          TouchableOpacity,
-          { testID: 'banner-dismiss-button', onPress: onDismiss },
-          ReactActual.createElement(Text, null, 'Dismiss'),
-        ),
-    );
-  },
-}));
-
-// Mock AccountDisplayItem
-jest.mock('../components/AccountDisplayItem/AccountDisplayItem', () => ({
-  __esModule: true,
-  default: function MockAccountDisplayItem({
-    account,
-  }: {
-    account: InternalAccount;
-  }) {
-    const ReactActual = jest.requireActual('react');
-    const { View, Text } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      { testID: 'account-display-item' },
-      ReactActual.createElement(
-        Text,
-        null,
-        account?.metadata?.name || 'Account',
-      ),
-    );
-  },
-}));
-
 // Mock hooks
 jest.mock('../hooks/useRewardOptinSummary', () => ({
   useRewardOptinSummary: jest.fn(),
-}));
-
-jest.mock('../hooks/useLinkAccountGroup', () => ({
-  useLinkAccountGroup: jest.fn(),
 }));
 
 jest.mock('../hooks/useRewardDashboardModals', () => ({
@@ -402,121 +208,14 @@ jest.mock('../hooks/useBulkLinkState', () => ({
   useBulkLinkState: jest.fn(),
 }));
 
-jest.mock('../utils', () => ({
-  convertInternalAccountToCaipAccountId: jest.fn(),
-}));
-
-// Mock TabsList with ref support
-jest.mock('../../../../component-library/components-temp/Tabs', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
-
-  const MockTabsList = ReactActual.forwardRef(
-    (
-      {
-        children,
-        onChangeTab,
-        initialActiveIndex = 0,
-        testID,
-      }: {
-        children: unknown;
-        onChangeTab?: (props: { i: number; ref: unknown }) => void;
-        initialActiveIndex?: number;
-        testID?: string;
-      },
-      ref: unknown,
-    ) => {
-      const [activeTab, setActiveTabLocal] =
-        ReactActual.useState(initialActiveIndex);
-
-      ReactActual.useImperativeHandle(ref, () => ({
-        goToTabIndex: (index: number) => {
-          setActiveTabLocal(index);
-          if (onChangeTab) {
-            onChangeTab({ i: index, ref: children });
-          }
-        },
-        getCurrentIndex: () => activeTab,
-      }));
-
-      const handleTabPress = (index: number) => {
-        setActiveTabLocal(index);
-        if (onChangeTab) {
-          onChangeTab({ i: index, ref: children });
-        }
-      };
-
-      // Filter and cast children to ReactElements
-      const validChildren = ReactActual.Children.toArray(children).filter(
-        (child: unknown) => ReactActual.isValidElement(child),
-      );
-
-      return ReactActual.createElement(
-        View,
-        { testID: testID || 'tabs-list' },
-        // Tab headers
-        ReactActual.createElement(
-          View,
-          { testID: 'tab-headers', style: { flexDirection: 'row' } },
-          validChildren.map((child: unknown, index: number) => {
-            if (!ReactActual.isValidElement(child)) return null;
-            const childElement = child as {
-              key?: string;
-              props?: { tabLabel?: string };
-            };
-            return ReactActual.createElement(
-              TouchableOpacity,
-              {
-                key: childElement.key || `tab-${index}`,
-                testID: `tab-${index}`,
-                onPress: () => handleTabPress(index),
-                style: { padding: 10 },
-              },
-              ReactActual.createElement(
-                Text,
-                {
-                  style: {
-                    fontWeight: activeTab === index ? 'bold' : 'normal',
-                  },
-                },
-                childElement.props?.tabLabel || `Tab ${index + 1}`,
-              ),
-            );
-          }),
-        ),
-        // Active tab content
-        ReactActual.createElement(
-          View,
-          { testID: 'tab-content' },
-          validChildren[activeTab],
-        ),
-      );
-    },
-  );
-
-  return {
-    TabsList: MockTabsList,
-  };
-});
-
-// Mock Alert
-const mockAlert = jest.fn();
-jest.spyOn(Alert, 'alert').mockImplementation(mockAlert);
-
 // Import mocked hooks
 import { useRewardOptinSummary } from '../hooks/useRewardOptinSummary';
-import { useLinkAccountGroup } from '../hooks/useLinkAccountGroup';
 import { useRewardDashboardModals } from '../hooks/useRewardDashboardModals';
 import { useBulkLinkState } from '../hooks/useBulkLinkState';
-import { convertInternalAccountToCaipAccountId } from '../utils';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 
 const mockUseRewardOptinSummary = useRewardOptinSummary as jest.MockedFunction<
   typeof useRewardOptinSummary
->;
-const mockUseLinkAccountGroup = useLinkAccountGroup as jest.MockedFunction<
-  typeof useLinkAccountGroup
 >;
 const mockUseRewardDashboardModals =
   useRewardDashboardModals as jest.MockedFunction<
@@ -525,37 +224,13 @@ const mockUseRewardDashboardModals =
 const mockUseBulkLinkState = useBulkLinkState as jest.MockedFunction<
   typeof useBulkLinkState
 >;
-const mockConvertInternalAccountToCaipAccountId =
-  convertInternalAccountToCaipAccountId as jest.MockedFunction<
-    typeof convertInternalAccountToCaipAccountId
-  >;
 
 describe('RewardsDashboard', () => {
-  const mockDispatch = jest.fn();
-  const mockLinkAccount = jest.fn();
   const mockShowUnlinkedAccountsModal = jest.fn();
   const mockShowNotOptedInModal = jest.fn();
   const mockShowNotSupportedModal = jest.fn();
   const mockHasShownModal = jest.fn();
-  const mockResetSessionTracking = jest.fn();
   const mockResumeBulkLink = jest.fn();
-  const mockStartBulkLink = jest.fn();
-  const mockCancelBulkLink = jest.fn();
-  const mockResetBulkLink = jest.fn();
-
-  const mockSelectedAccount = {
-    id: 'account-1',
-    address: '0x123',
-    type: 'eip155:eoa' as const,
-    options: {},
-    metadata: {
-      name: 'Account 1',
-      importTime: Date.now(),
-      keyring: { type: 'HD Key Tree' },
-    },
-    scopes: ['eip155:1'] as `${string}:${string}`[],
-    methods: ['eth_sendTransaction'],
-  };
 
   const mockSelectedAccountGroup = {
     id: 'keyring:wallet1/1' as const,
@@ -568,18 +243,12 @@ describe('RewardsDashboard', () => {
     type: AccountGroupType.SingleAccount as const,
   };
 
-  const currentSeasonId = '7c9fa360-8d4c-425a-8a3e-7e82e1d82179';
-
   const defaultSelectorValues = {
     activeTab: 'campaigns' as const,
     subscriptionId: 'test-subscription-id',
-    seasonId: currentSeasonId,
-    optinAllowedForGeo: false as boolean | null,
     hideUnlinkedAccountsBanner: false,
     hideCurrentAccountNotOptedInBannerArray: [],
-    selectedAccount: mockSelectedAccount,
     selectedAccountGroup: mockSelectedAccountGroup,
-    isCampaignsEnabled: true,
   };
 
   const defaultHookValues = {
@@ -592,25 +261,19 @@ describe('RewardsDashboard', () => {
       hasError: false,
       refresh: jest.fn(),
     },
-    useLinkAccountGroup: {
-      linkAccountGroup: mockLinkAccount,
-      isLoading: false,
-      isError: false,
-      error: null,
-    },
     useRewardDashboardModals: {
       showUnlinkedAccountsModal: mockShowUnlinkedAccountsModal,
       showNotOptedInModal: mockShowNotOptedInModal,
       showNotSupportedModal: mockShowNotSupportedModal,
       hasShownModal: mockHasShownModal,
-      resetSessionTracking: mockResetSessionTracking,
+      resetSessionTracking: jest.fn(),
       resetSessionTrackingForCurrentAccountGroup: jest.fn(),
       resetAllSessionTracking: jest.fn(),
     },
     useBulkLinkState: {
-      startBulkLink: mockStartBulkLink,
-      cancelBulkLink: mockCancelBulkLink,
-      resetBulkLink: mockResetBulkLink,
+      startBulkLink: jest.fn(),
+      cancelBulkLink: jest.fn(),
+      resetBulkLink: jest.fn(),
       resumeBulkLink: mockResumeBulkLink,
       isRunning: false,
       wasInterrupted: false,
@@ -627,17 +290,11 @@ describe('RewardsDashboard', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockAlert.mockClear();
-    mockLinkAccount.mockClear();
     mockShowUnlinkedAccountsModal.mockClear();
     mockShowNotOptedInModal.mockClear();
     mockShowNotSupportedModal.mockClear();
     mockHasShownModal.mockClear();
-    mockResetSessionTracking.mockClear();
     mockResumeBulkLink.mockClear();
-    mockStartBulkLink.mockClear();
-    mockCancelBulkLink.mockClear();
-    mockResetBulkLink.mockClear();
     mockTrackEvent.mockClear();
     mockCreateEventBuilder.mockClear();
     mockBuild.mockClear();
@@ -651,43 +308,29 @@ describe('RewardsDashboard', () => {
       build: mockBuild,
     });
 
-    mockUseDispatch.mockReturnValue(mockDispatch);
-
     // Setup selector mocks
     mockSelectActiveTab.mockReturnValue(defaultSelectorValues.activeTab);
     mockSelectRewardsSubscriptionId.mockReturnValue(
       defaultSelectorValues.subscriptionId,
     );
-    mockSelectSeasonId.mockReturnValue(defaultSelectorValues.seasonId);
     mockSelectHideUnlinkedAccountsBanner.mockReturnValue(
       defaultSelectorValues.hideUnlinkedAccountsBanner,
     );
     mockSelectHideCurrentAccountNotOptedInBannerArray.mockReturnValue(
       defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray,
     );
-
     mockSelectSelectedAccountGroup.mockReturnValue(
       defaultSelectorValues.selectedAccountGroup,
-    );
-    mockSelectCampaignsRewardsEnabledFlag.mockReturnValue(
-      defaultSelectorValues.isCampaignsEnabled,
-    );
-    mockSelectOptinAllowedForGeo.mockReturnValue(
-      defaultSelectorValues.optinAllowedForGeo,
     );
 
     // Setup hook mocks
     mockUseRewardOptinSummary.mockReturnValue(
       defaultHookValues.useRewardOptinSummary,
     );
-    mockUseLinkAccountGroup.mockReturnValue(
-      defaultHookValues.useLinkAccountGroup,
-    );
     mockUseRewardDashboardModals.mockReturnValue(
       defaultHookValues.useRewardDashboardModals,
     );
     mockUseBulkLinkState.mockReturnValue(defaultHookValues.useBulkLinkState);
-    mockConvertInternalAccountToCaipAccountId.mockReturnValue('eip155:1:0x123');
 
     // Setup default modal hook behavior - return false for all modal types by default
     mockHasShownModal.mockReturnValue(false);
@@ -696,23 +339,18 @@ describe('RewardsDashboard', () => {
       if (selector === selectActiveTab) return defaultSelectorValues.activeTab;
       if (selector === selectRewardsSubscriptionId)
         return defaultSelectorValues.subscriptionId;
-      if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
-      if (selector === selectOptinAllowedForGeo)
-        return defaultSelectorValues.optinAllowedForGeo;
       if (selector === selectHideUnlinkedAccountsBanner)
         return defaultSelectorValues.hideUnlinkedAccountsBanner;
       if (selector === selectHideCurrentAccountNotOptedInBannerArray)
         return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
       if (selector === selectSelectedAccountGroup)
         return defaultSelectorValues.selectedAccountGroup;
-      if (selector === selectCampaignsRewardsEnabledFlag)
-        return defaultSelectorValues.isCampaignsEnabled;
       return undefined;
     });
   });
 
   describe('rendering', () => {
-    it('should render main title', () => {
+    it('renders main title', () => {
       // Act
       const { getByText } = render(<RewardsDashboard />);
 
@@ -720,509 +358,118 @@ describe('RewardsDashboard', () => {
       expect(getByText('Rewards')).toBeTruthy();
     });
 
-    it('should render all child components when user is opted in', () => {
+    it('renders all child components', () => {
       // Act
       const { getByTestId } = render(<RewardsDashboard />);
 
       // Assert
       expect(getByTestId(REWARDS_VIEW_SELECTORS.SAFE_AREA_VIEW)).toBeTruthy();
-      expect(getByTestId(REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON)).toBeTruthy();
       expect(getByTestId(REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON)).toBeTruthy();
       expect(getByTestId('campaigns-preview')).toBeTruthy();
+      expect(getByTestId('earn-rewards-preview')).toBeTruthy();
     });
 
-    it('should call modal hooks when component is rendered', () => {
+    it('calls modal hooks when component is rendered', () => {
       // Act
       render(<RewardsDashboard />);
 
       // Assert
       expect(mockUseRewardDashboardModals).toHaveBeenCalled();
     });
-
-    it('should render previous season summary when campaigns disabled and geo not allowed', () => {
-      // Arrange - campaigns disabled, geo not allowed → just PreviousSeasonSummary
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
-      mockSelectCampaignsRewardsEnabledFlag.mockReturnValue(false);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo) return false;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-
-      // Act
-      const { getByTestId, queryByTestId } = render(<RewardsDashboard />);
-
-      // Assert - PreviousSeasonSummary shown without tabs
-      expect(
-        getByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeTruthy();
-      expect(queryByTestId('season-status')).toBeNull();
-      expect(queryByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeNull();
-    });
-
-    it('should not render previous season summary when campaigns enabled', () => {
-      // isCampaignsEnabled is true (default) so showPreviousSeasonSummary is false
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo) return true;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      // Act
-      const { queryByTestId } = render(<RewardsDashboard />);
-
-      // Assert - no previous season summary or tabs when season is active
-      expect(
-        queryByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeNull();
-      expect(queryByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeNull();
-    });
-
-    it('should render campaigns preview and referral button when campaigns enabled', () => {
-      // Act - defaults have campaigns enabled
-      const { getByTestId, queryByTestId } = render(<RewardsDashboard />);
-
-      // Assert
-      expect(getByTestId(REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON)).toBeTruthy();
-      expect(
-        queryByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeNull();
-    });
-
-    it('should not render previous season summary when seasonId is null', () => {
-      // Arrange
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return null;
-        if (selector === selectOptinAllowedForGeo)
-          return defaultSelectorValues.optinAllowedForGeo;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      // Act
-      const { queryByTestId } = render(<RewardsDashboard />);
-
-      // Assert
-      expect(
-        queryByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeNull();
-    });
-  });
-
-  describe('optinAllowedForGeo-based content', () => {
-    it('shows mUSD calculator tab when campaigns disabled and geo allowed', () => {
-      // Arrange - campaigns disabled + geo allowed
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo) return true;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-
-      // Act
-      const { getByTestId } = render(<RewardsDashboard />);
-
-      // Assert - two-tab layout with mUSD and Previous Season
-      expect(getByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeTruthy();
-      expect(getByTestId('musd-calculator-tab')).toBeTruthy();
-    });
-
-    it('hides mUSD calculator when campaigns disabled but geo not allowed', () => {
-      // Arrange - campaigns disabled + geo NOT allowed
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo) return false;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-
-      // Act
-      const { queryByTestId, getByTestId } = render(<RewardsDashboard />);
-
-      // Assert - just PreviousSeasonSummary, no tabs
-      expect(
-        getByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeTruthy();
-      expect(queryByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeNull();
-      expect(queryByTestId('musd-calculator-tab')).toBeNull();
-    });
-
-    it('shows campaigns preview when season is active regardless of geo', () => {
-      // Act - defaults have active season with campaigns enabled
-      const { queryByTestId, getByTestId } = render(<RewardsDashboard />);
-
-      // Assert - CampaignsPreview shown, no previous season content
-      expect(getByTestId('campaigns-preview')).toBeTruthy();
-      expect(queryByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeNull();
-      expect(queryByTestId('musd-calculator-tab')).toBeNull();
-    });
   });
 
   describe('header and SafeAreaView', () => {
     it('renders SafeAreaView wrapper', () => {
+      // Act
       const { getByTestId } = render(<RewardsDashboard />);
 
+      // Assert
       expect(
         getByTestId(REWARDS_VIEW_SELECTORS.SAFE_AREA_VIEW),
       ).toBeOnTheScreen();
     });
 
     it('renders HeaderRoot with title Rewards', () => {
+      // Act
       const { getByText } = render(<RewardsDashboard />);
 
+      // Assert
       expect(getByText('Rewards')).toBeOnTheScreen();
     });
 
     it('renders settings button in header', () => {
+      // Act
       const { getByTestId } = render(<RewardsDashboard />);
 
+      // Assert
       expect(
         getByTestId(REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON),
-      ).toBeOnTheScreen();
-    });
-
-    it('renders referral button in header', () => {
-      const { getByTestId } = render(<RewardsDashboard />);
-
-      expect(
-        getByTestId(REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON),
       ).toBeOnTheScreen();
     });
   });
 
   describe('navigation', () => {
-    it('should navigate to referral view when referral button is pressed', () => {
-      const { getByTestId } = render(<RewardsDashboard />);
-      const referralButton = getByTestId(
-        REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
-      );
-      fireEvent.press(referralButton);
-
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REFERRAL_REWARDS_VIEW);
-    });
-
     it('navigates to Rewards settings when settings button is pressed', () => {
+      // Act
       const { getByTestId } = render(<RewardsDashboard />);
       const settingsButton = getByTestId(
         REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
       );
       fireEvent.press(settingsButton);
 
+      // Assert
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_SETTINGS_VIEW);
     });
   });
 
-  describe('when isCampaignsEnabled is false', () => {
-    beforeEach(() => {
-      mockSelectCampaignsRewardsEnabledFlag.mockReturnValue(false);
-      mockSelectActiveTab.mockReturnValue('overview');
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab) return 'overview';
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-    });
-
-    it('does not render CampaignsPreview when campaigns is disabled', () => {
-      // Act
-      const { queryByTestId } = render(<RewardsDashboard />);
-
-      // Assert
-      expect(queryByTestId('campaigns-preview')).toBeNull();
-    });
-  });
-
-  describe('previous season summary', () => {
-    const setupCampaignsDisabledMocks = (
-      optinAllowed: boolean | null = false,
-    ) => {
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
-      mockSelectCampaignsRewardsEnabledFlag.mockReturnValue(false);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo) return optinAllowed;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-    };
-
-    it('should show PreviousSeasonSummary when campaigns disabled and geo not allowed', () => {
-      setupCampaignsDisabledMocks(false);
-
-      const { getByTestId, queryByTestId } = render(<RewardsDashboard />);
-
-      expect(
-        getByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeTruthy();
-      expect(queryByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeNull();
-    });
-
-    it('should show two-tab layout when campaigns disabled and geo allowed', () => {
-      setupCampaignsDisabledMocks(true);
-
-      const { getByTestId } = render(<RewardsDashboard />);
-
-      expect(getByTestId(REWARDS_VIEW_SELECTORS.TAB_CONTROL)).toBeTruthy();
-      expect(getByTestId('musd-calculator-tab')).toBeTruthy();
-    });
-
-    it('should not render previous season summary when campaigns enabled', () => {
-      // isCampaignsEnabled is true (default) so showPreviousSeasonSummary is false
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      // Act
-      const { queryByTestId } = render(<RewardsDashboard />);
-
-      expect(
-        queryByTestId(REWARDS_VIEW_SELECTORS.PREVIOUS_SEASON_SUMMARY),
-      ).toBeNull();
-    });
-
-    it('should hide referral button when showing previous season summary', () => {
+  describe('settings button state', () => {
+    it('disables settings button when user is not opted in', () => {
       // Arrange
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
-      mockSelectCampaignsRewardsEnabledFlag.mockReturnValue(false);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-
-      const { queryByTestId } = render(<RewardsDashboard />);
-
-      expect(queryByTestId(REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON)).toBeNull();
-    });
-
-    it('should show settings button when showing previous season summary', () => {
-      setupCampaignsDisabledMocks(false);
-      // Arrange
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      const { getByTestId } = render(<RewardsDashboard />);
-
-      expect(getByTestId(REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON)).toBeTruthy();
-    });
-  });
-
-  describe('button states when not opted in', () => {
-    beforeEach(() => {
       mockSelectRewardsSubscriptionId.mockReturnValue(null);
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectActiveTab)
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId) return null;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo)
-          return defaultSelectorValues.optinAllowedForGeo;
-        if (selector === selectCampaignsRewardsEnabledFlag) return true;
-        return undefined;
-      });
-    });
-
-    it('should disable referral button when user is not opted in', () => {
-      const { getByTestId } = render(<RewardsDashboard />);
-      const referralButton = getByTestId(
-        REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
-      );
-      const isDisabled =
-        referralButton.props.disabled === true ||
-        referralButton.props.accessibilityState?.disabled === true;
-      expect(isDisabled).toBe(true);
-    });
-
-    it('should disable settings button when user is not opted in', () => {
-      const { getByTestId } = render(<RewardsDashboard />);
-      const settingsButton = getByTestId(
-        REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
-      );
-      const isDisabled =
-        settingsButton.props.disabled === true ||
-        settingsButton.props.accessibilityState?.disabled === true;
-      expect(isDisabled).toBe(true);
-    });
-  });
-
-  describe('button states when opted in', () => {
-    it('should enable referral button when user is opted in', () => {
-      const { getByTestId } = render(<RewardsDashboard />);
-      const referralButton = getByTestId(
-        REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
-      );
-      const isDisabled =
-        referralButton.props.disabled === true ||
-        referralButton.props.accessibilityState?.disabled === true;
-      expect(isDisabled).toBe(false);
-    });
-
-    it('should enable settings button when user is opted in', () => {
-      const { getByTestId } = render(<RewardsDashboard />);
-      const settingsButton = getByTestId(
-        REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
-      );
-      const isDisabled =
-        settingsButton.props.disabled === true ||
-        settingsButton.props.accessibilityState?.disabled === true;
-      expect(isDisabled).toBe(false);
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle invalid activeTab gracefully', () => {
-      // Arrange
-      mockSelectActiveTab.mockReturnValue('nonexistent' as never);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab) return 'nonexistent';
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo)
-          return defaultSelectorValues.optinAllowedForGeo;
-        return undefined;
-      });
-
-      // Act & Assert
-      expect(() => render(<RewardsDashboard />)).not.toThrow();
-    });
-  });
-
-  describe('modal triggering for current account', () => {
-    it('should show not opted in modal when account group has opted out accounts and modal has not been shown', async () => {
-      // Arrange - Mock account group with opted out accounts
-      // isCampaignsEnabled is true so showPreviousSeasonSummary is false
-      // Note: The modal effect only runs when showPreviousSeasonSummary is false
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
         return undefined;
       });
 
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      const settingsButton = getByTestId(
+        REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
+      );
+
+      // Assert
+      const isDisabled =
+        settingsButton.props.disabled === true ||
+        settingsButton.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(true);
+    });
+
+    it('enables settings button when user is opted in', () => {
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      const settingsButton = getByTestId(
+        REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
+      );
+
+      // Assert
+      const isDisabled =
+        settingsButton.props.disabled === true ||
+        settingsButton.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(false);
+    });
+  });
+
+  describe('modal triggering for current account', () => {
+    it('shows not opted in modal when account group has opted out accounts and modal has not been shown', async () => {
+      // Arrange
       const mockAccountGroupWithOptedOut = {
         id: 'keyring:wallet1/1' as const,
         name: 'Account Group 1',
@@ -1256,31 +503,14 @@ describe('RewardsDashboard', () => {
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Wait for effects to run
+      // Assert
       await waitFor(() => {
         expect(mockShowNotOptedInModal).toHaveBeenCalled();
       });
     });
 
-    it('should show not supported modal when account group is not fully supported and modal has not been shown', async () => {
-      // Arrange - isCampaignsEnabled is true so showPreviousSeasonSummary is false
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
+    it('shows not supported modal when account group is not fully supported and modal has not been shown', async () => {
+      // Arrange
       mockUseRewardOptinSummary.mockReturnValue({
         ...defaultHookValues.useRewardOptinSummary,
         currentAccountGroupPartiallySupported: false,
@@ -1290,31 +520,15 @@ describe('RewardsDashboard', () => {
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Wait for effects to run
+      // Assert
       await waitFor(() => {
         expect(mockShowNotSupportedModal).toHaveBeenCalled();
       });
     });
 
-    it('should not show modal when modal has already been shown in session', () => {
+    it('does not show modal when modal has already been shown in session', () => {
       // Arrange
-      mockHasShownModal.mockReturnValue(true); // Modal already shown
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
+      mockHasShownModal.mockReturnValue(true);
 
       const mockAccountGroupWithOptedOut = {
         id: 'keyring:wallet1/1' as const,
@@ -1355,111 +569,46 @@ describe('RewardsDashboard', () => {
   });
 
   describe('modal triggering for unlinked accounts', () => {
-    beforeEach(() => {
-      // Set up default state for unlinked accounts modal tests
-      const mockWalletWithOptedOutAccounts = [
-        {
-          wallet: {
-            id: 'keyring:wallet1' as const,
-            metadata: {
-              name: 'Wallet 1',
-            },
-            groups: {},
-            type: AccountWalletType.Keyring as const,
-            status: 'in-progress:discovery' as const,
+    const mockWalletWithOptedOutAccounts = [
+      {
+        wallet: {
+          id: 'keyring:wallet1' as const,
+          metadata: {
+            name: 'Wallet 1',
           },
-          groups: [
-            {
-              id: 'keyring:wallet1/2' as const,
-              name: 'Account Group 2',
-              optedInAccounts: [],
-              optedOutAccounts: [
-                {
-                  id: 'account-2',
-                  address: '0x456',
-                  type: 'eip155:eoa' as const,
-                  options: {},
-                  metadata: {
-                    name: 'Account 2',
-                    importTime: Date.now(),
-                    keyring: { type: 'HD Key Tree' },
-                  },
-                  scopes: ['eip155:1'] as `${string}:${string}`[],
-                  methods: ['eth_sendTransaction'],
-                  hasOptedIn: false,
-                },
-              ],
-              unsupportedAccounts: [],
-            },
-          ],
+          groups: {},
+          type: AccountWalletType.Keyring as const,
+          status: 'in-progress:discovery' as const,
         },
-      ];
-
-      mockUseRewardOptinSummary.mockReturnValue({
-        ...defaultHookValues.useRewardOptinSummary,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        byWallet: mockWalletWithOptedOutAccounts as any,
-      });
-    });
-
-    it('should show unlinked accounts modal when there are unlinked accounts and user has subscription', async () => {
-      // Arrange - Mock account group as fully opted in and has unlinked accounts
-      // isCampaignsEnabled is true so showPreviousSeasonSummary is false
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      const mockWalletWithOptedOutAccounts = [
-        {
-          wallet: {
-            id: 'keyring:wallet1' as const,
-            metadata: {
-              name: 'Wallet 1',
-            },
-            groups: {},
-            type: AccountWalletType.Keyring as const,
-            status: 'in-progress:discovery' as const,
+        groups: [
+          {
+            id: 'keyring:wallet1/2' as const,
+            name: 'Account Group 2',
+            optedInAccounts: [],
+            optedOutAccounts: [
+              {
+                id: 'account-2',
+                address: '0x456',
+                type: 'eip155:eoa' as const,
+                options: {},
+                metadata: {
+                  name: 'Account 2',
+                  importTime: Date.now(),
+                  keyring: { type: 'HD Key Tree' },
+                },
+                scopes: ['eip155:1'] as `${string}:${string}`[],
+                methods: ['eth_sendTransaction'],
+                hasOptedIn: false,
+              },
+            ],
+            unsupportedAccounts: [],
           },
-          groups: [
-            {
-              id: 'keyring:wallet1/2' as const,
-              name: 'Account Group 2',
-              optedInAccounts: [],
-              optedOutAccounts: [
-                {
-                  id: 'account-2',
-                  address: '0x456',
-                  type: 'eip155:eoa' as const,
-                  options: {},
-                  metadata: {
-                    name: 'Account 2',
-                    importTime: Date.now(),
-                    keyring: { type: 'HD Key Tree' },
-                  },
-                  scopes: ['eip155:1'] as `${string}:${string}`[],
-                  methods: ['eth_sendTransaction'],
-                  hasOptedIn: false,
-                },
-              ],
-              unsupportedAccounts: [],
-            },
-          ],
-        },
-      ];
+        ],
+      },
+    ];
 
+    it('shows unlinked accounts modal when there are unlinked accounts and user has subscription', async () => {
+      // Arrange
       mockUseRewardOptinSummary.mockReturnValue({
         ...defaultHookValues.useRewardOptinSummary,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1471,13 +620,13 @@ describe('RewardsDashboard', () => {
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Wait for effects to run
+      // Assert
       await waitFor(() => {
         expect(mockShowUnlinkedAccountsModal).toHaveBeenCalled();
       });
     });
 
-    it('should not show unlinked accounts modal when hideUnlinkedAccountsBanner is true', () => {
+    it('does not show unlinked accounts modal when hideUnlinkedAccountsBanner is true', () => {
       // Arrange
       mockSelectHideUnlinkedAccountsBanner.mockReturnValue(true);
       mockUseSelector.mockImplementation((selector) => {
@@ -1485,14 +634,11 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
         if (selector === selectHideUnlinkedAccountsBanner) return true;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
         return undefined;
       });
 
@@ -1503,27 +649,11 @@ describe('RewardsDashboard', () => {
       expect(mockShowUnlinkedAccountsModal).not.toHaveBeenCalled();
     });
 
-    it('should not show unlinked accounts modal when modal has already been shown', () => {
-      // Arrange - setup mock to return true for unlinked accounts modal
+    it('does not show unlinked accounts modal when modal has already been shown', () => {
+      // Arrange
       mockHasShownModal.mockImplementation(
         (modalType) => modalType === 'unlinked-accounts',
       );
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
 
       // Act
       render(<RewardsDashboard />);
@@ -1534,13 +664,8 @@ describe('RewardsDashboard', () => {
   });
 
   describe('modal prioritization', () => {
-    it('should show unlinked accounts modal when current account banner dismissed and account group is fully opted in', async () => {
-      // Arrange - Mock account group as fully opted in and banner dismissed
-      // isCampaignsEnabled is true so showPreviousSeasonSummary is false
-      mockSelectHideCurrentAccountNotOptedInBannerArray.mockReturnValue([
-        { accountGroupId: 'keyring:wallet1/1' as const, hide: true },
-      ]);
-
+    it('shows unlinked accounts modal when current account banner dismissed and account group is fully opted in', async () => {
+      // Arrange
       const mockWalletWithOptedOutAccounts = [
         {
           wallet: {
@@ -1592,47 +717,27 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return [{ accountGroupId: 'keyring:wallet1/1', hide: true }];
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
         return undefined;
       });
 
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Wait for effects to run
+      // Assert
       await waitFor(() => {
         expect(mockShowUnlinkedAccountsModal).toHaveBeenCalled();
       });
       expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
     });
 
-    it('should prioritize not supported modal over other modals', async () => {
-      // Arrange - isCampaignsEnabled is true so showPreviousSeasonSummary is false
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
+    it('prioritizes not supported modal over other modals', async () => {
+      // Arrange
       const mockWalletWithOptedOutAccounts = [
         {
           wallet: {
@@ -1682,7 +787,7 @@ describe('RewardsDashboard', () => {
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Wait for effects to run
+      // Assert
       await waitFor(() => {
         expect(mockShowNotSupportedModal).toHaveBeenCalled();
       });
@@ -1692,25 +797,8 @@ describe('RewardsDashboard', () => {
   });
 
   describe('account group opt-in status logic', () => {
-    it('should not show modal when account group is fully opted in', () => {
-      // Arrange - Mock account group with all accounts opted in
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
+    it('does not show modal when account group is fully opted in', () => {
+      // Arrange
       const mockAccountGroupFullyOptedIn = {
         id: 'keyring:wallet1/1' as const,
         name: 'Account Group 1',
@@ -1722,20 +810,6 @@ describe('RewardsDashboard', () => {
             options: {},
             metadata: {
               name: 'Account 1',
-              importTime: Date.now(),
-              keyring: { type: 'HD Key Tree' },
-            },
-            scopes: ['eip155:1'] as `${string}:${string}`[],
-            methods: ['eth_sendTransaction'],
-            hasOptedIn: true,
-          },
-          {
-            id: 'account-2',
-            address: '0x456',
-            type: 'eip155:eoa' as const,
-            options: {},
-            metadata: {
-              name: 'Account 2',
               importTime: Date.now(),
               keyring: { type: 'HD Key Tree' },
             },
@@ -1763,26 +837,8 @@ describe('RewardsDashboard', () => {
       expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
     });
 
-    it('should show not supported modal when account group contains unsupported accounts', async () => {
-      // Arrange - Mock account group with unsupported accounts
-      // isCampaignsEnabled is true so showPreviousSeasonSummary is false
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
+    it('shows not supported modal when account group contains unsupported accounts', async () => {
+      // Arrange
       mockUseRewardOptinSummary.mockReturnValue({
         ...defaultHookValues.useRewardOptinSummary,
         currentAccountGroupPartiallySupported: false,
@@ -1792,22 +848,21 @@ describe('RewardsDashboard', () => {
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Wait for effects to run
+      // Assert
       await waitFor(() => {
         expect(mockShowNotSupportedModal).toHaveBeenCalled();
       });
       expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
     });
 
-    it('should handle null selectedAccountGroup gracefully', () => {
-      // Arrange - Mock null selectedAccountGroup
+    it('handles null selectedAccountGroup gracefully', () => {
+      // Arrange
       mockSelectSelectedAccountGroup.mockReturnValue(null);
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectActiveTab)
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
@@ -1823,14 +878,14 @@ describe('RewardsDashboard', () => {
         currentAccountGroupOptedInStatus: null,
       });
 
-      // Act & Assert - Should not throw error
+      // Act & Assert
       expect(() => render(<RewardsDashboard />)).not.toThrow();
       expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
       expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
     });
 
-    it('should not show not opted in modal when selectedAccountGroup has no id', () => {
-      // Arrange - Mock selectedAccountGroup without id
+    it('does not show modals when selectedAccountGroup has no id', () => {
+      // Arrange
       mockSelectSelectedAccountGroup.mockReturnValue({
         ...mockSelectedAccountGroup,
         id: undefined as never,
@@ -1840,66 +895,6 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return { ...mockSelectedAccountGroup, id: undefined };
-        return undefined;
-      });
-
-      const mockAccountGroupWithOptedOut = {
-        id: 'keyring:wallet1/1' as const,
-        name: 'Account Group 1',
-        optedInAccounts: [],
-        optedOutAccounts: [
-          {
-            id: 'account-1',
-            address: '0x123',
-            type: 'eip155:eoa' as const,
-            options: {},
-            metadata: {
-              name: 'Account 1',
-              importTime: Date.now(),
-              keyring: { type: 'HD Key Tree' },
-            },
-            scopes: ['eip155:1'] as `${string}:${string}`[],
-            methods: ['eth_sendTransaction'],
-            hasOptedIn: false,
-          },
-        ],
-        unsupportedAccounts: [],
-      };
-
-      mockUseRewardOptinSummary.mockReturnValue({
-        ...defaultHookValues.useRewardOptinSummary,
-        bySelectedAccountGroup: mockAccountGroupWithOptedOut,
-        currentAccountGroupPartiallySupported: true,
-        currentAccountGroupOptedInStatus: 'notOptedIn',
-      });
-
-      // Act
-      render(<RewardsDashboard />);
-
-      // Assert - Should not show modals when selectedAccountGroup has no id
-      expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
-      expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
-    });
-
-    it('should not show not supported modal when selectedAccountGroup has no id', () => {
-      // Arrange - Mock selectedAccountGroup without id
-      mockSelectSelectedAccountGroup.mockReturnValue({
-        ...mockSelectedAccountGroup,
-        id: undefined as never,
-      });
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
@@ -1918,197 +913,14 @@ describe('RewardsDashboard', () => {
       // Act
       render(<RewardsDashboard />);
 
-      // Assert - Should not show modals when selectedAccountGroup has no id
+      // Assert
       expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
       expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('early return conditions', () => {
-    it('should return early and not show modals when seasonId is null', () => {
-      // Arrange - Set seasonId to null
-      mockSelectSeasonId.mockReturnValue(null);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return null;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      // Setup conditions that would normally trigger modals
-      const mockAccountGroupWithOptedOut = {
-        id: 'keyring:wallet1/1' as const,
-        name: 'Account Group 1',
-        optedInAccounts: [],
-        optedOutAccounts: [
-          {
-            id: 'account-1',
-            address: '0x123',
-            type: 'eip155:eoa' as const,
-            options: {},
-            metadata: {
-              name: 'Account 1',
-              importTime: Date.now(),
-              keyring: { type: 'HD Key Tree' },
-            },
-            scopes: ['eip155:1'] as `${string}:${string}`[],
-            methods: ['eth_sendTransaction'],
-            hasOptedIn: false,
-          },
-        ],
-        unsupportedAccounts: [],
-      };
-
-      mockUseRewardOptinSummary.mockReturnValue({
-        ...defaultHookValues.useRewardOptinSummary,
-        bySelectedAccountGroup: mockAccountGroupWithOptedOut,
-        currentAccountGroupPartiallySupported: true,
-        currentAccountGroupOptedInStatus: 'notOptedIn',
-      });
-
-      // Act
-      render(<RewardsDashboard />);
-
-      // Assert - Should return early, no modals should be shown
-      expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
-      expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
-      expect(mockShowUnlinkedAccountsModal).not.toHaveBeenCalled();
-    });
-
-    it('should return early and not show modals when showPreviousSeasonSummary is true', () => {
-      // Arrange - isCampaignsEnabled must be false for showPreviousSeasonSummary to be true
-      mockSelectSeasonId.mockReturnValue(currentSeasonId);
-      mockSelectCampaignsRewardsEnabledFlag.mockReturnValue(false);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag) return false;
-        return undefined;
-      });
-
-      // Setup conditions that would normally trigger modals
-      const mockAccountGroupWithOptedOut = {
-        id: 'keyring:wallet1/1' as const,
-        name: 'Account Group 1',
-        optedInAccounts: [],
-        optedOutAccounts: [
-          {
-            id: 'account-1',
-            address: '0x123',
-            type: 'eip155:eoa' as const,
-            options: {},
-            metadata: {
-              name: 'Account 1',
-              importTime: Date.now(),
-              keyring: { type: 'HD Key Tree' },
-            },
-            scopes: ['eip155:1'] as `${string}:${string}`[],
-            methods: ['eth_sendTransaction'],
-            hasOptedIn: false,
-          },
-        ],
-        unsupportedAccounts: [],
-      };
-
-      mockUseRewardOptinSummary.mockReturnValue({
-        ...defaultHookValues.useRewardOptinSummary,
-        bySelectedAccountGroup: mockAccountGroupWithOptedOut,
-        currentAccountGroupPartiallySupported: true,
-        currentAccountGroupOptedInStatus: 'notOptedIn',
-      });
-
-      // Act
-      render(<RewardsDashboard />);
-
-      // Assert - Should return early when showPreviousSeasonSummary is true, no modals should be shown
-      expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
-      expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
-      expect(mockShowUnlinkedAccountsModal).not.toHaveBeenCalled();
-    });
-
-    it('should return early and not show modals when showPreviousSeasonSummary is null', () => {
-      // Arrange - Set seasonId to null so showPreviousSeasonSummary is null
-      // This tests the case where the useFocusEffect hasn't evaluated yet
-      mockSelectSeasonId.mockReturnValue(null);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab)
-          return defaultSelectorValues.activeTab;
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return null;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      // Setup conditions that would normally trigger modals
-      const mockAccountGroupWithOptedOut = {
-        id: 'keyring:wallet1/1' as const,
-        name: 'Account Group 1',
-        optedInAccounts: [],
-        optedOutAccounts: [
-          {
-            id: 'account-1',
-            address: '0x123',
-            type: 'eip155:eoa' as const,
-            options: {},
-            metadata: {
-              name: 'Account 1',
-              importTime: Date.now(),
-              keyring: { type: 'HD Key Tree' },
-            },
-            scopes: ['eip155:1'] as `${string}:${string}`[],
-            methods: ['eth_sendTransaction'],
-            hasOptedIn: false,
-          },
-        ],
-        unsupportedAccounts: [],
-      };
-
-      mockUseRewardOptinSummary.mockReturnValue({
-        ...defaultHookValues.useRewardOptinSummary,
-        bySelectedAccountGroup: mockAccountGroupWithOptedOut,
-        currentAccountGroupPartiallySupported: true,
-        currentAccountGroupOptedInStatus: 'notOptedIn',
-      });
-
-      // Act
-      render(<RewardsDashboard />);
-
-      // Assert - Should return early when showPreviousSeasonSummary is null, no modals should be shown
-      expect(mockShowNotOptedInModal).not.toHaveBeenCalled();
-      expect(mockShowNotSupportedModal).not.toHaveBeenCalled();
-      expect(mockShowUnlinkedAccountsModal).not.toHaveBeenCalled();
     });
   });
 
   describe('hook integration', () => {
-    it('should call useRewardDashboardModals hook', () => {
+    it('calls useRewardDashboardModals hook', () => {
       // Act
       render(<RewardsDashboard />);
 
@@ -2118,7 +930,7 @@ describe('RewardsDashboard', () => {
   });
 
   describe('metrics tracking', () => {
-    it('should track dashboard viewed event on mount', () => {
+    it('tracks dashboard viewed event on mount', () => {
       // Act
       render(<RewardsDashboard />);
 
@@ -2130,8 +942,8 @@ describe('RewardsDashboard', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith({ event: 'mock-event' });
     });
 
-    it('should track dashboard viewed event only once', () => {
-      // Act - Render component once
+    it('tracks dashboard viewed event only once', () => {
+      // Act
       const { rerender } = render(<RewardsDashboard />);
 
       // Count initial calls
@@ -2146,8 +958,7 @@ describe('RewardsDashboard', () => {
       // Rerender should not trigger the event again due to ref guard
       rerender(<RewardsDashboard />);
 
-      // Assert - should not be called again after initial render
-      // The ref guard prevents multiple calls
+      // Assert
       expect(mockCreateEventBuilder).not.toHaveBeenCalled();
     });
 
@@ -2158,23 +969,18 @@ describe('RewardsDashboard', () => {
       mockCreateEventBuilder.mockClear();
       mockBuild.mockClear();
 
-      // Act - change active tab from campaigns to activity
+      // Act
       mockSelectActiveTab.mockReturnValue('activity');
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectActiveTab) return 'activity';
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo)
-          return defaultSelectorValues.optinAllowedForGeo;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
         return undefined;
       });
       rerender(<RewardsDashboard />);
@@ -2186,92 +992,6 @@ describe('RewardsDashboard', () => {
       expect(mockAddProperties).toHaveBeenCalledWith({ tab: 'activity' });
       expect(mockBuild).toHaveBeenCalled();
       expect(mockTrackEvent).toHaveBeenCalledWith({ event: 'mock-event' });
-    });
-
-    it('tracks tab viewed event for each tab change', () => {
-      // Arrange
-      const { rerender } = render(<RewardsDashboard />);
-      mockTrackEvent.mockClear();
-      mockCreateEventBuilder.mockClear();
-      mockBuild.mockClear();
-      mockAddProperties.mockClear();
-
-      // Act - change to activity tab
-      mockSelectActiveTab.mockReturnValue('activity');
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab) return 'activity';
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo)
-          return defaultSelectorValues.optinAllowedForGeo;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-      rerender(<RewardsDashboard />);
-
-      // Assert - activity tab
-      expect(mockAddProperties).toHaveBeenCalledWith({ tab: 'activity' });
-
-      // Act - change back to campaigns tab
-      mockSelectActiveTab.mockReturnValue('campaigns');
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab) return 'campaigns';
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectOptinAllowedForGeo)
-          return defaultSelectorValues.optinAllowedForGeo;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-      rerender(<RewardsDashboard />);
-
-      // Assert - campaigns tab
-      expect(mockAddProperties).toHaveBeenCalledWith({ tab: 'campaigns' });
-    });
-  });
-
-  describe('TabsList ref functionality', () => {
-    it('handles Redux state changes for activeTab without crashing', () => {
-      // Arrange
-      mockSelectActiveTab.mockReturnValue('campaigns');
-      const { rerender } = render(<RewardsDashboard />);
-
-      // Act - change activeTab in Redux to campaigns
-      mockSelectActiveTab.mockReturnValue('campaigns');
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectActiveTab) return 'campaigns';
-        if (selector === selectRewardsSubscriptionId)
-          return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return currentSeasonId;
-        if (selector === selectHideUnlinkedAccountsBanner)
-          return defaultSelectorValues.hideUnlinkedAccountsBanner;
-        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
-          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedAccountGroup)
-          return defaultSelectorValues.selectedAccountGroup;
-        if (selector === selectCampaignsRewardsEnabledFlag)
-          return defaultSelectorValues.isCampaignsEnabled;
-        return undefined;
-      });
-
-      // Assert - does not crash when activeTab changes
-      expect(() => rerender(<RewardsDashboard />)).not.toThrow();
     });
   });
 

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { Box, IconName } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -19,28 +13,18 @@ import {
   selectActiveTab,
   selectHideUnlinkedAccountsBanner,
   selectHideCurrentAccountNotOptedInBannerArray,
-  selectSeasonId,
-  selectOptinAllowedForGeo,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { useRewardOptinSummary } from '../hooks/useRewardOptinSummary';
 import {
   useRewardDashboardModals,
   RewardsDashboardModalType,
 } from '../hooks/useRewardDashboardModals';
 import { useBulkLinkState } from '../hooks/useBulkLinkState';
-import MusdCalculatorTab from '../components/Tabs/MusdCalculatorTab/MusdCalculatorTab';
-import { TabsList } from '../../../../component-library/components-temp/Tabs';
-import {
-  TabsListRef,
-  TabViewProps,
-} from '../../../../component-library/components-temp/Tabs/TabsList/TabsList.types';
 import Toast from '../../../../component-library/components/Toast';
 import { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 import { MetaMetricsEvents, useMetrics } from '../../../hooks/useMetrics';
 import { selectSelectedAccountGroup } from '../../../../selectors/multichainAccounts/accountTreeController';
-import PreviousSeasonSummary from '../components/PreviousSeason/PreviousSeasonSummary';
 import CampaignsPreview from '../components/Campaigns/CampaignsPreview';
 import EarnRewardsPreview from '../components/EarnRewards/EarnRewardsPreview';
 
@@ -55,9 +39,6 @@ const RewardsDashboard: React.FC = () => {
   const hideUnlinkedAccountsBanner = useSelector(
     selectHideUnlinkedAccountsBanner,
   );
-  const seasonId = useSelector(selectSeasonId);
-  const optinAllowedForGeo = useSelector(selectOptinAllowedForGeo);
-  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
   const hideCurrentAccountNotOptedInBannerMap = useSelector(
     selectHideCurrentAccountNotOptedInBannerArray,
   );
@@ -72,11 +53,6 @@ const RewardsDashboard: React.FC = () => {
     }
     return false;
   }, [selectedAccountGroup?.id, hideCurrentAccountNotOptedInBannerMap]);
-
-  const [showPreviousSeasonSummary, setShowPreviousSeasonSummary] = useState<
-    boolean | null
-  >(null);
-  const tabsListRef = useRef<TabsListRef>(null);
 
   // Use the reward dashboard modals hook
   const {
@@ -127,26 +103,11 @@ const RewardsDashboard: React.FC = () => {
     }, [wasInterrupted, isRunning, resumeBulkLink]),
   );
 
-  // Evaluate showPreviousSeasonSummary when screen comes into focus
-  useFocusEffect(
-    useCallback(() => {
-      const shouldShow = Boolean(seasonId && !isCampaignsEnabled);
-      setShowPreviousSeasonSummary(shouldShow);
-    }, [seasonId, isCampaignsEnabled]),
-  );
-
   // Auto-trigger dashboard modals based on account/rewards state (session-aware)
   // This effect runs whenever key dependencies change and determines which informational
   // modal should be shown to guide the user. Each modal type is only shown once per app session.
   useFocusEffect(
     useCallback(() => {
-      if (
-        !seasonId ||
-        showPreviousSeasonSummary === null ||
-        showPreviousSeasonSummary
-      )
-        return;
-
       if (
         (totalOptedInAccountsSelectedGroup === 0 ||
           currentAccountGroupPartiallySupported === false) &&
@@ -182,8 +143,6 @@ const RewardsDashboard: React.FC = () => {
         }
       }
     }, [
-      seasonId,
-      showPreviousSeasonSummary,
       totalOptedInAccountsSelectedGroup,
       currentAccountGroupPartiallySupported,
       hideCurrentAccountNotOptedInBanner,
@@ -232,51 +191,11 @@ const RewardsDashboard: React.FC = () => {
               disabled: !subscriptionId,
               testID: REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
             },
-            ...(showPreviousSeasonSummary === false
-              ? [
-                  {
-                    iconName: IconName.UserCircleAdd,
-                    onPress: () =>
-                      navigation.navigate(Routes.REFERRAL_REWARDS_VIEW),
-                    disabled: !subscriptionId,
-                    testID: REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
-                  },
-                ]
-              : []),
           ]}
         />
         <Box twClassName="flex-1 gap-4">
-          {isCampaignsEnabled && <CampaignsPreview />}
-          {isCampaignsEnabled && <EarnRewardsPreview />}
-          {showPreviousSeasonSummary &&
-            (optinAllowedForGeo ? (
-              <TabsList
-                ref={tabsListRef}
-                initialActiveIndex={0}
-                testID={REWARDS_VIEW_SELECTORS.TAB_CONTROL}
-                tabsBarProps={{ twClassName: 'px-4' }}
-                tabsListContentTwClassName="px-0"
-              >
-                <Box
-                  key="musd"
-                  {...({ tabLabel: 'mUSD' } as TabViewProps)}
-                  twClassName="flex-1"
-                >
-                  <MusdCalculatorTab />
-                </Box>
-                <Box
-                  key="previous-season"
-                  {...({
-                    tabLabel: strings('rewards.season_1'),
-                  } as TabViewProps)}
-                  twClassName="flex-1"
-                >
-                  <PreviousSeasonSummary />
-                </Box>
-              </TabsList>
-            ) : (
-              <PreviousSeasonSummary />
-            ))}
+          <CampaignsPreview />
+          <EarnRewardsPreview />
         </Box>
       </SafeAreaView>
       <Toast ref={toastRef} />

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -335,5 +335,46 @@ describe('CampaignTile', () => {
         campaignId: 'camp-42',
       });
     });
+
+    it('calls custom onPress handler instead of navigating when provided', () => {
+      const campaign = createTestCampaign({ id: 'camp-custom' });
+      const mockOnPress = jest.fn();
+
+      const { getByTestId } = render(
+        <CampaignTile campaign={campaign} onPress={mockOnPress} />,
+      );
+      fireEvent.press(getByTestId('campaign-tile-camp-custom'));
+
+      expect(mockOnPress).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when isInteractive is false', () => {
+      const campaign = createTestCampaign({ id: 'camp-disabled' });
+
+      const { getByTestId } = render(
+        <CampaignTile campaign={campaign} isInteractive={false} />,
+      );
+      fireEvent.press(getByTestId('campaign-tile-camp-disabled'));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('does not call onPress when isInteractive is false', () => {
+      const campaign = createTestCampaign({ id: 'camp-both' });
+      const mockOnPress = jest.fn();
+
+      const { getByTestId } = render(
+        <CampaignTile
+          campaign={campaign}
+          isInteractive={false}
+          onPress={mockOnPress}
+        />,
+      );
+      fireEvent.press(getByTestId('campaign-tile-camp-both'));
+
+      expect(mockOnPress).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
@@ -26,13 +26,30 @@ import useGetCampaignParticipantStatus from '../../hooks/useGetCampaignParticipa
 
 interface CampaignTileProps {
   campaign: CampaignDto;
+  /**
+   * Whether the tile is interactive (pressable). Defaults to true.
+   * When false, the tile is displayed but cannot be tapped.
+   */
+  isInteractive?: boolean;
+  /**
+   * Custom press handler. If provided, this is called instead of the default
+   * navigation to campaign details. Only used when isInteractive is true.
+   */
+  onPress?: () => void;
 }
 
 /**
  * CampaignTile displays campaign information with status.
- * Tapping navigates to the campaign details screen.
+ * Tapping behavior can be customized via props:
+ * - Default: navigates to campaign details screen
+ * - With onPress: executes custom handler
+ * - With isInteractive=false: tile is not pressable
  */
-const CampaignTile: React.FC<CampaignTileProps> = ({ campaign }) => {
+const CampaignTile: React.FC<CampaignTileProps> = ({
+  campaign,
+  isInteractive = true,
+  onPress,
+}) => {
   const tw = useTailwind();
   const colorScheme = useColorScheme();
   const navigation = useNavigation();
@@ -58,16 +75,23 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign }) => {
       : campaign.details?.image?.lightModeUrl;
 
   const handlePress = () => {
-    navigation.navigate(Routes.CAMPAIGN_DETAILS, { campaignId: campaign.id });
+    if (!isInteractive) return;
+
+    if (onPress) {
+      onPress();
+    } else {
+      navigation.navigate(Routes.CAMPAIGN_DETAILS, { campaignId: campaign.id });
+    }
   };
 
   return (
     <Pressable
       onPress={handlePress}
+      disabled={!isInteractive}
       style={({ pressed }) =>
         tw.style(
           'rounded-xl overflow-hidden h-50 bg-muted',
-          pressed && 'opacity-70',
+          pressed && isInteractive && 'opacity-70',
         )
       }
       testID={`campaign-tile-${campaign.id}`}

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsGroup.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsGroup.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import CampaignTile from './CampaignTile';
 import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import PreviousSeasonTile from '../PreviousSeason/PreviousSeasonTile';
 import { selectSeasonName } from '../../../../../reducers/rewards/selectors';
-import { useSelector } from 'react-redux';
+import { selectCampaignsRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
 
 interface CampaignsGroupProps {
   title: string;
@@ -23,6 +24,7 @@ const CampaignsGroup: React.FC<CampaignsGroupProps> = ({
   displayPreviousSeason = false,
 }) => {
   const seasonName = useSelector(selectSeasonName);
+  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
   const showPreviousSeason = displayPreviousSeason && !!seasonName;
 
   if (campaigns.length === 0 && !showPreviousSeason) {
@@ -35,7 +37,11 @@ const CampaignsGroup: React.FC<CampaignsGroupProps> = ({
         {title}
       </Text>
       {campaigns.map((campaign) => (
-        <CampaignTile key={campaign.id} campaign={campaign} />
+        <CampaignTile
+          key={campaign.id}
+          campaign={campaign}
+          isInteractive={isCampaignsEnabled}
+        />
       ))}
       {showPreviousSeason && <PreviousSeasonTile />}
     </Box>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.test.tsx
@@ -14,6 +14,15 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+jest.mock('../../../../../selectors/featureFlagController/rewards', () => ({
+  selectCampaignsRewardsEnabledFlag: jest.fn(() => true),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
   return { ...actual };
@@ -38,6 +47,20 @@ jest.mock('./CampaignTile', () => {
         Text,
         { testID: `campaign-tile-${campaign.id}` },
         campaign.name,
+      ),
+  };
+});
+
+jest.mock('../PreviousSeason/PreviousSeasonTile', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactActual.createElement(
+        Text,
+        { testID: 'previous-season-tile' },
+        'Previous Season Tile',
       ),
   };
 });
@@ -82,10 +105,27 @@ describe('CampaignsPreview', () => {
     mockUseRewardCampaigns.mockReturnValue(mockHookDefaults);
   });
 
-  it('returns null when there are no campaigns in any category', () => {
-    const { queryByTestId } = render(<CampaignsPreview />);
+  it('renders PreviousSeasonTile when there are no campaigns in any category', () => {
+    const { getByTestId } = render(<CampaignsPreview />);
 
-    expect(queryByTestId(REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW)).toBeNull();
+    expect(
+      getByTestId(REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW),
+    ).toBeOnTheScreen();
+    expect(getByTestId('previous-season-tile')).toBeOnTheScreen();
+  });
+
+  it('renders PreviousSeasonTile when there is an error and no campaigns', () => {
+    mockUseRewardCampaigns.mockReturnValue({
+      ...mockHookDefaults,
+      hasError: true,
+    });
+
+    const { getByTestId } = render(<CampaignsPreview />);
+
+    expect(
+      getByTestId(REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW),
+    ).toBeOnTheScreen();
+    expect(getByTestId('previous-season-tile')).toBeOnTheScreen();
   });
 
   it('renders the section title when an active campaign exists', () => {
@@ -247,5 +287,14 @@ describe('CampaignsPreview', () => {
     fireEvent.press(getByText('Campaigns'));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.CAMPAIGNS_VIEW);
+  });
+
+  it('navigates to previous season view when title header is pressed and no campaigns exist', () => {
+    mockUseRewardCampaigns.mockReturnValue(mockHookDefaults);
+
+    const { getByText } = render(<CampaignsPreview />);
+    fireEvent.press(getByText('Campaigns'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREVIOUS_SEASON_VIEW);
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { Pressable, ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { useTheme } from '../../../../../util/theme';
 import {
   Box,
@@ -20,6 +21,8 @@ import { strings } from '../../../../../../locales/i18n';
 import { useRewardCampaigns } from '../../hooks/useRewardCampaigns';
 import CampaignTile from './CampaignTile';
 import RewardsErrorBanner from '../RewardsErrorBanner';
+import { selectCampaignsRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
+import PreviousSeasonTile from '../PreviousSeason/PreviousSeasonTile';
 
 /**
  * CampaignsPreview shows a single featured campaign on the dashboard.
@@ -29,6 +32,7 @@ const CampaignsPreview: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const { colors } = useTheme();
+  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
   const { categorizedCampaigns, isLoading, hasError, fetchCampaigns } =
     useRewardCampaigns();
 
@@ -46,8 +50,33 @@ const CampaignsPreview: React.FC = () => {
     navigation.navigate(Routes.CAMPAIGNS_VIEW);
   }, [navigation]);
 
-  if (!isLoading && !hasError && !featuredCampaign) {
-    return null;
+  const handleNavigateToPreviousSeason = useCallback(() => {
+    navigation.navigate(Routes.PREVIOUS_SEASON_VIEW);
+  }, [navigation]);
+
+  const showPreviousSeasonTile = !isLoading && !featuredCampaign;
+
+  if (showPreviousSeasonTile) {
+    return (
+      <Box
+        twClassName="gap-3 p-4"
+        testID={REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW}
+      >
+        <Pressable onPress={handleNavigateToPreviousSeason}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="gap-2"
+          >
+            <Text variant={TextVariant.HeadingMd}>
+              {strings('rewards.campaigns_preview.title')}
+            </Text>
+            <Icon name={IconName.ArrowRight} size={IconSize.Md} />
+          </Box>
+        </Pressable>
+        <PreviousSeasonTile />
+      </Box>
+    );
   }
 
   return (
@@ -84,7 +113,12 @@ const CampaignsPreview: React.FC = () => {
         />
       )}
 
-      {featuredCampaign && <CampaignTile campaign={featuredCampaign} />}
+      {featuredCampaign && (
+        <CampaignTile
+          campaign={featuredCampaign}
+          onPress={isCampaignsEnabled ? undefined : handleNavigateToCampaigns}
+        />
+      )}
     </Box>
   );
 };

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.test.ts
@@ -258,8 +258,10 @@ describe('useRewardCampaigns', () => {
       expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsLoading(false));
     });
 
-    it('returns empty list and does not fetch when feature flag is disabled', async () => {
+    it('fetches campaigns even when feature flag is disabled', async () => {
       setupSelectorMocks({ isCampaignsEnabled: false });
+      const mockCampaignsData = [createTestCampaign()];
+      mockEngineCall.mockResolvedValueOnce(mockCampaignsData);
 
       const { result } = renderHook(() => useRewardCampaigns());
 
@@ -267,10 +269,13 @@ describe('useRewardCampaigns', () => {
         await result.current.fetchCampaigns();
       });
 
-      expect(mockEngineCall).not.toHaveBeenCalled();
-      expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaigns([]));
-      expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsLoading(false));
-      expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsError(false));
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getCampaigns',
+        'subscription-1',
+      );
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetCampaigns(mockCampaignsData),
+      );
     });
 
     it('does not fetch when subscriptionId is null', async () => {
@@ -470,6 +475,104 @@ describe('useRewardCampaigns', () => {
       expect(result.current.categorizedCampaigns.previous[1].id).toBe(
         'complete-1',
       );
+    });
+
+    it('filters out active and previous campaigns when feature flag is disabled', () => {
+      const activeCampaign = createTestCampaign({
+        id: 'active-1',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2099-12-31T23:59:59.999Z',
+      });
+      const upcomingCampaign = createTestCampaign({
+        id: 'upcoming-1',
+        startDate: '2099-06-01T00:00:00.000Z',
+        endDate: '2099-12-31T23:59:59.999Z',
+      });
+      const completeCampaign = createTestCampaign({
+        id: 'complete-1',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2020-12-31T23:59:59.999Z',
+      });
+
+      setupSelectorMocks({
+        campaigns: [activeCampaign, upcomingCampaign, completeCampaign],
+        isCampaignsEnabled: false,
+      });
+
+      const { result } = renderHook(() => useRewardCampaigns());
+
+      expect(result.current.categorizedCampaigns.active).toEqual([]);
+      expect(result.current.categorizedCampaigns.upcoming).toEqual([
+        upcomingCampaign,
+      ]);
+      expect(result.current.categorizedCampaigns.previous).toEqual([]);
+    });
+
+    it('returns only upcoming campaigns when feature flag is disabled', () => {
+      const activeCampaign = createTestCampaign({
+        id: 'active-1',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2099-12-31T23:59:59.999Z',
+      });
+      const upcomingCampaign = createTestCampaign({
+        id: 'upcoming-1',
+        startDate: '2099-06-01T00:00:00.000Z',
+        endDate: '2099-12-31T23:59:59.999Z',
+      });
+      const completeCampaign = createTestCampaign({
+        id: 'complete-1',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2020-12-31T23:59:59.999Z',
+      });
+
+      setupSelectorMocks({
+        campaigns: [activeCampaign, upcomingCampaign, completeCampaign],
+        isCampaignsEnabled: false,
+      });
+
+      const { result } = renderHook(() => useRewardCampaigns());
+
+      expect(result.current.campaigns).toEqual([upcomingCampaign]);
+    });
+
+    it('returns all campaigns when feature flag is enabled', () => {
+      const activeCampaign = createTestCampaign({
+        id: 'active-1',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2099-12-31T23:59:59.999Z',
+      });
+      const upcomingCampaign = createTestCampaign({
+        id: 'upcoming-1',
+        startDate: '2099-06-01T00:00:00.000Z',
+        endDate: '2099-12-31T23:59:59.999Z',
+      });
+      const completeCampaign = createTestCampaign({
+        id: 'complete-1',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2020-12-31T23:59:59.999Z',
+      });
+
+      setupSelectorMocks({
+        campaigns: [activeCampaign, upcomingCampaign, completeCampaign],
+        isCampaignsEnabled: true,
+      });
+
+      const { result } = renderHook(() => useRewardCampaigns());
+
+      expect(result.current.campaigns).toEqual([
+        activeCampaign,
+        upcomingCampaign,
+        completeCampaign,
+      ]);
+      expect(result.current.categorizedCampaigns.active).toEqual([
+        activeCampaign,
+      ]);
+      expect(result.current.categorizedCampaigns.upcoming).toEqual([
+        upcomingCampaign,
+      ]);
+      expect(result.current.categorizedCampaigns.previous).toEqual([
+        completeCampaign,
+      ]);
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
@@ -25,7 +25,7 @@ interface CategorizedCampaigns {
 }
 
 interface UseRewardCampaignsReturn {
-  /** Campaigns fetched from the API, or empty array when flag is disabled */
+  /** Campaigns fetched from the API. When campaigns flag is disabled, only upcoming campaigns are returned */
   campaigns: CampaignDto[];
   /** Campaigns categorized by status */
   categorizedCampaigns: CategorizedCampaigns;
@@ -40,7 +40,8 @@ interface UseRewardCampaignsReturn {
 /**
  * Custom hook to fetch and manage campaigns data from the rewards API.
  * Categorizes campaigns into active, upcoming, and previous (complete).
- * Returns an empty list when the rewards-campaigns-enabled feature flag is off.
+ * When the campaigns feature flag is disabled, only upcoming campaigns are returned
+ * (active and previous are filtered out).
  */
 export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
@@ -52,7 +53,7 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
   const isLoadingRef = useRef(false);
 
   const fetchCampaigns = useCallback(async (): Promise<void> => {
-    if (!subscriptionId || !isCampaignsEnabled) {
+    if (!subscriptionId) {
       dispatch(setCampaigns([]));
       dispatch(setCampaignsLoading(false));
       dispatch(setCampaignsError(false));
@@ -80,7 +81,7 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
       isLoadingRef.current = false;
       dispatch(setCampaignsLoading(false));
     }
-  }, [dispatch, subscriptionId, isCampaignsEnabled]);
+  }, [dispatch, subscriptionId]);
 
   const categorizedCampaigns = useMemo((): CategorizedCampaigns => {
     const campaignsList = campaigns ?? [];
@@ -117,8 +118,13 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
       (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime(),
     );
 
+    // When campaigns feature is disabled, only show upcoming campaigns
+    if (!isCampaignsEnabled) {
+      return { active: [], upcoming, previous: [] };
+    }
+
     return { active, upcoming, previous };
-  }, [campaigns]);
+  }, [campaigns, isCampaignsEnabled]);
 
   useFocusEffect(
     useCallback(() => {
@@ -137,8 +143,15 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
 
   useInvalidateByRewardEvents(invalidateEvents, fetchCampaigns);
 
+  // When campaigns feature is disabled, only return upcoming campaigns
+  const filteredCampaigns = useMemo(
+    () =>
+      isCampaignsEnabled ? (campaigns ?? []) : categorizedCampaigns.upcoming,
+    [isCampaignsEnabled, campaigns, categorizedCampaigns.upcoming],
+  );
+
   return {
-    campaigns: campaigns ?? [],
+    campaigns: filteredCampaigns,
     categorizedCampaigns,
     isLoading,
     hasError,

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -18655,27 +18655,10 @@ describe('RewardsController', () => {
       );
     });
 
-    it('returns empty array when campaigns feature flag is disabled', async () => {
-      const disabledController = new RewardsController({
-        messenger: mockMessenger,
-        state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => false,
-      });
-
-      const result = await disabledController.getCampaigns(mockSubscriptionId);
-
-      expect(result).toEqual([]);
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
-        'RewardsDataService:getCampaigns',
-        expect.anything(),
-      );
-    });
-
-    it('fetches campaigns when campaigns feature flag is enabled', async () => {
+    it('fetches campaigns when rewards is enabled', async () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       const mockCampaigns = [createTestCampaign({ id: 'campaign-flag-test' })];
@@ -18694,7 +18677,6 @@ describe('RewardsController', () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       const mockCampaigns = [
@@ -18735,7 +18717,6 @@ describe('RewardsController', () => {
             },
           },
         },
-        isCampaignsEnabled: () => true,
       });
 
       const result = await controller.getCampaigns(mockSubscriptionId);
@@ -18760,7 +18741,6 @@ describe('RewardsController', () => {
             },
           },
         },
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(freshCampaigns);
@@ -18778,7 +18758,6 @@ describe('RewardsController', () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue([]);

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -3390,9 +3390,6 @@ export class RewardsController extends BaseController<
     if (!rewardsEnabled) {
       return [];
     }
-    if (!this.#isCampaignsEnabled()) {
-      return [];
-    }
     const result = await wrapWithCache<CampaignDto[]>({
       key: subscriptionId,
       ttl: CAMPAIGNS_CACHE_THRESHOLD_MS,


### PR DESCRIPTION
## **Description**

Updates how the campaigns feature flag controls behavior on the Rewards Dashboard:

- **Dashboard always renders** `CampaignsPreview` and `EarnRewardsPreview` components regardless of feature flag state
- **Feature flag logic moved to `useRewardCampaigns` hook** - when disabled:
  - Shows only upcoming campaigns (filtered by start date)
  - Falls back to previous season campaigns if no upcoming campaigns exist
- **Campaign tiles become non-interactive when disabled** - users cannot navigate to campaign details
- **Adds `fetchUpcomingOrPreviousSeasonCampaigns`** method to RewardsController for the fallback logic

### Key Changes

| Before | After |
|--------|-------|
| Feature flag hides entire campaigns section | Always shows campaigns section |
| N/A | When disabled: shows upcoming campaigns only |
| N/A | When disabled: falls back to previous season |
| All tiles navigable | Non-interactive tiles when flag disabled |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

_N/A_

## **Manual testing steps**

1. Enable campaigns feature flag → Full campaigns functionality
2. Disable campaigns feature flag → Only upcoming campaigns shown, tiles non-interactive
3. Disable flag with no upcoming campaigns → Previous season campaigns displayed

## **Screenshots/Recordings**

- Feature flag off: only show upcoming campaign as featured 
<img width="983" height="1958" alt="Screenshot from 2026-03-23 14-16-10" src="https://github.com/user-attachments/assets/97c27a9d-0bfd-4fe7-b058-24d59fbf2652" />

- Feature flag off: tapping section or featured tile on rewards dashboard leads to campaign overview page. Only previous season tile is tappable

<img width="983" height="1958" alt="Screenshot from 2026-03-23 14-16-17" src="https://github.com/user-attachments/assets/954d9a27-0a73-47c7-8c0d-029adc4a59eb" />

- Feature flag off: what would happen if no upcoming campaigns are found, we can fallback to the previous season tile, which would take you to the previous season summary if it/the section is tapped.

<img width="983" height="1958" alt="Screenshot from 2026-03-23 14-17-30" src="https://github.com/user-attachments/assets/6618359a-f2cd-470b-b17a-9a00319c7f68" />

- If feature flag is on, then we will not filter on upcoming and allow users to actually navigate to the campaign details page via campaign tiles.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template
- [x] I've included tests
- [x] I've documented any changes (if applicable)

## **Pre-merge reviewer checklist**

- [ ] I've verified the changes follow established patterns
- [ ] I've verified the test coverage is adequate

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/behavior change around the campaigns feature flag that alters what content is shown and which navigation paths are enabled; risk is mainly regressions in campaign visibility and tap behavior when the flag toggles.
> 
> **Overview**
> **Rewards dashboard now always renders** `CampaignsPreview` and `EarnRewardsPreview`, removing the prior conditional/previous-season UI paths (including the referral header action).
> 
> **Campaign feature flag behavior is pushed down into campaigns components/hooks:** `useRewardCampaigns` always fetches campaigns when subscribed but filters results to *upcoming-only* when the flag is off, while `CampaignTile` adds `isInteractive`/`onPress` to disable deep-link navigation and allow alternate navigation. `CampaignsPreview` adds a no-campaigns fallback that shows `PreviousSeasonTile` and navigates to `Routes.PREVIOUS_SEASON_VIEW`.
> 
> Tests were updated accordingly across `RewardsDashboard`, `CampaignsPreview`, `CampaignTile`, `useRewardCampaigns`, and `RewardsController` to reflect the new fetch/filtering and interactivity rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ca3bc099993abacae0728c279f8ea614799ff51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->