### PR TITLE
refactor(analytics): C3-d migrate Bridge hook analytics from useMetrics to useAnalytics

### DIFF
--- a/app/components/UI/Bridge/hooks/useGoToPortfolioBridge.ts
+++ b/app/components/UI/Bridge/hooks/useGoToPortfolioBridge.ts
@@ -62,6 +62,10 @@ export default function useGoToPortfolioBridge(location: string) {
     trackEvent(
       createEventBuilder(MetaMetricsEvents.BRIDGE_LINK_CLICKED)
         .addProperties({
+          // action and name are legacy properties from the generateOpt definition
+          // that AnalyticsEventBuilder does not carry over automatically
+          action: 'Bridge',
+          name: 'Bridge',
           bridgeUrl: AppConstants.BRIDGE.URL,
           location,
           chain_id_source: getDecimalChainId(chainId),

--- a/app/components/UI/Bridge/hooks/useGoToPortfolioBridge.ts
+++ b/app/components/UI/Bridge/hooks/useGoToPortfolioBridge.ts
@@ -9,7 +9,7 @@ import { selectEvmChainId } from '../../../../selectors/networkController';
 import type { BrowserTab } from '../../Tokens/types';
 import type { BrowserParams } from '../../../Views/Browser/Browser.types';
 import { getDecimalChainId } from '../../../../util/networks';
-import { useMetrics } from '../../../hooks/useMetrics';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { isBridgeUrl } from '../../../../util/url';
 import { useBuildPortfolioUrl } from '../../../hooks/useBuildPortfolioUrl';
 
@@ -24,7 +24,7 @@ export default function useGoToPortfolioBridge(location: string) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const browserTabs = useSelector((state: any) => state.browser.tabs);
   const { navigate } = useNavigation();
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const buildPortfolioUrlWithMetrics = useBuildPortfolioUrl();
   return (address?: string) => {
     const existingBridgeTab = browserTabs.find((tab: BrowserTab) =>


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replaces the deprecated `useMetrics` hook with the new `useAnalytics` hook in `useGoToPortfolioBridge.ts`.

This is part of the broader C3 analytics migration (#26686) that standardises all analytics calls across the mobile app to use the new `useAnalytics` abstraction instead of `useMetrics`. The hook interface is identical (`trackEvent`, `createEventBuilder`), so no behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #26814

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps analytics hook wiring and adds legacy `action`/`name` properties to the emitted event, without changing navigation or URL-building logic.
> 
> **Overview**
> Updates `useGoToPortfolioBridge` to use the new `useAnalytics` hook instead of deprecated `useMetrics` for `BRIDGE_LINK_CLICKED` tracking.
> 
> Also explicitly adds legacy `action` and `name` properties to the tracked event payload to preserve existing analytics fields during the migration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b45bf0fee4fb748d146b5944e6627455c076b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->