### PR TITLE
test(swap): enable Smart Transactions in swap and bridge E2E tests

### DIFF
--- a/tests/helpers/swap/smart-transactions-mocks.ts
+++ b/tests/helpers/swap/smart-transactions-mocks.ts
@@ -156,17 +156,18 @@ export async function setupSmartTransactionsMocks(
     responseCode: 200,
   });
 
-  // Mock GET /getTxStatus – mirrors the extension's mockGetTxStatus.
-  // The BridgeStatusController polls this endpoint to determine if the swap
-  // is complete. It must return status: 'COMPLETE' (uppercase) with srcChain
-  // and destChain txHash fields so the controller marks the tx as finished.
+  // Mock GET /getTxStatus – fallback for same-chain swap tests.
+  // Registered at priority 1 so bridge-mocks.ts (priority 999) always wins
+  // for bridge tests, where src and dest tx hashes legitimately differ.
+  // For same-chain swaps srcChainId == destChainId so reusing srcTxHash for
+  // both chains is correct.
   await mockServer
     .forGet('/proxy')
     .matching((request) => {
       const url = getDecodedProxiedURL(request.url);
       return url.includes('getTxStatus');
     })
-    .asPriority(999)
+    .asPriority(1)
     .thenCallback((request) => {
       const decodedUrl = getDecodedProxiedURL(request.url);
       const urlObj = new URL(decodedUrl);

--- a/tests/helpers/swap/smart-transactions-mocks.ts
+++ b/tests/helpers/swap/smart-transactions-mocks.ts
@@ -1,0 +1,194 @@
+import { Mockttp } from 'mockttp';
+import { setupMockRequest } from '../../api-mocking/helpers/mockHelpers';
+import { getDecodedProxiedURL } from '../../smoke/notifications/utils/helpers';
+import PortManager, { ResourceType } from '../../framework/PortManager';
+
+const STX_UUID = '0d506aaa-5e38-4cab-ad09-2039cb7a0f33';
+
+/**
+ * /getFees response body.
+ * The STX controller reads `txs[0].fees` to obtain gas fee parameters
+ * for signing the swap transaction locally before submitting to the backend.
+ */
+const GET_FEES_RESPONSE = {
+  txs: [
+    {
+      cancelFees: [],
+      return: '0x',
+      status: 1,
+      gasUsed: 190780,
+      gasLimit: 239420,
+      fees: [
+        {
+          maxFeePerGas: 4667609171,
+          maxPriorityFeePerGas: 1000000004,
+          gas: 239420,
+          balanceNeeded: 1217518987960240,
+          currentBalance: 751982303082919400,
+          error: '',
+        },
+      ],
+      feeEstimate: 627603309182220,
+      baseFeePerGas: 2289670348,
+      maxFeeEstimate: 1117518987720820,
+    },
+  ],
+};
+
+/**
+ * Sets up HTTP mocks that allow swap tests to execute with Smart Transactions enabled.
+ *
+ * ## How it works
+ *
+ * When Smart Transactions (STX) are enabled the publish hook intercepts every swap
+ * transaction before it reaches the network:
+ * 1. Calls `POST /getFees` → we return a static fee schedule.
+ * 2. Signs the transaction locally using those fees.
+ * 3. Calls `POST /submitTransactions` → we forward the raw signed tx to Anvil
+ * via `eth_sendRawTransaction` so it actually gets mined, then return a UUID.
+ * 4. Because `mobileReturnTxHashAsap: true` (set in the default remote feature-flag
+ * mock), the hook immediately uses the locally-computed `txHash` without waiting
+ * for `batchStatus` polling.
+ * 5. TransactionController polls Anvil for `eth_getTransactionReceipt` using that
+ * hash → Anvil returns a valid receipt → transaction is marked Confirmed.
+ *
+ * @param mockServer - The mockttp server instance.
+ * @param anvilPort  - The port Anvil is listening on (defaults to DEFAULT_ANVIL_PORT).
+ */
+export async function setupSmartTransactionsMocks(
+  mockServer: Mockttp,
+  anvilPort: number,
+): Promise<void> {
+  // anvilPort is the fallback (DEFAULT_ANVIL_PORT = 8545).
+  // On local dev the port manager allocates a random port, so we resolve
+  // the actual port at request time to avoid ECONNREFUSED errors.
+  const getActualAnvilRpcUrl = () => {
+    const actualPort =
+      PortManager.getInstance().getPort(ResourceType.ANVIL) ?? anvilPort;
+    return `http://localhost:${actualPort}`;
+  };
+
+  // Mock POST /getFees – returns a single fee tier so createSignedTransactions
+  // produces a non-empty rawTxs array that can be forwarded to Anvil.
+  await setupMockRequest(mockServer, {
+    url: /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/getFees/,
+    response: GET_FEES_RESPONSE,
+    requestMethod: 'POST',
+    responseCode: 200,
+  });
+
+  // Mock POST /submitTransactions – forward the signed transaction to Anvil so
+  // eth_getTransactionReceipt resolves once the block is mined.
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/submitTransactions/.test(
+        url,
+      );
+    })
+    .asPriority(999)
+    .thenCallback(async (request) => {
+      let rawTxs: string[] = [];
+
+      try {
+        const bodyText = await request.body.getText();
+        const body = JSON.parse(bodyText ?? '{}');
+        rawTxs = body?.rawTxs ?? [];
+      } catch {
+        // Ignore JSON-parse errors – we still return a valid UUID below.
+      }
+
+      // Submit all signed transactions to Anvil so the locally-computed txHashes
+      // are already on-chain when TransactionController polls for receipts.
+      // When STX is enabled and a swap requires an approval, both the approval
+      // tx and the swap tx are batched into a single submitTransactions call as
+      // rawTxs = [approvalTx, swapTx]. We must forward both sequentially so
+      // Anvil mines the approval before the swap (preserving nonce order).
+      for (let i = 0; i < rawTxs.length; i++) {
+        try {
+          await fetch(getActualAnvilRpcUrl(), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              method: 'eth_sendRawTransaction',
+              params: [rawTxs[i]],
+              id: i + 1,
+            }),
+          });
+        } catch {
+          // Non-fatal: the controller computes txHashes locally from rawTxs
+          // regardless of whether this submission succeeds.
+        }
+      }
+
+      return {
+        statusCode: 200,
+        json: { uuid: STX_UUID },
+      };
+    });
+
+  // Mock GET /batchStatus – the STX controller polls this in the background
+  // after submitTransactions. Mobile uses mobileReturnTxHashAsap: true so the
+  // hook does not wait for this, but polling still runs in the background.
+  // We always return SUCCESS so the background polling stops cleanly.
+  const GET_BATCH_STATUS_SUCCESS = {
+    [STX_UUID]: {
+      cancellationFeeWei: 0,
+      cancellationReason: 'not_cancelled',
+      deadlineRatio: 0,
+      isSettled: true,
+      minedTx: 'success',
+      wouldRevertMessage: null,
+      minedHash:
+        '0xec9d6214684d6dc191133ae4a7ec97db3e521fff9cfe5c4f48a84cb6c93a5fa5',
+      timedOut: true,
+      proxied: false,
+      type: 'sentinel',
+    },
+  };
+
+  await setupMockRequest(mockServer, {
+    url: /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/batchStatus/,
+    response: GET_BATCH_STATUS_SUCCESS,
+    requestMethod: 'GET',
+    responseCode: 200,
+  });
+
+  // Mock GET /getTxStatus – mirrors the extension's mockGetTxStatus.
+  // The BridgeStatusController polls this endpoint to determine if the swap
+  // is complete. It must return status: 'COMPLETE' (uppercase) with srcChain
+  // and destChain txHash fields so the controller marks the tx as finished.
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return url.includes('getTxStatus');
+    })
+    .asPriority(999)
+    .thenCallback((request) => {
+      const decodedUrl = getDecodedProxiedURL(request.url);
+      const urlObj = new URL(decodedUrl);
+      const txHash = urlObj.searchParams.get('srcTxHash');
+      const srcChainId = urlObj.searchParams.get('srcChainId');
+      const destChainId = urlObj.searchParams.get('destChainId');
+
+      return {
+        statusCode: 200,
+        json: {
+          status: 'COMPLETE',
+          isExpectedToken: true,
+          bridge: 'across',
+          srcChain: {
+            chainId: Number(srcChainId),
+            txHash,
+          },
+          destChain: {
+            chainId: Number(destChainId),
+            txHash,
+          },
+        },
+      };
+    });
+}

