### PR TITLE
test: add playwright assertions class

### DIFF
--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -29,18 +29,8 @@ export default class PlaywrightAssertions {
 
   static async expectTextDisplayed(
     text: string,
-    options: AssertionOptions & { allowDuplicates?: boolean } = {},
+    options: AssertionOptions = {},
   ): Promise<void> {
-    const { allowDuplicates = false } = options;
-    if (allowDuplicates) {
-      const elements = await PlaywrightMatchers.getAllElementsByText(text);
-      if (elements.length === 0) {
-        throw new Error(`No elements found with text "${text}"`);
-      }
-      await elements[0].waitForDisplayed({ timeout: this.getTimeout(options) });
-      return;
-    }
-
     const el = await PlaywrightMatchers.getElementByText(text);
     await el.waitForDisplayed({ timeout: this.getTimeout(options) });
   }

--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -1,4 +1,4 @@
-import Utilities, { BASE_DEFAULTS } from './Utilities.ts';
+import { BASE_DEFAULTS } from './Utilities.ts';
 import { AssertionOptions } from './types.ts';
 import type { PlaywrightElement } from './PlaywrightAdapter.ts';
 import PlaywrightMatchers from './PlaywrightMatchers.ts';

--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -1,0 +1,58 @@
+import Utilities, { BASE_DEFAULTS } from './Utilities.ts';
+import { AssertionOptions } from './types.ts';
+import type { PlaywrightElement } from './PlaywrightAdapter.ts';
+import PlaywrightMatchers from './PlaywrightMatchers.ts';
+
+export default class PlaywrightAssertions {
+  private static getTimeout(options: AssertionOptions): number {
+    return options.timeout ?? BASE_DEFAULTS.timeout;
+  }
+
+  static async expectElementToBeVisible(
+    targetElement: PlaywrightElement | Promise<PlaywrightElement>,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const el = await targetElement;
+    await el.waitForDisplayed({ timeout: this.getTimeout(options) });
+  }
+
+  static async expectElementToNotBeVisible(
+    targetElement: PlaywrightElement | Promise<PlaywrightElement>,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const el = await targetElement;
+    await el.waitForDisplayed({
+      reverse: true,
+      timeout: this.getTimeout(options),
+    });
+  }
+
+  static async expectTextDisplayed(
+    text: string,
+    options: AssertionOptions & { allowDuplicates?: boolean } = {},
+  ): Promise<void> {
+    const { allowDuplicates = false } = options;
+    if (allowDuplicates) {
+      const elements = await PlaywrightMatchers.getAllElementsByText(text);
+      if (elements.length === 0) {
+        throw new Error(`No elements found with text "${text}"`);
+      }
+      await elements[0].waitForDisplayed({ timeout: this.getTimeout(options) });
+      return;
+    }
+
+    const el = await PlaywrightMatchers.getElementByText(text);
+    await el.waitForDisplayed({ timeout: this.getTimeout(options) });
+  }
+
+  static async expectTextNotDisplayed(
+    text: string,
+    options: AssertionOptions = {},
+  ): Promise<void> {
+    const el = await PlaywrightMatchers.getElementByText(text);
+    await el.waitForDisplayed({
+      reverse: true,
+      timeout: this.getTimeout(options),
+    });
+  }
+}

--- a/tests/framework/index.ts
+++ b/tests/framework/index.ts
@@ -32,6 +32,7 @@ export { DappVariants, TestDapps } from './Constants.ts';
 export { PlaywrightElement, wrapElement, $, $$ } from './PlaywrightAdapter.ts';
 export { default as PlaywrightMatchers } from './PlaywrightMatchers.ts';
 export { default as PlaywrightGestures } from './PlaywrightGestures.ts';
+export { default as PlaywrightAssertions } from './PlaywrightAssertions.ts';
 
 // Export unified framework (Detox + WebdriverIO compatibility)
 export {

--- a/tests/page-objects/swaps/QuoteView.ts
+++ b/tests/page-objects/swaps/QuoteView.ts
@@ -3,6 +3,7 @@ import {
   Assertions,
   Gestures,
   Matchers,
+  PlaywrightAssertions,
   PlaywrightMatchers,
   UnifiedGestures,
   encapsulated,
@@ -175,7 +176,10 @@ class QuoteView {
           this.getTokenElementId(chainId, symbol),
           { exact: false },
         );
-        await tokenElement.waitForDisplayed({ timeout: TIMEOUT.TOKEN_SELECT });
+        await PlaywrightAssertions.expectElementToBeVisible(tokenElement, {
+          timeout: TIMEOUT.TOKEN_SELECT,
+          description: `Token ${symbol} should be visible`,
+        });
         await tokenElement.click();
       },
     });
