### PR TITLE
fix: make WCv2 session restore sequential 

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -13,6 +13,7 @@ import { Core } from '@walletconnect/core';
 import Routes from '../../constants/navigation/Routes';
 import { store } from '../../store';
 import { ActionType } from '../../actions/sdk';
+// eslint-disable-next-line import-x/no-namespace
 import * as waitUtil from '../SDKConnect/utils/wait.util';
 
 jest.mock('../AppConstants', () => ({

--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -13,6 +13,7 @@ import { Core } from '@walletconnect/core';
 import Routes from '../../constants/navigation/Routes';
 import { store } from '../../store';
 import { ActionType } from '../../actions/sdk';
+import * as waitUtil from '../SDKConnect/utils/wait.util';
 
 jest.mock('../AppConstants', () => ({
   WALLET_CONNECT: {
@@ -236,6 +237,11 @@ jest.mock('@walletconnect/core', () => ({
   })),
 }));
 
+jest.mock('../SDKConnect/utils/wait.util', () => ({
+  wait: jest.fn().mockResolvedValue(undefined),
+  waitForKeychainUnlocked: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe('WC2Manager', () => {
   let manager: WC2Manager;
   let mockApproveSession: jest.SpyInstance;
@@ -441,6 +447,140 @@ describe('WC2Manager', () => {
       // Should return the same instance, not create a new one
       expect(secondInstance).toBe(firstInstance);
       expect(secondInstance).toBeInstanceOf(WC2Manager);
+    });
+
+    describe('session restore', () => {
+      const SESSION_RESTORE_STAGGER_MS = 200;
+
+      const makeSession = (index: number) => ({
+        topic: `topic-${index}`,
+        pairingTopic: `pairing-${index}`,
+        peer: {
+          metadata: {
+            url: `https://dapp-${index}.example.com`,
+            name: `DApp ${index}`,
+            icons: [],
+          },
+        },
+      });
+
+      // The WalletKit mock always resolves to the same singleton mockClient.
+      // We access it through the manager created by the outer beforeEach so
+      // we can configure getActiveSessions before each fresh init() call.
+      let walletKitClient: IWalletKit;
+
+      beforeEach(() => {
+        walletKitClient = (manager as unknown as { web3Wallet: IWalletKit })
+          .web3Wallet;
+        (WC2Manager as any).instance = undefined;
+        (WC2Manager as any)._initialized = false;
+        jest.clearAllMocks();
+      });
+
+      it('calls updateSession for each active session on startup', async () => {
+        const sessions = [makeSession(1), makeSession(2), makeSession(3)];
+        (walletKitClient.getActiveSessions as jest.Mock).mockReturnValueOnce(
+          Object.fromEntries(sessions.map((s) => [s.topic, s])),
+        );
+
+        const mockUpdateSession = jest.fn().mockResolvedValue(undefined);
+        (WalletConnect2Session as jest.Mock).mockImplementation(() => ({
+          updateSession: mockUpdateSession,
+          handleRequest: jest.fn(),
+          removeListeners: jest.fn(),
+          setDeeplink: jest.fn(),
+          isHandlingRequest: jest.fn().mockReturnValue(false),
+          getCurrentChainId: jest.fn().mockReturnValue('0x1'),
+          getAllowedChainIds: ['eip155:1'],
+        }));
+
+        await WC2Manager.init({});
+
+        expect(mockUpdateSession).toHaveBeenCalledTimes(sessions.length);
+      });
+
+      it('does not start the next updateSession before the previous one resolves', async () => {
+        const sessions = [makeSession(1), makeSession(2), makeSession(3)];
+        (walletKitClient.getActiveSessions as jest.Mock).mockReturnValueOnce(
+          Object.fromEntries(sessions.map((s) => [s.topic, s])),
+        );
+
+        let concurrentCallCount = 0;
+        let maxConcurrentCalls = 0;
+        const mockUpdateSession = jest.fn().mockImplementation(async () => {
+          concurrentCallCount++;
+          maxConcurrentCalls = Math.max(maxConcurrentCalls, concurrentCallCount);
+          await Promise.resolve();
+          concurrentCallCount--;
+        });
+
+        (WalletConnect2Session as jest.Mock).mockImplementation(() => ({
+          updateSession: mockUpdateSession,
+          handleRequest: jest.fn(),
+          removeListeners: jest.fn(),
+          setDeeplink: jest.fn(),
+          isHandlingRequest: jest.fn().mockReturnValue(false),
+          getCurrentChainId: jest.fn().mockReturnValue('0x1'),
+          getAllowedChainIds: ['eip155:1'],
+        }));
+
+        await WC2Manager.init({});
+
+        expect(maxConcurrentCalls).toBe(1);
+      });
+
+      it('inserts a delay between successive session restores', async () => {
+        const sessions = [makeSession(1), makeSession(2), makeSession(3)];
+        (walletKitClient.getActiveSessions as jest.Mock).mockReturnValueOnce(
+          Object.fromEntries(sessions.map((s) => [s.topic, s])),
+        );
+
+        const waitSpy = jest.spyOn(waitUtil, 'wait');
+
+        await WC2Manager.init({});
+
+        const staggerCalls = waitSpy.mock.calls.filter(
+          ([ms]) => ms === SESSION_RESTORE_STAGGER_MS,
+        );
+        // One stagger wait after each restored session
+        expect(staggerCalls).toHaveLength(sessions.length);
+      });
+
+      it('skips sessions with internal/invalid URLs without restoring them', async () => {
+        // ORIGIN_METAMASK ('metamask') is a member of INTERNAL_ORIGINS
+        const internalUrl = 'metamask';
+        const sessions = [
+          {
+            topic: 'internal-topic',
+            pairingTopic: 'internal-pairing',
+            peer: { metadata: { url: internalUrl, name: 'Internal', icons: [] } },
+          },
+          makeSession(2),
+        ];
+        (walletKitClient.getActiveSessions as jest.Mock).mockReturnValueOnce(
+          Object.fromEntries(sessions.map((s) => [s.topic, s])),
+        );
+
+        const mockUpdateSession = jest.fn().mockResolvedValue(undefined);
+        (WalletConnect2Session as jest.Mock).mockImplementation(() => ({
+          updateSession: mockUpdateSession,
+          handleRequest: jest.fn(),
+          removeListeners: jest.fn(),
+          setDeeplink: jest.fn(),
+          isHandlingRequest: jest.fn().mockReturnValue(false),
+          getCurrentChainId: jest.fn().mockReturnValue('0x1'),
+          getAllowedChainIds: ['eip155:1'],
+        }));
+
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        await WC2Manager.init({});
+
+        // Only the valid session is restored
+        expect(mockUpdateSession).toHaveBeenCalledTimes(1);
+
+        consoleSpy.mockRestore();
+      });
     });
   });
 

--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -509,7 +509,10 @@ describe('WC2Manager', () => {
         let maxConcurrentCalls = 0;
         const mockUpdateSession = jest.fn().mockImplementation(async () => {
           concurrentCallCount++;
-          maxConcurrentCalls = Math.max(maxConcurrentCalls, concurrentCallCount);
+          maxConcurrentCalls = Math.max(
+            maxConcurrentCalls,
+            concurrentCallCount,
+          );
           await Promise.resolve();
           concurrentCallCount--;
         });
@@ -553,7 +556,9 @@ describe('WC2Manager', () => {
           {
             topic: 'internal-topic',
             pairingTopic: 'internal-pairing',
-            peer: { metadata: { url: internalUrl, name: 'Internal', icons: [] } },
+            peer: {
+              metadata: { url: internalUrl, name: 'Internal', icons: [] },
+            },
           },
           makeSession(2),
         ];

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -119,6 +119,23 @@ export class WC2Manager {
       },
     );
 
+  }
+
+  // Milliseconds to wait between consecutive session restorations on startup.
+  private static readonly SESSION_RESTORE_STAGGER_MS = 200;
+
+  /**
+   * Restores all active WalletConnect sessions one at a time.
+   *
+   * This method processes sessions serially with a small delay between
+   * each one so that relay traffic is smoothed out over time.
+   */
+  private async restoreSessions(): Promise<void> {
+    const activeSessions = this.getSessions();
+    if (!activeSessions?.length) {
+      return;
+    }
+
     const accountsController = (
       Engine.context as {
         AccountsController: AccountsController;
@@ -137,83 +154,80 @@ export class WC2Manager {
       }
     ).PermissionController;
 
-    const activeSessions = this.getSessions();
+    for (const session of activeSessions) {
+      if (INTERNAL_ORIGINS.includes(session.peer.metadata.url)) {
+        console.warn(
+          `WC2::init skipping session with invalid url: ${session.topic}`,
+        );
+        continue;
+      }
 
-    if (activeSessions) {
-      activeSessions.forEach(async (session) => {
-        if (INTERNAL_ORIGINS.includes(session.peer.metadata.url)) {
-          console.warn(
-            `WC2::init skipping session with invalid url: ${session.topic}`,
+      const sessionKey = session.topic;
+      const pairingTopic = session.pairingTopic;
+      try {
+        const wcSession = new WalletConnect2Session({
+          web3Wallet: this.web3Wallet,
+          channelId: pairingTopic,
+          navigation: this.navigation,
+          deeplink:
+            typeof this.deeplinkSessions[session.pairingTopic] !== 'undefined',
+          session,
+        });
+        this.sessions[sessionKey] = wcSession;
+
+        // Find approvedAccounts for current sessions
+        DevLogger.log(
+          `WC2::init getPermittedAccounts for ${sessionKey} origin=${sessionKey}`,
+          JSON.stringify(permissionController.state, null, 2),
+        );
+        const accountPermission = permissionController.getPermission(
+          pairingTopic,
+          'eth_accounts',
+        );
+
+        DevLogger.log(
+          `WC2::init accountPermission`,
+          JSON.stringify(accountPermission, null, 2),
+        );
+
+        let approvedAccounts = getPermittedAccounts(pairingTopic) ?? [];
+
+        DevLogger.log(
+          `WC2::init approvedAccounts id ${accountPermission?.id}`,
+          approvedAccounts,
+        );
+
+        if (approvedAccounts?.length === 0) {
+          DevLogger.log(
+            `WC2::init fallback to parsing accountPermission`,
+            accountPermission,
           );
-          return;
+          // FIXME: Why getPermitted accounts doesn't work???
+          approvedAccounts = extractApprovedAccounts(accountPermission);
+          DevLogger.log(`WC2::init approvedAccounts`, approvedAccounts);
         }
 
-        const sessionKey = session.topic;
-        const pairingTopic = session.pairingTopic;
-        try {
-          const wcSession = new WalletConnect2Session({
-            web3Wallet,
-            channelId: pairingTopic,
-            navigation: this.navigation,
-            deeplink:
-              typeof deeplinkSessions[session.pairingTopic] !== 'undefined',
-            session,
-          });
-          this.sessions[sessionKey] = wcSession;
+        updatePermittedChains(
+          pairingTopic,
+          wcSession.getAllowedChainIds,
+          true,
+        );
 
-          // Find approvedAccounts for current sessions
-          DevLogger.log(
-            `WC2::init getPermittedAccounts for ${sessionKey} origin=${sessionKey}`,
-            JSON.stringify(permissionController.state, null, 2),
-          );
-          const accountPermission = permissionController.getPermission(
-            pairingTopic,
-            'eth_accounts',
-          );
+        const chainId = wcSession.getCurrentChainId();
 
-          DevLogger.log(
-            `WC2::init accountPermission`,
-            JSON.stringify(accountPermission, null, 2),
-          );
-
-          let approvedAccounts = getPermittedAccounts(pairingTopic) ?? [];
-
-          DevLogger.log(
-            `WC2::init approvedAccounts id ${accountPermission?.id}`,
-            approvedAccounts,
-          );
-
-          if (approvedAccounts?.length === 0) {
-            DevLogger.log(
-              `WC2::init fallback to parsing accountPermission`,
-              accountPermission,
-            );
-            // FIXME: Why getPermitted accounts doesn't work???
-            approvedAccounts = extractApprovedAccounts(accountPermission);
-            DevLogger.log(`WC2::init approvedAccounts`, approvedAccounts);
-          }
-
-          updatePermittedChains(
-            pairingTopic,
-            wcSession.getAllowedChainIds,
-            true,
-          );
-
-          const chainId = wcSession.getCurrentChainId();
-
-          const nChainId = parseInt(chainId, 16);
-          DevLogger.log(
-            `WC2::init updateSession session=${pairingTopic} chainId=${chainId} nChainId=${nChainId} selectedAddress=${selectedInternalAccountChecksummedAddress}`,
-            approvedAccounts,
-          );
-          await this.sessions[sessionKey].updateSession({
-            chainId: nChainId,
-            accounts: approvedAccounts,
-          });
-        } catch (err) {
-          console.warn(`WC2::init can't update session ${sessionKey}`);
-        }
-      });
+        const nChainId = parseInt(chainId, 16);
+        DevLogger.log(
+          `WC2::init updateSession session=${pairingTopic} chainId=${chainId} nChainId=${nChainId} selectedAddress=${selectedInternalAccountChecksummedAddress}`,
+          approvedAccounts,
+        );
+        await this.sessions[sessionKey].updateSession({
+          chainId: nChainId,
+          accounts: approvedAccounts,
+        });
+      } catch (err) {
+        console.warn(`WC2::init can't update session ${sessionKey}`);
+      }
+      await wait(WC2Manager.SESSION_RESTORE_STAGGER_MS);
     }
   }
 
@@ -317,6 +331,7 @@ export class WC2Manager {
         navigation,
         sessions,
       );
+      await this.instance.restoreSessions();
     } catch (error) {
       Logger.error(error as Error, `WC2@init() failed to create instance`);
     }

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -118,7 +118,6 @@ export class WC2Manager {
         delete this.sessions[event.topic];
       },
     );
-
   }
 
   // Milliseconds to wait between consecutive session restorations on startup.
@@ -207,11 +206,7 @@ export class WC2Manager {
           DevLogger.log(`WC2::init approvedAccounts`, approvedAccounts);
         }
 
-        updatePermittedChains(
-          pairingTopic,
-          wcSession.getAllowedChainIds,
-          true,
-        );
+        updatePermittedChains(pairingTopic, wcSession.getAllowedChainIds, true);
 
         const chainId = wcSession.getCurrentChainId();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Changes WCv2 session/connection restores to be sequential. Previously they were concurrent. The concurrency was problematic because it would cause a large spike in relay traffic for users with numerous WCv2 connections.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1357

## **Manual testing steps**

1. Change `SESSION_RESTORE_STAGGER_MS` to be something larger like 10000
2. Make an ios expo build
3. Using safari native browser, connect to https://react-app.walletconnect.com/ AND https://wagmi-app.vercel.app/ using WalletConnect
4. Swipe away MetaMask
5. On the dapp you connected to last, trigger a personal sign
6. Ignore the deeplink
7. Reopen MetaMask manually from the homescreen
8. Login
9. It should take at least your `SESSION_RESTORE_STAGGER_MS` delay before you see the approval appear


Why this way instead of using the js debugger? Unfortunately restarting the app causes the debugger to disconnect, and so it isn't a reliable way to probe startup based flows.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WCv2 startup session restoration from concurrent async updates to a serialized loop with an added delay, which can impact connection readiness timing and expose ordering/regression issues in session/account syncing.
> 
> **Overview**
> WCv2 startup now restores existing WalletConnect sessions **sequentially** via a new `restoreSessions()` flow, adding a small stagger (`SESSION_RESTORE_STAGGER_MS`) between `updateSession` calls to avoid relay-traffic spikes.
> 
> Initialization (`WC2Manager.init`) now triggers this restore pass after constructing the manager, and tests were extended to assert serial execution, the per-session delay, and that sessions with internal/invalid URLs are skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c7c339fd0a24fbaffb3543760c66709ed5ea2c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->