### PR TITLE
fix(analytics): fix user traits types to match Segment schema

### DIFF
--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -29,10 +29,10 @@ export interface UserProfileMetaData {
   [UserProfileProperty.THEME]: string | null | undefined;
   [UserProfileProperty.TOKEN_DETECTION]: string;
   [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: string;
-  [UserProfileProperty.SECURITY_PROVIDERS]: string;
+  [UserProfileProperty.SECURITY_PROVIDERS]: string[];
   [UserProfileProperty.PRIMARY_CURRENCY]?: string;
   [UserProfileProperty.CURRENT_CURRENCY]?: string;
-  [UserProfileProperty.HAS_MARKETING_CONSENT]: string;
+  [UserProfileProperty.HAS_MARKETING_CONSENT]: boolean;
   [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]?: number;
   [UserProfileProperty.CHAIN_IDS]: CaipChainId[];
   [UserProfileProperty.HAS_REWARDS_OPTED_IN]?: string;

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -72,15 +72,15 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.THEME]: 'dark',
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.ON,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+      [UserProfileProperty.SECURITY_PROVIDERS]: ['blockaid'],
+      [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });
 
   it.each([
-    [UserProfileProperty.ON, true],
-    [UserProfileProperty.OFF, false],
+    [true, true],
+    [false, false],
   ])('returns marketing consent "%s"', (expected, stateConsentValue) => {
     mockGetState.mockReturnValue({
       ...mockState,
@@ -111,7 +111,7 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.NFT_AUTODETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.TOKEN_DETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: UserProfileProperty.OFF,
-      [UserProfileProperty.SECURITY_PROVIDERS]: '',
+      [UserProfileProperty.SECURITY_PROVIDERS]: [],
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
     });
   });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -41,11 +41,9 @@ const generateUserProfileAnalyticsMetaData = (): AnalyticsUserTraits => {
         ? UserProfileProperty.ON
         : UserProfileProperty.OFF,
     [UserProfileProperty.SECURITY_PROVIDERS]:
-      preferencesController?.securityAlertsEnabled ? 'blockaid' : '',
+      preferencesController?.securityAlertsEnabled ? ['blockaid'] : [],
     [UserProfileProperty.HAS_MARKETING_CONSENT]:
-      isDataCollectionForMarketingEnabled
-        ? UserProfileProperty.ON
-        : UserProfileProperty.OFF,
+      isDataCollectionForMarketingEnabled ?? false,
     [UserProfileProperty.CHAIN_IDS]: chainIds,
   };
   return traits;


### PR DESCRIPTION
## Description

Found that `security_providers` and `has_marketing_consent` traits are causing Segment schema violations because they're being sent as strings instead of the expected types.

Fixed both:
- `security_providers` now returns `['blockaid']` / `[]` instead of `'blockaid'` / `''`
- `has_marketing_consent` now returns actual `true`/`false` instead of `'ON'`/`'OFF'`

Also updated the `UserProfileMetaData` interface and tests to reflect this.

## Related Issue

Resolves #23970

## Testing

Existing unit tests updated - all assertions now check for correct types.
No UI changes involved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime shape of analytics identify traits (`security_providers` and `has_marketing_consent`), which could affect downstream analytics consumers expecting the previous string values, but is limited to metrics payload formatting.
> 
> **Overview**
> Fixes Segment identify trait type mismatches by sending correctly typed user profile traits.
> 
> `security_providers` is now emitted as a string array (e.g. `['blockaid']`/`[]`) and `has_marketing_consent` is now a boolean (`true`/`false`), with the `UserProfileMetaData` types and unit tests updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19502553584634956662ca84c8f6c66204221a6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->