@@ -245,8 +249,9 @@ class QuoteView {
       appium: async () => {
         const networkElement =
           await PlaywrightMatchers.getElementByCatchAll(network);
-        await networkElement.waitForDisplayed({
+        await PlaywrightAssertions.expectElementToBeVisible(networkElement, {
           timeout: TIMEOUT.NETWORK_SELECT,
+          description: `Network ${network} should be visible`,
         });
         await networkElement.click();
       },
@@ -294,8 +299,13 @@ class QuoteView {
         );
       },
       appium: async () => {
-        const el = await asPlaywrightElement(this.amountInput);
-        await el.waitForDisplayed({ timeout: TIMEOUT.SWAP_SCREEN_VISIBLE });
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(this.amountInput),
+          {
+            timeout: TIMEOUT.SWAP_SCREEN_VISIBLE,
+            description: 'Swap screen source token input should be visible',
+          },
+        );
       },
     });
   }
@@ -316,8 +326,13 @@ class QuoteView {
         );
       },
       appium: async () => {
-        const el = await asPlaywrightElement(this.feeDisclaimerLabel);
-        await el.waitForDisplayed({ timeout: TIMEOUT.QUOTE_DISPLAYED });
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(this.feeDisclaimerLabel),
+          {
+            timeout: TIMEOUT.QUOTE_DISPLAYED,
+            description: 'Fee disclaimer (quote) should be visible',
+          },
+        );
       },
     });
   }
@@ -350,7 +365,10 @@ class QuoteView {
         });
         for (const digit of amount) {
           const digitEl = await PlaywrightMatchers.getElementByText(digit);
-          await digitEl.waitForDisplayed({ timeout: TIMEOUT.KEYPAD_DIGIT });
+          await PlaywrightAssertions.expectElementToBeVisible(digitEl, {
+            timeout: TIMEOUT.KEYPAD_DIGIT,
+            description: `Keypad digit ${digit} should be visible`,
+          });
           await digitEl.click();
         }
       },

