### PR TITLE
fix: hides perps buttons in ai insights when user has a position cp-7.71.0

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -153,6 +153,8 @@ interface MarketInsightsRouteParams {
   tokenChainId?: string;
   /** When true, indicates the view was opened from the Perps market details view */
   isPerps?: boolean;
+  /** When true, the user has an existing perps position for this asset */
+  hasPerpsPosition?: boolean;
 }
 
 /**
@@ -182,6 +184,7 @@ const MarketInsightsView: React.FC = () => {
     tokenName,
     tokenChainId,
     isPerps = false,
+    hasPerpsPosition = false,
   } = route.params;
 
   const isMarketInsightsEnabled = isPerps
@@ -660,65 +663,79 @@ const MarketInsightsView: React.FC = () => {
           >
             {strings('market_insights.helpful_prompt')}
           </Text>
+          {isPerps && hasPerpsPosition && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              twClassName="pt-3"
+            >
+              {strings('market_insights.footer_disclaimer')}
+            </Text>
+          )}
         </Box>
       </ScrollView>
 
-      <Box
-        twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom + 8}px]`}
-      >
-        {isPerps ? (
-          <Box flexDirection={BoxFlexDirection.Row} gap={3}>
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              twClassName="flex-1"
-              onPress={() => handlePerpsDirectionPress('long')}
-              testID={MarketInsightsSelectorsIDs.LONG_BUTTON}
-            >
-              {strings('perps.market.long')}
-            </Button>
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              twClassName="flex-1"
-              onPress={() => handlePerpsDirectionPress('short')}
-              testID={MarketInsightsSelectorsIDs.SHORT_BUTTON}
-            >
-              {strings('perps.market.short')}
-            </Button>
-          </Box>
-        ) : (
-          <Box flexDirection={BoxFlexDirection.Row} gap={3}>
-            <Box twClassName="flex-1">
+      {!(isPerps && hasPerpsPosition) && (
+        <Box
+          twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom + 8}px]`}
+        >
+          {isPerps ? (
+            <Box flexDirection={BoxFlexDirection.Row} gap={3}>
               <Button
                 variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
-                isFullWidth
-                onPress={handleSwapPress}
-                testID={MarketInsightsSelectorsIDs.SWAP_BUTTON}
+                twClassName="flex-1"
+                onPress={() => handlePerpsDirectionPress('long')}
+                testID={MarketInsightsSelectorsIDs.LONG_BUTTON}
               >
-                {strings('market_insights.swap_button')}
+                {strings('perps.market.long')}
               </Button>
-            </Box>
-            <Box twClassName="flex-1">
               <Button
                 variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
-                isFullWidth
-                onPress={handleBuyPress}
-                testID={MarketInsightsSelectorsIDs.BUY_BUTTON}
+                twClassName="flex-1"
+                onPress={() => handlePerpsDirectionPress('short')}
+                testID={MarketInsightsSelectorsIDs.SHORT_BUTTON}
               >
-                {strings('market_insights.buy_button')}
+                {strings('perps.market.short')}
               </Button>
             </Box>
+          ) : (
+            <Box flexDirection={BoxFlexDirection.Row} gap={3}>
+              <Box twClassName="flex-1">
+                <Button
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Lg}
+                  isFullWidth
+                  onPress={handleSwapPress}
+                  testID={MarketInsightsSelectorsIDs.SWAP_BUTTON}
+                >
+                  {strings('market_insights.swap_button')}
+                </Button>
+              </Box>
+              <Box twClassName="flex-1">
+                <Button
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Lg}
+                  isFullWidth
+                  onPress={handleBuyPress}
+                  testID={MarketInsightsSelectorsIDs.BUY_BUTTON}
+                >
+                  {strings('market_insights.buy_button')}
+                </Button>
+              </Box>
+            </Box>
+          )}
+          <Box twClassName="pt-3" alignItems={BoxAlignItems.Center}>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {strings('market_insights.footer_disclaimer')}
+            </Text>
           </Box>
-        )}
-        <Box twClassName="pt-3" alignItems={BoxAlignItems.Center}>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {strings('market_insights.footer_disclaimer')}
-          </Text>
         </Box>
-      </Box>
+      )}
 
       {selectedTrend ? (
         <MarketInsightsTrendSourcesBottomSheet

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1041,8 +1041,9 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       assetSymbol: market.symbol,
       assetIdentifier: market.symbol,
       isPerps: true,
+      hasPerpsPosition: !!existingPosition,
     });
-  }, [market?.symbol, navigation, track]);
+  }, [market?.symbol, navigation, track, existingPosition]);
 
   // Handler for order selection - navigates to order details
   const handleOrderSelect = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is a bug fix for https://github.com/MetaMask/metamask-mobile/issues/27916  where:
- In the AI Market Insights in Perps, the action buttons are wrong when user has an open position: the action buttons should be the same in AI market insight page and market page, ie. “modify” and “Close” when user has an open position

Fix:
- When the user has an existing perps position, the MarketInsights footer action buttons (Long/Short) are hidden since the relevant actions (modify/close) live on the Perps market details page
- The "AI summary for information only" disclaimer is moved inline below the feedback section when the footer is hidden, so it remains visible
- Position state is passed via route params (hasPerpsPosition) from the caller rather than fetched async inside MarketInsightsView, preventing a flash where buttons briefly appear then disappear while the position loads

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing incorrect Perps action buttons to be displayed

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27916

## **Manual testing steps**

```gherkin
- Open MarketInsights from token details → Swap/Buy buttons visible with disclaimer in footer
- Open MarketInsights from perps with no position → Long/Short buttons visible with disclaimer in footer
- Open MarketInsights from perps with an existing position → no footer buttons, disclaimer shown below "Was this helpful?"
- Verify no flash/layout shift on the perps + position flow
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/0373c1bb-d433-4c9a-8768-117a40d98f9e



### **After**

<!-- [screenshots/recordings] -->
<img width="3699" height="3090" alt="SCR-20260325-nzfa" src="https://github.com/user-attachments/assets/4b058c59-6df0-4d16-acf7-8d6bb839183f" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation tweak that changes which CTAs are shown based on a new route param; main risk is incorrect param wiring causing missing actions or disclaimer placement in the Perps insights flow.
> 
> **Overview**
> Fixes Perps AI Market Insights showing inappropriate `Long`/`Short` CTAs when the user already has an open position.
> 
> Adds a `hasPerpsPosition` route param (set by `PerpsMarketDetailsView`) and uses it in `MarketInsightsView` to **hide the footer action buttons** for Perps-with-position while **keeping the informational disclaimer visible** by moving it inline under the feedback section for that case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 833593b6e060e6e8c51a711b921f69d7b53ed4aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->