### PR TITLE
fix(bridge): support cursor-aware custom slippage input

### DIFF
--- a/app/components/UI/Bridge/components/InputStepper/index.test.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/index.test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import {
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
+} from 'react-native';
 import { InputStepper } from './index';
 import { InputStepperDescriptionType } from './constants';
 import {
@@ -113,6 +117,39 @@ describe('InputStepper', () => {
 
       const input = getByTestId('input-stepper-input');
       expect(input.props.placeholder).toBe('Enter amount');
+    });
+
+    it('passes selection through to the input when provided', () => {
+      const { getByTestId } = render(
+        <InputStepper {...defaultProps} selection={{ start: 2, end: 2 }} />,
+      );
+
+      const input = getByTestId('input-stepper-input');
+      expect(input.props.selection).toEqual({ start: 2, end: 2 });
+    });
+
+    it('passes onSelectionChange through to the input when provided', () => {
+      const onSelectionChange = jest.fn();
+      const event = {
+        nativeEvent: {
+          selection: {
+            start: 1,
+            end: 1,
+          },
+        },
+      } as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
+      const { getByTestId } = render(
+        <InputStepper
+          {...defaultProps}
+          onSelectionChange={onSelectionChange}
+        />,
+      );
+
+      const input = getByTestId('input-stepper-input');
+      input.props.onSelectionChange(event);
+
+      expect(onSelectionChange).toHaveBeenCalledWith(event);
     });
   });
 

--- a/app/components/UI/Bridge/components/InputStepper/index.test.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/index.test.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import {
-  type NativeSyntheticEvent,
-  type TextInputSelectionChangeEventData,
-} from 'react-native';
 import { InputStepper } from './index';
 import { InputStepperDescriptionType } from './constants';
 import {
@@ -117,39 +113,6 @@ describe('InputStepper', () => {
 
       const input = getByTestId('input-stepper-input');
       expect(input.props.placeholder).toBe('Enter amount');
-    });
-
-    it('passes selection through to the input when provided', () => {
-      const { getByTestId } = render(
-        <InputStepper {...defaultProps} selection={{ start: 2, end: 2 }} />,
-      );
-
-      const input = getByTestId('input-stepper-input');
-      expect(input.props.selection).toEqual({ start: 2, end: 2 });
-    });
-
-    it('passes onSelectionChange through to the input when provided', () => {
-      const onSelectionChange = jest.fn();
-      const event = {
-        nativeEvent: {
-          selection: {
-            start: 1,
-            end: 1,
-          },
-        },
-      } as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
-
-      const { getByTestId } = render(
-        <InputStepper
-          {...defaultProps}
-          onSelectionChange={onSelectionChange}
-        />,
-      );
-
-      const input = getByTestId('input-stepper-input');
-      input.props.onSelectionChange(event);
-
-      expect(onSelectionChange).toHaveBeenCalledWith(event);
     });
   });
 

