### PR TITLE
feat(ramps): Remove redundant normalizeProviderCode from mobile call

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -44,10 +44,7 @@ import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './BuildQuote.styles';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { useTokenNetworkInfo } from '../../hooks/useTokenNetworkInfo';
-import {
-  RampsOrderStatus,
-  normalizeProviderCode,
-} from '@metamask/ramps-controller';
+import { RampsOrderStatus } from '@metamask/ramps-controller';
 import { useRampsController } from '../../hooks/useRampsController';
 import { useRampsQuotes } from '../../hooks/useRampsQuotes';
 import { createSettingsModalNavDetails } from '../Modals/SettingsModal';
@@ -619,7 +616,7 @@ function BuildQuote() {
     if (!selectedQuote) return;
     setIsContinueLoading(true);
     try {
-      const providerCode = normalizeProviderCode(selectedQuote.provider);
+      const providerCode = selectedQuote.provider;
       const isCustom = isCustomAction(selectedQuote);
       const { useExternalBrowser, redirectUrl } = getWidgetRedirectConfig(
         selectedQuote,

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -9,7 +9,6 @@ import { useTheme } from '../../../../../util/theme';
 import { getDepositNavbarOptions } from '../../../Navbar';
 import { callbackBaseUrl } from '../../Aggregator/sdk';
 import { getRampRoutingDecision } from '../../../../../reducers/fiatOrders';
-import { normalizeProviderCode } from '@metamask/ramps-controller';
 import { FIAT_ORDER_PROVIDERS } from '../../../../../constants/on-ramp';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -179,7 +178,7 @@ const Checkout = () => {
     registeredOrderIdsRef.current.add(effectiveOrderId);
     addPrecreatedOrder({
       orderId: effectiveOrderId,
-      providerCode: normalizeProviderCode(providerCode),
+      providerCode,
       walletAddress,
       chainId: network || undefined,
     });

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
@@ -22,7 +22,6 @@ import BankDetailRow from '../../Deposit/components/BankDetailRow';
 import {
   RampsOrderStatus,
   type TransakDepositOrder,
-  normalizeProviderCode,
 } from '@metamask/ramps-controller';
 import { useTheme } from '../../../../../util/theme';
 import Button, {
@@ -115,7 +114,7 @@ const V2BankDetails = () => {
         setDepositOrder(updatedDepositOrder);
       }
 
-      const providerCode = normalizeProviderCode(order.provider?.id ?? '');
+      const providerCode = order.provider?.id ?? '';
       await refreshOrder(
         providerCode,
         order.providerOrderId,

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -11,10 +11,7 @@ import {
   IconSize,
   FontWeight,
 } from '@metamask/design-system-react-native';
-import {
-  normalizeProviderCode,
-  RampsOrderStatus,
-} from '@metamask/ramps-controller';
+import { RampsOrderStatus } from '@metamask/ramps-controller';
 import { isBailedOrderStatus } from '../BuildQuote/BuildQuote';
 import { extractOrderCode } from '../../utils/extractOrderCode';
 import {
@@ -194,7 +191,7 @@ const OrderDetails = () => {
     try {
       setError(null);
       setIsRefreshing(true);
-      const providerCode = normalizeProviderCode(order.provider?.id ?? '');
+      const providerCode = order.provider?.id ?? '';
       await refreshOrder(
         providerCode,
         order.providerOrderId,

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -171,7 +171,6 @@ jest.mock('@metamask/ramps-controller', () => ({
       (orderId: string, _env: string) => `transformed-${orderId}`,
     ),
   },
-  normalizeProviderCode: (code: string) => code.replace(/^\/providers\//, ''),
 }));
 
 jest.mock('../Deposit/constants', () => ({

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -5,10 +5,7 @@ import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import { strings } from '../../../../../locales/i18n';
 import { useTheme } from '../../../../util/theme';
-import {
-  normalizeProviderCode,
-  type TransakBuyQuote,
-} from '@metamask/ramps-controller';
+import { type TransakBuyQuote } from '@metamask/ramps-controller';
 import { REDIRECTION_URL } from '../Deposit/constants';
 import { generateThemeParameters } from '../Deposit/utils';
 import { BasicInfoFormData } from '../Deposit/Views/BasicInfo/BasicInfo';
@@ -294,9 +291,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
           throw new Error('Missing order');
         }
 
-        const providerCode = normalizeProviderCode(
-          String(depositOrder.provider ?? 'transak-native'),
-        );
+        const providerCode = String(depositOrder.provider ?? 'transak-native');
         const rampsOrder = await refreshOrder(
           providerCode,
           depositOrder.providerOrderId,
@@ -454,8 +449,8 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
                   throw new Error('Missing order');
                 }
 
-                const providerCode = normalizeProviderCode(
-                  String(depositOrder.provider ?? 'transak-native'),
+                const providerCode = String(
+                  depositOrder.provider ?? 'transak-native',
                 );
                 const rampsOrder = await refreshOrder(
                   providerCode,

--- a/app/components/UI/Ramp/orderProcessor/unifiedOrderProcessor.test.ts
+++ b/app/components/UI/Ramp/orderProcessor/unifiedOrderProcessor.test.ts
@@ -114,9 +114,13 @@ describe('processUnifiedOrder', () => {
   });
 
   describe('successful poll', () => {
-    it('calls Engine.getOrder with provider code and order code from data', async () => {
+    it('calls Engine.getOrder with provider id and order code from data', async () => {
       await processUnifiedOrder(mockOrder);
-      expect(mockGetOrder).toHaveBeenCalledWith('transak', 'abc-123', '0xabc');
+      expect(mockGetOrder).toHaveBeenCalledWith(
+        '/providers/transak',
+        'abc-123',
+        '0xabc',
+      );
     });
 
     it('returns order with updated state and reset errorCount on success', async () => {

--- a/app/components/UI/Ramp/orderProcessor/unifiedOrderProcessor.ts
+++ b/app/components/UI/Ramp/orderProcessor/unifiedOrderProcessor.ts
@@ -1,7 +1,4 @@
-import {
-  normalizeProviderCode,
-  type RampsOrder,
-} from '@metamask/ramps-controller';
+import { type RampsOrder } from '@metamask/ramps-controller';
 import {
   FIAT_ORDER_PROVIDERS,
   FIAT_ORDER_STATES,
@@ -104,7 +101,7 @@ export async function processUnifiedOrder(
   try {
     const data = order.data as RampsOrder;
     const orderCode = data.providerOrderId;
-    const providerCode = normalizeProviderCode(data.provider?.id ?? '');
+    const providerCode = data.provider?.id ?? '';
 
     if (!providerCode || !orderCode) {
       throw new Error(

--- a/app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts
+++ b/app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts
@@ -25,7 +25,8 @@ export function buildQuoteWithRedirectUrl(
 }
 
 function getProviderDeeplinkRedirectUrl(providerCode: string): string {
-  return `metamask://on-ramp/providers/${providerCode}`;
+  const code = providerCode.replace(/^\/providers\//u, '');
+  return `metamask://on-ramp/providers/${code}`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.1.0",
     "@metamask/profile-sync-controller": "^28.0.0",
-    "@metamask/ramps-controller": "^12.0.1",
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@12.0.1-preview-2d89a26",
     "@metamask/react-native-acm": "1.2.0",
     "@metamask/react-native-actionsheet": "2.4.2",
     "@metamask/react-native-button": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9422,14 +9422,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^12.0.1":
-  version: 12.0.1
-  resolution: "@metamask/ramps-controller@npm:12.0.1"
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@12.0.1-preview-2d89a26":
+  version: 12.0.1-preview-2d89a26
+  resolution: "@metamask-previews/ramps-controller@npm:12.0.1-preview-2d89a26"
   dependencies:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.19.0"
     "@metamask/messenger": "npm:^0.3.0"
-  checksum: 10/a7f9428cb824bd0175ee1cc603d77c650fa7a23c7183e2cc0a0f21ee9b6378d80bbd1e496654e40d2edcfc840e60dd4a09d80feacb1746087a67b66761e1e6c7
+  checksum: 10/80be65d3a10a70d153739f1ed0508d2c89db549c6f8be3c166fcca9f254c48c430db9f3f11c13da3e2deb2b4b0f5c5a288a4f8482a22987e31c4ec53fe8b861c
   languageName: node
   linkType: hard
 
@@ -35596,7 +35596,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^3.1.0"
     "@metamask/profile-sync-controller": "npm:^28.0.0"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^12.0.1"
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@12.0.1-preview-2d89a26"
     "@metamask/react-native-acm": "npm:1.2.0"
     "@metamask/react-native-actionsheet": "npm:2.4.2"
     "@metamask/react-native-button": "npm:^3.0.0"


### PR DESCRIPTION
## Explanation

Removes redundant `normalizeProviderCode()` calls from mobile ramp call sites. Provider ID normalization (stripping the `/providers/` prefix) now happens inside `RampsService` at URL construction time, so callers can pass `provider.id` as-is without pre-processing.

This is the mobile counterpart to the core change. The service's `#toProviderSegment()` helper accepts both `/providers/transak` and `transak`, so this removal is backward-compatible — the double-strip that existed before was harmless, and now we just strip once at the boundary.

Changes:

1. **`BuildQuote.tsx`** — Pass `selectedQuote.provider` directly to `addPrecreatedOrder` and checkout navigation instead of wrapping in `normalizeProviderCode()`.

2. **`Checkout.tsx`** — Pass `providerCode` as-is to `addPrecreatedOrder` and `getOrderFromCallback`.

3. **`OrderDetails.tsx`** — Pass `order.provider?.id` directly to `refreshOrder`.

4. **`BankDetails.tsx`** — Pass `order.provider?.id` directly to `refreshOrder`.

5. **`useTransakRouting.ts`** — Remove `normalizeProviderCode` import and usage at two call sites (redirect handling and external browser callback).

6. **`unifiedOrderProcessor.ts`** — Pass `data.provider?.id` directly to `getOrder` instead of normalizing first.

7. **`useTransakRouting.test.ts`** — Remove the `normalizeProviderCode` mock (no longer imported by the hook).

8. **`unifiedOrderProcessor.test.ts`** — Update mock provider IDs to use `/providers/` prefixed format to match real API responses.

9. **`buildQuoteWithRedirectUrl.ts`** — Fix `getProviderDeeplinkRedirectUrl` to strip `/providers/` prefix before building the deeplink URL. Without this, passing a raw `provider.id` like `/providers/moonpay` would produce a doubled path: `metamask://on-ramp/providers//providers/moonpay`, breaking external browser redirect flows (PayPal, InAppBrowser callbacks).

## Link to core PR

Depends on: [MetaMask/core#8289](https://github.com/MetaMask/core/pull/8289) (`fix/ramps-3244-addPrecreatedOrder-id-format`)

## Changelog

CHANGELOG entry: @metamask/ramps-controller - Removed redundant `normalizeProviderCode()` calls from mobile ramp call sites; provider ID normalization now handled at the service boundary

## References

[TRAM-3244](https://consensyssoftware.atlassian.net/browse/TRAM-3244)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've applied the right labels on the PR

## Manual testing steps

```gherkin
Feature: Provider ID normalization removed from mobile

  Scenario: On-ramp buy flow works without normalizeProviderCode
    Given the app is built from this branch
    When user completes an on-ramp buy flow (aggregator or native)
    Then order is created, polled, and displayed correctly in Activity tab

  Scenario: Order details refresh works
    Given user has an existing pending order
    When user opens Order Details and pulls to refresh
    Then order refreshes successfully (no 400/404 from doubled path)

  Scenario: Transak native flow works
    Given user selects a Transak native provider
    When user completes bank details and callback redirect
    Then order is fetched and displayed correctly

  Scenario: Previously used provider detection still works
    Given user has completed orders in history
    When user starts a new buy flow
    Then the previously used provider is correctly recommended
```

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `providerCode` is passed through quote/checkout/order refresh and polling paths, which can break order creation/lookup if any downstream expects the stripped format. Also switches `@metamask/ramps-controller` to a preview build, increasing integration risk.
> 
> **Overview**
> Removes `normalizeProviderCode()` usage across unified ramps flows so mobile now passes provider IDs (often `/providers/...`) through `BuildQuote`, `Checkout`, native `BankDetails`, `OrderDetails`, `useTransakRouting`, and `unifiedOrderProcessor` without pre-processing.
> 
> Fixes external-browser deeplink redirects by stripping the `/providers/` prefix inside `getProviderDeeplinkRedirectUrl`, and updates tests to expect prefixed provider IDs. Updates the `@metamask/ramps-controller` dependency to a preview version to pick up the corresponding core-side normalization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f80d8177c779cf07420af2da5b82765e6c347b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->