### PR TITLE
fix: fixes the text wrapping in the predict outcome CTA button

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -687,10 +687,13 @@ const getActionButtons = () =>
     .getAllByTestId('button')
     .filter((button) => getActionButtonText(button).includes('¢'));
 
+const getActionButtonPrice = (button: ReactTestInstance) => {
+  const match = getActionButtonText(button).match(/(\d+(?:\.\d+)?)¢$/);
+  return match ? Number(match[1]) : null;
+};
+
 const findActionButtonByPrice = (price: number) =>
-  getActionButtons().find((button) =>
-    getActionButtonText(button).endsWith(`${price}¢`),
-  );
+  getActionButtons().find((button) => getActionButtonPrice(button) === price);
 
 describe('PredictMarketDetails', () => {
   afterEach(() => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -688,8 +688,8 @@ const getActionButtons = () =>
     .filter((button) => getActionButtonText(button).includes('¢'));
 
 const findActionButtonByPrice = (price: number) =>
-  getActionButtons().find(
-    (button) => getActionButtonText(button) === `•${price}¢`,
+  getActionButtons().find((button) =>
+    getActionButtonText(button).endsWith(`${price}¢`),
   );
 
 describe('PredictMarketDetails', () => {
@@ -1221,7 +1221,9 @@ describe('PredictMarketDetails', () => {
       const buttonLabels = actionButtons.map(getActionButtonText);
 
       expect(actionButtons).toHaveLength(2);
-      expect(buttonLabels).toEqual(expect.arrayContaining(['•65¢', '•35¢']));
+      expect(buttonLabels).toEqual(
+        expect.arrayContaining(['Yes•65¢', 'No•35¢']),
+      );
     });
 
     it('calculates percentage correctly from market price', () => {
@@ -1245,7 +1247,9 @@ describe('PredictMarketDetails', () => {
       const actionButtons = getActionButtons();
       const buttonLabels = actionButtons.map(getActionButtonText);
 
-      expect(buttonLabels).toEqual(expect.arrayContaining(['•75¢', '•25¢']));
+      expect(buttonLabels).toEqual(
+        expect.arrayContaining(['Yes•75¢', 'No•25¢']),
+      );
     });
   });
 
@@ -1298,7 +1302,7 @@ describe('PredictMarketDetails', () => {
       const actionButtons = getActionButtons();
       const buttonLabels = actionButtons.map(getActionButtonText);
 
-      expect(buttonLabels).toContain('•65¢');
+      expect(buttonLabels).toContain('Yes•65¢');
     });
 
     it('handles missing price data gracefully', () => {
@@ -1323,7 +1327,9 @@ describe('PredictMarketDetails', () => {
       const actionButtons = getActionButtons();
       const buttonLabels = actionButtons.map(getActionButtonText);
 
-      expect(buttonLabels).toEqual(expect.arrayContaining(['•0¢', '•100¢']));
+      expect(buttonLabels).toEqual(
+        expect.arrayContaining(['Yes•0¢', 'No•100¢']),
+      );
     });
   });
 
@@ -1498,6 +1504,31 @@ describe('PredictMarketDetails', () => {
           entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
         },
       );
+    });
+
+    it('renders stacked footer labels for long outcome names', () => {
+      const singleOutcomeMarket = createMockMarket({
+        title: 'College basketball winner',
+        status: 'open',
+        outcomes: [
+          {
+            id: 'outcome-1',
+            title: 'Winner',
+            tokens: [
+              { id: 'token-1', title: 'Howard Bison', price: 0.98 },
+              { id: 'token-2', title: 'Coppin State Eagles', price: 0.02 },
+            ],
+            volume: 1000000,
+          },
+        ],
+      });
+
+      setupPredictMarketDetailsTest(singleOutcomeMarket);
+
+      expect(screen.getByText('Howard Bison')).toBeOnTheScreen();
+      expect(screen.getByText('98¢')).toBeOnTheScreen();
+      expect(screen.getByText('Coppin State Eagles')).toBeOnTheScreen();
+      expect(screen.getByText('2¢')).toBeOnTheScreen();
     });
   });
 
@@ -1690,7 +1721,7 @@ describe('PredictMarketDetails', () => {
       const actionButtons = getActionButtons();
       const buttonLabels = actionButtons.map(getActionButtonText);
 
-      expect(buttonLabels).toContain('•65¢');
+      expect(buttonLabels).toContain('Yes•65¢');
     });
 
     it('renders action buttons only for single outcome markets', () => {
@@ -1714,7 +1745,9 @@ describe('PredictMarketDetails', () => {
       const actionButtons = getActionButtons();
       const buttonLabels = actionButtons.map(getActionButtonText);
 
-      expect(buttonLabels).toEqual(expect.arrayContaining(['•65¢', '•35¢']));
+      expect(buttonLabels).toEqual(
+        expect.arrayContaining(['Yes•65¢', 'No•35¢']),
+      );
     });
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
@@ -23,6 +23,12 @@ import {
   type PredictOutcomeToken,
 } from '../../../../types';
 
+const LONG_OUTCOME_LABEL_THRESHOLD = 12;
+const TALL_ACTION_BUTTON_MIN_HEIGHT = 48;
+
+const shouldUseStackedActionButtonLabel = (title?: string) =>
+  Boolean(title && title.length > LONG_OUTCOME_LABEL_THRESHOLD);
+
 export interface PredictMarketDetailsActionsProps {
   isClaimablePositionsLoading: boolean;
   hasPositivePnl: boolean;
@@ -72,6 +78,25 @@ const PredictMarketDetailsActions = memo(
           ) {
             // use openOutcomes for real-time (CLOB) prices
             const firstOpenOutcome = openOutcomes[0];
+            const yesTitle =
+              firstOpenOutcome?.tokens?.[0]?.title ??
+              market?.outcomes?.[0]?.tokens?.[0]?.title ??
+              '';
+            const noTitle =
+              firstOpenOutcome?.tokens?.[1]?.title ??
+              market?.outcomes?.[0]?.tokens?.[1]?.title ??
+              '';
+            const useStackedLabels =
+              shouldUseStackedActionButtonLabel(yesTitle) ||
+              shouldUseStackedActionButtonLabel(noTitle);
+            const actionButtonStyle = [
+              tw.style('flex-1'),
+              useStackedLabels && {
+                height: undefined,
+                minHeight: TALL_ACTION_BUTTON_MIN_HEIGHT,
+                paddingVertical: 8,
+              },
+            ];
             return (
               <Box
                 flexDirection={BoxFlexDirection.Row}
@@ -83,14 +108,33 @@ const PredictMarketDetailsActions = memo(
                   variant={ButtonVariants.Secondary}
                   size={ButtonSize.Lg}
                   width={ButtonWidthTypes.Full}
-                  style={tw.style('flex-1 bg-success-muted')}
+                  style={[actionButtonStyle, tw.style('bg-success-muted')]}
                   label={
-                    <Text
-                      style={tw.style('font-bold')}
-                      color={TextColor.SuccessDefault}
-                    >
-                      {firstOpenOutcome?.tokens[0].title} • {yesPercentage}¢
-                    </Text>
+                    useStackedLabels ? (
+                      <Box twClassName="w-full items-center py-0.5">
+                        <Text
+                          style={tw.style('font-bold text-center')}
+                          color={TextColor.SuccessDefault}
+                          numberOfLines={2}
+                          ellipsizeMode="tail"
+                        >
+                          {yesTitle}
+                        </Text>
+                        <Text
+                          style={tw.style('font-bold text-center')}
+                          color={TextColor.SuccessDefault}
+                        >
+                          {yesPercentage}¢
+                        </Text>
+                      </Box>
+                    ) : (
+                      <Text
+                        style={tw.style('font-bold text-center')}
+                        color={TextColor.SuccessDefault}
+                      >
+                        {yesTitle} • {yesPercentage}¢
+                      </Text>
+                    )
                   }
                   onPress={() =>
                     onBuyPress(
@@ -103,15 +147,33 @@ const PredictMarketDetailsActions = memo(
                   variant={ButtonVariants.Secondary}
                   size={ButtonSize.Lg}
                   width={ButtonWidthTypes.Full}
-                  style={tw.style('flex-1 bg-error-muted')}
+                  style={[actionButtonStyle, tw.style('bg-error-muted')]}
                   label={
-                    <Text
-                      style={tw.style('font-bold')}
-                      color={TextColor.ErrorDefault}
-                    >
-                      {firstOpenOutcome?.tokens[1].title} •{' '}
-                      {100 - yesPercentage}¢
-                    </Text>
+                    useStackedLabels ? (
+                      <Box twClassName="w-full items-center py-0.5">
+                        <Text
+                          style={tw.style('font-bold text-center')}
+                          color={TextColor.ErrorDefault}
+                          numberOfLines={2}
+                          ellipsizeMode="tail"
+                        >
+                          {noTitle}
+                        </Text>
+                        <Text
+                          style={tw.style('font-bold text-center')}
+                          color={TextColor.ErrorDefault}
+                        >
+                          {100 - yesPercentage}¢
+                        </Text>
+                      </Box>
+                    ) : (
+                      <Text
+                        style={tw.style('font-bold text-center')}
+                        color={TextColor.ErrorDefault}
+                      >
+                        {noTitle} • {100 - yesPercentage}¢
+                      </Text>
+                    )
                   }
                   onPress={() =>
                     onBuyPress(

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
@@ -125,14 +125,16 @@ const PredictMarketDetailsActions = memo(
             const useStackedLabels =
               shouldUseStackedActionButtonLabel(yesTitle) ||
               shouldUseStackedActionButtonLabel(noTitle);
-            const actionButtonStyle = [
-              tw.style('flex-1'),
-              useStackedLabels && {
-                height: undefined,
-                minHeight: TALL_ACTION_BUTTON_MIN_HEIGHT,
-                paddingVertical: 8,
-              },
-            ];
+            const getActionButtonStyle = (backgroundClassName: string) =>
+              tw.style(
+                'flex-1',
+                backgroundClassName,
+                useStackedLabels && {
+                  height: 'auto',
+                  minHeight: TALL_ACTION_BUTTON_MIN_HEIGHT,
+                  paddingVertical: 8,
+                },
+              );
             return (
               <Box
                 flexDirection={BoxFlexDirection.Row}
@@ -144,7 +146,7 @@ const PredictMarketDetailsActions = memo(
                   variant={ButtonVariants.Secondary}
                   size={ButtonSize.Lg}
                   width={ButtonWidthTypes.Full}
-                  style={[actionButtonStyle, tw.style('bg-success-muted')]}
+                  style={getActionButtonStyle('bg-success-muted')}
                   label={renderActionButtonLabel({
                     title: yesTitle,
                     price: yesPercentage,
@@ -161,7 +163,7 @@ const PredictMarketDetailsActions = memo(
                   variant={ButtonVariants.Secondary}
                   size={ButtonSize.Lg}
                   width={ButtonWidthTypes.Full}
-                  style={[actionButtonStyle, tw.style('bg-error-muted')]}
+                  style={getActionButtonStyle('bg-error-muted')}
                   label={renderActionButtonLabel({
                     title: noTitle,
                     price: 100 - yesPercentage,

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
@@ -59,6 +59,42 @@ const PredictMarketDetailsActions = memo(
   }: PredictMarketDetailsActionsProps) => {
     const tw = useTailwind();
 
+    const renderActionButtonLabel = ({
+      title,
+      price,
+      color,
+      useStackedLabels,
+    }: {
+      title: string;
+      price: number;
+      color: TextColor;
+      useStackedLabels: boolean;
+    }) => {
+      if (useStackedLabels) {
+        return (
+          <Box twClassName="w-full items-center py-0.5">
+            <Text
+              style={tw.style('font-bold text-center')}
+              color={color}
+              numberOfLines={2}
+              ellipsizeMode="tail"
+            >
+              {title}
+            </Text>
+            <Text style={tw.style('font-bold text-center')} color={color}>
+              {price}¢
+            </Text>
+          </Box>
+        );
+      }
+
+      return (
+        <Text style={tw.style('font-bold text-center')} color={color}>
+          {title} • {price}¢
+        </Text>
+      );
+    };
+
     return (
       <>
         {(() => {
@@ -78,14 +114,14 @@ const PredictMarketDetailsActions = memo(
           ) {
             // use openOutcomes for real-time (CLOB) prices
             const firstOpenOutcome = openOutcomes[0];
-            const yesTitle =
-              firstOpenOutcome?.tokens?.[0]?.title ??
-              market?.outcomes?.[0]?.tokens?.[0]?.title ??
-              '';
-            const noTitle =
-              firstOpenOutcome?.tokens?.[1]?.title ??
-              market?.outcomes?.[0]?.tokens?.[1]?.title ??
-              '';
+            const yesToken =
+              firstOpenOutcome?.tokens?.[0] ??
+              market?.outcomes?.[0]?.tokens?.[0];
+            const noToken =
+              firstOpenOutcome?.tokens?.[1] ??
+              market?.outcomes?.[0]?.tokens?.[1];
+            const yesTitle = yesToken?.title ?? '';
+            const noTitle = noToken?.title ?? '';
             const useStackedLabels =
               shouldUseStackedActionButtonLabel(yesTitle) ||
               shouldUseStackedActionButtonLabel(noTitle);
@@ -109,78 +145,34 @@ const PredictMarketDetailsActions = memo(
                   size={ButtonSize.Lg}
                   width={ButtonWidthTypes.Full}
                   style={[actionButtonStyle, tw.style('bg-success-muted')]}
-                  label={
-                    useStackedLabels ? (
-                      <Box twClassName="w-full items-center py-0.5">
-                        <Text
-                          style={tw.style('font-bold text-center')}
-                          color={TextColor.SuccessDefault}
-                          numberOfLines={2}
-                          ellipsizeMode="tail"
-                        >
-                          {yesTitle}
-                        </Text>
-                        <Text
-                          style={tw.style('font-bold text-center')}
-                          color={TextColor.SuccessDefault}
-                        >
-                          {yesPercentage}¢
-                        </Text>
-                      </Box>
-                    ) : (
-                      <Text
-                        style={tw.style('font-bold text-center')}
-                        color={TextColor.SuccessDefault}
-                      >
-                        {yesTitle} • {yesPercentage}¢
-                      </Text>
-                    )
-                  }
-                  onPress={() =>
-                    onBuyPress(
-                      firstOpenOutcome?.tokens[0] ??
-                        market?.outcomes[0].tokens[0],
-                    )
-                  }
+                  label={renderActionButtonLabel({
+                    title: yesTitle,
+                    price: yesPercentage,
+                    color: TextColor.SuccessDefault,
+                    useStackedLabels,
+                  })}
+                  onPress={() => {
+                    if (yesToken) {
+                      onBuyPress(yesToken);
+                    }
+                  }}
                 />
                 <Button
                   variant={ButtonVariants.Secondary}
                   size={ButtonSize.Lg}
                   width={ButtonWidthTypes.Full}
                   style={[actionButtonStyle, tw.style('bg-error-muted')]}
-                  label={
-                    useStackedLabels ? (
-                      <Box twClassName="w-full items-center py-0.5">
-                        <Text
-                          style={tw.style('font-bold text-center')}
-                          color={TextColor.ErrorDefault}
-                          numberOfLines={2}
-                          ellipsizeMode="tail"
-                        >
-                          {noTitle}
-                        </Text>
-                        <Text
-                          style={tw.style('font-bold text-center')}
-                          color={TextColor.ErrorDefault}
-                        >
-                          {100 - yesPercentage}¢
-                        </Text>
-                      </Box>
-                    ) : (
-                      <Text
-                        style={tw.style('font-bold text-center')}
-                        color={TextColor.ErrorDefault}
-                      >
-                        {noTitle} • {100 - yesPercentage}¢
-                      </Text>
-                    )
-                  }
-                  onPress={() =>
-                    onBuyPress(
-                      firstOpenOutcome?.tokens[1] ??
-                        market?.outcomes[0].tokens[1],
-                    )
-                  }
+                  label={renderActionButtonLabel({
+                    title: noTitle,
+                    price: 100 - yesPercentage,
+                    color: TextColor.ErrorDefault,
+                    useStackedLabels,
+                  })}
+                  onPress={() => {
+                    if (noToken) {
+                      onBuyPress(noToken);
+                    }
+                  }}
                 />
               </Box>
             );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously, long outcome names in the footer CTA buttons on the sports prediction market details screen could wrap awkwardly and break the button layout. This PR updates those CTA buttons to switch to a stacked title-and-price layout for longer labels and allows the buttons to grow vertically when needed, so the content stays readable, centered, and visually consistent. It also adds regression coverage for long outcome names.

## **Changelog**

CHANGELOG entry: Fixed a bug where long sports prediction outcome names could break the action button layout on market details.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: sports prediction market CTA layout

  Scenario: user views a market with long outcome names
    Given user is on an open sports prediction market details screen with long team names
    And the About tab is selected

    When the footer action buttons are shown
    Then each outcome name wraps cleanly within its button
    And each button grows tall enough to fit the wrapped text
    And the price remains visible and centered
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="391" height="777" alt="Screenshot 2026-03-23 at 4 41 02 PM" src="https://github.com/user-attachments/assets/f797efb4-fa64-4b7a-b429-9b463d754470" />

<!-- [screenshots/recordings] -->

### **After**

<img width="379" height="758" alt="Screenshot 2026-03-23 at 4 40 53 PM" src="https://github.com/user-attachments/assets/526a7a5d-64af-4c09-a9c4-839e0fbd9594" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to footer action button rendering plus test updates; main risk is minor layout regressions or missing token/title edge cases in the new label logic.
> 
> **Overview**
> Fixes footer CTA button layout for sports Predict markets by switching to a *stacked title + price* label when outcome names exceed a length threshold, and allowing the buttons to grow vertically (min height/padding) so long text wraps cleanly.
> 
> Updates `PredictMarketDetails` tests to match the new button label format, makes button selection resilient by parsing the trailing `¢` price instead of exact label strings, and adds a regression test asserting long outcome names render with visible title and price.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf74e3b856076fa19262269f0e3d917dd7c61f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->