### PR TITLE
test: Migrate page objects to unified framework (Onboarding)

### DIFF
--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -1,37 +1,116 @@
 import { ChoosePasswordSelectorsIDs } from '../../../app/components/Views/ChoosePassword/ChoosePassword.testIds';
+import Assertions from '../../framework/Assertions';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
 import enContent from '../../../locales/languages/en.json';
+import {
+  asDetoxElement,
+  asPlaywrightElement,
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import { encapsulatedAction } from '../../framework/encapsulatedAction';
+import PlaywrightAssertions from '../../framework/PlaywrightAssertions';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class CreatePasswordView {
   get container(): DetoxElement {
     return Matchers.getElementByID(ChoosePasswordSelectorsIDs.CONTAINER_ID);
   }
 
-  get newPasswordInput(): DetoxElement {
-    return device.getPlatform() === 'ios'
-      ? Matchers.getElementByID(
-          ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
-        )
-      : Matchers.getElementByLabel(
-          ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
-        );
+  get newPasswordInput(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        device.getPlatform() === 'ios'
+          ? Matchers.getElementByID(
+              ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+            )
+          : Matchers.getElementByLabel(
+              ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+            ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+            {
+              exact: true,
+            },
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByXPath(
+            '(//XCUIElementTypeOther[@name="textfield"])[1]',
+          ),
+      },
+    });
   }
 
-  get confirmPasswordInput(): DetoxElement {
-    return device.getPlatform() === 'ios'
-      ? Matchers.getElementByID(
-          ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
-        )
-      : Matchers.getElementByLabel(
-          ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
-        );
+  get confirmPasswordInput(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        device.getPlatform() === 'ios'
+          ? Matchers.getElementByID(
+              ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+            )
+          : Matchers.getElementByLabel(
+              ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+            ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+            {
+              exact: true,
+            },
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByXPath(
+            '(//XCUIElementTypeOther[@name="textfield"])[2]',
+          ),
+      },
+    });
   }
 
