### PR TITLE
feat: legacy-ios-feature-flag cp-7.71.0

### DIFF
--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -15,6 +15,7 @@ export enum FeatureFlagNames {
   tokenDetailsV2Buttons = 'tokenDetailsV2Buttons',
   tokenDetailsV2ButtonLayout = 'tokenDetailsV2ButtonLayout',
   complianceEnabled = 'complianceEnabled',
+  legacyIosGoogleConfigEnabled = 'legacyIosGoogleConfigEnabled',
 }
 
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<

--- a/app/selectors/featureFlagController/legacyIosGoogleConfig/index.test.ts
+++ b/app/selectors/featureFlagController/legacyIosGoogleConfig/index.test.ts
@@ -1,0 +1,56 @@
+import {
+  DEFAULT_LEGACY_IOS_GOOGLE_CONFIG_ENABLED,
+  selectLegacyIosGoogleConfigEnabled,
+} from '.';
+import { FeatureFlagNames } from '../../../constants/featureFlags';
+
+describe('Legacy iOS Google Config Feature Flag Selector', () => {
+  const originalEnv = process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED;
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED;
+      return;
+    }
+
+    process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED = originalEnv;
+  });
+
+  it('returns the default value when the remote flag is missing', () => {
+    const result = selectLegacyIosGoogleConfigEnabled.resultFunc({});
+
+    expect(result).toBe(DEFAULT_LEGACY_IOS_GOOGLE_CONFIG_ENABLED);
+  });
+
+  it('returns the remote flag value when present', () => {
+    const result = selectLegacyIosGoogleConfigEnabled.resultFunc({
+      [FeatureFlagNames.legacyIosGoogleConfigEnabled]: false,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('allows the local env var to force enable the legacy config', () => {
+    process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED = 'true';
+
+    const result = selectLegacyIosGoogleConfigEnabled.resultFunc({
+      [FeatureFlagNames.legacyIosGoogleConfigEnabled]: false,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('allows the local env var to force disable the legacy config', () => {
+    process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED = 'false';
+
+    const result = selectLegacyIosGoogleConfigEnabled.resultFunc({
+      [FeatureFlagNames.legacyIosGoogleConfigEnabled]: true,
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts
+++ b/app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts
@@ -5,8 +5,6 @@ import { getFeatureFlagValue } from '../env';
 import { selectRemoteFeatureFlags } from '..';
 
 export const DEFAULT_LEGACY_IOS_GOOGLE_CONFIG_ENABLED = true;
-export const LEGACY_IOS_GOOGLE_CONFIG_ENV_VAR =
-  'MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED';
 
 export const selectLegacyIosGoogleConfigEnabled = createSelector(
   selectRemoteFeatureFlags,
@@ -19,9 +17,9 @@ export const selectLegacyIosGoogleConfigEnabled = createSelector(
           remoteFeatureFlags[FeatureFlagNames.legacyIosGoogleConfigEnabled],
         )
       : DEFAULT_LEGACY_IOS_GOOGLE_CONFIG_ENABLED;
-
     return getFeatureFlagValue(
-      process.env[LEGACY_IOS_GOOGLE_CONFIG_ENV_VAR],
+      // Use direct env access so Babel can inline this value in app builds.
+      process.env.MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED,
       remoteValue,
     );
   },

--- a/app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts
+++ b/app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts
@@ -1,0 +1,28 @@
+import { hasProperty } from '@metamask/utils';
+import { createSelector } from 'reselect';
+import { FeatureFlagNames } from '../../../constants/featureFlags';
+import { getFeatureFlagValue } from '../env';
+import { selectRemoteFeatureFlags } from '..';
+
+export const DEFAULT_LEGACY_IOS_GOOGLE_CONFIG_ENABLED = true;
+export const LEGACY_IOS_GOOGLE_CONFIG_ENV_VAR =
+  'MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED';
+
+export const selectLegacyIosGoogleConfigEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteValue = hasProperty(
+      remoteFeatureFlags,
+      FeatureFlagNames.legacyIosGoogleConfigEnabled,
+    )
+      ? Boolean(
+          remoteFeatureFlags[FeatureFlagNames.legacyIosGoogleConfigEnabled],
+        )
+      : DEFAULT_LEGACY_IOS_GOOGLE_CONFIG_ENABLED;
+
+    return getFeatureFlagValue(
+      process.env[LEGACY_IOS_GOOGLE_CONFIG_ENV_VAR],
+      remoteValue,
+    );
+  },
+);

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -37,6 +37,7 @@ const newOverrides = [
       'app/components/UI/Ramp/hooks/useRampTokens.test.ts',
       'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts',
       'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.test.ts',
+      'app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts',
       'app/util/environment.ts',
       'app/util/environment.test.ts',
       'app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts',

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -38,6 +38,7 @@ const newOverrides = [
       'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.ts',
       'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.test.ts',
       'app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts',
+      'app/selectors/featureFlagController/legacyIosGoogleConfig/index.test.ts',
       'app/util/environment.ts',
       'app/util/environment.test.ts',
       'app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts',

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -742,14 +742,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  legacyIosGoogleConfigEnabled: {
-    name: 'legacyIosGoogleConfigEnabled',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: true,
-    status: FeatureFlagStatus.Active,
-  },
-
   config_registry_api_enabled: {
     name: 'config_registry_api_enabled',
     type: FeatureFlagType.Remote,
@@ -2834,6 +2826,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
       minimumVersion: '7.61.0',
       enabled: true,
     },
+    status: FeatureFlagStatus.Active,
+  },
+
+  legacyIosGoogleConfigEnabled: {
+    name: 'legacyIosGoogleConfigEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: true,
     status: FeatureFlagStatus.Active,
   },
 

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -742,6 +742,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  legacyIosGoogleConfigEnabled: {
+    name: 'legacyIosGoogleConfigEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: true,
+    status: FeatureFlagStatus.Active,
+  },
+
   config_registry_api_enabled: {
     name: 'config_registry_api_enabled',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7148
Support webcredential for ios google login
Part 2/4 - Add feature flag 

This pr add feature flag for the ios google login


PR list
Part 1/ 4 - https://github.com/MetaMask/metamask-mobile/pull/27741
Part 2/ 4 - https://github.com/MetaMask/metamask-mobile/pull/27848
Part 3/ 4 - https://github.com/MetaMask/metamask-mobile/pull/27850
Part 4/ 4 - https://github.com/MetaMask/metamask-mobile/pull/27875

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added legacyIosGoogleConfigEnabled feature flag

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new remote feature flag and selector with env override, without changing authentication flow yet; main risk is misconfiguration since the selector defaults to enabled.
> 
> **Overview**
> Adds a new remote feature flag, `legacyIosGoogleConfigEnabled`, including registry metadata and a dedicated selector `selectLegacyIosGoogleConfigEnabled` (defaulting to `true`) that can be force-overridden via `MM_LEGACY_IOS_GOOGLE_CONFIG_ENABLED`.
> 
> Includes unit tests covering default/remote/env override behavior, and updates `babel.config.tests.js` to avoid inlining env vars for the new selector and its tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca7e8132c44d06ba009029b1f83eb4412e10006f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->