### PR TITLE
test: MMQA-1384: Add coverage for address collection

### DIFF
--- a/tests/api-mocking/helpers/mockHelpers.test.ts
+++ b/tests/api-mocking/helpers/mockHelpers.test.ts
@@ -1,5 +1,6 @@
 import {
   filterProxiedRequests,
+  formatProxiedRequestMatcher,
   processPostRequestBody,
   PostRequestMatchingOptions,
   type SeenProxiedRequest,
@@ -430,6 +431,26 @@ describe('processPostRequestBody', () => {
       expect(result.matches).toBe(false);
       expect(result.error).toBe('Request body validation failed');
     });
+  });
+});
+
+describe('formatProxiedRequestMatcher', () => {
+  it('includes regex source and flags instead of empty object', () => {
+    const urlRegex = /profile\/accounts$/i;
+    const formatted = formatProxiedRequestMatcher({
+      method: 'GET',
+      urlRegex,
+    });
+    expect(formatted).toBe(
+      JSON.stringify({ method: 'GET', urlRegex: String(urlRegex) }),
+    );
+    expect(formatted).not.toContain('"urlRegex":{}');
+  });
+
+  it('omits undefined matcher fields', () => {
+    expect(formatProxiedRequestMatcher({ urlSubstring: 'x' })).toBe(
+      '{"urlSubstring":"x"}',
+    );
   });
 });
 

