### PR TITLE
chore(release): release-changelog/7.70.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed stale perpetuals data and missing 24h price change after returning from background (#27530)
+- Fixed a bug where closing positions on HIP-3 markets (e.g., xyz:BRENTOIL) failed with "Asset ID not found" when navigating via the Perps tab (#27854)
 
 ## [7.69.1]
 
@@ -10938,7 +10939,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
 [Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.70.1...HEAD
-[7.70.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.1...v7.70.1
+[7.70.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.70.0...v7.70.1
 [7.69.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.0...v7.69.1
 [7.69.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.3...v7.69.0
 [7.68.3]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.2...v7.68.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10938,7 +10938,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
 [Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.70.1...HEAD
-[7.70.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.70.0...v7.70.1
+[7.70.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.1...v7.70.1
 [7.69.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.0...v7.69.1
 [7.69.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.3...v7.69.0
 [7.68.3]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.2...v7.68.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.70.1]
+
+### Fixed
+
+- Fixed stale perpetuals data and missing 24h price change after returning from background (#27530)
+
 ## [7.69.1]
 
 ### Fixed
@@ -10931,7 +10937,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/MetaMask/metamask-mobile/pull/957): fix timeouts (#957)
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
-[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.70.1...HEAD
+[7.70.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.70.0...v7.70.1
 [7.69.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.69.0...v7.69.1
 [7.69.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.3...v7.69.0
 [7.68.3]: https://github.com/MetaMask/metamask-mobile/compare/v7.68.2...v7.68.3


### PR DESCRIPTION
## Description

Adds **7.70.1** release notes for hotfixes on `release/7.70.1`, and updates changelog compare links per release process.

User-facing changes documented:

- Fixed stale perpetuals data and missing 24h price change after returning from background ([#27530](https://github.com/MetaMask/metamask-mobile/pull/27530))
- Fixed a bug where closing positions on HIP-3 markets (e.g., xyz:BRENTOIL) failed with "Asset ID not found" when navigating via the Perps tab ([#27854](https://github.com/MetaMask/metamask-mobile/pull/27854))

## Changelog

CHANGELOG entry: null

## Related

- Release PR: [#27824](https://github.com/MetaMask/metamask-mobile/pull/27824) (`release/7.70.1` → `stable`)
- Cherry-picks: [#27826](https://github.com/MetaMask/metamask-mobile/pull/27826) (reconnection), [#27860](https://github.com/MetaMask/metamask-mobile/pull/27860) (HIP-3 / dual-cache)

## Compare links

- `[Unreleased]` → `v7.70.1...HEAD`
- `[7.70.1]` → `v7.70.0...v7.70.1` (patch compares to previous minor tag)
- Older version links (e.g. `[7.69.1]`) unchanged.

## Branch

- Merged current `release/7.70.1` into this branch so the changelog PR stays aligned with [#27824](https://github.com/MetaMask/metamask-mobile/pull/27824).

Merge with **Create a merge commit** (not squash), per release changelog workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change to `CHANGELOG.md` with no runtime or build impact.
> 
> **Overview**
> Documents the `7.70.1` hotfix in `CHANGELOG.md`, adding two *Fixed* items related to perpetuals market data refresh and HIP-3 perps position closing.
> 
> Updates the changelog compare links so `Unreleased` now compares from `v7.70.1`, and adds the new `7.70.1` compare URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33bab8a9792f642a8e77098d13ecb59d5f14dca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->