### PR TITLE
fix(e2e): preserve URL constraint in matching predicates

### DIFF
--- a/tests/api-mocking/GoMockServer.ts
+++ b/tests/api-mocking/GoMockServer.ts
@@ -640,14 +640,16 @@ export default class GoMockServer implements Resource {
           await makeTerminal(method, urlPredicate, null).thenCallback(handler);
         },
         matching: (predicate: MockttpPredicate) => {
-          const terminal = makeTerminal(method, predicate, null);
+          const combinedPredicate: MockttpPredicate = async (request) =>
+            (await urlPredicate(request)) && (await predicate(request));
+          const terminal = makeTerminal(method, combinedPredicate, null);
           return {
             ...terminal,
-            always: () => makeTerminal(method, predicate, null),
+            always: () => makeTerminal(method, combinedPredicate, null),
             withJsonBodyIncluding: (bodyMatcher: Record<string, unknown>) =>
-              makeTerminal(method, predicate, bodyMatcher),
+              makeTerminal(method, combinedPredicate, bodyMatcher),
             asPriority: (priority: number) =>
-              makeTerminal(method, predicate, null, priority),
+              makeTerminal(method, combinedPredicate, null, priority),
           };
         },
         asPriority: (priority: number) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes a regression in `GoMockServer`’s `MockttpCompat` implementation where `.matching(predicate)` dropped the original URL matcher and only evaluated the user predicate.

This caused callback bridge handlers to over-match unrelated requests, which can cascade into broad E2E instability (missing expected bridge/swap/perps responses and downstream UI assertion failures).

### What changed
- In `tests/api-mocking/GoMockServer.ts`, `.matching(predicate)` now composes a `combinedPredicate`:
  - first validates the original URL matcher (`urlPredicate`), then
  - evaluates the user-supplied predicate.
- Applied the same combined predicate consistently across:
  - `.matching(...).always()`
  - `.matching(...).withJsonBodyIncluding(...)`
  - `.matching(...).asPriority(...)`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #27904

## **Manual testing steps**

```gherkin
Feature: GoMockServer matching predicate behavior

  Scenario: matching preserves URL constraint
    Given a callback mock is registered with forPost("/proxy").matching(predicate)
    When another request with the same shape but different URL is forwarded to the bridge
    Then the handler should not match that unrelated URL

  Scenario: matching applies user predicate after URL check
    Given a callback mock is registered with forPost(targetUrl).matching(predicate)
    When a request to targetUrl fails predicate conditions
    Then the handler should not match
    And when predicate conditions pass
    Then the handler should match and return the configured response
```

## **Screenshots/Recordings**

N/A — test infrastructure change only.

## **Pre-merge author checklist**

- [x] I've followed MetaMask Mobile coding guidelines.
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests or rationale when tests were not feasible in this environment.
- [x] I've documented behavior changes where relevant.
- [ ] I've applied the right labels on the PR.

## **Pre-merge reviewer checklist**

- [ ] I’ve manually tested the PR.
- [ ] I confirm this addresses the intended regression.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14630ad0-f1e5-442f-b6e1-9e1f9206466a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14630ad0-f1e5-442f-b6e1-9e1f9206466a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

