### PR TITLE
docs(perps): add caching architecture and review anti-patterns docs

### DIFF
--- a/docs/perps/perps-caching-architecture.md
+++ b/docs/perps/perps-caching-architecture.md
@@ -1,0 +1,171 @@
+# Perps Caching Architecture
+
+## Overview
+
+Trading UX must feel instant. Users expect sub-second rendering of positions, orders, and prices — any loading skeleton on the Perps home screen feels like a broken app. Caching bridges the gap between slow REST APIs, WebSocket warmup latency, and the instant UI that traders demand.
+
+**Historical context**: The current architecture has a legacy REST preload layer that was built when WebSocket connections only existed while the Perps tab was visible. Now that `PerpsAlwaysOnProvider` keeps WS connected from wallet mount, parts of this preload infrastructure are redundant and candidates for removal.
+
+## How It Works Today
+
+Three tiers, from freshest to stalest:
+
+| Tier             | What                             | Lifetime        | Examples                                                  |
+| ---------------- | -------------------------------- | --------------- | --------------------------------------------------------- |
+| Real-time        | WebSocket via StreamManager      | While connected | Prices, positions, fills, orders, account balance         |
+| Session          | Provider + TradingReadinessCache | App lifetime    | DEX discovery, signing state, spot metadata, fee rates    |
+| Preload (legacy) | REST via Controller              | 5-min refresh   | Market list for home screen, positions before WS connects |
+
+The Preload tier exists because WS wasn't always-on historically. With `PerpsAlwaysOnProvider`, it's partially redundant — WS data arrives within 1-2 seconds of app launch, making the 5-min REST cycle a safety net rather than a primary data source.
+
+## Data Flow: Cold Start to Live Data
+
+What happens when the app launches:
+
+1. **App launches** — Controller preload fires REST fetch — `cachedMarketDataByProvider` populated
+2. **PerpsAlwaysOnProvider mounts** — WS connects — stream channels prewarm via `preloadSubscriptions()`
+3. **UI hooks mount** — read from stream channel cache (populated by WS prewarm) — instant render
+4. **If stream cache empty** — fall back to controller's REST preload cache via `getPreloadedData()` — still instant render
+5. **WS data arrives** — overrides everything with live data
+
+The key coupling point: `MarketDataStreamChannel.getCachedData()` falls back to the controller's REST cache. This fallback is what makes the preload layer still useful — it fills the gap between app launch and first WS message.
+
+## Per-Layer Details
+
+### Real-time Layer (Hooks + StreamManager + ConnectionManager)
+
+**UI Hooks** don't own caches — they read from stream channels first, then fall back to the controller's preloaded REST data via `getPreloadedData()`.
+
+**PerpsStreamManager** maintains 9 WebSocket channels:
+
+| Channel      | Cache key         | Scope      | What it stores           |
+| ------------ | ----------------- | ---------- | ------------------------ |
+| `prices`     | `priceCache` Map  | Global     | Per-symbol price updates |
+| `positions`  | `'positions'`     | Account    | User positions array     |
+| `orders`     | `'orders'`        | Account    | Open orders array        |
+| `account`    | `'account'`       | Account    | Account state (balance)  |
+| `fills`      | `'fills'`         | Account    | Recent fills (max 100)   |
+| `marketData` | `'markets'`       | Global     | Market data array        |
+| `oiCaps`     | `'oiCaps'`        | Global     | OI cap strings           |
+| `topOfBook`  | `cachedTopOfBook` | Per-symbol | Best bid/ask/spread      |
+| `candles`    | (external class)  | Per-symbol | Candle data              |
+
+All 9 channels support `pause()`/`resume()` — pausing blocks emission to React subscribers while keeping the WebSocket alive. Used during brief operations to prevent UI flicker.
+
+**PerpsConnectionManager** doesn't own caches — it orchestrates clearing of stream channels during lifecycle events. See [Cache Clearing Matrix](#cache-clearing-matrix).
+
+### Session Layer: Provider Instance Caches
+
+| Cache                         | What it stores                     | Scope   | Cleared on disconnect?  |
+| ----------------------------- | ---------------------------------- | ------- | ----------------------- |
+| `#cachedValidatedDexs`        | Feature-flag-filtered DEX names    | Global  | No (intentional)        |
+| `#cachedAllPerpDexs`          | Raw `perpDexs()` API objects       | Global  | No (intentional)        |
+| `#perpDexsCache`              | Extended DEX data with fee scales  | Session | Yes                     |
+| `#dexDiscoveryComplete`       | Boolean gate for retry logic       | Session | Yes (reset to false)    |
+| `#cachedMetaByDex`            | Per-DEX meta responses             | Session | Yes                     |
+| `#cachedSpotMeta`             | Spot metadata (USDC token info)    | Session | Yes                     |
+| `#cachedMarketDataWithPrices` | Last known-good market snapshot    | Global  | No                      |
+| `#symbolToAssetId`            | Symbol-to-asset-ID mapping         | Session | Rebuilt on init         |
+| `#maxLeverageCache`           | Per-asset max leverage (TTL-based) | Session | No (TTL-based eviction) |
+| `#userFeeCache`               | Per-user fee rates (TTL-based)     | Account | No (TTL-based eviction) |
+| `#referralCheckCache`         | Referral state per user            | Account | Yes                     |
+| `#builderFeeCheckCache`       | Builder fee approval per user      | Account | Yes                     |
+
+**Critical note**: `#cachedValidatedDexs` and `#cachedAllPerpDexs` are two views of the same `perpDexs()` API response. The [P1 dual-cache desync bug](postmortems/2026-03-24-hip3-asset-id-cache-poisoning.md) was caused by a code path writing one without the other.
+
+### Session Layer: TradingReadinessCache (Global Singleton)
+
+| Cache           | What it stores                         | Key format                   | Cleared on disconnect? |
+| --------------- | -------------------------------------- | ---------------------------- | ---------------------- |
+| Signing state   | DEX abstraction, builder fee, referral | `network:userAddress`        | Never (intentional)    |
+| In-flight locks | Concurrent signing operation guards    | `opType:network:userAddress` | Self-clearing          |
+
+This is the most important "survives everything" cache. Providers are recreated on account/network changes, which resets all instance-level caches. TradingReadinessCache persists as a global singleton specifically to remember that a hardware wallet user already approved DEX abstraction — without it, every reconnect would trigger another QR code scan.
+
+### Preload Layer: PerpsController (Legacy — candidate for removal)
+
+| Cache                        | What it stores                   | Key format           | Cleared on disconnect? |
+| ---------------------------- | -------------------------------- | -------------------- | ---------------------- |
+| `cachedMarketDataByProvider` | Market list from REST            | `providerId:network` | No (preserved)         |
+| `cachedUserDataByProvider`   | Positions, orders, account state | `providerId:network` | No (preserved)         |
+
+**Staleness & debounce constants**:
+
+| Constant             | Value         | Purpose                                                  |
+| -------------------- | ------------- | -------------------------------------------------------- |
+| `#preloadRefreshMs`  | 5 min         | Periodic `setInterval` refresh                           |
+| `#preloadGuardMs`    | 30 s          | Write debounce — skip fetch if entry is fresher than 30s |
+| Market data read TTL | 300 s (5 min) | Stale cutoff for consumer reads                          |
+| User data read TTL   | 60 s          | Stale cutoff for consumer reads                          |
+
+**Why this is legacy**: `startMarketDataPreload()` is called from `Wallet/index.tsx` and runs independently of `PerpsAlwaysOnProvider`. The user data preload already has a WS-connected guard that skips it when WS is streaming (mostly dormant). The market data preload still runs every 5 min via REST even when WS is streaming — redundant but harmless. Network switches don't clear these caches — different networks use different keys (`hyperliquid:mainnet` vs `hyperliquid:testnet`).
+
+## Cache Clearing Matrix
+
+| Trigger                               | Provider caches                                                                                                        | Controller preload                                                            | Stream channels                              | TradingReadinessCache |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------- | --------------------- |
+| `disconnect()` (grace period expires) | Meta, spot, fees, perpDexsCache cleared. DEX discovery (`#cachedValidatedDexs`, `#cachedAllPerpDexs`) **NOT** cleared. | Preserved                                                                     | All 9 cleared                                | Preserved             |
+| Account switch                        | Provider recreated (all instance caches reset)                                                                         | `cachedUserDataByProvider` cleared if address changed. Market data preserved. | All 9 cleared immediately (before reconnect) | Preserved             |
+| Network switch                        | Provider recreated                                                                                                     | Not cleared (different key avoids collision)                                  | All 9 cleared immediately                    | Preserved             |
+| Provider switch                       | Provider recreated                                                                                                     | Scoped by `providerId:network` key                                            | All 9 cleared immediately                    | Preserved             |
+| App → background                      | Nothing (20s grace period)                                                                                             | Nothing                                                                       | Nothing (WS stays alive)                     | Preserved             |
+| App → foreground                      | `performActualDisconnection()` runs full clear, then fresh connect                                                     | Nothing                                                                       | All 9 cleared, then re-prewarmed             | Preserved             |
+| User retry (force)                    | Provider recreated                                                                                                     | Nothing                                                                       | All 9 cleared                                | Preserved             |
+
+**Double-clear on account/network switch**: Stream channels are cleared twice — once immediately in the Redux store subscriber (prevents stale data flash), and again inside `performReconnection()` (ensures clean state for new subscriptions).
+
+## Simplification Roadmap
+
+### 1. Disk-backed cold-start cache (new capability)
+
+**Problem**: On cold start, there's a gap between app launch and first WS data. Currently filled by REST preload.
+
+**Proposal**: Write stream channel snapshots to MMKV after first WS data arrives. Read from MMKV on next cold start.
+
+**Implementation**:
+
+- Two MMKV keys: `PERPS_CACHE_MARKETS`, `PERPS_CACHE_USER_DATA`
+- Write via `StorageWrapper.setItem()` — fire-and-forget, MMKV writes are synchronous under the hood
+- Read in controller constructor or stream channel `getCachedData()` fallback
+- Invalidate on account switch
+- `StorageWrapper` is already used in 91+ files — it's the standard persistence layer
+
+**Result**: Instant display of last-known data on cold start. Prices stale by seconds/minutes, positions accurate until next trade. Live WS data overlays within 1-2 seconds.
+
+### 2. Remove REST preload timer (simplification)
+
+**Problem**: 5-min REST polling is redundant when WS is always connected via `PerpsAlwaysOnProvider`.
+
+**Proposal**: Remove `startMarketDataPreload()` interval. Keep a single REST fetch on first mount as a fallback before WS connects. With disk cache (proposal 1), even that may be unnecessary.
+
+**Dependencies**: Requires disk cache (proposal 1) to fill the cold-start gap.
+
+**What to remove**:
+
+- `#preloadRefreshMs` interval
+- `#preloadGuardMs` debounce
+- `#performMarketDataPreload` periodic calls
+- Keep `#performUserDataPreload` as a one-shot fallback (already guarded by WS check)
+
+### 3. Dual-cache unification in provider (bug prevention)
+
+**Problem**: `#cachedValidatedDexs` and `#cachedAllPerpDexs` must stay in sync because `#buildAssetMapping()` reads both. Three independent code paths call the same `perpDexs()` API and write to separate caches:
+
+| Path                            | Cache written                                 | Purpose             |
+| ------------------------------- | --------------------------------------------- | ------------------- |
+| `#fetchValidatedDexsInternal()` | `#cachedValidatedDexs` + `#cachedAllPerpDexs` | Init discovery      |
+| `#getStandaloneValidatedDexs()` | Same two caches                               | Pre-WebSocket reads |
+| `#getCachedPerpDexs()`          | `#perpDexsCache`                              | Fee calculation     |
+
+**Proposal**: Replace all three caches with a single `#dexDiscoveryState` object that atomically stores `raw`, `validated`, and `extended` views. One object assignment, one source of truth — eliminates the desync risk by construction.
+
+**Postmortem**: [2026-03-24-hip3-asset-id-cache-poisoning.md](postmortems/2026-03-24-hip3-asset-id-cache-poisoning.md)
+
+## Rules for Adding New Caches
+
+1. **Pick the right layer**: Provider for API data, Controller for preload, StreamManager for real-time, TradingReadinessCache for signing state.
+2. **Decide scope**: Global (market data) vs account-specific (positions, signing state).
+3. **If account-specific**: Must be cleared on account switch. Verify your cache is covered by the ConnectionManager's clearing sequence or the controller's account-change handler.
+4. **If two caches derive from the same source**: Unify into a single object or ensure atomic writes. Never let independent code paths write subsets of related caches.
+5. **Choose a freshness tier**: Real-time (WS), background (REST with TTL), or session (app lifetime). Don't mix — a cache that's sometimes WS-fed and sometimes REST-fed creates confusing staleness semantics.
+6. **Document in this file**: Add your cache to the appropriate per-layer inventory table.

