### PR TITLE
test(bridge): add gasless swap error banner view test

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -197,6 +197,44 @@ describeForPlatforms('BridgeView', () => {
     expect(await findByText('dest')).toBeOnTheScreen();
   });
 
+  describe('Gasless swap', () => {
+    it('shows error banner when gasless swap quote fetch fails and dismisses it on close', async () => {
+      const now = Date.now();
+
+      const { findByText, queryByText, getByTestId } = defaultBridgeWithTokens({
+        engine: {
+          backgroundState: {
+            BridgeController: {
+              quotes: [],
+              recommendedQuote: null,
+              quotesLastFetched: now,
+              quotesLoadingStatus: RequestStatus.FETCHED,
+              quoteFetchError: 'GaslessSwapSubmissionFailed',
+            },
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                gasFeesSponsoredNetwork: { '0x1': true },
+              },
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>);
+
+      // Error banner appears after the gasless swap quote fetch failure
+      expect(
+        await findByText(strings('bridge.error_banner_description')),
+      ).toBeOnTheScreen();
+
+      // User dismisses the error banner
+      fireEvent.press(getByTestId(CommonSelectorsIDs.BANNER_CLOSE_BUTTON_ICON));
+
+      // Banner is gone after dismissal
+      expect(
+        queryByText(strings('bridge.error_banner_description')),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
   describe('Swap team regression (bug matrix team-swaps-and-bridge)', () => {
     /** Issues covered: #24744, #24865, #24802, #25256 */
     // eslint-disable-next-line @metamask/design-tokens/color-no-hex -- "#24744" style references are GitHub issue IDs (e.g. "#2342"), not color literals


### PR DESCRIPTION
## Summary

- Adds a new component view test for the gasless swap error state in `BridgeView`
- Sets up a gasless swap scenario (ETH→USDC on the same chain with `gasFeesSponsoredNetwork` enabled for `0x1`) and a `quoteFetchError` in `BridgeController` to trigger the error banner
- Asserts the error banner appears after the quote fetch failure, then verifies it dismisses correctly when the user presses close (paired positive + negative assertions)
- 
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a UI view test only, exercising an error-state banner and its dismissal without changing production logic.
> 
> **Overview**
> Adds a new `BridgeView.view` test covering the *gasless swap* error state by simulating a `BridgeController.quoteFetchError` with sponsored gas enabled and asserting the generic error banner renders.
> 
> The test also verifies the banner can be dismissed via the close icon and is removed from the screen afterward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00688c85a74f79bfcb6c5d4f8c6e0969bef5c18e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->