### PR TITLE
test: expose app config for reuse

### DIFF
--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -1,3 +1,4 @@
+import { CurrentDeviceDetails } from './fixture';
 import { PlatformDetector } from './PlatformLocator';
 import { PlaywrightElement } from './PlaywrightAdapter';
 import { boxedStep, getDriver } from './PlaywrightUtilities';
@@ -167,20 +168,21 @@ export default class PlaywrightGestures {
 
   /**
    * Terminate the app
-   * @param packageName - The package name of the app to terminate (Android only)
-   * @param appId - The app id of the app to terminate (iOS only)
+   * @param currentDeviceDetails - The current device details
    */
   @boxedStep
   static async terminateApp(
-    packageName?: string,
-    appId?: string,
+    currentDeviceDetails: CurrentDeviceDetails,
   ): Promise<void> {
     const driver = getDriver();
     if (!driver) throw new Error('Driver is not available');
-    if ((await PlatformDetector.isAndroid()) && packageName) {
-      await driver.terminateApp(packageName);
-    } else if ((await PlatformDetector.isIOS()) && appId) {
-      await driver.terminateApp(appId);
+    if (
+      (await PlatformDetector.isAndroid()) &&
+      currentDeviceDetails.packageName
+    ) {
+      await driver.terminateApp(currentDeviceDetails.packageName);
+    } else if ((await PlatformDetector.isIOS()) && currentDeviceDetails.appId) {
+      await driver.terminateApp(currentDeviceDetails.appId);
     } else {
       throw new Error('Package name or app id is not available');
     }

--- a/tests/framework/config/ConfigHandler.ts
+++ b/tests/framework/config/ConfigHandler.ts
@@ -5,11 +5,11 @@ import {
   PlaywrightTestConfig,
   ReporterDescription,
 } from '@playwright/test';
-import { WebDriverConfig } from '../types.ts';
+import { WebDriverConfig } from '../types';
 import {
   DEFAULT_ACTION_TIMEOUT_MS,
   DEFAULT_IMPLICIT_WAIT_MS,
-} from '../Constants.ts';
+} from '../Constants';
 
 const resolveGlobalSetup = () => path.join(__dirname, 'global.setup.ts');
 

--- a/tests/framework/config/index.ts
+++ b/tests/framework/config/index.ts
@@ -1,1 +1,1 @@
-export { defineConfig } from './ConfigHandler.ts';
+export { defineConfig } from './ConfigHandler';

--- a/tests/framework/fixture/index.ts
+++ b/tests/framework/fixture/index.ts
@@ -21,9 +21,12 @@ declare global {
   var driver: WebdriverIO.Browser | undefined;
 }
 
-interface CurrentDeviceDetails {
+export interface CurrentDeviceDetails {
   platform: 'android' | 'ios';
   deviceName: string;
+  packageName?: string;
+  appId?: string;
+  launchableActivity?: string;
 }
 
 interface TestLevelFixtures {
@@ -60,6 +63,9 @@ export const test = base.extend<TestLevelFixtures>({
     const project = testInfo.project as FullProject<WebDriverConfig>;
     const platform = project.use.platform;
     const deviceName = project.use.device?.name;
+    const packageName = project.use.app?.packageName;
+    const appId = project.use.app?.appId;
+    const launchableActivity = project.use.app?.launchableActivity;
 
     const missingFields = [
       ...(!platform ? ['"use.platform"'] : []),
@@ -75,6 +81,9 @@ export const test = base.extend<TestLevelFixtures>({
     const deviceDetails: CurrentDeviceDetails = {
       platform: platform as 'android' | 'ios',
       deviceName: deviceName as string,
+      packageName,
+      appId,
+      launchableActivity,
     };
 
     await use(deviceDetails);

--- a/tests/framework/services/providers/browserstack/BrowserStackConfigBuilder.ts
+++ b/tests/framework/services/providers/browserstack/BrowserStackConfigBuilder.ts
@@ -106,6 +106,14 @@ export class BrowserStackConfigBuilder {
             ? { otherApps: [process.env.BROWSERSTACK_RN_PLAYGROUND_URL] }
             : {}),
         },
+        ...(platformName === 'android'
+          ? {
+              'appium:appPackage': this.project.use.app?.packageName,
+              'appium:appActivity': this.project.use.app?.launchableActivity,
+            }
+          : {
+              'appium:bundleId': this.project.use.app?.appId,
+            }),
         'appium:autoGrantPermissions': true,
         'appium:app': appBsUrl,
         'appium:autoAcceptAlerts': true,

--- a/tests/framework/services/providers/emulator/EmulatorConfigBuilder.ts
+++ b/tests/framework/services/providers/emulator/EmulatorConfigBuilder.ts
@@ -26,8 +26,14 @@ export class EmulatorConfigBuilder {
         'appium:automationName':
           platformName === Platform.ANDROID ? 'UIAutomator2' : 'XCUITest',
         'appium:platformVersion': device.osVersion,
-        'appium:appActivity': this.project.use.launchableActivity,
-        'appium:appPackage': device.packageName,
+        ...(platformName === Platform.ANDROID
+          ? {
+              'appium:appPackage': this.project.use.app?.packageName,
+              'appium:appActivity': this.project.use.app?.launchableActivity,
+            }
+          : {
+              'appium:bundleId': this.project.use.app?.appId,
+            }),
         platformName,
         'appium:autoGrantPermissions': true,
         'appium:app': this.project.use.buildPath,

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -48,7 +48,6 @@ export interface EmulatorConfig {
   provider: 'emulator';
   name?: string;
   osVersion?: string;
-  packageName?: string;
   launchableActivity?: string;
   udid?: string;
   orientation?: DeviceOrientation;
@@ -60,6 +59,12 @@ export interface BrowserStackConfig {
   osVersion: string;
   orientation?: DeviceOrientation;
   enableCameraImageInjection?: boolean;
+}
+
+export interface AppConfig {
+  appId?: string;
+  packageName?: string;
+  launchableActivity?: string;
 }
 
 export type DeviceConfig = EmulatorConfig | BrowserStackConfig;
@@ -76,8 +81,8 @@ export interface WebDriverConfig {
   device: DeviceConfig;
   buildPath: string;
   appBundleId: string;
-  launchableActivity: string;
   expectTimeout: number;
+  app: AppConfig;
 }
 /**
  * END OF WDIO PLAYWRIIGHT

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -48,7 +48,6 @@ export interface EmulatorConfig {
   provider: 'emulator';
   name?: string;
   osVersion?: string;
-  launchableActivity?: string;
   udid?: string;
   orientation?: DeviceOrientation;
 }

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -31,10 +31,12 @@ export default defineConfig({
           provider: 'emulator',
           name: 'Samsung Galaxy S24 Ultra',
           osVersion: '14', // 14 for local testing
+        },
+        app: {
           packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
         },
         buildPath: 'PATH-TO-BUILD', // Path to your .apk file
-        launchableActivity: 'io.metamask.MainActivity',
       },
     },
     {
@@ -48,6 +50,10 @@ export default defineConfig({
           name: process.env.BROWSERSTACK_DEVICE || 'Samsung Galaxy S23 Ultra', // this can changed
           osVersion: process.env.BROWSERSTACK_OS_VERSION || '13.0', // this can changed
         },
+        app: {
+          packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
+        },
         buildPath: process.env.BROWSERSTACK_ANDROID_APP_URL, // Path to Browserstack url
       },
     },
@@ -59,6 +65,9 @@ export default defineConfig({
         device: {
           provider: 'emulator',
           osVersion: '16.0',
+        },
+        app: {
+          appId: 'io.metamask.MetaMask',
         },
         buildPath: 'PATH-TO-BUILD', // Path to your .app file
       },
@@ -72,6 +81,9 @@ export default defineConfig({
           provider: 'browserstack',
           name: process.env.BROWSERSTACK_DEVICE || 'iPhone 14 Pro Max',
           osVersion: process.env.BROWSERSTACK_OS_VERSION || '16.0',
+        },
+        app: {
+          appId: 'io.metamask.MetaMask',
         },
         buildPath: process.env.BROWSERSTACK_IOS_APP_URL,
       },
@@ -87,6 +99,10 @@ export default defineConfig({
           name: process.env.BROWSERSTACK_DEVICE || 'Samsung Galaxy S23 Ultra',
           osVersion: process.env.BROWSERSTACK_OS_VERSION || '13.0',
         },
+        app: {
+          packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
+        },
         buildPath: process.env.BROWSERSTACK_ANDROID_CLEAN_APP_URL,
       },
     },
@@ -99,6 +115,9 @@ export default defineConfig({
           provider: 'browserstack',
           name: process.env.BROWSERSTACK_DEVICE || 'iPhone 14 Pro Max',
           osVersion: process.env.BROWSERSTACK_OS_VERSION || '16.0',
+        },
+        app: {
+          appId: 'io.metamask.MetaMask',
         },
         buildPath: process.env.BROWSERSTACK_IOS_CLEAN_APP_URL,
       },
@@ -113,6 +132,9 @@ export default defineConfig({
           name: process.env.BROWSERSTACK_DEVICE || 'iPhone 14 Pro Max',
           osVersion: process.env.BROWSERSTACK_OS_VERSION || '16.0',
         },
+        app: {
+          appId: 'io.metamask.MetaMask',
+        },
         buildPath: 'bs://a0ea40650b0a1108e32b27ec93ac73af3b393855', // Just a demo, CI will take care of this
       },
     },
@@ -124,6 +146,9 @@ export default defineConfig({
         device: {
           provider: 'emulator',
           osVersion: '16.0', // this can be changed to your simulator version
+        },
+        app: {
+          appId: 'io.metamask.MetaMask',
         },
         buildPath: 'PATH-TO-BUILD', // Path to your .app file
       },
@@ -138,6 +163,10 @@ export default defineConfig({
           name: process.env.BROWSERSTACK_DEVICE || 'Samsung Galaxy S23 Ultra', // this can changed
           osVersion: process.env.BROWSERSTACK_OS_VERSION || '13.0', // this can changed
         },
+        app: {
+          packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
+        },
         buildPath: process.env.BROWSERSTACK_ANDROID_APP_URL, // Path to Browserstack url
       },
     },
@@ -150,6 +179,10 @@ export default defineConfig({
           provider: 'emulator',
           name: 'Samsung Galaxy S24 Ultra', // this can be changed to your emulator name
           osVersion: '14', // this can be changed to your emulator version
+        },
+        app: {
+          packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
         },
         buildPath: 'PATH-TO-BUILD', // Path to your .apk file
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Exposes the app details for easier reuse across tests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk to the test harness because it changes how app identifiers are sourced for Appium capabilities and `terminateApp`, which could break Android/iOS runs if `use.app` is missing or misconfigured.
> 
> **Overview**
> Refactors Playwright test configuration to centralize app identifiers under a new `use.app` object (`appId`, `packageName`, `launchableActivity`) via a new `AppConfig` on `WebDriverConfig`, and updates `tests/playwright.config.ts` accordingly.
> 
> Updates the fixture to expose these fields through `CurrentDeviceDetails` (now exported) and changes `PlaywrightGestures.terminateApp` to take `currentDeviceDetails` instead of separate `packageName`/`appId` arguments.
> 
> Adjusts BrowserStack and local emulator capability builders to read app package/activity or bundle id from `project.use.app`, and cleans up config exports/imports to drop explicit `.ts` extensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f06862178b438da2e1294f6b89465994ea01b739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->