### PR TITLE
chore: migrate DeleteNetworkModal to MDMS BottomSheet

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 import { strings } from '../../../../../locales/i18n';
 import { IconColor } from '../../../../component-library/components/Icons/Icon';
 import { NetworkDetailsViewSelectorsIDs } from './NetworkDetailsView.testIds';
@@ -24,6 +25,8 @@ jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(() => false),
 }));
+
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
 
 jest.mock('../../../../core/Engine', () => ({
   context: {

--- a/app/components/Views/NetworksManagement/components/DeleteNetworkModal.test.tsx
+++ b/app/components/Views/NetworksManagement/components/DeleteNetworkModal.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
+import { strings } from '../../../../../locales/i18n';
+import { NetworksManagementViewSelectorsIDs } from '../NetworksManagementView.testIds';
+import DeleteNetworkModal from './DeleteNetworkModal';
+
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
+
+describe('DeleteNetworkModal', () => {
+  const networkName = 'TestNet';
+  const onClose = jest.fn();
+  const onConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders modal content', () => {
+    const { getByTestId, getByText } = render(
+      <DeleteNetworkModal
+        ref={null}
+        networkName={networkName}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(
+      getByTestId(NetworksManagementViewSelectorsIDs.DELETE_MODAL),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(
+        `${strings('app_settings.delete')} ${networkName} ${strings('app_settings.network')}`,
+      ),
+    ).toBeOnTheScreen();
+    expect(getByText(strings('app_settings.network_delete'))).toBeOnTheScreen();
+  });
+
+  it('calls onClose from cancel button', () => {
+    const { getByTestId } = render(
+      <DeleteNetworkModal
+        ref={null}
+        networkName={networkName}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.press(
+      getByTestId(NetworksManagementViewSelectorsIDs.DELETE_CANCEL_BUTTON),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm from delete button', () => {
+    const { getByTestId } = render(
+      <DeleteNetworkModal
+        ref={null}
+        networkName={networkName}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.press(
+      getByTestId(NetworksManagementViewSelectorsIDs.DELETE_CONFIRM_BUTTON),
+    );
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
+++ b/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
@@ -2,22 +2,16 @@ import React, { forwardRef } from 'react';
 
 import {
   Box,
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  type BottomSheetRef,
+  ButtonSize,
   Text,
   TextVariant,
   BoxAlignItems,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader';
-import BottomSheetFooter from '../../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter';
-import { ButtonsAlignment } from '../../../../component-library/components/BottomSheets/BottomSheetFooter';
-import { ButtonProps } from '../../../../component-library/components/Buttons/Button/Button.types';
-import {
-  ButtonVariants,
-  ButtonSize,
-} from '../../../../component-library/components/Buttons/Button';
 
 import { NetworksManagementViewSelectorsIDs } from '../NetworksManagementView.testIds';
 
@@ -29,19 +23,17 @@ interface DeleteNetworkModalProps {
 
 const DeleteNetworkModal = forwardRef<BottomSheetRef, DeleteNetworkModalProps>(
   ({ networkName, onClose, onConfirm }, ref) => {
-    const cancelButtonProps: ButtonProps = {
-      variant: ButtonVariants.Secondary,
-      label: strings('accountApproval.cancel'),
-      size: ButtonSize.Lg,
+    const cancelButtonProps = {
+      children: strings('accountApproval.cancel'),
       onPress: onClose,
+      size: ButtonSize.Lg,
       testID: NetworksManagementViewSelectorsIDs.DELETE_CANCEL_BUTTON,
     };
 
-    const deleteButtonProps: ButtonProps = {
-      variant: ButtonVariants.Primary,
-      label: strings('app_settings.delete'),
-      size: ButtonSize.Lg,
+    const deleteButtonProps = {
+      children: strings('app_settings.delete'),
       onPress: onConfirm,
+      size: ButtonSize.Lg,
       testID: NetworksManagementViewSelectorsIDs.DELETE_CONFIRM_BUTTON,
     };
 
@@ -49,10 +41,10 @@ const DeleteNetworkModal = forwardRef<BottomSheetRef, DeleteNetworkModalProps>(
       <BottomSheet
         ref={ref}
         onClose={onClose}
-        shouldNavigateBack={false}
+        goBack={onClose}
         testID={NetworksManagementViewSelectorsIDs.DELETE_MODAL}
       >
-        <BottomSheetHeader>
+        <BottomSheetHeader onClose={onClose}>
           {`${strings('app_settings.delete')} ${networkName} ${strings('app_settings.network')}`}
         </BottomSheetHeader>
         <Box alignItems={BoxAlignItems.Center} twClassName="px-4">
@@ -60,8 +52,8 @@ const DeleteNetworkModal = forwardRef<BottomSheetRef, DeleteNetworkModalProps>(
             {strings('app_settings.network_delete')}
           </Text>
           <BottomSheetFooter
-            buttonsAlignment={ButtonsAlignment.Horizontal}
-            buttonPropsArray={[cancelButtonProps, deleteButtonProps]}
+            secondaryButtonProps={cancelButtonProps}
+            primaryButtonProps={deleteButtonProps}
           />
         </Box>
       </BottomSheet>


### PR DESCRIPTION
## **Description**

Migrate the Networks Management delete confirmation sheet (`DeleteNetworkModal`) from the deprecated component-library BottomSheet components to the new `@metamask/design-system-react-native` (MDMS) BottomSheet components, as a single representative migration to validate the new API in-app.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Delete network bottom sheet

  Scenario: user opens delete network sheet and cancels
    Given the user is on a network details screen

    When the user taps "Delete"
    Then the delete network bottom sheet is shown

    When the user taps "Cancel"
    Then the bottom sheet closes

  Scenario: user confirms delete network
    Given the user is on a network details screen

    When the user taps "Delete"
    And the user taps the confirm delete button
    Then the network is deleted (or the delete flow continues)
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/41b65166-eea2-4c88-aa0f-8716d7339531

### **After**

https://github.com/user-attachments/assets/0c5765ec-c565-4a32-85ca-f442441ccb6d

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it swaps the underlying bottom sheet implementation and changes close/navigation props, which could affect the delete-confirmation UI/behavior at runtime. Changes are localized to the networks delete modal and its tests.
> 
> **Overview**
> Migrates `DeleteNetworkModal` from the deprecated component-library bottom sheet components to the `@metamask/design-system-react-native` (`BottomSheet`, `BottomSheetHeader`, `BottomSheetFooter`) API, updating button prop shapes and close/goBack wiring.
> 
> Adds a dedicated `DeleteNetworkModal.test.tsx` to verify rendering and cancel/confirm callbacks, and updates `NetworkDetailsView.test.tsx` to mock `react-native-safe-area-context` to keep bottom-sheet-related tests stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9013df55560f8cedf85e7d7315416a12f5c27ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->