### PR TITLE
test: update predict and confirmations components with proper testIDS

### DIFF
--- a/app/components/UI/Predict/Predict.testIds.ts
+++ b/app/components/UI/Predict/Predict.testIds.ts
@@ -80,6 +80,14 @@ export const getPredictFeedMockSelector = {
 // PREDICT MARKET DETAILS SELECTORS
 // ========================================
 
+export type PredictMarketDetailsTabKey = 'positions' | 'outcomes' | 'about';
+
+export const getPredictMarketDetailsSelector = {
+  tabBarTab: (tabKey: PredictMarketDetailsTabKey) =>
+    `predict-market-details-tab-bar-tab-${tabKey}`,
+  icon: (name: string) => `icon-${name}`,
+} as const;
+
 export const PredictMarketDetailsSelectorsIDs = {
   // Main screen
   SCREEN: 'predict-market-details-screen',
@@ -96,9 +104,9 @@ export const PredictMarketDetailsSelectorsIDs = {
   OUTCOMES_TAB: 'predict-market-details-outcomes-tab',
 
   // Tab labels
-  POSITIONS_TAB_LABEL: 'predict-market-details-tab-bar-tab-0',
-  OUTCOMES_TAB_LABEL: 'predict-market-details-tab-bar-tab-1',
-  ABOUT_TAB_LABEL: 'predict-market-details-tab-bar-tab-2',
+  POSITIONS_TAB_LABEL: getPredictMarketDetailsSelector.tabBarTab('positions'),
+  OUTCOMES_TAB_LABEL: getPredictMarketDetailsSelector.tabBarTab('outcomes'),
+  ABOUT_TAB_LABEL: getPredictMarketDetailsSelector.tabBarTab('about'),
 
   // Tab content containers
   ABOUT_TAB_CONTENT: 'about-tab-content',
@@ -117,11 +125,6 @@ export const PredictMarketDetailsSelectorsIDs = {
   DETAILS_CONTENT_SKELETON_LINE_1: 'predict-details-content-skeleton-line-1',
   DETAILS_BUTTONS_SKELETON_BUTTON_1:
     'predict-details-buttons-skeleton-button-1',
-} as const;
-
-export const getPredictMarketDetailsSelector = {
-  tabBarTab: (index: number) => `predict-market-details-tab-bar-tab-${index}`,
-  icon: (name: string) => `icon-${name}`,
 } as const;
 
 export const PredictMarketDetailsSelectorsText = {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -805,7 +805,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest();
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -818,7 +818,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest();
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -834,7 +834,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest();
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -848,7 +848,7 @@ describe('PredictMarketDetails', () => {
       const { mockNavigate } = setupPredictMarketDetailsTest();
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -1177,7 +1177,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest();
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -1351,7 +1351,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(marketWithoutEndDate);
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -1423,7 +1423,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -1606,7 +1606,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -1641,7 +1641,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -1788,7 +1788,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -1821,7 +1821,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -1854,7 +1854,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -2221,7 +2221,7 @@ describe('PredictMarketDetails', () => {
 
       // Switch to Positions tab (index 0 when positions exist)
       const positionsTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(0),
+        getPredictMarketDetailsSelector.tabBarTab('positions'),
       );
       fireEvent.press(positionsTab);
 
@@ -2661,7 +2661,7 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(closedMarket);
 
       const aboutTab = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(1),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTab);
 
@@ -2697,7 +2697,7 @@ describe('PredictMarketDetails', () => {
       );
 
       const aboutTabWithPositions = screen.getByTestId(
-        getPredictMarketDetailsSelector.tabBarTab(2),
+        getPredictMarketDetailsSelector.tabBarTab('about'),
       );
       fireEvent.press(aboutTabWithPositions);
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsTabBar/PredictMarketDetailsTabBar.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsTabBar/PredictMarketDetailsTabBar.tsx
@@ -9,12 +9,14 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { PredictMarketDetailsSelectorsIDs } from '../../../../Predict.testIds';
-
-type TabKey = 'positions' | 'outcomes' | 'about';
+import {
+  getPredictMarketDetailsSelector,
+  PredictMarketDetailsSelectorsIDs,
+  type PredictMarketDetailsTabKey,
+} from '../../../../Predict.testIds';
 
 export interface PredictMarketDetailsTabBarProps {
-  tabs: { label: string; key: TabKey }[];
+  tabs: { label: string; key: PredictMarketDetailsTabKey }[];
   activeTab: number | null;
   onTabPress: (tabIndex: number) => void;
 }
@@ -41,7 +43,7 @@ const PredictMarketDetailsTabBar = memo(
                 'w-1/3 py-3',
                 activeTab === index ? 'border-b-2 border-default' : '',
               )}
-              testID={`${PredictMarketDetailsSelectorsIDs.TAB_BAR}-tab-${index}`}
+              testID={getPredictMarketDetailsSelector.tabBarTab(tab.key)}
             >
               <Text
                 variant={TextVariant.BodyMd}

--- a/app/components/Views/confirmations/components/network-filter/network-filter.testIds.ts
+++ b/app/components/Views/confirmations/components/network-filter/network-filter.testIds.ts
@@ -1,0 +1,4 @@
+export const NETWORK_FILTER_ALL_TEST_ID = 'transaction-pay-network-filter-all';
+
+export const getNetworkFilterTestId = (chainId: string): string =>
+  `transaction-pay-network-filter-${chainId}`;

--- a/app/components/Views/confirmations/components/network-filter/network-filter.tsx
+++ b/app/components/Views/confirmations/components/network-filter/network-filter.tsx
@@ -20,6 +20,10 @@ import {
   NETWORK_FILTER_ALL,
 } from '../../hooks/send/useNetworkFilter';
 import { ScrollView } from 'react-native-gesture-handler';
+import {
+  getNetworkFilterTestId,
+  NETWORK_FILTER_ALL_TEST_ID,
+} from './network-filter.testIds';
 
 interface NetworkFilterTabProps {
   label: string;
@@ -27,6 +31,7 @@ interface NetworkFilterTabProps {
   isSelected: boolean;
   onPress: () => void;
   showIcon?: boolean;
+  testID: string;
 }
 
 const NetworkFilterTab: React.FC<NetworkFilterTabProps> = ({
@@ -35,6 +40,7 @@ const NetworkFilterTab: React.FC<NetworkFilterTabProps> = ({
   isSelected,
   onPress,
   showIcon = false,
+  testID,
 }) => {
   const tw = useTailwind();
 
@@ -49,6 +55,7 @@ const NetworkFilterTab: React.FC<NetworkFilterTabProps> = ({
         )
       }
       hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+      testID={testID}
     >
       {showIcon && imageSource && (
         <Box twClassName="mr-2">
@@ -135,6 +142,7 @@ export const NetworkFilter: React.FC<NetworkFilterProps> = ({
           isSelected={selectedNetworkFilter === NETWORK_FILTER_ALL}
           onPress={() => setSelectedNetworkFilter(NETWORK_FILTER_ALL)}
           showIcon={false}
+          testID={NETWORK_FILTER_ALL_TEST_ID}
         />
 
         {/* Individual Network Tabs */}
@@ -146,6 +154,7 @@ export const NetworkFilter: React.FC<NetworkFilterProps> = ({
             isSelected={selectedNetworkFilter === network.chainId}
             onPress={() => setSelectedNetworkFilter(network.chainId)}
             showIcon
+            testID={getNetworkFilterTestId(network.chainId)}
           />
         ))}
       </ScrollView>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> Updates Predict Market Details tab testIDs to be **stable and semantic** by switching from index-based IDs to typed tab-key IDs (`'positions' | 'outcomes' | 'about'`), and updates `PredictMarketDetailsTabBar` plus its unit tests to use the new `getPredictMarketDetailsSelector.tabBarTab(tabKey)` API.
> 
> Adds explicit testIDs to the confirmations `NetworkFilter` tabs by introducing `network-filter.testIds.ts` and passing a required `testID` prop into `NetworkFilterTab` for the “All networks” option and each per-chain tab.
> 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test ID generation and wiring for UI elements, with no business logic or data flow modifications.
> 
> **Overview**
> Updates Predict Market Details tab testIDs to be **stable and semantic** by switching from index-based IDs to typed tab-key IDs (`'positions' | 'outcomes' | 'about'`), and updates `PredictMarketDetailsTabBar` plus its unit tests to use the new `getPredictMarketDetailsSelector.tabBarTab(tabKey)` API.
> 
> Adds explicit testIDs to the confirmations `NetworkFilter` tabs by introducing `network-filter.testIds.ts` and passing a required `testID` prop into `NetworkFilterTab` for the “All networks” option and each per-chain tab.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bea4356a15416da2e62fbfb46082d4516c121ab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->