### PR TITLE
fix(swaps): scroll bridge to top from trending token details

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -222,6 +222,8 @@ jest.mock(
 );
 
 const mockNavigate = jest.fn();
+const mockSetParams = jest.fn();
+const mockFocusEffects: (() => void | (() => void))[] = [];
 const mockRoute = {
   params: {
     sourcePage: 'test',
@@ -232,8 +234,12 @@ jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
   return {
     ...actualNav,
+    useFocusEffect: jest.fn((callback: () => void | (() => void)) => {
+      mockFocusEffects.push(callback);
+    }),
     useNavigation: () => ({
       navigate: mockNavigate,
+      setParams: mockSetParams,
       setOptions: jest.fn(),
     }),
     useRoute: () => mockRoute,
@@ -354,6 +360,10 @@ describe('BridgeView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFocusEffects.length = 0;
+    mockRoute.params = {
+      sourcePage: 'test',
+    } as BridgeRouteParams;
   });
 
   it('renders source and destination token areas', async () => {
@@ -369,6 +379,29 @@ describe('BridgeView', () => {
     expect(
       getByTestId(BridgeViewSelectorsIDs.DESTINATION_TOKEN_AREA),
     ).toBeTruthy();
+  });
+
+  it('scrolls to top and clears the route param when requested on focus', () => {
+    mockRoute.params = {
+      sourcePage: 'test',
+      scrollToTopOnNav: true,
+    } as BridgeRouteParams;
+
+    renderScreen(
+      BridgeView,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: mockState },
+    );
+
+    act(() => {
+      mockFocusEffects[mockFocusEffects.length - 1]?.();
+    });
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      scrollToTopOnNav: undefined,
+    });
   });
 
   it('should open BridgeTokenSelector when clicking source token', async () => {

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -36,6 +36,7 @@ import {
 import {
   useNavigation,
   useRoute,
+  useFocusEffect,
   type RouteProp,
 } from '@react-navigation/native';
 import { getBridgeNavbar } from '../../../Navbar';
@@ -113,6 +114,7 @@ const BridgeView = () => {
   const route = useRoute<RouteProp<{ params: BridgeRouteParams }, 'params'>>();
   const { colors } = useTheme();
   const keypadRef = useRef<SwapsKeypadRef>(null);
+  const scrollViewRef = useRef<ScrollView>(null);
 
   // Needed to get gas fee estimates
   const selectedNetworkClientId = useSelector(selectSelectedNetworkClientId);
@@ -185,6 +187,16 @@ const BridgeView = () => {
   useRecipientInitialization(hasInitializedRecipient);
 
   useBridgeViewOnFocus({ inputRef, keypadRef });
+
+  // Scroll to top when navigating to the bridge view if requested
+  useFocusEffect(
+    useCallback(() => {
+      if (route.params?.scrollToTopOnNav && scrollViewRef.current) {
+        scrollViewRef.current.scrollTo({ y: 0, animated: false });
+        navigation.setParams({ scrollToTopOnNav: undefined });
+      }
+    }, [navigation, route.params?.scrollToTopOnNav]),
+  );
 
   useEffect(() => {
     if (route.params?.bridgeViewMode && bridgeViewMode === undefined) {
@@ -403,6 +415,7 @@ const BridgeView = () => {
         }}
       >
         <ScrollView
+          ref={scrollViewRef}
           testID={BridgeViewSelectorsIDs.BRIDGE_VIEW_SCROLL}
           style={styles.scrollView}
           contentContainerStyle={styles.scrollViewContent}

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -59,6 +59,7 @@ export interface BridgeRouteParams {
   destToken?: BridgeToken;
   sourceAmount?: string;
   location: MetaMetricsSwapsEventSource;
+  scrollToTopOnNav?: boolean;
 }
 
 export enum SwapBridgeNavigationLocation {
@@ -141,6 +142,7 @@ export const useSwapBridgeNavigation = ({
       sourceTokenOverride?: BridgeToken,
       destTokenOverride?: BridgeToken,
       buttonLabel?: string,
+      scrollToTopOnNav?: boolean,
     ) => {
       // Use tokenOverride if provided, otherwise fall back to tokenBase
       const effectiveSourceTokenBase = sourceTokenOverride ?? sourceTokenBase;
@@ -269,6 +271,7 @@ export const useSwapBridgeNavigation = ({
         sourcePage,
         bridgeViewMode,
         location: mappedLocation,
+        ...(scrollToTopOnNav && { scrollToTopOnNav: true }),
       };
 
       navigation.navigate(Routes.BRIDGE.ROOT, {
@@ -333,12 +336,14 @@ export const useSwapBridgeNavigation = ({
       tokenOverride?: BridgeToken,
       destTokenOverride?: BridgeToken,
       buttonLabel?: string,
+      scrollToTopOnNav?: boolean,
     ) => {
       goToNativeBridge(
         BridgeViewMode.Unified,
         tokenOverride,
         destTokenOverride,
         buttonLabel,
+        scrollToTopOnNav,
       );
     },
     [goToNativeBridge],

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
@@ -1272,4 +1272,28 @@ describe('useSwapBridgeNavigation', () => {
       expect(mockTrackEvent).toHaveBeenCalled();
     });
   });
+
+  it('includes scrollToTopOnNav in bridge params when requested', () => {
+    const { result } = renderHookWithProvider(
+      () =>
+        useSwapBridgeNavigation({
+          location: SwapBridgeNavigationLocation.TokenView,
+          sourcePage: mockSourcePage,
+          sourceToken: mockSourceToken,
+        }),
+      { state: initialState },
+    );
+
+    result.current.goToSwaps(undefined, undefined, undefined, true);
+
+    expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: expect.objectContaining({
+        sourceToken: mockSourceToken,
+        sourcePage: mockSourcePage,
+        location: 'Token View',
+        scrollToTopOnNav: true,
+      }),
+    });
+  });
 });

--- a/app/components/UI/TokenDetails/Views/TokenDetails.test.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ActivityIndicator } from 'react-native';
-import { render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { TokenDetails } from './TokenDetails';
 import { selectNetworkConfigurationByChainId } from '../../../../selectors/networkController';
 import { selectPerpsEnabledFlag } from '../../Perps';
@@ -284,6 +284,19 @@ describe('TokenDetails', () => {
 
       expect(getByText('Swap')).toBeOnTheScreen();
       expect(getByText('Buy')).toBeOnTheScreen();
+    });
+
+    it('passes scrollToTopOnNav when sticky Swap is pressed', () => {
+      const { getByText } = render(<TokenDetails />);
+
+      fireEvent.press(getByText('Swap'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        true,
+      );
     });
 
     it('shows only Swap when user has eligible tokens but token is not buyable', () => {

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -159,6 +159,13 @@ const TokenDetails: React.FC<{
       networkName,
     });
 
+  // Swaps view should always scroll to top when navigating from the token details view
+  const goToSwapsFromDetails = useCallback(
+    () =>
+      goToSwaps(undefined, undefined, undefined, token.isFromTrending === true),
+    [goToSwaps, token],
+  );
+
   const {
     transactions,
     submittedTxs,
@@ -215,7 +222,7 @@ const TokenDetails: React.FC<{
         onBuy={onBuy}
         onSend={onSend}
         onReceive={onReceive}
-        goToSwaps={goToSwaps}
+        goToSwaps={goToSwapsFromDetails}
         onMarketInsightsDisplayResolved={
           onMarketInsightsDisplayResolved
             ? (isDisplayed: boolean) =>
@@ -300,7 +307,7 @@ const TokenDetails: React.FC<{
           token={token}
           securityData={securityData}
           onBuy={onBuy}
-          goToSwaps={goToSwaps}
+          goToSwaps={goToSwapsFromDetails}
           hasEligibleSwapTokens={hasEligibleSwapTokens}
         />
       )}

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -161,9 +161,8 @@ const TokenDetails: React.FC<{
 
   // Swaps view should always scroll to top when navigating from the token details view
   const goToSwapsFromDetails = useCallback(
-    () =>
-      goToSwaps(undefined, undefined, undefined, token.isFromTrending === true),
-    [goToSwaps, token],
+    () => goToSwaps(undefined, undefined, undefined, true),
+    [goToSwaps],
   );
 
   const {

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
@@ -663,7 +663,7 @@ describe('useTokenActions', () => {
           symbol: defaultToken.symbol,
         }),
         'Buy',
-        false,
+        true,
       );
       expect(mockGoToBuy).not.toHaveBeenCalled();
     });
@@ -702,7 +702,7 @@ describe('useTokenActions', () => {
           address: defaultToken.address,
         }),
         'Buy',
-        false,
+        true,
       );
     });
 
@@ -755,7 +755,7 @@ describe('useTokenActions', () => {
           symbol: 'ETH',
         }),
         'Buy',
-        false,
+        true,
       );
       expect(mockGoToBuy).not.toHaveBeenCalled();
     });
@@ -781,7 +781,7 @@ describe('useTokenActions', () => {
         }),
         undefined,
         'Sell',
-        false,
+        true,
       );
     });
   });

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
@@ -663,6 +663,7 @@ describe('useTokenActions', () => {
           symbol: defaultToken.symbol,
         }),
         'Buy',
+        false,
       );
       expect(mockGoToBuy).not.toHaveBeenCalled();
     });
