### PR TITLE
feat: add marketing event for seedless users cp-7.72.0

### DIFF
--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -220,10 +220,11 @@ const mockMetrics = {
   isEnabled: mockMetricsIsEnabled,
   trackEvent: mockTrackEvent,
   enable: mockEnable,
-  addTraitsToUser: jest.fn(),
+  identify: jest.fn().mockResolvedValue(undefined),
+  addTraitsToUser: jest.fn().mockResolvedValue(undefined),
   createEventBuilder: jest.fn(() => ({
     addProperties: jest.fn().mockReturnThis(),
-    build: jest.fn(),
+    build: jest.fn(() => ({ name: 'Analytics Preference Selected' })),
   })),
   getMetaMetricsId: jest.fn(),
 };
@@ -658,6 +659,7 @@ describe('ChoosePassword', () => {
         ...mockRoute.params,
         [PREVIOUS_SCREEN]: ONBOARDING,
         oauthLoginSuccess: true,
+        provider: 'google',
       };
 
       const component = renderWithProviders(<ChoosePassword />);
@@ -677,6 +679,8 @@ describe('ChoosePassword', () => {
             },
           ],
         });
+        expect(mockTrackEvent).toHaveBeenCalled();
+        expect(mockMetrics.addTraitsToUser).toHaveBeenCalled();
       });
 
       mockNewWalletAndKeychain.mockRestore();
