### PR TITLE
fix: hide speed row on network fee section on confirmation page when gas fee token is selected

### DIFF
--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
@@ -272,6 +272,31 @@ describe('GasFeesDetailsRow', () => {
     expect(queryByText('0.0001 ETH')).toBeNull();
   });
 
+  it('hides gas speed row when simulation is loading', async () => {
+    mockUseBalanceChanges.mockReturnValue({
+      pending: true,
+      value: [],
+    });
+    const { queryByText } = renderWithProvider(<GasFeesDetailsRow />, {
+      state: createStateWithSimulationData(),
+    });
+
+    expect(queryByText('Speed')).toBeNull();
+  });
+
+  it('hides gas speed row when gas fee token is selected', async () => {
+    mockUseSelectedGasFeeToken.mockReturnValue(
+      GAS_FEE_TOKEN_MOCK as unknown as ReturnType<
+        typeof useSelectedGasFeeToken
+      >,
+    );
+    const { queryByText } = renderWithProvider(<GasFeesDetailsRow />, {
+      state: createStateWithSimulationData(),
+    });
+
+    expect(queryByText('Speed')).toBeNull();
+  });
+
   it('shows selected gas fee token', async () => {
     mockUseSelectedGasFeeToken.mockReturnValue(
       GAS_FEE_TOKEN_MOCK as unknown as ReturnType<

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -364,14 +364,17 @@ const GasFeesDetailsRow = ({
             </View>
           )}
         </AlertRow>
-        {isUserFeeLevelExists && !hideSpeed && (
-          <AlertRow
-            alertField={RowAlertKey.PendingTransaction}
-            label={strings('transactions.gas_modal.speed')}
-          >
-            <GasSpeed />
-          </AlertRow>
-        )}
+        {isUserFeeLevelExists &&
+          !hideSpeed &&
+          !gasFeeToken &&
+          !isSimulationLoading && (
+            <AlertRow
+              alertField={RowAlertKey.PendingTransaction}
+              label={strings('transactions.gas_modal.speed')}
+            >
+              <GasSpeed />
+            </AlertRow>
+          )}
       </Container>
       {gasModalVisible && (
         <GasFeeModal setGasModalVisible={setGasModalVisible} />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Hide speed row on network fee section on confirmation page when gas fee token is selected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1057

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
<img width="398" height="848" alt="Screenshot 2026-03-23 at 7 54 41 PM" src="https://github.com/user-attachments/assets/7e9c2a3f-af1b-4ea7-8f1f-beb4685fc633" />
<img width="394" height="844" alt="Screenshot 2026-03-23 at 7 54 12 PM" src="https://github.com/user-attachments/assets/ec597c61-9be2-40a2-a449-fd1339dda958" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-logic change gated by existing state (selected gas fee token / simulation loading) with added unit coverage. Main risk is accidentally suppressing the speed row in edge cases where these flags are miscomputed.
> 
> **Overview**
> Prevents the Network fee section from rendering the `Speed` row while simulation data is loading and whenever a non-native gas fee token is selected.
> 
> Adds test coverage to ensure `Speed` is hidden in both conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7720f780a62d55c4ee760e69c1bd2753b31a96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->