### PR TITLE
chore: Downgrade `@tanstack/react-query` to `^4.43.0`

### DIFF
--- a/app/components/UI/Card/hooks/useCardDetails.test.ts
+++ b/app/components/UI/Card/hooks/useCardDetails.test.ts
@@ -25,6 +25,7 @@ const mockRefetch = jest.fn();
 jest.mock('@tanstack/react-query', () => ({
   useQuery: jest.fn().mockReturnValue({
     data: undefined,
+    isFetching: false,
     isLoading: false,
     error: null,
     refetch: jest.fn(),
@@ -63,6 +64,7 @@ describe('useCardDetails', () => {
 
     (useQuery as jest.Mock).mockReturnValue({
       data: undefined,
+      isFetching: false,
       isLoading: false,
       error: null,
       refetch: mockRefetch,
@@ -90,6 +92,7 @@ describe('useCardDetails', () => {
       };
       (useQuery as jest.Mock).mockReturnValue({
         data: cardDetailsResult,
+        isFetching: false,
         isLoading: false,
         error: null,
         refetch: mockRefetch,
@@ -106,6 +109,7 @@ describe('useCardDetails', () => {
     it('returns loading state from useQuery', () => {
       (useQuery as jest.Mock).mockReturnValue({
         data: undefined,
+        isFetching: true,
         isLoading: true,
         error: null,
         refetch: mockRefetch,
@@ -141,6 +145,7 @@ describe('useCardDetails', () => {
       const mockError = new Error('Test error');
       (useQuery as jest.Mock).mockReturnValue({
         data: undefined,
+        isFetching: false,
         isLoading: false,
         error: mockError,
         refetch: mockRefetch,

--- a/app/components/UI/Card/hooks/useCardDetails.ts
+++ b/app/components/UI/Card/hooks/useCardDetails.ts
@@ -23,6 +23,7 @@ const useCardDetails = () => {
   const {
     data: cardDetailsData,
     isLoading,
+    isFetching,
     error,
     refetch,
   } = useQuery<CardDetailsResult | null>({
@@ -69,7 +70,7 @@ const useCardDetails = () => {
   return {
     cardDetails: cardDetailsData?.cardDetails ?? null,
     warning: cardDetailsData?.warning ?? null,
-    isLoading,
+    isLoading: isLoading && isFetching,
     error: error as Error | null,
     fetchCardDetails,
   };

--- a/app/components/UI/Card/hooks/useCardPinToken.ts
+++ b/app/components/UI/Card/hooks/useCardPinToken.ts
@@ -34,7 +34,11 @@ const useCardPinToken = (): UseCardPinTokenResult => {
     [theme.themeAppearance],
   );
 
-  const { mutateAsync, isPending, error, data, reset } = useMutation({
+  const { mutateAsync, isPending, error, data, reset } = useMutation<
+    CardPinTokenResponse,
+    Error,
+    { customCss: typeof customCss }
+  >({
     mutationKey: cardQueries.pin.keys.token(),
     mutationFn: cardQueries.pin.tokenMutationFn(sdk),
   });

--- a/app/components/UI/Card/hooks/useCashbackWallet.ts
+++ b/app/components/UI/Card/hooks/useCashbackWallet.ts
@@ -124,7 +124,7 @@ const useCashbackWallet = () => {
 
   return {
     cashbackWallet: walletQuery.data ?? null,
-    isLoading: walletQuery.isLoading,
+    isLoading: walletQuery.isLoading && walletQuery.isFetching,
     error: walletQuery.error,
     fetchCashbackWallet: walletQuery.refetch,
 

--- a/app/components/UI/Card/hooks/useGetCardExternalWalletDetails.ts
+++ b/app/components/UI/Card/hooks/useGetCardExternalWalletDetails.ts
@@ -69,7 +69,7 @@ const useGetCardExternalWalletDetails = (
   const sdkRef = useRef(sdk);
   sdkRef.current = sdk;
 
-  const { data, isLoading, error, refetch } = useQuery({
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
     queryKey: cardQueries.dashboard.keys.externalWalletDetails(),
     queryFn: async () => {
       const currentDelegationSettings =
@@ -155,7 +155,7 @@ const useGetCardExternalWalletDetails = (
 
   return {
     data: data ?? null,
-    isLoading,
+    isLoading: isLoading && isFetching,
     error: error as Error | null,
     fetchData,
   };

--- a/app/components/UI/Card/hooks/useGetDelegationSettings.test.ts
+++ b/app/components/UI/Card/hooks/useGetDelegationSettings.test.ts
@@ -369,6 +369,7 @@ describe('useGetDelegationSettings', () => {
     it('returns loading state from useQuery', () => {
       (useQuery as jest.Mock).mockReturnValue({
         data: undefined,
+        isFetching: true,
         isLoading: true,
         error: null,
       });

--- a/app/components/UI/Card/hooks/useGetDelegationSettings.ts
+++ b/app/components/UI/Card/hooks/useGetDelegationSettings.ts
@@ -27,7 +27,7 @@ const useGetDelegationSettings = () => {
     [],
   );
 
-  const { data, isLoading, error } =
+  const { data, isLoading, isFetching, error } =
     useQuery<DelegationSettingsResponse | null>({
       queryKey: QUERY_KEY,
       queryFn,
@@ -46,7 +46,7 @@ const useGetDelegationSettings = () => {
 
   return {
     data: data ?? null,
-    isLoading,
+    isLoading: isLoading && isFetching,
     error: error as Error | null,
     fetchData,
   };

--- a/app/components/UI/Card/hooks/useGetLatestAllowanceForPriorityToken.ts
+++ b/app/components/UI/Card/hooks/useGetLatestAllowanceForPriorityToken.ts
@@ -65,7 +65,9 @@ const useGetLatestAllowanceForPriorityToken = (
     : ('' as `${string}:${string}`);
   const decimals = applicable ? priorityToken.decimals || 0 : 0;
 
-  const { data, isLoading, error, refetch } = useQuery<string | null>({
+  const { data, isLoading, isFetching, error, refetch } = useQuery<
+    string | null
+  >({
     queryKey: cardQueries.dashboard.keys.latestAllowance(
       tokenAddress,
       delegationContract,
@@ -111,7 +113,7 @@ const useGetLatestAllowanceForPriorityToken = (
 
   return {
     latestAllowance: data ?? null,
-    isLoading,
+    isLoading: isLoading && isFetching,
     error: error as Error | null,
     refetch: refetchAllowance,
   };

--- a/app/components/UI/Card/hooks/useGetUserKYCStatus.ts
+++ b/app/components/UI/Card/hooks/useGetUserKYCStatus.ts
@@ -28,29 +28,32 @@ const useGetUserKYCStatus = (): UseGetUserKYCStatusResult => {
   const sdkRef = useRef(sdk);
   sdkRef.current = sdk;
 
-  const { data, isLoading, error, refetch } = useQuery<UserKYCStatus | null>({
-    queryKey: cardQueries.dashboard.keys.kycStatus(),
-    queryFn: async () => {
-      try {
-        const currentSdk = sdkRef.current;
-        if (!currentSdk) throw new Error('SDK not initialized');
-        const response = await currentSdk.getUserDetails();
+  const { data, isLoading, isFetching, error, refetch } =
+    useQuery<UserKYCStatus | null>({
+      queryKey: cardQueries.dashboard.keys.kycStatus(),
+      queryFn: async () => {
+        try {
+          const currentSdk = sdkRef.current;
+          if (!currentSdk) throw new Error('SDK not initialized');
+          const response = await currentSdk.getUserDetails();
 
-        return {
-          verificationState: response.verificationState ?? null,
-          userId: response.id,
-          userDetails: response,
-        };
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err : new Error('Failed to fetch KYC status');
-        Logger.log('useGetUserKYCStatus: Error fetching KYC status', err);
-        throw errorMessage;
-      }
-    },
-    enabled: false,
-    staleTime: 0,
-  });
+          return {
+            verificationState: response.verificationState ?? null,
+            userId: response.id,
+            userDetails: response,
+          };
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error
+              ? err
+              : new Error('Failed to fetch KYC status');
+          Logger.log('useGetUserKYCStatus: Error fetching KYC status', err);
+          throw errorMessage;
+        }
+      },
+      enabled: false,
+      staleTime: 0,
+    });
 
   const fetchKYCStatus = useCallback(async () => {
     const result = await refetch();
@@ -59,7 +62,7 @@ const useGetUserKYCStatus = (): UseGetUserKYCStatusResult => {
 
   return {
     kycStatus: data ?? null,
-    isLoading,
+    isLoading: isLoading && isFetching,
     error: error as Error | null,
     fetchKYCStatus,
   };

--- a/app/components/UI/Card/hooks/useRegistrationSettings.test.ts
+++ b/app/components/UI/Card/hooks/useRegistrationSettings.test.ts
@@ -11,11 +11,13 @@ const mockRefetch = jest.fn();
 let mockQueryFn: (() => Promise<unknown>) | undefined;
 let mockQueryReturn: {
   data: unknown;
+  isFetching: boolean;
   isLoading: boolean;
   error: Error | null;
   refetch: jest.Mock;
 } = {
   data: undefined,
+  isFetching: false,
   isLoading: false,
   error: null,
   refetch: mockRefetch,
@@ -49,6 +51,7 @@ describe('useRegistrationSettings', () => {
 
     mockQueryReturn = {
       data: undefined,
+      isFetching: false,
       isLoading: false,
       error: null,
       refetch: mockRefetch,
@@ -154,6 +157,7 @@ describe('useRegistrationSettings', () => {
     it('returns data from useQuery', () => {
       mockQueryReturn = {
         data: mockRegistrationSettingsResponse,
+        isFetching: false,
         isLoading: false,
         error: null,
         refetch: mockRefetch,
@@ -170,6 +174,7 @@ describe('useRegistrationSettings', () => {
     it('returns loading state from useQuery', () => {
       mockQueryReturn = {
         data: undefined,
+        isFetching: true,
         isLoading: true,
         error: null,
         refetch: mockRefetch,
@@ -185,6 +190,7 @@ describe('useRegistrationSettings', () => {
       mockQueryReturn = {
         data: undefined,
         isLoading: false,
+        isFetching: false,
         error: new Error('Registration settings error'),
         refetch: mockRefetch,
       };

--- a/app/components/UI/Card/hooks/useRegistrationSettings.ts
+++ b/app/components/UI/Card/hooks/useRegistrationSettings.ts
@@ -11,7 +11,7 @@ import { cardQueries } from '../queries';
 const useRegistrationSettings = () => {
   const { sdk } = useCardSDK();
 
-  const { data, isLoading, error, refetch } = useQuery({
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
     queryKey: cardQueries.dashboard.keys.registrationSettings(),
     queryFn: () => {
       if (!sdk) throw new Error('SDK not initialized');
@@ -28,7 +28,7 @@ const useRegistrationSettings = () => {
 
   return {
     data: data ?? null,
-    isLoading,
+    isLoading: isLoading && isFetching,
     error: error as Error | null,
     fetchData,
   };

--- a/app/components/UI/Card/hooks/useUserRegistrationStatus.test.ts
+++ b/app/components/UI/Card/hooks/useUserRegistrationStatus.test.ts
@@ -198,13 +198,11 @@ describe('useUserRegistrationStatus', () => {
     it('refetchInterval returns false when state is VERIFIED', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: { verificationState: string } | undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: { verificationState: string } | undefined,
+      ) => number | false;
 
-      const result = refetchIntervalFn({
-        state: { data: { verificationState: 'VERIFIED' } },
-      });
+      const result = refetchIntervalFn({ verificationState: 'VERIFIED' });
 
       expect(result).toBe(false);
     });
@@ -212,13 +210,11 @@ describe('useUserRegistrationStatus', () => {
     it('refetchInterval returns false when state is REJECTED', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: { verificationState: string } | undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: { verificationState: string } | undefined,
+      ) => number | false;
 
-      const result = refetchIntervalFn({
-        state: { data: { verificationState: 'REJECTED' } },
-      });
+      const result = refetchIntervalFn({ verificationState: 'REJECTED' });
 
       expect(result).toBe(false);
     });
@@ -226,13 +222,11 @@ describe('useUserRegistrationStatus', () => {
     it('refetchInterval returns 5000 when data is undefined', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: undefined,
+      ) => number | false;
 
-      const result = refetchIntervalFn({
-        state: { data: undefined },
-      });
+      const result = refetchIntervalFn(undefined);
 
       expect(result).toBe(5000);
     });
@@ -289,57 +283,43 @@ describe('useUserRegistrationStatus', () => {
     it('refetchInterval stops polling when state is VERIFIED', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: { verificationState: string } | undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: { verificationState: string } | undefined,
+      ) => number | false;
 
-      expect(
-        refetchIntervalFn({
-          state: { data: { verificationState: 'VERIFIED' } },
-        }),
-      ).toBe(false);
+      expect(refetchIntervalFn({ verificationState: 'VERIFIED' })).toBe(false);
     });
 
     it('refetchInterval stops polling when state is UNVERIFIED', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: { verificationState: string } | undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: { verificationState: string } | undefined,
+      ) => number | false;
 
-      expect(
-        refetchIntervalFn({
-          state: { data: { verificationState: 'UNVERIFIED' } },
-        }),
-      ).toBe(false);
+      expect(refetchIntervalFn({ verificationState: 'UNVERIFIED' })).toBe(
+        false,
+      );
     });
 
     it('refetchInterval stops polling when state is REJECTED', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: { verificationState: string } | undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: { verificationState: string } | undefined,
+      ) => number | false;
 
-      expect(
-        refetchIntervalFn({
-          state: { data: { verificationState: 'REJECTED' } },
-        }),
-      ).toBe(false);
+      expect(refetchIntervalFn({ verificationState: 'REJECTED' })).toBe(false);
     });
 
     it('refetchInterval continues polling when state is PENDING', () => {
       renderHook(() => useUserRegistrationStatus());
 
-      const refetchIntervalFn = mockQueryConfig.refetchInterval as (query: {
-        state: { data: { verificationState: string } | undefined };
-      }) => number | false;
+      const refetchIntervalFn = mockQueryConfig.refetchInterval as (
+        data: { verificationState: string } | undefined,
+      ) => number | false;
 
-      expect(
-        refetchIntervalFn({
-          state: { data: { verificationState: 'PENDING' } },
-        }),
-      ).toBe(5000);
+      expect(refetchIntervalFn({ verificationState: 'PENDING' })).toBe(5000);
     });
   });
 

--- a/app/components/UI/Card/hooks/useUserRegistrationStatus.ts
+++ b/app/components/UI/Card/hooks/useUserRegistrationStatus.ts
@@ -39,8 +39,8 @@ export const useUserRegistrationStatus =
         return sdk.getRegistrationStatus(onboardingId);
       },
       enabled: isPolling && !!sdk && !!onboardingId,
-      refetchInterval: (query) => {
-        const state = query.state.data?.verificationState;
+      refetchInterval: (data) => {
+        const state = data?.verificationState;
         if (state && state !== 'PENDING') return false;
         return POLLING_INTERVAL;
       },

--- a/app/components/UI/Card/hooks/useUserRegistrationStatus.ts
+++ b/app/components/UI/Card/hooks/useUserRegistrationStatus.ts
@@ -29,7 +29,7 @@ export const useUserRegistrationStatus =
     const onboardingId = useSelector(selectOnboardingId);
     const [isPolling, setIsPolling] = useState(false);
 
-    const { data, isLoading, error } = useQuery({
+    const { data, isLoading, isFetching, error } = useQuery({
       queryKey: cardQueries.dashboard.keys.registrationStatus(
         onboardingId ?? '',
       ),
@@ -66,7 +66,7 @@ export const useUserRegistrationStatus =
 
     return {
       verificationState,
-      isLoading,
+      isLoading: isLoading && isFetching,
       isError: !!error,
       error: error ? getErrorMessage(error) : null,
       startPolling,

--- a/app/components/UI/Predict/hooks/usePredictActivity.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActivity.test.ts
@@ -41,7 +41,7 @@ jest.mock('react-redux', () => ({
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    defaultOptions: { queries: { retry: false, cacheTime: Infinity } },
   });
 
   const Wrapper = ({ children }: { children: React.ReactNode }) =>

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -83,7 +83,7 @@ const createPosition = (
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    defaultOptions: { queries: { retry: false, cacheTime: Infinity } },
   });
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -219,7 +219,7 @@ describe('usePredictPositions', () => {
 
     expect(mockGetPositions).not.toHaveBeenCalled();
     expect(result.current.data).toBeUndefined();
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetching).toBe(false);
   });
 
   it('returns query error message when query fails', async () => {

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -66,7 +66,7 @@ describe('useUnrealizedPnL', () => {
     });
 
     expect(result.current.data).toBeUndefined();
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetching).toBe(false);
     expect(result.current.error).toBeNull();
     expect(mockGetUnrealizedPnL).not.toHaveBeenCalled();
   });

--- a/app/components/UI/Predict/queries/accountState.ts
+++ b/app/components/UI/Predict/queries/accountState.ts
@@ -91,7 +91,7 @@ export const predictAccountStateKeys = {
 };
 
 export const predictAccountStateOptions = () =>
-  queryOptions({
+  queryOptions<AccountState, Error>({
     queryKey: predictAccountStateKeys.all(),
     queryFn: async (): Promise<AccountState> => {
       await ensurePolygonNetwork();

--- a/app/components/UI/Predict/queries/activity.ts
+++ b/app/components/UI/Predict/queries/activity.ts
@@ -9,7 +9,7 @@ export const predictActivityKeys = {
 };
 
 export const predictActivityOptions = ({ address }: { address: string }) =>
-  queryOptions({
+  queryOptions<PredictActivity[], Error>({
     queryKey: predictActivityKeys.byAddress(address),
     queryFn: async (): Promise<PredictActivity[]> =>
       Engine.context.PredictController.getActivity({ address }),

--- a/app/components/UI/Predict/queries/balance.ts
+++ b/app/components/UI/Predict/queries/balance.ts
@@ -15,7 +15,7 @@ export const predictBalanceKeys = {
 };
 
 export const predictBalanceOptions = ({ address = '' }: GetBalanceParams) =>
-  queryOptions({
+  queryOptions<number, Error>({
     queryKey: predictBalanceKeys.detail(address),
     queryFn: async (): Promise<number> => {
       const balance = await Engine.context.PredictController.getBalance({

--- a/app/components/UI/Predict/queries/market.ts
+++ b/app/components/UI/Predict/queries/market.ts
@@ -14,7 +14,7 @@ export const predictMarketKeys = {
 };
 
 export const predictMarketOptions = ({ marketId }: { marketId: string }) =>
-  queryOptions({
+  queryOptions<PredictMarket | null, Error>({
     queryKey: predictMarketKeys.detail(marketId),
     queryFn: async (): Promise<PredictMarket | null> => {
       const controller = Engine.context.PredictController;

--- a/app/components/UI/Predict/queries/orderPreview.ts
+++ b/app/components/UI/Predict/queries/orderPreview.ts
@@ -1,4 +1,4 @@
-import { queryOptions, keepPreviousData } from '@tanstack/react-query';
+import { queryOptions } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import type { OrderPreview, PreviewOrderParams } from '../types';
 
@@ -24,7 +24,7 @@ export const predictOrderPreviewOptions = ({
   size,
   positionId,
 }: PreviewOrderParams) =>
-  queryOptions({
+  queryOptions<OrderPreview, Error>({
     queryKey: predictOrderPreviewKeys.detail({
       marketId,
       outcomeId,
@@ -43,5 +43,5 @@ export const predictOrderPreviewOptions = ({
         positionId,
       }),
     retry: false,
-    placeholderData: keepPreviousData,
+    keepPreviousData: true,
   });

--- a/app/components/UI/Predict/queries/positions.ts
+++ b/app/components/UI/Predict/queries/positions.ts
@@ -9,7 +9,7 @@ export const predictPositionsKeys = {
 };
 
 export const predictPositionsOptions = ({ address }: { address: string }) =>
-  queryOptions({
+  queryOptions<PredictPosition[], Error>({
     queryKey: predictPositionsKeys.byAddress(address),
     queryFn: async (): Promise<PredictPosition[]> =>
       Engine.context.PredictController.getPositions({ address }),

--- a/app/components/UI/Predict/queries/unrealizedPnL.ts
+++ b/app/components/UI/Predict/queries/unrealizedPnL.ts
@@ -10,7 +10,7 @@ export const predictUnrealizedPnLKeys = {
 };
 
 export const predictUnrealizedPnLOptions = ({ address }: { address: string }) =>
-  queryOptions({
+  queryOptions<UnrealizedPnL | null, Error>({
     queryKey: predictUnrealizedPnLKeys.byAddress(address),
     queryFn: async (): Promise<UnrealizedPnL | null> => {
       const result = await Engine.context.PredictController.getUnrealizedPnL({

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
@@ -100,7 +100,7 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     if (!queryEnabled) {
       return 'idle';
     }
-    if (paymentMethodsQuery.isPending) {
+    if (paymentMethodsQuery.isLoading) {
       return 'loading';
     }
     if (paymentMethodsQuery.isError) {
@@ -109,7 +109,7 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     return 'success';
   }, [
     paymentMethodsQuery.isError,
-    paymentMethodsQuery.isPending,
+    paymentMethodsQuery.isLoading,
     queryEnabled,
   ]);
 

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -67,14 +67,14 @@ export function useRampsQuotes(
     if (!queryEnabled) {
       return 'idle';
     }
-    if (quotesQuery.isPending) {
+    if (quotesQuery.isLoading) {
       return 'loading';
     }
     if (quotesQuery.isError) {
       return 'error';
     }
     return 'success';
-  }, [queryEnabled, quotesQuery.isError, quotesQuery.isPending]);
+  }, [queryEnabled, quotesQuery.isError, quotesQuery.isLoading]);
 
   return {
     getQuotes,

--- a/app/core/ReactQueryService/ReactQueryService.test.ts
+++ b/app/core/ReactQueryService/ReactQueryService.test.ts
@@ -48,7 +48,7 @@ describe('ReactQueryService', () => {
           queries: {
             staleTime: 1000 * 60 * 5,
             retry: 2,
-            gcTime: 1000 * 60 * 60 * 24,
+            cacheTime: 1000 * 60 * 60 * 24,
           },
         },
       });

--- a/app/core/ReactQueryService/ReactQueryService.ts
+++ b/app/core/ReactQueryService/ReactQueryService.ts
@@ -24,7 +24,7 @@ export class ReactQueryService {
           // On mobile, failures are often due to network drops.
           retry: 2,
           // Keep data in memory for longer.
-          gcTime: 1000 * 60 * 60 * 24, // 24 hours
+          cacheTime: 1000 * 60 * 60 * 24, // 24 hours
         },
       },
     });

--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
     "@sentry/react-native": "~6.15.0",
     "@shopify/flash-list": "2.0.3",
     "@solana/addresses": "2.0.0",
-    "@tanstack/react-query": "^5.90.20",
+    "@tanstack/react-query": "^4.43.0",
     "@tommasini/react-native-scrollable-tab-view": "^1.1.1",
     "@tradle/react-native-http": "2.0.1",
     "@types/he": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17427,21 +17427,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:5.90.20, @tanstack/query-core@npm:^5.62.16":
+"@tanstack/query-core@npm:4.43.0":
+  version: 4.43.0
+  resolution: "@tanstack/query-core@npm:4.43.0"
+  checksum: 10/c2a5a151c7adaea8311e01a643255f31946ae3164a71567ba80048242821ae14043f13f5516b695baebe5ea7e4b2cf717fd60908a929d18a5c5125fee925ff67
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-core@npm:^5.62.16":
   version: 5.90.20
   resolution: "@tanstack/query-core@npm:5.90.20"
   checksum: 10/25e38f4382442bc15e0f6cce8d787e9df8d8822c61d3f3e9427e89e01b1e2506f848292e086dae29aeb55f8ce71b097c34221f3c5eda37fb4a688b5ceca5d1b3
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^5.90.20":
-  version: 5.90.20
-  resolution: "@tanstack/react-query@npm:5.90.20"
+"@tanstack/react-query@npm:^4.43.0":
+  version: 4.43.0
+  resolution: "@tanstack/react-query@npm:4.43.0"
   dependencies:
-    "@tanstack/query-core": "npm:5.90.20"
+    "@tanstack/query-core": "npm:4.43.0"
+    use-sync-external-store: "npm:^1.6.0"
   peerDependencies:
-    react: ^18 || ^19
-  checksum: 10/ac98af011078717f4ee754f687b434a9396d05dc17a6b0dd80048c56a1081da921adf81aa48ccb92eaca80f06db6d28497ce4adfaebd5e01b16effd1e5f4ff85
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-native: "*"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 10/23f9d18d130fa2a1238d8fba8bc914c67e33753b7fc3a3c7856354a9873c4cbc5d18ce24dbf6364ecf86b8ea787575e1e60998ea75baa2b9e9647ad4b9127e10
   languageName: node
   linkType: hard
 
@@ -35679,7 +35694,7 @@ __metadata:
     "@storybook/addon-ondevice-controls": "npm:^6.5.6"
     "@storybook/builder-webpack5": "npm:^7.5.1"
     "@storybook/react-native": "npm:^6.5.6"
-    "@tanstack/react-query": "npm:^5.90.20"
+    "@tanstack/react-query": "npm:^4.43.0"
     "@testing-library/react": "npm:14.0.0"
     "@testing-library/react-hooks": "npm:^8.0.1"
     "@testing-library/react-native": "npm:^13.2.0"
@@ -46432,12 +46447,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.0.0":
+"use-sync-external-store@npm:1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10/a676216affc203876bd47981103f201f28c2731361bb186367e12d287a7566763213a8816910c6eb88265eccd4c230426eb783d64c373c4a180905be8820ed8e
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/b40ad2847ba220695bff2d4ba4f4d60391c0fb4fb012faa7a4c18eb38b69181936f5edc55a522c4d20a788d1a879b73c3810952c9d0fd128d01cb3f22042c09e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR downgrades `@tanstack/react-query` to `^4.43.0` to allow us to bring in shared tooling between extension and mobile for queries. This is a temporary measure until the extension gets to React 18, which is the minimum version for `@tanstack/react-query@5`.

Most of the breaking changes that impact our existing code is type related due to `TError` being `unknown` in v4. Additionally a couple of properties we use have been renamed between the two versions. The semantics of `isLoading` has also changed for `enabled: false` queries, but that can be recovered by using `isFetching && isLoading` This PR adjusts all of these.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it downgrades a core data-fetching library and adjusts loading/polling semantics across multiple hooks, which could change UI states or caching behavior if any edge cases were missed.
> 
> **Overview**
> Downgrades `@tanstack/react-query` from v5 to v4 (including lockfile updates) and updates the app’s `QueryClient` defaults to use v4’s `cacheTime` option.
> 
> Aligns hooks and tests with v4 API/behavior changes: replaces `gcTime` usage, updates `keepPreviousData` configuration, switches some status checks from `isPending` to `isLoading`, adds/propagates `isFetching`, and standardizes derived `isLoading` as `isLoading && isFetching` for disabled/manual queries (Card hooks, Ramp hooks, Predict query options, and related tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb3d69181b59acb17a41d934f790932c24299d4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->