### PR TITLE
fix: biometric bug with incorrect password during rehydration

### DIFF
--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -36,6 +36,7 @@ const mockReauthenticate = jest.fn();
 const mockRevealSRP = jest.fn();
 const mockRevealPrivateKey = jest.fn();
 const mockRequestBiometricsAccessControlForIOS = jest.fn();
+const mockUpdateAuthPreference = jest.fn();
 
 jest.mock('../../../core/Authentication/hooks/useAuthentication', () => ({
   __esModule: true,
@@ -49,6 +50,7 @@ jest.mock('../../../core/Authentication/hooks/useAuthentication', () => ({
     revealPrivateKey: mockRevealPrivateKey,
     requestBiometricsAccessControlForIOS:
       mockRequestBiometricsAccessControlForIOS,
+    updateAuthPreference: mockUpdateAuthPreference,
   }),
 }));
 
@@ -191,6 +193,7 @@ describe('OAuthRehydration', () => {
     mockRequestBiometricsAccessControlForIOS.mockResolvedValue(
       AUTHENTICATION_TYPE.PASSWORD,
     );
+    mockUpdateAuthPreference.mockResolvedValue(undefined);
     mockUseNetInfo.mockReturnValue({
       isConnected: true,
       isInternetReachable: true,
@@ -220,6 +223,9 @@ describe('OAuthRehydration', () => {
       await waitFor(() => {
         expect(mockReplace).toHaveBeenCalledWith(Routes.ONBOARDING.HOME_NAV);
       });
+      expect(mockUnlockWallet.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRequestBiometricsAccessControlForIOS.mock.invocationCallOrder[0],
+      );
       expect(mockRequestBiometricsAccessControlForIOS).toHaveBeenCalledWith(
         AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
       );
@@ -244,6 +250,18 @@ describe('OAuthRehydration', () => {
       await waitFor(() => {
         expect(getByTestId(LoginViewSelectors.PASSWORD_ERROR)).toBeTruthy();
       });
+    });
+
+    it('does not prompt biometrics when password unlock fails', async () => {
+      mockUnlockWallet.mockRejectedValue(new Error('Error: Decrypt failed'));
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      await enterPasswordAndSubmit(getByTestId, 'wrongPassword');
+
+      await waitFor(() => {
+        expect(getByTestId(LoginViewSelectors.PASSWORD_ERROR)).toBeTruthy();
+      });
+      expect(mockRequestBiometricsAccessControlForIOS).not.toHaveBeenCalled();
+      expect(mockUpdateAuthPreference).not.toHaveBeenCalled();
     });
 
     it('clears error when user types new password', async () => {
@@ -858,10 +876,22 @@ describe('OAuthRehydration', () => {
           expect.objectContaining({
             authPreference: expect.objectContaining({
               oauth2Login: false,
+              currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
             }),
           }),
         );
       });
+    });
+
+    it('does not prompt biometrics before unlock when password is wrong (outdated password flow)', async () => {
+      mockUnlockWallet.mockRejectedValue(new Error('Error: Decrypt failed'));
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      await enterPasswordAndSubmit(getByTestId, 'wrongPassword');
+
+      await waitFor(() => {
+        expect(getByTestId(LoginViewSelectors.PASSWORD_ERROR)).toBeTruthy();
+      });
+      expect(mockRequestBiometricsAccessControlForIOS).not.toHaveBeenCalled();
     });
 
     it('navigates to DELETE_WALLET modal on forgot password press', () => {

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -881,6 +881,12 @@ describe('OAuthRehydration', () => {
           }),
         );
       });
+      expect(mockUnlockWallet.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRequestBiometricsAccessControlForIOS.mock.invocationCallOrder[0],
+      );
+      expect(mockRequestBiometricsAccessControlForIOS).toHaveBeenCalledWith(
+        AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
+      );
     });
 
     it('does not prompt biometrics before unlock when password is wrong (outdated password flow)', async () => {

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -239,6 +239,47 @@ describe('OAuthRehydration', () => {
         expect(mockTrackOnboarding).toHaveBeenCalled();
       });
     });
+
+    it('logs error when post-unlock biometric prompt fails', async () => {
+      const biometricError = new Error('Biometric prompt failed');
+      mockRequestBiometricsAccessControlForIOS.mockRejectedValueOnce(
+        biometricError,
+      );
+
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      await enterPasswordAndSubmit(getByTestId);
+
+      await waitFor(() => {
+        expect(mockUnlockWallet).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(Logger.error).toHaveBeenCalledWith(
+          biometricError,
+          'OAuthRehydration: post-unlock biometric preference',
+        );
+      });
+    });
+
+    it('logs error when updateAuthPreference fails after choosing device auth', async () => {
+      mockRequestBiometricsAccessControlForIOS.mockResolvedValueOnce(
+        AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
+      );
+      const preferenceError = new Error('Keychain preference update failed');
+      mockUpdateAuthPreference.mockRejectedValueOnce(preferenceError);
+
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      await enterPasswordAndSubmit(getByTestId);
+
+      await waitFor(() => {
+        expect(mockUpdateAuthPreference).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(Logger.error).toHaveBeenCalledWith(
+          preferenceError,
+          'OAuthRehydration: post-unlock biometric preference',
+        );
+      });
+    });
   });
 
   describe('Password validation', () => {

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -594,6 +594,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         },
       );
 
+      await upgradeKeychainAuthAfterSuccessfulUnlock();
+
       // Best-effort post-unlock UX: show biometric cancelled alert if needed.
       // Failure here must not be treated as a login error — unlock already succeeded.
       try {
@@ -615,6 +617,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     handleLoginError,
     promptBiometricFailedAlert,
     unlockWallet,
+    upgradeKeychainAuthAfterSuccessfulUnlock,
   ]);
 
   // Cleanup for isMountedRef tracking

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -150,8 +150,38 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
   const passwordLoginAttemptTraceCtxRef = useRef<TraceContext | null>(null);
 
