### PR TITLE
feat(rewards): remove campaigns feature flag

### DIFF
--- a/.github/scripts/known-feature-flag-constants.ts
+++ b/.github/scripts/known-feature-flag-constants.ts
@@ -13,7 +13,6 @@ const FILE_SOURCES: Array<{ key: string; file: string; exportName: string }> = [
   { key: 'TRON_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'TRON_REWARDS_FLAG_NAME' },
   { key: 'SNAPSHOTS_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'SNAPSHOTS_REWARDS_FLAG_NAME' },
   { key: 'MISSING_ENROLLED_ACCOUNTS_FLAG_NAME', file: REWARDS_FILE, exportName: 'MISSING_ENROLLED_ACCOUNTS_FLAG_NAME' },
-  { key: 'CAMPAIGNS_REWARDS_FLAG_NAME', file: REWARDS_FILE, exportName: 'CAMPAIGNS_REWARDS_FLAG_NAME' },
   { key: 'ACCOUNT_MENU_FLAG_KEY', file: sel('accountMenu'), exportName: 'ACCOUNT_MENU_FLAG_KEY' },
   { key: 'NETWORK_MANAGEMENT_FLAG_KEY', file: sel('networkManagement'), exportName: 'NETWORK_MANAGEMENT_FLAG_KEY' },
   // FEATURE_FLAG_NAME is omitted (non-unique across rwa / gasFeesSponsored); per-file fallback handles it.

--- a/app/components/UI/Rewards/Views/CampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignDetailsView.test.tsx
@@ -120,6 +120,18 @@ jest.mock('../components/Campaigns/CampaignHowItWorks', () => {
   };
 });
 
+jest.mock('../components/PreviousSeason/PreviousSeasonSummary', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactActual.createElement(View, {
+        testID: 'previous-season-summary',
+      }),
+  };
+});
+
 jest.mock('../components/Campaigns/CampaignOptInSheet', () => {
   const ReactActual = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
@@ -190,18 +202,27 @@ jest.mock('../../../../../locales/i18n', () => ({
 
 const createTestCampaign = (
   overrides: Partial<CampaignDto> = {},
-): CampaignDto => ({
-  id: 'campaign-1',
-  type: CampaignType.ONDO_HOLDING,
-  name: 'Test Campaign',
-  startDate: '2027-01-01T00:00:00.000Z',
-  endDate: '2027-12-31T23:59:59.999Z',
-  termsAndConditions: null,
-  excludedRegions: [],
-  statusLabel: 'Active',
-  details: null,
-  ...overrides,
-});
+): CampaignDto => {
+  const now = new Date();
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const nextMonth = new Date(now);
+  nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+  return {
+    id: 'campaign-1',
+    type: CampaignType.ONDO_HOLDING,
+    name: 'Test Campaign',
+    startDate: yesterday.toISOString(),
+    endDate: nextMonth.toISOString(),
+    termsAndConditions: null,
+    excludedRegions: [],
+    statusLabel: 'Active',
+    details: null,
+    featured: true,
+    ...overrides,
+  };
+};
 
 const mockFetchCampaigns = jest.fn();
 const emptyCategorized = { active: [], upcoming: [], previous: [] };
@@ -331,6 +352,83 @@ describe('CampaignDetailsView', () => {
       const { queryByTestId } = render(<CampaignDetailsView />);
       expect(queryByTestId('campaign-how-it-works')).toBeNull();
     });
+
+    it('does not render CampaignHowItWorks for SEASON_1 campaigns', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            type: CampaignType.SEASON_1,
+            details: {
+              image: {
+                lightModeUrl: 'https://example.com/light.png',
+                darkModeUrl: 'https://example.com/dark.png',
+              },
+              howItWorks: {
+                title: 'How it works',
+                description: 'Description',
+                phases: [],
+              },
+            },
+          }),
+        ],
+      });
+      const { queryByTestId } = render(<CampaignDetailsView />);
+      expect(queryByTestId('campaign-how-it-works')).toBeNull();
+    });
+
+    it('renders PreviousSeasonSummary for complete SEASON_1 campaigns', () => {
+      const lastMonth = new Date();
+      lastMonth.setMonth(lastMonth.getMonth() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            type: CampaignType.SEASON_1,
+            startDate: lastMonth.toISOString(),
+            endDate: yesterday.toISOString(),
+          }),
+        ],
+      });
+      const { getByTestId } = render(<CampaignDetailsView />);
+      expect(getByTestId('previous-season-summary')).toBeDefined();
+    });
+
+    it('does not render PreviousSeasonSummary for active SEASON_1 campaigns', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const nextMonth = new Date();
+      nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            type: CampaignType.SEASON_1,
+            startDate: yesterday.toISOString(),
+            endDate: nextMonth.toISOString(),
+          }),
+        ],
+      });
+      const { queryByTestId } = render(<CampaignDetailsView />);
+      expect(queryByTestId('previous-season-summary')).toBeNull();
+    });
+
+    it('redirects to campaigns view for unsupported campaign types', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            type: 'UNSUPPORTED_TYPE' as CampaignType,
+          }),
+        ],
+      });
+      render(<CampaignDetailsView />);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CAMPAIGNS_VIEW);
+    });
   });
 
   describe('opt-in CTA', () => {
@@ -407,6 +505,48 @@ describe('CampaignDetailsView', () => {
       const { getByTestId } = render(<CampaignDetailsView />);
       fireEvent.press(getByTestId(CAMPAIGN_DETAILS_TEST_IDS.CTA_BUTTON));
       expect(getByTestId('campaign-opt-in-sheet')).toBeDefined();
+    });
+
+    it('renders the CTA as disabled when campaign is upcoming', () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const nextMonth = new Date();
+      nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            startDate: tomorrow.toISOString(),
+            endDate: nextMonth.toISOString(),
+          }),
+        ],
+      });
+      const { getByTestId } = render(<CampaignDetailsView />);
+      const cta = getByTestId(CAMPAIGN_DETAILS_TEST_IDS.CTA_BUTTON);
+      expect(cta).toBeDefined();
+      expect(
+        cta.props.isDisabled ?? cta.props.accessibilityState?.disabled,
+      ).toBeTruthy();
+    });
+
+    it('does not render the CTA when campaign is complete', () => {
+      const lastMonth = new Date();
+      lastMonth.setMonth(lastMonth.getMonth() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            startDate: lastMonth.toISOString(),
+            endDate: yesterday.toISOString(),
+          }),
+        ],
+      });
+      const { queryByTestId } = render(<CampaignDetailsView />);
+      expect(queryByTestId(CAMPAIGN_DETAILS_TEST_IDS.CTA_BUTTON)).toBeNull();
     });
   });
 

