### PR TITLE
feat: update Perps and Predictions sections to display unrealized P&L

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -21,9 +21,9 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
-import { TextColor } from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
 import { formatPnl, formatPercentage } from '../../utils/formatUtils';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -141,10 +141,9 @@ const PerpsHomeView = () => {
   const { positionsSubtitle, positionsSubtitleColor, positionsSubtitleSuffix } =
     useMemo(() => {
       const pnlNum = parseFloat(unrealizedPnl);
-      const isPnlZero = BigNumber(unrealizedPnl).isZero();
 
-      // Only show subtitle when there are positions and P&L is non-zero
-      if (!hasPositions || isPnlZero) {
+      // Open (filled) positions only — hide when flat so spacing matches homepage sections
+      if (!hasPositions) {
         return {
           positionsSubtitle: undefined,
           positionsSubtitleColor: undefined,
@@ -154,12 +153,11 @@ const PerpsHomeView = () => {
 
       const color =
         pnlNum > 0
-          ? TextColor.Success
+          ? TextColor.SuccessDefault
           : pnlNum < 0
-            ? TextColor.Error
-            : TextColor.Alternative;
+            ? TextColor.ErrorDefault
+            : TextColor.TextDefault;
 
-      // Format: "-$18.47 (2.1%)" colored + "Unrealized PnL" in default color
       const subtitle = `${formatPnl(pnlNum)} (${formatPercentage(roe, 1)})`;
       const suffix = strings('perps.unrealized_pnl');
 

--- a/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.test.tsx
@@ -4,7 +4,7 @@ import { View, Text } from 'react-native';
 import PerpsHomeSection from './PerpsHomeSection';
 import { PerpsHomeSectionTestIds } from './PerpsHomeSection.testIds';
 
-import { TextColor } from '../../../../../component-library/components/Texts/Text';
+import { TextColor } from '@metamask/design-system-react-native';
 
 describe('PerpsHomeSection', () => {
   const mockSkeleton = () => <View testID="skeleton-loader" />;
@@ -445,7 +445,7 @@ describe('PerpsHomeSection', () => {
         <PerpsHomeSection
           title="Test Section"
           subtitle="+$50.00 (5.0%) Unrealized P&L"
-          subtitleColor={TextColor.Success}
+          subtitleColor={TextColor.SuccessDefault}
           isLoading={false}
           isEmpty={false}
           renderSkeleton={mockSkeleton}
@@ -481,7 +481,7 @@ describe('PerpsHomeSection', () => {
         <PerpsHomeSection
           title="Positions"
           subtitle="-$18.47 (2.1%)"
-          subtitleColor={TextColor.Error}
+          subtitleColor={TextColor.ErrorDefault}
           isLoading={false}
           isEmpty={false}
           onActionPress={mockOnActionPress}
@@ -504,7 +504,7 @@ describe('PerpsHomeSection', () => {
         <PerpsHomeSection
           title="Positions"
           subtitle="-$18.47 (2.1%)"
-          subtitleColor={TextColor.Error}
+          subtitleColor={TextColor.ErrorDefault}
           subtitleSuffix="Unrealized PnL"
           subtitleTestID="test-subtitle"
           isLoading={false}

--- a/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeSection/PerpsHomeSection.tsx
@@ -1,17 +1,19 @@
 import React, { ReactNode } from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import {
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
   BoxJustifyContent,
   Icon,
   IconColor,
   IconName,
   IconSize,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
+import HomepageSectionUnrealizedPnlRow from '../../../../Views/Homepage/components/HomepageSectionUnrealizedPnlRow';
 import { PerpsHomeSectionTestIds } from './PerpsHomeSection.testIds';
 
 export interface PerpsHomeSectionProps {
@@ -24,15 +26,15 @@ export interface PerpsHomeSectionProps {
    */
   subtitle?: string;
   /**
-   * Color for subtitle text (e.g., Success for profit, Error for loss)
+   * Color for subtitle value text (e.g., Success for profit, Error for loss)
    */
   subtitleColor?: TextColor;
   /**
-   * Optional suffix for subtitle (rendered in default color, e.g., "Unrealized PnL")
+   * Optional suffix for subtitle (rendered in muted color, e.g., "Unrealized P&L")
    */
   subtitleSuffix?: string;
   /**
-   * Test ID for subtitle element
+   * Test ID for subtitle value element
    */
   subtitleTestID?: string;
   /**
@@ -107,7 +109,7 @@ const styles = StyleSheet.create({
 const PerpsHomeSection: React.FC<PerpsHomeSectionProps> = ({
   title,
   subtitle,
-  subtitleColor = TextColor.Alternative,
+  subtitleColor = TextColor.TextDefault,
   subtitleSuffix,
   subtitleTestID,
   isLoading,
@@ -146,29 +148,34 @@ const PerpsHomeSection: React.FC<PerpsHomeSectionProps> = ({
               </TouchableOpacity>
             ) : undefined
           }
-          twClassName="px-0 mb-2"
+          twClassName="px-0 mb-0"
         />
 
-        {/* Subtitle - NOT pressable */}
-        {subtitle && (
-          <Text
-            variant={TextVariant.BodySM}
-            color={subtitleColor}
-            testID={subtitleTestID}
-          >
-            {subtitle}
-            {subtitleSuffix && (
-              <Text
-                variant={TextVariant.BodySM}
-                color={TextColor.Alternative}
-                testID={subtitleTestID ? `${subtitleTestID}-suffix` : undefined}
-              >
-                {' '}
-                {subtitleSuffix}
-              </Text>
-            )}
-          </Text>
-        )}
+        {/* Value + muted label: same row as wallet homepage unrealized P&L (8px gap). */}
+        {subtitle && subtitleSuffix ? (
+          <HomepageSectionUnrealizedPnlRow
+            label={subtitleSuffix}
+            valueText={subtitle}
+            valueColor={subtitleColor}
+            paddingHorizontal={0}
+            marginTop={1}
+            valueTestID={subtitleTestID}
+            labelTestID={
+              subtitleTestID ? `${subtitleTestID}-suffix` : undefined
+            }
+          />
+        ) : subtitle ? (
+          <Box marginTop={1}>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={subtitleColor}
+              fontWeight={FontWeight.Medium}
+              testID={subtitleTestID}
+            >
+              {subtitle}
+            </Text>
+          </Box>
+        ) : null}
       </View>
 
       {/* Section Content */}

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -49,7 +49,11 @@ import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { selectPredictWonPositions } from '../../selectors/predictController';
 import { PredictPosition } from '../../types';
 import { PredictNavigationParamList } from '../../types/navigation';
-import { formatPercentage, formatPrice } from '../../utils/format';
+import {
+  formatPercentage,
+  formatPredictUnrealizedPnLStringParts,
+  formatPrice,
+} from '../../utils/format';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import PredictClaimButton from '../PredictActionButtons/PredictClaimButton';
 import { PredictEventValues } from '../../constants/eventNames';
@@ -163,16 +167,10 @@ const PredictPositionsHeader = forwardRef<
 
   const unrealizedAmount = unrealizedPnL?.cashUpnl ?? 0;
   const unrealizedPercent = unrealizedPnL?.percentUpnl ?? 0;
-
-  const formatAmount = (amount: number) => {
-    const sign = amount >= 0 ? '+' : '-';
-    return `${sign}$${Math.abs(amount).toFixed(2)}`;
-  };
-
-  const formatPercent = (percent: number) => {
-    const sign = percent >= 0 ? '+' : '';
-    return `${sign}${formatPercentage(percent)}`;
-  };
+  const unrealizedPnLDisplayParts = formatPredictUnrealizedPnLStringParts({
+    cashUpnl: unrealizedAmount,
+    percentUpnl: unrealizedPercent,
+  });
 
   const hasClaimableAmount =
     wonPositions.length > 0 && totalClaimableAmount !== undefined;
@@ -315,10 +313,10 @@ const PredictPositionsHeader = forwardRef<
                     isHidden={privacyMode}
                     length={SensitiveTextLength.Long}
                   >
-                    {strings('predict.unrealized_pnl_value', {
-                      amount: formatAmount(unrealizedAmount),
-                      percent: formatPercent(unrealizedPercent),
-                    })}
+                    {strings(
+                      'predict.unrealized_pnl_value',
+                      unrealizedPnLDisplayParts,
+                    )}
                   </SensitiveText>
                 )}
               </Box>

--- a/app/components/UI/Predict/utils/format.test.ts
+++ b/app/components/UI/Predict/utils/format.test.ts
@@ -11,6 +11,7 @@ import {
   calculateNetAmount,
   formatPriceWithSubscriptNotation,
   formatGameStartTime,
+  formatPredictUnrealizedPnLStringParts,
 } from './format';
 import { Recurrence, PredictSeries } from '../types';
 
@@ -2115,6 +2116,35 @@ describe('format utils', () => {
       [0.000000001, '$0.0₈1'],
     ])('formats %f as %s', (input, expected) => {
       expect(formatPriceWithSubscriptNotation(input)).toBe(expected);
+    });
+  });
+
+  describe('formatPredictUnrealizedPnLStringParts', () => {
+    it('formats positive cash and percent with explicit + on percent', () => {
+      expect(
+        formatPredictUnrealizedPnLStringParts({
+          cashUpnl: 95.39,
+          percentUpnl: 9.4,
+        }),
+      ).toEqual({ amount: '+$95.39', percent: '+9.4%' });
+    });
+
+    it('formats negative cash and percent', () => {
+      expect(
+        formatPredictUnrealizedPnLStringParts({
+          cashUpnl: -10.5,
+          percentUpnl: -3.25,
+        }),
+      ).toEqual({ amount: '-$10.50', percent: '-3.25%' });
+    });
+
+    it('formats zero with + on cash and percent (matches positions header)', () => {
+      expect(
+        formatPredictUnrealizedPnLStringParts({
+          cashUpnl: 0,
+          percentUpnl: 0,
+        }),
+      ).toEqual({ amount: '+$0.00', percent: '+0%' });
     });
   });
 

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -65,6 +65,22 @@ export const formatPercentage = (
 };
 
 /**
+ * Builds `amount` / `percent` for `strings('predict.unrealized_pnl_value', …)`.
+ * Same rules as PredictPositionsHeader: signed cash, signed % via `formatPercentage`.
+ */
+export function formatPredictUnrealizedPnLStringParts(data: {
+  cashUpnl: number;
+  percentUpnl: number;
+}): { amount: string; percent: string } {
+  const { cashUpnl, percentUpnl } = data;
+  const amountSign = cashUpnl >= 0 ? '+' : '-';
+  const amount = `${amountSign}$${Math.abs(cashUpnl).toFixed(2)}`;
+  const percentSign = percentUpnl >= 0 ? '+' : '';
+  const percent = `${percentSign}${formatPercentage(percentUpnl)}`;
+  return { amount, percent };
+}
+
+/**
  * Formats a price value as USD currency with rounding up to nearest cent
  * @param price - Raw numeric price value
  * @param options - Optional formatting options

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -59,6 +59,10 @@ jest.mock('../../UI/Perps/hooks', () => ({
     orders: [],
     isInitialLoading: false,
   })),
+  usePerpsLiveAccount: jest.fn(() => ({
+    account: null,
+    isInitialLoading: false,
+  })),
   usePerpsMarkets: jest.fn(() => ({
     markets: [],
     isLoading: false,
@@ -106,6 +110,24 @@ jest.mock('react-native-skeleton-placeholder', () => {
 
 jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
   selectPredictEnabledFlag: jest.fn(() => true),
+}));
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: jest.fn(() => ({
+      invalidateQueries: jest.fn(() => Promise.resolve()),
+    })),
+  };
+});
+
+jest.mock('../../UI/Predict/hooks/useUnrealizedPnL', () => ({
+  useUnrealizedPnL: jest.fn(() => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  })),
 }));
 
 jest.mock('../../UI/Predict/hooks/usePredictPositions', () => ({

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -48,6 +48,13 @@ jest.mock('../../../../UI/Perps/hooks', () => ({
     orders: [],
     isInitialLoading: false,
   })),
+  usePerpsLiveAccount: jest.fn(() => ({
+    account: {
+      unrealizedPnl: '95.39',
+      returnOnEquity: '9.4',
+    },
+    isInitialLoading: false,
+  })),
   usePerpsMarkets: jest.fn(() => ({
     markets: [],
     isLoading: false,
@@ -170,8 +177,12 @@ jest.mock('./components/PerpsMarketTileCard', () => {
   };
 });
 
-const { usePerpsLivePositions, usePerpsLiveOrders, usePerpsMarkets } =
-  jest.requireMock('../../../../UI/Perps/hooks');
+const {
+  usePerpsLivePositions,
+  usePerpsLiveOrders,
+  usePerpsMarkets,
+  usePerpsLiveAccount,
+} = jest.requireMock('../../../../UI/Perps/hooks');
 
 const makePosition = (overrides: Record<string, unknown> = {}) => ({
   symbol: 'BTC',
@@ -288,6 +299,45 @@ describe('PerpsSection', () => {
 
     expect(screen.getByText('BTC 10X position')).toBeOnTheScreen();
     expect(screen.getByText('ETH 40X position')).toBeOnTheScreen();
+  });
+
+  it('shows aggregate unrealized P&L row when user has filled positions', () => {
+    usePerpsLivePositions.mockReturnValue({
+      positions: [makePosition()],
+      isInitialLoading: false,
+    });
+    usePerpsLiveAccount.mockReturnValue({
+      account: {
+        unrealizedPnl: '95.39',
+        returnOnEquity: '9.4',
+      },
+      isInitialLoading: false,
+    });
+
+    renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(
+      screen.getByTestId('homepage-perps-unrealized-pnl'),
+    ).toBeOnTheScreen();
+  });
+
+  it('does not show unrealized P&L row when user has only open orders', () => {
+    usePerpsLivePositions.mockReturnValue({
+      positions: [],
+      isInitialLoading: false,
+    });
+    usePerpsLiveOrders.mockReturnValue({
+      orders: [makeOrder()],
+      isInitialLoading: false,
+    });
+
+    renderWithProvider(
+      <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(screen.queryByTestId('homepage-perps-unrealized-pnl')).toBeNull();
   });
 
   it('renders multiple position rows', () => {

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -12,6 +12,7 @@ import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
 import { useSelector } from 'react-redux';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
   type PerpsMarketData,
   type Position,
@@ -27,7 +28,12 @@ import {
   usePerpsLivePositions,
   usePerpsLiveOrders,
   usePerpsMarkets,
+  usePerpsLiveAccount,
 } from '../../../../UI/Perps/hooks';
+import {
+  formatPnl,
+  formatPercentage,
+} from '../../../../UI/Perps/utils/formatUtils';
 import { usePerpsConnection } from '../../../../UI/Perps/hooks/usePerpsConnection';
 import { filterAndSortMarkets } from '../../../../UI/Perps/utils/filterAndSortMarkets';
 import {
@@ -48,6 +54,9 @@ import useHomeViewedEvent, {
   HomeSectionNames,
 } from '../../hooks/useHomeViewedEvent';
 import type { PerpsSectionProps } from './PerpsSectionWithProvider';
+import HomepageSectionUnrealizedPnlRow, {
+  type HomepageUnrealizedPnlTone,
+} from '../../components/HomepageSectionUnrealizedPnlRow';
 
 const MAX_ITEMS = 5;
 const MAX_TRENDING_MARKETS = 5;
@@ -71,9 +80,15 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     const { error: connectionError, reconnectWithNewContext } =
       usePerpsConnection();
     const { track } = usePerpsEventTracking();
+    const privacyMode = useSelector(selectPrivacyMode);
 
     const { positions, isInitialLoading: positionsLoading } =
       usePerpsLivePositions({
+        throttleMs: HOMEPAGE_THROTTLE_MS,
+      });
+
+    const { account: perpsAccount, isInitialLoading: perpsAccountLoading } =
+      usePerpsLiveAccount({
         throttleMs: HOMEPAGE_THROTTLE_MS,
       });
 
@@ -112,10 +127,27 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     );
 
     const hasItems = displayPositions.length > 0 || displayOrders.length > 0;
+    const hasFilledPositions = positions.length > 0;
 
     // When user has no positions/orders, keep skeleton visible until markets load.
     const pendingTrending = !showSkeleton && !hasItems && marketsLoading;
     const showTrending = !showSkeleton && !hasItems && !marketsLoading;
+
+    const showHomepageUnrealizedPnl =
+      !showSkeleton && !pendingTrending && hasFilledPositions && !privacyMode;
+
+    const homepageUnrealizedPnl = useMemo(() => {
+      if (!showHomepageUnrealizedPnl) {
+        return null;
+      }
+      const unrealizedPnl = perpsAccount?.unrealizedPnl ?? '0';
+      const roe = parseFloat(perpsAccount?.returnOnEquity || '0');
+      const pnlNum = parseFloat(unrealizedPnl);
+      const valueText = `${formatPnl(pnlNum)} (${formatPercentage(roe, 1)})`;
+      const tone: HomepageUnrealizedPnlTone =
+        pnlNum > 0 ? 'positive' : pnlNum < 0 ? 'negative' : 'neutral';
+      return { valueText, tone };
+    }, [perpsAccount, showHomepageUnrealizedPnl]);
 
     const safeWatchlistSymbols = useMemo(
       () => watchlistSymbols ?? [],
@@ -271,7 +303,18 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
-          <SectionHeader title={title} onPress={handleViewAllPerps} />
+          <Box gap={1}>
+            <SectionHeader title={title} onPress={handleViewAllPerps} />
+            {showHomepageUnrealizedPnl && (
+              <HomepageSectionUnrealizedPnlRow
+                isLoading={perpsAccountLoading}
+                valueText={homepageUnrealizedPnl?.valueText}
+                tone={homepageUnrealizedPnl?.tone ?? 'neutral'}
+                label={strings('perps.unrealized_pnl')}
+                testID="homepage-perps-unrealized-pnl"
+              />
+            )}
+          </Box>
           {showSkeleton || pendingTrending ? (
             <SectionRow>
               <PerpsPositionSkeleton />

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -25,6 +25,29 @@ jest.mock('../../../../UI/Predict/hooks/usePredictClaim', () => ({
   usePredictClaim: () => ({ claim: mockClaim }),
 }));
 
+jest.mock('../../../../UI/Predict/hooks/useUnrealizedPnL', () => ({
+  useUnrealizedPnL: jest.fn(() => ({
+    data: { cashUpnl: 10, percentUpnl: 5, user: '0x0' },
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+jest.mock('../../../../../selectors/preferencesController', () => ({
+  ...jest.requireActual('../../../../../selectors/preferencesController'),
+  selectPrivacyMode: () => false,
+}));
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: jest.fn(() => ({
+      invalidateQueries: jest.fn(() => Promise.resolve()),
+    })),
+  };
+});
+
 // Mock the hooks
 jest.mock('./hooks', () => ({
   usePredictMarketsForHomepage: jest.fn(() => ({

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -2,8 +2,10 @@ import React, {
   forwardRef,
   useCallback,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { ScrollView, View } from 'react-native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -14,6 +16,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { WalletViewSelectorsIDs } from '../../../../Views/Wallet/WalletView.testIds';
 import { SectionRefreshHandle } from '../../types';
 import { selectPredictEnabledFlag } from '../../../../UI/Predict/selectors/featureFlags';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { strings } from '../../../../../../locales/i18n';
 import {
   usePredictMarketsForHomepage,
@@ -26,14 +29,24 @@ import {
   PredictPositionRowSkeleton,
 } from './components';
 import ViewMoreCard from '../../components/ViewMoreCard';
-import type { PredictPosition } from '../../../../UI/Predict/types';
+import type {
+  PredictPosition,
+  UnrealizedPnL,
+} from '../../../../UI/Predict/types';
 import type { PredictNavigationParamList } from '../../../../UI/Predict/types/navigation';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import { PredictClaimButton } from '../../../../UI/Predict/components/PredictActionButtons';
 import { usePredictClaim } from '../../../../UI/Predict/hooks/usePredictClaim';
+import { useUnrealizedPnL } from '../../../../UI/Predict/hooks/useUnrealizedPnL';
+import { predictQueries } from '../../../../UI/Predict/queries';
+import { getEvmAccountFromSelectedAccountGroup } from '../../../../UI/Predict/utils/accounts';
+import { formatPredictUnrealizedPnLStringParts } from '../../../../UI/Predict/utils/format';
 import useHomeViewedEvent, {
   HomeSectionNames,
 } from '../../hooks/useHomeViewedEvent';
+import HomepageSectionUnrealizedPnlRow, {
+  type HomepageUnrealizedPnlTone,
+} from '../../components/HomepageSectionUnrealizedPnlRow';
 
 const MAX_MARKETS_DISPLAYED = 5;
 
@@ -46,6 +59,48 @@ const SKELETON_KEYS = Array.from(
 interface PredictionsSectionProps {
   sectionIndex: number;
   totalSectionsLoaded: number;
+}
+
+interface PredictHomepageUnrealizedPnlRowState {
+  show: boolean;
+  isLoading: boolean;
+  valueText?: string;
+  tone: HomepageUnrealizedPnlTone;
+}
+
+function getPredictHomepageUnrealizedPnlRowState(input: {
+  hasPositions: boolean;
+  privacyMode: boolean;
+  isPnlLoading: boolean;
+  pnl: UnrealizedPnL | null | undefined;
+}): PredictHomepageUnrealizedPnlRowState {
+  const { hasPositions, privacyMode, isPnlLoading, pnl } = input;
+
+  if (!hasPositions || privacyMode) {
+    return { show: false, isLoading: false, tone: 'neutral' };
+  }
+  if (isPnlLoading) {
+    return { show: true, isLoading: true, tone: 'neutral' };
+  }
+  if (!pnl) {
+    return { show: false, isLoading: false, tone: 'neutral' };
+  }
+
+  const cashUpnl = pnl.cashUpnl ?? 0;
+  const valueText = strings(
+    'predict.unrealized_pnl_value',
+    formatPredictUnrealizedPnLStringParts({
+      cashUpnl,
+      percentUpnl: pnl.percentUpnl ?? 0,
+    }),
+  );
+
+  return {
+    show: true,
+    isLoading: false,
+    valueText,
+    tone: cashUpnl > 0 ? 'positive' : cashUpnl < 0 ? 'negative' : 'neutral',
+  };
 }
 
 /**
@@ -66,6 +121,8 @@ const PredictionsSection = forwardRef<
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const privacyMode = useSelector(selectPrivacyMode);
+  const queryClient = useQueryClient();
   const title = strings('homepage.sections.predictions');
   const { claim } = usePredictClaim();
 
@@ -93,6 +150,29 @@ const PredictionsSection = forwardRef<
 
   // Determine if user has positions
   const hasPositions = positions.length > 0;
+
+  const {
+    data: predictUnrealizedPnL,
+    isLoading: isPredictUnrealizedPnLLoading,
+  } = useUnrealizedPnL({
+    enabled: hasPositions,
+  });
+
+  const predictHomepageUnrealizedPnl = useMemo(
+    () =>
+      getPredictHomepageUnrealizedPnlRowState({
+        hasPositions,
+        privacyMode,
+        isPnlLoading: isPredictUnrealizedPnLLoading,
+        pnl: predictUnrealizedPnL,
+      }),
+    [
+      hasPositions,
+      privacyMode,
+      isPredictUnrealizedPnLLoading,
+      predictUnrealizedPnL,
+    ],
+  );
 
   const isLoading = isLoadingPositions || isLoadingMarkets;
 
@@ -127,8 +207,14 @@ const PredictionsSection = forwardRef<
   });
 
   const refresh = useCallback(async () => {
-    await Promise.all([refetchPositions(), refetchMarkets()]);
-  }, [refetchPositions, refetchMarkets]);
+    const addr = getEvmAccountFromSelectedAccountGroup()?.address;
+    const invalidatePnl = addr
+      ? queryClient.invalidateQueries({
+          queryKey: predictQueries.unrealizedPnL.keys.byAddress(addr),
+        })
+      : Promise.resolve();
+    await Promise.all([refetchPositions(), refetchMarkets(), invalidatePnl]);
+  }, [queryClient, refetchPositions, refetchMarkets]);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
@@ -167,13 +253,24 @@ const PredictionsSection = forwardRef<
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
         <Box gap={3}>
-          <SectionHeader
-            title={title}
-            onPress={handleViewAllPredictions}
-            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
-              'predictions',
+          <Box gap={1}>
+            <SectionHeader
+              title={title}
+              onPress={handleViewAllPredictions}
+              testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+                'predictions',
+              )}
+            />
+            {predictHomepageUnrealizedPnl.show && (
+              <HomepageSectionUnrealizedPnlRow
+                isLoading={predictHomepageUnrealizedPnl.isLoading}
+                valueText={predictHomepageUnrealizedPnl.valueText}
+                tone={predictHomepageUnrealizedPnl.tone}
+                label={strings('predict.unrealized_pnl_label')}
+                testID="homepage-predict-unrealized-pnl"
+              />
             )}
-          />
+          </Box>
           <Box>
             {isLoadingPositions ? (
               <>

--- a/app/components/Views/Homepage/components/HomepageSectionUnrealizedPnlRow/HomepageSectionUnrealizedPnlRow.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageSectionUnrealizedPnlRow/HomepageSectionUnrealizedPnlRow.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { TextColor } from '@metamask/design-system-react-native';
+import HomepageSectionUnrealizedPnlRow from './HomepageSectionUnrealizedPnlRow';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: (...args: string[]) => ({ testStyle: args.join(' ') }),
+  }),
+}));
+
+jest.mock('../../../../../component-library/components-temp/Skeleton', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    Skeleton: (props: { width: number; height: number }) => (
+      <View
+        testID="skeleton"
+        data-width={props.width}
+        data-height={props.height}
+      />
+    ),
+  };
+});
+
+describe('HomepageSectionUnrealizedPnlRow', () => {
+  it('renders null when valueText is undefined', () => {
+    const { toJSON } = render(
+      <HomepageSectionUnrealizedPnlRow label="Unrealized P&L" />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders null when valueText is empty string', () => {
+    const { toJSON } = render(
+      <HomepageSectionUnrealizedPnlRow label="Unrealized P&L" valueText="" />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders skeleton when isLoading is true', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="Unrealized P&L"
+        isLoading
+        testID="pnl-row"
+      />,
+    );
+    expect(screen.getByTestId('skeleton')).toBeOnTheScreen();
+    expect(screen.getByTestId('pnl-row')).toBeOnTheScreen();
+    expect(screen.queryByText('Unrealized P&L')).toBeNull();
+  });
+
+  it('renders value and label when valueText is provided', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="Unrealized P&L"
+        valueText="+$95.39 (+9.4%)"
+      />,
+    );
+    expect(screen.getByText('+$95.39 (+9.4%)')).toBeOnTheScreen();
+    expect(screen.getByText('Unrealized P&L')).toBeOnTheScreen();
+  });
+
+  it('derives value/label testIDs from testID prop', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="Unrealized P&L"
+        valueText="+$10"
+        testID="pnl"
+      />,
+    );
+    expect(screen.getByTestId('pnl')).toBeOnTheScreen();
+    expect(screen.getByTestId('pnl-value')).toBeOnTheScreen();
+    expect(screen.getByTestId('pnl-label')).toBeOnTheScreen();
+  });
+
+  it('uses explicit valueTestID and labelTestID over derived ones', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="P&L"
+        valueText="+$10"
+        testID="pnl"
+        valueTestID="custom-value"
+        labelTestID="custom-label"
+      />,
+    );
+    expect(screen.getByTestId('custom-value')).toBeOnTheScreen();
+    expect(screen.getByTestId('custom-label')).toBeOnTheScreen();
+    expect(screen.queryByTestId('pnl-value')).toBeNull();
+    expect(screen.queryByTestId('pnl-label')).toBeNull();
+  });
+
+  it('does not set testIDs on value/label when testID is not provided', () => {
+    render(<HomepageSectionUnrealizedPnlRow label="P&L" valueText="+$10" />);
+    expect(screen.getByText('+$10')).toBeOnTheScreen();
+    expect(screen.getByText('P&L')).toBeOnTheScreen();
+  });
+
+  describe('toneToColor mapping', () => {
+    it('applies success color for positive tone', () => {
+      render(
+        <HomepageSectionUnrealizedPnlRow
+          label="P&L"
+          valueText="+$10"
+          tone="positive"
+          valueTestID="val"
+        />,
+      );
+      expect(screen.getByTestId('val')).toBeOnTheScreen();
+    });
+
+    it('applies error color for negative tone', () => {
+      render(
+        <HomepageSectionUnrealizedPnlRow
+          label="P&L"
+          valueText="-$5"
+          tone="negative"
+          valueTestID="val"
+        />,
+      );
+      expect(screen.getByTestId('val')).toBeOnTheScreen();
+    });
+
+    it('applies default text color for neutral tone (default)', () => {
+      render(
+        <HomepageSectionUnrealizedPnlRow
+          label="P&L"
+          valueText="$0"
+          valueTestID="val"
+        />,
+      );
+      expect(screen.getByTestId('val')).toBeOnTheScreen();
+    });
+  });
+
+  it('uses valueColor prop over tone-derived color', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="P&L"
+        valueText="+$10"
+        tone="positive"
+        valueColor={TextColor.WarningDefault}
+        valueTestID="val"
+      />,
+    );
+    expect(screen.getByTestId('val')).toBeOnTheScreen();
+  });
+
+  it('passes paddingHorizontal=0 without error', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="P&L"
+        valueText="+$10"
+        paddingHorizontal={0}
+        testID="row"
+      />,
+    );
+    expect(screen.getByTestId('row')).toBeOnTheScreen();
+  });
+
+  it('passes marginTop=1 without error', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="P&L"
+        valueText="+$10"
+        marginTop={1}
+        testID="row"
+      />,
+    );
+    expect(screen.getByTestId('row')).toBeOnTheScreen();
+  });
+
+  it('renders skeleton with marginTop and paddingHorizontal when loading', () => {
+    render(
+      <HomepageSectionUnrealizedPnlRow
+        label="P&L"
+        isLoading
+        marginTop={1}
+        paddingHorizontal={0}
+        testID="loading-row"
+      />,
+    );
+    expect(screen.getByTestId('skeleton')).toBeOnTheScreen();
+    expect(screen.getByTestId('loading-row')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/Homepage/components/HomepageSectionUnrealizedPnlRow/HomepageSectionUnrealizedPnlRow.tsx
+++ b/app/components/Views/Homepage/components/HomepageSectionUnrealizedPnlRow/HomepageSectionUnrealizedPnlRow.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxFlexWrap,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
+
+export type HomepageUnrealizedPnlTone = 'positive' | 'negative' | 'neutral';
+
+const toneToColor = (tone: HomepageUnrealizedPnlTone): TextColor => {
+  if (tone === 'positive') {
+    return TextColor.SuccessDefault;
+  }
+  if (tone === 'negative') {
+    return TextColor.ErrorDefault;
+  }
+  return TextColor.TextDefault;
+};
+
+export interface HomepageSectionUnrealizedPnlRowProps {
+  /** Muted label after the value (e.g. Unrealized P&L) */
+  label: string;
+  /** When true, shows a placeholder instead of value + label */
+  isLoading?: boolean;
+  /** Main numeric segment, e.g. +$95.39 (+9.4%) */
+  valueText?: string;
+  tone?: HomepageUnrealizedPnlTone;
+  /**
+   * When set, used for the value text color instead of deriving from `tone`
+   * (Perps home “Your positions” line passes design-system colors from account state).
+   */
+  valueColor?: TextColor;
+  /** Container test id (homepage sections). */
+  testID?: string;
+  /** Value segment test id; default `${testID}-value` when `testID` is set. */
+  valueTestID?: string;
+  /** Label segment test id; default `${testID}-label` when `testID` is set. */
+  labelTestID?: string;
+  /**
+   * Horizontal padding (design-system spacing). `4` = 16px — wallet homepage;
+   * `0` when the parent section already applies horizontal inset (Perps “Your positions”).
+   */
+  paddingHorizontal?: 0 | 4;
+  /** `1` = 4px below title when the parent does not use `gap` (Perps home section). */
+  marginTop?: 1;
+}
+
+/**
+ * Section sub-row: colored unrealized P&L value + muted label.
+ * Used on wallet homepage (Perps / Predict) and Perps tab “Your positions”.
+ * Spacing: 8px gap between value and label; optional `marginTop` 4px below title when needed.
+ */
+const HomepageSectionUnrealizedPnlRow: React.FC<
+  HomepageSectionUnrealizedPnlRowProps
+> = ({
+  label,
+  isLoading,
+  valueText,
+  tone = 'neutral',
+  valueColor: valueColorProp,
+  testID,
+  valueTestID: valueTestIDProp,
+  labelTestID: labelTestIDProp,
+  paddingHorizontal = 4,
+  marginTop,
+}) => {
+  const tw = useTailwind();
+  const resolvedValueColor = valueColorProp ?? toneToColor(tone);
+  const valueTestID =
+    valueTestIDProp ?? (testID ? `${testID}-value` : undefined);
+  const labelTestID =
+    labelTestIDProp ?? (testID ? `${testID}-label` : undefined);
+
+  if (isLoading) {
+    return (
+      <Box
+        marginTop={marginTop}
+        paddingHorizontal={paddingHorizontal}
+        testID={testID}
+      >
+        <Skeleton width={280} height={18} style={tw.style('rounded-md')} />
+      </Box>
+    );
+  }
+
+  if (!valueText) {
+    return null;
+  }
+
+  return (
+    <Box marginTop={marginTop} testID={testID}>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        flexWrap={BoxFlexWrap.Wrap}
+        paddingHorizontal={paddingHorizontal}
+        gap={2}
+      >
+        <Text
+          variant={TextVariant.BodyMd}
+          color={resolvedValueColor}
+          fontWeight={FontWeight.Medium}
+          testID={valueTestID}
+        >
+          {valueText}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          fontWeight={FontWeight.Medium}
+          testID={labelTestID}
+        >
+          {label}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default HomepageSectionUnrealizedPnlRow;

--- a/app/components/Views/Homepage/components/HomepageSectionUnrealizedPnlRow/index.ts
+++ b/app/components/Views/Homepage/components/HomepageSectionUnrealizedPnlRow/index.ts
@@ -1,0 +1,5 @@
+export {
+  default,
+  type HomepageSectionUnrealizedPnlRowProps,
+  type HomepageUnrealizedPnlTone,
+} from './HomepageSectionUnrealizedPnlRow';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Users with open Perpetuals or Predict positions could not see aggregate unrealized P&L on the wallet homepage next to those sections, and the Perps tab “Your positions” subtitle duplicated similar layout logic.

This PR:

- **Wallet homepage — Perps:** Shows a sub-row under “Perpetuals” with aggregate unrealized P&L (and ROE %) when the user has **filled** open positions; hides it for privacy mode, while loading account data, or when there are no positions (including **orders-only** — no row). Colors follow profit (green) / loss (red) / flat (default text).
- **Wallet homepage — Predict:** Shows the same style of row under “Predictions” using the existing unrealized P&L API (`useUnrealizedPnL`); pull-to-refresh also invalidates that query. Respects privacy mode.
- **Perps home (tab):** Keeps the positions subtitle visible whenever there are open positions (including flat P&L), uses design-system text colors, and reuses the shared **`HomepageSectionUnrealizedPnlRow`** for the value + “Unrealized P&L” line so layout matches the homepage spec (4px under title, 8px between value and label).
- **Shared UI:** New `HomepageSectionUnrealizedPnlRow` under homepage components (used by homepage sections + `PerpsHomeSection`).
- **Predict:** `formatPredictUnrealizedPnLStringParts` in `format.ts` centralizes i18n interpolation for unrealized P&L strings; `PredictPositionsHeader` and `PredictionsSection` both use it.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added unrealized P&L summary on the wallet homepage for Perpetuals and Predictions, and aligned the Perps home “Your positions” subtitle with the same layout.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-584

## **Manual testing steps**

```gherkin
Feature: Unrealized P&L on homepage Perps and Predict

  Scenario: Perps section shows aggregate unrealized P&L with open positions
    Given the user has at least one open Perpetuals position and privacy mode is off
    When the user views the wallet homepage
    Then the Perpetuals section shows a line with signed dollar P&L, percentage, and an unrealized P&L label below the section title
    And positive P&L is green and negative P&L is red

  Scenario: Perps section hides P&L without open positions
    Given the user has no open Perpetuals positions (only limit orders or none)
    When the user views the wallet homepage
    Then no unrealized P&L sub-row appears under Perpetuals and spacing below the title is unchanged

  Scenario: Predict section shows unrealized P&L with open positions
    Given the user has open Predict positions and privacy mode is off
    When the user views the wallet homepage
    Then the Predictions section shows the unrealized P&L sub-row consistent with design

  Scenario: Privacy mode hides homepage P&L values
    Given privacy mode is enabled
    When the user views the wallet homepage with Perps and/or Predict positions
    Then unrealized P&L sub-rows for those sections are not shown

  Scenario: Perps tab positions subtitle matches homepage styling
    Given the user has open Perps positions
    When the user opens the Perps home screen
    Then “Your positions” shows the unrealized P&L value and label with the same visual treatment as the homepage row
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: adds new homepage UI rows driven by live Perps account state and Predict react-query data (including query invalidation on refresh), which could affect loading/visibility states and performance but does not touch auth or funds movement.
> 
> **Overview**
> Adds a shared `HomepageSectionUnrealizedPnlRow` component and uses it to display **aggregate unrealized P&L** under the Wallet homepage **Perpetuals** and **Predictions** section titles when the user has open positions (and not in privacy mode), including loading placeholders and tone-based coloring.
> 
> Refactors Perps tab `PerpsHomeSection`/`PerpsHomeView` to reuse the same value+label row, switch to design-system `TextColor` tokens, and keep the positions subtitle visible whenever positions exist (including flat P&L). Predict’s positions header and homepage section now share a centralized `formatPredictUnrealizedPnLStringParts` formatter, and Predictions pull-to-refresh also invalidates the unrealized P&L query; tests were updated/added accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50ae867b59ea612ddc8af1b579888b475eb0f36f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->