--- a/tests/regression/swap/swap-action-regression.spec.ts
+++ b/tests/regression/swap/swap-action-regression.spec.ts
@@ -12,7 +12,8 @@ import { loginToApp } from '../../flows/wallet.flow';
 import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
 import { testSpecificMock } from '../../helpers/swap/swap-mocks';
-import { AnvilManager } from '../../seeder/anvil-manager';
+import { setupSmartTransactionsMocks } from '../../helpers/swap/smart-transactions-mocks';
+import { AnvilManager, DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager';
 
 describe(RegressionTrade('Swap ETH <-> WETH from Actions'), (): void => {
   beforeEach(async (): Promise<void> => {
@@ -37,7 +38,6 @@ describe(RegressionTrade('Swap ETH <-> WETH from Actions'), (): void => {
               nickname: 'Localhost',
               ticker: 'ETH',
             })
-            .withDisabledSmartTransactions()
             .build();
         },
         localNodeOptions: [
@@ -49,7 +49,10 @@ describe(RegressionTrade('Swap ETH <-> WETH from Actions'), (): void => {
             },
           },
         ],
-        testSpecificMock,
+        testSpecificMock: async (mockServer) => {
+          await testSpecificMock(mockServer);
+          await setupSmartTransactionsMocks(mockServer, DEFAULT_ANVIL_PORT);
+        },
         restartDevice: true,
       },
       async () => {

--- a/tests/regression/swap/swap-token-chart.spec.ts
+++ b/tests/regression/swap/swap-token-chart.spec.ts
@@ -13,12 +13,13 @@ import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
 import { ActivitiesViewSelectorsText } from '../../../app/components/Views/ActivityView/ActivitiesView.testIds';
 import { submitSwapUnifiedUI } from '../../helpers/swap/swap-unified-ui';
 import { testSpecificMock } from '../../helpers/swap/swap-mocks';
+import { setupSmartTransactionsMocks } from '../../helpers/swap/smart-transactions-mocks';
 import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../seeder/anvil-manager';
+import { AnvilManager, DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager';
 
 describe(RegressionTrade('Swap from Token view'), (): void => {
-  jest.setTimeout(120000);
+  jest.setTimeout(180000);
 
   it('should complete a USDC to DAI swap from the token chart', async (): Promise<void> => {
     const FIRST_ROW: number = 0;
@@ -44,7 +45,6 @@ describe(RegressionTrade('Swap from Token view'), (): void => {
               nickname: 'Localhost',
               ticker: 'ETH',
             })
-            .withDisabledSmartTransactions()
             .build();
         },
         localNodeOptions: [
@@ -55,7 +55,10 @@ describe(RegressionTrade('Swap from Token view'), (): void => {
             },
           },
         ],
-        testSpecificMock,
+        testSpecificMock: async (mockServer) => {
+          await testSpecificMock(mockServer);
+          await setupSmartTransactionsMocks(mockServer, DEFAULT_ANVIL_PORT);
+        },
         restartDevice: true,
       },
       async () => {

--- a/tests/regression/swap/swap-token-rwa.spec.ts
+++ b/tests/regression/swap/swap-token-rwa.spec.ts
@@ -11,9 +11,10 @@ import {
   checkSwapActivity,
 } from '../../helpers/swap/swap-unified-ui';
 import { testSpecificMock } from '../../helpers/swap/swap-mocks';
+import { setupSmartTransactionsMocks } from '../../helpers/swap/smart-transactions-mocks';
 import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../seeder/anvil-manager';
+import { AnvilManager, DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager';
 
 describe(RegressionTrade('Swap RWA'), (): void => {
   jest.setTimeout(120000);
@@ -41,7 +42,6 @@ describe(RegressionTrade('Swap RWA'), (): void => {
               nickname: 'Localhost',
               ticker: 'ETH',
             })
-            .withDisabledSmartTransactions()
             .build();
         },
         localNodeOptions: [
@@ -53,7 +53,10 @@ describe(RegressionTrade('Swap RWA'), (): void => {
             },
           },
         ],
-        testSpecificMock,
+        testSpecificMock: async (mockServer) => {
+          await testSpecificMock(mockServer);
+          await setupSmartTransactionsMocks(mockServer, DEFAULT_ANVIL_PORT);
+        },
         restartDevice: true,
       },
       async () => {

--- a/tests/smoke/swap/bridge-action-smoke.spec.ts
+++ b/tests/smoke/swap/bridge-action-smoke.spec.ts
@@ -12,7 +12,8 @@ import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTest
 import { testSpecificMock } from '../../helpers/swap/bridge-mocks';
 import SoftAssert from '../../framework/SoftAssert';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../seeder/anvil-manager';
+import { AnvilManager, DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager';
+import { setupSmartTransactionsMocks } from '../../helpers/swap/smart-transactions-mocks';
 import { ActivitiesViewSelectorsText } from '../../../app/components/Views/ActivityView/ActivitiesView.testIds';
 
 enum eventsToCheck {
@@ -57,7 +58,6 @@ describe(SmokeTrade('Bridge functionality'), () => {
               nickname: 'Localhost',
               ticker: 'ETH',
             })
-            .withDisabledSmartTransactions()
             .build();
         },
         localNodeOptions: [
@@ -68,7 +68,10 @@ describe(SmokeTrade('Bridge functionality'), () => {
             },
           },
         ],
-        testSpecificMock,
+        testSpecificMock: async (mockServer) => {
+          await testSpecificMock(mockServer);
+          await setupSmartTransactionsMocks(mockServer, DEFAULT_ANVIL_PORT);
+        },
         restartDevice: true,
       },
       async () => {

--- a/tests/smoke/swap/swap-action-smoke.spec.ts
+++ b/tests/smoke/swap/swap-action-smoke.spec.ts
@@ -11,6 +11,7 @@ import {
 import { loginToApp } from '../../flows/wallet.flow';
 import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
 import { testSpecificMock } from '../../helpers/swap/swap-mocks';
+import { setupSmartTransactionsMocks } from '../../helpers/swap/smart-transactions-mocks';
 import { DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager';
 import {
   EventPayload,
@@ -57,7 +58,6 @@ describe(SmokeTrade('Swap from Actions'), (): void => {
             nickname: 'Localhost',
             ticker: 'ETH',
           })
-          .withDisabledSmartTransactions()
           .withMetaMetricsOptIn()
           .build(),
         localNodeOptions: [
@@ -71,7 +71,10 @@ describe(SmokeTrade('Swap from Actions'), (): void => {
             },
           },
         ],
-        testSpecificMock,
+        testSpecificMock: async (mockServer) => {
+          await testSpecificMock(mockServer);
+          await setupSmartTransactionsMocks(mockServer, DEFAULT_ANVIL_PORT);
+        },
         restartDevice: true,
         skipReactNativeReload: true,
       },


### PR DESCRIPTION
## Summary

- Introduces `tests/helpers/swap/smart-transactions-mocks.ts` — a reusable helper that mocks the STX backend (`/getFees`, `/submitTransactions`, `/batchStatus`, `/getTxStatus`) and forwards signed transactions to Anvil so they get mined and receipts resolve correctly.
- Removes `.withDisabledSmartTransactions()` from all affected test fixtures so tests run with the same STX-enabled configuration as production.
- Applies the new helper to all swap/bridge regression and smoke specs: `swap-action-regression`, `swap-token-chart`, `swap-token-rwa`, `swap-action-smoke`, and `bridge-action-smoke`.

## How Smart Transactions work in tests

When STX is enabled the swap publish hook intercepts the transaction before broadcast:

1. Calls `POST /getFees` → mock returns a static fee schedule so the controller can sign the tx locally.
2. Signs the tx locally and calls `POST /submitTransactions` → mock **forwards all `rawTxs` to Anvil** via `eth_sendRawTransaction` (sequentially, preserving nonce order for approval + swap batches), then returns a UUID.
3. Because `mobileReturnTxHashAsap: true` the hook resolves immediately with the locally-computed `txHash` — no polling needed.
4. `TransactionController` polls Anvil for `eth_getTransactionReceipt` using that hash → Anvil returns a valid receipt → tx is marked **Confirmed**.

### Key fix: ERC-20 → ETH batch submissions

Previously the mock only forwarded `rawTxs[0]` (the approval tx) to Anvil. The swap tx (`rawTxs[1]`) was never mined, so `TransactionController` never found a receipt and the swap stayed **Pending**. The fix loops over all entries in `rawTxs` and forwards each one sequentially.

## Modified scripts

- [x] `swap-action-regression` — ETH→WETH and WETH→ETH swaps confirm end-to-end
- [x] `swap-token-chart` — ETH→DAI swap from token chart confirms
- [x] `swap-token-rwa` — USDC→GOOGLON swap (CowSwap intent flow)
- [x] `swap-action-smoke` — ETH→USDC and USDC→ETH swaps confirm
- [x] `bridge-action-smoke` — ETH (Mainnet)→ETH (Base) bridge confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are isolated to E2E test harnesses/mocks; main risk is increased flakiness if STX mock assumptions (fee schema, proxy matching, Anvil forwarding) diverge from app behavior.
> 
> **Overview**
> **Swap/bridge E2E tests now run with Smart Transactions enabled** by removing `.withDisabledSmartTransactions()` from affected fixtures.
> 
> Adds `setupSmartTransactionsMocks` to mock the STX backend (`/getFees`, `/submitTransactions`, `/batchStatus`, and a low-priority `/getTxStatus` fallback) and, crucially, forwards all submitted `rawTxs` sequentially to Anvil via `eth_sendRawTransaction` so batched approval+swap flows get mined and receipts resolve.
> 
> Updates swap and bridge regression/smoke specs to wrap existing `testSpecificMock` with the new STX mocks (and bumps timeouts where needed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8082888131ff58f83e5424ebbf44da1a9e1d2790. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->