### PR TITLE
feat: Add WCv2 session amount limit

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -1872,15 +1872,14 @@ describe('WC2Manager', () => {
 
       const now = Math.floor(Date.now() / 1000);
 
-      // Pre-populate active sessions at the limit (20). The oldest session has the
-      // smallest expiry value (topic 'oldest-topic').
+      // Pre-populate 20 active sessions
       const existingSessions: Record<string, SessionTypes.Struct> = {};
       for (let i = 0; i < 20; i++) {
-        const topic = i === 0 ? 'oldest-topic' : `existing-topic-${i}`;
+        const topic = `topic-${i}`;
         existingSessions[topic] = {
           topic,
           pairingTopic: `pairing-${topic}`,
-          expiry: now + i * 100, // oldest has smallest expiry
+          expiry: now + i * 100,
           relay: { protocol: 'irn' },
           acknowledged: true,
           controller: 'controller',
@@ -1901,7 +1900,7 @@ describe('WC2Manager', () => {
       }
 
       // Make getActiveSessions return all 20 existing sessions plus the new one
-      // (i.e. 21 total) so enforceSessionLimit fires.
+      // so enforceSessionLimit fires.
       const newSessionTopic = 'new-session-topic';
       (web3Wallet.getActiveSessions as jest.Mock).mockReturnValue({
         ...existingSessions,
@@ -1970,9 +1969,8 @@ describe('WC2Manager', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await manager.onSessionProposal(proposal as any);
 
-      // The oldest session (smallest expiry) should have been disconnected.
       expect(mockDisconnectSession).toHaveBeenCalledWith(
-        expect.objectContaining({ topic: 'oldest-topic' }),
+        expect.objectContaining({ topic: 'topic-0' }),
       );
     });
 

--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -17,6 +17,7 @@ import { ActionType } from '../../actions/sdk';
 jest.mock('../AppConstants', () => ({
   WALLET_CONNECT: {
     PROJECT_ID: 'test-project-id',
+    LIMIT_SESSIONS: 20,
     METADATA: {
       name: 'Test Wallet',
       description: 'Test Wallet Description',
@@ -1860,6 +1861,202 @@ describe('WC2Manager', () => {
         validation: 'UNKNOWN',
         verifiedOrigin: 'https://example.com',
       });
+    });
+  });
+
+  describe('session limit enforcement', () => {
+    it('removes the oldest session when the session limit is exceeded', async () => {
+      const web3Wallet = (manager as unknown as { web3Wallet: IWalletKit })
+        .web3Wallet;
+      const mockDisconnectSession = jest.spyOn(web3Wallet, 'disconnectSession');
+
+      const now = Math.floor(Date.now() / 1000);
+
+      // Pre-populate active sessions at the limit (20). The oldest session has the
+      // smallest expiry value (topic 'oldest-topic').
+      const existingSessions: Record<string, SessionTypes.Struct> = {};
+      for (let i = 0; i < 20; i++) {
+        const topic = i === 0 ? 'oldest-topic' : `existing-topic-${i}`;
+        existingSessions[topic] = {
+          topic,
+          pairingTopic: `pairing-${topic}`,
+          expiry: now + i * 100, // oldest has smallest expiry
+          relay: { protocol: 'irn' },
+          acknowledged: true,
+          controller: 'controller',
+          namespaces: {},
+          requiredNamespaces: {},
+          optionalNamespaces: {},
+          self: { publicKey: 'self-key', metadata: {} as any },
+          peer: {
+            publicKey: 'peer-key',
+            metadata: {
+              url: 'https://example.com',
+              name: 'Test App',
+              description: '',
+              icons: [],
+            },
+          },
+        } as SessionTypes.Struct;
+      }
+
+      // Make getActiveSessions return all 20 existing sessions plus the new one
+      // (i.e. 21 total) so enforceSessionLimit fires.
+      const newSessionTopic = 'new-session-topic';
+      (web3Wallet.getActiveSessions as jest.Mock).mockReturnValue({
+        ...existingSessions,
+        [newSessionTopic]: {
+          topic: newSessionTopic,
+          pairingTopic: 'new-pairing',
+          expiry: now + 9999,
+          relay: { protocol: 'irn' },
+          acknowledged: true,
+          controller: 'controller',
+          namespaces: {},
+          requiredNamespaces: {},
+          optionalNamespaces: {},
+          self: { publicKey: 'self-key', metadata: {} as any },
+          peer: {
+            publicKey: 'peer-key',
+            metadata: {
+              url: 'https://example.com',
+              name: 'New App',
+              description: '',
+              icons: [],
+            },
+          },
+        } as SessionTypes.Struct,
+      });
+
+      mockApproveSession.mockResolvedValue({
+        topic: newSessionTopic,
+        pairingTopic: 'new-pairing',
+        peer: {
+          metadata: {
+            url: 'https://example.com',
+            name: 'New App',
+            icons: [],
+          },
+        },
+      });
+
+      const proposal = {
+        id: 9001,
+        params: {
+          id: 9001,
+          pairingTopic: 'new-pairing',
+          proposer: {
+            publicKey: 'test-public-key',
+            metadata: {
+              name: 'New App',
+              description: 'New App',
+              url: 'https://example.com',
+              icons: ['https://example.com/icon.png'],
+            },
+          },
+          expiryTimestamp: Date.now() + 300000,
+          relays: [{ protocol: 'irn' }],
+          requiredNamespaces: {
+            eip155: {
+              chains: ['eip155:1'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+            },
+          },
+          optionalNamespaces: {},
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await manager.onSessionProposal(proposal as any);
+
+      // The oldest session (smallest expiry) should have been disconnected.
+      expect(mockDisconnectSession).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'oldest-topic' }),
+      );
+    });
+
+    it('does not remove any session when the session count is at or below the limit', async () => {
+      const web3Wallet = (manager as unknown as { web3Wallet: IWalletKit })
+        .web3Wallet;
+      const mockDisconnectSession = jest.spyOn(web3Wallet, 'disconnectSession');
+
+      const now = Math.floor(Date.now() / 1000);
+
+      // Exactly 20 active sessions (at the limit, not over it).
+      const sessionsAtLimit: Record<string, SessionTypes.Struct> = {};
+      for (let i = 0; i < 20; i++) {
+        const topic = `at-limit-topic-${i}`;
+        sessionsAtLimit[topic] = {
+          topic,
+          pairingTopic: `pairing-${topic}`,
+          expiry: now + i * 100,
+          relay: { protocol: 'irn' },
+          acknowledged: true,
+          controller: 'controller',
+          namespaces: {},
+          requiredNamespaces: {},
+          optionalNamespaces: {},
+          self: { publicKey: 'self-key', metadata: {} as any },
+          peer: {
+            publicKey: 'peer-key',
+            metadata: {
+              url: 'https://example.com',
+              name: 'Test App',
+              description: '',
+              icons: [],
+            },
+          },
+        } as SessionTypes.Struct;
+      }
+
+      (web3Wallet.getActiveSessions as jest.Mock).mockReturnValue(
+        sessionsAtLimit,
+      );
+
+      mockApproveSession.mockResolvedValue({
+        topic: 'within-limit-topic',
+        pairingTopic: 'within-limit-pairing',
+        peer: {
+          metadata: {
+            url: 'https://example.com',
+            name: 'Test App',
+            icons: [],
+          },
+        },
+      });
+
+      const proposal = {
+        id: 9002,
+        params: {
+          id: 9002,
+          pairingTopic: 'within-limit-pairing',
+          proposer: {
+            publicKey: 'test-public-key',
+            metadata: {
+              name: 'Test App',
+              description: 'Test App',
+              url: 'https://example.com',
+              icons: ['https://example.com/icon.png'],
+            },
+          },
+          expiryTimestamp: Date.now() + 300000,
+          relays: [{ protocol: 'irn' }],
+          requiredNamespaces: {
+            eip155: {
+              chains: ['eip155:1'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+            },
+          },
+          optionalNamespaces: {},
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await manager.onSessionProposal(proposal as any);
+
+      expect(mockDisconnectSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -660,6 +660,8 @@ export class WC2Manager {
 
       this.sessions[activeSession.topic] = session;
 
+      await this.enforceSessionLimit();
+
       DevLogger.log(`WC2::session_proposal updateSession`, {
         chainId: walletChainIdDecimal,
         accounts: approvedAccounts,
@@ -709,6 +711,25 @@ export class WC2Manager {
         }),
       );
     }
+  }
+
+  private async enforceSessionLimit() {
+    const activeSessions = this.getSessions();
+    const limit = AppConstants.WALLET_CONNECT.LIMIT_SESSIONS;
+
+    if (activeSessions.length <= limit) {
+      return;
+    }
+
+    const oldestSession = activeSessions.reduce((oldest, session) =>
+      session.expiry < oldest.expiry ? session : oldest,
+    );
+
+    DevLogger.log(
+      `WC2::enforceSessionLimit removing oldest session topic=${oldestSession.topic} (${activeSessions.length} sessions exceed limit of ${limit})`,
+    );
+
+    await this.removeSession(oldestSession);
   }
 
   private async onSessionRequest(requestEvent: WalletKitTypes.SessionRequest) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Enforces the previously defined `LIMIT_SESSIONS` limit for WCv2 connections. When this limit (20 connections) is exceeded, the oldest connection is dropped.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1356

## **Manual testing steps**

1. Modify this constant to be 2
2. Use the ios expo build
3. Using native browser or QR code, connect to https://react-app.walletconnect.com/
4. Using native browser or QR code, connect to https://wagmi-app.vercel.app/
5. In the wallet, go to settings, experimental, wallet connect, and check that you have these two sessions
6. Using native browser or QR code, connect to https://rainbowkit.com/ (using WC)
7. In the wallet, go to settings, experimental, wallet connect, and check that you only have 2 sessions with the first one you connected no longer in the list of active sessions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/703ab57f-5dee-4889-957e-9b7e98b02d80



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic disconnection of an existing WalletConnect v2 session when new approvals push the active session count over a configured limit, which could unexpectedly drop a user’s oldest connection. Logic is small and covered by unit tests, but it affects live connection management.
> 
> **Overview**
> **Enforces a WalletConnect v2 session cap.** After approving a new session, `WC2Manager` now calls `enforceSessionLimit()` to ensure active sessions stay under `AppConstants.WALLET_CONNECT.LIMIT_SESSIONS` by disconnecting the *oldest* session (based on smallest `expiry`).
> 
> **Adds test coverage** for the new behavior, including cases where the limit is exceeded (oldest session is disconnected) and where the session count is at/under the limit (no disconnections).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf6c4518f775c398a2760c17d7d0714a07fc5cf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->