-  get iUnderstandCheckbox(): DetoxElement {
-    return Matchers.getElementByID(
-      ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
-    );
+  get newWalletConfirmPasswordInput(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        device.getPlatform() === 'ios'
+          ? Matchers.getElementByID(
+              ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+            )
+          : Matchers.getElementByLabel(
+              ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+            ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+            {
+              exact: true,
+            },
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByXPath(
+            '//XCUIElementTypeOther[@name="textfield" and @label="create-password-second-input-field"]',
+          ),
+      },
+    });
+  }
+
+  get iUnderstandCheckbox(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   get iUnderstandCheckboxNewWallet(): DetoxElement {
@@ -40,8 +119,18 @@ class CreatePasswordView {
     );
   }
 
-  get submitButton(): DetoxElement {
-    return Matchers.getElementByID(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID);
+  get submitButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   get passwordError(): DetoxElement {
@@ -49,12 +138,12 @@ class CreatePasswordView {
   }
 
   async resetPasswordInputs(): Promise<void> {
-    await Gestures.typeText(this.newPasswordInput, '', {
+    await Gestures.typeText(asDetoxElement(this.newPasswordInput), '', {
       hideKeyboard: true,
       clearFirst: true,
       checkVisibility: false,
     });
-    await Gestures.typeText(this.confirmPasswordInput, '', {
+    await Gestures.typeText(asDetoxElement(this.confirmPasswordInput), '', {
       hideKeyboard: true,
       clearFirst: true,
       checkVisibility: false,
@@ -62,34 +151,136 @@ class CreatePasswordView {
   }
 
   async enterPassword(password: string): Promise<void> {
-    await Gestures.typeText(this.newPasswordInput, password, {
-      elemDescription: 'Create Password New Password Input',
-      hideKeyboard: true,
-      checkVisibility: false,
-      checkEnabled: false,
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.typeText(
+          asDetoxElement(this.newPasswordInput),
+          password,
+          {
+            elemDescription: 'Create Password New Password Input',
+            hideKeyboard: true,
+            checkVisibility: false,
+            checkEnabled: false,
+          },
+        );
+      },
+      appium: async () => {
+        await UnifiedGestures.typeText(this.newPasswordInput, password, {
+          // once merged, remove me and create a typeText in Playwright Gestures
+
+          description: 'Create Password New Password Input',
+        });
+      },
     });
   }
 
   async reEnterPassword(password: string): Promise<void> {
-    await Gestures.typeText(this.confirmPasswordInput, password, {
-      elemDescription: 'Create Password Confirm Password Input',
-      hideKeyboard: true,
-      checkVisibility: false,
-      checkEnabled: false,
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.typeText(
+          asDetoxElement(this.confirmPasswordInput),
+          password,
+          {
+            elemDescription: 'Create Password Confirm Password Input',
+            hideKeyboard: true,
+            checkVisibility: false,
+            checkEnabled: false,
+          },
+        );
+      },
+      appium: async () => {
+        await UnifiedGestures.typeText(this.confirmPasswordInput, password, {
+          description: 'Create Password Confirm Password Input',
+        });
+      },
     });
   }
 
   async tapIUnderstandCheckBox(): Promise<void> {
-    await Gestures.tap(this.iUnderstandCheckbox, {
-      elemDescription: 'Create Password - I Understand Checkbox',
-      checkVisibility: false,
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.tap(asDetoxElement(this.iUnderstandCheckbox), {
+          elemDescription: 'Create Password - I Understand Checkbox',
+          checkVisibility: false,
+        });
+      },
+      appium: async () => {
+        await UnifiedGestures.tap(this.iUnderstandCheckbox, {
+          description: 'Create Password - I Understand Checkbox',
+        });
+      },
     });
   }
 
   async tapCreatePasswordButton(): Promise<void> {
-    await Gestures.waitAndTap(this.submitButton, {
-      elemDescription: 'Create Password Submit Button',
-      checkVisibility: false,
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.waitAndTap(asDetoxElement(this.submitButton), {
+          elemDescription: 'Create Password Submit Button',
+          checkVisibility: false,
+        });
+      },
+      appium: async () => {
+        await UnifiedGestures.waitAndTap(this.submitButton, {
+          description: 'Create Password Submit Button',
+        });
+      },
+    });
+  }
+
+  async isVisible(): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await Assertions.expectElementToBeVisible(
+          asDetoxElement(this.newPasswordInput),
+          {
+            description: 'Create password input should be visible',
+          },
+        );
+      },
+      appium: async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(this.newPasswordInput),
+          {
+            timeout: 10000,
+            description: 'Create password input should be visible',
+          },
+        );
+      },
+    });
+  }
+
+  async isNewAccountScreenFieldsVisible(): Promise<void> {
+    await this.isVisible();
+  }
+
+  async inputPasswordInFirstField(password: string): Promise<void> {
+    await this.enterPassword(password);
+  }
+
+  async inputConfirmPasswordField(password: string): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.typeText(
+          asDetoxElement(this.newWalletConfirmPasswordInput),
+          password,
+          {
+            elemDescription: 'Create Password Confirm Password Input',
+            hideKeyboard: true,
+            checkVisibility: false,
+            checkEnabled: false,
+          },
+        );
+      },
+      appium: async () => {
+        await UnifiedGestures.typeText(
+          this.newWalletConfirmPasswordInput,
+          password,
+          {
+            description: 'Create Password Confirm Password Input',
+          },
+        );
+      },
     });
   }
 }

--- a/tests/page-objects/Onboarding/ImportWalletView.ts
+++ b/tests/page-objects/Onboarding/ImportWalletView.ts
@@ -1,15 +1,36 @@
 import { ChoosePasswordSelectorsIDs } from '../../../app/components/Views/ChoosePassword/ChoosePassword.testIds';
 import { ImportFromSeedSelectorsIDs } from '../../../app/components/Views/ImportFromSecretRecoveryPhrase/ImportFromSeed.testIds';
