### PR TITLE
fix: add metrics opt In event cp-7.71.0

### DIFF
--- a/app/components/UI/OptinMetrics/index.test.tsx
+++ b/app/components/UI/OptinMetrics/index.test.tsx
@@ -147,6 +147,16 @@ describe('OptinMetrics', () => {
         expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
           1,
           expect.objectContaining({
+            name: MetaMetricsEvents.METRICS_OPT_IN.category,
+            properties: expect.objectContaining({
+              location: 'onboarding_metametrics',
+              updated_after_onboarding: false,
+            }),
+          }),
+        );
+        expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
             name: 'Analytics Preference Selected',
             properties: expect.objectContaining({
               has_marketing_consent: false,
@@ -177,6 +187,16 @@ describe('OptinMetrics', () => {
       await waitFor(() => {
         expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
           1,
+          expect.objectContaining({
+            name: MetaMetricsEvents.METRICS_OPT_IN.category,
+            properties: expect.objectContaining({
+              location: 'onboarding_metametrics',
+              updated_after_onboarding: false,
+            }),
+          }),
+        );
+        expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+          2,
           expect.objectContaining({
             name: 'Analytics Preference Selected',
             properties: expect.objectContaining({
@@ -212,6 +232,16 @@ describe('OptinMetrics', () => {
       );
 
       await waitFor(() => {
+        expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: MetaMetricsEvents.METRICS_OPT_IN.category,
+            properties: expect.objectContaining({
+              location: 'onboarding_metametrics',
+              updated_after_onboarding: false,
+              account_type: AccountType.Imported,
+            }),
+          }),
+        );
         expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
           expect.objectContaining({
             name: 'Analytics Preference Selected',

--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -168,8 +168,19 @@ const OptinMetrics = () => {
 
     dispatch(setDataCollectionForMarketing(isMarketingChecked));
 
-    // Track opt-out event if user opted out of metrics
-    if (!isBasicUsageChecked) {
+    // Track opt-in / opt-out for metrics
+    if (isBasicUsageChecked) {
+      metrics.trackEvent(
+        metrics
+          .createEventBuilder(MetaMetricsEvents.METRICS_OPT_IN)
+          .addProperties({
+            updated_after_onboarding: false,
+            location: 'onboarding_metametrics',
+            ...(accountType && { account_type: accountType }),
+          })
+          .build(),
+      );
+    } else {
       metrics.trackEvent(
         metrics
           .createEventBuilder(MetaMetricsEvents.METRICS_OPT_OUT)

--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -169,29 +169,20 @@ const OptinMetrics = () => {
     dispatch(setDataCollectionForMarketing(isMarketingChecked));
 
     // Track opt-in / opt-out for metrics
-    if (isBasicUsageChecked) {
-      metrics.trackEvent(
-        metrics
-          .createEventBuilder(MetaMetricsEvents.METRICS_OPT_IN)
-          .addProperties({
-            updated_after_onboarding: false,
-            location: 'onboarding_metametrics',
-            ...(accountType && { account_type: accountType }),
-          })
-          .build(),
-      );
-    } else {
-      metrics.trackEvent(
-        metrics
-          .createEventBuilder(MetaMetricsEvents.METRICS_OPT_OUT)
-          .addProperties({
-            updated_after_onboarding: false,
-            location: 'onboarding_metametrics',
-            ...(accountType && { account_type: accountType }),
-          })
-          .build(),
-      );
-    }
+    metrics.trackEvent(
+      metrics
+        .createEventBuilder(
+          isBasicUsageChecked
+            ? MetaMetricsEvents.METRICS_OPT_IN
+            : MetaMetricsEvents.METRICS_OPT_OUT,
+        )
+        .addProperties({
+          updated_after_onboarding: false,
+          location: 'onboarding_metametrics',
+          ...(accountType && { account_type: accountType }),
+        })
+        .build(),
+    );
 
     metrics.trackEvent(
       metrics

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -75,6 +75,7 @@ import { captureException } from '@sentry/react-native';
 import Logger from '../../../util/Logger';
 import { MIGRATION_ERROR_HAPPENED } from '../../../constants/storage';
 import { AccountType } from '../../../constants/onboarding';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 
 // Mock netinfo - using existing mock
 jest.mock('@react-native-community/netinfo');
@@ -1990,6 +1991,13 @@ describe('Onboarding', () => {
 
       await waitFor(() => {
         expect(mockAnalytics.optIn).toHaveBeenCalled();
+        expect(
+          mockCreateEventBuilder.mock.calls.some(
+            (call) =>
+              (call[0] as { category: string }).category ===
+              MetaMetricsEvents.METRICS_OPT_IN.category,
+          ),
+        ).toBe(true);
       });
     });
   });

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -733,6 +733,18 @@ const Onboarding = () => {
       discardBufferedTraces();
       await setupSentry();
 
+      const accountType = getSocialAccountType(provider, !createWallet);
+      metrics.trackEvent(
+        metrics
+          .createEventBuilder(MetaMetricsEvents.METRICS_OPT_IN)
+          .addProperties({
+            updated_after_onboarding: false,
+            location: 'onboarding_social_login',
+            account_type: accountType,
+          })
+          .build(),
+      );
+
       // use new trace instead of buffered trace for social login
       onboardingTraceCtx.current = trace({
         name: TraceName.OnboardingJourneyOverall,
@@ -740,7 +752,6 @@ const Onboarding = () => {
         tags: getTraceTags(store.getState()),
       });
 
-      const accountType = getSocialAccountType(provider, !createWallet);
       if (createWallet) {
         track(MetaMetricsEvents.WALLET_SETUP_STARTED, {
           account_type: accountType,

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.test.tsx
@@ -377,7 +377,18 @@ describe('MetaMetricsAndDataCollectionSection', () => {
             deviceProp: 'Device value',
             userProp: 'User value',
           });
-          expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+          expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+              name: MetaMetricsEvents.METRICS_OPT_IN.category,
+              properties: expect.objectContaining({
+                updated_after_onboarding: true,
+                location: 'settings',
+              }),
+            }),
+          );
+          expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+            2,
             expect.objectContaining({
               name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
               properties: expect.objectContaining({
@@ -407,7 +418,18 @@ describe('MetaMetricsAndDataCollectionSection', () => {
         fireEvent(metaMetricsSwitch, 'valueChange', true);
 
         await waitFor(() => {
-          expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+          expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+              name: MetaMetricsEvents.METRICS_OPT_IN.category,
+              properties: expect.objectContaining({
+                updated_after_onboarding: true,
+                location: 'onboarding_default_settings',
+              }),
+            }),
+          );
+          expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+            2,
             expect.objectContaining({
               name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
               properties: expect.objectContaining({
@@ -467,6 +489,16 @@ describe('MetaMetricsAndDataCollectionSection', () => {
         fireEvent(metaMetricsSwitch, 'valueChange', true);
 
         await waitFor(() => {
+          expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              name: MetaMetricsEvents.METRICS_OPT_IN.category,
+              properties: expect.objectContaining({
+                updated_after_onboarding: true,
+                location: 'settings',
+                account_type: AccountType.MetamaskGoogle,
+              }),
+            }),
+          );
           expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
             expect.objectContaining({
               name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
@@ -809,6 +841,16 @@ describe('MetaMetricsAndDataCollectionSection', () => {
             expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
               1,
               expect.objectContaining({
+                name: MetaMetricsEvents.METRICS_OPT_IN.category,
+                properties: expect.objectContaining({
+                  location: 'settings',
+                  updated_after_onboarding: true,
+                }),
+              }),
+            );
+            expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
+              2,
+              expect.objectContaining({
                 name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
                 properties: expect.objectContaining({
                   is_metrics_opted_in: true,
@@ -827,8 +869,8 @@ describe('MetaMetricsAndDataCollectionSection', () => {
             },
           );
           expect(mockAnalytics.trackEvent).toHaveBeenNthCalledWith(
-            // if MetaMetrics is initially disabled, trackEvent is called twice and this is 2nd call
-            !metaMetricsInitiallyEnabled ? 2 : 1,
+            // if MetaMetrics is initially disabled, marketing consent is the 3rd trackEvent
+            !metaMetricsInitiallyEnabled ? 3 : 1,
             expect.objectContaining({
               name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
               properties: expect.objectContaining({

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
@@ -116,6 +116,17 @@ const MetaMetricsAndDataCollectionSection: React.FC<
       analytics.identify(consolidatedTraits);
       analytics.trackEvent(
         AnalyticsEventBuilder.createEventBuilder(
+          MetaMetricsEvents.METRICS_OPT_IN,
+        )
+          .addProperties({
+            updated_after_onboarding: true,
+            location: analyticsLocation,
+            ...(accountType && { account_type: accountType }),
+          })
+          .build(),
+      );
+      analytics.trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(
           MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED,
         )
           .addProperties({

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -124,6 +124,7 @@ enum EVENT_NAME {
 
   // Analytics
   ANALYTICS_PREFERENCE_SELECTED = 'Analytics Preference Selected',
+  METRICS_OPT_IN = 'Metrics Opt In',
   METRICS_OPT_OUT = 'Metrics Opt Out',
   ANALYTICS_REQUEST_DATA_DELETION = 'Delete MetaMetrics Data Request Submitted',
   EXPERIMENT_VIEWED = 'Experiment Viewed',
@@ -831,6 +832,7 @@ const events = {
   ANALYTICS_PREFERENCE_SELECTED: generateOpt(
     EVENT_NAME.ANALYTICS_PREFERENCE_SELECTED,
   ),
+  METRICS_OPT_IN: generateOpt(EVENT_NAME.METRICS_OPT_IN),
   METRICS_OPT_OUT: generateOpt(EVENT_NAME.METRICS_OPT_OUT),
   ANALYTICS_REQUEST_DATA_DELETION: generateOpt(
     EVENT_NAME.ANALYTICS_REQUEST_DATA_DELETION,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* Add Metrics Opt In event in Onboarding, Optinmetrics and MetaMetricsAndDataCollectionSection screen
* Jira: https://consensyssoftware.atlassian.net/browse/TO-524
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: METRICS_OPT_IN analytics on user opt-in

  Scenario: User opts in from onboarding MetaMetrics screen
    Given the user is on the onboarding MetaMetrics / data collection screen with basic usage enabled by default

    When the user continues without turning off basic usage
    Then the app completes onboarding as before and analytics pipelines receive a "Metrics Opt In" event with onboarding location and expected properties in addition to "Analytics Preference Selected"

  Scenario: User enables MetaMetrics from Settings
    Given the user is logged in and MetaMetrics is currently off

    When the user opens Settings > Security & privacy and turns the MetaMetrics switch on
    Then the app opts in successfully and emits "Metrics Opt In" with settings location and updated_after_onboarding before the preference-selected event

  Scenario: User enables marketing which requires MetaMetrics
    Given MetaMetrics is off and marketing data collection is off

    When the user turns marketing data collection on (which enables MetaMetrics)
    Then MetaMetrics turns on and "Metrics Opt In" is recorded before the subsequent preference events

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="702" height="94" alt="Screenshot 2026-03-24 at 3 35 19 PM" src="https://github.com/user-attachments/assets/e5177be9-8c93-413b-ae76-8e10c3e50352" />
<img width="703" height="50" alt="Screenshot 2026-03-24 at 3 36 30 PM" src="https://github.com/user-attachments/assets/6da0d4cb-f660-49b9-818e-bb45fe1e413e" />
<img width="695" height="91" alt="Screenshot 2026-03-24 at 3 40 10 PM" src="https://github.com/user-attachments/assets/229e4a2d-80c3-469e-b1a9-639df7068c17" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that adds an additional tracking call when users enable metrics (onboarding, social login, and settings). Main risk is event ordering/duplication affecting downstream dashboards rather than app behavior.
> 
> **Overview**
> Adds a new `MetaMetricsEvents.METRICS_OPT_IN` event and emits it whenever users enable metrics, including the onboarding opt-in screen (`location: onboarding_metametrics`), social login onboarding flow (`location: onboarding_social_login`), and the settings MetaMetrics toggle (`location: settings` / `onboarding_default_settings`).
> 
> Updates tests to assert the new opt-in event is sent (and in settings/onboarding cases is sent *before* `ANALYTICS_PREFERENCE_SELECTED`), including verifying `updated_after_onboarding` and optional `account_type` properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9968f73a4a81ca8b53ccb4dcfc581560fc4652bd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->