### PR TITLE
fix(predict): invalidate EthQuery cache before Claim/Withdraw Safe TX signing

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1661,6 +1661,9 @@ export class PredictController extends BaseController<
         state.pendingClaims[signer.address] = 'pending';
       });
 
+      // Invalidate query cache (to avoid nonce issues)
+      await this.invalidateQueryCache(provider.chainId);
+
       // Prepare claim transaction - can fail if safe address not found, signing fails, etc.
       const prepareClaimResult = await provider.prepareClaim({
         positions: claimablePositions,
@@ -2715,6 +2718,9 @@ export class PredictController extends BaseController<
       'NetworkController:findNetworkClientIdByChainId',
       numberToHex(chainId),
     );
+
+    // Invalidate query cache (to avoid nonce issues)
+    await this.invalidateQueryCache(chainId);
 
     const { callData, amount } = await provider.signWithdraw({
       callData: withdrawTransaction?.data as Hex,


### PR DESCRIPTION
## **Description**

~2% of Claim/Withdraw transactions are failing with Safe GS026 or GS013 errors. Root cause: `EthQuery` caches query results for up to 15 minutes, which can serve a stale nonce when signing Safe transactions. This fix calls `invalidateQueryCache` before `prepareClaim` and `signWithdraw` so the Safe TX is always signed with a fresh nonce.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-769

## **Manual testing steps**

```gherkin
Feature: Predict Claim/Withdraw nonce freshness

  Scenario: User claims positions without GS026/GS013 errors
    Given the user has claimable positions on Predict
    And the EthQuery cache contains a stale nonce

    When the user initiates a Claim transaction
    Then the query cache is invalidated before signing the Safe TX
    And the transaction succeeds without GS026 or GS013 errors

  Scenario: User withdraws funds without GS026/GS013 errors
    Given the user has a balance available for withdrawal on Predict
    And the EthQuery cache contains a stale nonce

    When the user initiates a Withdraw transaction
    Then the query cache is invalidated before signing the Safe TX
    And the transaction succeeds without GS026 or GS013 errors
```

## **Screenshots/Recordings**

<!-- Not applicable — no UI changes -->

### **Before**

<!-- N/A -->

### **After**

<!-- N/A -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict claim/withdraw signing flow; while the change is small, it alters pre-sign network behavior and could impact transaction submission timing or error handling.
> 
> **Overview**
> Prevents stale Safe nonces during Predict **Claim** and **Withdraw** by invalidating the underlying `EthQuery` cache immediately before `prepareClaim` and `signWithdraw` run.
> 
> This adds an `invalidateQueryCache` call (via `blockTracker.checkForLatestBlock()`) to force fresh chain state before signing, reducing intermittent Safe `GS026/GS013` failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2144104837399e02de123da88ed5552d9110fc16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->