### PR TITLE
refactor(analytics): C5 migrate to useAnalytics in PredictGTMModal

### DIFF
--- a/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.test.tsx
+++ b/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.test.tsx
@@ -7,6 +7,8 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { PREDICT_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
 
 jest.mock('../../../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../../../util/theme');
@@ -41,12 +43,7 @@ const mockCreateEventBuilder = jest.fn().mockReturnValue({
   addProperties: jest.fn().mockReturnThis(),
   build: jest.fn().mockReturnValue({}),
 });
-jest.mock('../../../../../components/hooks/useMetrics', () => ({
-  useMetrics: () => ({
-    trackEvent: mockTrackEvent,
-    createEventBuilder: mockCreateEventBuilder,
-  }),
-}));
+jest.mock('../../../../../components/hooks/useAnalytics/useAnalytics');
 
 jest.mock('../../../../../util/metrics', () => ({
   __esModule: true,
@@ -65,7 +62,13 @@ const initialState = {
 describe('PredictGTMModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (StorageWrapper.getItem as jest.Mock).mockResolvedValue('false');
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        trackEvent: mockTrackEvent,
+        createEventBuilder: mockCreateEventBuilder,
+      }),
+    );
+    jest.mocked(StorageWrapper.getItem).mockResolvedValue('false');
   });
 
   it('renders correctly with all main elements', async () => {

--- a/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.tsx
+++ b/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.tsx
@@ -17,7 +17,7 @@ import Button, {
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import { useMetrics } from '../../../../../components/hooks/useMetrics';
+import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import PredictMarketingImage from '../../../../../images/predict-marketing.png';
@@ -36,7 +36,7 @@ import {
 import { PREDICT_GTM_MODAL_TEST_IDS } from './PredictGTMModal.testIds';
 
 const PredictGTMModal = () => {
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { navigate } = useNavigation();
   const theme = useTheme();
   const [imageLoaded, setImageLoaded] = useState(false);


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Part of the analytics C5 migration phase: replaces `useMetrics` with the new `useAnalytics` hook in `PredictGTMModal`.

The `useMetrics` hook is being deprecated in favour of `useAnalytics`, which provides the same `trackEvent` / `createEventBuilder` API through a unified interface. This commit updates the component and its unit test to use the new hook and the `createMockUseAnalyticsHook` test helper.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27883

## **Manual testing steps**

N/A — pure internal refactor with no user-facing behaviour change. Existing unit tests cover the analytics event firing.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal refactor that swaps the analytics hook used by `PredictGTMModal`; behavior should be unchanged aside from potential wiring/mocking issues in event tracking.
> 
> **Overview**
> Updates `PredictGTMModal` to use the new `useAnalytics` hook instead of `useMetrics` while keeping the same `trackEvent`/`createEventBuilder` flow for the modal’s analytics events.
> 
> Refactors `PredictGTMModal.test.tsx` accordingly by mocking `useAnalytics` and using the shared `createMockUseAnalyticsHook` helper, plus minor jest mocking cleanup for `StorageWrapper.getItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55c10d9fee62ed6aa433d665805f1e6b1956f588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->