### PR TITLE
fix: Fix redux store event handler leak in WCv2

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -219,6 +219,7 @@ describe('WalletConnect2Session', () => {
   let mockClient: IWalletKit;
   let mockSession: SessionTypes.Struct;
   let mockNavigation: NavigationContainerRef;
+  let mockStoreUnsubscribe: jest.Mock;
 
   const testChainId = '0x89';
   const testNetworkClientId = `test-network-${parseInt(testChainId, 16)}`;
@@ -295,6 +296,9 @@ describe('WalletConnect2Session', () => {
         rpcEndpoints: [{ networkClientId: testNetworkClientId }],
       },
     });
+
+    mockStoreUnsubscribe = jest.fn();
+    (store.subscribe as jest.Mock).mockReturnValue(mockStoreUnsubscribe);
 
     session = new WalletConnect2Session({
       web3Wallet: mockClient,
@@ -438,6 +442,7 @@ describe('WalletConnect2Session', () => {
 
     await session.removeListeners();
 
+    expect(mockStoreUnsubscribe).toHaveBeenCalled();
     expect(mockOnDisconnect).toHaveBeenCalled();
   });
 

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -72,6 +72,7 @@ class WalletConnect2Session {
   private lastChainId: Hex;
   private isHandlingChainChange = false;
   private _isHandlingRequest = false;
+  private storeUnsubscribe: (() => void) | null = null;
 
   public session: SessionTypes.Struct;
 
@@ -164,7 +165,7 @@ class WalletConnect2Session {
     this.checkPendingRequests();
     this.lastChainId = this.getCurrentChainId();
     // Subscribe to store changes to detect chain switches
-    store.subscribe(this.onStoreChange.bind(this));
+    this.storeUnsubscribe = store.subscribe(this.onStoreChange.bind(this));
   }
 
   /**
@@ -791,6 +792,8 @@ class WalletConnect2Session {
   };
 
   removeListeners = async () => {
+    this.storeUnsubscribe?.();
+    this.storeUnsubscribe = null;
     this.backgroundBridge.onDisconnect();
   };
 

--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -735,6 +735,23 @@ describe('WC2Manager', () => {
         JSON.stringify({}),
       );
     });
+
+    it('calls removeListeners on each WalletConnect2Session before clearing local sessions', async () => {
+      const removeListenersA = jest.fn().mockResolvedValue(undefined);
+      const removeListenersB = jest.fn().mockResolvedValue(undefined);
+      (manager as unknown as { sessions: Record<string, unknown> }).sessions = {
+        'topic-a': { removeListeners: removeListenersA },
+        'topic-b': { removeListeners: removeListenersB },
+      };
+
+      await manager.removeAll();
+
+      expect(removeListenersA).toHaveBeenCalledTimes(1);
+      expect(removeListenersB).toHaveBeenCalledTimes(1);
+      expect(
+        (manager as unknown as { sessions: Record<string, unknown> }).sessions,
+      ).toEqual({});
+    });
   });
 
   describe('WC2Manager isWalletConnect', () => {

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -382,6 +382,15 @@ export class WC2Manager {
 
   public async removeAll() {
     this.deeplinkSessions = {};
+    // Tear down WalletConnect2Session (Redux subscription, BackgroundBridge)
+    // before clearing the map. Otherwise session_delete may run after this.sessions
+    // is empty and skip removeListeners(), leaking listeners and relay churn.
+    const wcSessions = Object.values(this.sessions);
+    await Promise.allSettled(
+      wcSessions.map((wcSession) => wcSession.removeListeners()),
+    );
+    this.sessions = {};
+
     const actives = this.web3Wallet.getActiveSessions() || {};
     Object.values(actives).forEach(async (session) => {
       this.web3Wallet
@@ -393,9 +402,6 @@ export class WC2Manager {
           console.warn(`Can't remove active session ${session.topic}`, err);
         });
     });
-
-    // Clear local sessions
-    this.sessions = {};
 
     await StorageWrapper.setItem(
       AppConstants.WALLET_CONNECT.DEEPLINK_SESSIONS,


### PR DESCRIPTION
## **Description**

Fixes an issue where after a WCv2 connection could still send chainChanged events to the WC relay when the connection was removed. This was happening regardless of if the connection was removed on the wallet side or signaled removed from the WC side.

This PR fixes that by properly unsubscribing from the store.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

Not user facing.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1355

## **Manual testing steps**

1. Open app in iOS expo build
2. Open js debugger
3. add breakpoint to onStoreChange in WalletConnect2Session.ts
4. Connect a new WC session via [demo app](https://react-app.walletconnect.com/)
5. You should see onStoreChange fire
6. Visit settings, experimental, and disconnect this session (long tap)
7. You should not see onStoreChange fire anymore
8. reconnect to demo dapp
9. You should see onStoreChange fire
10. disconnect from the demo dapp
11. you should not see onStoreChange fire anymore



Visit https://react-app.walletconnect.com/ in the native browser and smoke test

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WalletConnect v2 session lifecycle/cleanup, so mistakes could leave sessions partially disconnected or change disconnect timing. Logic is straightforward and covered by updated unit tests, limiting risk.
> 
> **Overview**
> Fixes a WalletConnect v2 listener leak by storing the Redux `store.subscribe` unsubscribe in `WalletConnect2Session` and invoking it during `removeListeners()`.
> 
> Updates `WC2Manager.removeAll()` to **tear down every `WalletConnect2Session` via `removeListeners()` before clearing the sessions map**, preventing orphaned subscriptions/bridges when `session_delete` fires after local state is cleared. Tests were extended to assert the unsubscribe is called and `removeAll()` invokes `removeListeners()` for each session.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7633be54c99f400635d667c7e36fe4c5e3e5e965. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->