### PR TITLE
test: fix flaky TrendingTokensFullView search test

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -53,7 +53,7 @@ const assertTrendingTokenRowsVisibility = async (opts: {
         expect(queryByTestId(result.id)).not.toBeOnTheScreen();
       });
     },
-    { timeout: 2000 },
+    { timeout: 5000 },
   );
 };
 
@@ -317,6 +317,11 @@ describeForPlatforms('TrendingTokensFullView - Component Tests', () => {
       expect(
         getByTestId(TrendingViewSelectorsIDs.TRENDING_TOKENS_HEADER),
       ).toBeOnTheScreen();
+    });
+
+    await assertTrendingTokenRowsVisibility({
+      queryByTestId,
+      visible: [{ id: TRENDING_ETHEREUM_ID }],
     });
 
     const searchToggle = getByTestId(

--- a/tests/component-view/api-mocking/trending.ts
+++ b/tests/component-view/api-mocking/trending.ts
@@ -1,6 +1,11 @@
 /**
  * Trending tokens API mock for component view tests.
- * Intercepts GET https://token.api.cx.metamask.io/v3/tokens/trending via nock.
+ * Intercepts:
+ * - GET https://token.api.cx.metamask.io/v3/tokens/trending (trending list)
+ * - GET https://token.api.cx.metamask.io/tokens/search (token search from useSearchRequest)
+ *
+ * Search must be mocked when net connect is disabled; otherwise searchTokens can stall
+ * until fetch timeout while useTrendingSearch stays loading, and short waitFor timeouts flake.
  *
  * Use in beforeEach/afterEach of TrendingView.view.test.tsx (or any view that
  * loads trending data). See tests/component-view/api-mocking/ and references/navigation-mocking.md for adding other API mocks.
@@ -82,6 +87,7 @@ export const mockBnbChainToken: MockTrendingToken[] = [
 
 const TRENDING_ORIGIN = 'https://token.api.cx.metamask.io';
 const TRENDING_PATH = '/v3/tokens/trending';
+const TOKEN_SEARCH_PATH = '/tokens/search';
 
 /**
  * Sets up the nock mock for the trending tokens API.
@@ -105,6 +111,12 @@ export function setupTrendingApiFetchMock(
     .get(TRENDING_PATH)
     .query(true)
     .reply(200, (uri: string) => replyBody(uri))
+    .persist();
+
+  nock(TRENDING_ORIGIN)
+    .get(TOKEN_SEARCH_PATH)
+    .query(true)
+    .reply(200, { count: 0, data: [] })
     .persist();
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes flaky component view test **TrendingTokensFullView › user can search on trending tokens full view** (`TrendingView.view.test.tsx`).

### Root cause

- `setupTrendingApiFetchMock` only intercepted **`/v3/tokens/trending`**. Full-view search also calls **`searchTokens`**, which hits **`/tokens/search`** on `token.api.cx.metamask.io`.
- With **`nock.disableNetConnect()`**, that request was unmatched, so search completion and loading state were **slow or variable** while `useTrendingSearch` stayed in a loading path.
- Assertions used a **2s** `waitFor`, so the test could time out before `trending-token-row-item-*` appeared—especially with debounced search and typing.

### Changes

- **`tests/component-view/api-mocking/trending.ts`** — Persistent nock for **`GET /tokens/search`** returning `{ count: 0, data: [] }` so search resolves immediately; filtered rows still come from mocked trending data (e.g. “Ethereum” via local name match).
- **`TrendingView.view.test.tsx`** — `assertTrendingTokenRowsVisibility` timeout increased to **5s**; full-view search test **waits for the Ethereum row** after opening the full view **before** toggling search to avoid racing the initial trending fetch.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to component-view test code and nock mocks, with no production logic impact; main risk is inadvertently masking real network behavior in tests by broadly mocking `GET /tokens/search`.
> 
> **Overview**
> Fixes flakiness in the `TrendingTokensFullView` search test by ensuring all network calls are deterministically mocked and by reducing timing races.
> 
> The trending API mock now also persists a `GET /tokens/search` interceptor (returning an empty result set) so search requests don’t hang when net connect is disabled. The test helper `assertTrendingTokenRowsVisibility` uses a longer `waitFor` timeout (5s), and the full-view search test now waits for the initial Ethereum row to render before toggling search.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3db3c8cfe6b8458737a84510b138e844e31d5796. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->