--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -59,7 +59,7 @@ class LoginView {
     return encapsulated({
       detox: () => Matchers.getElementByID(LoginViewSelectors.TITLE_ID),
       appium: () =>
-        PlaywrightMatchers.getElementById(LoginViewSelectors.LOGIN_BUTTON_ID, {
+        PlaywrightMatchers.getElementById(LoginViewSelectors.TITLE_ID, {
           exact: true,
         }),
     });

--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -1,6 +1,7 @@
 import { LoginViewSelectors } from '../../../app/components/Views/Login/LoginView.testIds';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
+import { PlaywrightAssertions } from '../../framework';
 import {
   encapsulated,
   EncapsulatedElementType,
@@ -25,13 +26,13 @@ class LoginView {
         Matchers.getElementByLabel(LoginViewSelectors.PASSWORD_INPUT),
       appium: {
         android: () =>
+          PlaywrightMatchers.getElementByCatchAll(
+            LoginViewSelectors.PASSWORD_INPUT,
+          ),
+        ios: () =>
           PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT, {
             exact: true,
           }),
-        ios: () =>
-          PlaywrightMatchers.getElementByAccessibilityId(
-            LoginViewSelectors.PASSWORD_INPUT,
-          ),
       },
     });
   }
@@ -58,7 +59,9 @@ class LoginView {
     return encapsulated({
       detox: () => Matchers.getElementByID(LoginViewSelectors.TITLE_ID),
       appium: () =>
-        PlaywrightMatchers.getElementById(LoginViewSelectors.TITLE_ID),
+        PlaywrightMatchers.getElementById(LoginViewSelectors.LOGIN_BUTTON_ID, {
+          exact: true,
+        }),
     });
   }
 
@@ -89,8 +92,13 @@ class LoginView {
   async waitForScreenToDisplay(): Promise<void> {
     await encapsulatedAction({
       appium: async () => {
-        const titleEl = await asPlaywrightElement(this.title);
-        await titleEl.waitForDisplayed({ timeout: 15000 });
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(this.title),
+          {
+            timeout: 15000,
+            description: 'Login title should be visible',
+          },
+        );
       },
     });
   }

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -15,6 +15,7 @@ import UnifiedGestures from '../../framework/UnifiedGestures';
 import Matchers from '../../framework/Matchers';
 import TestHelpers from '../../helpers.js';
 import Assertions from '../../framework/Assertions';
+import PlaywrightAssertions from '../../framework/PlaywrightAssertions';
 import Utilities from '../../framework/Utilities';
 import {
   encapsulated,
@@ -232,6 +233,80 @@ class WalletView {
     return Matchers.getElementByID(
       WalletViewSelectorsIDs.COLLECTIBLE_FALLBACK,
       1,
+    );
+  }
+  // Wallet-specific action buttons (from AssetDetailsActions in Wallet view)
+  get walletBuyButton(): DetoxElement {
+    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_BUY_BUTTON);
+  }
+
+  get walletSwapButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_SWAP_BUTTON),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            WalletViewSelectorsIDs.WALLET_SWAP_BUTTON,
+            { exact: true },
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByAccessibilityId(
+            WalletViewSelectorsIDs.WALLET_SWAP_BUTTON,
+          ),
+      },
+    });
+  }
+
+  get walletBridgeButton(): DetoxElement {
+    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_BRIDGE_BUTTON);
+  }
+
+  get walletSendButton(): DetoxElement {
+    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_SEND_BUTTON);
+  }
+
+  // mUSD conversion (Earn) - asset list CTA, education screen, token list CTA, asset overview CTA
+  get musdConversionCta(): DetoxElement {
+    return Matchers.getElementByID(
+      EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA,
+    );
+  }
+
+  get getMusdButton(): DetoxElement {
+    return Matchers.getElementByText('Get mUSD');
+  }
+
+  get getStartedButton(): DetoxElement {
+    return Matchers.getElementByText('Get Started');
+  }
+
+  /** Token list item CTA: "Get 3% mUSD bonus" on USDC row. Use testID + index (1 = USDC after ETH) to avoid regex/text flakiness. */
+  get tokenListItemConvertToMusdCta(): DetoxElement {
+    return Matchers.getElementByID(SECONDARY_BALANCE_BUTTON_TEST_ID, 1);
+  }
+
+  get assetOverviewMusdCta(): DetoxElement {
+    return Matchers.getElementByID(
+      EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA,
+    );
+  }
+
+  get walletReceiveButton(): DetoxElement {
+    return Matchers.getElementByID(
+      WalletViewSelectorsIDs.WALLET_RECEIVE_BUTTON,
+    );
+  }
+  // Balance Empty State - displayed when account group has zero balance across all networks
+  get balanceEmptyStateContainer(): DetoxElement {
+    return Matchers.getElementByID(
+      WalletViewSelectorsIDs.BALANCE_EMPTY_STATE_CONTAINER,
+    );
+  }
+
+  get balanceEmptyStateActionButton(): DetoxElement {
+    return Matchers.getElementByID(
+      WalletViewSelectorsIDs.BALANCE_EMPTY_STATE_ACTION_BUTTON,
     );
   }
   getPredictCurrentPositionCardByIndex(index: number = 0): DetoxElement {
@@ -927,84 +1002,29 @@ class WalletView {
     }
   }
 