-  const { unlockWallet, getAuthType, requestBiometricsAccessControlForIOS } =
-    useAuthentication();
+  const {
+    unlockWallet,
+    getAuthType,
+    requestBiometricsAccessControlForIOS,
+    updateAuthPreference,
+  } = useAuthentication();
+
+  /**
+   * After a successful password unlock, offer device auth / biometrics for keychain storage.
+   */
+  const upgradeKeychainAuthAfterSuccessfulUnlock = useCallback(async () => {
+    try {
+      const upgradeAuthType = await requestBiometricsAccessControlForIOS(
+        AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
+      );
+      if (upgradeAuthType !== AUTHENTICATION_TYPE.PASSWORD) {
+        await updateAuthPreference({
+          authType: upgradeAuthType,
+          password,
+          fallbackToPassword: true,
+        });
+      }
+    } catch (postUnlockAuthErr) {
+      Logger.error(
+        ensureError(
+          postUnlockAuthErr,
+          'Post-unlock auth preference update failed',
+        ),
+        'OAuthRehydration: post-unlock biometric preference',
+      );
+    }
+  }, [password, requestBiometricsAccessControlForIOS, updateAuthPreference]);
 
   const track = useCallback(
     (
@@ -485,14 +515,9 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
       setLoading(true);
 
-      // Ask user to allow biometrics access control
-      const authType = await requestBiometricsAccessControlForIOS(
-        AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
-      );
-
-      // Only set oauth2Login for normal rehydration, not when password is outdated
+      // Password first: do not prompt biometrics until unlock succeeds
       const authData: AuthData = {
-        currentAuthType: authType,
+        currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
         oauth2Login: true,
       };
 
@@ -505,6 +530,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
           await unlockWallet({ password, authPreference: authData });
         },
       );
+
+      await upgradeKeychainAuthAfterSuccessfulUnlock();
 
       // Best-effort post-unlock UX: show biometric cancelled alert if needed.
       // Failure here must not be treated as a login error — unlock already succeeded.
@@ -542,7 +569,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     track,
     promptBiometricFailedAlert,
     unlockWallet,
-    requestBiometricsAccessControlForIOS,
+    upgradeKeychainAuthAfterSuccessfulUnlock,
   ]);
 
   const newGlobalPasswordLogin = useCallback(async () => {
@@ -551,14 +578,9 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
       setLoading(true);
 
-      // Ask user to allow biometrics access control
-      const authType = await requestBiometricsAccessControlForIOS(
-        AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
-      );
-
-      // Only set oauth2Login for normal rehydration, not when password is outdated
+      // biometrics/passcode preference is applied only after sync succeeds
       const authData: AuthData = {
-        currentAuthType: authType,
+        currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
         oauth2Login: false,
       };
 
@@ -593,7 +615,6 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     handleLoginError,
     promptBiometricFailedAlert,
     unlockWallet,
-    requestBiometricsAccessControlForIOS,
   ]);
 
   // Cleanup for isMountedRef tracking


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Seedless/OAuth rehydration was prompting biometrics with a wrong password entry too

**Solution**
Now the flow is password-first: unlockWallet runs with password only. After a successful unlock, post-unlock steps (including optional biometric upgrade). Failed unlocks no longer trigger biometric prompts.

Jira: https://consensyssoftware.atlassian.net/browse/TO-600

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TO-600

## **Manual testing steps**

```gherkin
Feature: Seedless OAuth rehydration password before biometrics

 Scenario: Wrong password does not trigger biometrics before unlock
    Given the user is on the OAuth rehydration screen with a seedless wallet
    And device biometrics are available

    When the user enters an incorrect password and submits
    Then the app shows an invalid password error
    And the system biometric prompt is not shown before unlock fails

  Scenario: Correct password offers biometrics after successful unlock (rehydration)
    Given the user is on the OAuth rehydration screen
    And device biometrics are available

    When the user enters the correct password and submits
    Then unlock completes successfully
    And the app may prompt for device biometrics / keychain upgrade only after unlock succeeds

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/e5ade971-0f7e-4316-b272-9f2aa7c58fb8

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the seedless/OAuth rehydration login flow and post-unlock auth preference updates, which can affect authentication UX and keychain storage behavior. Scope is limited to `OAuthRehydration` and adds/adjusts tests to cover ordering and failure cases.
> 
> **Overview**
> Updates `OAuthRehydration` so biometric/device-auth prompts no longer occur *before* password verification: `unlockWallet` is called with `currentAuthType: PASSWORD`, and an optional post-unlock step (`upgradeKeychainAuthAfterSuccessfulUnlock`) requests device auth and persists the result via `updateAuthPreference`.
> 
> Extends `OAuthRehydration` tests to assert call ordering (unlock precedes biometrics) and to ensure biometrics/auth-preference updates are not triggered when password unlock fails, including the outdated-password flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c39635adc100eb6e068a79bd21198a2b36986a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->