@@ -980,6 +984,7 @@ describe('ChoosePassword', () => {
         ...mockRoute.params,
         [PREVIOUS_SCREEN]: ONBOARDING,
         oauthLoginSuccess: true,
+        provider: 'google',
       };
       const spyUpdateMarketingOptInStatus = jest
         .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
@@ -993,6 +998,8 @@ describe('ChoosePassword', () => {
       await waitFor(() => {
         expect(mockNewWalletAndKeychain).toHaveBeenCalledTimes(1);
         expect(spyUpdateMarketingOptInStatus).toHaveBeenCalledWith(true);
+        expect(mockTrackEvent).toHaveBeenCalled();
+        expect(mockMetrics.addTraitsToUser).toHaveBeenCalled();
       });
 
       mockNewWalletAndKeychain.mockRestore();
@@ -1014,6 +1021,7 @@ describe('ChoosePassword', () => {
         ...mockRoute.params,
         [PREVIOUS_SCREEN]: ONBOARDING,
         oauthLoginSuccess: true,
+        provider: 'apple',
       };
       const spyUpdateMarketingOptInStatus = jest
         .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
@@ -1027,6 +1035,8 @@ describe('ChoosePassword', () => {
       await waitFor(() => {
         expect(mockNewWalletAndKeychain).toHaveBeenCalledTimes(1);
         expect(spyUpdateMarketingOptInStatus).toHaveBeenCalledWith(false);
+        expect(mockTrackEvent).toHaveBeenCalled();
+        expect(mockMetrics.addTraitsToUser).toHaveBeenCalled();
       });
 
       mockNewWalletAndKeychain.mockRestore();

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -87,6 +87,12 @@ import { AccountImportStrategy } from '@metamask/keyring-controller';
 import { setDataCollectionForMarketing } from '../../../actions/security';
 import { ChoosePasswordRouteParams } from './ChoosePassword.types';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
+import generateDeviceAnalyticsMetaData, {
+  UserSettingsAnalyticsMetaData as generateUserSettingsAnalyticsMetaData,
+} from '../../../util/metrics';
+import { getConfiguredCaipChainIds } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
+import { getSocialAccountType } from '../../../constants/onboarding';
 
 interface KeyringState {
   type: string;
@@ -310,6 +316,31 @@ const ChoosePassword = () => {
           },
         );
 
+        const oauthProvider = route.params?.provider;
+        const socialAccountType =
+          oauthProvider !== undefined
+            ? getSocialAccountType(oauthProvider, false)
+            : undefined;
+
+        metrics.trackEvent(
+          metrics
+            .createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)
+            .addProperties({
+              [UserProfileProperty.HAS_MARKETING_CONSENT]: Boolean(isSelected),
+              is_metrics_opted_in: true,
+              location: 'onboarding_choosePassword',
+              updated_after_onboarding: false,
+              ...(socialAccountType && { account_type: socialAccountType }),
+            })
+            .build(),
+        );
+
+        await metrics.addTraitsToUser({
+          ...generateDeviceAnalyticsMetaData(),
+          ...generateUserSettingsAnalyticsMetaData(),
+          [UserProfileProperty.CHAIN_IDS]: getConfiguredCaipChainIds(),
+        });
+
         navigation.reset({
           index: 0,
           routes: [
@@ -332,7 +363,15 @@ const ChoosePassword = () => {
         });
       }
     },
-    [dispatch, isSelected, navigation, tryExportSeedPhrase, password],
+    [
+      dispatch,
+      isSelected,
+      metrics,
+      navigation,
+      route.params?.provider,
+      tryExportSeedPhrase,
+      password,
+    ],
   );
 
   const handleWalletCreationError = useCallback(

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -91,7 +91,6 @@ import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalytics
 import generateDeviceAnalyticsMetaData, {
   UserSettingsAnalyticsMetaData as generateUserSettingsAnalyticsMetaData,
 } from '../../../util/metrics';
-import { getConfiguredCaipChainIds } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
 import { getSocialAccountType } from '../../../constants/onboarding';
 
 interface KeyringState {
@@ -322,24 +321,30 @@ const ChoosePassword = () => {
             ? getSocialAccountType(oauthProvider, false)
             : undefined;
 
-        metrics.trackEvent(
-          metrics
-            .createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)
-            .addProperties({
-              [UserProfileProperty.HAS_MARKETING_CONSENT]: Boolean(isSelected),
-              is_metrics_opted_in: true,
-              location: 'onboarding_choosePassword',
-              updated_after_onboarding: false,
-              ...(socialAccountType && { account_type: socialAccountType }),
-            })
-            .build(),
-        );
+        try {
+          metrics.trackEvent(
+            metrics
+              .createEventBuilder(
+                MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED,
+              )
+              .addProperties({
+                [UserProfileProperty.HAS_MARKETING_CONSENT]:
+                  Boolean(isSelected),
+                is_metrics_opted_in: true,
+                location: 'onboarding_choosePassword',
+                updated_after_onboarding: false,
+                ...(socialAccountType && { account_type: socialAccountType }),
+              })
+              .build(),
+          );
 
-        await metrics.addTraitsToUser({
-          ...generateDeviceAnalyticsMetaData(),
-          ...generateUserSettingsAnalyticsMetaData(),
-          [UserProfileProperty.CHAIN_IDS]: getConfiguredCaipChainIds(),
-        });
+          await metrics.addTraitsToUser({
+            ...generateDeviceAnalyticsMetaData(),
+            ...generateUserSettingsAnalyticsMetaData(),
+          });
+        } catch (analyticsError) {
+          Logger.error(analyticsError as Error);
+        }
 
         navigation.reset({
           index: 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* This PR improves analytics and marketing-consent for seedless / social (OAuth) onboarding 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved analytics consistency during social login onboarding.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

Scenario: Social new user completes password and reaches success
    Given seedless / social onboarding is enabled
    And the user signs in with Google or Apple as a new user
    When the user sets a password on Choose Password and submits
    Then the app navigates to onboarding success
    And marketing preference is sent to the auth API according to the checkbox
    And analytics receives preference for marketing consent.

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new analytics tracking and user-trait updates in the OAuth onboarding success path, including an awaited call that could impact timing or failure behavior before navigation.
> 
> **Overview**
> Adds explicit MetaMetrics instrumentation for *seedless/social (OAuth) onboarding* on the `ChoosePassword` success path: emits `ANALYTICS_PREFERENCE_SELECTED` with marketing-consent + `account_type` (derived from the OAuth `provider`) and updates the user profile via `addTraitsToUser` with device/user settings metadata and configured chain IDs.
> 
> Updates `ChoosePassword` tests to mock the expanded analytics API (`identify`, `addTraitsToUser`, event builder output), pass `provider` in OAuth route params, and assert the new tracking/trait calls occur when completing OAuth wallet creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d270aacd657e3bceb0064e6852444fda7d6ae6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->