### PR TITLE
refactor: split mm pay ui type cleanup into follow-up pr

### DIFF
--- a/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.test.tsx
@@ -876,6 +876,32 @@ describe('PerpsProgressBar', () => {
       );
     });
 
+    it('resumes progress from persisted state for the same withdrawal', () => {
+      const mockPersistentProgress = {
+        progress: 99,
+        lastUpdated: Date.now(),
+        activeWithdrawalId: 'withdrawal1',
+      };
+
+      mockUsePerpsSelector.mockReturnValue(mockPersistentProgress);
+      mockUseWithdrawalRequests.mockReturnValue({
+        withdrawalRequests: [mockWithdrawalRequests[0]],
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <PerpsProgressBar {...defaultProps} />,
+      );
+
+      expect(getByTestId('perps-progress-bar')).toBeTruthy();
+      expect(mockController.updateWithdrawalProgress).not.toHaveBeenCalledWith(
+        25,
+        'withdrawal1',
+      );
+    });
+
     it('handles withdrawal without ID gracefully', () => {
       const withdrawalWithoutId = {
         ...mockWithdrawalRequests[0],

--- a/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.test.tsx
@@ -876,32 +876,6 @@ describe('PerpsProgressBar', () => {
       );
     });
 
-    it('resumes progress from persisted state for the same withdrawal', () => {
-      const mockPersistentProgress = {
-        progress: 99,
-        lastUpdated: Date.now(),
-        activeWithdrawalId: 'withdrawal1',
-      };
-
-      mockUsePerpsSelector.mockReturnValue(mockPersistentProgress);
-      mockUseWithdrawalRequests.mockReturnValue({
-        withdrawalRequests: [mockWithdrawalRequests[0]],
-        isLoading: false,
-        error: null,
-        refetch: jest.fn(),
-      });
-
-      const { getByTestId } = renderWithProvider(
-        <PerpsProgressBar {...defaultProps} />,
-      );
-
-      expect(getByTestId('perps-progress-bar')).toBeTruthy();
-      expect(mockController.updateWithdrawalProgress).not.toHaveBeenCalledWith(
-        25,
-        'withdrawal1',
-      );
-    });
-
     it('handles withdrawal without ID gracefully', () => {
       const withdrawalWithoutId = {
         ...mockWithdrawalRequests[0],

--- a/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx
+++ b/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx
@@ -15,7 +15,6 @@ import { usePerpsSelector } from '../../hooks/usePerpsSelector';
 import {
   TransactionMeta,
   TransactionStatus,
-  TransactionType,
 } from '@metamask/transaction-controller';
 import Engine from '../../../../../core/Engine';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
@@ -25,6 +24,7 @@ import {
   PROGRESS_BAR_COMPLETION_DELAY_MS,
 } from '@metamask/perps-controller';
 import { HYPERLIQUID_WITHDRAWAL_PROGRESS_INTERVAL_MS } from '../../constants/perpsUIConfig';
+import { hasPerpsDepositTransactionType } from '../../../../../util/transactions/metamask-pay';
 
 interface PerpsProgressBarProps {
   /**
@@ -178,10 +178,7 @@ export const PerpsProgressBar: React.FC<PerpsProgressBarProps> = ({
     }: {
       transactionMeta: TransactionMeta;
     }) => {
-      if (
-        transactionMeta.type === TransactionType.perpsDeposit ||
-        transactionMeta.type === TransactionType.perpsDepositAndOrder
-      ) {
+      if (hasPerpsDepositTransactionType(transactionMeta)) {
         const progress = getProgressFromStatus(transactionMeta.status);
         setTransactionProgress(progress);
 

--- a/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx
+++ b/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx
@@ -15,6 +15,7 @@ import { usePerpsSelector } from '../../hooks/usePerpsSelector';
 import {
   TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import Engine from '../../../../../core/Engine';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
@@ -24,7 +25,6 @@ import {
   PROGRESS_BAR_COMPLETION_DELAY_MS,
 } from '@metamask/perps-controller';
 import { HYPERLIQUID_WITHDRAWAL_PROGRESS_INTERVAL_MS } from '../../constants/perpsUIConfig';
-import { hasPerpsDepositTransactionType } from '../../../../../util/transactions/metamask-pay';
 
 interface PerpsProgressBarProps {
   /**
@@ -178,7 +178,10 @@ export const PerpsProgressBar: React.FC<PerpsProgressBarProps> = ({
     }: {
       transactionMeta: TransactionMeta;
     }) => {
-      if (hasPerpsDepositTransactionType(transactionMeta)) {
+      if (
+        transactionMeta.type === TransactionType.perpsDeposit ||
+        transactionMeta.type === TransactionType.perpsDepositAndOrder
+      ) {
         const progress = getProgressFromStatus(transactionMeta.status);
         setTransactionProgress(progress);
 

--- a/app/components/UI/Perps/hooks/usePerpsDepositProgress.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositProgress.ts
@@ -1,11 +1,11 @@
 import {
   TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import { useEffect, useRef, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import { usePerpsLiveAccount } from './stream/usePerpsLiveAccount';
-import { hasPerpsDepositTransactionType } from '../../../../util/transactions/metamask-pay';
 
 /**
  * Hook to track deposit progress state for UI components
@@ -36,7 +36,10 @@ export const usePerpsDepositProgress = () => {
     }: {
       transactionMeta: TransactionMeta;
     }) => {
-      if (!hasPerpsDepositTransactionType(transactionMeta)) {
+      if (
+        transactionMeta.type !== TransactionType.perpsDepositAndOrder &&
+        transactionMeta.type !== TransactionType.perpsDeposit
+      ) {
         return;
       }
 

--- a/app/components/UI/Perps/hooks/usePerpsDepositProgress.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositProgress.ts
@@ -1,11 +1,11 @@
 import {
   TransactionMeta,
   TransactionStatus,
-  TransactionType,
 } from '@metamask/transaction-controller';
 import { useEffect, useRef, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import { usePerpsLiveAccount } from './stream/usePerpsLiveAccount';
+import { hasPerpsDepositTransactionType } from '../../../../util/transactions/metamask-pay';
 
 /**
  * Hook to track deposit progress state for UI components
@@ -36,10 +36,7 @@ export const usePerpsDepositProgress = () => {
     }: {
       transactionMeta: TransactionMeta;
     }) => {
-      if (
-        transactionMeta.type !== TransactionType.perpsDepositAndOrder &&
-        transactionMeta.type !== TransactionType.perpsDeposit
-      ) {
+      if (!hasPerpsDepositTransactionType(transactionMeta)) {
         return;
       }
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import usePrevious from '../../../hooks/usePrevious';
 import { BigNumber } from 'bignumber.js';
-import { TransactionType } from '@metamask/transaction-controller';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import type { CaipAccountId } from '@metamask/utils';
@@ -19,6 +18,7 @@ import {
   transformUserHistoryToTransactions,
   transformWalletPerpsDepositsToTransactions,
 } from '../utils/transactionTransforms';
+import { hasPerpsDepositTransactionType } from '../../../../util/transactions/metamask-pay';
 
 interface UsePerpsTransactionHistoryParams {
   startTime?: number;
@@ -71,8 +71,7 @@ export const usePerpsTransactionHistory = ({
       (tx) =>
         selectedAddress &&
         areAddressesEqual(tx.txParams?.from ?? '', selectedAddress) &&
-        (tx.type === TransactionType.perpsDeposit ||
-          tx.type === TransactionType.perpsDepositAndOrder),
+        hasPerpsDepositTransactionType(tx),
     );
     return transformWalletPerpsDepositsToTransactions(filtered);
   }, [walletTransactions, selectedAddress]);

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import usePrevious from '../../../hooks/usePrevious';
 import { BigNumber } from 'bignumber.js';
+import { TransactionType } from '@metamask/transaction-controller';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import type { CaipAccountId } from '@metamask/utils';
@@ -18,7 +19,6 @@ import {
   transformUserHistoryToTransactions,
   transformWalletPerpsDepositsToTransactions,
 } from '../utils/transactionTransforms';
-import { hasPerpsDepositTransactionType } from '../../../../util/transactions/metamask-pay';
 
 interface UsePerpsTransactionHistoryParams {
   startTime?: number;
@@ -71,7 +71,8 @@ export const usePerpsTransactionHistory = ({
       (tx) =>
         selectedAddress &&
         areAddressesEqual(tx.txParams?.from ?? '', selectedAddress) &&
-        hasPerpsDepositTransactionType(tx),
+        (tx.type === TransactionType.perpsDeposit ||
+          tx.type === TransactionType.perpsDepositAndOrder),
     );
     return transformWalletPerpsDepositsToTransactions(filtered);
   }, [walletTransactions, selectedAddress]);

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -20,7 +20,10 @@ import {
 } from '../types/transactionHistory';
 
 jest.mock('../../../Views/confirmations/utils/transaction-pay');
-jest.mock('../../../Views/confirmations/utils/transaction');
+jest.mock('../../../Views/confirmations/utils/transaction', () => ({
+  ...jest.requireActual('../../../Views/confirmations/utils/transaction'),
+  parseStandardTokenTransactionData: jest.fn(),
+}));
 jest.mock('../../../../util/transactions', () => ({
   ...jest.requireActual('../../../../util/transactions'),
   calcTokenAmount: jest.fn((value: string) => (Number(value) / 1e6).toString()),
@@ -1905,6 +1908,19 @@ describe('transactionTransforms', () => {
 
     it('uses Deposit title and zero amount when getTokenTransferData returns undefined', () => {
       mockGetTokenTransferData.mockReturnValue(undefined);
+
+      const result = transformWalletPerpsDepositsToTransactions([
+        createMockTx(),
+      ] as never);
+
+      expect(result[0].title).toBe('Deposit');
+      expect(result[0].depositWithdrawal?.amountNumber).toBe(0);
+    });
+
+    it('uses Deposit title and zero amount when parsed token data is missing a value', () => {
+      mockParseStandardTokenTransactionData.mockReturnValue({
+        args: {},
+      } as never);
 
       const result = transformWalletPerpsDepositsToTransactions([
         createMockTx(),

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -20,10 +20,7 @@ import {
 } from '../types/transactionHistory';
 
 jest.mock('../../../Views/confirmations/utils/transaction-pay');
-jest.mock('../../../Views/confirmations/utils/transaction', () => ({
-  ...jest.requireActual('../../../Views/confirmations/utils/transaction'),
-  parseStandardTokenTransactionData: jest.fn(),
-}));
+jest.mock('../../../Views/confirmations/utils/transaction');
 jest.mock('../../../../util/transactions', () => ({
   ...jest.requireActual('../../../../util/transactions'),
   calcTokenAmount: jest.fn((value: string) => (Number(value) / 1e6).toString()),
@@ -1908,19 +1905,6 @@ describe('transactionTransforms', () => {
 
     it('uses Deposit title and zero amount when getTokenTransferData returns undefined', () => {
       mockGetTokenTransferData.mockReturnValue(undefined);
-
-      const result = transformWalletPerpsDepositsToTransactions([
-        createMockTx(),
-      ] as never);
-
-      expect(result[0].title).toBe('Deposit');
-      expect(result[0].depositWithdrawal?.amountNumber).toBe(0);
-    });
-
-    it('uses Deposit title and zero amount when parsed token data is missing a value', () => {
-      mockParseStandardTokenTransactionData.mockReturnValue({
-        args: {},
-      } as never);
 
       const result = transformWalletPerpsDepositsToTransactions([
         createMockTx(),

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -22,6 +22,7 @@ import { getTokenTransferData } from '../../../Views/confirmations/utils/transac
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
 import { calcTokenAmount } from '../../../../util/transactions';
 import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
+import { hasPerpsDepositTransactionType } from '../../../../util/transactions/metamask-pay';
 
 /**
  * Determines the close direction category for aggregation purposes.
@@ -627,11 +628,7 @@ export function transformWalletPerpsDepositsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
   return transactions
-    .filter(
-      (tx) =>
-        tx.type === TransactionType.perpsDeposit ||
-        tx.type === TransactionType.perpsDepositAndOrder,
-    )
+    .filter((tx) => hasPerpsDepositTransactionType(tx))
     .map((tx) => {
       const tokenData = getTokenTransferData(tx);
       const decoded = tokenData?.data

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -22,7 +22,6 @@ import { getTokenTransferData } from '../../../Views/confirmations/utils/transac
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
 import { calcTokenAmount } from '../../../../util/transactions';
 import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
-import { hasPerpsDepositTransactionType } from '../../../../util/transactions/metamask-pay';
 
 /**
  * Determines the close direction category for aggregation purposes.
@@ -628,7 +627,11 @@ export function transformWalletPerpsDepositsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
   return transactions
-    .filter((tx) => hasPerpsDepositTransactionType(tx))
+    .filter(
+      (tx) =>
+        tx.type === TransactionType.perpsDeposit ||
+        tx.type === TransactionType.perpsDepositAndOrder,
+    )
     .map((tx) => {
       const tokenData = getTokenTransferData(tx);
       const decoded = tokenData?.data

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -66,6 +66,7 @@ import {
   getMonetizedPrimitive,
 } from '../../../core/Analytics/events/transactions';
 import { getTransactionTypeValue } from '../../../core/Engine/controllers/transaction-controller/metrics_properties/base';
+import { MM_PAY_DETAIL_TRANSACTION_TYPES } from '../../../util/transactions/metamask-pay';
 
 const createStyles = (colors, typography) =>
   StyleSheet.create({
@@ -149,15 +150,7 @@ const transactionIconReceivedFailed = require('../../../images/transaction-icons
 const transactionIconSwapFailed = require('../../../images/transaction-icons/swap-failed.png');
 /* eslint-enable import-x/no-commonjs */
 
-const NEW_TRANSACTION_DETAILS_TYPES = [
-  TransactionType.musdClaim,
-  TransactionType.musdConversion,
-  TransactionType.perpsDeposit,
-  TransactionType.perpsDepositAndOrder,
-  TransactionType.predictClaim,
-  TransactionType.predictDeposit,
-  TransactionType.predictWithdraw,
-];
+const NEW_TRANSACTION_DETAILS_TYPES = [...MM_PAY_DETAIL_TRANSACTION_TYPES];
 
 const INTENT_STATUS = {
   SUBMITTED: 'SUBMITTED',

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -66,7 +66,6 @@ import {
   getMonetizedPrimitive,
 } from '../../../core/Analytics/events/transactions';
 import { getTransactionTypeValue } from '../../../core/Engine/controllers/transaction-controller/metrics_properties/base';
-import { MM_PAY_DETAIL_TRANSACTION_TYPES } from '../../../util/transactions/metamask-pay';
 
 const createStyles = (colors, typography) =>
   StyleSheet.create({
@@ -150,7 +149,15 @@ const transactionIconReceivedFailed = require('../../../images/transaction-icons
 const transactionIconSwapFailed = require('../../../images/transaction-icons/swap-failed.png');
 /* eslint-enable import-x/no-commonjs */
 
-const NEW_TRANSACTION_DETAILS_TYPES = [...MM_PAY_DETAIL_TRANSACTION_TYPES];
+const NEW_TRANSACTION_DETAILS_TYPES = [
+  TransactionType.musdClaim,
+  TransactionType.musdConversion,
+  TransactionType.perpsDeposit,
+  TransactionType.perpsDepositAndOrder,
+  TransactionType.predictClaim,
+  TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
+];
 
 const INTENT_STATUS = {
   SUBMITTED: 'SUBMITTED',

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -47,14 +47,10 @@ import {
 import { selectSingleTokenByAddressAndChainId } from '../../../selectors/tokensController';
 import { selectTickerByChainId } from '../../../selectors/networkController';
 import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRatesController';
+import { MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES } from '../../../util/transactions/metamask-pay';
 
-const POSITIVE_TRANSFER_TRANSACTION_TYPES = [
-  TransactionType.musdConversion,
-  TransactionType.perpsDeposit,
-  TransactionType.perpsDepositAndOrder,
-  TransactionType.predictDeposit,
-  TransactionType.predictWithdraw,
-];
+const POSITIVE_TRANSFER_TRANSACTION_TYPES =
+  MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES;
 
 function getTokenTransfer(args) {
   const {

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -382,12 +382,20 @@ describe('Transaction Element Utils', () => {
         strings('transactions.tx_review_predict_deposit'),
       ],
       [
+        TransactionType.predictAcrossDeposit,
+        strings('transactions.tx_review_predict_deposit'),
+      ],
+      [
         TransactionType.predictWithdraw,
         strings('transactions.tx_review_predict_withdraw'),
       ],
       [
         TransactionType.musdConversion,
         strings('transactions.tx_review_musd_conversion'),
+      ],
+      [
+        TransactionType.perpsAcrossDeposit,
+        strings('transactions.tx_review_perps_deposit'),
       ],
     ])('if %s', async (transactionType, title) => {
       const args = {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -204,6 +204,32 @@ describe('TransactionDetailsHero', () => {
     expect(getByText('$75.50')).toBeDefined();
   });
 
+  it('renders amount for perpsDepositAndOrder transactions', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.perpsDepositAndOrder,
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+
+    expect(getByText('$123.46')).toBeDefined();
+  });
+
+  it('renders nothing for predictClaim transactions', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.predictClaim,
+      } as unknown as TransactionMeta,
+    });
+
+    const { queryByTestId } = render();
+
+    expect(queryByTestId('transaction-details-hero')).toBeNull();
+  });
+
   it('renders nothing for musdClaim without valid claim data', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -30,14 +30,13 @@ import {
 } from '../../../../../../selectors/currencyRateController';
 import { RootState } from '../../../../../../reducers';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
+import { MM_PAY_DETAIL_TRANSACTION_TYPES } from '../../../../../../util/transactions/metamask-pay';
 
-const SUPPORTED_TYPES = [
-  TransactionType.musdClaim,
-  TransactionType.musdConversion,
-  TransactionType.perpsDeposit,
-  TransactionType.predictDeposit,
-  TransactionType.predictWithdraw,
-];
+// Exclude `predictClaim` because this hero falls back to decoded transfer data,
+// which can show a misleading amount for claim transactions.
+const SUPPORTED_TYPES = MM_PAY_DETAIL_TRANSACTION_TYPES.filter(
+  (type) => type !== TransactionType.predictClaim,
+);
 
 export function TransactionDetailsHero() {
   const formatFiatPerps = useFiatFormatter({ currency: PERPS_CURRENCY });

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
@@ -23,7 +23,6 @@ export function ReceiveSummaryLine({
   const isPerpsDeposit = hasTransactionType(transactionMeta, [
     TransactionType.perpsDeposit,
   ]);
-
   const isPredictDeposit = hasTransactionType(transactionMeta, [
     TransactionType.predictDeposit,
   ]);

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -128,6 +128,34 @@ describe('TransactionDetailsSummary', () => {
     expect(getByText('ReceiveSummaryLine')).toBeDefined();
   });
 
+  it('routes predict deposit transactions to ReceiveSummaryLine', () => {
+    const { getByText } = render({
+      transactions: [
+        {
+          id: transactionIdMock,
+          chainId: '0x1',
+          type: TransactionType.predictDeposit,
+        },
+      ],
+    });
+
+    expect(getByText('ReceiveSummaryLine')).toBeDefined();
+  });
+
+  it('routes perpsAcrossDeposit transactions to DepositSummaryLine', () => {
+    const { getByText } = render({
+      transactions: [
+        {
+          id: transactionIdMock,
+          chainId: '0x1',
+          type: TransactionType.perpsAcrossDeposit,
+        },
+      ],
+    });
+
+    expect(getByText('DepositSummaryLine')).toBeDefined();
+  });
+
   it('routes unsupported types to DefaultSummaryLine', () => {
     const { getByText } = render({
       transactions: [

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -16,7 +16,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
-import { RELAY_DEPOSIT_TYPES } from '../../../constants/confirmations';
+import { MM_PAY_DEPOSIT_TYPES } from '../../../constants/confirmations';
 import { ProgressList } from '../../progress-list';
 import { SourceHashSummaryLine } from './source-hash-summary-line';
 import { DepositSummaryLine } from './deposit-summary-line';
@@ -99,7 +99,7 @@ function SummaryLine({
   parentTransaction: TransactionMeta;
 }) {
   // Relay deposit types render as send lines
-  if (hasTransactionType(transactionMeta, RELAY_DEPOSIT_TYPES)) {
+  if (hasTransactionType(transactionMeta, MM_PAY_DEPOSIT_TYPES)) {
     return (
       <DepositSummaryLine
         transactionMeta={transactionMeta}

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -186,6 +186,23 @@ describe('TransactionDetails', () => {
       );
     });
 
+    it('returns perps_deposit title for perpsDepositAndOrder type', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.perpsDepositAndOrder,
+        } as unknown as TransactionMeta,
+      });
+
+      render();
+
+      expect(mockSetOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: strings('transaction_details.title.perps_deposit'),
+        }),
+      );
+    });
+
     it('returns musd_claim title for musdClaim type', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -24,6 +24,7 @@ import { hasTransactionType } from '../../../utils/transaction';
 import { ScrollView } from 'react-native';
 import { TransactionDetailsRetry } from '../transaction-details-retry';
 import { TransactionDetailsAccountRow } from '../transaction-details-account-row';
+import { getMetaMaskPayUseCase } from '../../../../../../util/transactions/metamask-pay';
 
 export const SUMMARY_SECTION_TYPES = [
   TransactionType.musdClaim,
@@ -81,11 +82,17 @@ function getTitle(transactionMeta: TransactionMeta) {
     return strings('transaction_details.title.predict_claim');
   }
 
-  if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
+  const payUseCase = getMetaMaskPayUseCase(transactionMeta);
+
+  if (payUseCase === 'perps_deposit') {
+    return strings('transaction_details.title.perps_deposit');
+  }
+
+  if (payUseCase === 'predict_deposit') {
     return strings('transaction_details.title.predict_deposit');
   }
 
-  if (hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])) {
+  if (payUseCase === 'predict_withdraw') {
     return strings('transaction_details.title.predict_withdraw');
   }
 
@@ -94,8 +101,6 @@ function getTitle(transactionMeta: TransactionMeta) {
       return strings('transaction_details.title.musd_conversion');
     case TransactionType.musdClaim:
       return strings('transaction_details.title.musd_claim');
-    case TransactionType.perpsDeposit:
-      return strings('transaction_details.title.perps_deposit');
     default:
       return strings('transaction_details.title.default');
   }

--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -92,3 +92,9 @@ export const RELAY_DEPOSIT_TYPES = [
   TransactionType.perpsRelayDeposit,
   TransactionType.predictRelayDeposit,
 ];
+
+export const MM_PAY_DEPOSIT_TYPES = [
+  ...RELAY_DEPOSIT_TYPES,
+  TransactionType.perpsAcrossDeposit,
+  TransactionType.predictAcrossDeposit,
+];

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -341,6 +341,62 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
+  it('includes across strategy metric', async () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: noop,
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    useTransactionPayQuotesMock.mockReturnValue([
+      {
+        ...QUOTE_MOCK,
+        strategy: TransactionPayStrategy.Across,
+      } as TransactionPayQuote<Json>,
+    ]);
+
+    runHook();
+
+    await act(async () => noop());
+
+    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+      id: transactionIdMock,
+      params: {
+        properties: expect.objectContaining({
+          mm_pay_strategy: 'across',
+        }),
+        sensitiveProperties: {},
+      },
+    });
+  });
+
+  it('includes relay strategy metric', async () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: noop,
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    useTransactionPayQuotesMock.mockReturnValue([
+      {
+        ...QUOTE_MOCK,
+        strategy: TransactionPayStrategy.Relay,
+      } as TransactionPayQuote<Json>,
+    ]);
+
+    runHook();
+
+    await act(async () => noop());
+
+    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+      id: transactionIdMock,
+      params: {
+        properties: expect.objectContaining({
+          mm_pay_strategy: 'relay',
+        }),
+        sensitiveProperties: {},
+      },
+    });
+  });
+
   describe('mm_pay_sending_value_usd', () => {
     it('tracks USD value from required token amountUsd', async () => {
       useTransactionPayTokenMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -135,6 +135,10 @@ export function useTransactionPayMetrics() {
     properties.mm_pay_strategy = 'relay';
   }
 
+  if (strategy === TransactionPayStrategy.Across) {
+    properties.mm_pay_strategy = 'across';
+  }
+
   if (totals) {
     properties.mm_pay_network_fee_usd = new BigNumber(
       totals.fees.sourceNetwork.estimate.usd,

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -151,6 +151,39 @@ describe('Transaction Pay Utils', () => {
         index: 1,
       });
     });
+
+    it('returns undefined when nested transactions do not contain a token transfer', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x1234',
+          to: '0x5678',
+        },
+        nestedTransactions: [
+          {
+            data: '0x123456',
+            to: '0x567890',
+          },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(getTokenTransferData(transactionMeta)).toBeUndefined();
+    });
+
+    it('returns undefined when matching nested transfer is missing token data', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x1234',
+          to: '0x5678',
+        },
+        nestedTransactions: [
+          {
+            data: TOKEN_TRANSFER_DATA_MOCK,
+          },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(getTokenTransferData(transactionMeta)).toBeUndefined();
+    });
   });
 
   describe('getTokenAddress', () => {

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -22,8 +22,10 @@ import {
 } from '../../../../selectors/featureFlagController/confirmations';
 import { strings } from '../../../../../locales/i18n';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-
-const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+export {
+  getTokenAddress,
+  getTokenTransferData,
+} from '../../../../util/transactions/transaction-pay-token-transfer';
 
 export function getRequiredBalance(
   transactionMeta: TransactionMeta,
@@ -37,55 +39,6 @@ export function getRequiredBalance(
   }
 
   return undefined;
-}
-
-export function getTokenTransferData(
-  transactionMeta: TransactionMeta | undefined,
-):
-  | {
-      data: Hex;
-      to: Hex;
-      index?: number;
-    }
-  | undefined {
-  const { nestedTransactions, txParams } = transactionMeta ?? {};
-  const { data: singleData } = txParams ?? {};
-  const singleTo = txParams?.to as Hex | undefined;
-
-  if (singleData?.startsWith(FOUR_BYTE_TOKEN_TRANSFER) && singleTo) {
-    return { data: singleData as Hex, to: singleTo, index: undefined };
-  }
-
-  const nestedCallIndex = nestedTransactions?.findIndex((call) =>
-    call.data?.startsWith(FOUR_BYTE_TOKEN_TRANSFER),
-  );
-
-  const nestedCall =
-    nestedCallIndex !== undefined
-      ? nestedTransactions?.[nestedCallIndex]
-      : undefined;
-
-  if (nestedCall?.data && nestedCall.to) {
-    return {
-      data: nestedCall.data,
-      to: nestedCall.to,
-      index: nestedCallIndex,
-    };
-  }
-
-  return undefined;
-}
-
-export function getTokenAddress(
-  transactionMeta: TransactionMeta | undefined,
-): Hex {
-  const nestedCall = transactionMeta && getTokenTransferData(transactionMeta);
-
-  if (nestedCall) {
-    return nestedCall.to;
-  }
-
-  return transactionMeta?.txParams?.to as Hex;
 }
 
 export function getAvailableTokens({

--- a/app/core/Analytics/events/transactions/utils.ts
+++ b/app/core/Analytics/events/transactions/utils.ts
@@ -17,8 +17,12 @@ export function getMonetizedPrimitive(
       return MonetizedPrimitive.Swaps;
     case TransactionType.perpsDeposit:
     case TransactionType.perpsDepositAndOrder:
+    case TransactionType.perpsAcrossDeposit:
+    case TransactionType.perpsRelayDeposit:
       return MonetizedPrimitive.Perps;
     case TransactionType.predictDeposit:
+    case TransactionType.predictAcrossDeposit:
+    case TransactionType.predictRelayDeposit:
     case TransactionType.predictWithdraw:
     case TransactionType.predictClaim:
       return MonetizedPrimitive.Predict;

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.test.ts
@@ -34,6 +34,12 @@ describe('getTransactionTypeValue', () => {
     expect(getTransactionTypeValue(TransactionType.stakingUnstake)).toBe(
       'staking_unstake',
     );
+    expect(getTransactionTypeValue(TransactionType.perpsAcrossDeposit)).toBe(
+      'perps_across_deposit',
+    );
+    expect(getTransactionTypeValue(TransactionType.predictAcrossDeposit)).toBe(
+      'predict_across_deposit',
+    );
     expect(getTransactionTypeValue(TransactionType.swapAndSend)).toBe(
       'swap_and_send',
     );

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
@@ -91,8 +91,12 @@ export function getTransactionTypeValue(
       return 'perps_deposit';
     case TransactionType.perpsDepositAndOrder:
       return 'perps_deposit_and_order';
+    case TransactionType.perpsAcrossDeposit:
+      return 'perps_across_deposit';
     case TransactionType.perpsRelayDeposit:
       return 'perps_relay_deposit';
+    case TransactionType.predictAcrossDeposit:
+      return 'predict_across_deposit';
     case TransactionType.predictRelayDeposit:
       return 'predict_relay_deposit';
     case TransactionType.signTypedData:

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -301,6 +301,50 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
+  it('adds across quote strategy', () => {
+    request.transactionMeta.type = TransactionType.bridge;
+
+    request.allTransactions = [
+      {
+        id: 'child-0',
+        type: TransactionType.bridge,
+      } as TransactionMeta,
+      {
+        id: 'parent-1',
+        type: TransactionType.perpsDeposit,
+        requiredTransactionIds: ['child-0', 'child-1'],
+      } as TransactionMeta,
+      request.transactionMeta,
+    ];
+
+    const state = merge({}, PAY_CONTROLLER_STATE_MOCK) as RootState;
+
+    state.engine.backgroundState.TransactionPayController.transactionData[
+      'parent-1'
+    ] = {
+      quotes: [
+        {},
+        {
+          request: {
+            targetTokenAddress: '0x123',
+          },
+          strategy: TransactionPayStrategy.Across,
+        },
+      ],
+    } as unknown as (typeof state.engine.backgroundState.TransactionPayController.transactionData)[string];
+
+    getStateMock.mockReturnValue(state);
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay_strategy: 'across',
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
   it('adds dust property', () => {
     request.transactionMeta.type = TransactionType.bridge;
 
@@ -554,5 +598,15 @@ describe('Metamask Pay Metrics', () => {
 
       expect(result.properties).not.toHaveProperty('mm_pay_time_to_complete_s');
     });
+  });
+
+  it('adds execution latency when present on metamaskPay metadata', () => {
+    request.transactionMeta.metamaskPay = {
+      executionLatencyMs: 4321,
+    } as TransactionMeta['metamaskPay'];
+
+    const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+    expect(result.properties.mm_pay_execution_latency).toBe(4321);
   });
 });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -16,23 +16,23 @@ import { RootState } from '../../../../../reducers';
 import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
 import { Hex } from '@metamask/utils';
 import { TRANSACTION_EVENTS } from '../../../../Analytics/events/confirmations';
+import {
+  getMetaMaskPayUseCase,
+  hasMetaMaskPayDepositChildTransactionType,
+} from '../../../../../util/transactions/metamask-pay';
 
 const FOUR_BYTE_SAFE_PROXY_CREATE = '0xa1884d2c';
 
 const COPY_METRICS = [
   'mm_pay',
+  'mm_pay_execution_latency',
+  'mm_pay_strategy',
   'mm_pay_use_case',
   'mm_pay_transaction_step_total',
   'mm_pay_sending_value_usd',
   'mm_pay_receiving_value_usd',
   'mm_pay_metamask_fee_usd',
 ] as const;
-
-const PAY_TYPES = [
-  TransactionType.perpsDeposit,
-  TransactionType.predictDeposit,
-  TransactionType.predictWithdraw,
-];
 
 export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
   eventType,
@@ -44,11 +44,16 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
   const properties: JsonMap = {};
   const sensitiveProperties: JsonMap = {};
   const { batchId, id: transactionId, type } = transactionMeta;
+  const executionLatency = getExecutionLatency(transactionMeta);
+
+  if (executionLatency !== undefined) {
+    properties.mm_pay_execution_latency = executionLatency;
+  }
 
   const parentTransaction = allTransactions.find(
     (tx) =>
       tx.requiredTransactionIds?.includes(transactionId) ||
-      (batchId && hasTransactionType(tx, PAY_TYPES) && tx.batchId === batchId),
+      (batchId && isMetaMaskPayParentTransaction(tx) && tx.batchId === batchId),
   );
 
   if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
@@ -57,10 +62,10 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
     ).some((t) => t.data?.startsWith(FOUR_BYTE_SAFE_PROXY_CREATE));
   }
 
-  if (hasTransactionType(transactionMeta, PAY_TYPES) || !parentTransaction) {
+  if (isMetaMaskPayParentTransaction(transactionMeta) || !parentTransaction) {
     addFallbackProperties(properties, transactionMeta, getState());
 
-    if (hasTransactionType(transactionMeta, PAY_TYPES) || properties.mm_pay) {
+    if (isMetaMaskPayParentTransaction(transactionMeta) || properties.mm_pay) {
       addTimeToComplete(properties, eventType, transactionMeta.submittedTime);
     }
 
@@ -128,6 +133,10 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
       properties.mm_pay_bridge_provider = bridgeQuote.original.quote.bridgeId;
     }
 
+    if (quote?.strategy === TransactionPayStrategy.Across) {
+      properties.mm_pay_strategy = 'across';
+    }
+
     if (quote && quote.request.targetTokenAddress !== NATIVE_TOKEN_ADDRESS) {
       properties.mm_pay_dust_usd = parentMetrics?.properties?.mm_pay_dust_usd;
     }
@@ -173,9 +182,14 @@ function addFallbackProperties(
   }
 
   const { chainId, tokenAddress } = metamaskPay;
+  const payUseCase = getMetaMaskPayUseCase(transaction);
 
   properties.mm_pay = true;
   properties.mm_pay_chain_selected = chainId;
+
+  if (payUseCase) {
+    properties.mm_pay_use_case = payUseCase;
+  }
 
   properties.mm_pay_token_selected = getTokenSymbol(
     state,
@@ -192,4 +206,24 @@ function getTokenSymbol(state: RootState, chainId: Hex, tokenAddress: Hex) {
   );
 
   return token?.symbol;
+}
+
+function isMetaMaskPayParentTransaction(transaction: TransactionMeta): boolean {
+  return (
+    getMetaMaskPayUseCase(transaction) !== undefined &&
+    !hasMetaMaskPayDepositChildTransactionType(transaction)
+  );
+}
+
+type MetaMaskPayMetadataWithLatency = TransactionMeta['metamaskPay'] & {
+  executionLatencyMs?: number;
+};
+
+function getExecutionLatency(
+  transactionMeta: TransactionMeta,
+): number | undefined {
+  const metadata = transactionMeta.metamaskPay as
+    | MetaMaskPayMetadataWithLatency
+    | undefined;
+  return metadata?.executionLatencyMs;
 }

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -17,7 +17,7 @@ import {
 
 import {
   REDESIGNED_TRANSACTION_TYPES,
-  RELAY_DEPOSIT_TYPES,
+  MM_PAY_DEPOSIT_TYPES,
 } from '../../../../components/Views/confirmations/constants/confirmations';
 import {
   getSmartTransactionsFeatureFlagsForChain,
@@ -365,7 +365,7 @@ function beforeSign(
 }
 
 function isAutomaticGasFeeUpdateEnabled(transaction: TransactionMeta) {
-  if (hasTransactionType(transaction, RELAY_DEPOSIT_TYPES)) {
+  if (hasTransactionType(transaction, MM_PAY_DEPOSIT_TYPES)) {
     return false;
   }
 

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
@@ -6,11 +6,21 @@ import {
   TransactionPayController,
   TransactionPayControllerMessenger,
   TransactionPayControllerOptions,
+  TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
 import { TransactionPayControllerInit } from './transaction-pay-controller-init';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import Logger from '../../../../util/Logger';
+import { getDelegationTransaction } from '../../../../util/transactions/delegation';
 
 jest.mock('@metamask/transaction-pay-controller');
+jest.mock('../../../../util/transactions/delegation', () => ({
+  getDelegationTransaction: jest.fn(),
+}));
 
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
@@ -44,6 +54,7 @@ describe('Transaction Pay Controller Init', () => {
   const transactionPayControllerClassMock = jest.mocked(
     TransactionPayController,
   );
+  const mockGetDelegationTransaction = jest.mocked(getDelegationTransaction);
 
   /**
    * Extract a constructor option passed to the controller.
@@ -90,5 +101,168 @@ describe('Transaction Pay Controller Init', () => {
     });
 
     expect(state).toBe(MOCK_TRANSACTION_PAY_CONTROLLER_STATE);
+  });
+
+  it('passes getDelegationTransaction through to the controller callback', () => {
+    const requestMock = buildInitRequestMock();
+    const transactionMeta = {
+      id: 'tx-1',
+    } as TransactionMeta;
+    const delegationTransaction = {
+      data: '0x1234',
+      to: '0xabc',
+      value: '0x0',
+    };
+
+    mockGetDelegationTransaction.mockReturnValue(
+      delegationTransaction as never,
+    );
+
+    TransactionPayControllerInit(requestMock);
+
+    const getDelegationTransactionOption = transactionPayControllerClassMock
+      .mock.calls[0][0].getDelegationTransaction as NonNullable<
+      TransactionPayControllerOptions['getDelegationTransaction']
+    >;
+
+    expect(
+      getDelegationTransactionOption({ transaction: transactionMeta }),
+    ).toBe(delegationTransaction);
+    expect(mockGetDelegationTransaction).toHaveBeenCalledWith(
+      requestMock.initMessenger,
+      transactionMeta,
+    );
+  });
+
+  it('passes getStrategies and does not pass getStrategy', () => {
+    const controllerMessenger = {
+      call: jest.fn().mockReturnValue({
+        localOverrides: {},
+        remoteFeatureFlags: {
+          confirmations_pay: {
+            payStrategies: {
+              across: { enabled: true },
+              relay: { enabled: true },
+            },
+            routingOverrides: {
+              overrides: {
+                perpsDeposit: {
+                  chains: {
+                    '0xa4b1': ['across'],
+                  },
+                  default: ['relay'],
+                },
+              },
+            },
+            strategyOrder: ['relay'],
+          },
+        },
+      }),
+    } as unknown as TransactionPayControllerMessenger;
+
+    const getStrategies = testConstructorOption('getStrategies', undefined, {
+      controllerMessenger,
+    }) as NonNullable<TransactionPayControllerOptions['getStrategies']>;
+
+    expect(getStrategies).toBeDefined();
+    expect(
+      transactionPayControllerClassMock.mock.calls[0][0].getStrategy,
+    ).toBeUndefined();
+
+    expect(
+      getStrategies({
+        chainId: '0xa4b1',
+        txParams: { to: '0xabc' },
+        type: TransactionType.perpsDeposit,
+      } as unknown as TransactionMeta),
+    ).toEqual([TransactionPayStrategy.Across]);
+  });
+
+  it('applies local overrides when resolving strategies', () => {
+    const controllerMessenger = {
+      call: jest.fn().mockReturnValue({
+        localOverrides: {
+          confirmations_pay: {
+            payStrategies: {
+              across: { enabled: true },
+              relay: { enabled: true },
+            },
+            routingOverrides: {
+              overrides: {
+                perpsDeposit: {
+                  chains: {
+                    '0xa4b1': ['across'],
+                  },
+                },
+              },
+            },
+            strategyOrder: ['across'],
+          },
+        },
+        remoteFeatureFlags: {
+          confirmations_pay: {
+            payStrategies: {
+              across: { enabled: false },
+              relay: { enabled: true },
+            },
+            routingOverrides: {
+              overrides: {
+                perpsDeposit: {
+                  chains: {
+                    '0xa4b1': ['relay'],
+                  },
+                },
+              },
+            },
+            strategyOrder: ['relay'],
+          },
+        },
+      }),
+    } as unknown as TransactionPayControllerMessenger;
+
+    const getStrategies = testConstructorOption('getStrategies', undefined, {
+      controllerMessenger,
+    }) as NonNullable<TransactionPayControllerOptions['getStrategies']>;
+
+    expect(
+      getStrategies({
+        chainId: '0xa4b1',
+        txParams: { to: '0xabc' },
+        type: TransactionType.perpsDeposit,
+      } as unknown as TransactionMeta),
+    ).toEqual([TransactionPayStrategy.Across]);
+  });
+
+  it('logs and rethrows when controller initialization fails', () => {
+    const requestMock = buildInitRequestMock();
+    const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
+
+    transactionPayControllerClassMock.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    expect(() => TransactionPayControllerInit(requestMock)).toThrow('boom');
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Failed to initialize TransactionPayController',
+    );
+  });
+
+  it('falls back to default routing when feature flag state is unavailable', () => {
+    const controllerMessenger = {
+      call: jest.fn().mockReturnValue(undefined),
+    } as unknown as TransactionPayControllerMessenger;
+
+    const getStrategies = testConstructorOption('getStrategies', undefined, {
+      controllerMessenger,
+    }) as NonNullable<TransactionPayControllerOptions['getStrategies']>;
+
+    expect(
+      getStrategies({
+        chainId: '0xa4b1',
+        txParams: { to: '0xabc' },
+        type: TransactionType.perpsDeposit,
+      } as unknown as TransactionMeta),
+    ).toEqual([TransactionPayStrategy.Relay]);
   });
 });

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -3,11 +3,15 @@ import Logger from '../../../../util/Logger';
 import {
   TransactionPayController,
   TransactionPayControllerMessenger,
-  TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { getDelegationTransaction } from '../../../../util/transactions/delegation';
+import {
+  getTransactionPayRouteContext,
+  normalizeMetaMaskPayRoutingFlags,
+  resolveMetaMaskPayStrategies,
+} from '../../../../util/transactions/transaction-pay-routing';
 
 export const TransactionPayControllerInit: ControllerInitFunction<
   TransactionPayController,
@@ -20,7 +24,8 @@ export const TransactionPayControllerInit: ControllerInitFunction<
     const transactionPayController = new TransactionPayController({
       getDelegationTransaction: ({ transaction }) =>
         getDelegationTransaction(initMessenger, transaction),
-      getStrategy,
+      getStrategies: (transaction) =>
+        getTransactionPayStrategies(transaction, controllerMessenger),
       messenger: controllerMessenger,
       state: persistedState.TransactionPayController,
     });
@@ -35,6 +40,22 @@ export const TransactionPayControllerInit: ControllerInitFunction<
   }
 };
 
-function getStrategy(_transaction: TransactionMeta): TransactionPayStrategy {
-  return TransactionPayStrategy.Relay;
+function getTransactionPayStrategies(
+  transaction: TransactionMeta,
+  messenger: TransactionPayControllerMessenger,
+) {
+  const featureFlagState = messenger.call(
+    'RemoteFeatureFlagController:getState',
+  );
+  const featureFlags = {
+    ...(featureFlagState?.remoteFeatureFlags ?? {}),
+    ...(featureFlagState?.localOverrides ?? {}),
+  };
+
+  const routeContext = getTransactionPayRouteContext(transaction);
+  const routingFlags = normalizeMetaMaskPayRoutingFlags(
+    featureFlags.confirmations_pay,
+  );
+
+  return resolveMetaMaskPayStrategies(routeContext, routingFlags);
 }

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -7,11 +7,7 @@ import {
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { getDelegationTransaction } from '../../../../util/transactions/delegation';
-import {
-  getTransactionPayRouteContext,
-  normalizeMetaMaskPayRoutingFlags,
-  resolveMetaMaskPayStrategies,
-} from '../../../../util/transactions/transaction-pay-routing';
+import { getMetaMaskPayStrategiesForTransaction } from '../../../../util/transactions/transaction-pay-routing';
 
 export const TransactionPayControllerInit: ControllerInitFunction<
   TransactionPayController,
@@ -52,10 +48,8 @@ function getTransactionPayStrategies(
     ...(featureFlagState?.localOverrides ?? {}),
   };
 
-  const routeContext = getTransactionPayRouteContext(transaction);
-  const routingFlags = normalizeMetaMaskPayRoutingFlags(
+  return getMetaMaskPayStrategiesForTransaction(
+    transaction,
     featureFlags.confirmations_pay,
   );
-
-  return resolveMetaMaskPayStrategies(routeContext, routingFlags);
 }

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -14,21 +14,13 @@ import { store } from '../store';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller';
 
 import Logger from '../util/Logger';
-import {
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionStatus } from '@metamask/transaction-controller';
 import { endTrace, trace, TraceName } from '../util/trace';
 import { hasTransactionType } from '../components/Views/confirmations/utils/transaction';
+import { MM_PAY_DETAIL_TRANSACTION_TYPES } from '../util/transactions/metamask-pay';
 
 export const SKIP_NOTIFICATION_TRANSACTION_TYPES = [
-  TransactionType.musdClaim,
-  TransactionType.musdConversion,
-  TransactionType.perpsDeposit,
-  TransactionType.perpsDepositAndOrder,
-  TransactionType.predictDeposit,
-  TransactionType.predictClaim,
-  TransactionType.predictWithdraw,
+  ...MM_PAY_DETAIL_TRANSACTION_TYPES,
 ];
 
 export const IN_PROGRESS_SKIP_STATUS = [

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -1,7 +1,6 @@
 import { cloneDeep } from 'lodash';
 import {
   selectMetaMaskPayFlags,
-  selectMetaMaskPayRoutingFlags,
   selectMetaMaskPayStrategiesForRoute,
   selectMetaMaskPayTokensFlags,
   BUFFER_STEP_DEFAULT,
@@ -148,9 +147,6 @@ describe('MetaMask Pay Feature Flags', () => {
 describe('MetaMask Pay Routing Flags', () => {
   it('returns the default global order when routing flags are missing', () => {
     expect(
-      selectMetaMaskPayRoutingFlags(mockedEmptyFlagsState).strategyOrder,
-    ).toEqual([TransactionPayStrategy.Relay, TransactionPayStrategy.Across]);
-    expect(
       selectMetaMaskPayStrategiesForRoute(
         mockedEmptyFlagsState as RootState,
         'perpsDeposit',
@@ -173,10 +169,14 @@ describe('MetaMask Pay Routing Flags', () => {
         },
       };
 
-    expect(selectMetaMaskPayRoutingFlags(state).strategyOrder).toEqual([
-      TransactionPayStrategy.Across,
-      TransactionPayStrategy.Relay,
-    ]);
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        state as RootState,
+        'perpsDeposit',
+        '0xa4b1' as Hex,
+        '0xabc' as Hex,
+      ),
+    ).toEqual([TransactionPayStrategy.Across, TransactionPayStrategy.Relay]);
   });
 
   it('applies local overrides when resolving routing flags', () => {

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -1,6 +1,8 @@
 import { cloneDeep } from 'lodash';
 import {
   selectMetaMaskPayFlags,
+  selectMetaMaskPayRoutingFlags,
+  selectMetaMaskPayStrategiesForRoute,
   selectMetaMaskPayTokensFlags,
   BUFFER_STEP_DEFAULT,
   BUFFER_INITIAL_DEFAULT,
@@ -21,6 +23,7 @@ import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
 import { Hex } from '@metamask/utils';
 import { RootState } from '../../../reducers';
+import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
 
 jest.mock('../../../core/Engine', () => ({
   init: () => mockedEngine.init(),
@@ -139,6 +142,212 @@ describe('MetaMask Pay Feature Flags', () => {
       };
 
     expect(selectMetaMaskPayFlags(state).stxDisabled).toEqual(true);
+  });
+});
+
+describe('MetaMask Pay Routing Flags', () => {
+  it('returns the default global order when routing flags are missing', () => {
+    expect(
+      selectMetaMaskPayRoutingFlags(mockedEmptyFlagsState).strategyOrder,
+    ).toEqual([TransactionPayStrategy.Relay, TransactionPayStrategy.Across]);
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        mockedEmptyFlagsState as RootState,
+        'perpsDeposit',
+        '0xa4b1' as Hex,
+        '0xabc' as Hex,
+      ),
+    ).toEqual([TransactionPayStrategy.Relay]);
+  });
+
+  it('filters invalid and duplicate strategies from the global order', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay: {
+          strategyOrder: ['across', 'relay', 'across', 'bridge', 'invalid'],
+          payStrategies: {
+            across: { enabled: true },
+            relay: { enabled: true },
+          },
+        },
+      };
+
+    expect(selectMetaMaskPayRoutingFlags(state).strategyOrder).toEqual([
+      TransactionPayStrategy.Across,
+      TransactionPayStrategy.Relay,
+    ]);
+  });
+
+  it('applies local overrides when resolving routing flags', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay: {
+          strategyOrder: ['relay'],
+          payStrategies: {
+            across: { enabled: false },
+            relay: { enabled: true },
+          },
+        },
+      };
+
+    const remoteFeatureFlagControllerState = state.engine.backgroundState
+      .RemoteFeatureFlagController as {
+      remoteFeatureFlags: Record<string, unknown>;
+      cacheTimestamp: number;
+      localOverrides: Record<string, unknown>;
+    };
+
+    remoteFeatureFlagControllerState.localOverrides = {
+      confirmations_pay: {
+        strategyOrder: ['across'],
+        payStrategies: {
+          across: { enabled: true },
+          relay: { enabled: true },
+        },
+        routingOverrides: {
+          overrides: {
+            perpsDeposit: {
+              default: ['across'],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        state as RootState,
+        'perpsDeposit',
+        '0xa4b1' as Hex,
+        '0xabc' as Hex,
+      ),
+    ).toEqual([TransactionPayStrategy.Across]);
+  });
+
+  it('prefers token overrides over chain overrides', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay: {
+          strategyOrder: ['relay'],
+          payStrategies: {
+            across: { enabled: true },
+            relay: { enabled: true },
+          },
+          routingOverrides: {
+            overrides: {
+              perpsDeposit: {
+                default: ['relay'],
+                chains: {
+                  '0xa4b1': ['across'],
+                },
+                tokens: {
+                  '0xa4b1': {
+                    '0xabc': ['relay'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        state as RootState,
+        'perpsDeposit',
+        '0xA4B1' as Hex,
+        '0xAbC' as Hex,
+      ),
+    ).toEqual([TransactionPayStrategy.Relay]);
+  });
+
+  it('prefers chain overrides over transaction-type defaults', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay: {
+          strategyOrder: ['relay'],
+          payStrategies: {
+            across: { enabled: true },
+            relay: { enabled: true },
+          },
+          routingOverrides: {
+            overrides: {
+              perpsDeposit: {
+                default: ['relay'],
+                chains: {
+                  '0xa4b1': ['across'],
+                },
+              },
+            },
+          },
+        },
+      };
+
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        state as RootState,
+        'perpsDeposit',
+        '0xa4b1' as Hex,
+        '0xabc' as Hex,
+      ),
+    ).toEqual([TransactionPayStrategy.Across]);
+  });
+
+  it('removes disabled strategies and falls back to a broader level', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay: {
+          strategyOrder: ['relay'],
+          payStrategies: {
+            across: { enabled: false },
+            relay: { enabled: true },
+          },
+          routingOverrides: {
+            overrides: {
+              perpsDeposit: {
+                default: ['across'],
+              },
+            },
+          },
+        },
+      };
+
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        state as RootState,
+        'perpsDeposit',
+        '0xa4b1' as Hex,
+        '0xabc' as Hex,
+      ),
+    ).toEqual([TransactionPayStrategy.Relay]);
+  });
+
+  it('returns an empty list when every strategy in the fallback order is disabled', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay: {
+          strategyOrder: ['relay', 'across'],
+          payStrategies: {
+            across: { enabled: false },
+            relay: { enabled: false },
+          },
+        },
+      };
+
+    expect(
+      selectMetaMaskPayStrategiesForRoute(
+        state as RootState,
+        'perpsDeposit',
+        '0xa4b1' as Hex,
+        '0xabc' as Hex,
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -2,11 +2,7 @@ import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import { Hex, Json } from '@metamask/utils';
 import { RootState } from '../../../reducers';
-import {
-  type MetaMaskPayRoutingFlags,
-  normalizeMetaMaskPayRoutingFlags,
-  resolveMetaMaskPayStrategies,
-} from '../../../util/transactions/transaction-pay-routing';
+import { getMetaMaskPayStrategiesForRoute } from '../../../util/transactions/transaction-pay-routing';
 
 export const ATTEMPTS_MAX_DEFAULT = 2;
 export const BUFFER_INITIAL_DEFAULT = 0.025;
@@ -119,15 +115,9 @@ export const selectMetaMaskPayFlags = createSelector(
   },
 );
 
-export const selectMetaMaskPayRoutingFlags = createSelector(
-  selectRemoteFeatureFlags,
-  (featureFlags): MetaMaskPayRoutingFlags =>
-    normalizeMetaMaskPayRoutingFlags(featureFlags?.confirmations_pay),
-);
-
 export const selectMetaMaskPayStrategiesForRoute = createSelector(
   [
-    selectMetaMaskPayRoutingFlags,
+    selectRemoteFeatureFlags,
     (_state: RootState, transactionType?: string) => transactionType,
     (_state: RootState, _transactionType?: string, chainId?: Hex) => chainId,
     (
@@ -137,14 +127,14 @@ export const selectMetaMaskPayStrategiesForRoute = createSelector(
       tokenAddress?: Hex,
     ) => tokenAddress,
   ],
-  (routingFlags, transactionType, chainId, tokenAddress) =>
-    resolveMetaMaskPayStrategies(
+  (featureFlags, transactionType, chainId, tokenAddress) =>
+    getMetaMaskPayStrategiesForRoute(
       {
-        chainId: chainId?.toLowerCase() as Hex | undefined,
-        tokenAddress: tokenAddress?.toLowerCase() as Hex | undefined,
+        chainId,
+        tokenAddress,
         transactionType,
       },
-      routingFlags,
+      featureFlags?.confirmations_pay,
     ),
 );
 

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -2,6 +2,11 @@ import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import { Hex, Json } from '@metamask/utils';
 import { RootState } from '../../../reducers';
+import {
+  type MetaMaskPayRoutingFlags,
+  normalizeMetaMaskPayRoutingFlags,
+  resolveMetaMaskPayStrategies,
+} from '../../../util/transactions/transaction-pay-routing';
 
 export const ATTEMPTS_MAX_DEFAULT = 2;
 export const BUFFER_INITIAL_DEFAULT = 0.025;
@@ -112,6 +117,35 @@ export const selectMetaMaskPayFlags = createSelector(
       stxDisabled,
     };
   },
+);
+
+export const selectMetaMaskPayRoutingFlags = createSelector(
+  selectRemoteFeatureFlags,
+  (featureFlags): MetaMaskPayRoutingFlags =>
+    normalizeMetaMaskPayRoutingFlags(featureFlags?.confirmations_pay),
+);
+
+export const selectMetaMaskPayStrategiesForRoute = createSelector(
+  [
+    selectMetaMaskPayRoutingFlags,
+    (_state: RootState, transactionType?: string) => transactionType,
+    (_state: RootState, _transactionType?: string, chainId?: Hex) => chainId,
+    (
+      _state: RootState,
+      _transactionType?: string,
+      _chainId?: Hex,
+      tokenAddress?: Hex,
+    ) => tokenAddress,
+  ],
+  (routingFlags, transactionType, chainId, tokenAddress) =>
+    resolveMetaMaskPayStrategies(
+      {
+        chainId: chainId?.toLowerCase() as Hex | undefined,
+        tokenAddress: tokenAddress?.toLowerCase() as Hex | undefined,
+        transactionType,
+      },
+      routingFlags,
+    ),
 );
 
 export const selectMetaMaskPayTokensFlags = createSelector(

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -76,6 +76,11 @@ import {
   isValidSwapsContractAddress,
   getSwapsContractAddress,
 } from '@metamask/bridge-controller';
+import {
+  hasPerpsDepositTransactionType,
+  hasPredictDepositTransactionType,
+  hasPredictWithdrawTransactionType,
+} from './metamask-pay';
 
 const { SAI_ADDRESS } = AppConstants;
 
@@ -600,7 +605,11 @@ export async function getTransactionActionKey(transaction, chainId) {
     return TRANSFER_FROM_ACTION_KEY;
   }
 
-  if (hasTransactionType(transaction, [TransactionType.predictDeposit])) {
+  if (hasPerpsDepositTransactionType(transaction)) {
+    return TransactionType.perpsDeposit;
+  }
+
+  if (hasPredictDepositTransactionType(transaction)) {
     return TransactionType.predictDeposit;
   }
 
@@ -608,7 +617,7 @@ export async function getTransactionActionKey(transaction, chainId) {
     return TransactionType.predictClaim;
   }
 
-  if (hasTransactionType(transaction, [TransactionType.predictWithdraw])) {
+  if (hasPredictWithdrawTransactionType(transaction)) {
     return TransactionType.predictWithdraw;
   }
 

--- a/app/util/transactions/metamask-pay.test.ts
+++ b/app/util/transactions/metamask-pay.test.ts
@@ -1,0 +1,84 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+
+import {
+  MM_PAY_DEPOSIT_CHILD_TRANSACTION_TYPES,
+  MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES,
+  getMetaMaskPayUseCase,
+  getMetaMaskPayRouteTransactionType,
+  hasMetaMaskPayDepositChildTransactionType,
+  hasPerpsDepositTransactionType,
+  hasPredictDepositTransactionType,
+} from './metamask-pay';
+
+describe('MetaMask Pay transaction helpers', () => {
+  it('classifies perpsAcrossDeposit as a perps deposit child transaction', () => {
+    const transactionMeta = {
+      type: TransactionType.perpsAcrossDeposit,
+    } as TransactionMeta;
+
+    expect(hasPerpsDepositTransactionType(transactionMeta)).toBe(true);
+    expect(hasMetaMaskPayDepositChildTransactionType(transactionMeta)).toBe(
+      true,
+    );
+    expect(MM_PAY_DEPOSIT_CHILD_TRANSACTION_TYPES).toContain(
+      TransactionType.perpsAcrossDeposit,
+    );
+    expect(getMetaMaskPayUseCase(transactionMeta)).toBe('perps_deposit');
+  });
+
+  it('classifies predictAcrossDeposit as a predict deposit child transaction', () => {
+    const transactionMeta = {
+      type: TransactionType.predictAcrossDeposit,
+    } as TransactionMeta;
+
+    expect(hasPredictDepositTransactionType(transactionMeta)).toBe(true);
+    expect(hasMetaMaskPayDepositChildTransactionType(transactionMeta)).toBe(
+      true,
+    );
+    expect(MM_PAY_DEPOSIT_CHILD_TRANSACTION_TYPES).toContain(
+      TransactionType.predictAcrossDeposit,
+    );
+    expect(getMetaMaskPayUseCase(transactionMeta)).toBe('predict_deposit');
+  });
+
+  it('groups provider-specific deposit variants under the parent route type', () => {
+    expect(
+      getMetaMaskPayRouteTransactionType({
+        type: TransactionType.perpsDepositAndOrder,
+      } as TransactionMeta),
+    ).toBe(TransactionType.perpsDeposit);
+
+    expect(
+      getMetaMaskPayRouteTransactionType({
+        type: TransactionType.perpsAcrossDeposit,
+      } as TransactionMeta),
+    ).toBe(TransactionType.perpsDeposit);
+
+    expect(
+      getMetaMaskPayRouteTransactionType({
+        type: TransactionType.predictAcrossDeposit,
+      } as TransactionMeta),
+    ).toBe(TransactionType.predictDeposit);
+  });
+
+  it('excludes claim types from positive transfer classification', () => {
+    expect(MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES).toContain(
+      TransactionType.perpsAcrossDeposit,
+    );
+    expect(MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES).toContain(
+      TransactionType.predictAcrossDeposit,
+    );
+    expect(MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES).toContain(
+      TransactionType.predictWithdraw,
+    );
+    expect(MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES).not.toContain(
+      TransactionType.musdClaim,
+    );
+    expect(MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES).not.toContain(
+      TransactionType.predictClaim,
+    );
+  });
+});

--- a/app/util/transactions/metamask-pay.ts
+++ b/app/util/transactions/metamask-pay.ts
@@ -1,0 +1,135 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../components/Views/confirmations/utils/transaction';
+
+type MetaMaskPayUseCase =
+  | 'perps_deposit'
+  | 'predict_deposit'
+  | 'predict_withdraw';
+
+export const PERPS_DEPOSIT_TRANSACTION_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsRelayDeposit,
+  TransactionType.perpsAcrossDeposit,
+] as const;
+
+export const PREDICT_DEPOSIT_TRANSACTION_TYPES = [
+  TransactionType.predictDeposit,
+  TransactionType.predictRelayDeposit,
+  TransactionType.predictAcrossDeposit,
+] as const;
+
+export const PREDICT_WITHDRAW_TRANSACTION_TYPES = [
+  TransactionType.predictWithdraw,
+] as const;
+
+export const MM_PAY_DEPOSIT_CHILD_TRANSACTION_TYPES = [
+  TransactionType.relayDeposit,
+  TransactionType.perpsRelayDeposit,
+  TransactionType.predictRelayDeposit,
+  TransactionType.perpsAcrossDeposit,
+  TransactionType.predictAcrossDeposit,
+] as const;
+
+export const MM_PAY_POSITIVE_TRANSFER_TRANSACTION_TYPES = [
+  TransactionType.musdConversion,
+  ...PERPS_DEPOSIT_TRANSACTION_TYPES,
+  ...PREDICT_DEPOSIT_TRANSACTION_TYPES,
+  ...PREDICT_WITHDRAW_TRANSACTION_TYPES,
+] as const;
+
+export const MM_PAY_DETAIL_TRANSACTION_TYPES = [
+  TransactionType.musdClaim,
+  TransactionType.musdConversion,
+  TransactionType.predictClaim,
+  ...PERPS_DEPOSIT_TRANSACTION_TYPES,
+  ...PREDICT_DEPOSIT_TRANSACTION_TYPES,
+  ...PREDICT_WITHDRAW_TRANSACTION_TYPES,
+] as const;
+
+export function hasPerpsDepositTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+) {
+  return hasTransactionType(
+    transactionMeta,
+    PERPS_DEPOSIT_TRANSACTION_TYPES as unknown as readonly TransactionType[],
+  );
+}
+
+export function hasPredictDepositTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+) {
+  return hasTransactionType(
+    transactionMeta,
+    PREDICT_DEPOSIT_TRANSACTION_TYPES as unknown as readonly TransactionType[],
+  );
+}
+
+export function hasPredictWithdrawTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+) {
+  return hasTransactionType(
+    transactionMeta,
+    PREDICT_WITHDRAW_TRANSACTION_TYPES as unknown as readonly TransactionType[],
+  );
+}
+
+export function hasMetaMaskPayDepositChildTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+) {
+  return hasTransactionType(
+    transactionMeta,
+    MM_PAY_DEPOSIT_CHILD_TRANSACTION_TYPES as unknown as readonly TransactionType[],
+  );
+}
+
+export function getMetaMaskPayUseCase(
+  transactionMeta: TransactionMeta | undefined,
+): MetaMaskPayUseCase | undefined {
+  if (hasPerpsDepositTransactionType(transactionMeta)) {
+    return 'perps_deposit';
+  }
+
+  if (hasPredictDepositTransactionType(transactionMeta)) {
+    return 'predict_deposit';
+  }
+
+  if (hasPredictWithdrawTransactionType(transactionMeta)) {
+    return 'predict_withdraw';
+  }
+
+  return undefined;
+}
+
+export function getMetaMaskPayRouteTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+): TransactionType | undefined {
+  if (!transactionMeta) {
+    return undefined;
+  }
+
+  if (hasTransactionType(transactionMeta, [TransactionType.musdClaim])) {
+    return TransactionType.musdClaim;
+  }
+
+  if (hasTransactionType(transactionMeta, [TransactionType.musdConversion])) {
+    return TransactionType.musdConversion;
+  }
+
+  if (hasPerpsDepositTransactionType(transactionMeta)) {
+    return TransactionType.perpsDeposit;
+  }
+
+  if (hasPredictDepositTransactionType(transactionMeta)) {
+    return TransactionType.predictDeposit;
+  }
+
+  if (hasPredictWithdrawTransactionType(transactionMeta)) {
+    return TransactionType.predictWithdraw;
+  }
+
+  return undefined;
+}

--- a/app/util/transactions/transaction-pay-routing.test.ts
+++ b/app/util/transactions/transaction-pay-routing.test.ts
@@ -5,55 +5,46 @@ import {
 import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
 
 import {
-  getTransactionPayRouteContext,
-  normalizeMetaMaskPayRoutingFlags,
-  resolveMetaMaskPayStrategies,
+  getMetaMaskPayStrategiesForRoute,
+  getMetaMaskPayStrategiesForTransaction,
 } from './transaction-pay-routing';
 
 describe('transaction pay routing', () => {
   it('normalizes invalid routing flags and drops empty overrides', () => {
-    const routingFlags = normalizeMetaMaskPayRoutingFlags({
-      strategyOrder: [123, 'relay', 'relay'],
-      payStrategies: {
-        across: { enabled: true },
-        relay: { enabled: false },
+    const strategies = getMetaMaskPayStrategiesForRoute(
+      {
+        chainId: '0xa4b2',
+        tokenAddress: '0xdef',
+        transactionType: TransactionType.perpsDeposit,
       },
-      routingOverrides: {
-        overrides: {
-          perpsDeposit: {
-            default: [123, 'invalid'],
-            chains: {
-              '0xa4b1': [123],
-              '0xa4b2': ['relay'],
-            },
-            tokens: {
-              '0xa4b1': undefined,
-              '0xa4b2': {
-                '0xabc': [123],
-                '0xdef': ['across'],
+      {
+        strategyOrder: [123, 'relay', 'relay'],
+        payStrategies: {
+          across: { enabled: true },
+          relay: { enabled: false },
+        },
+        routingOverrides: {
+          overrides: {
+            perpsDeposit: {
+              default: [123, 'invalid'],
+              chains: {
+                '0xa4b1': [123],
+                '0xa4b2': ['relay'],
+              },
+              tokens: {
+                '0xa4b1': undefined,
+                '0xa4b2': {
+                  '0xabc': [123],
+                  '0xdef': ['across'],
+                },
               },
             },
           },
         },
       },
-    });
+    );
 
-    expect(routingFlags.strategyOrder).toEqual([TransactionPayStrategy.Relay]);
-    expect(
-      routingFlags.routingOverrides.overrides.perpsDeposit.default,
-    ).toBeUndefined();
-    expect(routingFlags.routingOverrides.overrides.perpsDeposit.chains).toEqual(
-      {
-        '0xa4b2': [TransactionPayStrategy.Relay],
-      },
-    );
-    expect(routingFlags.routingOverrides.overrides.perpsDeposit.tokens).toEqual(
-      {
-        '0xa4b2': {
-          '0xdef': [TransactionPayStrategy.Across],
-        },
-      },
-    );
+    expect(strategies).toEqual([TransactionPayStrategy.Across]);
   });
 
   it('uses destination values for post-quote transactions', () => {
@@ -70,13 +61,25 @@ describe('transaction pay routing', () => {
       type: TransactionType.perpsDeposit,
     } as unknown as TransactionMeta;
 
-    const routeContext = getTransactionPayRouteContext(transactionMeta);
-
-    expect(routeContext).toEqual({
-      chainId: '0x89',
-      tokenAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-      transactionType: TransactionType.perpsDeposit,
-    });
+    expect(
+      getMetaMaskPayStrategiesForTransaction(transactionMeta, {
+        payStrategies: {
+          across: { enabled: true },
+          relay: { enabled: true },
+        },
+        routingOverrides: {
+          overrides: {
+            perpsDeposit: {
+              chains: {
+                '0x89': ['across'],
+              },
+              default: ['relay'],
+            },
+          },
+        },
+        strategyOrder: ['relay'],
+      }),
+    ).toEqual([TransactionPayStrategy.Across]);
   });
 
   it('groups perpsDepositAndOrder under the perpsDeposit routing key', () => {
@@ -88,45 +91,42 @@ describe('transaction pay routing', () => {
       type: TransactionType.perpsDepositAndOrder,
     } as unknown as TransactionMeta;
 
-    const routeContext = getTransactionPayRouteContext(transactionMeta);
-
-    expect(routeContext.transactionType).toBe(TransactionType.perpsDeposit);
-
-    const routingFlags = normalizeMetaMaskPayRoutingFlags({
-      payStrategies: {
-        across: { enabled: true },
-        relay: { enabled: true },
-      },
-      routingOverrides: {
-        overrides: {
-          perpsDeposit: {
-            chains: {
-              '0xa4b1': ['across'],
+    expect(
+      getMetaMaskPayStrategiesForTransaction(transactionMeta, {
+        payStrategies: {
+          across: { enabled: true },
+          relay: { enabled: true },
+        },
+        routingOverrides: {
+          overrides: {
+            perpsDeposit: {
+              chains: {
+                '0xa4b1': ['across'],
+              },
+              default: ['relay'],
             },
-            default: ['relay'],
           },
         },
-      },
-      strategyOrder: ['relay'],
-    });
-
-    expect(resolveMetaMaskPayStrategies(routeContext, routingFlags)).toEqual([
-      TransactionPayStrategy.Across,
-    ]);
+        strategyOrder: ['relay'],
+      }),
+    ).toEqual([TransactionPayStrategy.Across]);
   });
 
-  it('returns an empty strategy list when the route context cannot resolve', () => {
-    const routingFlags = {
-      payStrategies: {
-        across: { enabled: true },
-        relay: { enabled: true },
-      },
-      routingOverrides: {
-        overrides: {},
-      },
-      strategyOrder: ['bridge' as unknown as TransactionPayStrategy],
-    };
-
-    expect(resolveMetaMaskPayStrategies({}, routingFlags)).toEqual([]);
+  it('returns an empty strategy list when every fallback strategy is disabled', () => {
+    expect(
+      getMetaMaskPayStrategiesForRoute(
+        {},
+        {
+          payStrategies: {
+            across: { enabled: false },
+            relay: { enabled: false },
+          },
+          routingOverrides: {
+            overrides: {},
+          },
+          strategyOrder: ['relay', 'across'],
+        },
+      ),
+    ).toEqual([]);
   });
 });

--- a/app/util/transactions/transaction-pay-routing.test.ts
+++ b/app/util/transactions/transaction-pay-routing.test.ts
@@ -1,0 +1,132 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
+
+import {
+  getTransactionPayRouteContext,
+  normalizeMetaMaskPayRoutingFlags,
+  resolveMetaMaskPayStrategies,
+} from './transaction-pay-routing';
+
+describe('transaction pay routing', () => {
+  it('normalizes invalid routing flags and drops empty overrides', () => {
+    const routingFlags = normalizeMetaMaskPayRoutingFlags({
+      strategyOrder: [123, 'relay', 'relay'],
+      payStrategies: {
+        across: { enabled: true },
+        relay: { enabled: false },
+      },
+      routingOverrides: {
+        overrides: {
+          perpsDeposit: {
+            default: [123, 'invalid'],
+            chains: {
+              '0xa4b1': [123],
+              '0xa4b2': ['relay'],
+            },
+            tokens: {
+              '0xa4b1': undefined,
+              '0xa4b2': {
+                '0xabc': [123],
+                '0xdef': ['across'],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(routingFlags.strategyOrder).toEqual([TransactionPayStrategy.Relay]);
+    expect(
+      routingFlags.routingOverrides.overrides.perpsDeposit.default,
+    ).toBeUndefined();
+    expect(routingFlags.routingOverrides.overrides.perpsDeposit.chains).toEqual(
+      {
+        '0xa4b2': [TransactionPayStrategy.Relay],
+      },
+    );
+    expect(routingFlags.routingOverrides.overrides.perpsDeposit.tokens).toEqual(
+      {
+        '0xa4b2': {
+          '0xdef': [TransactionPayStrategy.Across],
+        },
+      },
+    );
+  });
+
+  it('uses destination values for post-quote transactions', () => {
+    const transactionMeta = {
+      chainId: '0xa4b1',
+      destinationChainId: '0x89',
+      destinationTokenAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      metamaskPay: {
+        isPostQuote: true,
+      },
+      txParams: {
+        to: '0x1234567890abcdef1234567890abcdef12345678',
+      },
+      type: TransactionType.perpsDeposit,
+    } as unknown as TransactionMeta;
+
+    const routeContext = getTransactionPayRouteContext(transactionMeta);
+
+    expect(routeContext).toEqual({
+      chainId: '0x89',
+      tokenAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      transactionType: TransactionType.perpsDeposit,
+    });
+  });
+
+  it('groups perpsDepositAndOrder under the perpsDeposit routing key', () => {
+    const transactionMeta = {
+      chainId: '0xa4b1',
+      txParams: {
+        to: '0x1234567890abcdef1234567890abcdef12345678',
+      },
+      type: TransactionType.perpsDepositAndOrder,
+    } as unknown as TransactionMeta;
+
+    const routeContext = getTransactionPayRouteContext(transactionMeta);
+
+    expect(routeContext.transactionType).toBe(TransactionType.perpsDeposit);
+
+    const routingFlags = normalizeMetaMaskPayRoutingFlags({
+      payStrategies: {
+        across: { enabled: true },
+        relay: { enabled: true },
+      },
+      routingOverrides: {
+        overrides: {
+          perpsDeposit: {
+            chains: {
+              '0xa4b1': ['across'],
+            },
+            default: ['relay'],
+          },
+        },
+      },
+      strategyOrder: ['relay'],
+    });
+
+    expect(resolveMetaMaskPayStrategies(routeContext, routingFlags)).toEqual([
+      TransactionPayStrategy.Across,
+    ]);
+  });
+
+  it('returns an empty strategy list when the route context cannot resolve', () => {
+    const routingFlags = {
+      payStrategies: {
+        across: { enabled: true },
+        relay: { enabled: true },
+      },
+      routingOverrides: {
+        overrides: {},
+      },
+      strategyOrder: ['bridge' as unknown as TransactionPayStrategy],
+    };
+
+    expect(resolveMetaMaskPayStrategies({}, routingFlags)).toEqual([]);
+  });
+});

--- a/app/util/transactions/transaction-pay-routing.ts
+++ b/app/util/transactions/transaction-pay-routing.ts
@@ -1,0 +1,265 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
+import { Hex } from '@metamask/utils';
+
+import {
+  getMetaMaskPayRouteTransactionType,
+  hasPredictWithdrawTransactionType,
+} from './metamask-pay';
+import { getTokenAddress } from './transaction-pay-token-transfer';
+
+export const DEFAULT_META_MASK_PAY_STRATEGY_ORDER = [
+  TransactionPayStrategy.Relay,
+  TransactionPayStrategy.Across,
+] as const;
+
+const ROUTED_PAY_STRATEGIES = new Set<TransactionPayStrategy>([
+  TransactionPayStrategy.Relay,
+  TransactionPayStrategy.Across,
+]);
+
+interface RawRoutingOverride {
+  default?: unknown;
+  chains?: Record<string, unknown>;
+  tokens?: Record<string, Record<string, unknown>>;
+}
+
+interface RawPayStrategies {
+  across?: {
+    enabled?: boolean;
+  };
+  relay?: {
+    enabled?: boolean;
+  };
+}
+
+interface RawMetaMaskPayRoutingFlags {
+  strategyOrder?: unknown;
+  payStrategies?: RawPayStrategies;
+  routingOverrides?: {
+    overrides?: Record<string, RawRoutingOverride>;
+  };
+}
+
+export interface MetaMaskPayRouteContext {
+  chainId?: Hex;
+  tokenAddress?: Hex;
+  transactionType?: string;
+}
+
+export interface MetaMaskPayRoutingOverride {
+  chains: Record<Hex, TransactionPayStrategy[]>;
+  default?: TransactionPayStrategy[];
+  tokens: Record<Hex, Record<Hex, TransactionPayStrategy[]>>;
+}
+
+export interface MetaMaskPayRoutingFlags {
+  payStrategies: {
+    across: {
+      enabled: boolean;
+    };
+    relay: {
+      enabled: boolean;
+    };
+  };
+  routingOverrides: {
+    overrides: Record<string, MetaMaskPayRoutingOverride>;
+  };
+  strategyOrder: TransactionPayStrategy[];
+}
+
+function normalizeHex(value: string | undefined): Hex | undefined {
+  return value?.toLowerCase() as Hex | undefined;
+}
+
+function normalizeStrategy(
+  strategy: unknown,
+): TransactionPayStrategy | undefined {
+  if (typeof strategy !== 'string') {
+    return undefined;
+  }
+
+  const normalized = strategy.toLowerCase() as TransactionPayStrategy;
+
+  if (!ROUTED_PAY_STRATEGIES.has(normalized)) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function normalizeStrategyList(strategies: unknown): TransactionPayStrategy[] {
+  if (!Array.isArray(strategies)) {
+    return [];
+  }
+
+  const dedupedStrategies: TransactionPayStrategy[] = [];
+  const seenStrategies = new Set<TransactionPayStrategy>();
+
+  for (const strategy of strategies) {
+    const normalizedStrategy = normalizeStrategy(strategy);
+
+    if (!normalizedStrategy || seenStrategies.has(normalizedStrategy)) {
+      continue;
+    }
+
+    dedupedStrategies.push(normalizedStrategy);
+    seenStrategies.add(normalizedStrategy);
+  }
+
+  return dedupedStrategies;
+}
+
+function normalizeRoutingOverride(
+  override: RawRoutingOverride | undefined,
+): MetaMaskPayRoutingOverride {
+  const chains = Object.entries(override?.chains ?? {}).reduce<
+    Record<Hex, TransactionPayStrategy[]>
+  >((result, [chainId, strategies]) => {
+    const normalizedStrategies = normalizeStrategyList(strategies);
+
+    if (normalizedStrategies.length) {
+      result[normalizeHex(chainId) as Hex] = normalizedStrategies;
+    }
+
+    return result;
+  }, {});
+
+  const tokens = Object.entries(override?.tokens ?? {}).reduce<
+    Record<Hex, Record<Hex, TransactionPayStrategy[]>>
+  >((result, [chainId, tokenOverrides]) => {
+    const normalizedTokenOverrides = Object.entries(
+      tokenOverrides ?? {},
+    ).reduce<Record<Hex, TransactionPayStrategy[]>>(
+      (tokenResult, [tokenAddress, strategies]) => {
+        const normalizedStrategies = normalizeStrategyList(strategies);
+
+        if (normalizedStrategies.length) {
+          tokenResult[normalizeHex(tokenAddress) as Hex] = normalizedStrategies;
+        }
+
+        return tokenResult;
+      },
+      {},
+    );
+
+    if (Object.keys(normalizedTokenOverrides).length) {
+      result[normalizeHex(chainId) as Hex] = normalizedTokenOverrides;
+    }
+
+    return result;
+  }, {});
+
+  const defaultStrategies = normalizeStrategyList(override?.default);
+
+  return {
+    chains,
+    default: defaultStrategies.length ? defaultStrategies : undefined,
+    tokens,
+  };
+}
+
+function filterEnabledStrategies(
+  strategies: readonly TransactionPayStrategy[] | undefined,
+  routingFlags: MetaMaskPayRoutingFlags,
+): TransactionPayStrategy[] {
+  if (!strategies?.length) {
+    return [];
+  }
+
+  return strategies.filter((strategy) => {
+    switch (strategy) {
+      case TransactionPayStrategy.Across:
+        return routingFlags.payStrategies.across.enabled;
+      case TransactionPayStrategy.Relay:
+        return routingFlags.payStrategies.relay.enabled;
+      default:
+        return false;
+    }
+  });
+}
+
+export function getTransactionPayRouteContext(
+  transactionMeta: TransactionMeta | undefined,
+): MetaMaskPayRouteContext {
+  const transactionType = getMetaMaskPayRouteTransactionType(transactionMeta);
+  const isPostQuote =
+    transactionMeta?.metamaskPay?.isPostQuote ??
+    hasPredictWithdrawTransactionType(transactionMeta);
+
+  return {
+    chainId: normalizeHex(
+      (isPostQuote
+        ? transactionMeta?.destinationChainId
+        : transactionMeta?.chainId) as string | undefined,
+    ),
+    tokenAddress: normalizeHex(
+      (isPostQuote
+        ? transactionMeta?.destinationTokenAddress
+        : getTokenAddress(transactionMeta)) as string | undefined,
+    ),
+    transactionType,
+  };
+}
+
+export function normalizeMetaMaskPayRoutingFlags(
+  rawFlags: unknown,
+): MetaMaskPayRoutingFlags {
+  const flags = (rawFlags ?? {}) as RawMetaMaskPayRoutingFlags;
+  const strategyOrder = normalizeStrategyList(flags.strategyOrder);
+
+  return {
+    payStrategies: {
+      across: {
+        enabled: flags.payStrategies?.across?.enabled ?? false,
+      },
+      relay: {
+        enabled: flags.payStrategies?.relay?.enabled ?? true,
+      },
+    },
+    routingOverrides: {
+      overrides: Object.entries(flags.routingOverrides?.overrides ?? {}).reduce<
+        Record<string, MetaMaskPayRoutingOverride>
+      >((result, [transactionType, override]) => {
+        result[transactionType] = normalizeRoutingOverride(override);
+        return result;
+      }, {}),
+    },
+    strategyOrder:
+      strategyOrder.length > 0
+        ? strategyOrder
+        : [...DEFAULT_META_MASK_PAY_STRATEGY_ORDER],
+  };
+}
+
+export function resolveMetaMaskPayStrategies(
+  routeContext: MetaMaskPayRouteContext,
+  routingFlags: MetaMaskPayRoutingFlags,
+): TransactionPayStrategy[] {
+  const { chainId, tokenAddress, transactionType } = routeContext;
+  const override = transactionType
+    ? routingFlags.routingOverrides.overrides[transactionType]
+    : undefined;
+
+  const candidates: (readonly TransactionPayStrategy[] | undefined)[] = [
+    chainId && tokenAddress
+      ? override?.tokens[chainId]?.[tokenAddress]
+      : undefined,
+    chainId ? override?.chains[chainId] : undefined,
+    override?.default,
+    routingFlags.strategyOrder,
+  ];
+
+  for (const strategies of candidates) {
+    const resolvedStrategies = filterEnabledStrategies(
+      strategies,
+      routingFlags,
+    );
+
+    if (resolvedStrategies.length) {
+      return resolvedStrategies;
+    }
+  }
+
+  return [];
+}

--- a/app/util/transactions/transaction-pay-routing.ts
+++ b/app/util/transactions/transaction-pay-routing.ts
@@ -1,5 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
+// eslint-disable-next-line import-x/no-namespace -- this module is runtime-probed for an optional export from a newer core version
+import * as TransactionPayControllerPackage from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 
 import {
@@ -8,7 +9,25 @@ import {
 } from './metamask-pay';
 import { getTokenAddress } from './transaction-pay-token-transfer';
 
-export const DEFAULT_META_MASK_PAY_STRATEGY_ORDER = [
+const { TransactionPayStrategy } = TransactionPayControllerPackage;
+
+type TransactionPayStrategy =
+  TransactionPayControllerPackage.TransactionPayStrategy;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- this is an intersection over the runtime module shape
+type TransactionPayControllerPackageWithRouteSupport =
+  typeof TransactionPayControllerPackage & {
+    getStrategyOrderForRouteFromFeatureFlags?: (
+      rawFeatureFlags: unknown,
+      routeContext: MetaMaskPayStrategyRoute,
+    ) => TransactionPayStrategy[];
+  };
+
+const getStrategyOrderForRouteFromFeatureFlags = (
+  TransactionPayControllerPackage as TransactionPayControllerPackageWithRouteSupport
+).getStrategyOrderForRouteFromFeatureFlags;
+
+const DEFAULT_META_MASK_PAY_STRATEGY_ORDER = [
   TransactionPayStrategy.Relay,
   TransactionPayStrategy.Across,
 ] as const;
@@ -41,19 +60,25 @@ interface RawMetaMaskPayRoutingFlags {
   };
 }
 
-export interface MetaMaskPayRouteContext {
+interface MetaMaskPayRouteContext {
   chainId?: Hex;
   tokenAddress?: Hex;
   transactionType?: string;
 }
 
-export interface MetaMaskPayRoutingOverride {
+export interface MetaMaskPayStrategyRoute {
+  chainId?: Hex;
+  tokenAddress?: Hex;
+  transactionType?: string;
+}
+
+interface MetaMaskPayRoutingOverride {
   chains: Record<Hex, TransactionPayStrategy[]>;
   default?: TransactionPayStrategy[];
   tokens: Record<Hex, Record<Hex, TransactionPayStrategy[]>>;
 }
 
-export interface MetaMaskPayRoutingFlags {
+interface MetaMaskPayRoutingFlags {
   payStrategies: {
     across: {
       enabled: boolean;
@@ -179,7 +204,7 @@ function filterEnabledStrategies(
   });
 }
 
-export function getTransactionPayRouteContext(
+function getTransactionPayRouteContext(
   transactionMeta: TransactionMeta | undefined,
 ): MetaMaskPayRouteContext {
   const transactionType = getMetaMaskPayRouteTransactionType(transactionMeta);
@@ -202,7 +227,7 @@ export function getTransactionPayRouteContext(
   };
 }
 
-export function normalizeMetaMaskPayRoutingFlags(
+function normalizeMetaMaskPayRoutingFlags(
   rawFlags: unknown,
 ): MetaMaskPayRoutingFlags {
   const flags = (rawFlags ?? {}) as RawMetaMaskPayRoutingFlags;
@@ -232,7 +257,7 @@ export function normalizeMetaMaskPayRoutingFlags(
   };
 }
 
-export function resolveMetaMaskPayStrategies(
+function resolveMetaMaskPayStrategies(
   routeContext: MetaMaskPayRouteContext,
   routingFlags: MetaMaskPayRoutingFlags,
 ): TransactionPayStrategy[] {
@@ -262,4 +287,42 @@ export function resolveMetaMaskPayStrategies(
   }
 
   return [];
+}
+
+function normalizeRoute(
+  route: MetaMaskPayStrategyRoute,
+): MetaMaskPayRouteContext {
+  return {
+    chainId: normalizeHex(route.chainId),
+    tokenAddress: normalizeHex(route.tokenAddress),
+    transactionType: route.transactionType,
+  };
+}
+
+export function getMetaMaskPayStrategiesForRoute(
+  route: MetaMaskPayStrategyRoute,
+  rawFeatureFlags: unknown,
+): TransactionPayStrategy[] {
+  const normalizedRoute = normalizeRoute(route);
+
+  if (getStrategyOrderForRouteFromFeatureFlags) {
+    return getStrategyOrderForRouteFromFeatureFlags(
+      rawFeatureFlags,
+      normalizedRoute,
+    );
+  }
+
+  const routingFlags = normalizeMetaMaskPayRoutingFlags(rawFeatureFlags);
+
+  return resolveMetaMaskPayStrategies(normalizedRoute, routingFlags);
+}
+
+export function getMetaMaskPayStrategiesForTransaction(
+  transactionMeta: TransactionMeta | undefined,
+  rawFeatureFlags: unknown,
+): TransactionPayStrategy[] {
+  return getMetaMaskPayStrategiesForRoute(
+    getTransactionPayRouteContext(transactionMeta),
+    rawFeatureFlags,
+  );
 }

--- a/app/util/transactions/transaction-pay-token-transfer.ts
+++ b/app/util/transactions/transaction-pay-token-transfer.ts
@@ -1,0 +1,54 @@
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+
+export function getTokenTransferData(
+  transactionMeta: TransactionMeta | undefined,
+):
+  | {
+      data: Hex;
+      to: Hex;
+      index?: number;
+    }
+  | undefined {
+  const { nestedTransactions, txParams } = transactionMeta ?? {};
+  const { data: singleData } = txParams ?? {};
+  const singleTo = txParams?.to as Hex | undefined;
+
+  if (singleData?.startsWith(FOUR_BYTE_TOKEN_TRANSFER) && singleTo) {
+    return { data: singleData as Hex, to: singleTo, index: undefined };
+  }
+
+  const nestedCallIndex = nestedTransactions?.findIndex((call) =>
+    call.data?.startsWith(FOUR_BYTE_TOKEN_TRANSFER),
+  );
+
+  if (nestedCallIndex === undefined || nestedCallIndex < 0) {
+    return undefined;
+  }
+
+  const nestedCall = nestedTransactions?.[nestedCallIndex];
+
+  if (nestedCall?.data && nestedCall.to) {
+    return {
+      data: nestedCall.data,
+      to: nestedCall.to,
+      index: nestedCallIndex,
+    };
+  }
+
+  return undefined;
+}
+
+export function getTokenAddress(
+  transactionMeta: TransactionMeta | undefined,
+): Hex {
+  const nestedCall = transactionMeta && getTokenTransferData(transactionMeta);
+
+  if (nestedCall) {
+    return nestedCall.to;
+  }
+
+  return transactionMeta?.txParams?.to as Hex;
+}


### PR DESCRIPTION
## **Description**

This PR splits two UI type-grouping changes out of the MM Pay provider fallback rollout into a smaller follow-up PR for code-owner review. It reapplies the `PerpsProgressBar` transaction-type helper change and the `TransactionElement` detail-type constant move on top of `pnf/plan-provider-fallback-rollout`, so those changes can be reviewed independently without expanding the initial rollout PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: deferred MM Pay UI type cleanup

  Scenario: user views Perps progress and transaction details
    Given the app includes the MM Pay provider fallback rollout branch
    When user opens Perps deposit progress and MM Pay transaction detail surfaces
    Then Perps progress uses the shared Perps deposit type helper
    And transaction details use the shared MM Pay detail type grouping
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
