### PR TITLE
fix: address Bugbot review issues in Go mock server PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24.2'
       - name: Rebuild binaries and check for drift
         run: |
           cd tests/mock-server
@@ -810,6 +810,7 @@ jobs:
       - e2e-smoke-tests-ios
       - e2e-smoke-tests-android-flask
       - e2e-smoke-tests-ios-flask
+      - check-go-mock-server-binaries
     steps:
       - run: |
           # Check if all non-E2E jobs passed

--- a/tests/api-mocking/GoMockServer.ts
+++ b/tests/api-mocking/GoMockServer.ts
@@ -156,9 +156,9 @@ class CallbackBridge {
       getJson<T = unknown>(): Promise<T>;
     };
   }[] {
-    return this._seenRequests.map(({ url, bodyText }) => ({
+    return this._seenRequests.map(({ url, bodyText, method }) => ({
       url,
-      method: 'POST',
+      method,
       body: {
         getText: async () => bodyText || undefined,
         getJson: async <T = unknown>(): Promise<T> => {

--- a/tests/helpers/swap/smart-transactions-mocks.ts
+++ b/tests/helpers/swap/smart-transactions-mocks.ts
@@ -66,6 +66,8 @@ export async function setupSmartTransactionsMocks(
   mockServer: MockttpCompat,
   anvilPort: number,
 ): Promise<void> {
+  stxSubmitCount = 0;
+
   // anvilPort is the fallback (DEFAULT_ANVIL_PORT = 8545).
   // On local dev the port manager allocates a random port, so we resolve
   // the actual port at request time to avoid ECONNREFUSED errors.

--- a/tests/mock-server/forwarder.go
+++ b/tests/mock-server/forwarder.go
@@ -69,6 +69,11 @@ func (f *Forwarder) Forward(w http.ResponseWriter, method, targetURL string, bod
 		return
 	}
 
+	for key, vals := range resp.Header {
+		for _, v := range vals {
+			w.Header().Add(key, v)
+		}
+	}
 	w.WriteHeader(resp.StatusCode)
 	w.Write(respBody)
 }

--- a/tests/mock-server/matcher.go
+++ b/tests/mock-server/matcher.go
@@ -8,7 +8,7 @@ import (
 )
 
 func matchRule(rule *MockRule, method, url string, body []byte) bool {
-	if rule.Method != method {
+	if rule.Method != "*" && rule.Method != method {
 		return false
 	}
 	if !matchURL(rule, url) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes 6 bugs identified by Cursor Bugbot in PR #27904 ([DO NOT MERGE] feat(e2e): replace Mockttp with Go-based mock server).

## Bugs Fixed

### High Severity
- **Go version mismatch in CI** (`ci.yml`): `check-go-mock-server-binaries` was installing Go `1.21` but `tests/mock-server/go.mod` declares `go 1.24.2`. Updated `go-version` to `1.24.2` to match the `go.mod` minimum requirement and prevent silent toolchain auto-download or build failures.

### Medium Severity
- **`getSeenRequests` hardcoded `method: 'POST'`** (`GoMockServer.ts`): `CallbackBridge.getSeenRequests()` was destructuring only `url` and `bodyText` from `SeenBridgeRequest`, discarding the stored `method` field and replacing it with `'POST'`. Fixed to destructure and return the actual `method`.

- **Forwarder drops upstream response headers** (`forwarder.go`): The `Forward` method read upstream response body and wrote status code, but never copied `resp.Header` to `w.Header()`. Forwarded responses (e.g. Anvil/Ganache) lost `Content-Type: application/json`. Fixed to copy all response headers before writing the status code.

- **`stxSubmitCount` never resets between tests** (`smart-transactions-mocks.ts`): The module-level counter monotonically incremented across successive test runs in a worker. Fixed by resetting `stxSubmitCount = 0` at the start of `setupSmartTransactionsMocks`, ensuring deterministic UUIDs per test.

- **`check-go-mock-server-binaries` not gating merges** (`ci.yml`): The new freshness-check job was not listed in `check-all-jobs-pass`'s `needs`, so stale-binary failures did not block merges. Added it to the `needs` list.

### Low Severity
- **Go matcher ignores `'*'` wildcard method** (`matcher.go`): `matchRule` compared `rule.Method != method` without handling `'*'` as a wildcard. Rules created by `forAnyRequest()` (which posts `method: '*'`) never matched any request. Fixed to skip the method check when `rule.Method == "*"`.

## Related issues

Fixes bugs reported in: https://github.com/MetaMask/metamask-mobile/pull/27904

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0c4cc4e-84de-47ee-af58-e9f1fc3e9460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0c4cc4e-84de-47ee-af58-e9f1fc3e9460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