--- a/app/components/UI/Bridge/components/InputStepper/index.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/index.tsx
@@ -25,6 +25,8 @@ export const InputStepper = ({
   maxAmount,
   postValue,
   placeholder = '0',
+  selection,
+  onSelectionChange,
 }: InputStepperProps) => {
   const fontSize = calculateInputFontSize(value.length);
   const { styles } = useStyles(inputStepperStyles, { fontSize });
@@ -61,6 +63,10 @@ export const InputStepper = ({
               value={displayedAmount}
               style={styles.input}
               testID="input-stepper-input"
+              // Slippage controls selection so keypad edits can target the
+              // displayed caret position instead of always appending.
+              selection={selection}
+              onSelectionChange={onSelectionChange}
             />
           </View>
           {postValue && (

--- a/app/components/UI/Bridge/components/InputStepper/types.ts
+++ b/app/components/UI/Bridge/components/InputStepper/types.ts
@@ -4,6 +4,10 @@ import {
   IconSize,
   TextColor,
 } from '@metamask/design-system-react-native';
+import {
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
+} from 'react-native';
 
 export interface InputStepperProps {
   value: string;
@@ -22,4 +26,11 @@ export interface InputStepperProps {
   maxAmount: number;
   postValue?: string;
   placeholder?: string;
+  selection?: {
+    start: number;
+    end: number;
+  };
+  onSelectionChange?: (
+    event: NativeSyntheticEvent<TextInputSelectionChangeEventData>,
+  ) => void;
 }

--- a/app/components/UI/Bridge/components/SlippageModal/CustomSlippageModal.test.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/CustomSlippageModal.test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import {
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
+} from 'react-native';
 import { CustomSlippageModal } from './CustomSlippageModal';
 
 // Mock BottomSheet
@@ -45,16 +49,15 @@ jest.mock(
 // Mock InputStepper
 jest.mock('../InputStepper', () => ({
   InputStepper: jest.fn(
-    ({
-      value,
-      onIncrease,
-      onDecrease,
-      description,
-    }: {
+    (props: {
       value: string;
       onIncrease: () => void;
       onDecrease: () => void;
       description: unknown;
+      selection?: { start: number; end: number };
+      onSelectionChange?: (
+        event: NativeSyntheticEvent<TextInputSelectionChangeEventData>,
+      ) => void;
     }) => {
       const ReactNative = jest.requireActual('react-native');
       const { View, Text, TouchableOpacity } = ReactNative;
@@ -63,18 +66,18 @@ jest.mock('../InputStepper', () => ({
         <View testID="input-stepper">
           <TouchableOpacity
             testID="input-stepper-decrease"
-            onPress={onDecrease}
+            onPress={props.onDecrease}
           >
             <Text>-</Text>
           </TouchableOpacity>
-          <Text testID="input-stepper-value">{value}</Text>
+          <Text testID="input-stepper-value">{props.value}</Text>
           <TouchableOpacity
             testID="input-stepper-increase"
-            onPress={onIncrease}
+            onPress={props.onIncrease}
           >
             <Text>+</Text>
           </TouchableOpacity>
-          {description && <View testID="input-stepper-description" />}
+          {props.description && <View testID="input-stepper-description" />}
         </View>
       );
     },
@@ -199,6 +202,18 @@ const mockInputStepper = InputStepper as jest.MockedFunction<
 >;
 const mockKeypad = Keypad as jest.MockedFunction<typeof Keypad>;
 
+const createSelectionEvent = (
+  start: number,
+): NativeSyntheticEvent<TextInputSelectionChangeEventData> =>
+  ({
+    nativeEvent: {
+      selection: {
+        start,
+        end: start,
+      },
+    },
+  }) as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
 describe('CustomSlippageModal', () => {
   const mockSlippageConfig = {
     input_step: 0.1,
@@ -278,6 +293,21 @@ describe('CustomSlippageModal', () => {
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
           payload: '5',
+        }),
+      );
+    });
+
+    it('sanitizes a trailing decimal before dispatching slippage', () => {
+      mockSelector.mockReturnValue('2.');
+
+      const { getByText } = render(<CustomSlippageModal />);
+
+      const confirmButton = getByText('Confirm');
+      fireEvent.press(confirmButton);
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: '2',
         }),
       );
     });
@@ -513,10 +543,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Try to input value that exceeds max_amount (e.g., 150)
-      keypadOnChange({
-        value: '150',
-        valueAsNumber: 150,
-        pressedKey: '0' as never,
+      act(() => {
+        keypadOnChange({
+          value: '150',
+          valueAsNumber: 150,
+          pressedKey: '0' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -543,10 +575,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Try to input value with 3 decimals (exceeds input_max_decimals: 2)
-      keypadOnChange({
-        value: '1.234',
-        valueAsNumber: 1.234,
-        pressedKey: '4' as never,
+      act(() => {
+        keypadOnChange({
+          value: '1.234',
+          valueAsNumber: 1.234,
+          pressedKey: '4' as never,
+        });
       });
 
       // Value should remain unchanged (rejected)
@@ -563,10 +597,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Input value with exactly 2 decimals (should be accepted)
-      keypadOnChange({
-        value: '1.25',
-        valueAsNumber: 1.25,
-        pressedKey: '5' as never,
+      act(() => {
+        keypadOnChange({
+          value: '1.25',
+          valueAsNumber: 1.25,
+          pressedKey: '5' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -586,10 +622,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Try to add decimal point to max amount (100.)
-      keypadOnChange({
-        value: '100.',
-        valueAsNumber: 100,
-        pressedKey: 'Period' as never,
+      act(() => {
+        keypadOnChange({
+          value: '100.',
+          valueAsNumber: 100,
+          pressedKey: 'Period' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -635,10 +673,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Input valid value
-      keypadOnChange({
-        value: '25',
-        valueAsNumber: 25,
-        pressedKey: '5' as never,
+      act(() => {
+        keypadOnChange({
+          value: '25',
+          valueAsNumber: 25,
+          pressedKey: '5' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -662,10 +702,12 @@ describe('CustomSlippageModal', () => {
 
       // Simulate backspace press that results in trailing dot
       // e.g., user had "5.5", pressed backspace, keypad returns "5."
-      keypadOnChange({
-        value: '5.',
-        valueAsNumber: 5,
-        pressedKey: 'Back' as never,
+      act(() => {
+        keypadOnChange({
+          value: '5.',
+          valueAsNumber: 5,
+          pressedKey: 'Back' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -685,10 +727,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Simulate backspace press on "0.5" resulting in "0."
-      keypadOnChange({
-        value: '0.',
-        valueAsNumber: 0,
-        pressedKey: 'Back' as never,
+      act(() => {
+        keypadOnChange({
+          value: '0.',
+          valueAsNumber: 0,
+          pressedKey: 'Back' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -708,10 +752,12 @@ describe('CustomSlippageModal', () => {
       const keypadOnChange = mockKeypad.mock.calls[0][0].onChange;
 
       // Simulate period key press (not backspace)
-      keypadOnChange({
-        value: '5.',
-        valueAsNumber: 5,
-        pressedKey: 'Period' as never,
+      act(() => {
+        keypadOnChange({
+          value: '5.',
+          valueAsNumber: 5,
+          pressedKey: 'Period' as never,
+        });
       });
 
       // Re-render to apply state change
@@ -801,6 +847,18 @@ describe('CustomSlippageModal', () => {
       );
     });
 
+    it('passes selection handlers to InputStepper', () => {
+      render(<CustomSlippageModal />);
+
+      expect(mockInputStepper).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selection: undefined,
+          onSelectionChange: expect.any(Function),
+        }),
+        expect.anything(),
+      );
+    });
+
     it('passes correct props to Keypad', () => {
       mockSelector.mockReturnValue('3.5');
 
@@ -813,6 +871,58 @@ describe('CustomSlippageModal', () => {
         }),
         expect.anything(),
       );
+    });
+
+    it('updates the displayed value at the selected cursor position', () => {
+      mockUseSlippageConfig.mockReturnValue({
+        ...mockSlippageConfig,
+        max_amount: 1000,
+      });
+      mockSelector.mockReturnValue('12.5');
+
+      const { getByTestId } = render(<CustomSlippageModal />);
+
+      const inputStepperProps = mockInputStepper.mock.calls[0][0];
+
+      act(() => {
+        inputStepperProps.onSelectionChange?.(createSelectionEvent(1));
+      });
+      const keypadOnChange =
+        mockKeypad.mock.calls[mockKeypad.mock.calls.length - 1][0].onChange;
+      act(() => {
+        keypadOnChange({
+          value: '12.55',
+          valueAsNumber: 12.55,
+          pressedKey: '5' as never,
+        });
+      });
+
+      expect(getByTestId('input-stepper-value').props.children).toBe('152.5');
+    });
+
+    it('resets the cursor when stepper buttons change the value', () => {
+      mockSelector.mockReturnValue('12.5');
+
+      const { getByTestId } = render(<CustomSlippageModal />);
+
+      const initialInputStepperProps = mockInputStepper.mock.calls[0][0];
+      act(() => {
+        initialInputStepperProps.onSelectionChange?.(createSelectionEvent(1));
+      });
+
+      fireEvent.press(getByTestId('input-stepper-increase'));
+
+      const latestKeypadOnChange =
+        mockKeypad.mock.calls[mockKeypad.mock.calls.length - 1][0].onChange;
+      act(() => {
+        latestKeypadOnChange({
+          value: '12.65',
+          valueAsNumber: 12.65,
+          pressedKey: '5' as never,
+        });
+      });
+
+      expect(getByTestId('input-stepper-value').props.children).toBe('12.65');
     });
   });
 

--- a/app/components/UI/Bridge/components/SlippageModal/CustomSlippageModal.test.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/CustomSlippageModal.test.tsx
@@ -847,18 +847,6 @@ describe('CustomSlippageModal', () => {
       );
     });
 
-    it('passes selection handlers to InputStepper', () => {
-      render(<CustomSlippageModal />);
-
-      expect(mockInputStepper).toHaveBeenCalledWith(
-        expect.objectContaining({
-          selection: undefined,
-          onSelectionChange: expect.any(Function),
-        }),
-        expect.anything(),
-      );
-    });
-
     it('passes correct props to Keypad', () => {
       mockSelector.mockReturnValue('3.5');
 

--- a/app/components/UI/Bridge/components/SlippageModal/CustomSlippageModal.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/CustomSlippageModal.tsx
@@ -10,7 +10,7 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
-import Keypad, { Keys } from '../../../../Base/Keypad';
+import Keypad from '../../../../Base/Keypad';
 import { InputStepper } from '../InputStepper';
 import { DefaultSlippageModalParams } from './types';
 import { customSlippageModalStyles } from './styles';
@@ -23,6 +23,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { useSlippageStepperDescription } from '../../hooks/useSlippageStepperDescription';
 import { useShouldDisableCustomSlippageConfirm } from '../../hooks/useShouldDisableCustomSlippageConfirm';
+import { useCustomSlippageCursor } from './useCustomSlippageCursor';
 
 export const CustomSlippageModal = () => {
   const dispatch = useDispatch();
@@ -42,52 +43,30 @@ export const CustomSlippageModal = () => {
     slippageConfig,
     hasAttemptedToExceedMax,
   });
+  const { selection, handleSelectionChange, handleKeypadChange, resetCursor } =
+    useCustomSlippageCursor({
+      value: inputAmount,
+      inputMaxDecimals: slippageConfig.input_max_decimals,
+      maxAmount: slippageConfig.max_amount,
+      onValueChange: setInputAmount,
+      onAttemptExceedMaxChange: setHasAttemptedToExceedMax,
+    });
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
   }, []);
 
   const handleConfirm = useCallback(() => {
-    dispatch(setSlippage(inputAmount));
+    const sanitizedInputAmount = inputAmount.endsWith('.')
+      ? inputAmount.slice(0, -1)
+      : inputAmount;
+
+    dispatch(setSlippage(sanitizedInputAmount));
     sheetRef.current?.onCloseBottomSheet();
   }, [dispatch, inputAmount]);
 
-  const handleKeypadChange = useCallback(
-    (data: { value: string; valueAsNumber: number; pressedKey: Keys }) => {
-      let newValue = data.value;
-      setHasAttemptedToExceedMax(false);
-
-      // If user pressed backspace and the result ends with a trailing dot, remove it
-      if (data.pressedKey === Keys.Back && newValue.endsWith('.')) {
-        newValue = newValue.slice(0, -1);
-      }
-
-      const [, decimalPart] = newValue.split('.');
-      const valueAsNumber = parseFloat(newValue) || 0;
-
-      // Cap the value to input_max_decimals
-      if ((decimalPart?.length ?? 0) > slippageConfig.input_max_decimals) {
-        return;
-      }
-
-      if (valueAsNumber > slippageConfig.max_amount) {
-        setHasAttemptedToExceedMax(true);
-        return;
-      }
-
-      // Do not render dot when reaching max_amount
-      if (newValue === slippageConfig.max_amount + '.') {
-        setInputAmount(String(slippageConfig.max_amount));
-        setHasAttemptedToExceedMax(true);
-        return;
-      }
-
-      setInputAmount(newValue);
-    },
-    [slippageConfig],
-  );
-
   const handleOnIncreasePress = useCallback(() => {
+    resetCursor();
     setHasAttemptedToExceedMax(false);
 
     setInputAmount((value) => {
@@ -99,9 +78,10 @@ export const CustomSlippageModal = () => {
             parseFloat(newValue.toFixed(slippageConfig.input_max_decimals)),
           );
     });
-  }, [slippageConfig]);
+  }, [resetCursor, slippageConfig]);
 
   const handleOnDecreasePress = useCallback(() => {
+    resetCursor();
     setHasAttemptedToExceedMax(false);
 
     setInputAmount((value) => {
@@ -113,7 +93,7 @@ export const CustomSlippageModal = () => {
             parseFloat(newValue.toFixed(slippageConfig.input_max_decimals)),
           );
     });
-  }, [slippageConfig]);
+  }, [resetCursor, slippageConfig]);
 
   return (
     <BottomSheet ref={sheetRef}>
@@ -130,6 +110,8 @@ export const CustomSlippageModal = () => {
           minAmount={slippageConfig.min_amount}
           maxAmount={slippageConfig.max_amount}
           postValue="%"
+          selection={selection}
+          onSelectionChange={handleSelectionChange}
         />
       </View>
       <View style={customSlippageModalStyles.keypadContainer}>

--- a/app/components/UI/Bridge/components/SlippageModal/useCustomSlippageCursor.test.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/useCustomSlippageCursor.test.ts
@@ -1,0 +1,227 @@
+import { act, renderHook } from '@testing-library/react-native';
+import {
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
+} from 'react-native';
+import { Keys } from '../../../../Base/Keypad';
+import { useCustomSlippageCursor } from './useCustomSlippageCursor';
+
+const createSelectionEvent = (
+  start: number,
+): NativeSyntheticEvent<TextInputSelectionChangeEventData> =>
+  ({
+    nativeEvent: {
+      selection: {
+        start,
+        end: start,
+      },
+    },
+  }) as NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
+describe('useCustomSlippageCursor', () => {
+  it('inserts a digit at the selected cursor position', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '12.5',
+        inputMaxDecimals: 2,
+        maxAmount: 1000,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(1));
+    });
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '12.55',
+        valueAsNumber: 12.55,
+        pressedKey: Keys.Digit5,
+      });
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith('152.5');
+    expect(onAttemptExceedMaxChange).toHaveBeenCalledWith(false);
+  });
+
+  it('backspaces at the selected cursor position', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '12.5',
+        inputMaxDecimals: 2,
+        maxAmount: 100,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(2));
+    });
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '12',
+        valueAsNumber: 12,
+        pressedKey: Keys.Back,
+      });
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith('1.5');
+    expect(onAttemptExceedMaxChange).toHaveBeenCalledWith(false);
+  });
+
+  it('rejects edits beyond the configured decimal precision', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '1.23',
+        inputMaxDecimals: 2,
+        maxAmount: 100,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(4));
+    });
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '1.234',
+        valueAsNumber: 1.234,
+        pressedKey: Keys.Digit4,
+      });
+    });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('rejects values above maxAmount and sets the exceed flag', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '99',
+        inputMaxDecimals: 2,
+        maxAmount: 100,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(2));
+    });
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '999',
+        valueAsNumber: 999,
+        pressedKey: Keys.Digit9,
+      });
+    });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onAttemptExceedMaxChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('collapses maxAmount followed by a decimal back to maxAmount', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '100',
+        inputMaxDecimals: 2,
+        maxAmount: 100,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(3));
+    });
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '100.',
+        valueAsNumber: 100,
+        pressedKey: Keys.Period,
+      });
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith('100');
+    expect(onAttemptExceedMaxChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('allows editing back from an over-limit value when the next value is valid', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '100.1',
+        inputMaxDecimals: 2,
+        maxAmount: 100,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(3));
+    });
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '100',
+        valueAsNumber: 100,
+        pressedKey: Keys.Back,
+      });
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith('10.1');
+    expect(onAttemptExceedMaxChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('clears the controlled selection when resetCursor is called', () => {
+    const onValueChange = jest.fn();
+    const onAttemptExceedMaxChange = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCustomSlippageCursor({
+        value: '12.5',
+        inputMaxDecimals: 2,
+        maxAmount: 100,
+        onValueChange,
+        onAttemptExceedMaxChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectionChange(createSelectionEvent(2));
+    });
+
+    expect(result.current.selection).toEqual({ start: 2, end: 2 });
+
+    act(() => {
+      result.current.resetCursor();
+    });
+
+    expect(result.current.selection).toBeUndefined();
+  });
+});

--- a/app/components/UI/Bridge/components/SlippageModal/useCustomSlippageCursor.ts
+++ b/app/components/UI/Bridge/components/SlippageModal/useCustomSlippageCursor.ts
@@ -1,0 +1,159 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
+} from 'react-native';
+import { Keys, type KeypadChangeData } from '../../../../Base/Keypad';
+import { formatAmountWithLocaleSeparators } from '../../utils/formatAmountWithLocaleSeparators';
+import { applyKeyAtCursor } from '../../utils/applyKeyAtCursor';
+import {
+  mapFormattedCursorToRaw,
+  mapRawCursorToFormatted,
+} from '../../utils/cursorPosition';
+
+interface UseCustomSlippageCursorParams {
+  value: string;
+  inputMaxDecimals: number;
+  maxAmount: number;
+  onValueChange: (value: string) => void;
+  onAttemptExceedMaxChange: (value: boolean) => void;
+}
+
+interface UseCustomSlippageCursorResult {
+  selection?: {
+    start: number;
+    end: number;
+  };
+  handleSelectionChange: (
+    event: NativeSyntheticEvent<TextInputSelectionChangeEventData>,
+  ) => void;
+  handleKeypadChange: ({ value, pressedKey }: KeypadChangeData) => void;
+  resetCursor: () => void;
+}
+
+const normalizeKeypadValue = (value: string, pressedKey: Keys) =>
+  pressedKey === Keys.Back && value.endsWith('.') ? value.slice(0, -1) : value;
+
+export const useCustomSlippageCursor = ({
+  value,
+  inputMaxDecimals,
+  maxAmount,
+  onValueChange,
+  onAttemptExceedMaxChange,
+}: UseCustomSlippageCursorParams): UseCustomSlippageCursorResult => {
+  const [rawCursorPosition, setRawCursorPosition] = useState<
+    number | undefined
+  >();
+
+  const rawValue = value || '0';
+  const formattedValue =
+    value && value !== '0' ? formatAmountWithLocaleSeparators(value) : rawValue;
+
+  const selection = useMemo(() => {
+    if (typeof rawCursorPosition !== 'number') {
+      return undefined;
+    }
+
+    const formattedCursorPosition = mapRawCursorToFormatted({
+      rawValue,
+      formattedValue,
+      rawCursorIndex: rawCursorPosition,
+    });
+
+    return {
+      start: formattedCursorPosition,
+      end: formattedCursorPosition,
+    };
+  }, [formattedValue, rawCursorPosition, rawValue]);
+
+  const applyNextValue = useCallback(
+    ({
+      nextValue,
+      nextCursorPosition,
+    }: {
+      nextValue: string;
+      nextCursorPosition?: number;
+    }) => {
+      if (nextValue === `${maxAmount}.`) {
+        const collapsedValue = String(maxAmount);
+        onAttemptExceedMaxChange(true);
+        setRawCursorPosition(collapsedValue.length);
+        onValueChange(collapsedValue);
+        return;
+      }
+
+      const numericValue = parseFloat(nextValue) || 0;
+      if (numericValue > maxAmount) {
+        onAttemptExceedMaxChange(true);
+        return;
+      }
+
+      if (nextValue === rawValue && nextCursorPosition === rawCursorPosition) {
+        return;
+      }
+
+      onAttemptExceedMaxChange(false);
+      if (typeof nextCursorPosition === 'number') {
+        setRawCursorPosition(nextCursorPosition);
+      }
+      onValueChange(nextValue);
+    },
+    [
+      maxAmount,
+      onAttemptExceedMaxChange,
+      onValueChange,
+      rawCursorPosition,
+      rawValue,
+    ],
+  );
+
+  const handleSelectionChange = useCallback(
+    (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
+      const nextRawCursorPosition = mapFormattedCursorToRaw({
+        rawValue,
+        formattedValue,
+        formattedCursorIndex: event.nativeEvent.selection.start,
+      });
+      setRawCursorPosition(nextRawCursorPosition);
+    },
+    [formattedValue, rawValue],
+  );
+
+  const handleKeypadChange = useCallback(
+    ({ value: keypadValue, pressedKey }: KeypadChangeData) => {
+      const nextValue = normalizeKeypadValue(keypadValue, pressedKey);
+
+      if (typeof rawCursorPosition !== 'number') {
+        const [, decimalPart = ''] = nextValue.split('.');
+        if (decimalPart.length > inputMaxDecimals) {
+          return;
+        }
+
+        applyNextValue({ nextValue });
+        return;
+      }
+
+      const updatedValue = applyKeyAtCursor({
+        currentValue: rawValue,
+        pressedKey,
+        cursorPosition: rawCursorPosition,
+        decimals: inputMaxDecimals,
+      });
+
+      applyNextValue({
+        nextValue: updatedValue.value,
+        nextCursorPosition: updatedValue.cursorPosition,
+      });
+    },
+    [applyNextValue, inputMaxDecimals, rawCursorPosition, rawValue],
+  );
+
+  const resetCursor = useCallback(() => setRawCursorPosition(undefined), []);
+
+  return {
+    selection,
+    handleSelectionChange,
+    handleKeypadChange,
+    resetCursor,
+  };
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR makes the custom slippage modal cursor-aware. It adds a dedicated slippage cursor hook that reuses the shared raw cursor editing utilities, wires controlled `selection` / `onSelectionChange` through `InputStepper`, preserves the existing slippage-specific max and decimal validation rules, resets cursor state when the stepper buttons change the value, and sanitizes trailing decimals such as `2.` before saving the selected slippage.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed custom slippage input so keypad edits respect cursor placement and trailing decimals are sanitized before saving.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: custom slippage cursor-aware editing

  Scenario: user inserts a digit at a chosen cursor position
    Given the user opens Bridge and opens the custom slippage modal
    And the custom slippage value is "12.5"

    When the user places the caret between "1" and "2"
    And the user taps "5" on the keypad
    Then the displayed custom slippage value updates to "152.5"

  Scenario: user resets the cursor by using the stepper buttons
    Given the user opens Bridge and opens the custom slippage modal
    And the user places the caret in the middle of the custom slippage value

    When the user taps the "+" stepper button
    And the user taps "5" on the keypad
    Then the next keypad edit follows the new stepper-updated value instead of the old caret position

  Scenario: user confirms a value with a trailing decimal
    Given the user opens Bridge and opens the custom slippage modal
    And the custom slippage value is "2."

    When the user taps "Confirm"
    Then the saved slippage value is "2"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user input/editing logic in the Bridge slippage flow (cursor mapping + keypad handling), which can introduce subtle edge-case regressions, but scope is localized and covered by new tests.
> 
> **Overview**
> Makes the Bridge `CustomSlippageModal` cursor-aware by introducing `useCustomSlippageCursor`, which tracks and maps selection between formatted and raw values and applies keypad edits at the current caret position (while preserving max/decimal validation and over-max flagging).
> 
> Extends `InputStepper` to accept controlled `selection`/`onSelectionChange`, wires these through the slippage modal, resets cursor state when +/- stepper buttons adjust the value, and sanitizes trailing decimals (e.g., `2.` -> `2`) before dispatching `setSlippage`. Tests are updated/added to cover cursor insertion/backspace behavior, trailing-decimal sanitization, and the new selection plumbing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9635769569aa76fcbc2ce7b9c24c85ec160c400. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->