### PR TITLE
test: fix perf login tests

### DIFF
--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -29,9 +29,7 @@ class LoginView {
             LoginViewSelectors.PASSWORD_INPUT,
           ),
         ios: () =>
-          PlaywrightMatchers.getElementByIOSClassChain(
-            LoginViewSelectors.PASSWORD_INPUT,
-          ),
+          PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT),
       },
     });
   }

--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -25,11 +25,13 @@ class LoginView {
         Matchers.getElementByLabel(LoginViewSelectors.PASSWORD_INPUT),
       appium: {
         android: () =>
+          PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT, {
+            exact: true,
+          }),
+        ios: () =>
           PlaywrightMatchers.getElementByAccessibilityId(
             LoginViewSelectors.PASSWORD_INPUT,
           ),
-        ios: () =>
-          PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT),
       },
     });
   }

--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -25,11 +25,11 @@ class LoginView {
         Matchers.getElementByLabel(LoginViewSelectors.PASSWORD_INPUT),
       appium: {
         android: () =>
-          PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT, {
-            exact: true,
-          }),
-        ios: () =>
           PlaywrightMatchers.getElementByAccessibilityId(
+            LoginViewSelectors.PASSWORD_INPUT,
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByIOSClassChain(
             LoginViewSelectors.PASSWORD_INPUT,
           ),
       },

--- a/wdio/screen-objects/LoginScreen.js
+++ b/wdio/screen-objects/LoginScreen.js
@@ -19,9 +19,11 @@ class LoginScreen {
   get loginScreen() {
     if (!this._device) {
       return Selectors.getXpathElementByResourceId(LoginViewSelectors.CONTAINER);
-    } else {
-      return AppwrightSelectors.getElementByResourceId(this._device, LoginViewSelectors.CONTAINER);
     }
+    return AppwrightSelectors.getElementByID(
+      this._device,
+      LoginViewSelectors.CONTAINER,
+    );
   }
 
   get welcomeBackText() {
@@ -52,16 +54,17 @@ class LoginScreen {
       return Selectors.getXpathElementByResourceId(
         LoginViewSelectors.PASSWORD_INPUT,
       );
-    } else {
-      if (AppwrightSelectors.isAndroid(this._device)) {
-        return AppwrightSelectors.getElementByID(
-          this._device,
-          LoginViewSelectors.PASSWORD_INPUT,
-        );
-      } else {
-        return AppwrightSelectors.getElementByID(this._device, "textfield", true);
-      }
     }
+     if (AppwrightSelectors.isAndroid(this._device)) {
+      return AppwrightSelectors.getElementByCatchAll(
+        this._device,
+        LoginViewSelectors.PASSWORD_INPUT,
+      );
+    }
+    return AppwrightSelectors.getElementByID(
+      this._device,
+      LoginViewSelectors.PASSWORD_INPUT,
+    );
   }
 
   // Migrated to LoginView.ts (tests/page-objects/wallet/LoginView.ts)


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> Updates the `LoginScreen` WDIO page object to use Appwright `getElementByID` for the login container when running with a device, aligning element lookup with test IDs.
> 
> Refines password field lookup in `getPasswordInputElement` by switching Android to the more flexible `getElementByCatchAll` and removing the iOS-specific fallback to a generic `textfield`, instead targeting `LoginViewSelectors.PASSWORD_INPUT` directly.
> 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that updates element lookup strategies; main risk is flaky or broken login E2E tests if the new IDs/catch-all matching don’t resolve consistently across platforms.
> 
> **Overview**
> Updates the WDIO `LoginScreen` page object to use Appwright `getElementByID` for the login container when a device is present, instead of using the resource-id based lookup.
> 
> Refines `getPasswordInputElement` to use `getElementByCatchAll` on Android and removes the iOS fallback to a generic `textfield`, consistently targeting `LoginViewSelectors.PASSWORD_INPUT` via Appwright.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7681d1d777b54002c586ecc60a2fcd79b9a951c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->