--- a/app/components/UI/Rewards/Views/CampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignDetailsView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ScrollView } from 'react-native';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import {
@@ -16,9 +16,15 @@ import ErrorBoundary from '../../../Views/ErrorBoundary';
 import CampaignStatus from '../components/Campaigns/CampaignStatus';
 import CampaignHowItWorks from '../components/Campaigns/CampaignHowItWorks';
 import CampaignOptInSheet from '../components/Campaigns/CampaignOptInSheet';
+import PreviousSeasonSummary from '../components/PreviousSeason/PreviousSeasonSummary';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import {
+  getCampaignStatus,
+  isCampaignTypeSupported,
+} from '../components/Campaigns/CampaignTile.utils';
+import { CampaignType } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 
@@ -52,6 +58,48 @@ const CampaignDetailsView: React.FC = () => {
 
   const { status: participantStatus, isLoading: isStatusLoading } =
     useGetCampaignParticipantStatus(campaignId);
+
+  const campaignStatus = campaign ? getCampaignStatus(campaign) : null;
+  const isCampaignActive = campaignStatus === 'active';
+  const isCampaignComplete = campaignStatus === 'complete';
+
+  // Redirect to campaigns overview if campaign type is not supported
+  useEffect(() => {
+    if (campaign && !isCampaignTypeSupported(campaign.type)) {
+      navigation.navigate(Routes.CAMPAIGNS_VIEW);
+    }
+  }, [campaign, navigation]);
+
+  const campaignDetailsContent = useMemo(() => {
+    if (!campaign) return null;
+
+    // For ONDO_HOLDING campaigns, show How It Works section
+    if (
+      campaign.type === CampaignType.ONDO_HOLDING &&
+      campaign.details?.howItWorks
+    ) {
+      return (
+        <>
+          <Box twClassName="border-b border-border-muted" />
+          <Box twClassName="px-4 py-4">
+            <CampaignHowItWorks howItWorks={campaign.details.howItWorks} />
+          </Box>
+        </>
+      );
+    }
+
+    // For SEASON_1 campaigns that are complete, show PreviousSeasonSummary
+    if (campaign.type === CampaignType.SEASON_1 && isCampaignComplete) {
+      return (
+        <>
+          <Box twClassName="border-b border-border-muted" />
+          <PreviousSeasonSummary />
+        </>
+      );
+    }
+
+    return null;
+  }, [campaign, isCampaignComplete]);
 
   return (
     <ErrorBoundary navigation={navigation} view="CampaignDetailsView">
@@ -110,38 +158,30 @@ const CampaignDetailsView: React.FC = () => {
           {campaign && (
             <>
               <CampaignStatus campaign={campaign} />
-
-              {campaign.details?.howItWorks && (
-                <>
-                  <Box twClassName="border-b border-border-muted" />
-                  <Box twClassName="px-4 py-4">
-                    <CampaignHowItWorks
-                      howItWorks={campaign.details.howItWorks}
-                    />
-                  </Box>
-                </>
-              )}
+              {campaignDetailsContent}
             </>
           )}
         </ScrollView>
 
-        {campaign && participantStatus?.optedIn !== true && (
-          <Box twClassName="px-4 pb-4 pt-2">
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              isFullWidth
-              onPress={() => setIsOptInSheetOpen(true)}
-              isLoading={isStatusLoading}
-              isDisabled={isStatusLoading}
-              testID={CAMPAIGN_DETAILS_TEST_IDS.CTA_BUTTON}
-            >
-              {isStatusLoading
-                ? strings('rewards.campaign_details.checking_opt_in_status')
-                : strings('rewards.campaign_details.join_campaign')}
-            </Button>
-          </Box>
-        )}
+        {campaign &&
+          participantStatus?.optedIn !== true &&
+          !isCampaignComplete && (
+            <Box twClassName="px-4 pb-4 pt-2">
+              <Button
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.Lg}
+                isFullWidth
+                onPress={() => setIsOptInSheetOpen(true)}
+                isLoading={isStatusLoading}
+                isDisabled={isStatusLoading || !isCampaignActive}
+                testID={CAMPAIGN_DETAILS_TEST_IDS.CTA_BUTTON}
+              >
+                {isStatusLoading
+                  ? strings('rewards.campaign_details.checking_opt_in_status')
+                  : strings('rewards.campaign_details.join_campaign')}
+              </Button>
+            </Box>
+          )}
 
         {isOptInSheetOpen && campaign && (
           <CampaignOptInSheet

--- a/app/components/UI/Rewards/Views/CampaignMechanicsView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignMechanicsView.test.tsx
@@ -142,6 +142,7 @@ const createTestCampaign = (
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 

--- a/app/components/UI/Rewards/Views/CampaignsView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignsView.test.tsx
@@ -145,6 +145,7 @@ const createTestCampaign = (
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 

--- a/app/components/UI/Rewards/Views/CampaignsView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignsView.tsx
@@ -91,7 +91,6 @@ const CampaignsView: React.FC = () => {
           title={strings('rewards.campaigns_view.previous_title')}
           campaigns={previous}
           testID={REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIOUS_SECTION}
-          displayPreviousSeason
         />
       </Box>
     );

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
@@ -167,6 +167,7 @@ const createTestCampaign = (
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatus.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatus.test.tsx
@@ -35,6 +35,7 @@ const createTestCampaign = (overrides = {}): CampaignDto => ({
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -86,6 +86,7 @@ const createTestCampaign = (overrides = {}): CampaignDto => ({
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.test.ts
@@ -7,6 +7,7 @@ import {
   formatCampaignStatusLabel,
   getCampaignPillLabel,
   getCampaignStatusInfo,
+  isCampaignTypeSupported,
 } from './CampaignTile.utils';
 import {
   type CampaignDto,
@@ -43,6 +44,7 @@ function buildCampaignDto(overrides: Partial<CampaignDto> = {}): CampaignDto {
     excludedRegions: [],
     statusLabel: 'Active',
     details: null,
+    featured: true,
     ...overrides,
   };
 }
@@ -164,7 +166,7 @@ describe('CampaignTile.utils', () => {
       expect(result).toContain('"date"');
     });
 
-    it('returns formatted endDate for complete status without localization', () => {
+    it('returns localized ended_date for complete status with formatted endDate', () => {
       const campaign = buildCampaignDto({
         startDate: '2025-01-01T00:00:00.000Z',
         endDate: '2025-07-04T18:00:00.000Z',
@@ -172,8 +174,11 @@ describe('CampaignTile.utils', () => {
 
       const result = formatCampaignStatusLabel('complete', campaign);
 
-      expect(strings).not.toHaveBeenCalled();
-      expect(result).toBe('July 4');
+      expect(strings).toHaveBeenCalledWith('rewards.campaign.ended_date', {
+        date: 'July 4',
+      });
+      expect(result).toContain('rewards.campaign.ended_date:');
+      expect(result).toContain('"date"');
     });
 
     it('returns empty string for unknown status', () => {
@@ -275,9 +280,23 @@ describe('CampaignTile.utils', () => {
       expect(result).toEqual({
         status: 'complete',
         statusLabel: 'rewards.campaign.pill_complete',
-        dateLabel: 'December 31',
+        dateLabel: expect.stringContaining('rewards.campaign.ended_date'),
         dateLabelIcon: 'Confirmation',
       });
+    });
+  });
+
+  describe('isCampaignTypeSupported', () => {
+    it('returns true for ONDO_HOLDING campaign type', () => {
+      expect(isCampaignTypeSupported(CampaignType.ONDO_HOLDING)).toBe(true);
+    });
+
+    it('returns true for SEASON_1 campaign type', () => {
+      expect(isCampaignTypeSupported(CampaignType.SEASON_1)).toBe(true);
+    });
+
+    it('returns false for unknown campaign types', () => {
+      expect(isCampaignTypeSupported('UNKNOWN' as CampaignType)).toBe(false);
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.ts
@@ -1,9 +1,29 @@
 import { IconName } from '@metamask/design-system-react-native';
-import type {
-  CampaignDto,
-  CampaignStatus,
+import {
+  CampaignType,
+  type CampaignDto,
+  type CampaignStatus,
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../../locales/i18n';
+
+/**
+ * Set of campaign types that have full UI support (details view, opt-in, etc.)
+ */
+const SUPPORTED_CAMPAIGN_TYPES = new Set<CampaignType>([
+  CampaignType.ONDO_HOLDING,
+  CampaignType.SEASON_1,
+]);
+
+/**
+ * Checks if a campaign type has full UI support.
+ * Campaigns without support will display as non-interactive tiles.
+ *
+ * @param campaignType - The type of campaign
+ * @returns Whether the campaign type is fully supported
+ */
+export function isCampaignTypeSupported(campaignType: CampaignType): boolean {
+  return SUPPORTED_CAMPAIGN_TYPES.has(campaignType);
+}
 
 /**
  * Derives the status of a campaign based on its date fields.
@@ -86,7 +106,9 @@ export function formatCampaignStatusLabel(
     }
     case 'complete': {
       const endDate = new Date(campaign.endDate);
-      return formatCampaignDate(endDate);
+      return strings('rewards.campaign.ended_date', {
+        date: formatCampaignDate(endDate),
+      });
     }
     default:
       return '';
@@ -153,4 +175,23 @@ export function getCampaignStatusInfo(
     dateLabel: formatCampaignStatusLabel(status, campaign),
     dateLabelIcon: getStatusIcon(status),
   };
+}
+
+/**
+ * Returns a comparator function for sorting campaigns based on status.
+ * - Active/Upcoming: sorted by start date ascending (earliest first)
+ * - Complete: sorted by end date descending (most recent first)
+ *
+ * @param status - The campaign status to get the sort comparator for
+ * @returns Comparator function suitable for Array.prototype.sort()
+ */
+export function getCampaignSortComparator(
+  status: CampaignStatus,
+): (a: CampaignDto, b: CampaignDto) => number {
+  if (status === 'complete') {
+    return (a, b) =>
+      new Date(b.endDate).getTime() - new Date(a.endDate).getTime();
+  }
+  return (a, b) =>
+    new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
 }

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsGroup.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsGroup.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import CampaignsGroup from './CampaignsGroup';
-import type {
-  CampaignDto,
+import {
+  type CampaignDto,
   CampaignType,
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
 
@@ -10,7 +10,7 @@ const createTestCampaign = (
   overrides: Partial<CampaignDto> = {},
 ): CampaignDto => ({
   id: 'campaign-1',
-  type: 'ONDO_HOLDING' as CampaignType,
+  type: CampaignType.ONDO_HOLDING,
   name: 'Test Campaign',
   startDate: '2025-01-01T00:00:00.000Z',
   endDate: '2027-12-31T23:59:59.999Z',
@@ -18,6 +18,7 @@ const createTestCampaign = (
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 
@@ -26,31 +27,22 @@ jest.mock('./CampaignTile', () => {
   const { Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ campaign }: { campaign: { name: string } }) =>
-      ReactActual.createElement(Text, null, campaign.name),
+    default: ({
+      campaign,
+      isInteractive,
+    }: {
+      campaign: { name: string };
+      isInteractive: boolean;
+    }) =>
+      ReactActual.createElement(
+        Text,
+        { testID: isInteractive ? 'interactive' : 'non-interactive' },
+        campaign.name,
+      ),
   };
 });
-
-jest.mock('../PreviousSeason/PreviousSeasonTile', () => {
-  const ReactActual = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () => ReactActual.createElement(Text, null, 'PreviousSeasonTile'),
-  };
-});
-
-const mockUseSelector = jest.fn();
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (selector: unknown) => mockUseSelector(selector),
-}));
 
 describe('CampaignsGroup', () => {
-  beforeEach(() => {
-    mockUseSelector.mockReturnValue(null);
-  });
-
   it('renders title and campaign tiles', () => {
     const campaigns = [
       createTestCampaign({ id: '1', name: 'Campaign One' }),
@@ -75,37 +67,51 @@ describe('CampaignsGroup', () => {
     expect(queryByText('Test Campaign')).toBeNull();
   });
 
-  it('renders PreviousSeasonTile when displayPreviousSeason is true and seasonName exists', () => {
-    mockUseSelector.mockReturnValue('Season 1');
+  it('renders campaigns with supported types as interactive', () => {
+    const campaigns = [
+      createTestCampaign({
+        id: '1',
+        name: 'Ondo Campaign',
+        type: CampaignType.ONDO_HOLDING,
+      }),
+    ];
 
-    const { getByText } = render(
-      <CampaignsGroup title="Previous" campaigns={[]} displayPreviousSeason />,
-    );
-
-    expect(getByText('Previous')).toBeOnTheScreen();
-    expect(getByText('PreviousSeasonTile')).toBeOnTheScreen();
-  });
-
-  it('returns null when displayPreviousSeason is true but seasonName is empty', () => {
-    mockUseSelector.mockReturnValue(null);
-
-    const { queryByText } = render(
-      <CampaignsGroup title="Previous" campaigns={[]} displayPreviousSeason />,
-    );
-
-    expect(queryByText('Previous')).toBeNull();
-    expect(queryByText('PreviousSeasonTile')).toBeNull();
-  });
-
-  it('does not render PreviousSeasonTile when displayPreviousSeason is false', () => {
-    mockUseSelector.mockReturnValue('Season 1');
-
-    const campaigns = [createTestCampaign({ id: '1', name: 'Campaign One' })];
-
-    const { queryByText } = render(
+    const { getByTestId } = render(
       <CampaignsGroup title="Active" campaigns={campaigns} />,
     );
 
-    expect(queryByText('PreviousSeasonTile')).toBeNull();
+    expect(getByTestId('interactive')).toBeOnTheScreen();
+  });
+
+  it('renders SEASON_1 campaigns as interactive', () => {
+    const campaigns = [
+      createTestCampaign({
+        id: '1',
+        name: 'Season 1 Campaign',
+        type: CampaignType.SEASON_1,
+      }),
+    ];
+
+    const { getByTestId } = render(
+      <CampaignsGroup title="Previous" campaigns={campaigns} />,
+    );
+
+    expect(getByTestId('interactive')).toBeOnTheScreen();
+  });
+
+  it('renders campaigns with unsupported types as non-interactive', () => {
+    const campaigns = [
+      createTestCampaign({
+        id: '1',
+        name: 'Unknown Campaign',
+        type: 'UNKNOWN_TYPE' as CampaignType,
+      }),
+    ];
+
+    const { getByTestId } = render(
+      <CampaignsGroup title="Previous" campaigns={campaigns} />,
+    );
+
+    expect(getByTestId('non-interactive')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsGroup.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsGroup.tsx
@@ -1,33 +1,25 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import CampaignTile from './CampaignTile';
 import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
-import PreviousSeasonTile from '../PreviousSeason/PreviousSeasonTile';
-import { selectSeasonName } from '../../../../../reducers/rewards/selectors';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
+import { isCampaignTypeSupported } from './CampaignTile.utils';
 
 interface CampaignsGroupProps {
   title: string;
   campaigns: CampaignDto[];
   testID?: string;
-  displayPreviousSeason?: boolean;
 }
 
 /**
  * Section component for displaying a group of campaigns with a title.
+ * Campaign interactivity is determined by whether the campaign type is supported.
  */
 const CampaignsGroup: React.FC<CampaignsGroupProps> = ({
   title,
   campaigns,
   testID,
-  displayPreviousSeason = false,
 }) => {
-  const seasonName = useSelector(selectSeasonName);
-  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
-  const showPreviousSeason = displayPreviousSeason && !!seasonName;
-
-  if (campaigns.length === 0 && !showPreviousSeason) {
+  if (campaigns.length === 0) {
     return null;
   }
 
@@ -40,10 +32,9 @@ const CampaignsGroup: React.FC<CampaignsGroupProps> = ({
         <CampaignTile
           key={campaign.id}
           campaign={campaign}
-          isInteractive={isCampaignsEnabled}
+          isInteractive={isCampaignTypeSupported(campaign.type)}
         />
       ))}
-      {showPreviousSeason && <PreviousSeasonTile />}
     </Box>
   );
 };

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.test.tsx
@@ -14,15 +14,6 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-jest.mock('../../../../../selectors/featureFlagController/rewards', () => ({
-  selectCampaignsRewardsEnabledFlag: jest.fn(() => true),
-}));
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (selector: (state: unknown) => unknown) => selector({}),
-}));
-
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
   return { ...actual };
@@ -42,25 +33,20 @@ jest.mock('./CampaignTile', () => {
   const { Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ campaign }: { campaign: CampaignDto }) =>
+    default: ({
+      campaign,
+      isInteractive,
+    }: {
+      campaign: CampaignDto;
+      isInteractive: boolean;
+    }) =>
       ReactActual.createElement(
         Text,
-        { testID: `campaign-tile-${campaign.id}` },
+        {
+          testID: `campaign-tile-${campaign.id}`,
+          accessibilityState: { disabled: !isInteractive },
+        },
         campaign.name,
-      ),
-  };
-});
-
-jest.mock('../PreviousSeason/PreviousSeasonTile', () => {
-  const ReactActual = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () =>
-      ReactActual.createElement(
-        Text,
-        { testID: 'previous-season-tile' },
-        'Previous Season Tile',
       ),
   };
 });
@@ -74,28 +60,34 @@ jest.mock('../../../../../../locales/i18n', () => ({
   },
 }));
 
+const now = new Date();
+const futureDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+const farFutureDate = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000);
+const pastDate = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+const farPastDate = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+
 const createTestCampaign = (
   overrides: Partial<CampaignDto> = {},
 ): CampaignDto => ({
   id: 'campaign-1',
   type: CampaignType.ONDO_HOLDING,
   name: 'Test Campaign',
-  startDate: '2027-01-01T00:00:00.000Z',
-  endDate: '2027-12-31T23:59:59.999Z',
+  startDate: pastDate.toISOString(),
+  endDate: futureDate.toISOString(),
   termsAndConditions: null,
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 
-const emptyCategorized = { active: [], upcoming: [], previous: [] };
-
 const mockHookDefaults = {
   campaigns: [],
-  categorizedCampaigns: emptyCategorized,
+  categorizedCampaigns: { active: [], upcoming: [], previous: [] },
   isLoading: false,
   hasError: false,
+  hasLoaded: true,
   fetchCampaigns: jest.fn(),
 };
 
@@ -105,37 +97,50 @@ describe('CampaignsPreview', () => {
     mockUseRewardCampaigns.mockReturnValue(mockHookDefaults);
   });
 
-  it('renders PreviousSeasonTile when there are no campaigns in any category', () => {
-    const { getByTestId } = render(<CampaignsPreview />);
+  it('renders the section with no campaigns when none are featured', () => {
+    const { getByTestId, queryByTestId } = render(<CampaignsPreview />);
 
     expect(
       getByTestId(REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW),
     ).toBeOnTheScreen();
-    expect(getByTestId('previous-season-tile')).toBeOnTheScreen();
+    expect(queryByTestId('campaign-tile-campaign-1')).toBeNull();
   });
 
-  it('renders PreviousSeasonTile when there is an error and no campaigns', () => {
+  it('renders loading skeleton when campaigns have never been loaded', () => {
+    mockUseRewardCampaigns.mockReturnValue({
+      ...mockHookDefaults,
+      hasLoaded: false,
+      isLoading: false,
+    });
+
+    const { Skeleton } = jest.requireActual(
+      '@metamask/design-system-react-native',
+    );
+    const { UNSAFE_getByType } = render(<CampaignsPreview />);
+
+    expect(UNSAFE_getByType(Skeleton)).toBeDefined();
+  });
+
+  it('renders error banner when there is an error and no featured campaigns', () => {
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
       hasError: true,
     });
 
-    const { getByTestId } = render(<CampaignsPreview />);
+    const { getByText } = render(<CampaignsPreview />);
 
-    expect(
-      getByTestId(REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW),
-    ).toBeOnTheScreen();
-    expect(getByTestId('previous-season-tile')).toBeOnTheScreen();
+    expect(getByText('rewards.campaigns_view.error_title')).toBeOnTheScreen();
   });
 
-  it('renders the section title when an active campaign exists', () => {
+  it('renders the section title when a featured active campaign exists', () => {
     const activeCampaign = createTestCampaign({
       id: 'active-1',
       name: 'Active Campaign',
+      featured: true,
     });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: { ...emptyCategorized, active: [activeCampaign] },
+      campaigns: [activeCampaign],
     });
 
     const { getByText, getByTestId } = render(<CampaignsPreview />);
@@ -146,14 +151,15 @@ describe('CampaignsPreview', () => {
     expect(getByText('Campaigns')).toBeOnTheScreen();
   });
 
-  it('renders a CampaignTile for the first active campaign', () => {
+  it('renders a CampaignTile for a featured active campaign', () => {
     const activeCampaign = createTestCampaign({
       id: 'active-1',
       name: 'Active Campaign',
+      featured: true,
     });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: { ...emptyCategorized, active: [activeCampaign] },
+      campaigns: [activeCampaign],
     });
 
     const { getByText } = render(<CampaignsPreview />);
@@ -161,126 +167,122 @@ describe('CampaignsPreview', () => {
     expect(getByText('Active Campaign')).toBeOnTheScreen();
   });
 
-  it('renders the upcoming campaign as a CampaignTile when no active campaign exists', () => {
-    const upcomingCampaign = createTestCampaign({
-      id: 'up-1',
-      name: 'Upcoming Campaign',
+  it('does not render non-featured campaigns', () => {
+    const nonFeaturedCampaign = createTestCampaign({
+      id: 'non-featured',
+      name: 'Non Featured',
+      featured: false,
     });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: {
-        ...emptyCategorized,
-        upcoming: [upcomingCampaign],
-      },
+      campaigns: [nonFeaturedCampaign],
     });
 
-    const { getByTestId } = render(<CampaignsPreview />);
+    const { queryByTestId } = render(<CampaignsPreview />);
 
-    expect(getByTestId('campaign-tile-up-1')).toBeOnTheScreen();
+    expect(queryByTestId('campaign-tile-non-featured')).toBeNull();
   });
 
-  it('renders the most recent previous campaign when no active or upcoming exist', () => {
-    const previousCampaign = createTestCampaign({
-      id: 'prev-1',
-      name: 'Previous Campaign',
-    });
-    mockUseRewardCampaigns.mockReturnValue({
-      ...mockHookDefaults,
-      categorizedCampaigns: {
-        ...emptyCategorized,
-        previous: [previousCampaign],
-      },
-    });
-
-    const { getByTestId } = render(<CampaignsPreview />);
-
-    expect(getByTestId('campaign-tile-prev-1')).toBeOnTheScreen();
-  });
-
-  it('shows the active campaign over upcoming when both exist', () => {
+  it('renders multiple featured campaigns in order: active, upcoming, past', () => {
     const activeCampaign = createTestCampaign({
       id: 'active-1',
       name: 'Active Campaign',
+      startDate: pastDate.toISOString(),
+      endDate: futureDate.toISOString(),
+      featured: true,
     });
     const upcomingCampaign = createTestCampaign({
-      id: 'up-1',
+      id: 'upcoming-1',
       name: 'Upcoming Campaign',
+      startDate: futureDate.toISOString(),
+      endDate: farFutureDate.toISOString(),
+      featured: true,
+    });
+    const pastCampaign = createTestCampaign({
+      id: 'past-1',
+      name: 'Past Campaign',
+      startDate: farPastDate.toISOString(),
+      endDate: pastDate.toISOString(),
+      featured: true,
     });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: {
-        ...emptyCategorized,
-        active: [activeCampaign],
-        upcoming: [upcomingCampaign],
-      },
+      campaigns: [pastCampaign, upcomingCampaign, activeCampaign],
     });
 
-    const { getByTestId, queryByTestId } = render(<CampaignsPreview />);
+    const { getByTestId, getAllByTestId } = render(<CampaignsPreview />);
 
     expect(getByTestId('campaign-tile-active-1')).toBeOnTheScreen();
-    expect(queryByTestId('campaign-tile-up-1')).toBeNull();
+    expect(getByTestId('campaign-tile-upcoming-1')).toBeOnTheScreen();
+    expect(getByTestId('campaign-tile-past-1')).toBeOnTheScreen();
+
+    const tiles = getAllByTestId(/^campaign-tile-/);
+    expect(tiles).toHaveLength(3);
   });
 
-  it('shows the upcoming campaign over previous when no active exists', () => {
-    const upcomingCampaign = createTestCampaign({
-      id: 'up-1',
-      name: 'Upcoming Campaign',
-    });
-    const previousCampaign = createTestCampaign({
-      id: 'prev-1',
-      name: 'Previous Campaign',
+  it('renders SEASON_1 campaign type as interactive', () => {
+    const season1Campaign = createTestCampaign({
+      id: 'season-1',
+      name: 'Season 1 Campaign',
+      type: CampaignType.SEASON_1,
+      featured: true,
     });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: {
-        ...emptyCategorized,
-        upcoming: [upcomingCampaign],
-        previous: [previousCampaign],
-      },
+      campaigns: [season1Campaign],
     });
 
-    const { getByTestId, queryByTestId } = render(<CampaignsPreview />);
+    const { getByTestId } = render(<CampaignsPreview />);
 
-    expect(getByTestId('campaign-tile-up-1')).toBeOnTheScreen();
-    expect(queryByTestId('campaign-tile-prev-1')).toBeNull();
+    const tile = getByTestId('campaign-tile-season-1');
+    expect(tile.props.accessibilityState.disabled).toBe(false);
   });
 
-  it('only shows the first active campaign even when multiple exist', () => {
-    const first = createTestCampaign({ id: 'a1', name: 'First Active' });
-    const second = createTestCampaign({ id: 'a2', name: 'Second Active' });
+  it('renders unsupported campaign types as non-interactive', () => {
+    const unknownCampaign = createTestCampaign({
+      id: 'unknown-1',
+      name: 'Unknown Campaign',
+      type: 'UNKNOWN_TYPE' as CampaignType,
+      featured: true,
+    });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: { ...emptyCategorized, active: [first, second] },
+      campaigns: [unknownCampaign],
     });
 
-    const { getByTestId, queryByTestId } = render(<CampaignsPreview />);
+    const { getByTestId } = render(<CampaignsPreview />);
 
-    expect(getByTestId('campaign-tile-a1')).toBeOnTheScreen();
-    expect(queryByTestId('campaign-tile-a2')).toBeNull();
+    const tile = getByTestId('campaign-tile-unknown-1');
+    expect(tile.props.accessibilityState.disabled).toBe(true);
   });
 
-  it('only shows the first upcoming campaign even when multiple exist', () => {
-    const first = createTestCampaign({ id: 'u1', name: 'First Upcoming' });
-    const second = createTestCampaign({ id: 'u2', name: 'Second Upcoming' });
+  it('renders supported campaign types as interactive', () => {
+    const ondoCampaign = createTestCampaign({
+      id: 'ondo-1',
+      name: 'Ondo Campaign',
+      type: CampaignType.ONDO_HOLDING,
+      featured: true,
+    });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: { ...emptyCategorized, upcoming: [first, second] },
+      campaigns: [ondoCampaign],
     });
 
-    const { getByTestId, queryByTestId } = render(<CampaignsPreview />);
+    const { getByTestId } = render(<CampaignsPreview />);
 
-    expect(getByTestId('campaign-tile-u1')).toBeOnTheScreen();
-    expect(queryByTestId('campaign-tile-u2')).toBeNull();
+    const tile = getByTestId('campaign-tile-ondo-1');
+    expect(tile.props.accessibilityState.disabled).toBe(false);
   });
 
   it('navigates to campaigns view when the title header is pressed', () => {
     const activeCampaign = createTestCampaign({
       id: 'active-1',
       name: 'Active Campaign',
+      featured: true,
     });
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
-      categorizedCampaigns: { ...emptyCategorized, active: [activeCampaign] },
+      campaigns: [activeCampaign],
     });
 
     const { getByText } = render(<CampaignsPreview />);
@@ -289,12 +291,12 @@ describe('CampaignsPreview', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.CAMPAIGNS_VIEW);
   });
 
-  it('navigates to previous season view when title header is pressed and no campaigns exist', () => {
+  it('navigates to campaigns view even when no featured campaigns exist', () => {
     mockUseRewardCampaigns.mockReturnValue(mockHookDefaults);
 
     const { getByText } = render(<CampaignsPreview />);
     fireEvent.press(getByText('Campaigns'));
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREVIOUS_SEASON_VIEW);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.CAMPAIGNS_VIEW);
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.test.tsx
@@ -125,11 +125,29 @@ describe('CampaignsPreview', () => {
     mockUseRewardCampaigns.mockReturnValue({
       ...mockHookDefaults,
       hasError: true,
+      hasLoaded: true,
     });
 
     const { getByText } = render(<CampaignsPreview />);
 
     expect(getByText('rewards.campaigns_view.error_title')).toBeOnTheScreen();
+  });
+
+  it('renders error banner on first-load failure (not skeleton)', () => {
+    const { Skeleton } = jest.requireActual(
+      '@metamask/design-system-react-native',
+    );
+    mockUseRewardCampaigns.mockReturnValue({
+      ...mockHookDefaults,
+      hasError: true,
+      hasLoaded: true,
+      isLoading: false,
+    });
+
+    const { getByText, UNSAFE_queryByType } = render(<CampaignsPreview />);
+
+    expect(getByText('rewards.campaigns_view.error_title')).toBeOnTheScreen();
+    expect(UNSAFE_queryByType(Skeleton)).toBeNull();
   });
 
   it('renders the section title when a featured active campaign exists', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { Pressable, ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { useTheme } from '../../../../../util/theme';
 import {
   Box,
@@ -21,63 +20,65 @@ import { strings } from '../../../../../../locales/i18n';
 import { useRewardCampaigns } from '../../hooks/useRewardCampaigns';
 import CampaignTile from './CampaignTile';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
-import PreviousSeasonTile from '../PreviousSeason/PreviousSeasonTile';
+import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import {
+  getCampaignSortComparator,
+  getCampaignStatus,
+  isCampaignTypeSupported,
+} from './CampaignTile.utils';
 
 /**
- * CampaignsPreview shows a single featured campaign on the dashboard.
- * Priority: first active (soonest start date) → first upcoming (soonest start date) → most recent previous (latest end date).
+ * CampaignsPreview shows featured campaigns on the dashboard.
+ * Campaigns are ordered by status: active first, then upcoming, then past (complete).
+ * Only campaigns marked as featured are displayed.
  */
 const CampaignsPreview: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const { colors } = useTheme();
-  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
-  const { categorizedCampaigns, isLoading, hasError, fetchCampaigns } =
+  const { campaigns, isLoading, hasError, hasLoaded, fetchCampaigns } =
     useRewardCampaigns();
 
-  // Priority: first active (soonest start) → first upcoming (soonest start) → most recent previous (latest end)
-  const featuredCampaign = useMemo(
-    () =>
-      categorizedCampaigns.active[0] ??
-      categorizedCampaigns.upcoming[0] ??
-      categorizedCampaigns.previous[0] ??
-      null,
-    [categorizedCampaigns],
-  );
+  /**
+   * Get featured campaigns ordered by status priority:
+   * 1. Active campaigns (sorted by start date ascending)
+   * 2. Upcoming campaigns (sorted by start date ascending)
+   * 3. Past/complete campaigns (sorted by end date descending - most recent first)
+   */
+  const featuredCampaigns = useMemo((): CampaignDto[] => {
+    const featured = (campaigns ?? []).filter((c) => c.featured);
+
+    const active: CampaignDto[] = [];
+    const upcoming: CampaignDto[] = [];
+    const past: CampaignDto[] = [];
+
+    featured.forEach((campaign) => {
+      const status = getCampaignStatus(campaign);
+      switch (status) {
+        case 'active':
+          active.push(campaign);
+          break;
+        case 'upcoming':
+          upcoming.push(campaign);
+          break;
+        case 'complete':
+          past.push(campaign);
+          break;
+      }
+    });
+
+    active.sort(getCampaignSortComparator('active'));
+    upcoming.sort(getCampaignSortComparator('upcoming'));
+    past.sort(getCampaignSortComparator('complete'));
+
+    return [...active, ...upcoming, ...past];
+  }, [campaigns]);
+
+  const hasFeaturedCampaigns = featuredCampaigns.length > 0;
 
   const handleNavigateToCampaigns = useCallback(() => {
     navigation.navigate(Routes.CAMPAIGNS_VIEW);
   }, [navigation]);
-
-  const handleNavigateToPreviousSeason = useCallback(() => {
-    navigation.navigate(Routes.PREVIOUS_SEASON_VIEW);
-  }, [navigation]);
-
-  const showPreviousSeasonTile = !isLoading && !featuredCampaign;
-
-  if (showPreviousSeasonTile) {
-    return (
-      <Box
-        twClassName="gap-3 p-4"
-        testID={REWARDS_VIEW_SELECTORS.CAMPAIGNS_PREVIEW}
-      >
-        <Pressable onPress={handleNavigateToPreviousSeason}>
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="gap-2"
-          >
-            <Text variant={TextVariant.HeadingMd}>
-              {strings('rewards.campaigns_preview.title')}
-            </Text>
-            <Icon name={IconName.ArrowRight} size={IconSize.Md} />
-          </Box>
-        </Pressable>
-        <PreviousSeasonTile />
-      </Box>
-    );
-  }
 
   return (
     <Box
@@ -90,7 +91,7 @@ const CampaignsPreview: React.FC = () => {
           alignItems={BoxAlignItems.Center}
           twClassName="gap-2"
         >
-          {isLoading && !featuredCampaign && (
+          {(isLoading || !hasLoaded) && !hasFeaturedCampaigns && (
             <ActivityIndicator size="small" color={colors.primary.default} />
           )}
           <Text variant={TextVariant.HeadingMd}>
@@ -100,11 +101,11 @@ const CampaignsPreview: React.FC = () => {
         </Box>
       </Pressable>
 
-      {isLoading && !featuredCampaign && (
+      {(isLoading || !hasLoaded) && !hasFeaturedCampaigns && (
         <Skeleton style={tw.style('h-50 rounded-xl')} />
       )}
 
-      {!isLoading && hasError && !featuredCampaign && (
+      {!isLoading && hasLoaded && hasError && !hasFeaturedCampaigns && (
         <RewardsErrorBanner
           title={strings('rewards.campaigns_view.error_title')}
           description={strings('rewards.campaigns_view.error_description')}
@@ -113,12 +114,13 @@ const CampaignsPreview: React.FC = () => {
         />
       )}
 
-      {featuredCampaign && (
+      {featuredCampaigns.map((campaign) => (
         <CampaignTile
-          campaign={featuredCampaign}
-          onPress={isCampaignsEnabled ? undefined : handleNavigateToCampaigns}
+          key={campaign.id}
+          campaign={campaign}
+          isInteractive={isCampaignTypeSupported(campaign.type)}
         />
-      )}
+      ))}
     </Box>
   );
 };

--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.test.ts
@@ -3,7 +3,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useGetCampaignParticipantStatus } from './useGetCampaignParticipantStatus';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectCampaignParticipantStatusById } from '../../../../reducers/rewards/selectors';
 import { setCampaignParticipantStatus } from '../../../../reducers/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
@@ -24,10 +23,6 @@ jest.mock('./useInvalidateByRewardEvents', () => ({
 
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
-}));
-
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectCampaignsRewardsEnabledFlag: jest.fn(),
 }));
 
 jest.mock('../../../../reducers/rewards/selectors', () => ({
@@ -68,7 +63,6 @@ const mockParticipantStatusSelector = jest.fn();
 
 function setupSelectors(
   subscriptionId: string | null,
-  campaignsEnabled: boolean,
   participantStatus: CampaignParticipantStatusDto | null = null,
 ) {
   mockParticipantStatusSelector.mockReturnValue(participantStatus);
@@ -90,7 +84,6 @@ function setupSelectors(
 
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectRewardsSubscriptionId) return subscriptionId;
-    if (selector === selectCampaignsRewardsEnabledFlag) return campaignsEnabled;
     if (selector === mockParticipantStatusSelector) return currentStatus;
     return undefined;
   });
@@ -106,20 +99,8 @@ describe('useGetCampaignParticipantStatus', () => {
     }));
   });
 
-  it('skips fetch and returns null status when feature flag is disabled', async () => {
-    setupSelectors(SUB_ID, false);
-    const { result } = renderHook(() =>
-      useGetCampaignParticipantStatus(CAMPAIGN_ID),
-    );
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(mockCall).not.toHaveBeenCalled();
-    expect(result.current.status).toBeNull();
-  });
-
   it('fetches and dispatches status on mount', async () => {
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall.mockResolvedValueOnce(STATUS as never);
 
     const { result, waitForNextUpdate } = renderHook(() =>
@@ -146,7 +127,7 @@ describe('useGetCampaignParticipantStatus', () => {
   });
 
   it('sets hasError on failure', async () => {
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall.mockRejectedValueOnce(new Error('fail') as never);
 
     const { result, waitForNextUpdate } = renderHook(() =>
@@ -161,7 +142,7 @@ describe('useGetCampaignParticipantStatus', () => {
   });
 
   it('subscribes to RewardsController:campaignOptedIn to auto-refetch', () => {
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall.mockResolvedValue({
       optedIn: false,
       participantCount: 0,
@@ -177,7 +158,7 @@ describe('useGetCampaignParticipantStatus', () => {
 
   it('allows manual refetch', async () => {
     const INITIAL_STATUS = { optedIn: false, participantCount: 0 };
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall
       .mockResolvedValueOnce(INITIAL_STATUS as never)
       .mockResolvedValueOnce(STATUS as never);
@@ -195,5 +176,17 @@ describe('useGetCampaignParticipantStatus', () => {
       await waitForNextUpdate();
     });
     expect(result.current.status).toEqual(STATUS);
+  });
+
+  it('skips fetch when subscriptionId is missing', async () => {
+    setupSelectors(null);
+    const { result } = renderHook(() =>
+      useGetCampaignParticipantStatus(CAMPAIGN_ID),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockCall).not.toHaveBeenCalled();
+    expect(result.current.status).toBeNull();
   });
 });

--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
@@ -2,14 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectCampaignParticipantStatusById } from '../../../../reducers/rewards/selectors';
 import { setCampaignParticipantStatus } from '../../../../reducers/rewards';
 import type { CampaignParticipantStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 
 export interface UseGetCampaignParticipantStatusResult {
-  /** Participant status, or null when flag is disabled / not yet loaded */
+  /** Participant status, or null when not yet loaded */
   status: CampaignParticipantStatusDto | null;
   /** Whether the status is being fetched */
   isLoading: boolean;
@@ -21,21 +20,19 @@ export interface UseGetCampaignParticipantStatusResult {
 
 /**
  * Hook to fetch the campaign participant status for the current subscription.
- * Returns null status and skips the API call when the campaigns feature flag is off.
  * Results are cached for 5 minutes by the RewardsController.
  */
 export const useGetCampaignParticipantStatus = (
   campaignId: string | undefined,
 ): UseGetCampaignParticipantStatusResult => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
   const status = useSelector(selectCampaignParticipantStatusById(campaignId));
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [hasError, setHasError] = useState(false);
 
   const fetchStatus = useCallback(async (): Promise<void> => {
-    if (!isCampaignsEnabled || !subscriptionId || !campaignId) {
+    if (!subscriptionId || !campaignId) {
       return;
     }
 
@@ -53,7 +50,7 @@ export const useGetCampaignParticipantStatus = (
     } finally {
       setIsLoading(false);
     }
-  }, [dispatch, subscriptionId, isCampaignsEnabled, campaignId]);
+  }, [dispatch, subscriptionId, campaignId]);
 
   useEffect(() => {
     fetchStatus();

--- a/app/components/UI/Rewards/hooks/useOptInToCampaign.test.ts
+++ b/app/components/UI/Rewards/hooks/useOptInToCampaign.test.ts
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { useOptInToCampaign } from './useOptInToCampaign';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -17,10 +16,6 @@ jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));
 
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectCampaignsRewardsEnabledFlag: jest.fn(),
-}));
-
 const mockCall = Engine.controllerMessenger.call as jest.MockedFunction<
   typeof Engine.controllerMessenger.call
 >;
@@ -30,13 +25,9 @@ const SUB_ID = 'sub-123';
 const CAMPAIGN_ID = 'camp-456';
 const STATUS = { optedIn: true, participantCount: 42 };
 
-function setupSelectors(
-  subscriptionId: string | null,
-  campaignsEnabled: boolean,
-) {
+function setupSelectors(subscriptionId: string | null) {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectRewardsSubscriptionId) return subscriptionId;
-    if (selector === selectCampaignsRewardsEnabledFlag) return campaignsEnabled;
     return undefined;
   });
 }
@@ -46,19 +37,8 @@ describe('useOptInToCampaign', () => {
     jest.clearAllMocks();
   });
 
-  it('returns null when feature flag is disabled', async () => {
-    setupSelectors(SUB_ID, false);
-    const { result } = renderHook(() => useOptInToCampaign());
-    let returnValue;
-    await act(async () => {
-      returnValue = await result.current.optInToCampaign(CAMPAIGN_ID);
-    });
-    expect(returnValue).toBeNull();
-    expect(mockCall).not.toHaveBeenCalled();
-  });
-
   it('returns null when subscriptionId is missing', async () => {
-    setupSelectors(null, true);
+    setupSelectors(null);
     const { result } = renderHook(() => useOptInToCampaign());
     let returnValue;
     await act(async () => {
@@ -69,7 +49,7 @@ describe('useOptInToCampaign', () => {
   });
 
   it('calls the controller and returns status on success', async () => {
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall.mockResolvedValueOnce(STATUS as never);
 
     const { result } = renderHook(() => useOptInToCampaign());
@@ -89,7 +69,7 @@ describe('useOptInToCampaign', () => {
   });
 
   it('sets optInError and rethrows on failure', async () => {
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall.mockRejectedValueOnce(new Error('Network error') as never);
 
     const { result } = renderHook(() => useOptInToCampaign());
@@ -104,7 +84,7 @@ describe('useOptInToCampaign', () => {
   });
 
   it('clears optInError when clearOptInError is called', async () => {
-    setupSelectors(SUB_ID, true);
+    setupSelectors(SUB_ID);
     mockCall.mockRejectedValueOnce(new Error('err') as never);
 
     const { result } = renderHook(() => useOptInToCampaign());

--- a/app/components/UI/Rewards/hooks/useOptInToCampaign.ts
+++ b/app/components/UI/Rewards/hooks/useOptInToCampaign.ts
@@ -2,7 +2,6 @@ import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import type { CampaignParticipantStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 export interface UseOptInToCampaignResult {
@@ -20,11 +19,9 @@ export interface UseOptInToCampaignResult {
 
 /**
  * Hook to opt the current subscription into a campaign.
- * Returns null immediately when the campaigns feature flag is disabled.
  */
 export const useOptInToCampaign = (): UseOptInToCampaignResult => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
   const [isOptingIn, setIsOptingIn] = useState(false);
   const [optInError, setOptInError] = useState<string | undefined>(undefined);
 
@@ -32,7 +29,7 @@ export const useOptInToCampaign = (): UseOptInToCampaignResult => {
     async (
       campaignId: string,
     ): Promise<CampaignParticipantStatusDto | null> => {
-      if (!isCampaignsEnabled || !subscriptionId) {
+      if (!subscriptionId) {
         return null;
       }
 
@@ -53,7 +50,7 @@ export const useOptInToCampaign = (): UseOptInToCampaignResult => {
         setIsOptingIn(false);
       }
     },
-    [subscriptionId, isCampaignsEnabled],
+    [subscriptionId],
   );
 
   const clearOptInError = useCallback(() => setOptInError(undefined), []);

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.test.ts
@@ -12,12 +12,12 @@ import {
   selectCampaigns,
   selectCampaignsLoading,
   selectCampaignsError,
+  selectCampaignsHasLoaded,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
-import type {
-  CampaignDto,
+import {
+  type CampaignDto,
   CampaignType,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 
@@ -43,14 +43,11 @@ jest.mock('../../../../reducers/rewards/selectors', () => ({
   selectCampaigns: jest.fn(),
   selectCampaignsLoading: jest.fn(),
   selectCampaignsError: jest.fn(),
+  selectCampaignsHasLoaded: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
-}));
-
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectCampaignsRewardsEnabledFlag: jest.fn(),
 }));
 
 jest.mock('@react-navigation/native', () => ({
@@ -78,7 +75,7 @@ const createTestCampaign = (
   overrides: Partial<CampaignDto> = {},
 ): CampaignDto => ({
   id: 'campaign-1',
-  type: 'ONDO_HOLDING' as CampaignType,
+  type: CampaignType.ONDO_HOLDING,
   name: 'ONDO Holding Campaign',
   startDate: '2025-01-01T00:00:00.000Z',
   endDate: '2027-01-01T00:00:00.000Z',
@@ -86,6 +83,7 @@ const createTestCampaign = (
   excludedRegions: [],
   statusLabel: 'Active',
   details: null,
+  featured: true,
   ...overrides,
 });
 
@@ -142,7 +140,7 @@ describe('useRewardCampaigns', () => {
       campaigns?: CampaignDto[];
       isLoading?: boolean;
       hasError?: boolean;
-      isCampaignsEnabled?: boolean;
+      hasLoaded?: boolean;
     } = {},
   ) => {
     const {
@@ -150,7 +148,7 @@ describe('useRewardCampaigns', () => {
       campaigns = [],
       isLoading = false,
       hasError = false,
-      isCampaignsEnabled = true,
+      hasLoaded = true,
     } = options;
 
     mockUseSelector.mockImplementation((selector) => {
@@ -158,8 +156,7 @@ describe('useRewardCampaigns', () => {
       if (selector === selectCampaigns) return campaigns;
       if (selector === selectCampaignsLoading) return isLoading;
       if (selector === selectCampaignsError) return hasError;
-      if (selector === selectCampaignsRewardsEnabledFlag)
-        return isCampaignsEnabled;
+      if (selector === selectCampaignsHasLoaded) return hasLoaded;
       return undefined;
     });
   };
@@ -174,7 +171,16 @@ describe('useRewardCampaigns', () => {
       expect(result.current.campaigns).toEqual(testCampaigns);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.hasError).toBe(false);
+      expect(result.current.hasLoaded).toBe(true);
       expect(typeof result.current.fetchCampaigns).toBe('function');
+    });
+
+    it('returns hasLoaded as false when campaigns have never been loaded', () => {
+      setupSelectorMocks({ hasLoaded: false });
+
+      const { result } = renderHook(() => useRewardCampaigns());
+
+      expect(result.current.hasLoaded).toBe(false);
     });
 
     it('returns empty array when campaigns selector returns undefined', () => {
@@ -184,7 +190,6 @@ describe('useRewardCampaigns', () => {
         if (selector === selectRewardsSubscriptionId) return 'subscription-1';
         if (selector === selectCampaignsLoading) return false;
         if (selector === selectCampaignsError) return false;
-        if (selector === selectCampaignsRewardsEnabledFlag) return true;
         return undefined;
       });
 
@@ -256,26 +261,6 @@ describe('useRewardCampaigns', () => {
 
       expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsError(true));
       expect(mockDispatch).toHaveBeenCalledWith(mockSetCampaignsLoading(false));
-    });
-
-    it('fetches campaigns even when feature flag is disabled', async () => {
-      setupSelectorMocks({ isCampaignsEnabled: false });
-      const mockCampaignsData = [createTestCampaign()];
-      mockEngineCall.mockResolvedValueOnce(mockCampaignsData);
-
-      const { result } = renderHook(() => useRewardCampaigns());
-
-      await act(async () => {
-        await result.current.fetchCampaigns();
-      });
-
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:getCampaigns',
-        'subscription-1',
-      );
-      expect(mockDispatch).toHaveBeenCalledWith(
-        mockSetCampaigns(mockCampaignsData),
-      );
     });
 
     it('does not fetch when subscriptionId is null', async () => {
@@ -477,7 +462,7 @@ describe('useRewardCampaigns', () => {
       );
     });
 
-    it('filters out active and previous campaigns when feature flag is disabled', () => {
+    it('returns all campaigns', () => {
       const activeCampaign = createTestCampaign({
         id: 'active-1',
         startDate: '2020-01-01T00:00:00.000Z',
@@ -496,65 +481,6 @@ describe('useRewardCampaigns', () => {
 
       setupSelectorMocks({
         campaigns: [activeCampaign, upcomingCampaign, completeCampaign],
-        isCampaignsEnabled: false,
-      });
-
-      const { result } = renderHook(() => useRewardCampaigns());
-
-      expect(result.current.categorizedCampaigns.active).toEqual([]);
-      expect(result.current.categorizedCampaigns.upcoming).toEqual([
-        upcomingCampaign,
-      ]);
-      expect(result.current.categorizedCampaigns.previous).toEqual([]);
-    });
-
-    it('returns only upcoming campaigns when feature flag is disabled', () => {
-      const activeCampaign = createTestCampaign({
-        id: 'active-1',
-        startDate: '2020-01-01T00:00:00.000Z',
-        endDate: '2099-12-31T23:59:59.999Z',
-      });
-      const upcomingCampaign = createTestCampaign({
-        id: 'upcoming-1',
-        startDate: '2099-06-01T00:00:00.000Z',
-        endDate: '2099-12-31T23:59:59.999Z',
-      });
-      const completeCampaign = createTestCampaign({
-        id: 'complete-1',
-        startDate: '2020-01-01T00:00:00.000Z',
-        endDate: '2020-12-31T23:59:59.999Z',
-      });
-
-      setupSelectorMocks({
-        campaigns: [activeCampaign, upcomingCampaign, completeCampaign],
-        isCampaignsEnabled: false,
-      });
-
-      const { result } = renderHook(() => useRewardCampaigns());
-
-      expect(result.current.campaigns).toEqual([upcomingCampaign]);
-    });
-
-    it('returns all campaigns when feature flag is enabled', () => {
-      const activeCampaign = createTestCampaign({
-        id: 'active-1',
-        startDate: '2020-01-01T00:00:00.000Z',
-        endDate: '2099-12-31T23:59:59.999Z',
-      });
-      const upcomingCampaign = createTestCampaign({
-        id: 'upcoming-1',
-        startDate: '2099-06-01T00:00:00.000Z',
-        endDate: '2099-12-31T23:59:59.999Z',
-      });
-      const completeCampaign = createTestCampaign({
-        id: 'complete-1',
-        startDate: '2020-01-01T00:00:00.000Z',
-        endDate: '2020-12-31T23:59:59.999Z',
-      });
-
-      setupSelectorMocks({
-        campaigns: [activeCampaign, upcomingCampaign, completeCampaign],
-        isCampaignsEnabled: true,
       });
 
       const { result } = renderHook(() => useRewardCampaigns());

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
@@ -11,9 +11,9 @@ import {
   selectCampaigns,
   selectCampaignsLoading,
   selectCampaignsError,
+  selectCampaignsHasLoaded,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignsRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 import type { CampaignDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
@@ -25,7 +25,7 @@ interface CategorizedCampaigns {
 }
 
 interface UseRewardCampaignsReturn {
-  /** Campaigns fetched from the API. When campaigns flag is disabled, only upcoming campaigns are returned */
+  /** Campaigns fetched from the API */
   campaigns: CampaignDto[];
   /** Campaigns categorized by status */
   categorizedCampaigns: CategorizedCampaigns;
@@ -33,6 +33,8 @@ interface UseRewardCampaignsReturn {
   isLoading: boolean;
   /** Whether there was an error fetching campaigns */
   hasError: boolean;
+  /** Whether campaigns have been loaded at least once */
+  hasLoaded: boolean;
   /** Fetch campaigns from the API */
   fetchCampaigns: () => Promise<void>;
 }
@@ -40,15 +42,13 @@ interface UseRewardCampaignsReturn {
 /**
  * Custom hook to fetch and manage campaigns data from the rewards API.
  * Categorizes campaigns into active, upcoming, and previous (complete).
- * When the campaigns feature flag is disabled, only upcoming campaigns are returned
- * (active and previous are filtered out).
  */
 export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const campaigns = useSelector(selectCampaigns);
   const isLoading = useSelector(selectCampaignsLoading);
   const hasError = useSelector(selectCampaignsError);
-  const isCampaignsEnabled = useSelector(selectCampaignsRewardsEnabledFlag);
+  const hasLoaded = useSelector(selectCampaignsHasLoaded);
   const dispatch = useDispatch();
   const isLoadingRef = useRef(false);
 
@@ -118,13 +118,8 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
       (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime(),
     );
 
-    // When campaigns feature is disabled, only show upcoming campaigns
-    if (!isCampaignsEnabled) {
-      return { active: [], upcoming, previous: [] };
-    }
-
     return { active, upcoming, previous };
-  }, [campaigns, isCampaignsEnabled]);
+  }, [campaigns]);
 
   useFocusEffect(
     useCallback(() => {
@@ -143,18 +138,12 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
 
   useInvalidateByRewardEvents(invalidateEvents, fetchCampaigns);
 
-  // When campaigns feature is disabled, only return upcoming campaigns
-  const filteredCampaigns = useMemo(
-    () =>
-      isCampaignsEnabled ? (campaigns ?? []) : categorizedCampaigns.upcoming,
-    [isCampaignsEnabled, campaigns, categorizedCampaigns.upcoming],
-  );
-
   return {
-    campaigns: filteredCampaigns,
+    campaigns: campaigns ?? [],
     categorizedCampaigns,
     isLoading,
     hasError,
+    hasLoaded,
     fetchCampaigns,
   };
 };

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -18810,27 +18810,10 @@ describe('RewardsController', () => {
       );
     });
 
-    it('returns { optedIn: false, participantCount: 0 } when campaigns feature flag is disabled', async () => {
-      const disabledController = new RewardsController({
-        messenger: mockMessenger,
-        state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => false,
-      });
-
-      const result = await disabledController.optInToCampaign(
-        mockCampaignId,
-        mockSubscriptionId,
-      );
-
-      expect(result).toEqual({ optedIn: false, participantCount: 0 });
-      expect(mockMessenger.call).not.toHaveBeenCalled();
-    });
-
     it('calls data service and returns status on success', async () => {
       const ctrl = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(mockStatus);
@@ -18852,7 +18835,6 @@ describe('RewardsController', () => {
       const ctrl = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(mockStatus);
@@ -18880,7 +18862,6 @@ describe('RewardsController', () => {
             },
           },
         },
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(mockStatus);
@@ -18926,27 +18907,10 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    it('returns { optedIn: false, participantCount: 0 } when campaigns feature flag is disabled', async () => {
-      const disabledController = new RewardsController({
-        messenger: mockMessenger,
-        state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => false,
-      });
-
-      const result = await disabledController.getCampaignParticipantStatus(
-        mockCampaignId,
-        mockSubscriptionId,
-      );
-
-      expect(result).toEqual({ optedIn: false, participantCount: 0 });
-      expect(mockMessenger.call).not.toHaveBeenCalled();
-    });
-
     it('fetches status from API and caches result', async () => {
       const ctrl = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(mockStatus);
@@ -18986,7 +18950,6 @@ describe('RewardsController', () => {
             },
           },
         },
-        isCampaignsEnabled: () => true,
       });
 
       const result = await ctrl.getCampaignParticipantStatus(
@@ -19014,7 +18977,6 @@ describe('RewardsController', () => {
             },
           },
         },
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(mockStatus);
@@ -19036,7 +18998,6 @@ describe('RewardsController', () => {
       const ctrl = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
-        isCampaignsEnabled: () => true,
       });
 
       mockMessenger.call.mockResolvedValue(mockStatus);

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -35,6 +35,7 @@ import {
   type OffDeviceSubscriptionAccountsState,
   type ClientVersionRequirementDto,
   BASE32_REGEX,
+  CampaignType,
 } from './types';
 import type { RewardsControllerMessenger } from '../../messengers/rewards-controller-messenger';
 import {
@@ -315,7 +316,6 @@ export class RewardsController extends BaseController<
   #isDisabled: () => boolean;
   #isBitcoinOptinEnabled: () => boolean;
   #isTronOptinEnabled: () => boolean;
-  #isCampaignsEnabled: () => boolean;
   #reauthPromises: Map<string, Promise<void>> = new Map();
 
   /**
@@ -468,14 +468,12 @@ export class RewardsController extends BaseController<
     isDisabled,
     isBitcoinOptinEnabled,
     isTronOptinEnabled,
-    isCampaignsEnabled,
   }: {
     messenger: RewardsControllerMessenger;
     state?: Partial<RewardsControllerState>;
     isDisabled?: () => boolean;
     isBitcoinOptinEnabled?: () => boolean;
     isTronOptinEnabled?: () => boolean;
-    isCampaignsEnabled?: () => boolean;
   }) {
     super({
       name: controllerName,
@@ -490,7 +488,6 @@ export class RewardsController extends BaseController<
     this.#isDisabled = isDisabled ?? (() => false);
     this.#isBitcoinOptinEnabled = isBitcoinOptinEnabled ?? (() => false);
     this.#isTronOptinEnabled = isTronOptinEnabled ?? (() => false);
-    this.#isCampaignsEnabled = isCampaignsEnabled ?? (() => false);
 
     this.#registerActionHandlers();
     this.#initializeEventSubscriptions();
@@ -3438,7 +3435,7 @@ export class RewardsController extends BaseController<
     campaignId: string,
     subscriptionId: string,
   ): Promise<CampaignParticipantStatusDto> {
-    if (!this.isRewardsFeatureEnabled() || !this.#isCampaignsEnabled()) {
+    if (!this.isRewardsFeatureEnabled()) {
       return { optedIn: false, participantCount: 0 };
     }
     const key = `${subscriptionId}:${campaignId}`;
@@ -3476,7 +3473,7 @@ export class RewardsController extends BaseController<
     campaignId: string,
     subscriptionId: string,
   ): Promise<CampaignParticipantStatusDto> {
-    if (!this.isRewardsFeatureEnabled() || !this.#isCampaignsEnabled()) {
+    if (!this.isRewardsFeatureEnabled()) {
       return { optedIn: false, participantCount: 0 };
     }
     const key = `${subscriptionId}:${campaignId}`;

--- a/app/core/Engine/controllers/rewards-controller/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.ts
@@ -2,7 +2,6 @@ import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings'
 import {
   selectBitcoinRewardsEnabledFlag,
   selectTronRewardsEnabledFlag,
-  selectCampaignsRewardsEnabledFlag,
 } from '../../../../selectors/featureFlagController/rewards/rewardsEnabled';
 import type { ControllerInitFunction } from '../../types';
 import {
@@ -34,7 +33,6 @@ export const rewardsControllerInit: ControllerInitFunction<
     },
     isBitcoinOptinEnabled: () => selectBitcoinRewardsEnabledFlag(getState()),
     isTronOptinEnabled: () => selectTronRewardsEnabledFlag(getState()),
-    isCampaignsEnabled: () => selectCampaignsRewardsEnabledFlag(getState()),
   });
 
   return { controller };

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -92,6 +92,7 @@ export interface ApplyBonusCodeDto {
  */
 export enum CampaignType {
   ONDO_HOLDING = 'ONDO_HOLDING',
+  SEASON_1 = 'SEASON_1',
 }
 
 /**
@@ -150,6 +151,12 @@ export interface CampaignDto {
    * @example { image: { lightModeUrl: 'https://example.com/image.png', darkModeUrl: 'https://example.com/image-dark.png' }, howItWorks: { title: 'How it works', description: 'How it works', phases: [{ name: 'Phase 1', daysLabel: 'Days', sortOrder: 1, steps: [{ title: 'Step 1', description: 'Step 1', iconName: 'icon-name' }] }] } }
    */
   details: CampaignDetails | null;
+
+  /**
+   * Whether this campaign is featured (shown prominently in the UI)
+   * @example true
+   */
+  featured: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -180,10 +187,12 @@ export type CampaignsState = {
             description: string;
             iconName: string;
           }[];
+          days?: number | null;
         }[];
         notes?: Json | null;
       };
     } | null;
+    featured: boolean;
   }[];
   lastFetched: number;
 };
@@ -220,6 +229,10 @@ export interface OndoCampaignPhase {
   daysLabel: string;
   sortOrder: number;
   steps: OndoCampaignStep[];
+  /**
+   * Number of days in the phase, used to calculate phase cut-off dates
+   */
+  days?: number | null;
 }
 
 export interface OndoCampaignHowItWorks {

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4577,40 +4577,60 @@ describe('setCampaignsLoading', () => {
 });
 
 describe('setCampaignsError', () => {
-  it('should set campaignsError to true', () => {
+  it('should set campaignsError to true and mark hasLoaded as true', () => {
     const action = setCampaignsError(true);
 
     const state = rewardsReducer(initialState, action);
 
     expect(state.campaignsError).toBe(true);
+    expect(state.campaignsHasLoaded).toBe(true);
   });
 
-  it('should set campaignsError to false', () => {
+  it('should set campaignsError to false without changing hasLoaded', () => {
     const stateWithError: RewardsState = {
       ...initialState,
       campaignsError: true,
+      campaignsHasLoaded: true,
     };
     const action = setCampaignsError(false);
 
     const state = rewardsReducer(stateWithError, action);
 
     expect(state.campaignsError).toBe(false);
+    expect(state.campaignsHasLoaded).toBe(true);
   });
 
-  it('should toggle error state correctly', () => {
+  it('should not change hasLoaded when clearing error and hasLoaded was false', () => {
+    const stateWithErrorNoLoad: RewardsState = {
+      ...initialState,
+      campaignsError: true,
+      campaignsHasLoaded: false,
+    };
+    const action = setCampaignsError(false);
+
+    const state = rewardsReducer(stateWithErrorNoLoad, action);
+
+    expect(state.campaignsError).toBe(false);
+    expect(state.campaignsHasLoaded).toBe(false);
+  });
+
+  it('should toggle error state correctly while maintaining hasLoaded', () => {
     let currentState = initialState;
 
     let action = setCampaignsError(true);
     currentState = rewardsReducer(currentState, action);
     expect(currentState.campaignsError).toBe(true);
+    expect(currentState.campaignsHasLoaded).toBe(true);
 
     action = setCampaignsError(false);
     currentState = rewardsReducer(currentState, action);
     expect(currentState.campaignsError).toBe(false);
+    expect(currentState.campaignsHasLoaded).toBe(true);
 
     action = setCampaignsError(true);
     currentState = rewardsReducer(currentState, action);
     expect(currentState.campaignsError).toBe(true);
+    expect(currentState.campaignsHasLoaded).toBe(true);
   });
 });
 

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -467,6 +467,9 @@ const rewardsSlice = createSlice({
     },
     setCampaignsError: (state, action: PayloadAction<boolean>) => {
       state.campaignsError = action.payload;
+      if (action.payload) {
+        state.campaignsHasLoaded = true;
+      }
     },
 
     setCampaignParticipantStatus: (

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -120,6 +120,7 @@ export interface RewardsState {
   campaigns: CampaignDto[];
   campaignsLoading: boolean;
   campaignsError: boolean;
+  campaignsHasLoaded: boolean;
 
   // Campaign participant status (keyed by campaignId)
   campaignParticipantStatuses: Record<string, CampaignParticipantStatusDto>;
@@ -194,6 +195,7 @@ export const initialState: RewardsState = {
   campaigns: [],
   campaignsLoading: false,
   campaignsError: false,
+  campaignsHasLoaded: false,
 
   // Campaign participant statuses initial state
   campaignParticipantStatuses: {},
@@ -455,6 +457,7 @@ const rewardsSlice = createSlice({
     setCampaigns: (state, action: PayloadAction<CampaignDto[]>) => {
       state.campaigns = action.payload;
       state.campaignsError = false;
+      state.campaignsHasLoaded = true;
     },
     setCampaignsLoading: (state, action: PayloadAction<boolean>) => {
       if (action.payload && state.campaigns.length) {

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -161,6 +161,9 @@ export const selectCampaignsLoading = (state: RootState) =>
 export const selectCampaignsError = (state: RootState) =>
   state.rewards.campaignsError;
 
+export const selectCampaignsHasLoaded = (state: RootState) =>
+  state.rewards.campaignsHasLoaded;
+
 // Campaign participant status selectors
 export const selectCampaignParticipantStatuses = (state: RootState) =>
   state.rewards.campaignParticipantStatuses;

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -6,10 +6,7 @@ export {
   selectTronRewardsEnabledRawFlag,
   selectMissingEnrolledAccountsRewardsEnabledFlag,
   selectMissingEnrolledAccountsRewardsEnabledRawFlag,
-  selectCampaignsRewardsEnabledFlag,
-  selectCampaignsRewardsEnabledRawFlag,
   BITCOIN_REWARDS_FLAG_NAME,
   TRON_REWARDS_FLAG_NAME,
   MISSING_ENROLLED_ACCOUNTS_FLAG_NAME,
-  CAMPAIGNS_REWARDS_FLAG_NAME,
 } from './rewardsEnabled';

--- a/app/selectors/featureFlagController/rewards/rewardsEnabled.test.ts
+++ b/app/selectors/featureFlagController/rewards/rewardsEnabled.test.ts
@@ -5,12 +5,9 @@ import {
   selectTronRewardsEnabledFlag,
   selectMissingEnrolledAccountsRewardsEnabledRawFlag,
   selectMissingEnrolledAccountsRewardsEnabledFlag,
-  selectCampaignsRewardsEnabledRawFlag,
-  selectCampaignsRewardsEnabledFlag,
   BITCOIN_REWARDS_FLAG_NAME,
   TRON_REWARDS_FLAG_NAME,
   MISSING_ENROLLED_ACCOUNTS_FLAG_NAME,
-  CAMPAIGNS_REWARDS_FLAG_NAME,
 } from './rewardsEnabled';
 // eslint-disable-next-line import-x/no-namespace
 import * as remoteFeatureFlagModule from '../../../util/remoteFeatureFlag';
@@ -312,74 +309,6 @@ describe('Rewards Enabled Feature Flag Selectors', () => {
         false,
         false,
       );
-
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectCampaignsRewardsEnabledRawFlag', () => {
-    it('returns true when remote flag is enabled and version matches', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(true);
-
-      const result = selectCampaignsRewardsEnabledRawFlag.resultFunc({
-        [CAMPAIGNS_REWARDS_FLAG_NAME]: {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-      });
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when remote flag is enabled but version does not match', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(false);
-
-      const result = selectCampaignsRewardsEnabledRawFlag.resultFunc({
-        [CAMPAIGNS_REWARDS_FLAG_NAME]: {
-          enabled: true,
-          minimumVersion: '99.0.0',
-        },
-      });
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote feature flags are empty', () => {
-      const result = selectCampaignsRewardsEnabledRawFlag.resultFunc({});
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when flag property is missing', () => {
-      const result = selectCampaignsRewardsEnabledRawFlag.resultFunc({
-        someOtherFlag: true,
-      });
-
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectCampaignsRewardsEnabledFlag', () => {
-    it('returns true when basic functionality is enabled and raw flag is true', () => {
-      const result = selectCampaignsRewardsEnabledFlag.resultFunc(true, true);
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when basic functionality is enabled and raw flag is false', () => {
-      const result = selectCampaignsRewardsEnabledFlag.resultFunc(true, false);
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when basic functionality is disabled even if raw flag is true', () => {
-      const result = selectCampaignsRewardsEnabledFlag.resultFunc(false, true);
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when basic functionality is disabled and raw flag is false', () => {
-      const result = selectCampaignsRewardsEnabledFlag.resultFunc(false, false);
 
       expect(result).toBe(false);
     });

--- a/app/selectors/featureFlagController/rewards/rewardsEnabled.ts
+++ b/app/selectors/featureFlagController/rewards/rewardsEnabled.ts
@@ -11,12 +11,10 @@ export const BITCOIN_REWARDS_FLAG_NAME = 'rewardsBitcoinEnabled';
 export const TRON_REWARDS_FLAG_NAME = 'rewardsTronEnabled';
 export const MISSING_ENROLLED_ACCOUNTS_FLAG_NAME =
   'rewards-missing-enrolled-accounts';
-export const CAMPAIGNS_REWARDS_FLAG_NAME = 'rewardsCampaignsEnabled';
 
 const DEFAULT_BITCOIN_REWARDS_ENABLED = false;
 const DEFAULT_TRON_REWARDS_ENABLED = false;
 const DEFAULT_MISSING_ENROLLED_ACCOUNTS_ENABLED = false;
-const DEFAULT_CAMPAIGNS_REWARDS_ENABLED = false;
 
 /**
  * Selector for the raw Bitcoin rewards enabled remote flag value.
@@ -121,41 +119,5 @@ export const selectMissingEnrolledAccountsRewardsEnabledFlag = createSelector(
       return false;
     }
     return missingEnrolledAccountsEnabledRawFlag;
-  },
-);
-
-/**
- * Selector for the raw campaigns rewards enabled remote flag value.
- * Returns the flag value without considering basic functionality.
- */
-export const selectCampaignsRewardsEnabledRawFlag = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    if (!hasProperty(remoteFeatureFlags, CAMPAIGNS_REWARDS_FLAG_NAME)) {
-      return DEFAULT_CAMPAIGNS_REWARDS_ENABLED;
-    }
-    const remoteFlag = remoteFeatureFlags[
-      CAMPAIGNS_REWARDS_FLAG_NAME
-    ] as unknown as VersionGatedFeatureFlag;
-
-    return (
-      validatedVersionGatedFeatureFlag(remoteFlag) ??
-      DEFAULT_CAMPAIGNS_REWARDS_ENABLED
-    );
-  },
-);
-
-/**
- * Selector for the campaigns rewards enabled flag.
- * Returns false if basic functionality is disabled, otherwise returns the remote flag value.
- */
-export const selectCampaignsRewardsEnabledFlag = createSelector(
-  selectBasicFunctionalityEnabled,
-  selectCampaignsRewardsEnabledRawFlag,
-  (isBasicFunctionalityEnabled, campaignsRewardsEnabledRawFlag) => {
-    if (!isBasicFunctionalityEnabled) {
-      return false;
-    }
-    return campaignsRewardsEnabledRawFlag;
   },
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7860,6 +7860,7 @@
     "campaign": {
       "starts_date": "Starts {{date}}",
       "ends_date": "Ends {{date}}",
+      "ended_date": "Ended {{date}}",
       "pill_up_next": "Up next",
       "pill_active": "Live",
       "pill_complete": "Complete",


### PR DESCRIPTION
## **Description**

Remove the campaigns-specific feature flag (`rewardsCampaignsEnabled`) and simplify the rewards feature flag logic. Campaigns functionality is now controlled by the main `rewardsEnabled` feature flag.

## **Related issues**

N/A

## **Manual testing steps**

1. Enable the rewards feature flag
2. Navigate to the Rewards section
3. Verify campaigns display correctly and all campaign interactions work

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR
- [x] I've properly set the pull request status:
  - [ ] In case it's not

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR

## **Changelog**

<!--
If your PR makes any user-facing change, it must be communicated properly. You may choose to
add a changelog message describing your change here; your change will also be highlighted
in the release notes.

Format: `[<tag>]: <changelog message>`

Available tags: `[added]`, `[changed]`, `[deprecated]`, `[fixed]`, `[removed]`, `[security]`
-->

CHANGELOG entry: [removed]: Remove rewardsCampaignsEnabled feature flag; campaigns are now controlled by rewardsEnabled

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the `rewardsCampaignsEnabled` gating so campaign opt-in/status calls and UI behavior now depend on the broader rewards enablement, which can change who sees/executes campaign flows. Also changes dashboard/CTA rendering logic (featured filtering, sorting, disabled states) which may affect user navigation and campaign visibility.
> 
> **Overview**
> **Removes the campaigns-specific feature flag (`rewardsCampaignsEnabled`)** and its selectors/constants, updating `RewardsController` and UI hooks (`useRewardCampaigns`, `useOptInToCampaign`, `useGetCampaignParticipantStatus`) to no longer short-circuit campaign fetch/opt-in/status based on that flag.
> 
> **Refines campaigns UI behavior** by introducing `CampaignType.SEASON_1`, adding `featured` to `CampaignDto`, and centralizing support rules via `isCampaignTypeSupported` (unsupported types render as non-interactive and `CampaignDetailsView` redirects to `Routes.CAMPAIGNS_VIEW`). `CampaignDetailsView` now conditionally shows `How It Works` only for `ONDO_HOLDING`, shows `PreviousSeasonSummary` for completed `SEASON_1`, and disables/hides the opt-in CTA when upcoming/complete.
> 
> **Updates dashboard preview and loading semantics**: `CampaignsPreview` now displays *multiple* featured campaigns ordered by derived status (active → upcoming → complete), adds a `campaignsHasLoaded`/`hasLoaded` state to distinguish first-load skeleton vs error banner, and localizes completed date labels via new `rewards.campaign.ended_date` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fdcbe1c3cf99c79f9396ae55de5186daa4ba29a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

