### PR TITLE
feat(swaps): add verified badges to asset picker

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -426,7 +426,12 @@ jest.mock('../TokenSelectorItem', () => ({
     onPress,
     children,
   }: {
-    token: { symbol: string; address: string; chainId: string };
+    token: {
+      symbol: string;
+      address: string;
+      chainId: string;
+      isVerified?: boolean;
+    };
     onPress: (token: {
       symbol: string;
       address: string;
@@ -440,6 +445,13 @@ jest.mock('../TokenSelectorItem', () => ({
       TouchableOpacity,
       { onPress: () => onPress(token), testID: `token-${token.symbol}` },
       createElement(Text, null, token.symbol),
+      token.isVerified
+        ? createElement(
+            Text,
+            { testID: `verified-${token.symbol}` },
+            'verified',
+          )
+        : null,
       createElement(View, null, children),
     );
   },
@@ -561,10 +573,14 @@ describe('tokenToIncludeAsset', () => {
   });
 });
 
-const createSearchToken = (symbol: string) =>
+const createSearchToken = (
+  symbol: string,
+  overrides: Partial<ReturnType<typeof createMockPopularToken>> = {},
+) =>
   createMockPopularToken({
     assetId: `eip155:1/erc20:0x${symbol.toLowerCase()}` as never,
     symbol,
+    ...overrides,
   });
 
 describe('BridgeTokenSelector', () => {
@@ -628,6 +644,23 @@ describe('BridgeTokenSelector', () => {
       );
       await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
     });
+
+    it('passes verified popular tokens through to selector rows', async () => {
+      mockPopularTokensState = {
+        popularTokens: [
+          createMockPopularToken({
+            symbol: 'ETH',
+            name: 'Ethereum',
+            isVerified: true,
+          }),
+        ],
+        isLoading: false,
+      };
+
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+
+      await waitFor(() => expect(getByTestId('verified-ETH')).toBeTruthy());
+    });
   });
 
   describe('search', () => {
@@ -646,6 +679,19 @@ describe('BridgeTokenSelector', () => {
       const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
       fireEvent.changeText(getByTestId('bridge-token-search-input'), 'WET');
       await waitFor(() => expect(getByTestId('token-WETH')).toBeTruthy());
+    });
+
+    it('passes verified search results through to selector rows', async () => {
+      mockSearchTokensState = {
+        ...mockSearchTokensState,
+        searchResults: [createSearchToken('WETH', { isVerified: true })],
+        currentSearchQuery: 'WET',
+      };
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+
+      fireEvent.changeText(getByTestId('bridge-token-search-input'), 'WET');
+
+      await waitFor(() => expect(getByTestId('verified-WETH')).toBeTruthy());
     });
 
     it('clears search when clear button is pressed', async () => {

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -78,18 +78,28 @@ jest.mock('../../../../component-library/components/Avatars/Avatar', () => ({
   AvatarSize: { Md: 'Md' },
 }));
 
-jest.mock('../../../../component-library/components/Icons/Icon', () => {
+jest.mock('@metamask/design-system-react-native', () => {
   const { createElement } = jest.requireActual('react');
   const { Text } = jest.requireActual('react-native');
+  const Icon = jest.fn(({ testID, name }: { testID?: string; name: string }) =>
+    createElement(Text, { testID }, name),
+  );
   return {
     __esModule: true,
-    default: ({ testID, name }: { testID?: string; name: string }) =>
-      createElement(Text, { testID }, name),
-    IconColor: { Info: 'Info' },
+    default: Icon,
+    Icon,
+    __mockIcon: Icon,
+    IconColor: { InfoDefault: 'InfoDefault' },
     IconName: { VerifiedFilled: 'VerifiedFilled' },
-    IconSize: { Xs: 'Xs' },
+    IconSize: { Sm: 'Sm' },
   };
 });
+
+const { __mockIcon: mockDSIcon } = jest.requireMock(
+  '@metamask/design-system-react-native',
+) as {
+  __mockIcon: jest.Mock;
+};
 
 jest.mock('../../../../component-library/base-components/TagBase', () => {
   const { createElement } = jest.requireActual('react');
@@ -210,6 +220,15 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(getByTestId('token-verified-icon-ETH')).toBeTruthy();
+      expect(mockDSIcon).toHaveBeenCalled();
+      expect(mockDSIcon.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          testID: 'token-verified-icon-ETH',
+          name: 'VerifiedFilled',
+          size: 'Sm',
+          color: 'InfoDefault',
+        }),
+      );
     });
 
     it('does not render verified icon when token is not verified', () => {
@@ -223,6 +242,7 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(queryByTestId('token-verified-icon-ETH')).toBeNull();
+      expect(mockDSIcon).not.toHaveBeenCalled();
     });
 
     it('renders verified icon alongside no fee badge', () => {

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -41,6 +41,10 @@ jest.mock('../../../../component-library/hooks', () => ({
       badgeWrapper: {},
       noFeeBadge: {},
       selectedItemWrapperReset: {},
+      tokenSymbolRow: {},
+      tokenSymbol: {},
+      verifiedIcon: {},
+      childrenWrapper: {},
     },
   }),
 }));
@@ -73,6 +77,19 @@ jest.mock(
 jest.mock('../../../../component-library/components/Avatars/Avatar', () => ({
   AvatarSize: { Md: 'Md' },
 }));
+
+jest.mock('../../../../component-library/components/Icons/Icon', () => {
+  const { createElement } = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID, name }: { testID?: string; name: string }) =>
+      createElement(Text, { testID }, name),
+    IconColor: { Info: 'Info' },
+    IconName: { VerifiedFilled: 'VerifiedFilled' },
+    IconSize: { Xs: 'Xs' },
+  };
+});
 
 jest.mock('../../../../component-library/base-components/TagBase', () => {
   const { createElement } = jest.requireActual('react');
@@ -179,6 +196,46 @@ describe('TokenSelectorItem', () => {
         <TokenSelectorItem token={token} onPress={mockOnPress} isNoFeeAsset />,
       );
 
+      expect(getByText('No MM Fee')).toBeTruthy();
+    });
+
+    it('renders verified icon when token is verified', () => {
+      const token = createMockTokenWithBalance({
+        symbol: 'ETH',
+        isVerified: true,
+      });
+
+      const { getByTestId } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      expect(getByTestId('token-verified-icon-ETH')).toBeTruthy();
+    });
+
+    it('does not render verified icon when token is not verified', () => {
+      const token = createMockTokenWithBalance({
+        symbol: 'ETH',
+        isVerified: false,
+      });
+
+      const { queryByTestId } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      expect(queryByTestId('token-verified-icon-ETH')).toBeNull();
+    });
+
+    it('renders verified icon alongside no fee badge', () => {
+      const token = createMockTokenWithBalance({
+        symbol: 'ETH',
+        isVerified: true,
+      });
+
+      const { getByTestId, getByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} isNoFeeAsset />,
+      );
+
+      expect(getByTestId('token-verified-icon-ETH')).toBeTruthy();
       expect(getByText('No MM Fee')).toBeTruthy();
     });
 

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -110,7 +110,6 @@ const createStyles = ({
       alignItems: 'center',
       flexShrink: 1,
       minWidth: 0,
-      marginRight: 4,
     },
     tokenSymbol: {
       flexShrink: 1,

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -28,10 +28,6 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-} from '../../../../component-library/components/Icons/Icon';
 import { Box } from '../../Box/Box';
 import { ethers } from 'ethers';
 import { AlignItems, FlexDirection, JustifyContent } from '../../Box/box.types';
@@ -58,6 +54,12 @@ import {
   TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
   TokenSelectorBalanceLayoutVariant,
 } from './TokenSelectorItem.abTestConfig';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 
 const createStyles = ({
   theme,
@@ -377,6 +379,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                       testID={`token-verified-icon-${token.symbol}`}
                       name={IconName.VerifiedFilled}
                       size={IconSize.Sm}
+                      color={IconColor.InfoDefault}
                       style={styles.verifiedIcon}
                     />
                   )}

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -28,6 +28,10 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../component-library/components/Texts/Text';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../component-library/components/Icons/Icon';
 import { Box } from '../../Box/Box';
 import { ethers } from 'ethers';
 import { AlignItems, FlexDirection, JustifyContent } from '../../Box/box.types';
@@ -98,6 +102,21 @@ const createStyles = ({
       flexShrink: 1,
       minWidth: 0,
       marginRight: 8,
+    },
+    tokenSymbolRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flexShrink: 1,
+      minWidth: 0,
+      marginRight: 4,
+    },
+    tokenSymbol: {
+      flexShrink: 1,
+      minWidth: 0,
+    },
+    verifiedIcon: {
+      marginLeft: 4,
+      flexShrink: 0,
     },
     rightValue: {
       flexShrink: 0,
@@ -344,13 +363,24 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
               justifyContent={JustifyContent.spaceBetween}
             >
               <Box style={styles.tokenMainInfo} gap={4}>
-                <Text
-                  variant={TextVariant.BodyMDMedium}
-                  numberOfLines={1}
-                  ellipsizeMode="tail"
-                >
-                  {token.symbol}
-                </Text>
+                <Box style={styles.tokenSymbolRow}>
+                  <Text
+                    variant={TextVariant.BodyMDMedium}
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                    style={styles.tokenSymbol}
+                  >
+                    {token.symbol}
+                  </Text>
+                  {token.isVerified && (
+                    <Icon
+                      testID={`token-verified-icon-${token.symbol}`}
+                      name={IconName.VerifiedFilled}
+                      size={IconSize.Sm}
+                      style={styles.verifiedIcon}
+                    />
+                  )}
+                </Box>
                 {label && <Tag label={label} />}
                 {showNoFeeBadge && (
                   <TagBase

--- a/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
@@ -17,7 +17,11 @@ jest.mock('../../../../core/Engine', () => ({
 }));
 
 const mockPopularTokens = [
-  createMockPopularToken({ symbol: 'TEST', name: 'Test Token' }),
+  createMockPopularToken({
+    symbol: 'TEST',
+    name: 'Test Token',
+    isVerified: true,
+  }),
   createMockPopularToken({
     symbol: 'ANOT',
     name: 'Another Token',
@@ -53,6 +57,7 @@ describe('usePopularTokens', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       expect(result.current.popularTokens).toEqual(mockPopularTokens);
+      expect(result.current.popularTokens[0].isVerified).toBe(true);
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/getTokens/popular'),

--- a/app/components/UI/Bridge/hooks/usePopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.ts
@@ -10,6 +10,7 @@ export interface PopularToken {
   iconUrl: string;
   name: string;
   symbol: string;
+  isVerified?: boolean;
   noFee?: {
     isSource: boolean;
     isDestination: boolean;

--- a/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
@@ -45,7 +45,9 @@ describe('useSearchTokens', () => {
 
   describe('searching', () => {
     it('fetches search results when searchTokens is called', async () => {
-      const mockResponse = createMockSearchResponse();
+      const mockResponse = createMockSearchResponse({
+        data: [createMockPopularToken({ symbol: 'SRCH', isVerified: true })],
+      });
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         json: async () => mockResponse,
       });
@@ -59,6 +61,7 @@ describe('useSearchTokens', () => {
       await waitFor(() => expect(result.current.isSearchLoading).toBe(false));
 
       expect(result.current.searchResults).toEqual(mockResponse.data);
+      expect(result.current.searchResults[0].isVerified).toBe(true);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/getTokens/search'),
         expect.objectContaining({
@@ -177,7 +180,7 @@ describe('useSearchTokens', () => {
   describe('pagination', () => {
     it('handles pagination with cursor', async () => {
       const firstPage = createMockPaginatedResponse({
-        data: [createMockPopularToken({ symbol: 'FIRST' })],
+        data: [createMockPopularToken({ symbol: 'FIRST', isVerified: true })],
         cursor: 'cursor123',
       });
       const secondPage = createMockSearchResponse({
@@ -206,6 +209,7 @@ describe('useSearchTokens', () => {
 
       expect(result.current.searchResults[0].symbol).toBe('FIRST');
       expect(result.current.searchResults[1].symbol).toBe('SECOND');
+      expect(result.current.searchResults[0].isVerified).toBe(true);
     });
 
     it('sets isLoadingMore for pagination requests', async () => {

--- a/app/components/UI/Bridge/hooks/useTokensWithBalances.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalances.test.ts
@@ -169,6 +169,18 @@ describe('useTokensWithBalances', () => {
         isDestination: false,
       });
     });
+
+    it('preserves isVerified property from API token', () => {
+      const mockToken = createMockPopularToken({
+        isVerified: true,
+      });
+
+      const { result } = renderHook(() =>
+        useTokensWithBalances([mockToken], {}),
+      );
+
+      expect(result.current[0].isVerified).toBe(true);
+    });
   });
 
   describe('accountType property', () => {

--- a/app/components/UI/Bridge/testUtils/fixtures.ts
+++ b/app/components/UI/Bridge/testUtils/fixtures.ts
@@ -91,7 +91,9 @@ export const createMockSearchResponse = (
     endCursor?: string;
   } = {},
 ) => ({
-  data: overrides.data ?? [createMockPopularToken({ symbol: 'SRCH' })],
+  data: overrides.data ?? [
+    createMockPopularToken({ symbol: 'SRCH', isVerified: true }),
+  ],
   count: overrides.data?.length ?? 1,
   totalCount: overrides.data?.length ?? 1,
   pageInfo: {

--- a/app/components/UI/Bridge/types.ts
+++ b/app/components/UI/Bridge/types.ts
@@ -21,6 +21,7 @@ export interface BridgeToken {
     isSource: boolean;
     isDestination: boolean;
   };
+  isVerified?: boolean;
   aggregators?: string[];
   metadata?: Record<string, unknown>;
   rwaData?: TokenRwaData;

--- a/tests/helpers/swap/constants.ts
+++ b/tests/helpers/swap/constants.ts
@@ -802,6 +802,7 @@ export const GET_POPULAR_TOKENS_MAINNET_RESPONSE = [
       'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
     name: 'Ethereum',
     symbol: 'ETH',
+    isVerified: true,
   },
   {
     assetId: 'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f',


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This adds a verified trust signal to the swap/bridge asset picker when the backend returns `isVerified` on popular and search token results. The change threads the new field through the bridge token models, preserves it during token-to-balance merging, renders the verified badge inline in picker rows, and adds focused coverage for popular tokens, search results, and row rendering.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added verified badges to swap asset picker tokens

## **Related issues**

Fixes:
Refs: SWAPS-4219

## **Manual testing steps**

```gherkin
Feature: Swap asset picker verified trust signals

  Background:
    Given I am logged into MetaMask Mobile
    And I can open the swap or bridge asset picker

  Scenario: user sees a verified badge for a popular token
    Given the popular token response includes a token with isVerified set to true

    When user opens the source or destination asset picker
    Then the verified token should display a verified badge in its list row
    And tokens without isVerified should not display the badge

  Scenario: user sees a verified badge for a searched token
    Given the search token response includes a token with isVerified set to true

    When user searches for that token in the asset picker
    Then the search result should display a verified badge in its list row
    And the token should remain selectable as usual
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/model threading of a new optional `isVerified` flag; main risk is minor layout/test regressions in the token picker row rendering.
> 
> **Overview**
> Adds support for an optional `isVerified` trust signal on Bridge API token results and threads it into the in-app `BridgeToken` model.
> 
> Updates the token picker row (`TokenSelectorItem`) to render a small verified icon next to the token symbol when `token.isVerified` is true, and extends unit tests/fixtures to assert the flag is preserved through popular/search fetching and balance-merging, and is passed through `BridgeTokenSelector` into row rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a4efd7ce40cacd6bd73594460abf8cd98ada13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->