### PR TITLE
fix(perps): resolve incorrect default pay token and insufficient funds flash

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -109,7 +109,10 @@ jest.mock('../../hooks/stream/usePerpsLiveAccount', () => ({
 }));
 
 jest.mock('../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance', () => ({
-  useDefaultPayWithTokenWhenNoPerpsBalance: jest.fn(() => null),
+  useDefaultPayWithTokenWhenNoPerpsBalance: jest.fn(() => ({
+    token: null,
+    balanceUsd: undefined,
+  })),
 }));
 
 const mockUseDefaultPayWithTokenWhenNoPerpsBalance =
@@ -729,7 +732,10 @@ describe('PerpsMarketDetailsView', () => {
       isInitialLoading: false,
     });
 
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+      token: null,
+      balanceUsd: undefined,
+    });
 
     mockUseHasExistingPosition.mockReturnValue({
       hasPosition: false,
@@ -937,9 +943,12 @@ describe('PerpsMarketDetailsView', () => {
       // Override with zero balance; return a default pay token so Add funds CTA is not shown
       // (when user has allowlist token they can pay with, we show Long/Short)
       mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
-        address: '0xUSDC' as const,
-        chainId: '0xa4b1' as const,
-        description: 'USDC',
+        token: {
+          address: '0xUSDC' as const,
+          chainId: '0xa4b1' as const,
+          description: 'USDC',
+        },
+        balanceUsd: 500,
       });
       mockUsePerpsAccount.mockReturnValue({
         account: {
@@ -987,7 +996,10 @@ describe('PerpsMarketDetailsView', () => {
     });
 
     it('shows add funds CTA when user balance is below threshold and no allowlist token', () => {
-      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+        token: null,
+        balanceUsd: undefined,
+      });
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
@@ -1028,7 +1040,10 @@ describe('PerpsMarketDetailsView', () => {
     });
 
     it('calls navigateToConfirmation and depositWithConfirmation when add funds is pressed', async () => {
-      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+        token: null,
+        balanceUsd: undefined,
+      });
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
@@ -1074,7 +1089,10 @@ describe('PerpsMarketDetailsView', () => {
     });
 
     it('handles depositWithConfirmation rejection without throwing', async () => {
-      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+        token: null,
+        balanceUsd: undefined,
+      });
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -420,7 +420,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   });
 
   const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
-  const defaultPayTokenWhenNoPerpsBalance =
+  const { token: defaultPayTokenWhenNoPerpsBalance } =
     useDefaultPayWithTokenWhenNoPerpsBalance();
   const { depositWithConfirmation } = usePerpsTrading();
   const { navigateToConfirmation } = useConfirmNavigation();

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -147,6 +147,7 @@ import createStyles from './PerpsOrderView.styles';
 import { PerpsPayRow } from './PerpsPayRow';
 import { useUpdateTokenAmount } from '../../../../Views/confirmations/hooks/transactions/useUpdateTokenAmount';
 import { useConfirmActions } from '../../../../Views/confirmations/hooks/useConfirmActions';
+import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 
 // Navigation params interface
 interface OrderRouteParams {
@@ -1927,6 +1928,11 @@ const PerpsOrderView: React.FC = () => {
   const { payToken } = useTransactionPayToken();
   const hasCustomTokenSelected = !useIsPerpsBalanceSelected();
 
+  // Pre-compute default token so the balance is available from the first render,
+  // before PerpsPayRow's effect applies it asynchronously.
+  const { balanceUsd: defaultTokenBalanceUsd } =
+    useDefaultPayWithTokenWhenNoPerpsBalance();
+
   // Get navigation params to pass to context provider
   const {
     direction = 'long',
@@ -1939,10 +1945,18 @@ const PerpsOrderView: React.FC = () => {
   } = route.params || {};
 
   const effectiveAvailableBalance = useMemo(() => {
-    if (!hasCustomTokenSelected) return undefined;
-    const amount = payToken?.balanceUsd;
-    return amount !== undefined ? Number(amount) : undefined;
-  }, [hasCustomTokenSelected, payToken?.balanceUsd]);
+    if (hasCustomTokenSelected) {
+      const amount = payToken?.balanceUsd;
+      return amount !== undefined ? Number(amount) : undefined;
+    }
+    // When perps balance is selected but a default token will be applied by
+    // PerpsPayRow on the next render, use the default token's balance so the
+    // form doesn't briefly see 0 and flash "Insufficient funds".
+    if (defaultTokenBalanceUsd !== undefined) {
+      return defaultTokenBalanceUsd;
+    }
+    return undefined;
+  }, [hasCustomTokenSelected, payToken?.balanceUsd, defaultTokenBalanceUsd]);
 
   return (
     <PerpsOrderProvider

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -138,7 +138,10 @@ describe('PerpsPayRow', () => {
     mockIsHardwareAccount.mockReturnValue(false);
     mockUsePerpsSelector.mockReturnValue({});
     mockUsePerpsPayWithToken.mockReturnValue(null);
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+      token: null,
+      balanceUsd: undefined,
+    });
   });
 
   it('renders pay with label', () => {
@@ -301,7 +304,10 @@ describe('PerpsPayRow', () => {
   it('calls setSelectedPaymentToken(null) when pending config has no selected token', () => {
     mockUsePerpsSelector.mockReturnValue({});
     mockUsePerpsPayWithToken.mockReturnValue(null);
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+      token: null,
+      balanceUsd: undefined,
+    });
 
     renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
 
@@ -319,7 +325,10 @@ describe('PerpsPayRow', () => {
     };
     mockUsePerpsSelector.mockReturnValue({});
     mockUsePerpsPayWithToken.mockReturnValue(null);
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(defaultToken);
+    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue({
+      token: defaultToken,
+      balanceUsd: 500,
+    });
     mockUseTransactionPayToken.mockReturnValue({
       payToken: null,
       setPayToken: setPayTokenMock,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -117,7 +117,7 @@ export const PerpsPayRow = ({
     selectPendingTradeConfiguration(state, initialAsset),
   );
   const selectedPaymentToken = usePerpsPayWithToken();
-  const defaultPayTokenWhenNoPerpsBalance =
+  const { token: defaultPayTokenWhenNoPerpsBalance } =
     useDefaultPayWithTokenWhenNoPerpsBalance();
 
   const pendingConfigSelectedPaymentToken = pendingConfig?.selectedPaymentToken;

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.test.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.test.ts
@@ -69,7 +69,7 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
     mockUsePerpsPaymentTokens.mockReturnValue([]);
   });
 
-  it('returns null when available perps balance is above threshold', () => {
+  it('returns null token when available perps balance is above threshold', () => {
     mockUsePerpsPaymentTokens.mockReturnValue([
       {
         address: '0xusdc',
@@ -87,10 +87,11 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       }),
     );
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
   });
 
-  it('returns null when feature flag is disabled', () => {
+  it('returns null token when feature flag is disabled', () => {
     mockUsePerpsPaymentTokens.mockReturnValue([
       {
         address: '0xusdc',
@@ -108,16 +109,18 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       }),
     );
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
   });
 
-  it('returns null when allowlist is empty', () => {
+  it('returns null token when allowlist is empty', () => {
     const { result } = runHook(getState({ allowlistAssets: [] }));
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
   });
 
-  it('returns null when no payment tokens match allowlist', () => {
+  it('returns null token when no payment tokens match allowlist', () => {
     mockUsePerpsPaymentTokens.mockReturnValue([
       {
         address: '0xusdc',
@@ -130,10 +133,11 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
 
     const { result } = runHook(getState({ allowlistAssets: ['0x1.0xother'] }));
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
   });
 
-  it('returns null when top allowlist token balance is below threshold', () => {
+  it('returns null token when top allowlist token balance is below threshold', () => {
     mockUsePerpsPaymentTokens.mockReturnValue([
       {
         address: '0xusdc',
@@ -148,7 +152,8 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       getState({ allowlistAssets: ['0xa4b1.0xusdc'] }),
     );
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
   });
 
   it('returns top allowlist token by fiat balance when perps balance is below threshold', () => {
@@ -175,10 +180,11 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       }),
     );
 
-    expect(result.current).not.toBeNull();
-    expect(result.current?.address).toBe('0xusdc');
-    expect(result.current?.chainId).toBe('0xa4b1');
-    expect(result.current?.description).toBe('USDC');
+    expect(result.current.token).not.toBeNull();
+    expect(result.current.token?.address).toBe('0xusdc');
+    expect(result.current.token?.chainId).toBe('0xa4b1');
+    expect(result.current.token?.description).toBe('USDC');
+    expect(result.current.balanceUsd).toBe(500);
   });
 
   it('treats null perps account as zero balance and returns default token when allowlist has balance', () => {
@@ -199,8 +205,9 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       }),
     );
 
-    expect(result.current).not.toBeNull();
-    expect(result.current?.description).toBe('USDC');
+    expect(result.current.token).not.toBeNull();
+    expect(result.current.token?.description).toBe('USDC');
+    expect(result.current.balanceUsd).toBe(500);
   });
 
   it('excludes current perps provider chain tokens from allowlist result', () => {
@@ -221,7 +228,8 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       }),
     );
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
   });
 
   it('excludes default provider chain when activeProvider is aggregated', () => {
@@ -242,6 +250,54 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
       }),
     );
 
-    expect(result.current).toBeNull();
+    expect(result.current.token).toBeNull();
+    expect(result.current.balanceUsd).toBeUndefined();
+  });
+
+  it('parses balanceFiat with $ prefix correctly', () => {
+    mockUsePerpsPaymentTokens.mockReturnValue([
+      {
+        address: '0xusdc',
+        chainId: '0xa4b1',
+        symbol: 'USDC',
+        balanceFiat: '$250.75',
+        decimals: 6,
+      },
+    ] as PerpsToken[]);
+
+    const { result } = runHook(
+      getState({ allowlistAssets: ['0xa4b1.0xusdc'] }),
+    );
+
+    expect(result.current.token).not.toBeNull();
+    expect(result.current.token?.address).toBe('0xusdc');
+    expect(result.current.balanceUsd).toBe(250.75);
+  });
+
+  it('selects highest balance token regardless of currency format', () => {
+    mockUsePerpsPaymentTokens.mockReturnValue([
+      {
+        address: '0xeth',
+        chainId: '0x1',
+        symbol: 'ETH',
+        balanceFiat: '$50',
+        decimals: 18,
+      },
+      {
+        address: '0xusdc',
+        chainId: '0xa4b1',
+        symbol: 'USDC',
+        balanceFiat: 'US$200',
+        decimals: 6,
+      },
+    ] as PerpsToken[]);
+
+    const { result } = runHook(
+      getState({ allowlistAssets: ['0x1.0xeth', '0xa4b1.0xusdc'] }),
+    );
+
+    expect(result.current.token?.address).toBe('0xusdc');
+    expect(result.current.token?.description).toBe('USDC');
+    expect(result.current.balanceUsd).toBe(200);
   });
 });

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
@@ -18,12 +18,18 @@ import {
 import { usePerpsNetwork } from './index';
 import { usePerpsPaymentTokens } from './usePerpsPaymentTokens';
 
+export interface DefaultPayTokenResult {
+  token: PerpsSelectedPaymentToken | null;
+  /** Fiat balance (USD) of the selected token; undefined when no token selected */
+  balanceUsd: number | undefined;
+}
+
 /**
  * When the user has no perps balance and the pay-with-any-token allowlist is enabled,
  * returns the allowlist token with the highest balance to use as the default payment method.
  * Otherwise returns null (caller should default to "Perps balance").
  */
-export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPaymentToken | null {
+export function useDefaultPayWithTokenWhenNoPerpsBalance(): DefaultPayTokenResult {
   const featureEnabled = useSelector(
     selectPerpsDefaultPayTokenWhenNoBalanceEnabledFlag,
   );
@@ -35,19 +41,24 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
   const currentNetwork = usePerpsNetwork();
   const paymentTokens = usePerpsPaymentTokens();
 
+  const NO_TOKEN: DefaultPayTokenResult = useMemo(
+    () => ({ token: null, balanceUsd: undefined }),
+    [],
+  );
+
   return useMemo(() => {
     if (!featureEnabled) {
-      return null;
+      return NO_TOKEN;
     }
     const availableBalance = Number.parseFloat(
       perpsAccount?.availableBalance?.toString() ?? '0',
     );
 
     if (availableBalance > PERPS_MIN_BALANCE_THRESHOLD) {
-      return null;
+      return NO_TOKEN;
     }
     if (!allowlistAssets?.length) {
-      return null;
+      return NO_TOKEN;
     }
 
     const allowSet = new Set(allowlistAssets);
@@ -70,27 +81,31 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
       return allowSet.has(key);
     });
 
-    if (allowlistTokens.length === 0) return null;
+    if (allowlistTokens.length === 0) return NO_TOKEN;
 
     const tokensWithBalance = allowlistTokens
       .map((token) => ({
         ...token,
         balanceFiat: Number.parseFloat(
-          token.balanceFiat?.replace('US$', '').trim() || '0',
+          token.balanceFiat?.replace(/[^0-9.-]/g, '') || '0',
         ),
       }))
       .sort((a, b) => b.balanceFiat - a.balanceFiat);
 
     const top = tokensWithBalance[0];
 
-    if (top.balanceFiat < PERPS_MIN_BALANCE_THRESHOLD) return null;
+    if (top.balanceFiat < PERPS_MIN_BALANCE_THRESHOLD) return NO_TOKEN;
 
     return {
-      address: top.address as Hex,
-      chainId: top.chainId as Hex,
-      description: top.symbol,
+      token: {
+        address: top.address as Hex,
+        chainId: top.chainId as Hex,
+        description: top.symbol,
+      },
+      balanceUsd: top.balanceFiat,
     };
   }, [
+    NO_TOKEN,
     featureEnabled,
     perpsAccount?.availableBalance,
     allowlistAssets,


### PR DESCRIPTION
## **Description**

Fixes three interconnected bugs in the Perps "pay with any token" flow that caused:
1. The default payment token to randomly alternate between USDC on Arbitrum and ETH on Ethereum
2. The CTA to flash "Insufficient funds" and become disabled
3. Error messages "Insufficient balance. Required $X, Available $Y" and "Not enough funds available. Deposit funds or select a different payment method" to appear briefly

### Root causes

**Currency parsing bug** — `useDefaultPayWithTokenWhenNoPerpsBalance` parsed `balanceFiat` with `replace('US$', '')`, which only strips the `US$` prefix. Most tokens use a `$` prefix (e.g. `$500.00`), so `Number.parseFloat('$500.00')` returned `NaN`, making the token sorting unpredictable.

**Race condition** — The default payment token was resolved inside `PerpsPayRow` (a child of `PerpsOrderProvider`) via an effect that runs *after* the first render. But `effectiveAvailableBalance` was computed in the outer `PerpsOrderView` based on the current selection state. On the first render no token was selected yet, so `effectiveAvailableBalance` was `undefined`, the form briefly saw balance = 0, and flashed "Insufficient funds".

### Solution

- Fixed `balanceFiat` parsing to use `replace(/[^0-9.-]/g, '')` which strips all non-numeric characters regardless of currency format
- Changed `useDefaultPayWithTokenWhenNoPerpsBalance` to also return the resolved `balanceUsd` alongside the token
- Called the hook in the outer `PerpsOrderView` component to pre-compute `effectiveAvailableBalance` *before* `PerpsPayRow` mounts, eliminating the first-render race
- Updated all consumers (`PerpsPayRow`, `PerpsMarketDetailsView`) for the new return shape

## **Changelog**

CHANGELOG entry: Fixed an issue where the Perps order screen briefly showed "Insufficient funds" and alternated between payment tokens when the user had no Perps balance

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2785

## **Manual testing steps**

```gherkin
Feature: Perps default payment token selection

  Scenario: user opens order screen with no perps balance but tokens in wallet
    Given the user has 0 perps balance
    And the user has USDC on Arbitrum with $500 balance
    And the user has ETH on Ethereum with $200 balance
    And the pay-with-any-token feature flag is enabled

    When user navigates to the Perps order screen
    Then the CTA button should show "Long BTC" or "Short BTC" (not "Insufficient funds")
    And the pay-with row should consistently show USDC on Arbitrum (highest balance)
    And no "Insufficient balance" or "Not enough funds" error should appear

  Scenario: user opens order screen with sufficient perps balance
    Given the user has $100 perps balance

    When user navigates to the Perps order screen
    Then the pay-with row should show "Perps balance"
    And the CTA should show the normal "Long/Short" label

  Scenario: user opens order screen with zero balance and no wallet tokens
    Given the user has 0 perps balance
    And the user has no tokens in wallet

    When user navigates to the Perps order screen
    Then the "Not enough funds available" warning should appear
    And the CTA should show "Insufficient funds"
```

## **Screenshots/Recordings**

N/A — no UI layout changes; fix addresses timing/logic bugs in existing UI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