+import Assertions from '../../framework/Assertions';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
+import {
+  asDetoxElement,
+  asPlaywrightElement,
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import { encapsulatedAction } from '../../framework/encapsulatedAction';
+import PlaywrightAssertions from '../../framework/PlaywrightAssertions';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class ImportWalletView {
   get container(): DetoxElement {
     return Matchers.getElementByID(ImportFromSeedSelectorsIDs.CONTAINER_ID);
   }
 
-  get title(): DetoxElement {
-    return Matchers.getElementByID(ImportFromSeedSelectorsIDs.SCREEN_TITLE_ID);
+  get title(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(ImportFromSeedSelectorsIDs.SCREEN_TITLE_ID),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          ImportFromSeedSelectorsIDs.SCREEN_TITLE_ID,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   get newPasswordInput(): DetoxElement {
@@ -24,21 +45,60 @@ class ImportWalletView {
     );
   }
 
-  seedPhraseInput(index: number): DetoxElement {
-    if (index !== 0) {
-      return Matchers.getElementByID(
-        `${ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}_${index}`,
-      );
+  getAppiumIosSeedPhraseXPath(index: number, onboarding = true): string {
+    if (onboarding) {
+      if (index === 0) {
+        return '//XCUIElementTypeOther[@name="textfield"]';
+      }
+
+      return `//XCUIElementTypeOther[@name="textfield" and @label="${index + 1}."]`;
     }
-    return Matchers.getElementByID(
-      ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID,
-    );
+
+    if (index === 0) {
+      return "//*[@name='textfield' or @label='textfield']";
+    }
+
+    return `//*[@label="${index + 1}."]`;
   }
 
-  get continueButton(): DetoxElement {
-    return Matchers.getElementByID(
-      ImportFromSeedSelectorsIDs.CONTINUE_BUTTON_ID,
-    );
+  seedPhraseInput(index: number, onboarding = true): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          index === 0
+            ? ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID
+            : `${ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}_${index}`,
+        ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            index === 0
+              ? ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID
+              : `${ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}_${index}`,
+            {
+              exact: true,
+            },
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByXPath(
+            this.getAppiumIosSeedPhraseXPath(index, onboarding),
+          ),
+      },
+    });
+  }
+
+  get continueButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(ImportFromSeedSelectorsIDs.CONTINUE_BUTTON_ID),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          ImportFromSeedSelectorsIDs.CONTINUE_BUTTON_ID,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   async enterPassword(password: string): Promise<void> {
@@ -53,36 +113,133 @@ class ImportWalletView {
     });
   }
 
-  async enterSecretRecoveryPhrase(secretRecoveryPhrase: string): Promise<void> {
-    if (device.getPlatform() === 'ios') {
-      const srpArray = secretRecoveryPhrase.split(' ');
-      for (const [i, word] of srpArray.entries()) {
-        await Gestures.typeText(this.seedPhraseInput(i), `${word} `, {
-          elemDescription: 'Import Wallet Secret Recovery Phrase Input Box',
-          hideKeyboard: i === srpArray.length - 1,
-        });
-      }
-    } else {
-      await Gestures.replaceText(
-        this.seedPhraseInput(0),
-        secretRecoveryPhrase,
-        {
-          elemDescription: 'Import Wallet Secret Recovery Phrase Input Box',
-          checkVisibility: false,
-        },
-      );
-    }
+  async enterSecretRecoveryPhrase(
+    secretRecoveryPhrase: string,
+    onboarding = true,
+  ): Promise<void> {
+    await this.typeSecretRecoveryPhrase(secretRecoveryPhrase, onboarding);
   }
 
-  async tapContinueButton(): Promise<void> {
-    await Gestures.tap(this.continueButton, {
-      elemDescription: 'Import Wallet Continue Button',
+  async typeSecretRecoveryPhrase(
+    secretRecoveryPhrase: string,
+    onboarding = true,
+  ): Promise<void> {
+    const srpArray = secretRecoveryPhrase.split(' ');
+
+    await encapsulatedAction({
+      detox: async () => {
+        if (device.getPlatform() === 'ios') {
+          for (const [i, word] of srpArray.entries()) {
+            await Gestures.typeText(
+              asDetoxElement(this.seedPhraseInput(i, onboarding)),
+              `${word} `,
+              {
+                elemDescription:
+                  'Import Wallet Secret Recovery Phrase Input Box',
+                hideKeyboard: i === srpArray.length - 1,
+              },
+            );
+          }
+
+          return;
+        }
+
+        await Gestures.replaceText(
+          asDetoxElement(this.seedPhraseInput(0, onboarding)),
+          secretRecoveryPhrase,
+          {
+            elemDescription: 'Import Wallet Secret Recovery Phrase Input Box',
+            checkVisibility: false,
+          },
+        );
+      },
+      appium: async () => {
+        for (const [i, word] of srpArray.entries()) {
+          const suffix = i === srpArray.length - 1 ? '' : ' ';
+          await UnifiedGestures.typeText(
+            // once merged, remove me and create a typeText in Playwright Gestures
+            this.seedPhraseInput(i, onboarding),
+            `${word}${suffix}`,
+            {
+              description: 'Import Wallet Secret Recovery Phrase Input Box',
+            },
+          );
+        }
+      },
+    });
+  }
+
+  async tapContinueButton(onboarding = true): Promise<void> {
+    if (onboarding) {
+      await UnifiedGestures.waitAndTap(this.continueButton, {
+        description: 'Import Wallet Continue Button',
+      });
+      return;
+    }
+
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.tap(asDetoxElement(this.continueButton), {
+          elemDescription: 'Import Wallet Continue Button',
+        });
+      },
+      appium: async () => {
+        await UnifiedGestures.tap(
+          encapsulated({
+            appium: {
+              android: () => PlaywrightMatchers.getElementByText('Continue'),
+              ios: () =>
+                PlaywrightMatchers.getElementById('import-button', {
+                  exact: true,
+                }),
+            },
+          }),
+          {
+            description: 'Import Wallet Continue Button',
+          },
+        );
+      },
     });
   }
 
   async tapTitle(): Promise<void> {
-    await Gestures.tap(this.title, {
-      elemDescription: 'Import Wallet Title',
+    await UnifiedGestures.tap(this.title, {
+      description: 'Import Wallet Title',
+    });
+  }
+
+  async isScreenTitleVisible(onboarding = true): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await Assertions.expectElementToBeVisible(asDetoxElement(this.title), {
+          description: 'Import wallet title should be visible',
+        });
+      },
+      appium: async () => {
+        if (!onboarding) {
+          await PlaywrightAssertions.expectTextDisplayed('Import a wallet', {
+            timeout: 10000,
+            description: 'Import a wallet text should be visible',
+          });
+          return;
+        }
+
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(this.title),
+          {
+            timeout: 10000,
+            description: 'Import wallet title should be visible',
+          },
+        );
+      },
+    });
+  }
+
+  async tapImportScreenTitleToDismissKeyboard(
+    _onboarding = true,
+  ): Promise<void> {
+    await UnifiedGestures.tap(this.title, {
+      description: 'Import Wallet Title',
     });
   }
 }