--- a/docs/perps/perps-review-antipatterns.md
+++ b/docs/perps/perps-review-antipatterns.md
@@ -1,0 +1,101 @@
+# Perps Domain Anti-Patterns
+
+> Patterns to watch for when reviewing perps-related code. Generic code quality is handled by standard review.
+
+## Controller Portability (Core Sync)
+
+The controller at `app/controllers/perps/` is published as `@metamask/perps-controller` and synced to `core` monorepo via `scripts/perps/validate-core-sync.sh`. It must remain platform-agnostic — no mobile-specific imports.
+
+- **Mobile import in controller** — `react-native`, `Engine`, `Sentry`, `DevLogger` imported directly in `app/controllers/perps/`. All platform services must flow through `PerpsPlatformDependencies` (DI). The sync script checks for these but a PR could introduce them.
+- **Direct controller import from app code** — app files importing `from '../../controllers/perps/...'` instead of `from '@metamask/perps-controller'`. ESLint rule exists but may be suppressed.
+- **`__DEV__` in controller code** — must not appear in controller files. Core replaces it with `false` during sync. If new code adds `__DEV__` checks, sync breaks.
+- **New dependency not in DI interface** — controller code reaching outside its boundary (e.g., importing a hook, React context, or mobile utility). Everything the controller needs must come through `infrastructure: PerpsPlatformDependencies` constructor param.
+- **Breaking the publisher contract** — changing PerpsController's public API (state shape, method signatures, event names) without considering extension consumers. Controller is a publisher — mobile and extension both consume it.
+
+## Magic Strings, Magic Numbers & Placeholder Values
+
+Constants live in `app/controllers/perps/constants/perpsConfig.ts` (controller-portable) and `app/components/UI/Perps/constants/perpsConfig.ts` (UI-only). PRs must use these — not inline literals.
+
+- **Defaulting to `0` when data is unavailable** — the most common mistake. When price/percentage/data hasn't loaded yet, use the placeholder constants, NOT `0`, `$0`, or `0%`:
+  - `PERPS_CONSTANTS.FallbackPriceDisplay` (`'$---'`) — price not yet loaded
+  - `PERPS_CONSTANTS.FallbackPercentageDisplay` (`'--%'`) — percentage not yet loaded
+  - `PERPS_CONSTANTS.FallbackDataDisplay` (`'--'`) — generic data not yet loaded
+  - `PERPS_CONSTANTS.ZeroAmountDisplay` (`'$0'`) / `ZeroAmountDetailedDisplay` (`'$0.00'`) — ONLY for actual confirmed zero values (e.g., no volume), never for "loading" or "unavailable"
+  - Defaulting to `0` hides loading states, makes bugs invisible, and can mislead users into thinking their balance/PnL is actually zero.
+- **Inline timeout/delay values** — hardcoded `5000`, `10000`, `300` instead of `PERPS_CONSTANTS.WebsocketTimeout`, `PERPS_CONSTANTS.ConnectionTimeoutMs`, `PERFORMANCE_CONFIG.ValidationDebounceMs`, etc. Every timing constant has a named export.
+- **Hardcoded slippage** — using `0.03` or `300` instead of `ORDER_SLIPPAGE_CONFIG.DefaultMarketSlippageBps`, `DefaultTpslSlippageBps`, `DefaultLimitSlippageBps`.
+- **Hardcoded leverage fallback** — using `3` or `50` instead of `PERPS_CONSTANTS.DefaultMaxLeverage` or `MARGIN_ADJUSTMENT_CONFIG.FallbackMaxLeverage`.
+- **Hardcoded precision** — using `6`, `2`, `5` for decimal places instead of `DECIMAL_PRECISION_CONFIG.MaxPriceDecimals`, `MaxSignificantFigures`, `FallbackSizeDecimals`, or `CLOSE_POSITION_CONFIG.UsdDecimalPlaces`.
+- **Hardcoded API URLs** — inline `'https://perps.api...'` instead of `DATA_LAKE_API_CONFIG.OrdersEndpoint`.
+- **Hardcoded provider name** — `'hyperliquid'` string instead of `PROVIDER_CONFIG.DefaultProvider`.
+- **Hardcoded validation thresholds** — `20` for high leverage warning, `0.1` for price deviation, instead of `VALIDATION_THRESHOLDS.HighLeverageWarning`, `VALIDATION_THRESHOLDS.PriceDeviation`.
+- **Hardcoded cache durations** — inline `5 * 60 * 1000` instead of `PERFORMANCE_CONFIG.MarketDataCacheDurationMs`, `FeeDiscountCacheDurationMs`, etc.
+
+## Protocol Abstraction
+
+All provider access must go through `AggregatedPerpsProvider` → `ProviderRouter`. HyperLiquid is primary, MYX is feature-flagged.
+
+- **Hardcoded provider** — uses HyperLiquid or MYX APIs directly instead of going through `AggregatedPerpsProvider` / `ProviderRouter`. All operations must route through the abstraction.
+- **Provider-specific branching in UI** — `if (provider === 'hyperliquid')` in components or hooks. Provider differences must be normalized in the aggregation layer, not leaked to the view.
+- **Provider-specific error handling** — catches errors from one provider but not others. All providers must have consistent error boundaries via the aggregated layer.
+- **Hardcoded market symbols** — string literals `"BTC"` or `"ETH"` instead of market config constants. Breaks when new markets or providers are added.
+- **Hardcoded decimals/precision** — using provider-native decimal formats without normalization. HyperLiquid and MYX use different precision for prices, sizes, and leverage. Must go through `MarketDataFormatters` (DI).
+
+## MetaMetrics Events
+
+8 consolidated events with typed constants. Reference: `docs/perps/perps-metametrics-reference.md`.
+
+- **Magic string event properties** — using `'status'`, `'asset'`, `'direction'` instead of `PERPS_EVENT_PROPERTY.STATUS`, `PERPS_EVENT_PROPERTY.ASSET`, etc. from `@metamask/perps-controller`.
+- **Magic string event values** — using `'executed'`, `'long'`, `'market'` instead of `PERPS_EVENT_VALUE.STATUS.EXECUTED`, `PERPS_EVENT_VALUE.DIRECTION.LONG`, `PERPS_EVENT_VALUE.ORDER_TYPE.MARKET`.
+- **New event instead of property** — creating a 9th event when the change should be a new `screen_type`, `interaction_type`, or `action_type` value on an existing event. The 8-event model is intentional (Segment cost optimization).
+- **Missing `source` on screen view** — `PERPS_SCREEN_VIEWED` without `source` property loses navigation flow tracking. Source = current screen, not earlier in the chain.
+- **Hardcoded source in reusable component** — reusable components (`PerpsMarketTypeSection`, `PerpsWatchlistMarkets`, `PerpsCard`) must receive `source` as a prop from the parent screen, not set it implicitly.
+- **New screen/view without tracking** — adding a new view without `PERPS_SCREEN_VIEWED` event + `usePerpsMeasurement` Sentry trace.
+- **Missing `completion_duration` on transaction events** — all transaction events (`PERPS_TRADE_TRANSACTION`, `PERPS_POSITION_CLOSE_TRANSACTION`, etc.) require duration tracking.
+
+## Sentry Tracing
+
+38+ traces for performance monitoring. Reference: `docs/perps/perps-sentry-reference.md`.
+
+- **New screen without `usePerpsMeasurement`** — every new view needs a Sentry performance trace with appropriate `conditions` for when data is loaded.
+- **Missing error context** — `Logger.error()` calls without `{ feature: 'perps', context: 'ClassName.method', provider, network }`. Sentry filtering depends on these fields.
+- **Missing `ensureError()` wrapper** — catching errors without `ensureError(error)` before passing to `Logger.error()`. Non-Error objects crash Sentry reporting.
+- **New trace without TraceName enum** — hardcoded trace name strings instead of adding to `TraceName` enum in `app/util/trace.ts`.
+- **Missing `endTrace` in finally block** — `trace()` started but `endTrace()` not in a `finally` block. Orphaned traces leak in Sentry.
+
+## Connection & WebSocket Architecture
+
+Single `PerpsAlwaysOnProvider` at wallet root owns lifecycle. All `PerpsConnectionProvider` instances use `manageLifecycle={false}`.
+
+- **New `PerpsConnectionProvider` with lifecycle** — adding a `PerpsConnectionProvider` without `manageLifecycle={false}` creates reference-count bugs. Only `PerpsAlwaysOnProvider` manages connect/disconnect.
+- **Unthrottled WS → setState** — every WS tick triggers state update. Must use `useLivePrices` with appropriate `throttleMs` (100ms for charts, 2s for lists, 10s for order forms).
+- **Per-component WS subscription** — creating a new WebSocket connection per component instead of using `PerpsStreamManager` shared subscriptions with reference counting.
+- **WS subscription leak** — subscribing on mount without unsubscribing on unmount or market switch. `PerpsStreamManager` handles ref counting but custom subscriptions must clean up.
+- **Stale data after async gap** — reading position/order state, awaiting something, then using the stale read. WS updates change state between awaits. Re-read after async boundaries.
+- **Missing cache invalidation** — after trade/withdrawal/position change, not calling `PerpsCacheInvalidator.invalidate()` for affected cache types (`positions`, `accountState`). Standalone queries on token detail pages show stale data.
+
+## Data Flow & State
+
+Controller → Redux → Hooks → Components. Standalone mode for lightweight queries without full init.
+
+- **Direct controller call from component** — components calling `PerpsController.method()` directly instead of going through hooks (`usePerpsTrading`, `usePerpsAccount`, etc.).
+- **Missing `accountState` check** — accessing positions/orders/balances without verifying accountState is loaded. Causes undefined errors on first load or account switch.
+- **Stale position after close** — position in UI after close because local state not cleared or WS update not processed. Must refresh via `PerpsCacheInvalidator`.
+- **Preload data not seeded** — new hook not using `getPreloadedData()` lazy initializer. First render shows skeleton instead of cached data from the 5-minute preload cycle.
+- **Order state race** — submitting order and immediately reading order state. WS confirmation hasn't arrived. Use transaction receipt or poll with backoff.
+- **Leverage/validation bypass** — allowing values outside market's `maxLeverage` or skipping pre-trade checks (balance, market open, position limit).
+
+## Trade Flow
+
+- **Pre-trade checks missing** — submitting trade without verifying: sufficient balance, market open, position limit, leverage within bounds, slippage tolerance set.
+- **Post-trade state not refreshed** — after trade confirmation, not triggering refresh of balances, positions, orders. User sees stale data until next WS tick.
+- **Missing slippage in order params** — creating order without slippage tolerance, or hardcoding slippage instead of user preference.
+
+## Agentic Testability (testIDs)
+
+PRs that touch UI components must include testIDs so agentic recipes and E2E tests can navigate and assert on the app without manual interaction.
+
+- **Missing testID on interactive elements** — any `TextInput`, `Pressable`, `Button`, or touchable in a new or modified component without a `testID` prop. Agentic recipes use `app-state.sh press <testID>` and `eval_sync` fiber-walk queries to interact with and assert on UI. If the element has no testID, the recipe cannot press it or read its value — the fix is untestable agentically.
+- **testID not in `Perps.testIds.ts`** — testIDs defined as inline strings instead of exported constants from `app/components/UI/Perps/Perps.testIds.ts`. All testIDs must be centralized so recipes can reference them by constant name.
+- **testID missing from the element that holds the value** — adding testID to a wrapper View instead of the `TextInput` or Text that actually contains the value. CDP fiber-walk reads `value` from the React element with the matching testID — the testID must be on the element that owns the state.
+- **TP/SL price inputs without testID** — the trigger price `TextInput` components in `PerpsTPSLView` (and similar order-form screens) frequently lack testIDs, making it impossible to assert the accepted decimal precision agentically. Any PR touching these screens must add `testID` to both the Take Profit and Stop Loss price inputs.


