### PR TITLE
fix(card): fix missing network issue

### DIFF
--- a/app/components/UI/Card/hooks/useCardDelegation.test.ts
+++ b/app/components/UI/Card/hooks/useCardDelegation.test.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useCardDelegation, UserCancelledError } from './useCardDelegation';
 import { useCardSDK } from '../sdk';
 import { useNeedsGasFaucet } from './useNeedsGasFaucet';
+import { useEnsureCardNetworkExists } from './useEnsureCardNetworkExists';
 import { CardSDK } from '../sdk/CardSDK';
 import { CardTokenAllowance, AllowanceState } from '../types';
 import Engine from '../../../../core/Engine';
@@ -33,6 +34,10 @@ jest.mock('./useNeedsGasFaucet', () => ({
   useNeedsGasFaucet: jest.fn(),
 }));
 
+jest.mock('./useEnsureCardNetworkExists', () => ({
+  useEnsureCardNetworkExists: jest.fn(),
+}));
+
 jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
 }));
@@ -58,9 +63,6 @@ jest.mock('../../../../core/Engine', () => ({
     TransactionController: {
       addTransaction: jest.fn(),
     },
-    NetworkController: {
-      findNetworkClientIdByChainId: jest.fn(),
-    },
   },
   controllerMessenger: {
     subscribeOnceIf: jest.fn(),
@@ -73,6 +75,11 @@ const mockUseAnalytics = jest.mocked(useAnalytics);
 const mockUseNeedsGasFaucet = useNeedsGasFaucet as jest.MockedFunction<
   typeof useNeedsGasFaucet
 >;
+const mockEnsureNetworkExists = jest.fn();
+const mockUseEnsureCardNetworkExists =
+  useEnsureCardNetworkExists as jest.MockedFunction<
+    typeof useEnsureCardNetworkExists
+  >;
 const mockToTokenMinimalUnit = toTokenMinimalUnit as jest.MockedFunction<
   typeof toTokenMinimalUnit
 >;
@@ -180,9 +187,11 @@ describe('useCardDelegation', () => {
           id: 'transaction-meta-id-123',
         },
       });
-    Engine.context.NetworkController.findNetworkClientIdByChainId = jest
-      .fn()
-      .mockReturnValue(mockNetworkClientId);
+    // Setup useEnsureCardNetworkExists mock
+    mockEnsureNetworkExists.mockResolvedValue(mockNetworkClientId);
+    mockUseEnsureCardNetworkExists.mockReturnValue({
+      ensureNetworkExists: mockEnsureNetworkExists,
+    });
 
     // Setup controllerMessenger mock to simulate transaction confirmation
     Engine.controllerMessenger.subscribeOnceIf = jest
@@ -968,7 +977,7 @@ describe('useCardDelegation', () => {
       );
     });
 
-    it('finds network client by chain ID', async () => {
+    it('ensures network exists for the token chain ID', async () => {
       const mockToken = createMockToken({ caipChainId: 'eip155:137' });
       const params = createMockDelegationParams();
 
@@ -978,9 +987,7 @@ describe('useCardDelegation', () => {
         await result.current.submitDelegation(params);
       });
 
-      expect(
-        Engine.context.NetworkController.findNetworkClientIdByChainId,
-      ).toHaveBeenCalled();
+      expect(mockEnsureNetworkExists).toHaveBeenCalledWith('eip155:137');
     });
 
     it('subscribes to transaction confirmation event', async () => {

--- a/app/components/UI/Card/hooks/useCardDelegation.ts
+++ b/app/components/UI/Card/hooks/useCardDelegation.ts
@@ -12,9 +12,8 @@ import Logger from '../../../../util/Logger';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { useCardSDK } from '../sdk';
 import { CardNetwork, CardTokenAllowance } from '../types';
-import { safeFormatChainIdToHex } from '../util/safeFormatChainIdToHex';
-import { Hex } from '@metamask/utils';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { useEnsureCardNetworkExists } from './useEnsureCardNetworkExists';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { ARBITRARY_ALLOWANCE } from '../constants';
 import { toTokenMinimalUnit } from '../../../../util/number';
@@ -52,8 +51,8 @@ interface DelegationParams {
  */
 export const useCardDelegation = (token?: CardTokenAllowance | null) => {
   const { sdk } = useCardSDK();
-  const { KeyringController, TransactionController, NetworkController } =
-    Engine.context;
+  const { KeyringController, TransactionController } = Engine.context;
+  const { ensureNetworkExists } = useEnsureCardNetworkExists();
   const selectAccountByScope = useSelector(
     selectSelectedInternalAccountByScope,
   );
@@ -106,8 +105,8 @@ export const useCardDelegation = (token?: CardTokenAllowance | null) => {
         throw new Error('Missing token address');
       }
 
-      const networkClientId = NetworkController.findNetworkClientIdByChainId(
-        safeFormatChainIdToHex(token.caipChainId ?? '') as Hex,
+      const networkClientId = await ensureNetworkExists(
+        token.caipChainId ?? '',
       );
 
       // Convert amount to minimal units based on token decimals
@@ -210,7 +209,7 @@ export const useCardDelegation = (token?: CardTokenAllowance | null) => {
         throw error;
       }
     },
-    [sdk, token, TransactionController, NetworkController],
+    [sdk, token, TransactionController, ensureNetworkExists],
   );
 
   /**

--- a/app/components/UI/Card/hooks/useEnsureCardNetworkExists.test.ts
+++ b/app/components/UI/Card/hooks/useEnsureCardNetworkExists.test.ts
@@ -1,0 +1,214 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { useSelector } from 'react-redux';
+import { useEnsureCardNetworkExists } from './useEnsureCardNetworkExists';
+import Engine from '../../../../core/Engine';
+import { useNetworkEnablement } from '../../../hooks/useNetworkEnablement/useNetworkEnablement';
+
+jest.mock('../../../../core/Engine');
+jest.mock('../../../hooks/useNetworkEnablement/useNetworkEnablement');
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockEnableNetwork = jest.fn();
+const mockAddNetwork = jest.fn();
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+interface MockEngineContext {
+  NetworkController: {
+    addNetwork: jest.Mock;
+  };
+}
+
+const MONAD_CAIP_CHAIN_ID = 'eip155:143';
+const MONAD_HEX_CHAIN_ID = '0x8f';
+const UNKNOWN_CAIP_CHAIN_ID = 'eip155:99999';
+
+describe('useEnsureCardNetworkExists', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useNetworkEnablement as jest.Mock).mockReturnValue({
+      enableNetwork: mockEnableNetwork,
+    });
+
+    (Engine.context as unknown as MockEngineContext) = {
+      NetworkController: {
+        addNetwork: mockAddNetwork,
+      },
+    };
+
+    // Default: no networks configured
+    mockUseSelector.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns ensureNetworkExists function', () => {
+    const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+    expect(result.current).toEqual({
+      ensureNetworkExists: expect.any(Function),
+    });
+  });
+
+  describe('ensureNetworkExists', () => {
+    describe('when network already exists in user configurations', () => {
+      const existingNetworkClientId = 'monad-mainnet';
+
+      beforeEach(() => {
+        mockUseSelector.mockReturnValue({
+          [MONAD_HEX_CHAIN_ID]: {
+            chainId: MONAD_HEX_CHAIN_ID,
+            defaultRpcEndpointIndex: 0,
+            rpcEndpoints: [{ networkClientId: existingNetworkClientId }],
+          },
+        });
+      });
+
+      it('returns the existing networkClientId', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        let networkClientId: string | undefined;
+        await act(async () => {
+          networkClientId =
+            await result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID);
+        });
+
+        expect(networkClientId).toBe(existingNetworkClientId);
+      });
+
+      it('does not call addNetwork', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID);
+        });
+
+        expect(mockAddNetwork).not.toHaveBeenCalled();
+      });
+
+      it('does not call enableNetwork', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID);
+        });
+
+        expect(mockEnableNetwork).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when network is missing', () => {
+      const newNetworkClientId = 'monad-mainnet-new';
+
+      beforeEach(() => {
+        mockAddNetwork.mockResolvedValue({
+          chainId: MONAD_HEX_CHAIN_ID,
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [{ networkClientId: newNetworkClientId }],
+        });
+      });
+
+      it('calls addNetwork with Monad config from PopularList', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID);
+        });
+
+        expect(mockAddNetwork).toHaveBeenCalledWith({
+          chainId: MONAD_HEX_CHAIN_ID,
+          blockExplorerUrls: ['https://monadscan.com/'],
+          defaultRpcEndpointIndex: 0,
+          defaultBlockExplorerUrlIndex: 0,
+          name: 'Monad',
+          nativeCurrency: 'MON',
+          rpcEndpoints: [
+            {
+              url: expect.stringContaining(
+                'https://monad-mainnet.infura.io/v3/',
+              ),
+              failoverUrls: expect.any(Array),
+              name: 'Monad',
+              type: RpcEndpointType.Custom,
+            },
+          ],
+        });
+      });
+
+      it('enables the network after adding it', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID);
+        });
+
+        expect(mockEnableNetwork).toHaveBeenCalledWith(MONAD_CAIP_CHAIN_ID);
+        expect(mockEnableNetwork).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns the new networkClientId', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        let networkClientId: string | undefined;
+        await act(async () => {
+          networkClientId =
+            await result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID);
+        });
+
+        expect(networkClientId).toBe(newNetworkClientId);
+      });
+
+      it('throws when addNetwork returns no networkClientId', async () => {
+        mockAddNetwork.mockResolvedValue({
+          chainId: MONAD_HEX_CHAIN_ID,
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [{}],
+        });
+
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await expect(
+            result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID),
+          ).rejects.toThrow(
+            `Failed to get networkClientId after adding network for ${MONAD_CAIP_CHAIN_ID}`,
+          );
+        });
+      });
+
+      it('propagates addNetwork errors', async () => {
+        const networkError = new Error('Network addition failed');
+        mockAddNetwork.mockRejectedValue(networkError);
+
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await expect(
+            result.current.ensureNetworkExists(MONAD_CAIP_CHAIN_ID),
+          ).rejects.toThrow('Network addition failed');
+        });
+      });
+    });
+
+    describe('when chain ID is not in PopularList', () => {
+      it('throws a descriptive error', async () => {
+        const { result } = renderHook(() => useEnsureCardNetworkExists());
+
+        await act(async () => {
+          await expect(
+            result.current.ensureNetworkExists(UNKNOWN_CAIP_CHAIN_ID),
+          ).rejects.toThrow(
+            `Network not found in PopularList for chain ID ${UNKNOWN_CAIP_CHAIN_ID}`,
+          );
+        });
+
+        expect(mockAddNetwork).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/app/components/UI/Card/hooks/useEnsureCardNetworkExists.ts
+++ b/app/components/UI/Card/hooks/useEnsureCardNetworkExists.ts
@@ -1,0 +1,89 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { CaipChainId, Hex } from '@metamask/utils';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { toHex } from '@metamask/controller-utils';
+import Engine from '../../../../core/Engine';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
+import { useNetworkEnablement } from '../../../hooks/useNetworkEnablement/useNetworkEnablement';
+import { PopularList } from '../../../../util/networks/customNetworks';
+import { safeFormatChainIdToHex } from '../util/safeFormatChainIdToHex';
+
+/**
+ * Ensures a Card-supported EVM network exists in the user's network list.
+ * If the network is missing, it automatically adds it from the PopularList and enables it.
+ */
+export const useEnsureCardNetworkExists = () => {
+  const networkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+  const { enableNetwork } = useNetworkEnablement();
+
+  /**
+   * Ensures the network for the given CAIP chain ID exists and returns its networkClientId.
+   */
+  const ensureNetworkExists = useCallback(
+    async (caipChainId: string): Promise<string> => {
+      const hexChainId = safeFormatChainIdToHex(caipChainId) as Hex;
+
+      // Network already exists — return existing networkClientId
+      const existingConfig = networkConfigurations[hexChainId];
+      if (existingConfig) {
+        const { rpcEndpoints, defaultRpcEndpointIndex } = existingConfig;
+        return rpcEndpoints[defaultRpcEndpointIndex].networkClientId;
+      }
+
+      // Network is missing — find it in PopularList and add it
+      const popularEntry = PopularList.find(
+        (network) => toHex(network.chainId as string) === hexChainId,
+      );
+
+      if (!popularEntry) {
+        throw new Error(
+          `Network not found in PopularList for chain ID ${caipChainId}`,
+        );
+      }
+
+      const { NetworkController } = Engine.context;
+
+      const addedNetwork = await NetworkController.addNetwork({
+        chainId: hexChainId,
+        blockExplorerUrls: popularEntry.rpcPrefs?.blockExplorerUrl
+          ? [popularEntry.rpcPrefs.blockExplorerUrl]
+          : [],
+        defaultRpcEndpointIndex: 0,
+        defaultBlockExplorerUrlIndex: popularEntry.rpcPrefs?.blockExplorerUrl
+          ? 0
+          : undefined,
+        name: popularEntry.nickname,
+        nativeCurrency: popularEntry.ticker,
+        rpcEndpoints: [
+          {
+            url: popularEntry.rpcUrl,
+            failoverUrls: popularEntry.failoverRpcUrls,
+            name: popularEntry.nickname,
+            type: RpcEndpointType.Custom,
+          },
+        ],
+      });
+
+      // Enable the newly added network in the network filter
+      enableNetwork(caipChainId as CaipChainId);
+
+      const networkClientId =
+        addedNetwork?.rpcEndpoints?.[addedNetwork.defaultRpcEndpointIndex]
+          ?.networkClientId;
+
+      if (!networkClientId) {
+        throw new Error(
+          `Failed to get networkClientId after adding network for ${caipChainId}`,
+        );
+      }
+
+      return networkClientId;
+    },
+    [networkConfigurations, enableNetwork],
+  );
+
+  return { ensureNetworkExists };
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes Card spending-limit delegation when the token’s chain (e.g. Monad) is **not yet added** to the user’s network list. Previously, `useCardDelegation` resolved the approval transaction’s `networkClientId` via **`NetworkController.findNetworkClientIdByChainId`**, which only works for networks the wallet already knows about—so flows could fail for Card-supported chains that were missing from the client.

**What changed**:

- **`useEnsureCardNetworkExists` (new)**: Hook that, given a CAIP chain ID, returns the correct `networkClientId`. If the EVM network is already in **`selectEvmNetworkConfigurationsByChainId`**, it returns the existing client id. If not, it looks up the chain in **`PopularList`**, calls **`NetworkController.addNetwork`** with that RPC/metadata, **`enableNetwork`** so the network filter includes it, then returns the new `networkClientId`. Throws a clear error if the chain is not in `PopularList` or if `addNetwork` does not yield a client id.
- **`useCardDelegation`**: Replaces `findNetworkClientIdByChainId` + `safeFormatChainIdToHex` with **`await ensureNetworkExists(token.caipChainId)`** before **`TransactionController.addTransaction`** for the approval.
- **Tests**: **`useEnsureCardNetworkExists.test.ts`** covers existing vs missing network, Monad-style `PopularList` add + enable, errors for unknown chains and failed adds; **`useCardDelegation.test.ts`** mocks the new hook and asserts **`ensureNetworkExists`** is called with the token’s CAIP chain id.

## **Changelog**

CHANGELOG entry: Card delegation now auto-adds Card-supported EVM networks from the popular list when missing, so approval transactions get a valid `networkClientId` (e.g. Monad).

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card delegation when network is not in the wallet

  Scenario: Delegation on a chain already in the network list
    Given I have the Card token’s chain already added (e.g. Polygon)
    When I complete the spending limit / delegation approval flow
    Then the approval transaction submits without adding a duplicate network

  Scenario: Delegation on a Card-supported chain not yet added (e.g. Monad)
    Given the token’s CAIP chain is in PopularList but not in my networks
    When I run the Card delegation approval flow
    Then the app adds the network from the popular list, enables it, and submits the approval on that network

  Scenario: Unsupported chain not in PopularList
    Given a chain ID that is not in PopularList (if testable)
    When delegation runs
    Then the user sees a failure path consistent with the thrown error (network not found in PopularList)
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/0cd1b22f-5296-41f3-b961-316f05c3ae79

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes transaction routing by potentially auto-adding and enabling EVM networks at runtime, which could impact network configuration/state if the PopularList entry or enablement flow is wrong.
> 
> **Overview**
> Fixes Card spending-limit delegation failing when the token’s chain isn’t already in the user’s configured networks by resolving a valid `networkClientId` even for missing chains.
> 
> Adds `useEnsureCardNetworkExists`, which checks existing EVM network configs and otherwise adds the chain from `PopularList` via `NetworkController.addNetwork` and enables it before returning the new `networkClientId`. `useCardDelegation` now calls this hook (replacing `findNetworkClientIdByChainId`) and tests are updated/added to cover the new behavior and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9386501051c496b9906bae6edbf8ba5d80eee4e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->