### PR TITLE
feat: migrate Button (confirmations scope)

### DIFF
--- a/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
@@ -998,7 +998,7 @@ exports[`DeveloperOptions renders correctly 1`] = `
                           >
                             Withdraw
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                         <Text
                           accessibilityRole="text"
                           style={
@@ -1029,46 +1029,96 @@ exports[`DeveloperOptions renders correctly 1`] = `
                         >
                           Trigger a Perps withdraw confirmation.
                         </Text>
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Withdraw"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "marginTop": 16,
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#b4b4b528",
+                                "borderColor": "transparent",
+                                "borderRadius": 12,
+                                "borderWidth": 1,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "marginTop": 16,
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                           testID="confirmations-developer-options-perps-withdraw-button"
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Withdraw
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                         <View
                           style={
                             [

--- a/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Settings/DeveloperOptions/__snapshots__/index.test.tsx.snap
@@ -672,45 +672,95 @@ exports[`DeveloperOptions renders correctly 1`] = `
                         >
                           Trigger a Predict deposit confirmation.
                         </Text>
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Deposit"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "marginTop": 16,
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#b4b4b528",
+                                "borderColor": "transparent",
+                                "borderRadius": 12,
+                                "borderWidth": 1,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "marginTop": 16,
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Deposit
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                         <Text
                           accessibilityRole="text"
                           style={
@@ -741,45 +791,95 @@ exports[`DeveloperOptions renders correctly 1`] = `
                         >
                           Trigger a Predict claim confirmation.
                         </Text>
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Claim"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "marginTop": 16,
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#b4b4b528",
+                                "borderColor": "transparent",
+                                "borderRadius": 12,
+                                "borderWidth": 1,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "marginTop": 16,
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Claim
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                         <Text
                           accessibilityRole="text"
                           style={
@@ -810,40 +910,90 @@ exports[`DeveloperOptions renders correctly 1`] = `
                         >
                           Trigger a Predict withdraw confirmation.
                         </Text>
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Withdraw"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "marginTop": 16,
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": false,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#b4b4b528",
+                                "borderColor": "transparent",
+                                "borderRadius": 12,
+                                "borderWidth": 1,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 1,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "marginTop": 16,
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#131416",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#131416",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Withdraw

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
@@ -4,10 +4,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
 import { usePerpsTrading } from '../../../../../UI/Perps/hooks';
@@ -52,12 +49,13 @@ export function TransactionDetailsRetry() {
   return (
     <Box flexDirection={FlexDirection.Column} alignItems={AlignItems.stretch}>
       <Button
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         onPress={handlePress}
-        label={strings('transaction_details.label.retry_button')}
-        variant={ButtonVariants.Primary}
+        variant={ButtonVariant.Primary}
         style={styles.button}
-      />
+      >
+        {strings('transaction_details.label.retry_button')}
+      </Button>
     </Box>
   );
 }

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -2,9 +2,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 import KeypadComponent, { KeypadChangeData } from '../../../../Base/Keypad';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './deposit-keyboard.styles';
-import Button, {
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { Box } from '../../../../UI/Box/Box';
 import { FlexDirection, JustifyContent } from '../../../../UI/Box/box.types';
 import { strings } from '../../../../../../locales/i18n';
@@ -100,32 +98,35 @@ export const DepositKeyboard = memo(
           {alertMessage && (
             <Button
               testID="deposit-keyboard-alert"
-              label={alertMessage}
               style={[styles.button, styles.disabledButton]}
               onPress={noop}
-              disabled
-              variant={ButtonVariants.Primary}
-            />
+              isDisabled
+              variant={ButtonVariant.Primary}
+            >
+              {alertMessage}
+            </Button>
           )}
           {!alertMessage &&
             !hasInput &&
             buttons.map(({ label, value: buttonValue }) => (
               <Button
                 key={buttonValue}
-                label={label}
                 style={styles.button}
                 onPress={() => handlePercentagePress(buttonValue)}
-                variant={ButtonVariants.Secondary}
-              />
+                variant={ButtonVariant.Secondary}
+              >
+                {label}
+              </Button>
             ))}
           {!alertMessage && hasInput && (
             <Button
               testID="deposit-keyboard-done-button"
-              label={doneLabel ?? strings('confirm.edit_amount_done')}
               style={styles.button}
               onPress={onDonePress}
-              variant={ButtonVariants.Primary}
-            />
+              variant={ButtonVariant.Primary}
+            >
+              {doneLabel ?? strings('confirm.edit_amount_done')}
+            </Button>
           )}
         </Box>
         <KeypadComponent

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -6,11 +6,11 @@ import Text, {
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from '../../../../Settings/DeveloperOptions/DeveloperOptions.styles';
 import { Hex } from '@metamask/utils';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { useTheme } from '@react-navigation/native';
 import { addTransactionBatch } from '../../../../../../util/transaction-controller';
 import { useSelector } from 'react-redux';
@@ -275,14 +275,15 @@ function DeveloperButton({
         {description}
       </Text>
       <Button
-        variant={ButtonVariants.Secondary}
+        variant={ButtonVariant.Secondary}
         size={ButtonSize.Lg}
-        label={buttonLabel}
         onPress={onPress}
         testID={testID}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         style={styles.accessory}
-      />
+      >
+        {buttonLabel}
+      </Button>
     </>
   );
 }

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.tsx
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.tsx
@@ -7,9 +7,7 @@ import KeypadComponent, {
 } from '../../../../Base/Keypad';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './edit-amount-keyboard.styles';
-import Button, {
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { Box } from '../../../../UI/Box/Box';
 import { FlexDirection, JustifyContent } from '../../../../UI/Box/box.types';
 import { strings } from '../../../../../../locales/i18n';
@@ -72,19 +70,21 @@ export function EditAmountKeyboard({
             <Button
               key={`${val}-${label}`}
               testID={`percentage-button-${val}`}
-              label={label}
               style={styles.percentageButton}
               onPress={() => onPercentagePress(val)}
-              variant={ButtonVariants.Secondary}
-            />
+              variant={ButtonVariant.Secondary}
+            >
+              {label}
+            </Button>
           ))}
           {!hideDoneButton && onDonePress && (
             <Button
-              label={strings('confirm.edit_amount_done')}
               style={styles.percentageButton}
               onPress={onDonePress}
-              variant={ButtonVariants.Secondary}
-            />
+              variant={ButtonVariant.Secondary}
+            >
+              {strings('confirm.edit_amount_done')}
+            </Button>
           )}
         </Box>
       )}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -47,11 +47,11 @@ import { strings } from '../../../../../../../locales/i18n';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { TransactionType } from '@metamask/transaction-controller';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { useAlerts } from '../../../context/alert-system-context';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
 import EngineService from '../../../../../../core/EngineService';
@@ -263,12 +263,13 @@ function BuySection() {
         </Text>
       )}
       <Button
-        label={strings('confirm.custom_amount.buy_button')}
-        variant={ButtonVariants.Primary}
+        variant={ButtonVariant.Primary}
         onPress={handleBuyPress}
-        width={ButtonWidthTypes.Full}
+        isFullWidth
         size={ButtonSize.Lg}
-      />
+      >
+        {strings('confirm.custom_amount.buy_button')}
+      </Button>
     </Box>
   );
 }
@@ -287,13 +288,14 @@ function ConfirmButton({
     <Button
       style={[disabled && styles.disabledButton]}
       size={ButtonSize.Lg}
-      label={alertTitle ?? buttonLabel}
-      variant={ButtonVariants.Primary}
-      width={ButtonWidthTypes.Full}
-      disabled={disabled}
+      variant={ButtonVariant.Primary}
+      isFullWidth
+      isDisabled={disabled}
       onPress={onConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
-    />
+    >
+      {alertTitle ?? buttonLabel}
+    </Button>
   );
 }
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -291,7 +291,7 @@ function ConfirmButton({
       variant={ButtonVariant.Primary}
       isFullWidth
       isDisabled={disabled}
-      onPress={onConfirm}
+      onPress={() => onConfirm()}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
     >
       {alertTitle ?? buttonLabel}

--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.test.tsx
@@ -214,7 +214,7 @@ describe('MusdMaxConversionInfo', () => {
       const confirmButton = screen.getByTestId(
         MusdMaxConversionInfoTestIds.CONFIRM_BUTTON,
       );
-      expect(confirmButton.props.disabled).toBe(true);
+      expect(confirmButton).toBeDisabled();
     });
 
     it('disables confirm button when quotes are loading', () => {
@@ -225,7 +225,7 @@ describe('MusdMaxConversionInfo', () => {
       const confirmButton = screen.getByTestId(
         MusdMaxConversionInfoTestIds.CONFIRM_BUTTON,
       );
-      expect(confirmButton.props.disabled).toBe(true);
+      expect(confirmButton).toBeDisabled();
     });
 
     it('disables confirm button when alerts contain isBlocking entry', () => {
@@ -246,7 +246,7 @@ describe('MusdMaxConversionInfo', () => {
       const confirmButton = screen.getByTestId(
         MusdMaxConversionInfoTestIds.CONFIRM_BUTTON,
       );
-      expect(confirmButton.props.disabled).toBe(true);
+      expect(confirmButton).toBeDisabled();
     });
 
     it('enables confirm button when not loading and no blocking alerts', () => {
@@ -255,7 +255,7 @@ describe('MusdMaxConversionInfo', () => {
       const confirmButton = screen.getByTestId(
         MusdMaxConversionInfoTestIds.CONFIRM_BUTTON,
       );
-      expect(confirmButton.props.disabled).toBe(false);
+      expect(confirmButton).toBeEnabled();
     });
   });
 });

--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
@@ -3,11 +3,11 @@ import { Image, View } from 'react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionConfirm } from '../../../hooks/transactions/useTransactionConfirm';
@@ -104,13 +104,14 @@ export const MusdMaxConversionInfo = () => {
       <View style={styles.buttonContainer}>
         <Button
           onPress={onConfirm}
-          label={buttonLabel}
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
+          variant={ButtonVariant.Primary}
+          isFullWidth
           size={ButtonSize.Lg}
           isDisabled={isConfirmDisabled}
           testID={MusdMaxConversionInfoTestIds.CONFIRM_BUTTON}
-        />
+        >
+          {buttonLabel}
+        </Button>
       </View>
     </View>
   );

--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
@@ -103,7 +103,7 @@ export const MusdMaxConversionInfo = () => {
       <BlockingAlertMessage />
       <View style={styles.buttonContainer}>
         <Button
-          onPress={onConfirm}
+          onPress={() => onConfirm()}
           variant={ButtonVariant.Primary}
           isFullWidth
           size={ButtonSize.Lg}

--- a/app/components/Views/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/advanced-eip1559-modal/advanced-eip1559-modal.tsx
@@ -8,10 +8,11 @@ import {
 import { pickBy } from 'lodash';
 
 import { useStyles } from '../../../../../../component-library/hooks';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
   ButtonSize,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { updateTransactionGasFees } from '../../../../../../util/transaction-controller';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
@@ -134,12 +135,13 @@ export const AdvancedEIP1559Modal = ({
         </View>
         <Button
           isDisabled={hasError}
-          label={strings('transactions.gas_modal.save')}
           onPress={handleSaveClick}
           size={ButtonSize.Lg}
           style={styles.button}
-          variant={ButtonVariants.Primary}
-        />
+          variant={ButtonVariant.Primary}
+        >
+          {strings('transactions.gas_modal.save')}
+        </Button>
       </View>
     </BottomModal>
   );

--- a/app/components/Views/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.tsx
@@ -5,10 +5,11 @@ import { pickBy } from 'lodash';
 import { TransactionMeta } from '@metamask/transaction-controller';
 
 import { useStyles } from '../../../../../../component-library/hooks';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
   ButtonSize,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { updateTransactionGasFees } from '../../../../../../util/transaction-controller';
 import { GasModalHeader } from '../../../components/gas/gas-modal-header';
@@ -106,13 +107,14 @@ export const AdvancedGasPriceModal = ({
         </View>
         <Button
           isDisabled={hasError}
-          label={strings('transactions.gas_modal.save')}
           onPress={handleSaveClick}
           size={ButtonSize.Lg}
           style={styles.button}
           testID="save-gas-price-button"
-          variant={ButtonVariants.Primary}
-        />
+          variant={ButtonVariant.Primary}
+        >
+          {strings('transactions.gas_modal.save')}
+        </Button>
       </View>
     </BottomModal>
   );

--- a/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.tsx
@@ -8,7 +8,10 @@ import {
   ButtonVariant,
   IconName as DesignSystemIconName,
 } from '@metamask/design-system-react-native';
-import { ButtonSize as ButtonLinkSize, ButtonWidthTypes } from '../../../../../../component-library/components/Buttons/Button';
+import {
+  ButtonSize as ButtonLinkSize,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import Checkbox from '../../../../../../component-library/components/Checkbox';
 import Icon, {
   IconName,

--- a/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.tsx
@@ -2,11 +2,12 @@ import React, { useCallback, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useTheme } from '../../../../../../util/theme';
 import BottomModal from '../../../components/UI/bottom-modal';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
+import { ButtonWidthTypes } from '../../../../../../component-library/components/Buttons/Button';
 import Checkbox from '../../../../../../component-library/components/Checkbox';
 import Icon, {
   IconName,
@@ -119,26 +120,28 @@ const ConfirmAlertModal: React.FC<ConfirmAlertModalProps> = ({
         <View style={styles.buttonsContainer}>
           <Button
             onPress={handleReject}
-            label={strings('confirm.cancel')}
             style={styles.footerButton}
             size={ButtonSize.Lg}
-            variant={ButtonVariants.Secondary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Secondary}
+            isFullWidth
             testID="confirm-alert-cancel-button"
-          />
+          >
+            {strings('confirm.cancel')}
+          </Button>
           <View style={styles.buttonDivider} />
           <Button
             onPress={handleConfirm}
-            label={strings('confirm.confirm')}
             style={styles.footerButton}
             size={ButtonSize.Lg}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            isFullWidth
             isDisabled={!confirmCheckbox}
             startIconName={IconName.Danger}
             isDanger
             testID="confirm-alert-confirm-button"
-          />
+          >
+            {strings('confirm.confirm')}
+          </Button>
         </View>
       </View>
     </BottomModal>

--- a/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.tsx
@@ -6,8 +6,9 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
+  IconName as DesignSystemIconName,
 } from '@metamask/design-system-react-native';
-import { ButtonWidthTypes } from '../../../../../../component-library/components/Buttons/Button';
+import { ButtonSize as ButtonLinkSize, ButtonWidthTypes } from '../../../../../../component-library/components/Buttons/Button';
 import Checkbox from '../../../../../../component-library/components/Checkbox';
 import Icon, {
   IconName,
@@ -99,7 +100,7 @@ const ConfirmAlertModal: React.FC<ConfirmAlertModalProps> = ({
             label={strings('alert_system.confirm_modal.review_alerts')}
             startIconName={IconName.SecuritySearch}
             width={ButtonWidthTypes.Auto}
-            size={ButtonSize.Lg}
+            size={ButtonLinkSize.Lg}
             labelTextVariant={TextVariant.BodyMD}
           />
         )}
@@ -136,7 +137,7 @@ const ConfirmAlertModal: React.FC<ConfirmAlertModalProps> = ({
             variant={ButtonVariant.Primary}
             isFullWidth
             isDisabled={!confirmCheckbox}
-            startIconName={IconName.Danger}
+            startIconName={DesignSystemIconName.Danger}
             isDanger
             testID="confirm-alert-confirm-button"
           >

--- a/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.tsx
@@ -3,10 +3,11 @@ import { View } from 'react-native';
 
 import { ApproveComponentIDs } from '../../../ConfirmationView.testIds';
 import { useStyles } from '../../../../../../component-library/hooks';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import Text, {
   TextVariant,
@@ -91,18 +92,18 @@ export const EditSpendingCapModal = ({
 
         <View style={styles.buttonsContainer}>
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
             isDisabled={isDataUpdating}
             style={styles.button}
-            label={strings('confirm.edit_spending_cap_modal.cancel')}
             onPress={handleCloseModal}
-          />
+          >
+            {strings('confirm.edit_spending_cap_modal.cancel')}
+          </Button>
           <Button
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             style={styles.button}
-            label={strings('confirm.edit_spending_cap_modal.save')}
             isDisabled={!!error}
             testID={ApproveComponentIDs.EDIT_SPENDING_CAP_SAVE_BUTTON}
             onPress={async () => {
@@ -111,7 +112,9 @@ export const EditSpendingCapModal = ({
               onClose();
               setIsDataUpdating(false);
             }}
-          />
+          >
+            {strings('confirm.edit_spending_cap_modal.save')}
+          </Button>
         </View>
       </View>
     </BottomModal>

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
@@ -159,9 +159,7 @@ describe('Amount', () => {
     } as unknown as ReturnType<typeof useSendContext>);
 
     const { getByRole } = renderComponent(undefined, '');
-    expect(
-      getByRole('button', { name: 'Next' }).props.style.backgroundColor,
-    ).toEqual(mockTheme.colors.text.muted);
+    expect(getByRole('button', { name: 'Next' })).toBeDisabled();
   });
 
   it('call updateValue with MaxMode true when Max button is pressed', () => {

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.tsx
@@ -2,11 +2,11 @@ import React, { useCallback } from 'react';
 
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { useParams } from '../../../../../../../util/navigation/navUtils.ts';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import { AssetType, TokenStandard } from '../../../../types/token';
@@ -135,17 +135,16 @@ export const AmountKeyboard = ({
       additionalRow={
         amount.length > 0 || isNFT ? (
           <Button
-            disabled={Boolean(amountError) || !amount}
-            label={
-              amountError ??
-              (isNFT ? strings('send.next') : strings('send.continue'))
-            }
+            isDisabled={Boolean(amountError) || !amount}
             onPress={goToNextPage}
             size={ButtonSize.Lg}
             style={styles.continueButton}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-          />
+            variant={ButtonVariant.Primary}
+            isFullWidth
+          >
+            {amountError ??
+              (isNFT ? strings('send.next') : strings('send.continue'))}
+          </Button>
         ) : undefined
       }
       enableEmptyValueString


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replace deprecated `Button` usage with DSRN package.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d022ebd3-23b0-4f82-9684-c3d99810eca3

### **After**

https://github.com/user-attachments/assets/3fcd6842-1a84-4f3f-b9fb-21fbcf2608a9

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it swaps the underlying `Button` implementation across multiple confirmation keyboards/modals, which could subtly change disabled/press behavior and layout in transaction-critical screens.
> 
> **Overview**
> Migrates confirmation-flow buttons from the deprecated component-library `Button` to `@metamask/design-system-react-native`, updating APIs (e.g., `label` to children, `disabled` to `isDisabled`, `width` to `isFullWidth`, and new `ButtonVariant` enums) across keyboards, developer options, transaction retry, and gas/alert/spending-cap modals.
> 
> Updates associated tests and snapshots to match the new rendered structure/props, including switching assertions to `toBeDisabled()` / `toBeEnabled()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 845cb7370156bc0b19e9b353e23f778b66ae9fa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->