### PR TITLE
refactor: centralise SUCCESS_ERROR_SHEET navigation via navigateToSuccessErrorSheet helper

### DIFF
--- a/app/components/UI/Earn/utils/tron.ts
+++ b/app/components/UI/Earn/utils/tron.ts
@@ -14,6 +14,7 @@ import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { safeParseBigNumber } from '../../../../util/number/bignumber';
 import type { TronSpecialAssetsMap } from '../../../../selectors/assets/assets-list';
+import { navigateToSuccessErrorSheet } from '../../../Views/SuccessErrorSheet/utils';
 
 /**
  * Returns the total staked TRX (sTRX) amount from Tron special assets.
@@ -163,24 +164,18 @@ export const handleTronStakingNavigationResult = (
 
     navigation.goBack();
     requestAnimationFrame(() => {
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-        params: {
-          title: strings(copy.successTitleKey),
-          description: strings(copy.successDescriptionKey),
-          type: 'success',
-          closeOnPrimaryButtonPress: true,
-        },
+      navigateToSuccessErrorSheet(navigation, {
+        title: strings(copy.successTitleKey),
+        description: strings(copy.successDescriptionKey),
+        type: 'success',
+        closeOnPrimaryButtonPress: true,
       });
     });
   } else {
-    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-      params: {
-        title: strings(copy.errorTitleKey),
-        description: getLocalizedErrorMessage(result?.errors),
-        type: 'error',
-      },
+    navigateToSuccessErrorSheet(navigation, {
+      title: strings(copy.errorTitleKey),
+      description: getLocalizedErrorMessage(result?.errors),
+      type: 'error',
     });
   }
 };

--- a/app/components/Views/ManualBackupStep2/index.js
+++ b/app/components/Views/ManualBackupStep2/index.js
@@ -38,6 +38,7 @@ import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder
 import Routes from '../../../constants/navigation/Routes';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { CommonActions } from '@react-navigation/native';
+import { navigateToSuccessErrorSheet } from '../SuccessErrorSheet/utils';
 import {
   AccountType,
   ONBOARDING_SUCCESS_FLOW,
@@ -420,30 +421,24 @@ const ManualBackupStep2 = ({
         ).build(),
         saveOnboardingEvent,
       );
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-        params: {
-          title: strings('manual_backup_step_2.success-title'),
-          description: strings('manual_backup_step_2.success-description'),
-          primaryButtonLabel: strings('manual_backup_step_2.success-button'),
-          type: 'success',
-          onClose: () => goNext(),
-          onPrimaryButtonPress: () => goNext(),
-          closeOnPrimaryButtonPress: true,
-        },
+      navigateToSuccessErrorSheet(navigation, {
+        title: strings('manual_backup_step_2.success-title'),
+        description: strings('manual_backup_step_2.success-description'),
+        primaryButtonLabel: strings('manual_backup_step_2.success-button'),
+        type: 'success',
+        onClose: () => goNext(),
+        onPrimaryButtonPress: () => goNext(),
+        closeOnPrimaryButtonPress: true,
       });
     } else {
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-        params: {
-          title: strings('manual_backup_step_2.error-title'),
-          description: strings('manual_backup_step_2.error-description'),
-          primaryButtonLabel: strings('manual_backup_step_2.error-button'),
-          type: 'error',
-          onClose: () => generateMissingWords(),
-          onPrimaryButtonPress: () => generateMissingWords(),
-          closeOnPrimaryButtonPress: true,
-        },
+      navigateToSuccessErrorSheet(navigation, {
+        title: strings('manual_backup_step_2.error-title'),
+        description: strings('manual_backup_step_2.error-description'),
+        primaryButtonLabel: strings('manual_backup_step_2.error-button'),
+        type: 'error',
+        onClose: () => generateMissingWords(),
+        onPrimaryButtonPress: () => generateMissingWords(),
+        closeOnPrimaryButtonPress: true,
       });
     }
   };

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -454,6 +454,17 @@ describe('OAuthRehydration', () => {
           Routes.MODAL.ROOT_MODAL_FLOW,
           expect.objectContaining({
             screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+            params: expect.objectContaining({
+              title: strings('error_sheet.no_internet_connection_title'),
+              description: strings(
+                'error_sheet.no_internet_connection_description',
+              ),
+              primaryButtonLabel: strings(
+                'error_sheet.no_internet_connection_button',
+              ),
+              closeOnPrimaryButtonPress: true,
+              type: 'error',
+            }),
           }),
         );
       });

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -66,6 +66,7 @@ import {
 } from '../../../core/Engine/controllers/seedless-onboarding-controller/error';
 import { useNetInfo } from '@react-native-community/netinfo';
 import { SuccessErrorSheetParams } from '../SuccessErrorSheet/interface';
+import { navigateToSuccessErrorSheet } from '../SuccessErrorSheet/utils';
 import { usePromptSeedlessRelogin } from '../../hooks/SeedlessHooks';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { useStyles } from '../../../component-library/hooks/useStyles';
@@ -289,10 +290,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
           closeOnPrimaryButtonPress: true,
           type: 'error',
         };
-        navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-          screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-          params,
-        });
+        navigateToSuccessErrorSheet(navigation, params);
         return;
       }
 

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -1234,7 +1234,7 @@ describe('Onboarding', () => {
             title: strings('error_sheet.user_cancelled_title'),
             description: strings('error_sheet.user_cancelled_description'),
             descriptionAlign: 'center',
-            buttonLabel: strings('error_sheet.user_cancelled_button'),
+            primaryButtonLabel: strings('error_sheet.user_cancelled_button'),
             type: 'error',
           }),
         }),
@@ -1281,7 +1281,56 @@ describe('Onboarding', () => {
             title: strings('error_sheet.oauth_error_title'),
             description: strings('error_sheet.oauth_error_description'),
             descriptionAlign: 'center',
-            buttonLabel: strings('error_sheet.oauth_error_button'),
+            primaryButtonLabel: strings('error_sheet.oauth_error_button'),
+            type: 'error',
+          }),
+        }),
+      );
+    });
+
+    it('shows oauth_error sheet for unexpected non-OAuthError with primaryButtonLabel and closeOnPrimaryButtonPress', async () => {
+      const unexpectedError = new Error('Unexpected network failure');
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockRejectedValue(unexpectedError);
+
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        {
+          state: mockInitialState,
+        },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      const googleOAuthFunction = navCall[1].params.onPressContinueWithGoogle;
+
+      mockNavigate.mockClear();
+      await act(async () => {
+        await googleOAuthFunction(true);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.MODAL.ROOT_MODAL_FLOW,
+        expect.objectContaining({
+          screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+          params: expect.objectContaining({
+            title: strings('error_sheet.oauth_error_title'),
+            description: strings('error_sheet.oauth_error_description'),
+            descriptionAlign: 'center',
+            primaryButtonLabel: strings('error_sheet.oauth_error_button'),
+            closeOnPrimaryButtonPress: true,
             type: 'error',
           }),
         }),

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -110,7 +110,10 @@ import {
 } from '@metamask/design-system-twrnc-preset';
 
 import { getBuildNumber, getVersion } from 'react-native-device-info';
-import { navigateToSuccessErrorSheetPromise } from '../SuccessErrorSheet/utils';
+import {
+  navigateToSuccessErrorSheet,
+  navigateToSuccessErrorSheetPromise,
+} from '../SuccessErrorSheet/utils';
 import {
   IconColor,
   IconName,
@@ -678,15 +681,12 @@ const Onboarding = () => {
         socialLoginTraceCtx.current = undefined;
       }
 
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-        params: {
-          title: strings(`error_sheet.${errorMessage}_title`),
-          description: strings(`error_sheet.${errorMessage}_description`),
-          descriptionAlign: 'center',
-          buttonLabel: strings(`error_sheet.${errorMessage}_button`),
-          type: 'error',
-        },
+      navigateToSuccessErrorSheet(navigation, {
+        title: strings(`error_sheet.${errorMessage}_title`),
+        description: strings(`error_sheet.${errorMessage}_description`),
+        descriptionAlign: 'center',
+        primaryButtonLabel: strings(`error_sheet.${errorMessage}_button`),
+        type: 'error',
       });
     },
     [

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -686,6 +686,7 @@ const Onboarding = () => {
         description: strings(`error_sheet.${errorMessage}_description`),
         descriptionAlign: 'center',
         primaryButtonLabel: strings(`error_sheet.${errorMessage}_button`),
+        closeOnPrimaryButtonPress: true,
         type: 'error',
       });
     },

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -826,8 +826,10 @@ class ResetPassword extends PureComponent {
   };
 
   handleConfirmAction = () => {
-    const navigation = NavigationService.navigation;
-    if (!navigation) {
+    let navigation;
+    try {
+      navigation = NavigationService.navigation;
+    } catch {
       return;
     }
 

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -66,6 +66,7 @@ import NavigationService from '../../../core/NavigationService';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../util/analytics/analytics';
+import { navigateToSuccessErrorSheet } from '../SuccessErrorSheet/utils';
 import Checkbox from '../../../component-library/components/Checkbox';
 import fox from '../../../animations/Searching_Fox.json';
 import LottieView from 'lottie-react-native';
@@ -425,50 +426,44 @@ class ResetPassword extends PureComponent {
 
   handleSeedlessChangePasswordError = () => {
     // show seedless password error modal and redirect to security settings screen
-    this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-      params: {
-        title: strings(
-          'reset_password.seedless_change_password_error_modal_title',
-        ),
-        description: strings(
-          'reset_password.seedless_change_password_error_modal_content',
-        ),
-        primaryButtonLabel: strings(
-          'reset_password.seedless_change_password_error_modal_confirm',
-        ),
-        type: 'error',
-        icon: IconName.Danger,
-        isInteractable: false,
-        onPrimaryButtonPress: async () => {
-          this.props.navigation.replace(Routes.SETTINGS.SECURITY_SETTINGS);
-        },
-        closeOnPrimaryButtonPress: true,
+    navigateToSuccessErrorSheet(this.props.navigation, {
+      title: strings(
+        'reset_password.seedless_change_password_error_modal_title',
+      ),
+      description: strings(
+        'reset_password.seedless_change_password_error_modal_content',
+      ),
+      primaryButtonLabel: strings(
+        'reset_password.seedless_change_password_error_modal_confirm',
+      ),
+      type: 'error',
+      icon: IconName.Danger,
+      isInteractable: false,
+      onPrimaryButtonPress: async () => {
+        this.props.navigation.replace(Routes.SETTINGS.SECURITY_SETTINGS);
       },
+      closeOnPrimaryButtonPress: true,
     });
   };
 
   handleSeedlessPasswordOutdated = () => {
     // show seedless password outdated modal and force user to lock app
-    this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-      params: {
-        title: strings('login.seedless_password_outdated_modal_title'),
-        description: strings('login.seedless_password_outdated_modal_content'),
-        primaryButtonLabel: strings(
-          'login.seedless_password_outdated_modal_confirm',
-        ),
-        type: 'error',
-        icon: IconName.Danger,
-        isInteractable: false,
-        onPrimaryButtonPress: async () => {
-          await Authentication.lockApp({ locked: true }).catch((error) => {
-            Logger.error(error);
-            this.handleSeedlessChangePasswordError();
-          });
-        },
-        closeOnPrimaryButtonPress: true,
+    navigateToSuccessErrorSheet(this.props.navigation, {
+      title: strings('login.seedless_password_outdated_modal_title'),
+      description: strings('login.seedless_password_outdated_modal_content'),
+      primaryButtonLabel: strings(
+        'login.seedless_password_outdated_modal_confirm',
+      ),
+      type: 'error',
+      icon: IconName.Danger,
+      isInteractable: false,
+      onPrimaryButtonPress: async () => {
+        await Authentication.lockApp({ locked: true }).catch((error) => {
+          Logger.error(error);
+          this.handleSeedlessChangePasswordError();
+        });
       },
+      closeOnPrimaryButtonPress: true,
     });
   };
 
@@ -831,35 +826,37 @@ class ResetPassword extends PureComponent {
   };
 
   handleConfirmAction = () => {
-    NavigationService.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-      params: {
-        title: strings('reset_password.warning_password_change_title'),
-        description: this.props.isSeedlessOnboardingLoginFlow ? (
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-            {strings('reset_password.warning_password_change_description')}{' '}
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Primary}
-              onPress={this.learnMoreSocialLogin}
-            >
-              {strings('reset_password.learn_more')}
-            </Text>
+    const navigation = NavigationService.navigation;
+    if (!navigation) {
+      return;
+    }
+
+    navigateToSuccessErrorSheet(navigation, {
+      title: strings('reset_password.warning_password_change_title'),
+      description: this.props.isSeedlessOnboardingLoginFlow ? (
+        <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          {strings('reset_password.warning_password_change_description')}{' '}
+          <Text
+            variant={TextVariant.BodyMD}
+            color={TextColor.Primary}
+            onPress={this.learnMoreSocialLogin}
+          >
+            {strings('reset_password.learn_more')}
           </Text>
-        ) : (
-          `${strings('reset_password.warning_password_change_description')}.`
-        ),
-        type: 'error',
-        icon: IconName.Danger,
-        secondaryButtonLabel: strings(
-          'reset_password.warning_password_cancel_button',
-        ),
-        primaryButtonLabel: strings(
-          'reset_password.warning_password_change_button',
-        ),
-        onPrimaryButtonPress: this.onPressCreate,
-        closeOnPrimaryButtonPress: true,
-      },
+        </Text>
+      ) : (
+        `${strings('reset_password.warning_password_change_description')}.`
+      ),
+      type: 'error',
+      icon: IconName.Danger,
+      secondaryButtonLabel: strings(
+        'reset_password.warning_password_cancel_button',
+      ),
+      primaryButtonLabel: strings(
+        'reset_password.warning_password_change_button',
+      ),
+      onPrimaryButtonPress: this.onPressCreate,
+      closeOnPrimaryButtonPress: true,
     });
   };
 

--- a/app/components/Views/ResetPassword/index.test.tsx
+++ b/app/components/Views/ResetPassword/index.test.tsx
@@ -494,6 +494,47 @@ describe('ResetPassword', () => {
     });
   });
 
+  it('handleConfirmAction does not throw when NavigationService.navigation is null', async () => {
+    const component = await renderConfirmPasswordView();
+
+    const newPasswordInput = component.getByTestId(
+      ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+    );
+
+    await act(async () => {
+      fireEvent.changeText(newPasswordInput, 'NewPassword123');
+    });
+
+    const confirmPasswordInput = component.getByTestId(
+      ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+    );
+
+    await act(async () => {
+      fireEvent.changeText(confirmPasswordInput, 'NewPassword123');
+    });
+
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
+
+    const originalNavigation = NavigationService.navigation;
+    NavigationService.navigation =
+      null as unknown as typeof NavigationService.navigation;
+
+    await expect(
+      act(async () => {
+        fireEvent.press(submitButton);
+      }),
+    ).resolves.not.toThrow();
+
+    expect(NavigationService.navigation).toBeNull();
+    expect((originalNavigation.navigate as jest.Mock).mock.calls.length).toBe(
+      0,
+    );
+
+    NavigationService.navigation = originalNavigation;
+  });
+
   it('open webview on learnMore click for seedless onboarding login flow', async () => {
     const component = await renderConfirmPasswordView();
 

--- a/app/components/Views/SuccessErrorSheet/interface.ts
+++ b/app/components/Views/SuccessErrorSheet/interface.ts
@@ -5,7 +5,6 @@ import {
 
 export interface SuccessErrorSheetParams {
   onClose?: () => void;
-  onButtonPress?: () => void;
   title: string | React.ReactNode;
   description: string | React.ReactNode;
   customButton?: React.ReactNode;

--- a/app/components/Views/SuccessErrorSheet/utils.test.ts
+++ b/app/components/Views/SuccessErrorSheet/utils.test.ts
@@ -1,4 +1,4 @@
-import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { NavigationContainerRef } from '@react-navigation/native';
 import Routes from '../../../constants/navigation/Routes';
 import {
   navigateToSuccessErrorSheet,
@@ -8,7 +8,7 @@ import {
 const mockNavigate = jest.fn();
 const mockNavigation = {
   navigate: mockNavigate,
-} as unknown as NavigationProp<ParamListBase>;
+} as unknown as NavigationContainerRef;
 
 const baseParams = {
   type: 'error' as const,

--- a/app/components/Views/SuccessErrorSheet/utils.ts
+++ b/app/components/Views/SuccessErrorSheet/utils.ts
@@ -1,9 +1,11 @@
-import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { NavigationContainerRef } from '@react-navigation/native';
 import { SuccessErrorSheetParams } from './interface';
 import Routes from '../../../constants/navigation/Routes';
 
+type SuccessErrorSheetNavigation = Pick<NavigationContainerRef, 'navigate'>;
+
 export const navigateToSuccessErrorSheet = (
-  navigation: NavigationProp<ParamListBase>,
+  navigation: SuccessErrorSheetNavigation,
   params: SuccessErrorSheetParams,
 ) => {
   navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
@@ -15,7 +17,7 @@ export const navigateToSuccessErrorSheet = (
 };
 
 export const navigateToSuccessErrorSheetPromise = async (
-  navigation: NavigationProp<ParamListBase>,
+  navigation: SuccessErrorSheetNavigation,
   params: SuccessErrorSheetParams,
 ) =>
   new Promise<void>((resolve) => {

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -88,6 +88,7 @@ import {
 } from '../../../component-library/components/Toast';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import Routes from '../../../constants/navigation/Routes';
+import { navigateToSuccessErrorSheet } from '../SuccessErrorSheet/utils';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   trackActionButtonClick,
@@ -898,20 +899,17 @@ const Wallet = ({
 
   useEffect(() => {
     if (isConnectionRemoved && isSocialLogin) {
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-        params: {
-          title: strings('connection_removed_modal.title'),
-          description: strings('connection_removed_modal.content'),
-          primaryButtonLabel: strings('connection_removed_modal.tryAgain'),
-          type: 'error',
-          icon: IconName.Danger,
-          iconColor: IconColor.Warning,
-          isInteractable: false,
-          closeOnPrimaryButtonPress: true,
-          onPrimaryButtonPress: () => {
-            dispatch(setIsConnectionRemoved(false));
-          },
+      navigateToSuccessErrorSheet(navigation, {
+        title: strings('connection_removed_modal.title'),
+        description: strings('connection_removed_modal.content'),
+        primaryButtonLabel: strings('connection_removed_modal.tryAgain'),
+        type: 'error',
+        icon: IconName.Danger,
+        iconColor: IconColor.Warning,
+        isInteractable: false,
+        closeOnPrimaryButtonPress: true,
+        onPrimaryButtonPress: () => {
+          dispatch(setIsConnectionRemoved(false));
         },
       });
     }

--- a/app/components/hooks/SeedlessHooks/usePromptSeedlessRelogin.ts
+++ b/app/components/hooks/SeedlessHooks/usePromptSeedlessRelogin.ts
@@ -6,6 +6,7 @@ import { useSignOut } from '../../../util/identity/hooks/useAuthentication';
 import Routes from '../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
 import { SuccessErrorSheetParams } from '../../Views/SuccessErrorSheet/interface';
+import { navigateToSuccessErrorSheet } from '../../Views/SuccessErrorSheet/utils';
 import { clearHistory } from '../../../actions/browser';
 import { strings } from '../../../../locales/i18n';
 import { Authentication } from '../../../core';
@@ -89,10 +90,7 @@ const usePromptSeedlessRelogin = () => {
       },
       closeOnPrimaryButtonPress: true,
     };
-    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-      params: errorSheetParams,
-    });
+    navigateToSuccessErrorSheet(navigation, errorSheetParams);
   }, [navigation, deleteWallet]);
 
   return { isDeletingInProgress, deleteWalletError, promptSeedlessRelogin };

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -4430,6 +4430,39 @@ describe('Authentication', () => {
       expect(analytics.trackEvent).not.toHaveBeenCalled();
     });
 
+    it('does not call navigate when NavigationService.navigation is null', async () => {
+      // Arrange
+      mockIsOutdated = true;
+      mockCheckIsSeedlessPasswordOutdated.mockResolvedValue(true);
+      const mockState: RecursivePartial<RootState> = {
+        engine: {
+          backgroundState: {
+            SeedlessOnboardingController: {
+              vault: 'existing vault data' as string,
+            },
+          },
+        },
+      };
+
+      jest.spyOn(ReduxService, 'store', 'get').mockReturnValue({
+        dispatch: jest.fn(),
+        getState: jest.fn(() => mockState),
+      } as unknown as ReduxStore);
+
+      const NavigationService = jest.requireMock('../NavigationService');
+      jest
+        .spyOn(NavigationService.default, 'navigation', 'get')
+        .mockReturnValue(null);
+
+      // Act
+      await expect(
+        Authentication.checkAndShowSeedlessPasswordOutdatedModal(true),
+      ).resolves.not.toThrow();
+
+      // Assert
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
     it('navigates to modal when password is outdated', async () => {
       // Arrange
       mockIsOutdated = true;

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -33,6 +33,7 @@ import {
 import StorageWrapper from '../../store/storage-wrapper';
 import NavigationService from '../NavigationService';
 import Routes from '../../constants/navigation/Routes';
+import { navigateToSuccessErrorSheet } from '../../components/Views/SuccessErrorSheet/utils';
 import { TraceName, TraceOperation, trace, endTrace } from '../../util/trace';
 import { discoverAccounts } from '../../multichain-accounts/discovery';
 import ReduxService from '../redux';
@@ -87,6 +88,7 @@ import {
 } from 'expo-local-authentication';
 import { getAuthIcon, getAuthLabel, getAuthType } from './utils';
 import { IconName } from '@metamask/design-system-react-native';
+import { IconName as OldIconName } from '../../component-library/components/Icons/Icon';
 import { containsErrorMessage } from '../../util/errorHandling';
 import { ensureError } from '../../util/errorUtils';
 
@@ -1448,22 +1450,24 @@ class AuthenticationService {
     );
 
     // show seedless password outdated modal and force user to lock app
-    NavigationService.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
-      params: {
-        title: strings('login.seedless_password_outdated_modal_title'),
-        description: strings('login.seedless_password_outdated_modal_content'),
-        primaryButtonLabel: strings(
-          'login.seedless_password_outdated_modal_confirm',
-        ),
-        type: 'error',
-        icon: IconName.Danger,
-        isInteractable: false,
-        onPrimaryButtonPress: async () => {
-          await this.lockApp({ locked: true });
-        },
-        closeOnPrimaryButtonPress: true,
+    const navigation = NavigationService.navigation;
+    if (!navigation) {
+      return;
+    }
+
+    navigateToSuccessErrorSheet(navigation, {
+      title: strings('login.seedless_password_outdated_modal_title'),
+      description: strings('login.seedless_password_outdated_modal_content'),
+      primaryButtonLabel: strings(
+        'login.seedless_password_outdated_modal_confirm',
+      ),
+      type: 'error',
+      icon: OldIconName.Danger,
+      isInteractable: false,
+      onPrimaryButtonPress: async () => {
+        await this.lockApp({ locked: true });
       },
+      closeOnPrimaryButtonPress: true,
     });
   };
 

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1450,12 +1450,14 @@ class AuthenticationService {
     );
 
     // show seedless password outdated modal and force user to lock app
-    const navigation = NavigationService.navigation;
-    if (!navigation) {
+    let navigation;
+    try {
+      navigation = NavigationService.navigation;
+    } catch {
       return;
     }
 
-    navigateToSuccessErrorSheet(navigation, {
+    navigateToSuccessErrorSheet(NavigationService.navigation, {
       title: strings('login.seedless_password_outdated_modal_title'),
       description: strings('login.seedless_password_outdated_modal_content'),
       primaryButtonLabel: strings(

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1457,7 +1457,7 @@ class AuthenticationService {
       return;
     }
 
-    navigateToSuccessErrorSheet(NavigationService.navigation, {
+    navigateToSuccessErrorSheet(navigation, {
       title: strings('login.seedless_password_outdated_modal_title'),
       description: strings('login.seedless_password_outdated_modal_content'),
       primaryButtonLabel: strings(


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Eight call sites across the codebase were manually repeating the same three-line navigation pattern to open the `SuccessErrorSheet`:

```ts
navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
  screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
  params: { ... },
});
```

This PR replaces all of those with the existing `navigateToSuccessErrorSheet` / `navigateToSuccessErrorSheetPromise` helpers from `app/components/Views/SuccessErrorSheet/utils.ts`, which already encapsulate that pattern.

Additional fixes included as part of the refactor:

- **Type narrowing** – the helpers' navigation parameter was typed as `NavigationProp<ParamListBase>`, which rejected `NavigationContainerRef` from `NavigationService`. The parameter is now typed as `Pick<NavigationContainerRef, 'navigate'>` — the minimal shape the helper actually uses — so it accepts both screen navigation props and the service ref.
- **Null guard** – the two `NavigationService.navigation?.navigate(...)` optional-chain calls in `ResetPassword` and `Authentication` are replaced with an explicit null check before calling the helper, making the early-return intent explicit.
- **Stale field removed** – `onButtonPress` was removed from `SuccessErrorSheetParams`; it was unused in the component and had no callers.
- **`buttonLabel` → `primaryButtonLabel`** – one call site in `Onboarding` was passing a non-existent `buttonLabel` field; corrected to `primaryButtonLabel`.
- **Icon enum alignment** – `Authentication.ts` imported `IconName` from `@metamask/design-system-react-native` but the sheet interface uses `IconName` from the component library; the imports are now correctly distinguished with an alias.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a navigation refactor with small typing/param fixes; risk is limited to potential regressions in how the success/error sheet is invoked or how button labels are passed.
> 
> **Overview**
> Refactors multiple flows (TRON staking, manual SRP backup, OAuth rehydration, onboarding social login errors, reset password, wallet connection-removed, and seedless relogin prompt) to open `SUCCESS_ERROR_SHEET` via `navigateToSuccessErrorSheet(...)` instead of repeating the modal navigation object.
> 
> Updates the helper to accept the minimal navigation shape (`Pick<NavigationContainerRef, 'navigate'>`) and removes the unused `onButtonPress` param from `SuccessErrorSheetParams`. Fixes a mismatched param name (`buttonLabel` → `primaryButtonLabel`), aligns `IconName` imports in `Authentication.ts`, and adds explicit null-guard/early-return behavior when `NavigationService.navigation` is unavailable, with new/updated tests covering these cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e517d1f09a157f747ac1184e5b70a7fc37f42be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->