### PR TITLE
fix(musd): fix inconsistent rounding in Max Convert bottom sheet

### DIFF
--- a/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
+++ b/app/components/Views/confirmations/components/info/musd-max-conversion-info/musd-max-conversion-info.tsx
@@ -97,7 +97,7 @@ export const MusdMaxConversionInfo = () => {
       <View style={styles.detailsSection}>
         <TokenConversionRateRow />
         <BridgeFeeRow />
-        <TotalRow />
+        <TotalRow excludeFees />
         <PercentageRow />
       </View>
       <BlockingAlertMessage />

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -15,8 +15,8 @@ jest.mock('../../../hooks/pay/useTransactionPayData');
 
 const TOTAL_FIAT_MOCK = '$123.46';
 
-function render() {
-  return renderWithProvider(<TotalRow />, {
+function render({ excludeFees }: { excludeFees?: boolean } = {}) {
+  return renderWithProvider(<TotalRow excludeFees={excludeFees} />, {
     state: merge(
       {},
       simpleSendTransactionControllerMock,
@@ -53,5 +53,15 @@ describe('TotalRow', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('total-row-skeleton')).toBeDefined();
+  });
+
+  it('renders targetAmount when excludeFees is true', () => {
+    useTransactionPayTotalsMock.mockReturnValue({
+      total: { usd: '100.456' },
+      targetAmount: { usd: '200.456' },
+    } as TransactionPayTotals);
+
+    const { getByText } = render({ excludeFees: true });
+    expect(getByText('$200.46')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -19,15 +19,16 @@ import { ConfirmationRowComponentIDs } from '../../../ConfirmationView.testIds';
  * Row component that displays the total cost for deposit/payment transactions.
  * For withdrawal transactions, use ReceiveRow instead.
  */
-export function TotalRow() {
+export function TotalRow({ excludeFees }: { excludeFees?: boolean } = {}) {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const totals = useTransactionPayTotals();
 
   const totalUsd = useMemo(() => {
-    if (!totals?.total) return '';
-    return formatFiat(new BigNumber(totals.total.usd));
-  }, [totals, formatFiat]);
+    const rawUsd = excludeFees ? totals?.targetAmount?.usd : totals?.total?.usd;
+    if (!rawUsd) return '';
+    return formatFiat(new BigNumber(rawUsd));
+  }, [totals, excludeFees, formatFiat]);
 
   if (isLoading) {
     return <InfoRowSkeleton testId="total-row-skeleton" />;


### PR DESCRIPTION
## **Description**

The Total row in the mUSD Max Convert bottom sheet displayed a lower amount ($183.36) than the header amounts ($183.64) for the same conversion. This caused confusion as users expected the total to match the 1:1 USDC→mUSD conversion shown above.

**Root cause:** The `TotalRow` component reads `totals.total.usd`, which is computed by `@metamask/transaction-pay-controller` using market-price-based token valuation. The header reads `totals.targetAmount.usd`, which uses stablecoin face value ($1.00 per token) via a stablecoin override in the Relay quote normalizer. When mUSD trades slightly below peg (~$0.9985), the market-price total diverges from the face-value header.

**Fix:** Added an `excludeFees` prop to `TotalRow`. When enabled, it reads `totals.targetAmount.usd` (face value) instead of `totals.total.usd`, ensuring the total matches the header for mUSD max conversions.

## **Changelog**

CHANGELOG entry: Fixed inconsistent total amount in mUSD Max Convert bottom sheet

## **Related issues**

Fixes: MUSD-355

## **Manual testing steps**

```gherkin
Feature: mUSD Max Convert total consistency

  Scenario: Total matches header amounts in Max Convert
    Given user has USDC balance and is on the mUSD conversion screen

    When user taps Max to convert all USDC to mUSD
    Then the Total amount in the bottom sheet matches the USDC and mUSD amounts shown in the header
```

## **Screenshots/Recordings**

### **Before**

Header shows $183.64 for both USDC and mUSD, but Total shows $183.36.

### **After**

Total now matches the header amounts exactly.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.