-  // Wallet-specific action buttons (from AssetDetailsActions in Wallet view)
-  get walletBuyButton(): DetoxElement {
-    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_BUY_BUTTON);
-  }
-
-  get walletSwapButton(): EncapsulatedElementType {
-    return encapsulated({
-      detox: () =>
-        Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_SWAP_BUTTON),
-      appium: {
-        android: () =>
-          PlaywrightMatchers.getElementById(
-            WalletViewSelectorsIDs.WALLET_SWAP_BUTTON,
-            { exact: true },
-          ),
-        ios: () =>
-          PlaywrightMatchers.getElementByAccessibilityId(
-            WalletViewSelectorsIDs.WALLET_SWAP_BUTTON,
-          ),
-      },
-    });
-  }
-
-  get walletBridgeButton(): DetoxElement {
-    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_BRIDGE_BUTTON);
-  }
-
-  get walletSendButton(): DetoxElement {
-    return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_SEND_BUTTON);
-  }
-
-  // mUSD conversion (Earn) - asset list CTA, education screen, token list CTA, asset overview CTA
-  get musdConversionCta(): DetoxElement {
-    return Matchers.getElementByID(
-      EARN_TEST_IDS.MUSD.ASSET_LIST_CONVERSION_CTA,
-    );
-  }
-
-  get getMusdButton(): DetoxElement {
-    return Matchers.getElementByText('Get mUSD');
-  }
-
-  get getStartedButton(): DetoxElement {
-    return Matchers.getElementByText('Get Started');
-  }
-
-  /** Token list item CTA: "Get 3% mUSD bonus" on USDC row. Use testID + index (1 = USDC after ETH) to avoid regex/text flakiness. */
-  get tokenListItemConvertToMusdCta(): DetoxElement {
-    return Matchers.getElementByID(SECONDARY_BALANCE_BUTTON_TEST_ID, 1);
-  }
-
-  get assetOverviewMusdCta(): DetoxElement {
-    return Matchers.getElementByID(
-      EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA,
-    );
-  }
-
-  get walletReceiveButton(): DetoxElement {
-    return Matchers.getElementByID(
-      WalletViewSelectorsIDs.WALLET_RECEIVE_BUTTON,
-    );
-  }
-  // Balance Empty State - displayed when account group has zero balance across all networks
-  get balanceEmptyStateContainer(): DetoxElement {
-    return Matchers.getElementByID(
-      WalletViewSelectorsIDs.BALANCE_EMPTY_STATE_CONTAINER,
-    );
-  }
-
-  get balanceEmptyStateActionButton(): DetoxElement {
-    return Matchers.getElementByID(
-      WalletViewSelectorsIDs.BALANCE_EMPTY_STATE_ACTION_BUTTON,
-    );
-  }
-
   async tapWalletBuyButton(): Promise<void> {
     await Gestures.waitAndTap(this.walletBuyButton, {
       elemDescription: 'Wallet Buy Button',
+    });
+  }
+
+  async waitForScreenToDisplay(): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await Assertions.expectElementToBeVisible(this.container, {
+          timeout: 30000,
+          description: 'Wallet view should be visible',
+        });
+      },
+      appium: async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(this.walletSwapButton),
+          {
+            timeout: 30000,
+            description: 'Wallet swap button should be visible',
+          },
+        );
+      },
     });
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Introduces a new PlaywrightAssertions helper with common visibility/text expectations (including timeout defaults and duplicate-text handling) to standardize Playwright/Appium assertions.

Updates swap/bridge QuoteView and wallet LoginView/WalletView Appium flows to use PlaywrightAssertions.expectElementToBeVisible instead of direct waitForDisplayed, adding explicit descriptions/timeouts and adjusting some Playwright selectors (notably LoginView password/title element targeting). Also adds a WalletView.waitForScreenToDisplay that waits for the view to be ready on both Detox and Appium.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk product-wise since changes are confined to the test framework, but it may impact Appium/Playwright E2E stability due to updated selectors and new visibility waits/timeouts.
> 
> **Overview**
> Adds a new `PlaywrightAssertions` helper to standardize common Playwright/Appium expectations (visible/not-visible and text displayed/not-displayed) with default timeouts.
> 
> Migrates Appium flows in `QuoteView` and `LoginView` from ad-hoc `waitForDisplayed` calls to `PlaywrightAssertions.expectElementToBeVisible`, consistently passing explicit timeouts/descriptions, and tightens some selectors (e.g., `LoginView` password input and title `exact` matching).
> 
> Introduces `WalletView.waitForScreenToDisplay()` with Detox and Appium readiness checks, and exports `PlaywrightAssertions` from the framework index for easier consumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14fadad00b22b5f7dc8f9ec97772166fef4a152b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->