### PR TITLE
feat: migrate Button (web3auth scope)

### DIFF
--- a/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
@@ -785,45 +785,91 @@ exports[`ImportFromSecretRecoveryPhrase Import a wallet UI render matches snapsh
                           ]
                         }
                       >
-                        <TouchableOpacity
+                        <View
+                          accessibilityLabel="Continue"
                           accessibilityRole="button"
-                          accessible={true}
-                          activeOpacity={1}
-                          disabled={true}
-                          onPress={[Function]}
-                          onPressIn={[Function]}
-                          onPressOut={[Function]}
-                          style={
+                          accessibilityState={
                             {
-                              "alignItems": "center",
-                              "alignSelf": "stretch",
-                              "backgroundColor": "#131416",
-                              "borderRadius": 12,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "opacity": 0.5,
-                              "overflow": "hidden",
-                              "paddingHorizontal": 16,
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": true,
+                              "expanded": undefined,
+                              "selected": undefined,
                             }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "backgroundColor": "#131416",
+                                "borderRadius": 12,
+                                "columnGap": 8,
+                                "flexDirection": "row",
+                                "height": 48,
+                                "justifyContent": "center",
+                                "minWidth": 80,
+                                "opacity": 0.5,
+                                "overflow": "hidden",
+                                "paddingLeft": 16,
+                                "paddingRight": 16,
+                                "width": "100%",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
                           }
                           testID="import-from-seed-screen-continue-button-id"
                         >
                           <Text
                             accessibilityRole="text"
+                            ellipsizeMode="clip"
+                            numberOfLines={1}
                             style={
-                              {
-                                "color": "#ffffff",
-                                "fontFamily": "Geist-Medium",
-                                "fontSize": 16,
-                                "letterSpacing": 0,
-                                "lineHeight": 24,
-                              }
+                              [
+                                {
+                                  "color": "#ffffff",
+                                  "flexGrow": 0,
+                                  "flexShrink": 1,
+                                  "flexWrap": "wrap",
+                                  "fontFamily": "Geist-Medium",
+                                  "fontSize": 16,
+                                  "fontWeight": 400,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                },
+                                undefined,
+                              ]
                             }
                           >
                             Continue
                           </Text>
-                        </TouchableOpacity>
+                        </View>
                       </View>
                       <View />
                     </RNCSafeAreaView>

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -50,6 +50,9 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   FontWeight,
   Label,
   Text,
@@ -65,10 +68,8 @@ import { ChoosePasswordSelectorsIDs } from '../ChoosePassword/ChoosePassword.tes
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
 import Checkbox from '../../../component-library/components/Checkbox';
-import Button, {
+import OldButton, {
   ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
 } from '../../../component-library/components/Buttons/Button';
 import Icon, {
   IconName,
@@ -782,7 +783,7 @@ const ImportFromSecretRecoveryPhrase = ({
                   style={tw.style('items-start')}
                   testID={ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID}
                 />
-                <Button
+                <OldButton
                   variant={ButtonVariants.Link}
                   onPress={() => setLearnMore(!learnMore)}
                   style={tw.style(
@@ -815,16 +816,16 @@ const ImportFromSecretRecoveryPhrase = ({
                 )}
               >
                 <Button
-                  loading={loading}
-                  width={ButtonWidthTypes.Full}
-                  variant={ButtonVariants.Primary}
-                  label={strings('import_from_seed.import_create_password_cta')}
+                  isLoading={loading}
+                  isFullWidth
+                  variant={ButtonVariant.Primary}
                   onPress={onPressImport}
-                  disabled={isContinueButtonDisabled}
                   size={ButtonSize.Lg}
                   isDisabled={isContinueButtonDisabled}
                   testID={ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID}
-                />
+                >
+                  {strings('import_from_seed.import_create_password_cta')}
+                </Button>
               </Box>
             </Box>
           )}
@@ -833,14 +834,15 @@ const ImportFromSecretRecoveryPhrase = ({
       {currentStep === 0 && (
         <Box twClassName="px-4 py-4 bg-default">
           <Button
-            variant={ButtonVariants.Primary}
-            label={strings('import_from_seed.continue')}
+            variant={ButtonVariant.Primary}
             onPress={handleContinueImportFlow}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             size={ButtonSize.Lg}
             isDisabled={isSRPContinueButtonDisabled}
             testID={ImportFromSeedSelectorsIDs.CONTINUE_BUTTON_ID}
-          />
+          >
+            {strings('import_from_seed.continue')}
+          </Button>
         </Box>
       )}
       {isSrpWordSuggestionsEnabled &&

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -220,7 +220,7 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       );
 
       const continueButton = getByRole('button', { name: 'Continue' });
-      expect(continueButton.props.disabled).toBe(true);
+      expect(continueButton).toBeDisabled();
     });
 
     it('renders paste button when no seed phrase is entered', () => {
@@ -335,7 +335,7 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       // Wait for continue button to be enabled
       await waitFor(
         () => {
-          expect(continueButton.props.disabled).toBe(false);
+          expect(continueButton).toBeEnabled();
         },
         { timeout: 3000 },
       );
@@ -513,7 +513,7 @@ describe('ImportFromSecretRecoveryPhrase', () => {
 
       // Verify continue button is still disabled (since it's not a complete seed phrase)
       const continueButton = getByRole('button', { name: 'Continue' });
-      expect(continueButton.props.disabled).toBe(false);
+      expect(continueButton).toBeEnabled();
     });
 
     it('on backspace key press, the input field length is updated', async () => {

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
@@ -250,7 +250,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
     await waitFor(() => {
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-      expect(importButton.props.disabled).toBe(false);
+      expect(importButton).toBeEnabled();
     });
 
     const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -286,7 +286,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
     await waitFor(() => {
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-      expect(importButton.props.disabled).toBe(false);
+      expect(importButton).toBeEnabled();
     });
 
     const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -313,7 +313,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
     );
 
     const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-    expect(importButton.props.disabled).toBe(true);
+    expect(importButton).toBeDisabled();
   });
 
   it('disables import button when SRP length is invalid', async () => {
@@ -332,7 +332,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
     });
 
     const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-    expect(importButton.props.disabled).toBe(true);
+    expect(importButton).toBeDisabled();
   });
 
   it('shows clear button after pasting SRP', async () => {
@@ -409,7 +409,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
     await waitFor(() => {
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-      expect(importButton.props.disabled).toBe(false);
+      expect(importButton).toBeEnabled();
     });
 
     const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -455,7 +455,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
     await waitFor(() => {
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-      expect(importButton.props.disabled).toBe(false);
+      expect(importButton).toBeEnabled();
     });
 
     const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -566,7 +566,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
       await waitFor(() => {
         const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-        expect(importButton.props.disabled).toBe(false);
+        expect(importButton).toBeEnabled();
       });
 
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -609,7 +609,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
       await waitFor(() => {
         const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-        expect(importButton.props.disabled).toBe(false);
+        expect(importButton).toBeEnabled();
       });
 
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -650,7 +650,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
       await waitFor(() => {
         const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-        expect(importButton.props.disabled).toBe(false);
+        expect(importButton).toBeEnabled();
       });
 
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -691,7 +691,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
 
       await waitFor(() => {
         const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-        expect(importButton.props.disabled).toBe(false);
+        expect(importButton).toBeEnabled();
       });
 
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
@@ -765,7 +765,7 @@ describe('ImportNewSecretRecoveryPhrase', () => {
       });
 
       const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
-      expect(importButton.props.disabled).toBe(true);
+      expect(importButton).toBeDisabled();
     });
 
     it('handles empty string in textarea', async () => {

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
@@ -9,11 +9,6 @@ import React, {
 import { Alert, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
-import Button, {
-  ButtonVariants,
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../../component-library/components/Buttons/Button';
 import { ScreenshotDeterrent } from '../../UI/ScreenshotDeterrent';
 import {
   KeyboardAwareScrollView,
@@ -27,7 +22,10 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  Button,
   ButtonIcon,
+  ButtonSize,
+  ButtonVariant,
   IconName,
   IconColor,
   Text,
@@ -317,15 +315,16 @@ const ImportNewSecretRecoveryPhrase = () => {
       </KeyboardAwareScrollView>
       <Box twClassName="px-4 py-4 bg-default">
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('import_new_secret_recovery_phrase.cta_text')}
+          isFullWidth
           onPress={onSubmit}
           isDisabled={isSRPContinueButtonDisabled || loading}
-          loading={loading}
+          isLoading={loading}
           testID={ImportSRPIDs.IMPORT_BUTTON}
-        />
+        >
+          {strings('import_new_secret_recovery_phrase.cta_text')}
+        </Button>
       </Box>
       {isSrpWordSuggestionsEnabled && isKeyboardVisible && (
         <KeyboardStickyView

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -589,7 +589,7 @@ describe('OAuthRehydration', () => {
     it('disables login button when password is empty', () => {
       const { getByTestId } = renderWithProvider(<OAuthRehydration />);
       const loginButton = getByTestId(LoginViewSelectors.LOGIN_BUTTON_ID);
-      expect(loginButton.props.disabled).toBe(true);
+      expect(loginButton).toBeDisabled();
     });
 
     it('enables login button when password is entered', () => {
@@ -598,14 +598,15 @@ describe('OAuthRehydration', () => {
       const loginButton = getByTestId(LoginViewSelectors.LOGIN_BUTTON_ID);
 
       fireEvent.changeText(passwordInput, 'password123');
-      expect(loginButton.props.disabled).toBe(false);
+      expect(loginButton).toBeEnabled();
     });
 
     it('shows loading state when isDeletingInProgress is true', () => {
       mockIsDeletingInProgress.mockReturnValue(true);
       const { getByTestId } = renderWithProvider(<OAuthRehydration />);
       const loginButton = getByTestId(LoginViewSelectors.LOGIN_BUTTON_ID);
-      expect(loginButton.props.loading).toBe(true);
+      expect(loginButton).toBeDisabled();
+      expect(loginButton.props.accessibilityState.busy).toBe(true);
     });
 
     it('does not submit when already loading', async () => {

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -20,10 +20,9 @@ import Text, {
   TextColor,
 } from '../../../component-library/components/Texts/Text';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import Button, {
-  ButtonSize,
+import OldButton, {
   ButtonVariants,
-  ButtonWidthTypes,
+  ButtonSize as OldButtonSize,
 } from '../../../component-library/components/Buttons/Button';
 import { strings } from '../../../../locales/i18n';
 import FadeOutOverlay from '../../UI/FadeOutOverlay';
@@ -82,6 +81,9 @@ import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import FOX_LOGO from '../../../images/branding/fox.png';
 import METAMASK_NAME from '../../../images/branding/metamask-name.png';
 import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
   Label,
   FontWeight,
   TextColor as DSTextColor,
@@ -765,28 +767,29 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
               <View style={styles.ctaWrapperRehydration}>
                 <Button
-                  variant={ButtonVariants.Primary}
-                  width={ButtonWidthTypes.Full}
+                  variant={ButtonVariant.Primary}
+                  isFullWidth
                   size={ButtonSize.Lg}
                   onPress={handleLogin}
-                  label={strings('login.unlock_button')}
                   isDisabled={
                     password.length === 0 || disabledInput || finalLoading
                   }
                   testID={LoginViewSelectors.LOGIN_BUTTON_ID}
-                  loading={finalLoading}
-                />
+                  isLoading={finalLoading}
+                >
+                  {strings('login.unlock_button')}
+                </Button>
               </View>
 
               {isSeedlessPasswordOutdated ? (
-                <Button
+                <OldButton
                   style={styles.goBack}
                   variant={ButtonVariants.Link}
                   onPress={toggleWarningModal}
                   testID={LoginViewSelectors.RESET_WALLET}
                   label={strings('login.forgot_password')}
                   isDisabled={loading}
-                  size={ButtonSize.Lg}
+                  size={OldButtonSize.Lg}
                 />
               ) : (
                 <View style={styles.footer}>

--- a/app/components/Views/SocialLoginIosUser/index.tsx
+++ b/app/components/Views/SocialLoginIosUser/index.tsx
@@ -11,11 +11,11 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../component-library/components/Texts/Text';
-import Button, {
+import {
+  Button,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
 import { PREVIOUS_SCREEN, ONBOARDING } from '../../../constants/navigation';
@@ -97,21 +97,22 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
 
         <View style={styles.ctaContainer}>
           <Button
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             testID={
               isUserTypeNew
                 ? OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_BUTTON
                 : OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_EXISTING_USER_BUTTON
             }
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             size={Device.isMediumDevice() ? ButtonSize.Md : ButtonSize.Lg}
-            label={strings(
+            onPress={isUserTypeNew ? handleSetMetaMaskPin : handleSecureWallet}
+          >
+            {strings(
               isUserTypeNew
                 ? 'social_login_ios_user.new_user_button'
                 : 'social_login_ios_user.existing_user_button',
             )}
-            onPress={isUserTypeNew ? handleSetMetaMaskPin : handleSecureWallet}
-          />
+          </Button>
         </View>
       </View>
     </SafeAreaView>

--- a/app/components/Views/WalletCreationError/SRPErrorScreen.tsx
+++ b/app/components/Views/WalletCreationError/SRPErrorScreen.tsx
@@ -9,6 +9,9 @@ import { Dispatch } from 'redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   Text,
   TextVariant,
   TextColor,
@@ -27,10 +30,9 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
 import { ITrackingEvent } from '../../../core/Analytics/MetaMetrics.types';
 import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder';
-import Button, {
+import OldButton, {
   ButtonVariants,
-  ButtonSize,
-  ButtonWidthTypes,
+  ButtonSize as OldButtonSize,
 } from '../../../component-library/components/Buttons/Button';
 import { IconName as CLibIconName } from '../../../component-library/components/Icons/Icon';
 
@@ -192,9 +194,9 @@ const SRPErrorScreen = ({
               <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
                 {strings('wallet_creation_error.error_report')}
               </Text>
-              <Button
+              <OldButton
                 variant={ButtonVariants.Link}
-                size={ButtonSize.Sm}
+                size={OldButtonSize.Sm}
                 label={
                   copied
                     ? strings('wallet_creation_error.copied')
@@ -218,21 +220,23 @@ const SRPErrorScreen = ({
 
         <Box twClassName="w-full pt-4 pb-6">
           <Button
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
-            label={strings('wallet_creation_error.send_error_report')}
+            isFullWidth
             onPress={handleSendErrorReport}
             style={tw.style('mb-4')}
-          />
+          >
+            {strings('wallet_creation_error.send_error_report')}
+          </Button>
 
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
-            label={strings('wallet_creation_error.try_again')}
+            isFullWidth
             onPress={handleTryAgain}
-          />
+          >
+            {strings('wallet_creation_error.try_again')}
+          </Button>
         </Box>
       </ScrollView>
     </SafeAreaView>

--- a/app/components/Views/WalletCreationError/SocialLoginErrorSheet.tsx
+++ b/app/components/Views/WalletCreationError/SocialLoginErrorSheet.tsx
@@ -8,6 +8,9 @@ import {
   Text,
   TextVariant,
   TextColor,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   Icon,
   IconName,
   IconSize,
@@ -16,11 +19,6 @@ import {
 
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import Button, {
-  ButtonVariants,
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../../component-library/components/Buttons/Button';
 
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
@@ -116,12 +114,13 @@ const SocialLoginErrorSheet = ({ error }: SocialLoginErrorSheetProps) => {
         </Text>
 
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('wallet_creation_error.try_again')}
+          isFullWidth
           onPress={handleTryAgain}
-        />
+        >
+          {strings('wallet_creation_error.try_again')}
+        </Button>
       </Box>
     </SafeAreaView>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replace deprecated `Button` usage with DSRN package.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/8cc0ccb2-5b79-4f37-8d8f-ae326849716d

### **After**

https://github.com/user-attachments/assets/e42afbad-ebe8-41a6-b80d-2bcb0964358e

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical onboarding/login entry points by swapping button components and props; risk is mainly UI/interaction regressions (disabled/loading/accessibility) rather than logic changes.
> 
> **Overview**
> Migrates several onboarding/authentication screens from the deprecated component-library `Button` to the design-system `Button` (DSRN), updating props (`variant`, `isFullWidth`, `isDisabled`, `isLoading`) and switching to children-based labels.
> 
> Link-style buttons that aren’t yet migrated remain on the old component (`OldButton`). Tests and snapshots are updated accordingly, including switching assertions to `toBeDisabled()`/`toBeEnabled()` and reflecting the new button render/accessibility structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40ba4e78e9658ac3daa609492a78bdb6bd9c2134. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->