--- a/tests/api-mocking/helpers/mockHelpers.test.ts
+++ b/tests/api-mocking/helpers/mockHelpers.test.ts
@@ -1,6 +1,8 @@
 import {
+  filterProxiedRequests,
   processPostRequestBody,
   PostRequestMatchingOptions,
+  type SeenProxiedRequest,
 } from './mockHelpers.ts';
 
 describe('processPostRequestBody', () => {
@@ -428,5 +430,38 @@ describe('processPostRequestBody', () => {
       expect(result.matches).toBe(false);
       expect(result.error).toBe('Request body validation failed');
     });
+  });
+});
+
+describe('filterProxiedRequests', () => {
+  const sample: SeenProxiedRequest[] = [
+    {
+      method: 'GET',
+      proxiedUrl:
+        'https://accounts.api.cx.metamask.io/v2/supportedNetworks?foo=1',
+    },
+    {
+      method: 'PUT',
+      proxiedUrl:
+        'https://authentication.api.cx.metamask.io/api/v2/profile/accounts',
+    },
+    { method: 'POST', proxiedUrl: 'https://example.com/other' },
+  ];
+
+  it('filters by method and url substring', () => {
+    const matches = filterProxiedRequests(sample, {
+      method: 'GET',
+      urlSubstring: 'accounts.api.cx.metamask.io/v2/supportedNetworks',
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.method).toBe('GET');
+  });
+
+  it('filters by url regex', () => {
+    const matches = filterProxiedRequests(sample, {
+      urlRegex: /profile\/accounts$/,
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.method).toBe('PUT');
   });
 });

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -1,4 +1,4 @@
-import { Mockttp } from 'mockttp';
+import type { Mockttp, MockttpServer } from 'mockttp';
 import _ from 'lodash';
 import {
   createLogger,
@@ -6,6 +6,7 @@ import {
   MockApiEndpoint,
   MockEventsObject,
 } from '../../framework';
+import Utilities from '../../framework/Utilities.ts';
 import { getDecodedProxiedURL } from '../../smoke/notifications/utils/helpers.ts';
 import { safeGetBodyText } from '../MockServerE2E.ts';
 
@@ -461,4 +462,109 @@ export async function setupAccountsV2SupportedNetworksMock(
     },
     responseCode: 200,
   });
+}
+
+// --- Proxied traffic observation (same source as getEventsPayloads: getMockedEndpoints + getSeenRequests) ---
+
+/** Substring match for GET supported networks (see setupAccountsV2SupportedNetworksMock). */
+export const ACCOUNTS_API_SUPPORTED_NETWORKS_URL_MARKER =
+  'accounts.api.cx.metamask.io/v2/supportedNetworks';
+
+/**
+ * MMQA-1384: user profile / address collection — `PUT …/api/v2/profile/accounts`
+ * (default mock: tests/api-mocking/mock-responses/defaults/index.ts).
+ */
+export const AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER =
+  'authentication.api.cx.metamask.io/api/v2/profile/accounts';
+
+export interface SeenProxiedRequest {
+  method: string;
+  proxiedUrl: string;
+}
+
+export interface ProxiedRequestMatcher {
+  method?: string;
+  urlSubstring?: string;
+  urlRegex?: RegExp;
+}
+
+/**
+ * Completed requests seen by mockttp rules, with the real target URL decoded from `/proxy?url=…`.
+ * Same pattern as `getEventsPayloads` in tests/helpers/analytics/helpers.ts (without MetaMetrics filtering).
+ */
+export async function collectSeenProxiedRequests(
+  mockServer: Mockttp | MockttpServer,
+): Promise<SeenProxiedRequest[]> {
+  const mockedEndpoints = await mockServer.getMockedEndpoints();
+  const requests = (
+    await Promise.all(
+      mockedEndpoints.map((endpoint) => endpoint.getSeenRequests()),
+    )
+  ).flat();
+
+  return requests.map((request) => ({
+    method: request.method,
+    proxiedUrl: getDecodedProxiedURL(request.url),
+  }));
+}
+
+export function filterProxiedRequests(
+  seen: SeenProxiedRequest[],
+  matcher: ProxiedRequestMatcher,
+): SeenProxiedRequest[] {
+  return seen.filter((r) => {
+    if (matcher.method !== undefined && r.method !== matcher.method) {
+      return false;
+    }
+    if (
+      matcher.urlSubstring !== undefined &&
+      !r.proxiedUrl.includes(matcher.urlSubstring)
+    ) {
+      return false;
+    }
+    if (
+      matcher.urlRegex !== undefined &&
+      !matcher.urlRegex.test(r.proxiedUrl)
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Polls until at least `minCount` proxied requests match, or throws after timeout.
+ */
+export async function waitForProxiedRequestsMatching(
+  mockServer: Mockttp | MockttpServer,
+  matcher: ProxiedRequestMatcher,
+  options: {
+    minCount?: number;
+    timeout?: number;
+    description: string;
+  },
+): Promise<SeenProxiedRequest[]> {
+  const { minCount = 1, timeout = 20000, description } = options;
+
+  return Utilities.executeWithRetry(
+    async () => {
+      const seen = await collectSeenProxiedRequests(mockServer);
+      const matches = filterProxiedRequests(seen, matcher);
+      if (matches.length < minCount) {
+        throw new Error(
+          `Expected at least ${String(minCount)} proxied request(s) matching ${JSON.stringify(
+            matcher,
+          )}, got ${String(matches.length)} (total proxied rows: ${String(
+            seen.length,
+          )})`,
+        );
+      }
+      return matches;
+    },
+    {
+      timeout,
+      interval: 500,
+      description,
+    },
+  );
 }

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -5,13 +5,13 @@ import {
   LogLevel,
   MockApiEndpoint,
   MockEventsObject,
+  sleep,
 } from '../../framework';
-import Utilities from '../../framework/Utilities.ts';
 import { getDecodedProxiedURL } from '../../smoke/notifications/utils/helpers.ts';
 import { safeGetBodyText } from '../MockServerE2E.ts';
 
 // Creates a logger with INFO level as the mockServer produces too much noise
-// Change this to DEBUG as needed
+// Change this to DEBUG as needed (required to see `waitForProxiedRequestsMatching` dumps)
 const logger = createLogger({
   name: 'TestSpecificMockHelpers',
   level: LogLevel.INFO,
@@ -477,6 +477,13 @@ export const ACCOUNTS_API_SUPPORTED_NETWORKS_URL_MARKER =
 export const AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER =
   'authentication.api.cx.metamask.io/api/v2/profile/accounts';
 
+/**
+ * MMQA-1384: backup-and-sync — `PUT` to user-storage (multichain account tree /
+ * address book; see USER_STORAGE_MOCK). Used in new-wallet analytics E2E where applicable.
+ */
+export const USER_STORAGE_ACCOUNT_SYNC_PUT_URL_MARKER =
+  'user-storage.api.cx.metamask.io/api/v1/userstorage';
+
 export interface SeenProxiedRequest {
   method: string;
   proxiedUrl: string;
@@ -534,6 +541,8 @@ export function filterProxiedRequests(
 
 /**
  * Polls until at least `minCount` proxied requests match, or throws after timeout.
+ * Polls every `interval` ms (default 1000) for up to `timeout` ms (default 60000).
+ * On timeout only: logs the full proxied request list at DEBUG (see module LogLevel).
  */
 export async function waitForProxiedRequestsMatching(
   mockServer: Mockttp | MockttpServer,
@@ -541,30 +550,72 @@ export async function waitForProxiedRequestsMatching(
   options: {
     minCount?: number;
     timeout?: number;
+    interval?: number;
     description: string;
   },
 ): Promise<SeenProxiedRequest[]> {
-  const { minCount = 1, timeout = 20000, description } = options;
+  const {
+    minCount = 1,
+    timeout = 60000,
+    interval = 1000,
+    description,
+  } = options;
 
-  return Utilities.executeWithRetry(
-    async () => {
-      const seen = await collectSeenProxiedRequests(mockServer);
-      const matches = filterProxiedRequests(seen, matcher);
-      if (matches.length < minCount) {
-        throw new Error(
-          `Expected at least ${String(minCount)} proxied request(s) matching ${JSON.stringify(
-            matcher,
-          )}, got ${String(matches.length)} (total proxied rows: ${String(
-            seen.length,
-          )})`,
-        );
-      }
-      return matches;
-    },
-    {
-      timeout,
-      interval: 500,
-      description,
-    },
+  const pollIntervalMs = Math.max(1, interval);
+  const startMs = Date.now();
+
+  logger.info(
+    `Polling proxied requests for "${description}" (matcher ${JSON.stringify(
+      matcher,
+    )}, minCount ${String(minCount)}, every ${String(
+      pollIntervalMs,
+    )}ms, up to ${String(timeout)}ms)`,
   );
+
+  for (;;) {
+    const seen = await collectSeenProxiedRequests(mockServer);
+    const matches = filterProxiedRequests(seen, matcher);
+
+    if (matches.length >= minCount) {
+      const matchedRequestsDump = matches
+        .map(
+          (request, index) =>
+            `[${String(index + 1)}] ${request.method} ${request.proxiedUrl}`,
+        )
+        .join('\n');
+      logger.info(
+        `Matched proxied request(s) for "${description}": ${String(matches.length)} (required: ${String(minCount)})\n${matchedRequestsDump}`,
+      );
+      return matches;
+    }
+
+    const elapsedMs = Date.now() - startMs;
+    if (elapsedMs >= timeout) {
+      const seenRequestsDump = seen
+        .map(
+          (request, index) =>
+            `[${String(index + 1)}] ${request.method} ${request.proxiedUrl}`,
+        )
+        .join('\n');
+
+      logger.debug(
+        `Proxied requests mismatch for "${description}": expected >= ${String(minCount)} matching ${JSON.stringify(
+          matcher,
+        )}, got ${String(matches.length)} (total proxied rows: ${String(
+          seen.length,
+        )})\nSeen proxied requests:\n${seenRequestsDump || '(none)'}`,
+      );
+
+      throw new Error(
+        `Expected at least ${String(minCount)} proxied request(s) matching ${JSON.stringify(
+          matcher,
+        )}, got ${String(matches.length)} (total proxied rows: ${String(
+          seen.length,
+        )})`,
+      );
+    }
+
+    const remainingMs = timeout - elapsedMs;
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+  }
 }

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -465,23 +465,12 @@ export async function setupAccountsV2SupportedNetworksMock(
 
 // --- Proxied traffic observation (same source as getEventsPayloads: getMockedEndpoints + getSeenRequests) ---
 
-/** Substring match for GET supported networks (see setupAccountsV2SupportedNetworksMock). */
-export const ACCOUNTS_API_SUPPORTED_NETWORKS_URL_MARKER =
-  'accounts.api.cx.metamask.io/v2/supportedNetworks';
-
 /**
  * MMQA-1384: user profile / address collection — `PUT …/api/v2/profile/accounts`
  * (default mock: tests/api-mocking/mock-responses/defaults/index.ts).
  */
 export const AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER =
   'authentication.api.cx.metamask.io/api/v2/profile/accounts';
-
-/**
- * MMQA-1384: backup-and-sync — `PUT` to user-storage (multichain account tree /
- * address book; see USER_STORAGE_MOCK). Used in new-wallet analytics E2E where applicable.
- */
-export const USER_STORAGE_ACCOUNT_SYNC_PUT_URL_MARKER =
-  'user-storage.api.cx.metamask.io/api/v1/userstorage';
 
 export interface SeenProxiedRequest {
   method: string;
@@ -492,6 +481,26 @@ export interface ProxiedRequestMatcher {
   method?: string;
   urlSubstring?: string;
   urlRegex?: RegExp;
+}
+
+/**
+ * Stable string for logs and errors for {@link ProxiedRequestMatcher}.
+ * Unlike `JSON.stringify(matcher)`, serializes `urlRegex` as `/source/flags` instead of `{}`.
+ */
+export function formatProxiedRequestMatcher(
+  matcher: ProxiedRequestMatcher,
+): string {
+  const record: Record<string, string> = {};
+  if (matcher.method !== undefined) {
+    record.method = matcher.method;
+  }
+  if (matcher.urlSubstring !== undefined) {
+    record.urlSubstring = matcher.urlSubstring;
+  }
+  if (matcher.urlRegex !== undefined) {
+    record.urlRegex = String(matcher.urlRegex);
+  }
+  return JSON.stringify(record);
 }
 
 /**
@@ -557,6 +566,7 @@ export interface WaitForAdditionalProxiedRequestsOptions {
   interval?: number;
   /**
    * After a successful wait, logs `label: new count=<delta>` at INFO on `logger`.
+   * Delta is `matches.length - baselineMatchCount` from the same snapshot as the wait.
    */
   successLog?: {
     logger: { info: (message: string) => void };
@@ -584,8 +594,9 @@ export async function waitForAdditionalProxiedRequestsMatching(
   });
 
   if (options.successLog) {
-    const afterCount = await countProxiedRequestsMatching(mockServer, matcher);
-    const delta = afterCount - baselineMatchCount;
+    // Derive delta from `matches` (same snapshot as wait success) — avoids a second
+    // collectSeenProxiedRequests pass and TOCTOU inflation from requests after return.
+    const delta = matches.length - baselineMatchCount;
     options.successLog.logger.info(
       `${options.successLog.label}: new count=${String(delta)}`,
     );
@@ -620,7 +631,7 @@ export async function waitForProxiedRequestsMatching(
   const startMs = Date.now();
 
   logger.info(
-    `Polling proxied requests for "${description}" (matcher ${JSON.stringify(
+    `Polling proxied requests for "${description}" (matcher ${formatProxiedRequestMatcher(
       matcher,
     )}, minCount ${String(minCount)}, every ${String(
       pollIntervalMs,
@@ -654,7 +665,7 @@ export async function waitForProxiedRequestsMatching(
         .join('\n');
 
       logger.debug(
-        `Proxied requests mismatch for "${description}": expected >= ${String(minCount)} matching ${JSON.stringify(
+        `Proxied requests mismatch for "${description}": expected >= ${String(minCount)} matching ${formatProxiedRequestMatcher(
           matcher,
         )}, got ${String(matches.length)} (total proxied rows: ${String(
           seen.length,
@@ -662,7 +673,7 @@ export async function waitForProxiedRequestsMatching(
       );
 
       throw new Error(
-        `Expected at least ${String(minCount)} proxied request(s) matching ${JSON.stringify(
+        `Expected at least ${String(minCount)} proxied request(s) matching ${formatProxiedRequestMatcher(
           matcher,
         )}, got ${String(matches.length)} (total proxied rows: ${String(
           seen.length,

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -463,15 +463,6 @@ export async function setupAccountsV2SupportedNetworksMock(
   });
 }
 
-// --- Proxied traffic observation (same source as getEventsPayloads: getMockedEndpoints + getSeenRequests) ---
-
-/**
- * MMQA-1384: user profile / address collection — `PUT …/api/v2/profile/accounts`
- * (default mock: tests/api-mocking/mock-responses/defaults/index.ts).
- */
-export const AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER =
-  'authentication.api.cx.metamask.io/api/v2/profile/accounts';
-
 export interface SeenProxiedRequest {
   method: string;
   proxiedUrl: string;

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -1,12 +1,11 @@
 import type { Mockttp, MockttpServer } from 'mockttp';
 import _ from 'lodash';
-import {
-  createLogger,
-  LogLevel,
+import { createLogger, LogLevel } from '../../framework/logger.ts';
+import type {
   MockApiEndpoint,
   MockEventsObject,
-  sleep,
-} from '../../framework';
+} from '../../framework/types.ts';
+import { sleep } from '../../framework/Utilities.ts';
 import { getDecodedProxiedURL } from '../../smoke/notifications/utils/helpers.ts';
 import { safeGetBodyText } from '../MockServerE2E.ts';
 
@@ -537,6 +536,62 @@ export function filterProxiedRequests(
     }
     return true;
   });
+}
+
+/**
+ * Count of proxied requests matching `matcher` (for baselines before a flow).
+ */
+export async function countProxiedRequestsMatching(
+  mockServer: Mockttp | MockttpServer,
+  matcher: ProxiedRequestMatcher,
+): Promise<number> {
+  const seen = await collectSeenProxiedRequests(mockServer);
+  return filterProxiedRequests(seen, matcher).length;
+}
+
+export interface WaitForAdditionalProxiedRequestsOptions {
+  description: string;
+  /** Matching requests beyond baseline required (default 1). */
+  additional?: number;
+  timeout?: number;
+  interval?: number;
+  /**
+   * After a successful wait, logs `label: new count=<delta>` at INFO on `logger`.
+   */
+  successLog?: {
+    logger: { info: (message: string) => void };
+    label: string;
+  };
+}
+
+/**
+ * Waits until at least `baselineMatchCount + additional` proxied requests match,
+ * then optionally logs how many new matches appeared since baseline.
+ * Use with {@link countProxiedRequestsMatching} before the flow under test.
+ */
+export async function waitForAdditionalProxiedRequestsMatching(
+  mockServer: Mockttp | MockttpServer,
+  matcher: ProxiedRequestMatcher,
+  baselineMatchCount: number,
+  options: WaitForAdditionalProxiedRequestsOptions,
+): Promise<SeenProxiedRequest[]> {
+  const additional = options.additional ?? 1;
+  const matches = await waitForProxiedRequestsMatching(mockServer, matcher, {
+    minCount: baselineMatchCount + additional,
+    description: options.description,
+    timeout: options.timeout,
+    interval: options.interval,
+  });
+
+  if (options.successLog) {
+    const afterCount = await countProxiedRequestsMatching(mockServer, matcher);
+    const delta = afterCount - baselineMatchCount;
+    options.successLog.logger.info(
+      `${options.successLog.label}: new count=${String(delta)}`,
+    );
+  }
+
+  return matches;
 }
 
 /**

--- a/tests/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/tests/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -109,6 +109,19 @@ export const remoteFeatureMultichainAccountsAccountDetailsV2 = (
   },
 });
 
+/**
+ * Disables the full-screen Predict / Polymarket GTM onboarding shown after reaching wallet home.
+ * Production remote-flag defaults enable this; `selectPredictGtmOnboardingModalEnabledFlag` prefers
+ * the remote value over `MM_PREDICT_GTM_MODAL_ENABLED`, so E2E tests should merge this into
+ * {@link setupRemoteFeatureFlagsMock} when the modal would block flows.
+ */
+export const remoteFeaturePredictGtmOnboardingModalDisabled = () => ({
+  predictGtmOnboardingModalEnabled: {
+    enabled: false,
+    minimumVersion: '7.60.0',
+  },
+});
+
 export const remoteFeatureFlagPredictEnabled = (enabled = true) => ({
   predictEnabled: enabled,
   predictTradingEnabled: {

--- a/tests/framework/index.ts
+++ b/tests/framework/index.ts
@@ -16,6 +16,11 @@ export { boxedStep, getDriver } from './PlaywrightUtilities.ts';
 
 // Mock server utilities
 export { safeGetBodyText } from '../api-mocking/MockServerE2E.ts';
+export {
+  countProxiedRequestsMatching,
+  waitForAdditionalProxiedRequestsMatching,
+  type WaitForAdditionalProxiedRequestsOptions,
+} from '../api-mocking/helpers/mockHelpers.ts';
 
 // Dapp server exports for standalone usage (e.g., Appwright tests)
 export { default as DappServer } from './DappServer.ts';

--- a/tests/smoke/wallet/analytics/constants.ts
+++ b/tests/smoke/wallet/analytics/constants.ts
@@ -1,0 +1,5 @@
+export const AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER =
+  'authentication.api.cx.metamask.io/api/v2/profile/accounts';
+
+/** Wait for proxied PUT profile/accounts after onboarding (CI / Android can be slow). */
+export const PROFILE_ACCOUNTS_PROXIED_REQUEST_TIMEOUT_MS = 90_000;

--- a/tests/smoke/wallet/analytics/import-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/import-wallet.spec.ts
@@ -7,17 +7,16 @@ import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { remoteFeatureMultichainAccountsAccountDetails } from '../../../api-mocking/mock-responses/feature-flags-mocks';
-import { createLogger } from '../../../framework';
+import {
+  createLogger,
+  countProxiedRequestsMatching,
+  waitForAdditionalProxiedRequestsMatching,
+} from '../../../framework';
+import { AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER } from '../../../api-mocking/helpers/mockHelpers';
 import {
   importWalletMetricsOptOutExpectations,
   importWalletWithMetricsOptInExpectations,
 } from '../../../helpers/analytics/expectations/import-wallet.analytics';
-import {
-  AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
-  collectSeenProxiedRequests,
-  filterProxiedRequests,
-  waitForProxiedRequestsMatching,
-} from '../../../api-mocking/helpers/mockHelpers';
 import {
   IDENTITY_TEAM_PASSWORD,
   IDENTITY_TEAM_SEED_PHRASE,
@@ -56,12 +55,10 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           method: 'PUT' as const,
           urlSubstring: AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
         };
-        const seenBeforeWalletImport =
-          await collectSeenProxiedRequests(mockServer);
-        const profileAccountsBaseline = filterProxiedRequests(
-          seenBeforeWalletImport,
+        const profileAccountsBaseline = await countProxiedRequestsMatching(
+          mockServer,
           profileAccountsMatcher,
-        ).length;
+        );
 
         await importWalletWithRecoveryPhrase({
           seedPhrase: IDENTITY_TEAM_SEED_PHRASE,
@@ -69,27 +66,20 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           optInToMetrics: true,
         });
 
-        await waitForProxiedRequestsMatching(
+        // MMQA-1384: PUT authentication profile/accounts after import
+        await waitForAdditionalProxiedRequestsMatching(
           mockServer,
           profileAccountsMatcher,
+          profileAccountsBaseline,
           {
-            minCount: profileAccountsBaseline + 1,
             description:
               'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet import',
+            successLog: {
+              logger,
+              label:
+                'PUT authentication.api.cx.metamask.io/api/v2/profile/accounts after import',
+            },
           },
-        );
-
-        const seenAfterProfileAccountsWait =
-          await collectSeenProxiedRequests(mockServer);
-        const profileAccountsAfter = filterProxiedRequests(
-          seenAfterProfileAccountsWait,
-          profileAccountsMatcher,
-        ).length;
-
-        logger.info(
-          `PUT authentication.api.cx.metamask.io/api/v2/profile/accounts after import: new count=${String(
-            profileAccountsAfter - profileAccountsBaseline,
-          )}`,
         );
       },
     );

--- a/tests/smoke/wallet/analytics/import-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/import-wallet.spec.ts
@@ -6,13 +6,19 @@ import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureMultichainAccountsAccountDetails } from '../../../api-mocking/mock-responses/feature-flags-mocks';
+import {
+  remoteFeatureMultichainAccountsAccountDetails,
+  remoteFeaturePredictGtmOnboardingModalDisabled,
+} from '../../../api-mocking/mock-responses/feature-flags-mocks';
 import {
   createLogger,
   countProxiedRequestsMatching,
   waitForAdditionalProxiedRequestsMatching,
 } from '../../../framework';
-import { AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER } from '../../../api-mocking/helpers/mockHelpers';
+import {
+  AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
+  PROFILE_ACCOUNTS_PROXIED_REQUEST_TIMEOUT_MS,
+} from './constants';
 import {
   importWalletMetricsOptOutExpectations,
   importWalletWithMetricsOptInExpectations,
@@ -37,10 +43,10 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetails(),
-          );
+          await setupRemoteFeatureFlagsMock(mockServer, {
+            ...remoteFeatureMultichainAccountsAccountDetails(),
+            ...remoteFeaturePredictGtmOnboardingModalDisabled(),
+          });
         },
         analyticsExpectations: importWalletWithMetricsOptInExpectations,
       },
@@ -66,7 +72,6 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           optInToMetrics: true,
         });
 
-        // MMQA-1384: PUT authentication profile/accounts after import
         await waitForAdditionalProxiedRequestsMatching(
           mockServer,
           profileAccountsMatcher,
@@ -74,6 +79,7 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           {
             description:
               'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet import',
+            timeout: PROFILE_ACCOUNTS_PROXIED_REQUEST_TIMEOUT_MS,
             successLog: {
               logger,
               label:
@@ -91,10 +97,10 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(
-            mockServer,
-            remoteFeatureMultichainAccountsAccountDetails(),
-          );
+          await setupRemoteFeatureFlagsMock(mockServer, {
+            ...remoteFeatureMultichainAccountsAccountDetails(),
+            ...remoteFeaturePredictGtmOnboardingModalDisabled(),
+          });
         },
         analyticsExpectations: importWalletMetricsOptOutExpectations,
       },

--- a/tests/smoke/wallet/analytics/import-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/import-wallet.spec.ts
@@ -7,14 +7,25 @@ import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { remoteFeatureMultichainAccountsAccountDetails } from '../../../api-mocking/mock-responses/feature-flags-mocks';
+import { createLogger } from '../../../framework';
 import {
   importWalletMetricsOptOutExpectations,
   importWalletWithMetricsOptInExpectations,
 } from '../../../helpers/analytics/expectations/import-wallet.analytics';
 import {
+  AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
+  collectSeenProxiedRequests,
+  filterProxiedRequests,
+  waitForProxiedRequestsMatching,
+} from '../../../api-mocking/helpers/mockHelpers';
+import {
   IDENTITY_TEAM_PASSWORD,
   IDENTITY_TEAM_SEED_PHRASE,
 } from '../../identity/utils/constants';
+
+const logger = createLogger({
+  name: 'ImportWalletAnalyticsSpec',
+});
 
 describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
   beforeAll(async () => {
@@ -34,12 +45,52 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
         },
         analyticsExpectations: importWalletWithMetricsOptInExpectations,
       },
-      async () => {
+      async ({ mockServer }) => {
+        if (!mockServer) {
+          throw new Error(
+            'Mock server is not defined, check testSpecificMock setup',
+          );
+        }
+
+        const profileAccountsMatcher = {
+          method: 'PUT' as const,
+          urlSubstring: AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
+        };
+        const seenBeforeWalletImport =
+          await collectSeenProxiedRequests(mockServer);
+        const profileAccountsBaseline = filterProxiedRequests(
+          seenBeforeWalletImport,
+          profileAccountsMatcher,
+        ).length;
+
         await importWalletWithRecoveryPhrase({
           seedPhrase: IDENTITY_TEAM_SEED_PHRASE,
           password: IDENTITY_TEAM_PASSWORD,
           optInToMetrics: true,
         });
+
+        await waitForProxiedRequestsMatching(
+          mockServer,
+          profileAccountsMatcher,
+          {
+            minCount: profileAccountsBaseline + 1,
+            description:
+              'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet import',
+          },
+        );
+
+        const seenAfterProfileAccountsWait =
+          await collectSeenProxiedRequests(mockServer);
+        const profileAccountsAfter = filterProxiedRequests(
+          seenAfterProfileAccountsWait,
+          profileAccountsMatcher,
+        ).length;
+
+        logger.info(
+          `PUT authentication.api.cx.metamask.io/api/v2/profile/accounts after import: new count=${String(
+            profileAccountsAfter - profileAccountsBaseline,
+          )}`,
+        );
       },
     );
   });

--- a/tests/smoke/wallet/analytics/new-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/new-wallet.spec.ts
@@ -9,12 +9,18 @@ import {
   countProxiedRequestsMatching,
   waitForAdditionalProxiedRequestsMatching,
 } from '../../../framework';
-import { AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER } from '../../../api-mocking/helpers/mockHelpers';
+import {
+  AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
+  PROFILE_ACCOUNTS_PROXIED_REQUEST_TIMEOUT_MS,
+} from './constants';
 import {
   getEventsPayloads,
   onboardingEvents,
 } from '../../../helpers/analytics/helpers';
 import SoftAssert from '../../../framework/SoftAssert';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { remoteFeaturePredictGtmOnboardingModalDisabled } from '../../../api-mocking/mock-responses/feature-flags-mocks';
 import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 
@@ -41,11 +47,17 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
     await TestHelpers.reverseServerPort();
   });
 
-  it('should track analytics events during new wallet flow', async () => {
+  it.only('should track analytics events during new wallet flow', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),
         restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await setupRemoteFeatureFlagsMock(
+            mockServer,
+            remoteFeaturePredictGtmOnboardingModalDisabled(),
+          );
+        },
       },
       async ({ mockServer }) => {
         if (!mockServer) {
@@ -156,7 +168,6 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
 
         softAssert.throwIfErrors();
 
-        // MMQA-1384: PUT authentication profile/accounts after new wallet
         await waitForAdditionalProxiedRequestsMatching(
           mockServer,
           profileAccountsMatcher,
@@ -164,6 +175,7 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           {
             description:
               'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet creation',
+            timeout: PROFILE_ACCOUNTS_PROXIED_REQUEST_TIMEOUT_MS,
             successLog: {
               logger,
               label:
@@ -180,6 +192,12 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
       {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),
         restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await setupRemoteFeatureFlagsMock(
+            mockServer,
+            remoteFeaturePredictGtmOnboardingModalDisabled(),
+          );
+        },
       },
       async ({ mockServer }) => {
         await CreateNewWallet({

--- a/tests/smoke/wallet/analytics/new-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/new-wallet.spec.ts
@@ -4,7 +4,12 @@ import { SmokeWalletPlatform } from '../../../tags';
 import { CreateNewWallet } from '../../../flows/wallet.flow';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../framework/Assertions';
-import { createLogger } from '../../../framework';
+import {
+  createLogger,
+  countProxiedRequestsMatching,
+  waitForAdditionalProxiedRequestsMatching,
+} from '../../../framework';
+import { AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER } from '../../../api-mocking/helpers/mockHelpers';
 import {
   getEventsPayloads,
   onboardingEvents,
@@ -12,12 +17,6 @@ import {
 import SoftAssert from '../../../framework/SoftAssert';
 import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
-import {
-  AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
-  collectSeenProxiedRequests,
-  filterProxiedRequests,
-  waitForProxiedRequestsMatching,
-} from '../../../api-mocking/helpers/mockHelpers';
 
 const logger = createLogger({
   name: 'NewWalletAnalyticsSpec',
@@ -60,11 +59,10 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           urlSubstring: AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
         };
 
-        const seenBeforeWallet = await collectSeenProxiedRequests(mockServer);
-        const profileAccountsBaseline = filterProxiedRequests(
-          seenBeforeWallet,
+        const profileAccountsBaseline = await countProxiedRequestsMatching(
+          mockServer,
           profileAccountsMatcher,
-        ).length;
+        );
 
         await CreateNewWallet();
 
@@ -158,27 +156,20 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
 
         softAssert.throwIfErrors();
 
-        await waitForProxiedRequestsMatching(
+        // MMQA-1384: PUT authentication profile/accounts after new wallet
+        await waitForAdditionalProxiedRequestsMatching(
           mockServer,
           profileAccountsMatcher,
+          profileAccountsBaseline,
           {
-            minCount: profileAccountsBaseline + 1,
             description:
               'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet creation',
+            successLog: {
+              logger,
+              label:
+                'PUT authentication.api.cx.metamask.io/api/v2/profile/accounts after new wallet',
+            },
           },
-        );
-
-        const seenAfterProfileAccountsWait =
-          await collectSeenProxiedRequests(mockServer);
-        const profileAccountsAfter = filterProxiedRequests(
-          seenAfterProfileAccountsWait,
-          profileAccountsMatcher,
-        ).length;
-
-        logger.info(
-          `PUT authentication.api.cx.metamask.io/api/v2/profile/accounts after new wallet: new count=${String(
-            profileAccountsAfter - profileAccountsBaseline,
-          )}`,
         );
       },
     );

--- a/tests/smoke/wallet/analytics/new-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/new-wallet.spec.ts
@@ -4,6 +4,7 @@ import { SmokeWalletPlatform } from '../../../tags';
 import { CreateNewWallet } from '../../../flows/wallet.flow';
 import TestHelpers from '../../../helpers';
 import Assertions from '../../../framework/Assertions';
+import { createLogger } from '../../../framework';
 import {
   getEventsPayloads,
   onboardingEvents,
@@ -17,6 +18,10 @@ import {
   filterProxiedRequests,
   waitForProxiedRequestsMatching,
 } from '../../../api-mocking/helpers/mockHelpers';
+
+const logger = createLogger({
+  name: 'NewWalletAnalyticsSpec',
+});
 
 const eventNames = [
   onboardingEvents.ANALYTICS_PREFERENCE_SELECTED,
@@ -54,8 +59,10 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           method: 'PUT' as const,
           urlSubstring: AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
         };
+
+        const seenBeforeWallet = await collectSeenProxiedRequests(mockServer);
         const profileAccountsBaseline = filterProxiedRequests(
-          await collectSeenProxiedRequests(mockServer),
+          seenBeforeWallet,
           profileAccountsMatcher,
         ).length;
 
@@ -151,8 +158,6 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
 
         softAssert.throwIfErrors();
 
-        // MMQA-1384: address collection — PUT profile/accounts after new wallet
-        // (same proxy observation pattern as MetaMetrics above).
         await waitForProxiedRequestsMatching(
           mockServer,
           profileAccountsMatcher,
@@ -161,6 +166,19 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
             description:
               'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet creation',
           },
+        );
+
+        const seenAfterProfileAccountsWait =
+          await collectSeenProxiedRequests(mockServer);
+        const profileAccountsAfter = filterProxiedRequests(
+          seenAfterProfileAccountsWait,
+          profileAccountsMatcher,
+        ).length;
+
+        logger.info(
+          `PUT authentication.api.cx.metamask.io/api/v2/profile/accounts after new wallet: new count=${String(
+            profileAccountsAfter - profileAccountsBaseline,
+          )}`,
         );
       },
     );

--- a/tests/smoke/wallet/analytics/new-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/new-wallet.spec.ts
@@ -47,7 +47,7 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
     await TestHelpers.reverseServerPort();
   });
 
-  it.only('should track analytics events during new wallet flow', async () => {
+  it('should track analytics events during new wallet flow', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().withOnboardingFixture().build(),

--- a/tests/smoke/wallet/analytics/new-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/new-wallet.spec.ts
@@ -11,6 +11,12 @@ import {
 import SoftAssert from '../../../framework/SoftAssert';
 import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import {
+  AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
+  collectSeenProxiedRequests,
+  filterProxiedRequests,
+  waitForProxiedRequestsMatching,
+} from '../../../api-mocking/helpers/mockHelpers';
 
 const eventNames = [
   onboardingEvents.ANALYTICS_PREFERENCE_SELECTED,
@@ -38,13 +44,22 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
         restartDevice: true,
       },
       async ({ mockServer }) => {
-        await CreateNewWallet();
-
         if (!mockServer) {
           throw new Error(
             'Mock server is not defined, check testSpecificMock setup',
           );
         }
+
+        const profileAccountsMatcher = {
+          method: 'PUT' as const,
+          urlSubstring: AUTHENTICATION_PROFILE_ACCOUNTS_URL_MARKER,
+        };
+        const profileAccountsBaseline = filterProxiedRequests(
+          await collectSeenProxiedRequests(mockServer),
+          profileAccountsMatcher,
+        ).length;
+
+        await CreateNewWallet();
 
         const events = await getEventsPayloads(mockServer, eventNames);
 
@@ -135,6 +150,18 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
         ]);
 
         softAssert.throwIfErrors();
+
+        // MMQA-1384: address collection — PUT profile/accounts after new wallet
+        // (same proxy observation pattern as MetaMetrics above).
+        await waitForProxiedRequestsMatching(
+          mockServer,
+          profileAccountsMatcher,
+          {
+            minCount: profileAccountsBaseline + 1,
+            description:
+              'New PUT authentication.api.cx.metamask.io/api/v2/profile/accounts observed after wallet creation',
+          },
+        );
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

MMQA-1384: Extends the existing new-wallet analytics smoke test to assert a new proxied PUT to authentication.api.cx.metamask.io/api/v2/profile/accounts after onboarding (baseline + 1).

Adds proxy observation helpers in mockHelpers.ts (collectSeenProxiedRequests, filterProxiedRequests, waitForProxiedRequestsMatching) plus unit tests for filterProxiedRequests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test utilities and smoke tests, adding polling/assertions around proxied network calls and a feature-flag override that may affect test stability but not production code.
> 
> **Overview**
> Adds new mock-server helper utilities to **collect, filter, and poll for proxied requests** seen by `mockttp`, including stable matcher formatting (`formatProxiedRequestMatcher`) and baseline+delta waiting (`waitForAdditionalProxiedRequestsMatching`). Unit tests were added for the matcher formatting and filtering logic.
> 
> Updates wallet analytics smoke tests to **disable the Predict GTM onboarding modal via remote flags** and to assert that an additional proxied `PUT` to `authentication.../profile/accounts` occurs after new-wallet creation and wallet import, using a shared constants file and a longer timeout for slower environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c4682582e8d600cd9681d0b6e173f7ad2912c5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->