--- a/tests/page-objects/Onboarding/MetaMetricsOptInView.ts
+++ b/tests/page-objects/Onboarding/MetaMetricsOptInView.ts
@@ -1,6 +1,15 @@
 import { MetaMetricsOptInSelectorsIDs } from '../../../app/components/UI/OptinMetrics/MetaMetricsOptIn.testIds';
+import Assertions from '../../framework/Assertions';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
+import {
+  asDetoxElement,
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import { encapsulatedAction } from '../../framework/encapsulatedAction';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class MetaMetricsOptIn {
   get container(): DetoxElement {
@@ -9,16 +18,42 @@ class MetaMetricsOptIn {
     );
   }
 
+  get screenTitle(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_TITLE_ID,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_TITLE_ID,
+          {
+            exact: true,
+          },
+        ),
+    });
+  }
+
   get optInMetricsContent(): DetoxElement {
     return Matchers.getElementByID(
       MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_PRIVACY_POLICY_DESCRIPTION_CONTENT_1_ID,
     );
   }
 
-  get iAgreeButton(): DetoxElement {
-    return Matchers.getElementByID(
-      MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_CONTINUE_BUTTON_ID,
-    );
+  get iAgreeButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_CONTINUE_BUTTON_ID,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_CONTINUE_BUTTON_ID,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   get metricsCheckbox(): DetoxElement {
@@ -28,18 +63,40 @@ class MetaMetricsOptIn {
   }
 
   async swipeContentUp(): Promise<void> {
-    await Gestures.swipe(this.optInMetricsContent, 'up', {
-      speed: 'fast',
-      percentage: 0.9,
-      elemDescription: 'Opt-in Metrics Privacy Policy Content',
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.swipe(this.optInMetricsContent, 'up', {
+          speed: 'fast',
+          percentage: 0.9,
+          elemDescription: 'Opt-in Metrics Privacy Policy Content',
+        });
+      },
+      appium: async () => undefined,
     });
   }
 
   async tapAgreeButton(): Promise<void> {
-    await this.swipeContentUp();
-    await Gestures.waitAndTap(this.iAgreeButton, {
-      elemDescription: 'Opt-in Metrics Continue Button',
+    await this.tapIAgreeButton();
+  }
+
+  async tapIAgreeButton(): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await this.swipeContentUp();
+        await Gestures.waitAndTap(asDetoxElement(this.iAgreeButton), {
+          elemDescription: 'Opt-in Metrics Continue Button',
+        });
+      },
+      appium: async () => {
+        await UnifiedGestures.tap(this.iAgreeButton, {
+          description: 'Opt-in Metrics Continue Button',
+        });
+      },
     });
