### PR TITLE
fix: matching() in MockttpCompat now ANDs url and user predicates

### DIFF
--- a/tests/api-mocking/GoMockServer.ts
+++ b/tests/api-mocking/GoMockServer.ts
@@ -640,14 +640,16 @@ export default class GoMockServer implements Resource {
           await makeTerminal(method, urlPredicate, null).thenCallback(handler);
         },
         matching: (predicate: MockttpPredicate) => {
-          const terminal = makeTerminal(method, predicate, null);
+          const combinedPredicate: MockttpPredicate = async (request) =>
+            (await urlPredicate(request)) && (await predicate(request));
+          const terminal = makeTerminal(method, combinedPredicate, null);
           return {
             ...terminal,
-            always: () => makeTerminal(method, predicate, null),
+            always: () => makeTerminal(method, combinedPredicate, null),
             withJsonBodyIncluding: (bodyMatcher: Record<string, unknown>) =>
-              makeTerminal(method, predicate, bodyMatcher),
+              makeTerminal(method, combinedPredicate, bodyMatcher),
             asPriority: (priority: number) =>
-              makeTerminal(method, predicate, null, priority),
+              makeTerminal(method, combinedPredicate, null, priority),
           };
         },
         asPriority: (priority: number) =>


### PR DESCRIPTION
Previously forPost('/proxy').matching(predicate) would discard the '/proxy' URL constraint and register a bridge handler that matched solely on the user predicate. This could cause unexpected cross-path matches if the predicate happened to match a request to a different URL.

Fix: build a combinedPredicate that short-circuits on the URL check (fast path) before evaluating the caller's predicate.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-matching behavior in the E2E mock server bridge so existing tests may start matching (or not matching) different handlers, potentially causing unexpected test failures.
> 
> **Overview**
> Fixes `GoMockServer`'s `MockttpCompat` rule builder so `.matching(userPredicate)` **ANDs** the original URL predicate with the caller-provided predicate instead of replacing it.
> 
> This ensures chained calls like `forPost('/proxy').matching(...)` keep the `/proxy` constraint for `always`, `withJsonBodyIncluding`, and `asPriority` terminal chains, preventing cross-path matches in callback-based mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39f95f52f2f23689571bab14c8a07bdc504cbdd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->