@@ -701,6 +702,7 @@ describe('useTokenActions', () => {
           address: defaultToken.address,
         }),
         'Buy',
+        false,
       );
     });
 
@@ -753,6 +755,7 @@ describe('useTokenActions', () => {
           symbol: 'ETH',
         }),
         'Buy',
+        false,
       );
       expect(mockGoToBuy).not.toHaveBeenCalled();
     });
@@ -778,6 +781,7 @@ describe('useTokenActions', () => {
         }),
         undefined,
         'Sell',
+        false,
       );
     });
   });

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.ts
@@ -94,7 +94,12 @@ export interface UseTokenActionsResult {
   onBuy: () => void;
   onSend: () => Promise<void>;
   onReceive: () => void;
-  goToSwaps: () => void;
+  goToSwaps: (
+    tokenOverride?: BridgeToken,
+    destTokenOverride?: BridgeToken,
+    buttonLabel?: string,
+    scrollToTopOnNav?: boolean,
+  ) => void;
   /** Sticky bar Buy handler - smart source selection, current asset as destination */
   handleBuyPress: () => void;
   /** Sticky bar Sell handler - current asset as source, mUSD/native as destination */
@@ -443,6 +448,7 @@ export const useTokenActions = ({
       buySourceToken,
       currentTokenAsBridgeToken,
       strings('asset_overview.buy_button'),
+      true,
     );
   }, [
     goToSwaps,
@@ -460,6 +466,7 @@ export const useTokenActions = ({
       currentTokenAsBridgeToken,
       undefined,
       strings('asset_overview.sell_button'),
+      true,
     );
   }, [goToSwaps, currentTokenAsBridgeToken]);
 


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes [#27843](https://github.com/MetaMask/metamask-mobile/issues/27843), where opening Swap from a trending token details page could land the user back on Bridge with the view still scrolled down and the prefilled form off-screen. The fix adds a minimal `scrollToTopOnNav` route param for that navigation path and has `BridgeView` consume it once on focus so token-details Swap entry points return with the swap form visible at the top.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that kept the swap screen scrolled down after opening Swap from a trending token details page.

## **Related issues**

Fixes: #27843

## **Manual testing steps**

```gherkin
Feature: Swap navigation from trending token details

  Scenario: user opens swap from the token details action row
    Given the user is on the Home tab
    And the user opens Swap
    And the user scrolls to the Trending tokens list
    And the user opens a trending token details page
    When the user taps "Swap"
    Then the Bridge view opens with the prefilled swap form visible at the top of the screen

  Scenario: user opens swap from the token details sticky footer
    Given the user is on a trending token details page with the sticky footer visible
    When the user taps the sticky footer swap action
    Then the Bridge view opens with the prefilled swap form visible at the top of the screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a one-time navigation flag that triggers a `ScrollView.scrollTo` on focus and clears itself; scope is limited to swaps/bridge navigation and related tests.
> 
> **Overview**
> Fixes a navigation UX bug where returning to `BridgeView` from Token Details (notably trending tokens) could leave the unified swap form scrolled off-screen.
> 
> This introduces a `scrollToTopOnNav` route param in `useSwapBridgeNavigation`, has `BridgeView` consume it via `useFocusEffect` to scroll the main `ScrollView` to `y=0` and then `setParams` to clear the flag, and updates Token Details swap entry points (including sticky footer and buy/sell handlers) to request this behavior. Tests were updated/added to cover the new param propagation and one-time clearing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86c6e2d7d5945638a4ff90b7109102cb5d956aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->