### PR TITLE
feat(card): add balance properties on SpendingLimit Card Viewed screen

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -301,7 +301,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
                     {accountGroupName ?? selectedAccount.metadata.name}
                   </Text>
                   <Icon
-                    name={IconName.ArrowRight}
+                    name={IconName.ArrowDown}
                     size={IconSize.Md}
                     color={IconColor.IconDefault}
                     style={tw.style('self-center shrink-0')}
@@ -355,7 +355,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
                   {tokenLabel}
                 </Text>
                 <Icon
-                  name={IconName.ArrowRight}
+                  name={IconName.ArrowDown}
                   size={IconSize.Md}
                   color={IconColor.IconDefault}
                   style={tw.style('self-center shrink-0')}
@@ -386,7 +386,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
                   {spendingLimitLabel}
                 </Text>
                 <Icon
-                  name={IconName.ArrowRight}
+                  name={IconName.ArrowDown}
                   size={IconSize.Md}
                   color={IconColor.IconDefault}
                   style={tw.style('self-center shrink-0')}

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -1077,10 +1077,10 @@ describe('useSpendingLimit', () => {
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
-      // 0x1 → eip155:1, not in caipChainIdToNetwork → falls back to 'eip155:1'
+      // 0x1 → eip155:1, not in caipChainIdToNetwork → strips namespace → '1:eth'
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({
-          top_wallet_chain_asset: 'eip155:1:eth',
+          top_wallet_chain_asset: '1:eth',
           top_wallet_asset_balance: 9000,
         }),
       );

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -1037,7 +1037,9 @@ describe('useSpendingLimit', () => {
     });
 
     it('emits null for top_card_chain_asset when wallet token is not in card-supported allTokens', () => {
-      // Native SOL has an address but is not in allTokens (card does not support it)
+      // Native SOL has an address but is not in allTokens (card does not support it).
+      // allTokens contains only an unrelated USDC token so allTokens.length > 0,
+      // which lets the effect fire while still excluding nativeSol from the result.
       const nativeSol = {
         address: 'So11111111111111111111111111111111111111112',
         symbol: 'SOL',
@@ -1048,10 +1050,8 @@ describe('useSpendingLimit', () => {
         .mockReturnValueOnce([nativeSol]) // walletTokens
         .mockReturnValueOnce([nativeSol]);
 
-      // allTokens is empty (no card-supported tokens) → nativeSol is excluded
-      renderHook(() =>
-        useSpendingLimit(createDefaultParams({ allTokens: [] })),
-      );
+      // allTokens has a card-supported token (USDC on Linea) but NOT nativeSol
+      renderHook(() => useSpendingLimit(createDefaultParams()));
 
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({ top_card_chain_asset: null }),

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -269,7 +269,9 @@ describe('useSpendingLimit', () => {
       {},
     ] as never);
 
-    // Default selected account
+    // Default selected account (all useSelector calls use this by default;
+    // selectEvmNetworkConfigurationsByChainId call gets an object whose keys
+    // are not real chain IDs, but useTokensWithBalance is mocked so it doesn't matter)
     mockUseSelector.mockReturnValue({
       id: 'account-1',
       address: '0xaccount1',
@@ -959,6 +961,128 @@ describe('useSpendingLimit', () => {
       expect(mockTrackEvent).toHaveBeenCalled();
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({ flow: 'onboarding' }),
+      );
+    });
+
+    it('includes musd_linea_balance from walletTokens', () => {
+      const musdToken = {
+        address: '0xmusd',
+        symbol: 'mUSD',
+        chainId: LINEA_CAIP_CHAIN_ID,
+        tokenFiatAmount: 450,
+      };
+      (useTokensWithBalance as jest.Mock)
+        .mockReturnValueOnce([musdToken]) // walletTokens (card)
+        .mockReturnValueOnce([]); // allWalletTokens
+
+      renderHook(() => useSpendingLimit(createDefaultParams()));
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ musd_linea_balance: 450 }),
+      );
+    });
+
+    it('emits musd_linea_balance of 0 when mUSD not in wallet', () => {
+      (useTokensWithBalance as jest.Mock)
+        .mockReturnValueOnce([]) // walletTokens — no mUSD
+        .mockReturnValueOnce([]);
+
+      renderHook(() => useSpendingLimit(createDefaultParams()));
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ musd_linea_balance: 0 }),
+      );
+    });
+
+    it('includes top_card_chain_asset for highest-balance card token', () => {
+      const lowToken = {
+        address: '0xlow',
+        symbol: 'USDC',
+        chainId: LINEA_CAIP_CHAIN_ID,
+        tokenFiatAmount: 50,
+      };
+      const highToken = {
+        address: '0xhigh',
+        symbol: 'mUSD',
+        chainId: LINEA_CAIP_CHAIN_ID,
+        tokenFiatAmount: 500,
+      };
+      // allTokens must include the same addresses so cardSupportedKeys accepts them
+      const allTokens = [
+        createMockToken({ address: '0xlow', symbol: 'USDC' }),
+        createMockToken({ address: '0xhigh', symbol: 'mUSD' }),
+      ];
+      (useTokensWithBalance as jest.Mock)
+        .mockReturnValueOnce([lowToken, highToken]) // walletTokens (card)
+        .mockReturnValueOnce([]);
+
+      renderHook(() => useSpendingLimit(createDefaultParams({ allTokens })));
+
+      // LINEA_CAIP_CHAIN_ID maps to 'linea' in caipChainIdToNetwork
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ top_card_chain_asset: 'linea:musd' }),
+      );
+    });
+
+    it('emits null for top_card_chain_asset when no card tokens have balance', () => {
+      (useTokensWithBalance as jest.Mock)
+        .mockReturnValueOnce([]) // walletTokens — empty
+        .mockReturnValueOnce([]);
+
+      renderHook(() => useSpendingLimit(createDefaultParams()));
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ top_card_chain_asset: null }),
+      );
+    });
+
+    it('emits null for top_card_chain_asset when wallet token is not in card-supported allTokens', () => {
+      // Native SOL has an address but is not in allTokens (card does not support it)
+      const nativeSol = {
+        address: 'So11111111111111111111111111111111111111112',
+        symbol: 'SOL',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        tokenFiatAmount: 1200,
+      };
+      (useTokensWithBalance as jest.Mock)
+        .mockReturnValueOnce([nativeSol]) // walletTokens
+        .mockReturnValueOnce([nativeSol]);
+
+      // allTokens is empty (no card-supported tokens) → nativeSol is excluded
+      renderHook(() =>
+        useSpendingLimit(createDefaultParams({ allTokens: [] })),
+      );
+
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({ top_card_chain_asset: null }),
+      );
+    });
+
+    it('includes top_wallet_chain_asset from all-wallet tokens', () => {
+      const cardToken = {
+        address: '0xcard',
+        symbol: 'mUSD',
+        chainId: LINEA_CAIP_CHAIN_ID,
+        tokenFiatAmount: 100,
+      };
+      const walletToken = {
+        address: '0xwallet',
+        symbol: 'ETH',
+        chainId: '0x1', // Ethereum mainnet — not a card chain
+        tokenFiatAmount: 9000,
+      };
+      (useTokensWithBalance as jest.Mock)
+        .mockReturnValueOnce([cardToken]) // walletTokens (card)
+        .mockReturnValueOnce([walletToken]); // allWalletTokens
+
+      renderHook(() => useSpendingLimit(createDefaultParams()));
+
+      // 0x1 → eip155:1, not in caipChainIdToNetwork → falls back to 'eip155:1'
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          top_wallet_chain_asset: 'eip155:1:eth',
+          top_wallet_asset_balance: 9000,
+        }),
       );
     });
   });

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -146,6 +146,10 @@ const useSpendingLimit = ({
   const selectedAccount = useSelector(selectSelectedInternalAccount);
   const accountIdRef = useRef(selectedAccount?.id);
 
+  // Guard that ensures the screen-view analytics event fires exactly once,
+  // but only after allTokens has loaded (non-empty) so cardSupportedKeys is accurate.
+  const screenViewFiredRef = useRef(false);
+
   useEffect(() => {
     if (selectedAccount?.id && selectedAccount.id !== accountIdRef.current) {
       accountIdRef.current = selectedAccount.id;
@@ -204,12 +208,15 @@ const useSpendingLimit = ({
     return `${network}:${token.symbol?.toLowerCase() ?? ''}`;
   };
 
-  // Track screen view
+  // Track screen view — fires exactly once, after allTokens has loaded so that
+  // cardSupportedKeys is accurate and top_card_chain_asset is not spuriously null.
   useEffect(() => {
+    if (screenViewFiredRef.current || allTokens.length === 0) return;
+    screenViewFiredRef.current = true;
+
     const screen =
       flow === 'enable' ? CardScreens.ENABLE_TOKEN : CardScreens.SPENDING_LIMIT;
 
-    // Balance context — snapshots Redux cache at mount time
     const musdOnLinea = walletTokens.find(
       (t) =>
         t.symbol?.toUpperCase() === 'MUSD' &&
@@ -262,8 +269,14 @@ const useSpendingLimit = ({
         })
         .build(),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trackEvent, createEventBuilder, flow]);
+  }, [
+    trackEvent,
+    createEventBuilder,
+    flow,
+    allTokens,
+    walletTokens,
+    allWalletTokens,
+  ]);
 
   useEffect(() => {
     if (hasInitialized) return;

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -188,7 +188,9 @@ const useSpendingLimit = ({
   const allWalletTokens = useTokensWithBalance({ chainIds: allWalletChainIds });
 
   // Returns 'network:symbol' (e.g. 'linea:musd', 'base:usdc') for analytics.
-  // Falls back to the CAIP chain ID for chains not in cardNetworkInfos.
+  // For card chains, uses the friendly network name from caipChainIdToNetwork.
+  // For unknown chains, strips the CAIP namespace prefix so the output is
+  // always a clean two-part 'chainId:symbol' string (e.g. '1:eth', '137:usdc').
   const toNetworkAsset = (token: {
     chainId: string;
     symbol?: string | null;
@@ -196,7 +198,9 @@ const useSpendingLimit = ({
     const caipId = token.chainId.startsWith('0x')
       ? `eip155:${parseInt(token.chainId, 16)}`
       : token.chainId;
-    const network = caipChainIdToNetwork[caipId as CaipChainId] ?? caipId;
+    const network =
+      caipChainIdToNetwork[caipId as CaipChainId] ??
+      caipId.replace(/^[^:]+:/, '');
     return `${network}:${token.symbol?.toLowerCase() ?? ''}`;
   };
 

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTheme } from '../../../../util/theme';
 import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
 import { createAccountSelectorNavDetails } from '../../../Views/AccountSelector';
 import { useCardDelegation, UserCancelledError } from './useCardDelegation';
 import { useCardSDK } from '../sdk';
@@ -28,6 +29,7 @@ import {
   BAANX_MAX_LIMIT,
   caipChainIdToNetwork,
   CARD_CHAIN_IDS,
+  cardNetworkInfos,
 } from '../constants';
 import {
   buildTokenListFromSettings,
@@ -48,6 +50,7 @@ import {
   ToastVariants,
 } from '../../../../component-library/components/Toast';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { CardActions, CardScreens } from '../util/metrics';
@@ -161,18 +164,6 @@ const useSpendingLimit = ({
 
   const isLoading = isDelegationLoading || isProcessing;
 
-  // Track screen view
-  useEffect(() => {
-    const screen =
-      flow === 'enable' ? CardScreens.ENABLE_TOKEN : CardScreens.SPENDING_LIMIT;
-
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.CARD_VIEWED)
-        .addProperties({ screen, flow })
-        .build(),
-    );
-  }, [trackEvent, createEventBuilder, flow]);
-
   // Wallet-only token balances for the currently selected MetaMask account.
   // Using this (instead of useAssetBalances) ensures sorting reflects the active
   // account's real wallet balance — not the card's availableBalance or another
@@ -180,6 +171,95 @@ const useSpendingLimit = ({
   const walletTokens = useTokensWithBalance({
     chainIds: CARD_CHAIN_IDS,
   });
+
+  // All-wallet token balances across every EVM chain the user has configured
+  // plus Solana mainnet — used for the top_wallet_chain_asset metric.
+  const evmNetworkConfigs = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+  const allWalletChainIds = useMemo(
+    () =>
+      [
+        ...(Object.keys(evmNetworkConfigs) as Hex[]),
+        cardNetworkInfos.solana.caipChainId,
+      ] as (Hex | CaipChainId)[],
+    [evmNetworkConfigs],
+  );
+  const allWalletTokens = useTokensWithBalance({ chainIds: allWalletChainIds });
+
+  // Returns 'network:symbol' (e.g. 'linea:musd', 'base:usdc') for analytics.
+  // Falls back to the CAIP chain ID for chains not in cardNetworkInfos.
+  const toNetworkAsset = (token: {
+    chainId: string;
+    symbol?: string | null;
+  }): string => {
+    const caipId = token.chainId.startsWith('0x')
+      ? `eip155:${parseInt(token.chainId, 16)}`
+      : token.chainId;
+    const network = caipChainIdToNetwork[caipId as CaipChainId] ?? caipId;
+    return `${network}:${token.symbol?.toLowerCase() ?? ''}`;
+  };
+
+  // Track screen view
+  useEffect(() => {
+    const screen =
+      flow === 'enable' ? CardScreens.ENABLE_TOKEN : CardScreens.SPENDING_LIMIT;
+
+    // Balance context — snapshots Redux cache at mount time
+    const musdOnLinea = walletTokens.find(
+      (t) =>
+        t.symbol?.toUpperCase() === 'MUSD' &&
+        (t.chainId === LINEA_CAIP_CHAIN_ID ||
+          t.chainId === safeFormatChainIdToHex(LINEA_CAIP_CHAIN_ID)),
+    );
+    // Only consider tokens actually supported by the card (present in allTokens)
+    const cardSupportedKeys = new Set(
+      allTokens.map((t) => {
+        const chainId = isSolanaChainId(t.caipChainId)
+          ? t.caipChainId
+          : safeFormatChainIdToHex(t.caipChainId ?? '');
+        return `${chainId}:${t.address?.toLowerCase()}`;
+      }),
+    );
+    const topCardToken =
+      [...walletTokens]
+        .filter((t) => {
+          if (!t.address || (t.tokenFiatAmount ?? 0) <= 0) return false;
+          const wtChainId = isSolanaChainId(t.chainId)
+            ? t.chainId
+            : safeFormatChainIdToHex(t.chainId);
+          return cardSupportedKeys.has(
+            `${wtChainId}:${t.address.toLowerCase()}`,
+          );
+        })
+        .sort(
+          (a, b) => (b.tokenFiatAmount ?? 0) - (a.tokenFiatAmount ?? 0),
+        )[0] ?? null;
+    const topWalletToken =
+      [...allWalletTokens]
+        .filter((t) => t.address && (t.tokenFiatAmount ?? 0) > 0)
+        .sort(
+          (a, b) => (b.tokenFiatAmount ?? 0) - (a.tokenFiatAmount ?? 0),
+        )[0] ?? null;
+
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_VIEWED)
+        .addProperties({
+          screen,
+          flow,
+          musd_linea_balance: musdOnLinea?.tokenFiatAmount ?? 0,
+          top_card_chain_asset: topCardToken
+            ? toNetworkAsset(topCardToken)
+            : null,
+          top_wallet_chain_asset: topWalletToken
+            ? toNetworkAsset(topWalletToken)
+            : null,
+          top_wallet_asset_balance: topWalletToken?.tokenFiatAmount ?? 0,
+        })
+        .build(),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trackEvent, createEventBuilder, flow]);
 
   useEffect(() => {
     if (hasInitialized) return;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds **wallet balance context** to the Card **`CARD_VIEWED`** event when the user opens the **Spending limit** (or enable-token) flow, and aligns row affordance icons with a **down** chevron on the settings-style rows.

**Why**: Product and analytics need to understand **Linea mUSD exposure**, which **card-supported asset** has the highest fiat balance for the current account, and which asset is **top across the whole wallet** (EVM networks plus Solana) at screen view time—without inferring this from other screens.

**What changed**:

- **`useSpendingLimit.ts`**
  - Calls **`useTokensWithBalance`** twice: **card chain IDs** (`CARD_CHAIN_IDS`) for `walletTokens`, and **all configured EVM chain IDs plus Solana** (via **`selectEvmNetworkConfigurationsByChainId`** and **`cardNetworkInfos.solana.caipChainId`**) for `allWalletTokens`.
  - On **`MetaMetricsEvents.CARD_VIEWED`**, adds:
    - **`musd_linea_balance`**: fiat amount for **mUSD on Linea** on the selected account, or **0** if absent.
    - **`top_card_chain_asset`**: `network:symbol` (e.g. `linea:musd`) for the **highest fiat** token among **card-supported** balances (`allTokens` intersection), or **`null`** if none / unsupported-only (e.g. top balance not in card list).
    - **`top_wallet_chain_asset`** / **`top_wallet_asset_balance`**: highest fiat token across **all wallet tokens** and its fiat value (or **`null`** / **0** when applicable). Network label uses **`caipChainIdToNetwork`** where mapped, otherwise the CAIP chain id string.
  - Introduces **`toNetworkAsset`** to normalize **`network:symbol`** for analytics.
  - Analytics effect runs after wallet token hooks; dependency array intentionally limited (with eslint comment) so the viewed snapshot stays stable at mount.
- **`SpendingLimit.tsx`**: **Account**, **Token**, and **Spending limit** row trailing icons **`ArrowRight` → `ArrowDown`** for clearer expand/dropdown affordance.
- **`useSpendingLimit.test.ts`**: Tests for **`musd_linea_balance`**, **`top_card_chain_asset`** (including empty list, non-card-supported top token), and **`top_wallet_chain_asset`** / **`top_wallet_asset_balance`**; clarifies default selector mock comment.

## **Changelog**

CHANGELOG entry: Card Spending limit screen analytics include Linea mUSD fiat balance, top card-supported asset by fiat, and top wallet-wide asset by fiat when the screen is viewed.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Spending limit viewed analytics and row icons

  Scenario: CARD_VIEWED includes balance properties
    Given I open Spending limit (or enable flow) with a known Linea mUSD balance and other tokens
    When the screen is tracked as viewed
    Then CARD_VIEWED includes musd_linea_balance, top_card_chain_asset, top_wallet_chain_asset, and top_wallet_asset_balance consistent with the selected account and supported tokens

  Scenario: Row chevrons
    When I view the Spending limit settings rows (Account, Token, Spending limit)
    Then each row shows a down chevron affordance instead of a right arrow
```

## **Screenshots/Recordings**

Optional: capture the three rows showing **down** chevrons. For analytics, verify in debug/logs or analytics tooling that **`CARD_VIEWED`** payloads include the new properties.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new analytics properties derived from wallet token balances and network configuration, including multi-chain sorting logic and a one-time firing guard; mistakes could skew metrics or add minor performance overhead on screen mount.
> 
> **Overview**
> **Enriches the card Spending Limit/Enable flow `CARD_VIEWED` analytics event** with wallet balance context: `musd_linea_balance`, the highest-fiat *card-supported* asset (`top_card_chain_asset`), and the highest-fiat asset across all configured wallet chains plus Solana (`top_wallet_chain_asset` + `top_wallet_asset_balance`).
> 
> Updates `useSpendingLimit` to fetch balances via `useTokensWithBalance` for both card chains and all wallet chains, normalizes `network:symbol` formatting, and delays/fires the screen-view event **exactly once** after `allTokens` is non-empty to avoid unsupported/empty snapshots; adds unit tests covering these new metrics.
> 
> Adjusts the Spending Limit settings rows’ trailing affordance icons from `ArrowRight` to `ArrowDown` for Account/Token/Spending limit rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1b5724e407c9fcda47a07f25a59b640284e6a4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->