### PR TITLE
refactor(analytics): C3-b migrate TabBar analytics from useMetrics to useAnalytics

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -18,7 +18,7 @@ import { IconName } from '../../Icons/Icon';
 
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { getDecimalChainId } from '../../../../util/networks';
-import { useMetrics } from '../../../../components/hooks/useMetrics';
+import { useAnalytics } from '../../../../components/hooks/useAnalytics/useAnalytics';
 import { strings } from '../../../../../locales/i18n';
 
 // Internal dependencies.
@@ -38,7 +38,7 @@ const FILLED_ICONS: Partial<Record<TabBarIconKey, IconName>> = {
 };
 
 const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const chainId = useSelector(selectChainId);
   const isAccountMenuEnabled = useAccountMenuEnabled();


### PR DESCRIPTION
---

## **Description**

<!-- 
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replaces the deprecated `useMetrics` hook with the new `useAnalytics` hook in `TabBar.tsx`.

This is part of the broader C3 analytics migration (#26686) that standardises all analytics calls across the mobile app to use the new `useAnalytics` abstraction instead of `useMetrics`. The hook interface is identical (`trackEvent`, `createEventBuilder`), so no behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #26814

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that swaps a deprecated analytics hook for its replacement while keeping the same `trackEvent`/`createEventBuilder` interface; main risk is accidental import/path or hook wiring issues affecting event emission.
> 
> **Overview**
> Updates `TabBar.tsx` to use the new `useAnalytics` hook instead of the deprecated `useMetrics`, leaving the existing `trackEvent`/`createEventBuilder` usage intact (e.g., for the wallet actions button click event).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c31f62f940909156db3f5cb3eb516888dcea5d48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->