### PR TITLE
feat: migrate Button (perps scope)

### DIFF
--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -113,7 +113,10 @@ jest.mock('../../components/PerpsOrderHeader', () => {
   };
 });
 jest.mock('../../components/PerpsAmountDisplay', () => 'PerpsAmountDisplay');
-jest.mock('../../components/PerpsBottomSheetTooltip', () => 'PerpsBottomSheetTooltip');
+jest.mock(
+  '../../components/PerpsBottomSheetTooltip',
+  () => 'PerpsBottomSheetTooltip',
+);
 jest.mock('../../components/PerpsSlider', () => {
   const ReactModule = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
@@ -133,8 +136,15 @@ jest.mock('@metamask/design-system-react-native', () => {
   const { TouchableOpacity, Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Button: ({ label, onPress, isDisabled, isLoading, children, ...props }: any) => (
+    Button: ({
+      label,
+      onPress,
+      isDisabled,
+      isLoading,
+      children,
+      ...props
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }: any) => (
       <TouchableOpacity
         onPress={onPress}
         disabled={isDisabled}

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -113,6 +113,7 @@ jest.mock('../../components/PerpsOrderHeader', () => {
   };
 });
 jest.mock('../../components/PerpsAmountDisplay', () => 'PerpsAmountDisplay');
+jest.mock('../../components/PerpsBottomSheetTooltip', () => 'PerpsBottomSheetTooltip');
 jest.mock('../../components/PerpsSlider', () => {
   const ReactModule = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
@@ -125,6 +126,33 @@ jest.mock('../../components/PerpsSlider', () => {
       testID: 'mock-perps-slider',
       onValueChange,
     });
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Button: ({ label, onPress, isDisabled, isLoading, children, ...props }: any) => (
+      <TouchableOpacity
+        onPress={onPress}
+        disabled={isDisabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        {...props}
+      >
+        {!isLoading && <Text>{label ?? children}</Text>}
+      </TouchableOpacity>
+    ),
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+    },
+    ButtonSize: {
+      Lg: 'Lg',
+      Sm: 'Sm',
+    },
   };
 });
 
@@ -411,12 +439,10 @@ describe('PerpsAdjustMarginView', () => {
 
       render(<PerpsAdjustMarginView />);
 
-      // When loading, button text is rendered but hidden (opacity: 0)
-      const buttonText = screen.queryByText('perps.adjust_margin.add_margin');
-      expect(buttonText).toBeTruthy();
-      expect(buttonText?.props.style).toEqual(
-        expect.arrayContaining([expect.objectContaining({ opacity: 0 })]),
-      );
+      // When loading, button text is not rendered
+      expect(
+        screen.queryByText('perps.adjust_margin.add_margin'),
+      ).not.toBeOnTheScreen();
     });
 
     it('displays button text when not adjusting', () => {

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -411,10 +411,12 @@ describe('PerpsAdjustMarginView', () => {
 
       render(<PerpsAdjustMarginView />);
 
-      // When loading, button text is not rendered
-      expect(
-        screen.queryByText('perps.adjust_margin.add_margin'),
-      ).not.toBeOnTheScreen();
+      // When loading, button text is rendered but hidden (opacity: 0)
+      const buttonText = screen.queryByText('perps.adjust_margin.add_margin');
+      expect(buttonText).toBeTruthy();
+      expect(buttonText?.props.style).toEqual(
+        expect.arrayContaining([expect.objectContaining({ opacity: 0 })]),
+      );
     });
 
     it('displays button text when not adjusting', () => {

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
@@ -7,11 +7,11 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { type Position, PERPS_CONSTANTS } from '@metamask/perps-controller';
 import styleSheet from './PerpsAdjustMarginView.styles';
@@ -424,51 +424,56 @@ const PerpsAdjustMarginView: React.FC = () => {
         <View style={styles.footer}>
           <Button
             testID={PerpsAdjustMarginViewSelectorsIDs.CONFIRM_BUTTON}
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
-            label={buttonLabel}
+            isFullWidth
             onPress={handleConfirm}
             isDisabled={
               marginAmount <= 0 ||
               isAdjusting ||
               (!isAddMode && marginAmount > flooredMaxAmount)
             }
-            loading={isAdjusting}
-          />
+            isLoading={isAdjusting}
+          >
+            {buttonLabel}
+          </Button>
         </View>
       ) : (
         <View style={styles.keypadFooter}>
           <View style={styles.percentageButtonsContainer}>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label="25%"
               onPress={() => handlePercentagePress(0.25)}
               style={styles.percentageButton}
-            />
+            >
+              25%
+            </Button>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label="50%"
               onPress={() => handlePercentagePress(0.5)}
               style={styles.percentageButton}
-            />
+            >
+              50%
+            </Button>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label={strings('perps.deposit.max_button')}
               onPress={handleMaxPress}
               style={styles.percentageButton}
-            />
+            >
+              {strings('perps.deposit.max_button')}
+            </Button>
             <Button
               testID={PerpsAdjustMarginViewSelectorsIDs.DONE_BUTTON}
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label={strings('perps.deposit.done_button')}
               onPress={handleDonePress}
               style={styles.percentageButton}
-            />
+            >
+              {strings('perps.deposit.done_button')}
+            </Button>
           </View>
 
           <Keypad

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -346,7 +346,8 @@ describe('PerpsClosePositionView', () => {
       const confirmButton = getByTestId(
         PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
       );
-      expect(confirmButton.props.loading).toBe(true);
+      expect(confirmButton).toBeDisabled();
+      expect(confirmButton.props.accessibilityState.busy).toBe(true);
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -14,11 +14,11 @@ import { ScrollView, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { PerpsClosePositionViewSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -684,33 +684,37 @@ const PerpsClosePositionView: React.FC = () => {
           {Summary}
           <View style={styles.percentageButtonsContainer}>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label="25%"
               onPress={() => handlePercentagePress(0.25)}
               style={styles.percentageButton}
-            />
+            >
+              25%
+            </Button>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label="50%"
               onPress={() => handlePercentagePress(0.5)}
               style={styles.percentageButton}
-            />
+            >
+              50%
+            </Button>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label={strings('perps.deposit.max_button')}
               onPress={handleMaxPress}
               style={styles.percentageButton}
-            />
+            >
+              {strings('perps.deposit.max_button')}
+            </Button>
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Md}
-              label={strings('perps.deposit.done_button')}
               onPress={handleDonePress}
               style={styles.percentageButton}
-            />
+            >
+              {strings('perps.deposit.done_button')}
+            </Button>
           </View>
 
           <Keypad
@@ -729,14 +733,9 @@ const PerpsClosePositionView: React.FC = () => {
         {!isInputFocused && Summary}
         {!isInputFocused && (
           <Button
-            label={
-              isClosing
-                ? strings('perps.close_position.closing')
-                : strings('perps.close_position.button')
-            }
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             onPress={handleConfirm}
             isDisabled={
               isClosing ||
@@ -745,11 +744,15 @@ const PerpsClosePositionView: React.FC = () => {
               (orderType === 'market' && closePercentage === 0) ||
               !validationResult.isValid
             }
-            loading={isClosing}
+            isLoading={isClosing}
             testID={
               PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON
             }
-          />
+          >
+            {isClosing
+              ? strings('perps.close_position.closing')
+              : strings('perps.close_position.button')}
+          </Button>
         )}
       </View>
 

--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
@@ -16,11 +16,11 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import {
   IconName,
   IconColor,
@@ -519,16 +519,17 @@ const PerpsHeroCardView: React.FC = () => {
       {/* Footer Button */}
       <View style={styles.footerButtonContainer}>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('perps.pnl_hero_card.share_button')}
+          isFullWidth
           startIconName={isSharing ? undefined : IconName.Share}
           onPress={handleShare}
-          loading={isSharing}
+          isLoading={isSharing}
           isDisabled={isSharing}
           testID={PerpsHeroCardViewSelectorsIDs.SHARE_BUTTON}
-        />
+        >
+          {strings('perps.pnl_hero_card.share_button')}
+        </Button>
       </View>
     </SafeAreaView>
   );

--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
@@ -20,6 +20,7 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  IconName as DSIconName,
 } from '@metamask/design-system-react-native';
 import {
   IconName,
@@ -522,7 +523,7 @@ const PerpsHeroCardView: React.FC = () => {
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           isFullWidth
-          startIconName={isSharing ? undefined : IconName.Share}
+          startIconName={isSharing ? undefined : DSIconName.Share}
           onPress={handleShare}
           isLoading={isSharing}
           isDisabled={isSharing}

--- a/app/components/UI/Perps/Views/PerpsMarketAndRiskFlow.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketAndRiskFlow.view.test.tsx
@@ -270,12 +270,7 @@ describe('Market Browsing & Risk Awareness Flow', () => {
     expect(
       await screen.findByTestId(PerpsStopLossPromptSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
-    expect(
-      screen.getByTestId(PerpsStopLossPromptSelectorsIDs.LOADING),
-    ).toBeOnTheScreen();
-    expect(
-      screen.queryByText(strings('perps.stop_loss_prompt.set_button')),
-    ).not.toBeOnTheScreen();
+    expect(screen.getByTestId('spinner-container')).toBeOnTheScreen();
 
     // Stop-loss success state — button shows check icon
     cleanup();

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1,5 +1,7 @@
 import {
   Box,
+  Button as DSButton,
+  ButtonVariant,
   ButtonSize as ButtonSizeRNDesignSystem,
   IconName,
 } from '@metamask/design-system-react-native';
@@ -35,11 +37,6 @@ import { setPerpsChartPreferredCandlePeriod } from '../../../../../actions/setti
 import ButtonSemantic, {
   ButtonSemanticSeverity,
 } from '../../../../../component-library/components-temp/Buttons/ButtonSemantic';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import Text, {
   TextColor,
@@ -1462,29 +1459,29 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
           {hasLongShortButtons && existingPosition && (
             <View style={styles.actionsContainer}>
               <View style={styles.actionButtonWrapper}>
-                <Button
-                  variant={ButtonVariants.Secondary}
-                  size={ButtonSize.Lg}
-                  width={ButtonWidthTypes.Full}
-                  label={strings('perps.market.modify')}
+                <DSButton
+                  variant={ButtonVariant.Secondary}
+                  size={ButtonSizeRNDesignSystem.Lg}
+                  isFullWidth
                   onPress={handleModifyPress}
                   testID={PerpsMarketDetailsViewSelectorsIDs.MODIFY_BUTTON}
-                />
+                >
+                  {strings('perps.market.modify')}
+                </DSButton>
               </View>
 
               <View style={styles.actionButtonWrapper}>
-                <Button
-                  variant={ButtonVariants.Primary}
-                  size={ButtonSize.Lg}
-                  width={ButtonWidthTypes.Full}
-                  label={
-                    parseFloat(existingPosition.size) >= 0
-                      ? strings('perps.market.close_long')
-                      : strings('perps.market.close_short')
-                  }
+                <DSButton
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSizeRNDesignSystem.Lg}
+                  isFullWidth
                   onPress={handleClosePosition}
                   testID={PerpsMarketDetailsViewSelectorsIDs.CLOSE_BUTTON}
-                />
+                >
+                  {parseFloat(existingPosition.size) >= 0
+                    ? strings('perps.market.close_long')
+                    : strings('perps.market.close_short')}
+                </DSButton>
               </View>
             </View>
           )}
@@ -1493,14 +1490,15 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
           {shouldShowAddFundsCTASection && (
             <View style={styles.actionsContainer}>
               <View style={styles.actionButtonWrapper}>
-                <Button
-                  variant={ButtonVariants.Primary}
-                  size={ButtonSize.Lg}
-                  width={ButtonWidthTypes.Full}
-                  label={strings('perps.add_funds')}
+                <DSButton
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSizeRNDesignSystem.Lg}
+                  isFullWidth
                   onPress={handleAddFunds}
                   testID={PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON}
-                />
+                >
+                  {strings('perps.add_funds')}
+                </DSButton>
               </View>
             </View>
           )}
@@ -1509,15 +1507,16 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
             <View style={styles.actionsContainer}>
               <View style={styles.actionButtonWrapper}>
                 {buttonColorVariant === 'monochrome' ? (
-                  <Button
-                    variant={ButtonVariants.Primary}
-                    size={ButtonSize.Lg}
-                    width={ButtonWidthTypes.Full}
-                    label={strings('perps.market.long')}
+                  <DSButton
+                    variant={ButtonVariant.Primary}
+                    size={ButtonSizeRNDesignSystem.Lg}
+                    isFullWidth
                     onPress={handleLongPress}
                     isDisabled={isAtOICap}
                     testID={PerpsMarketDetailsViewSelectorsIDs.LONG_BUTTON}
-                  />
+                  >
+                    {strings('perps.market.long')}
+                  </DSButton>
                 ) : (
                   <ButtonSemantic
                     severity={ButtonSemanticSeverity.Success}
@@ -1534,15 +1533,16 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
 
               <View style={styles.actionButtonWrapper}>
                 {buttonColorVariant === 'monochrome' ? (
-                  <Button
-                    variant={ButtonVariants.Primary}
-                    size={ButtonSize.Lg}
-                    width={ButtonWidthTypes.Full}
-                    label={strings('perps.market.short')}
+                  <DSButton
+                    variant={ButtonVariant.Primary}
+                    size={ButtonSizeRNDesignSystem.Lg}
+                    isFullWidth
                     onPress={handleShortPress}
                     isDisabled={isAtOICap}
                     testID={PerpsMarketDetailsViewSelectorsIDs.SHORT_BUTTON}
-                  />
+                  >
+                    {strings('perps.market.short')}
+                  </DSButton>
                 ) : (
                   <ButtonSemantic
                     severity={ButtonSemanticSeverity.Danger}

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -1,4 +1,8 @@
-import { ButtonSize as ButtonSizeRNDesignSystem } from '@metamask/design-system-react-native';
+import {
+  Button as DSButton,
+  ButtonVariant,
+  ButtonSize as ButtonSizeRNDesignSystem,
+} from '@metamask/design-system-react-native';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import React, {
   useCallback,
@@ -28,11 +32,6 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -681,43 +680,44 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
         {existingPosition ? (
           <View style={styles.actionsContainer}>
             <View style={styles.actionButtonWrapper}>
-              <Button
-                variant={ButtonVariants.Secondary}
-                size={ButtonSize.Lg}
-                width={ButtonWidthTypes.Full}
-                label={strings('perps.market.modify')}
+              <DSButton
+                variant={ButtonVariant.Secondary}
+                size={ButtonSizeRNDesignSystem.Lg}
+                isFullWidth
                 onPress={handleModifyPress}
                 testID={PerpsOrderBookViewSelectorsIDs.MODIFY_BUTTON}
-              />
+              >
+                {strings('perps.market.modify')}
+              </DSButton>
             </View>
 
             <View style={styles.actionButtonWrapper}>
-              <Button
-                variant={ButtonVariants.Primary}
-                size={ButtonSize.Lg}
-                width={ButtonWidthTypes.Full}
-                label={
-                  parseFloat(existingPosition.size) >= 0
-                    ? strings('perps.market.close_long')
-                    : strings('perps.market.close_short')
-                }
+              <DSButton
+                variant={ButtonVariant.Primary}
+                size={ButtonSizeRNDesignSystem.Lg}
+                isFullWidth
                 onPress={handleClosePosition}
                 testID={PerpsOrderBookViewSelectorsIDs.CLOSE_BUTTON}
-              />
+              >
+                {parseFloat(existingPosition.size) >= 0
+                  ? strings('perps.market.close_long')
+                  : strings('perps.market.close_short')}
+              </DSButton>
             </View>
           </View>
         ) : (
           <View style={styles.actionsContainer}>
             <View style={styles.actionButtonWrapper}>
               {buttonColorVariant === 'monochrome' ? (
-                <Button
-                  variant={ButtonVariants.Primary}
-                  size={ButtonSize.Lg}
-                  width={ButtonWidthTypes.Full}
-                  label={strings('perps.market.long')}
+                <DSButton
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSizeRNDesignSystem.Lg}
+                  isFullWidth
                   onPress={handleLongPress}
                   testID={PerpsOrderBookViewSelectorsIDs.LONG_BUTTON}
-                />
+                >
+                  {strings('perps.market.long')}
+                </DSButton>
               ) : (
                 <ButtonSemantic
                   severity={ButtonSemanticSeverity.Success}
@@ -733,14 +733,15 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
 
             <View style={styles.actionButtonWrapper}>
               {buttonColorVariant === 'monochrome' ? (
-                <Button
-                  variant={ButtonVariants.Primary}
-                  size={ButtonSize.Lg}
-                  width={ButtonWidthTypes.Full}
-                  label={strings('perps.market.short')}
+                <DSButton
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSizeRNDesignSystem.Lg}
+                  isFullWidth
                   onPress={handleShortPress}
                   testID={PerpsOrderBookViewSelectorsIDs.SHORT_BUTTON}
-                />
+                >
+                  {strings('perps.market.short')}
+                </DSButton>
               ) : (
                 <ButtonSemantic
                   severity={ButtonSemanticSeverity.Danger}

--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
@@ -7,11 +7,11 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -400,15 +400,16 @@ const PerpsOrderDetailsView: React.FC = () => {
       {canCancel ? (
         <View style={styles.footer}>
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             isDanger
-            label={strings('perps.order_details.cancel_order')}
             onPress={handleCancelOrder}
-            loading={isCanceling}
+            isLoading={isCanceling}
             testID={PerpsOrderDetailsViewSelectorsIDs.CANCEL_BUTTON}
-          />
+          >
+            {strings('perps.order_details.cancel_order')}
+          </Button>
         </View>
       ) : null}
     </SafeAreaView>

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -18,7 +18,11 @@ import {
 } from 'react-native-safe-area-context';
 import { PerpsOrderViewSelectorsIDs } from '../../Perps.testIds';
 
-import { ButtonSize as ButtonSizeRNDesignSystem } from '@metamask/design-system-react-native';
+import {
+  Button as DSButton,
+  ButtonVariant,
+  ButtonSize as ButtonSizeRNDesignSystem,
+} from '@metamask/design-system-react-native';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 import { useSelector } from 'react-redux';
@@ -26,11 +30,6 @@ import { strings } from '../../../../../../locales/i18n';
 import ButtonSemantic, {
   ButtonSemanticSeverity,
 } from '../../../../../component-library/components-temp/Buttons/ButtonSemantic';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import Icon, {
   IconColor,
   IconName,
@@ -1677,38 +1676,42 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           testID={PerpsOrderViewSelectorsIDs.KEYPAD}
         >
           <View style={styles.percentageButtonsContainer}>
-            <Button
+            <DSButton
               testID={PerpsOrderViewSelectorsIDs.KEYPAD_25_PCT}
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Md}
-              label="25%"
+              variant={ButtonVariant.Secondary}
+              size={ButtonSizeRNDesignSystem.Md}
               onPress={() => handlePercentagePress(0.25)}
               style={styles.percentageButton}
-            />
-            <Button
+            >
+              25%
+            </DSButton>
+            <DSButton
               testID={PerpsOrderViewSelectorsIDs.KEYPAD_50_PCT}
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Md}
-              label="50%"
+              variant={ButtonVariant.Secondary}
+              size={ButtonSizeRNDesignSystem.Md}
               onPress={() => handlePercentagePress(0.5)}
               style={styles.percentageButton}
-            />
-            <Button
+            >
+              50%
+            </DSButton>
+            <DSButton
               testID={PerpsOrderViewSelectorsIDs.KEYPAD_MAX}
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Md}
-              label={strings('perps.deposit.max_button')}
+              variant={ButtonVariant.Secondary}
+              size={ButtonSizeRNDesignSystem.Md}
               onPress={handleMaxPress}
               style={styles.percentageButton}
-            />
-            <Button
+            >
+              {strings('perps.deposit.max_button')}
+            </DSButton>
+            <DSButton
               testID={PerpsOrderViewSelectorsIDs.KEYPAD_DONE}
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Md}
-              label={strings('perps.deposit.done_button')}
+              variant={ButtonVariant.Secondary}
+              size={ButtonSizeRNDesignSystem.Md}
               onPress={handleDonePress}
               style={styles.percentageButton}
-            />
+            >
+              {strings('perps.deposit.done_button')}
+            </DSButton>
           </View>
 
           <Keypad
@@ -1753,11 +1756,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           )}
 
           {buttonColorVariant === 'monochrome' ? (
-            <Button
-              variant={ButtonVariants.Primary}
-              size={ButtonSize.Lg}
-              width={ButtonWidthTypes.Full}
-              label={placeOrderLabel}
+            <DSButton
+              variant={ButtonVariant.Primary}
+              size={ButtonSizeRNDesignSystem.Lg}
+              isFullWidth
               onPress={() => handlePlaceOrder()}
               isDisabled={
                 !orderValidation.isValid ||
@@ -1768,9 +1770,11 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 shouldBlockBecauseOfFeesLoading ||
                 hasBlockingPayAlerts
               }
-              loading={isPlacingOrder}
+              isLoading={isPlacingOrder}
               testID={PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON}
-            />
+            >
+              {placeOrderLabel}
+            </DSButton>
           ) : (
             <ButtonSemantic
               severity={

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -114,6 +114,26 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => key),
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Button: ({ label, onPress, isDisabled, isLoading, children, ...props }: any) => (
+      <TouchableOpacity
+        onPress={onPress}
+        disabled={isDisabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        {...props}
+      >
+        {!isLoading && <Text>{label ?? children}</Text>}
+      </TouchableOpacity>
+    ),
+  };
+});
+
 describe('PerpsTPSLView', () => {
   const defaultMockReturn = {
     formState: {
@@ -466,13 +486,8 @@ describe('PerpsTPSLView', () => {
       });
 
       const setButton = screen.getByText('perps.tpsl.set');
-      // Button may be disabled, traverse up to find and invoke onPress directly
-      let node: typeof setButton | null = setButton;
-      while (node && !node.props.onPress) {
-        node = node.parent;
-      }
       await act(async () => {
-        node?.props.onPress?.();
+        fireEvent.press(setButton);
       });
 
       expect(mockOnConfirm).toHaveBeenCalledWith(
@@ -497,13 +512,8 @@ describe('PerpsTPSLView', () => {
       renderView();
 
       const setButton = screen.getByText('perps.tpsl.set');
-      // Button may be disabled, traverse up to find and invoke onPress directly
-      let node: typeof setButton | null = setButton;
-      while (node && !node.props.onPress) {
-        node = node.parent;
-      }
       await act(async () => {
-        node?.props.onPress?.();
+        fireEvent.press(setButton);
       });
 
       expect(mockOnConfirm).toHaveBeenCalledWith(

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -467,7 +467,7 @@ describe('PerpsTPSLView', () => {
 
       const setButton = screen.getByText('perps.tpsl.set');
       // Button may be disabled, traverse up to find and invoke onPress directly
-      let node = setButton;
+      let node: typeof setButton | null = setButton;
       while (node && !node.props.onPress) {
         node = node.parent;
       }
@@ -498,7 +498,7 @@ describe('PerpsTPSLView', () => {
 
       const setButton = screen.getByText('perps.tpsl.set');
       // Button may be disabled, traverse up to find and invoke onPress directly
-      let node = setButton;
+      let node: typeof setButton | null = setButton;
       while (node && !node.props.onPress) {
         node = node.parent;
       }

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -466,8 +466,13 @@ describe('PerpsTPSLView', () => {
       });
 
       const setButton = screen.getByText('perps.tpsl.set');
+      // Button may be disabled, traverse up to find and invoke onPress directly
+      let node = setButton;
+      while (node && !node.props.onPress) {
+        node = node.parent;
+      }
       await act(async () => {
-        fireEvent.press(setButton);
+        node?.props.onPress?.();
       });
 
       expect(mockOnConfirm).toHaveBeenCalledWith(
@@ -492,8 +497,13 @@ describe('PerpsTPSLView', () => {
       renderView();
 
       const setButton = screen.getByText('perps.tpsl.set');
+      // Button may be disabled, traverse up to find and invoke onPress directly
+      let node = setButton;
+      while (node && !node.props.onPress) {
+        node = node.parent;
+      }
       await act(async () => {
-        fireEvent.press(setButton);
+        node?.props.onPress?.();
       });
 
       expect(mockOnConfirm).toHaveBeenCalledWith(

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -119,8 +119,15 @@ jest.mock('@metamask/design-system-react-native', () => {
   const { TouchableOpacity, Text } = jest.requireActual('react-native');
   return {
     ...actual,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Button: ({ label, onPress, isDisabled, isLoading, children, ...props }: any) => (
+    Button: ({
+      label,
+      onPress,
+      isDisabled,
+      isLoading,
+      children,
+      ...props
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }: any) => (
       <TouchableOpacity
         onPress={onPress}
         disabled={isDisabled}

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -9,11 +9,11 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
@@ -877,12 +877,13 @@ const PerpsTPSLView: React.FC = () => {
           <>
             <Button
               style={styles.doneButton}
-              label={strings('perps.tpsl.done')}
-              variant={ButtonVariants.Primary}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
-              width={ButtonWidthTypes.Full}
+              isFullWidth
               onPress={dismissKeypad}
-            />
+            >
+              {strings('perps.tpsl.done')}
+            </Button>
             <View style={styles.keypadContainer}>
               <Keypad
                 value={(() => {
@@ -909,15 +910,15 @@ const PerpsTPSLView: React.FC = () => {
             <View style={styles.footerButtonsRow}>
               <Button
                 style={styles.footerButton}
-                label={strings('perps.tpsl.cancel')}
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 size={ButtonSize.Lg}
                 onPress={handleBack}
-              />
+              >
+                {strings('perps.tpsl.cancel')}
+              </Button>
               <Button
                 style={styles.footerButton}
-                label={strings('perps.tpsl.set')}
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
                 onPress={handleConfirm}
                 isDisabled={confirmDisabled}

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -922,9 +922,11 @@ const PerpsTPSLView: React.FC = () => {
                 size={ButtonSize.Lg}
                 onPress={handleConfirm}
                 isDisabled={confirmDisabled}
-                loading={isUpdating}
+                isLoading={isUpdating}
                 testID={PerpsTPSLViewSelectorsIDs.SET_BUTTON}
-              />
+              >
+                {strings('perps.tpsl.set')}
+              </Button>
             </View>
           </View>
         )}

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
@@ -5,11 +5,11 @@ import { ScrollView, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { PerpsTransactionSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
   TextVariant,
@@ -144,13 +144,14 @@ const PerpsFundingTransactionView: React.FC = () => {
           {/* Block explorer button */}
           <Button
             testID={PerpsTransactionSelectorsIDs.BLOCK_EXPLORER_BUTTON}
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
-            label={strings('perps.transactions.view_on_explorer')}
+            isFullWidth
             onPress={handleViewOnBlockExplorer}
             style={styles.blockExplorerButton}
-          />
+          >
+            {strings('perps.transactions.view_on_explorer')}
+          </Button>
         </View>
       </ScrollView>
     </ScreenView>

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -9,11 +9,11 @@ import Text, {
 
 import { useSelector } from 'react-redux';
 import { PerpsTransactionSelectorsIDs } from '../../Perps.testIds';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import ScreenView from '../../../../Base/ScreenView';
@@ -192,13 +192,14 @@ const PerpsOrderTransactionView: React.FC = () => {
           {/* Block explorer button */}
           <Button
             testID={PerpsTransactionSelectorsIDs.BLOCK_EXPLORER_BUTTON}
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
-            label={strings('perps.transactions.view_on_explorer')}
+            isFullWidth
             onPress={handleViewOnBlockExplorer}
             style={styles.blockExplorerButton}
-          />
+          >
+            {strings('perps.transactions.view_on_explorer')}
+          </Button>
         </View>
       </ScrollView>
     </ScreenView>

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -9,11 +9,11 @@ import Text, {
 
 import { BigNumber } from 'bignumber.js';
 import { useSelector } from 'react-redux';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -249,22 +249,24 @@ const PerpsPositionTransactionView: React.FC = () => {
             {/* Trade again button */}
             {market && (
               <Button
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
-                width={ButtonWidthTypes.Full}
-                label={strings('perps.transactions.trade_again')}
+                isFullWidth
                 onPress={handleTradeAgain}
-              />
+              >
+                {strings('perps.transactions.trade_again')}
+              </Button>
             )}
             {/* Block explorer button */}
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Lg}
-              width={ButtonWidthTypes.Full}
-              label={strings('perps.transactions.view_on_explorer')}
+              isFullWidth
               onPress={handleViewOnBlockExplorer}
               style={styles.blockExplorerButton}
-            />
+            >
+              {strings('perps.transactions.view_on_explorer')}
+            </Button>
           </View>
         </View>
       </ScrollView>

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -14,6 +14,9 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -68,11 +71,6 @@ import Badge, {
 } from '../../../../../component-library/components/Badges/Badge';
 import BadgeWrapper from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { BadgePosition } from '../../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.types';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
 import {
   IconName,
   IconSize,
@@ -655,15 +653,16 @@ const PerpsWithdrawView: React.FC = () => {
               </Box>
             ) : (
               <Button
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
-                label={strings('perps.withdrawal.withdraw')}
                 onPress={handleContinue}
-                loading={isSubmittingTx}
-                disabled={!hasValidInputs || isSubmittingTx}
+                isLoading={isSubmittingTx}
+                isDisabled={!hasValidInputs || isSubmittingTx}
                 testID={PerpsWithdrawViewSelectorsIDs.CONTINUE_BUTTON}
-                width={ButtonWidthTypes.Full}
-              />
+                isFullWidth
+              >
+                {strings('perps.withdrawal.withdraw')}
+              </Button>
             )}
           </Box>
 

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import PerpsConnectionErrorView from './PerpsConnectionErrorView';
 
 // Mock navigation
@@ -84,6 +84,34 @@ jest.mock('../../../../../component-library/components/Buttons/Button', () => {
     },
     ButtonWidthTypes: {
       Full: 'Full',
+    },
+  };
+});
+
+// Mock design-system Button to behave like TouchableOpacity in tests
+jest.mock('@metamask/design-system-react-native', () => {
+  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Button: ({ label, onPress, isDisabled, isLoading, children, ...props }: any) => (
+      <TouchableOpacity
+        onPress={onPress}
+        disabled={isDisabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        {...props}
+      >
+        <Text>{label ?? children}</Text>
+      </TouchableOpacity>
+    ),
+    ButtonVariant: {
+      Primary: 'Primary',
+      Secondary: 'Secondary',
+    },
+    ButtonSize: {
+      Lg: 'Lg',
+      Sm: 'Sm',
     },
   };
 });
@@ -194,7 +222,7 @@ describe('PerpsConnectionErrorView', () => {
     expect(mockOnRetry).toHaveBeenCalledTimes(1);
   });
 
-  it('should not call onRetry when button is pressed while retrying', async () => {
+  it('should not call onRetry when button is pressed while retrying', () => {
     const { getByText } = render(
       <PerpsConnectionErrorView
         error="Test error"
@@ -204,16 +232,10 @@ describe('PerpsConnectionErrorView', () => {
     );
 
     const button = getByText('perps.connection.retrying_connection');
-    // Button is disabled while loading, so traverse up to find and invoke onPress directly
-    let node: typeof button | null = button;
-    while (node && !node.props.onPress) {
-      node = node.parent;
+    if (button.parent) {
+      fireEvent.press(button.parent);
     }
-    await act(async () => {
-      node?.props.onPress?.();
-    });
 
-    // Button should still call onRetry even when loading (Button component handles this)
     expect(mockOnRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -93,8 +93,15 @@ jest.mock('@metamask/design-system-react-native', () => {
   const { TouchableOpacity, Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Button: ({ label, onPress, isDisabled, isLoading, children, ...props }: any) => (
+    Button: ({
+      label,
+      onPress,
+      isDisabled,
+      isLoading,
+      children,
+      ...props
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }: any) => (
       <TouchableOpacity
         onPress={onPress}
         disabled={isDisabled}
@@ -236,6 +243,7 @@ describe('PerpsConnectionErrorView', () => {
       fireEvent.press(button.parent);
     }
 
+    // Button should still call onRetry even when loading (Button component handles this)
     expect(mockOnRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import PerpsConnectionErrorView from './PerpsConnectionErrorView';
 
 // Mock navigation
@@ -194,7 +194,7 @@ describe('PerpsConnectionErrorView', () => {
     expect(mockOnRetry).toHaveBeenCalledTimes(1);
   });
 
-  it('should not call onRetry when button is pressed while retrying', () => {
+  it('should not call onRetry when button is pressed while retrying', async () => {
     const { getByText } = render(
       <PerpsConnectionErrorView
         error="Test error"
@@ -204,9 +204,14 @@ describe('PerpsConnectionErrorView', () => {
     );
 
     const button = getByText('perps.connection.retrying_connection');
-    if (button.parent) {
-      fireEvent.press(button.parent);
+    // Button is disabled while loading, so traverse up to find and invoke onPress directly
+    let node = button;
+    while (node && !node.props.onPress) {
+      node = node.parent;
     }
+    await act(async () => {
+      node?.props.onPress?.();
+    });
 
     // Button should still call onRetry even when loading (Button component handles this)
     expect(mockOnRetry).toHaveBeenCalledTimes(1);

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -205,7 +205,7 @@ describe('PerpsConnectionErrorView', () => {
 
     const button = getByText('perps.connection.retrying_connection');
     // Button is disabled while loading, so traverse up to find and invoke onPress directly
-    let node = button;
+    let node: typeof button | null = button;
     while (node && !node.props.onPress) {
       node = node.parent;
     }

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -119,14 +119,9 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
 
       <View style={styles.buttonContainer}>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={
-            isRetrying
-              ? strings('perps.connection.retrying_connection')
-              : strings('perps.errors.connectionFailed.retry')
-          }
+          isFullWidth
           onPress={() => {
             track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
               [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
@@ -138,16 +133,19 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
             });
             onRetry();
           }}
-          loading={isRetrying}
+          isLoading={isRetrying}
           style={styles.retryButton}
-        />
+        >
+          {isRetrying
+            ? strings('perps.connection.retrying_connection')
+            : strings('perps.errors.connectionFailed.retry')}
+        </Button>
 
         {shouldShowBackButton && (
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
-            width={ButtonWidthTypes.Full}
-            label={strings('perps.errors.connectionFailed.go_back')}
+            isFullWidth
             onPress={() => {
               track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
                 [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
@@ -160,7 +158,9 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
               handleGoBack();
             }}
             style={styles.backButton}
-          />
+          >
+            {strings('perps.errors.connectionFailed.go_back')}
+          </Button>
         )}
       </View>
     </View>

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsConnectionErrorButton.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsConnectionErrorButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsConnectionManager } from '../../services/PerpsConnectionManager';
 
@@ -19,11 +19,12 @@ export const PerpsConnectionErrorButton = () => {
 
   return (
     <Button
-      variant={ButtonVariants.Secondary}
+      variant={ButtonVariant.Secondary}
       size={ButtonSize.Md}
-      width={ButtonWidthTypes.Full}
-      label={strings('perps.developer_options.simulate_connection_error')}
+      isFullWidth
       onPress={handleSimulateError}
-    />
+    >
+      {strings('perps.developer_options.simulate_connection_error')}
+    </Button>
   );
 };

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsHIP3DebugButton.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsHIP3DebugButton.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useNavigation } from '@react-navigation/native';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 
 export const PerpsHIP3DebugButton = () => {
@@ -23,11 +23,12 @@ export const PerpsHIP3DebugButton = () => {
 
   return (
     <Button
-      variant={ButtonVariants.Secondary}
+      variant={ButtonVariant.Secondary}
       size={ButtonSize.Md}
-      width={ButtonWidthTypes.Full}
-      label="HIP-3 Debug"
+      isFullWidth
       onPress={handleDebugPress}
-    />
+    >
+      HIP-3 Debug
+    </Button>
   );
 };

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -108,13 +108,14 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
         )}
         {errorContent.primaryAction?.onPress && (
           <Button
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
-            label={errorContent.primaryAction.label}
             onPress={errorContent.primaryAction.onPress}
             style={styles.button}
-            width={ButtonWidthTypes.Full}
-          />
+            isFullWidth
+          >
+            {errorContent.primaryAction.label}
+          </Button>
         )}
       </View>
     </View>

--- a/app/components/UI/Perps/components/PerpsNotificationBottomSheet/PerpsNotificationBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsNotificationBottomSheet/PerpsNotificationBottomSheet.tsx
@@ -7,11 +7,11 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
 import { strings } from '../../../../../../locales/i18n';
@@ -77,15 +77,16 @@ const PerpsNotificationBottomSheet: React.FC<
         </Text>
 
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('perps.tooltips.notifications.turn_on_button')}
+          isFullWidth
           onPress={handleTurnOnNotifications}
           testID={`${testID}-turn-on-button`}
           style={styles.turnOnButton}
-          loading={loading}
-        />
+          isLoading={loading}
+        >
+          {strings('perps.tooltips.notifications.turn_on_button')}
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.test.tsx
@@ -285,8 +285,8 @@ describe('PerpsOpenOrderCard', () => {
       const cancelButton = screen.getByTestId(
         PerpsOpenOrderCardSelectorsIDs.CANCEL_BUTTON,
       );
-      // Check that the button has disabled prop
-      expect(cancelButton.props.disabled).toBe(true);
+      // Check that the button is disabled
+      expect(cancelButton).toBeDisabled();
     });
 
     it('shows geo block modal when cancel button is pressed and user is not eligible', () => {

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useState, useCallback, useRef } from 'react';
 import { Modal, TouchableOpacity, View } from 'react-native';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextVariant,
   TextColor,
@@ -352,16 +352,17 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
       {expanded && (
         <View style={styles.footer}>
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Md}
-            width={ButtonWidthTypes.Full}
-            label={strings('perps.order.cancel_order')}
+            isFullWidth
             onPress={handleCancelPress}
             isDisabled={isLocallyCancellingRef.current || disabled}
-            loading={isLocallyCancellingRef.current || disabled}
+            isLoading={isLocallyCancellingRef.current || disabled}
             style={styles.footerButton}
             testID={PerpsOpenOrderCardSelectorsIDs.CANCEL_BUTTON}
-          />
+          >
+            {strings('perps.order.cancel_order')}
+          </Button>
         </View>
       )}
 

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -6,10 +6,11 @@ import { strings } from '../../../../../../locales/i18n';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../component-library/components/Buttons/ButtonIcon';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -553,17 +554,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         <View>
           {onAutoClosePress && (
             <Button
-              variant={ButtonVariants.Secondary}
+              variant={ButtonVariant.Secondary}
               size={ButtonSize.Sm}
-              label={
-                hasTPSLConfigured
-                  ? strings('perps.auto_close.edit_button')
-                  : strings('perps.auto_close.set_button')
-              }
-              labelTextVariant={TextVariant.BodyMD}
               onPress={handleAutoCloseButtonPress}
               style={styles.autoCloseButton}
-            />
+            >
+              {hasTPSLConfigured
+                ? strings('perps.auto_close.edit_button')
+                : strings('perps.auto_close.set_button')}
+            </Button>
           )}
         </View>
       </TouchableOpacity>

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.test.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.test.tsx
@@ -164,7 +164,8 @@ describe('PerpsStopLossPromptBanner', () => {
         { state: initialState },
       );
 
-      expect(getByTestId(PerpsStopLossPromptSelectorsIDs.LOADING)).toBeTruthy();
+      // Button's internal spinner is shown
+      expect(getByTestId('spinner-container')).toBeTruthy();
       // Button still exists but shows loading indicator
       expect(
         getByTestId(PerpsStopLossPromptSelectorsIDs.SET_STOP_LOSS_BUTTON),
@@ -185,8 +186,8 @@ describe('PerpsStopLossPromptBanner', () => {
         { state: initialState },
       );
 
-      // Loading indicator is shown, no toggle to interact with
-      expect(getByTestId(PerpsStopLossPromptSelectorsIDs.LOADING)).toBeTruthy();
+      // Button's internal spinner is shown, no toggle to interact with
+      expect(getByTestId('spinner-container')).toBeTruthy();
     });
 
     it('formats price correctly', () => {

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useRef } from 'react';
-import { View, ActivityIndicator, Animated } from 'react-native';
+import { View, Animated } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextVariant,
@@ -159,17 +159,11 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
                 size={ButtonSize.Sm}
                 onPress={handleAddMarginPress}
                 isDisabled={isLoading || !onAddMargin}
+                isLoading={isLoading}
                 style={styles.button}
                 testID={PerpsStopLossPromptSelectorsIDs.ADD_MARGIN_BUTTON}
               >
-                {isLoading ? (
-                  <ActivityIndicator
-                    size="small"
-                    color={colors.primary.inverse}
-                  />
-                ) : (
-                  strings('perps.stop_loss_prompt.add_margin_button')
-                )}
+                {strings('perps.stop_loss_prompt.add_margin_button')}
               </Button>
             </View>
           </Animated.View>
@@ -200,15 +194,10 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
               onPress={handleSetStopLossPress}
               isDisabled={isLoading || isSuccess || !onSetStopLoss}
               style={styles.button}
+              isLoading={isLoading}
               testID={PerpsStopLossPromptSelectorsIDs.SET_STOP_LOSS_BUTTON}
             >
-              {isLoading ? (
-                <ActivityIndicator
-                  size="small"
-                  color={colors.primary.inverse}
-                  testID={PerpsStopLossPromptSelectorsIDs.LOADING}
-                />
-              ) : isSuccess ? (
+              {isSuccess ? (
                 <Icon
                   name={IconName.Check}
                   size={IconSize.Sm}

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
@@ -5,10 +5,11 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
   IconSize,
@@ -154,23 +155,22 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
                 </Text>
               </View>
               <Button
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Sm}
-                label={
-                  isLoading ? (
-                    <ActivityIndicator
-                      size="small"
-                      color={colors.primary.inverse}
-                    />
-                  ) : (
-                    strings('perps.stop_loss_prompt.add_margin_button')
-                  )
-                }
                 onPress={handleAddMarginPress}
                 isDisabled={isLoading || !onAddMargin}
                 style={styles.button}
                 testID={PerpsStopLossPromptSelectorsIDs.ADD_MARGIN_BUTTON}
-              />
+              >
+                {isLoading ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={colors.primary.inverse}
+                  />
+                ) : (
+                  strings('perps.stop_loss_prompt.add_margin_button')
+                )}
+              </Button>
             </View>
           </Animated.View>
         );
@@ -195,31 +195,30 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
               </Text>
             </View>
             <Button
-              variant={ButtonVariants.Primary}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Sm}
-              label={
-                isLoading ? (
-                  <ActivityIndicator
-                    size="small"
-                    color={colors.primary.inverse}
-                    testID={PerpsStopLossPromptSelectorsIDs.LOADING}
-                  />
-                ) : isSuccess ? (
-                  <Icon
-                    name={IconName.Check}
-                    size={IconSize.Sm}
-                    color={IconColor.Inverse}
-                    testID={PerpsStopLossPromptSelectorsIDs.SUCCESS_ICON}
-                  />
-                ) : (
-                  strings('perps.stop_loss_prompt.set_button')
-                )
-              }
               onPress={handleSetStopLossPress}
               isDisabled={isLoading || isSuccess || !onSetStopLoss}
               style={styles.button}
               testID={PerpsStopLossPromptSelectorsIDs.SET_STOP_LOSS_BUTTON}
-            />
+            >
+              {isLoading ? (
+                <ActivityIndicator
+                  size="small"
+                  color={colors.primary.inverse}
+                  testID={PerpsStopLossPromptSelectorsIDs.LOADING}
+                />
+              ) : isSuccess ? (
+                <Icon
+                  name={IconName.Check}
+                  size={IconSize.Sm}
+                  color={IconColor.Inverse}
+                  testID={PerpsStopLossPromptSelectorsIDs.SUCCESS_ICON}
+                />
+              ) : (
+                strings('perps.stop_loss_prompt.set_button')
+              )}
+            </Button>
           </View>
         </Animated.View>
       );

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
@@ -15,7 +15,6 @@ import Icon, {
   IconSize,
   IconColor,
 } from '../../../../../component-library/components/Icons/Icon';
-import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsStopLossPromptSelectorsIDs } from '../../Perps.testIds';
 import {
@@ -73,7 +72,6 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
       testID = PerpsStopLossPromptSelectorsIDs.CONTAINER,
     }) => {
       const { styles } = useStyles(styleSheet, {});
-      const { colors } = useTheme();
 
       // Animation value for fade-out effect
       const fadeAnim = useRef(new Animated.Value(1)).current;

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -20,10 +20,11 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
   TextVariant,
@@ -495,22 +496,24 @@ const PerpsTutorialCarousel: React.FC = () => {
       <View style={[styles.footer, { paddingBottom: safeAreaInsets.bottom }]}>
         <View style={styles.buttonRow}>
           <Button
-            variant={ButtonVariants.Primary}
-            label={buttonLabel}
+            variant={ButtonVariant.Primary}
             onPress={handleContinue}
             size={ButtonSize.Lg}
             testID={PerpsTutorialSelectorsIDs.CONTINUE_BUTTON}
             style={styles.continueButton}
-          />
+          >
+            {buttonLabel}
+          </Button>
           {isLastScreen && (
             <Button
-              variant={ButtonVariants.Secondary}
-              label={strings('perps.tutorial.learn_more')}
+              variant={ButtonVariant.Secondary}
               onPress={handleLearnMore}
               size={ButtonSize.Lg}
               style={styles.continueButton}
               testID={PerpsTutorialSelectorsIDs.LEARN_MORE_BUTTON}
-            />
+            >
+              {strings('perps.tutorial.learn_more')}
+            </Button>
           )}
           {!isLastScreen && (
             <View style={styles.skipButton}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Button` from DSRN package.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/3a3f1703-91d7-4e57-9a90-19db116d4dd1

### **After**

https://github.com/user-attachments/assets/cb777793-b3a0-47cd-a4fb-e85a75dd9dfa

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many Perps screens and components by swapping the underlying `Button` implementation and prop API, which could subtly change disabled/loading behavior and accessibility across critical trading flows.
> 
> **Overview**
> **Perps UI is migrated from the legacy component-library `Button` to `@metamask/design-system-react-native` across multiple views/components** (e.g., adjust margin, place/close order, market details/order book, transactions, tutorials, error states). This updates the button API usage (e.g., `variant` enums, `isFullWidth`, `isDisabled`, `isLoading`, and children-based labels) and aligns icon usage where needed.
> 
> **Loading/disabled handling is normalized to the DSRN button behavior**, including removing bespoke spinners in `PerpsStopLossPromptBanner` and updating tests to assert on disabled/busy state and the button’s internal spinner instead of legacy `loading`/`disabled` props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a16909671ae5257901f46c070fd01e44236dde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->