+  }
+
+  async tapContinueButton(): Promise<void> {
+    await this.tapIAgreeButton();
   }
 
   async tapMetricsCheckbox(): Promise<void> {

--- a/tests/page-objects/Onboarding/OnboardingSheet.ts
+++ b/tests/page-objects/Onboarding/OnboardingSheet.ts
@@ -1,45 +1,75 @@
 import Matchers from '../../framework/Matchers';
-import Gestures from '../../framework/Gestures';
 import { OnboardingSheetSelectorIDs } from '../../../app/components/Views/OnboardingSheet/OnboardingSheet.testIds';
+import {
+  asPlaywrightElement,
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class OnboardingSheet {
   get container(): DetoxElement {
     return Matchers.getElementByID(OnboardingSheetSelectorIDs.CONTAINER_ID);
   }
 
-  get googleLoginButton(): DetoxElement {
-    return Matchers.getElementByID(
-      OnboardingSheetSelectorIDs.GOOGLE_LOGIN_BUTTON,
-    );
+  get googleLoginButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(OnboardingSheetSelectorIDs.GOOGLE_LOGIN_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          OnboardingSheetSelectorIDs.GOOGLE_LOGIN_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
-  get appleLoginButton(): DetoxElement {
-    return Matchers.getElementByID(
-      OnboardingSheetSelectorIDs.APPLE_LOGIN_BUTTON,
-    );
+  get appleLoginButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(OnboardingSheetSelectorIDs.APPLE_LOGIN_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          OnboardingSheetSelectorIDs.APPLE_LOGIN_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
-  get importSeedButton(): DetoxElement {
-    return Matchers.getElementByID(
-      OnboardingSheetSelectorIDs.IMPORT_SEED_BUTTON,
-    );
+  get importSeedButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(OnboardingSheetSelectorIDs.IMPORT_SEED_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          OnboardingSheetSelectorIDs.IMPORT_SEED_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   async tapGoogleLoginButton(): Promise<void> {
-    await Gestures.waitAndTap(this.googleLoginButton, {
-      elemDescription: 'Google Login Button in Onboarding Sheet',
+    await UnifiedGestures.waitAndTap(this.googleLoginButton, {
+      description: 'Google Login Button in Onboarding Sheet',
     });
   }
 
   async tapAppleLoginButton(): Promise<void> {
-    await Gestures.waitAndTap(this.appleLoginButton, {
-      elemDescription: 'Apple Login Button in Onboarding Sheet',
+    await UnifiedGestures.waitAndTap(this.appleLoginButton, {
+      description: 'Apple Login Button in Onboarding Sheet',
     });
   }
 
   async tapImportSeedButton(): Promise<void> {
-    await Gestures.waitAndTap(this.importSeedButton, {
-      elemDescription: 'Import Seed Button in Onboarding Sheet',
+    await UnifiedGestures.waitAndTap(this.importSeedButton, {
+      description: 'Import Seed Button in Onboarding Sheet',
     });
   }
 }

--- a/tests/page-objects/Onboarding/OnboardingSuccessView.ts
+++ b/tests/page-objects/Onboarding/OnboardingSuccessView.ts
@@ -1,19 +1,35 @@
 import { OnboardingSuccessSelectorIDs } from '../../../app/components/Views/OnboardingSuccess/OnboardingSuccess.testIds';
 import Matchers from '../../framework/Matchers';
-import Gestures from '../../framework/Gestures';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class OnboardingSuccessView {
   get container(): DetoxElement {
     return Matchers.getElementByID(OnboardingSuccessSelectorIDs.CONTAINER_ID);
   }
 
-  get doneButton(): DetoxElement {
-    return Matchers.getElementByID(OnboardingSuccessSelectorIDs.DONE_BUTTON);
+  get doneButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(OnboardingSuccessSelectorIDs.DONE_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          OnboardingSuccessSelectorIDs.DONE_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   async tapDone(): Promise<void> {
-    await Gestures.waitAndTap(this.doneButton, {
-      elemDescription: 'Onboarding Success Done Button',
+    await UnifiedGestures.waitAndTap(this.doneButton, {
+      description: 'Onboarding Success Done Button',
     });
   }
 }

--- a/tests/page-objects/Onboarding/OnboardingView.ts
+++ b/tests/page-objects/Onboarding/OnboardingView.ts
@@ -1,31 +1,58 @@
 import { OnboardingSelectorIDs } from '../../../app/components/Views/Onboarding/Onboarding.testIds';
 import Matchers from '../../framework/Matchers';
-import Gestures from '../../framework/Gestures';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class OnboardingView {
   get container(): DetoxElement {
     return Matchers.getElementByID(OnboardingSelectorIDs.CONTAINER_ID);
   }
 
-  get existingWalletButton() {
-    return Matchers.getElementByID(
-      OnboardingSelectorIDs.EXISTING_WALLET_BUTTON,
-    );
-  }
-
-  get newWalletButton(): DetoxElement {
-    return Matchers.getElementByID(OnboardingSelectorIDs.NEW_WALLET_BUTTON);
-  }
-
-  async tapCreateWallet(): Promise<void> {
-    await Gestures.waitAndTap(this.newWalletButton, {
-      elemDescription: 'Onboarding  - Create New Wallet Button',
+  get existingWalletButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(OnboardingSelectorIDs.EXISTING_WALLET_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          OnboardingSelectorIDs.EXISTING_WALLET_BUTTON,
+          {
+            exact: true,
+          },
+        ),
     });
   }
 
+  get newWalletButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(OnboardingSelectorIDs.NEW_WALLET_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
+  }
+
+  async tapCreateWallet(): Promise<void> {
+    await UnifiedGestures.waitAndTap(this.newWalletButton, {
+      description: 'Onboarding  - Create New Wallet Button',
+    });
+  }
+
+  async tapCreateNewWalletButton(): Promise<void> {
+    await this.tapCreateWallet();
+  }
+
   async tapHaveAnExistingWallet() {
-    await Gestures.waitAndTap(this.existingWalletButton, {
-      elemDescription: 'Onboarding Have an Existing Wallet Button',
+    await UnifiedGestures.waitAndTap(this.existingWalletButton, {
+      description: 'Onboarding Have an Existing Wallet Button',
     });
   }
 }

--- a/tests/page-objects/Onboarding/ProtectYourWalletView.ts
+++ b/tests/page-objects/Onboarding/ProtectYourWalletView.ts
@@ -1,6 +1,11 @@
 import { ManualBackUpStepsSelectorsIDs } from '../../../app/components/Views/ManualBackupStep1/ManualBackUpSteps.testIds';
 import Matchers from '../../framework/Matchers';
-import Gestures from '../../framework/Gestures';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class ProtectYourWalletView {
   get container(): DetoxElement {
@@ -9,14 +14,30 @@ class ProtectYourWalletView {
     );
   }
 
-  get remindMeLaterButton(): DetoxElement {
-    return Matchers.getElementByID(
-      ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON,
-    );
+  get remindMeLaterButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   async tapOnRemindMeLaterButton(): Promise<void> {
-    await Gestures.waitAndTap(this.remindMeLaterButton);
+    await UnifiedGestures.waitAndTap(this.remindMeLaterButton, {
+      description: 'Protect Your Wallet Remind Me Later Button',
+    });
+  }
+
+  async tapRemindMeLater(): Promise<void> {
+    await this.tapOnRemindMeLaterButton();
   }
 }
 

--- a/tests/page-objects/Onboarding/SkipAccountSecurityModal.ts
+++ b/tests/page-objects/Onboarding/SkipAccountSecurityModal.ts
@@ -1,40 +1,99 @@
 import { SkipAccountSecurityModalSelectorsIDs } from '../../../app/components/UI/SkipAccountSecurityModal/SkipAccountSecurityModal.testIds';
-import Gestures from '../../framework/Gestures';
 import Matchers from '../../framework/Matchers';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class SkipAccountSecurityModal {
-  get iUnderstandCheckbox(): DetoxElement {
-    return device.getPlatform() === 'android'
-      ? Matchers.getElementByID(
-          SkipAccountSecurityModalSelectorsIDs.ANDROID_SKIP_BACKUP_BUTTON_ID,
-        )
-      : Matchers.getElementByID(
-          SkipAccountSecurityModalSelectorsIDs.iOS_SKIP_BACKUP_BUTTON_ID,
-        );
+  get container(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(SkipAccountSecurityModalSelectorsIDs.CONTAINER),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          SkipAccountSecurityModalSelectorsIDs.CONTAINER,
+          { exact: true },
+        ),
+    });
   }
 
-  get skipButton(): DetoxElement {
-    return Matchers.getElementByID(
-      SkipAccountSecurityModalSelectorsIDs.SKIP_BUTTON,
-    );
+  get iUnderstandCheckbox(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        device.getPlatform() === 'android'
+          ? Matchers.getElementByID(
+              SkipAccountSecurityModalSelectorsIDs.ANDROID_SKIP_BACKUP_BUTTON_ID,
+            )
+          : Matchers.getElementByID(
+              SkipAccountSecurityModalSelectorsIDs.iOS_SKIP_BACKUP_BUTTON_ID,
+            ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            SkipAccountSecurityModalSelectorsIDs.ANDROID_SKIP_BACKUP_BUTTON_ID,
+            { exact: true },
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementById(
+            SkipAccountSecurityModalSelectorsIDs.iOS_SKIP_BACKUP_BUTTON_ID,
+            { exact: true },
+          ),
+      },
+    });
   }
 
-  get cancelButton(): DetoxElement {
-    return Matchers.getElementByID(
-      SkipAccountSecurityModalSelectorsIDs.CANCEL_BUTTON,
-    );
+  get skipButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          SkipAccountSecurityModalSelectorsIDs.SKIP_BUTTON,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          SkipAccountSecurityModalSelectorsIDs.SKIP_BUTTON,
+          { exact: true },
+        ),
+    });
+  }
+
+  get cancelButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          SkipAccountSecurityModalSelectorsIDs.CANCEL_BUTTON,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          SkipAccountSecurityModalSelectorsIDs.CANCEL_BUTTON,
+          { exact: true },
+        ),
+    });
   }
 
   async tapIUnderstandCheckBox(): Promise<void> {
-    await Gestures.waitAndTap(this.iUnderstandCheckbox);
+    await UnifiedGestures.waitAndTap(this.iUnderstandCheckbox, {
+      description: 'Skip account security checkbox',
+    });
   }
 
   async tapSkipButton(): Promise<void> {
-    await Gestures.waitAndTap(this.skipButton);
+    await UnifiedGestures.waitAndTap(this.skipButton, {
+      description: 'Skip account security confirm button',
+    });
   }
 
   async tapCancelButton(): Promise<void> {
-    await Gestures.waitAndTap(this.cancelButton);
+    await UnifiedGestures.waitAndTap(this.cancelButton, {
+      description: 'Skip account security cancel button',
+    });
+  }
+
+  async proceedWithoutWalletSecure(): Promise<void> {
+    await this.tapIUnderstandCheckBox();
+    await this.tapSkipButton();
   }
 }
 

--- a/tests/page-objects/Onboarding/TermsOfUseModal.ts
+++ b/tests/page-objects/Onboarding/TermsOfUseModal.ts
@@ -1,51 +1,123 @@
 import { TermsOfUseModalSelectorsIDs } from '../../../app/util/termsOfUse/TermsOfUseModal.testIds';
 import Matchers from '../../framework/Matchers';
-import Gestures from '../../framework/Gestures';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class TermsOfUseModal {
-  get container(): DetoxElement {
-    return Matchers.getElementByID(TermsOfUseModalSelectorsIDs.CONTAINER);
+  get container(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(TermsOfUseModalSelectorsIDs.CONTAINER),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          TermsOfUseModalSelectorsIDs.CONTAINER,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
-  get checkbox(): DetoxElement {
-    return Matchers.getElementByID(TermsOfUseModalSelectorsIDs.CHECKBOX);
+  get checkbox(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(TermsOfUseModalSelectorsIDs.CHECKBOX),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          TermsOfUseModalSelectorsIDs.CHECKBOX,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
-  get scrollArrowButton(): DetoxElement {
-    return Matchers.getElementByID(
-      TermsOfUseModalSelectorsIDs.SCROLL_ARROW_BUTTON,
-    );
+  get scrollArrowButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          TermsOfUseModalSelectorsIDs.SCROLL_ARROW_BUTTON,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          TermsOfUseModalSelectorsIDs.SCROLL_ARROW_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
-  get acceptButton(): DetoxElement {
-    return Matchers.getElementByID(TermsOfUseModalSelectorsIDs.ACCEPT_BUTTON);
+  get acceptButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(TermsOfUseModalSelectorsIDs.ACCEPT_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          TermsOfUseModalSelectorsIDs.ACCEPT_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
-  get closeButton(): DetoxElement {
-    return Matchers.getElementByID(TermsOfUseModalSelectorsIDs.CLOSE_BUTTON);
+  get webview(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByID(TermsOfUseModalSelectorsIDs.WEBVIEW),
+      appium: () =>
+        PlaywrightMatchers.getElementById(TermsOfUseModalSelectorsIDs.WEBVIEW, {
+          exact: true,
+        }),
+    });
+  }
+
+  get lastUpdatedText(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByTextContains('Last Updated'),
+      appium: () => PlaywrightMatchers.getElementByCatchAll('Last Updated'),
+    });
+  }
+
+  get closeButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(TermsOfUseModalSelectorsIDs.CLOSE_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          TermsOfUseModalSelectorsIDs.CLOSE_BUTTON,
+          {
+            exact: true,
+          },
+        ),
+    });
   }
 
   async tapAgreeCheckBox(): Promise<void> {
-    await Gestures.waitAndTap(this.checkbox, {
-      elemDescription: 'Terms of Use Modal Agree Checkbox',
+    await UnifiedGestures.waitAndTap(this.checkbox, {
+      description: 'Terms of Use Modal Agree Checkbox',
     });
   }
 
   async tapScrollEndButton(): Promise<void> {
-    await Gestures.waitAndTap(this.scrollArrowButton, {
-      elemDescription: 'Terms of Use Modal Scroll Arrow Button',
+    await UnifiedGestures.waitAndTap(this.scrollArrowButton, {
+      description: 'Terms of Use Modal Scroll Arrow Button',
     });
   }
 
   async tapAcceptButton(): Promise<void> {
-    await Gestures.waitAndTap(this.acceptButton, {
-      elemDescription: 'Terms of Use Modal Accept Button',
+    await UnifiedGestures.waitAndTap(this.acceptButton, {
+      description: 'Terms of Use Modal Accept Button',
     });
   }
 
   async tapCloseButton(): Promise<void> {
-    await Gestures.waitAndTap(this.closeButton, {
-      elemDescription: 'Terms of Use Modal Close Button',
+    await UnifiedGestures.waitAndTap(this.closeButton, {
+      description: 'Terms of Use Modal Close Button',
     });
   }
 }

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -173,10 +173,36 @@ class WalletView {
     });
   }
 
+  get accountNameLabelText(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT,
+          { exact: true },
+        ),
+    });
+  }
+
   get accountName(): DetoxElement {
     return Matchers.getElementByID(
       WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT,
     );
+  }
+
+  get accountNameLabelInput(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_INPUT,
+        ),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_INPUT,
+          { exact: true },
+        ),
+    });
   }
 
   get hideTokensLabel(): DetoxElement {
@@ -342,6 +368,18 @@ class WalletView {
   async tapCurrentMainWalletAccountActions(): Promise<void> {
     await Gestures.waitAndTap(this.currentMainWalletAccountActions, {
       elemDescription: 'Current Main Wallet Account Actions',
+    });
+  }
+
+  async longPressAccountNameLabel(): Promise<void> {
+    await UnifiedGestures.longPress(this.accountNameLabelText, {
+      description: 'Account name label',
+    });
+  }
+
+  async editAccountNameLabel(text: string): Promise<void> {
+    await UnifiedGestures.typeText(this.accountNameLabelInput, text, {
+      description: 'Account name label input',
     });
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> Updates several onboarding test page objects to use the unified cross-runner abstraction (`encapsulated` elements + `UnifiedGestures`/`encapsulatedAction`) instead of Detox-only `Gestures`.
> 
> Adds Appium/Playwright locator support (including iOS XPath fallbacks) and new helper methods for visibility checks and alternate onboarding/non-onboarding flows (notably SRP entry and continue button behavior in `ImportWalletView`, plus `CreatePasswordView` field handling).
> 
> Extends `WalletView` with unified elements and actions to long-press and edit the account name label.
> 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes selector strategies and interaction flows across multiple onboarding E2E page objects, which could introduce cross-platform/Appium locator flakiness or regress existing Detox tests.
> 
> **Overview**
> Updates several onboarding test page objects to use the unified cross-runner abstraction (`encapsulated` elements + `UnifiedGestures`/`encapsulatedAction`) instead of Detox-only `Gestures`.
> 
> Adds Appium/Playwright locator support (including iOS XPath fallbacks) and new helper methods for visibility checks and alternate onboarding/non-onboarding flows (notably SRP entry and continue button behavior in `ImportWalletView`, plus `CreatePasswordView` field handling).
> 
> Extends `WalletView` with unified elements and actions to long-press and edit the account name label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66ef544d5e036bf3656ca4f9cd05c57d69a69d99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->