### PR DESCRIPTION
## **Description**

Adds two new reference documents for the Perps domain:
- **perps-caching-architecture.md** — Documents the three-tier caching strategy (real-time WS, session, legacy preload), explains how data flows, and identifies legacy preload as partially redundant now that `PerpsAlwaysOnProvider` keeps WS connected from wallet mount.
- **perps-review-antipatterns.md** — Catalogues domain-specific anti-patterns to watch for during code review (controller portability, magic strings, placeholder values, etc.).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

Documentation only — no runtime changes.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation only and does not change runtime behavior, APIs, or data handling.
> 
> **Overview**
> Adds a new `perps-caching-architecture.md` reference documenting the current three-tier Perps caching model (WS real-time, session/provider caches, and legacy REST preload), including cache lifetimes/clearing behavior and a roadmap to simplify (disk-backed cold-start cache, removing REST polling, and unifying DEX discovery caches to prevent desync).
> 
> Adds `perps-review-antipatterns.md`, a code-review checklist of Perps-specific pitfalls (controller portability for core sync, avoiding magic constants/placeholders, enforcing provider abstraction, consistent metrics/tracing, WS lifecycle rules, cache invalidation, and testID requirements for agentic/E2E testability).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2511ffba3e2307df4f9cfe01373bf5f09e77339a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->