### PR TITLE
refactor: replace deprecated SheetHeader with BottomSheetHeader

### DIFF
--- a/app/components/Views/AddNewAccount/AddNewAccount.tsx
+++ b/app/components/Views/AddNewAccount/AddNewAccount.tsx
@@ -9,7 +9,7 @@ import React, {
 import { SafeAreaView, View } from 'react-native';
 
 // External dependencies.
-import SheetHeader from '../../../component-library/components/Sheet/SheetHeader';
+import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import { strings } from '../../../../locales/i18n';
 
 // Internal dependencies
@@ -181,14 +181,11 @@ const AddNewAccount = ({
   return (
     <SafeAreaView testID={AddNewAccountIds.CONTAINER}>
       <Fragment>
-        <SheetHeader
-          title={
-            showSRPList
-              ? strings('accounts.select_secret_recovery_phrase')
-              : addAccountTitle
-          }
-          onBack={handleOnBack}
-        />
+        <BottomSheetHeader onBack={handleOnBack}>
+          {showSRPList
+            ? strings('accounts.select_secret_recovery_phrase')
+            : addAccountTitle}
+        </BottomSheetHeader>
         {showSRPList ? (
           <SRPList onKeyringSelect={(id) => onKeyringSelection(id)} />
         ) : (

--- a/app/components/Views/Browser/MaxBrowserTabsModal.tsx
+++ b/app/components/Views/Browser/MaxBrowserTabsModal.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
-import SheetHeader from '../../../component-library/components/Sheet/SheetHeader';
+import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -38,7 +38,7 @@ const MaxBrowserTabsModal = () => {
           color={colors.primary.default}
         />
       </View>
-      <SheetHeader title={strings('browser.max_tabs_title')} />
+      <BottomSheetHeader>{strings('browser.max_tabs_title')}</BottomSheetHeader>
       <View style={styles.sheet}>
         <Text style={styles.dialogDescription}>
           {strings('browser.max_tabs_desc')}

--- a/app/components/Views/ShowTokenIdSheet/ShowTokenIdSheet.tsx
+++ b/app/components/Views/ShowTokenIdSheet/ShowTokenIdSheet.tsx
@@ -5,7 +5,7 @@ import React, { useRef } from 'react';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
-import SheetHeader from '../../../component-library/components/Sheet/SheetHeader/SheetHeader';
+import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import Text from '../../../component-library/components/Texts/Text/Text';
 import { strings } from '../../../../locales/i18n';
 
@@ -22,10 +22,9 @@ const ShowTokenIdSheet = () => {
 
   return (
     <BottomSheet ref={sheetRef}>
-      <SheetHeader
-        style={styles.header}
-        title={strings('nft_details.token_id')}
-      />
+      <BottomSheetHeader style={styles.header}>
+        {strings('nft_details.token_id')}
+      </BottomSheetHeader>
       <View style={styles.textContent}>
         <Text>{tokenId}</Text>
       </View>


### PR DESCRIPTION
## Description

Noticed SheetHeader is still used in a few places while going through #14217. Swapped it out for BottomSheetHeader in three components:

- `MaxBrowserTabsModal` — simple title, no props change needed
- `ShowTokenIdSheet` — same deal, just moved title to children
- `AddNewAccount` — had an `onBack` handler, mapped it directly

Kept it small (3 files) as requested in the issue guidelines.

## Related Issue

Part of #14217

## Testing

No functional changes — just swapping one component for its replacement. Both expose the same visual layout. Snapshot tests will need an update to reflect the new component name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to header component swaps in three screens; main risk is minor UI/layout or snapshot test diffs due to the different header implementation.
> 
> **Overview**
> Replaces deprecated `SheetHeader` with `BottomSheetHeader` in `AddNewAccount`, `MaxBrowserTabsModal`, and `ShowTokenIdSheet`.
> 
> Updates call sites to pass the header title as children (instead of a `title` prop) and keeps existing back navigation wiring via `onBack` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33e0b9c10ebd3c83e0c8c06d32c6a53b54815171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->