### PR TITLE
feat(perps): add perpsWithdraw transaction display and activity support

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -157,6 +157,7 @@ const NEW_TRANSACTION_DETAILS_TYPES = [
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
   TransactionType.predictClaim,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
@@ -447,13 +448,14 @@ class TransactionElement extends PureComponent {
         ? transactions?.find((t) => t.id === requiredTransactionIds[0])?.chainId
         : undefined;
 
-    const predictWithdrawChainId = hasTransactionType(this.props.tx, [
+    const withdrawChainId = hasTransactionType(this.props.tx, [
       TransactionType.predictWithdraw,
+      TransactionType.perpsWithdraw,
     ])
       ? this.props.tx.metamaskPay?.chainId
       : undefined;
 
-    const chainId = perpsDepositChainId ?? predictWithdrawChainId ?? txChainId;
+    const chainId = perpsDepositChainId ?? withdrawChainId ?? txChainId;
 
     return (
       <BadgeWrapper

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -52,6 +52,7 @@ const POSITIVE_TRANSFER_TRANSACTION_TYPES = [
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
 ];
@@ -230,8 +231,12 @@ function getMetamaskPayTargetFiat(tx, decimals) {
 // user-currency fiat from the USD targetFiat stored in metamaskPay.
 function getPostQuoteDisplay(tx, currentCurrency) {
   const { metamaskPay } = tx ?? {};
+
   if (
-    !hasTransactionType(tx, [TransactionType.predictWithdraw]) ||
+    !hasTransactionType(tx, [
+      TransactionType.predictWithdraw,
+      TransactionType.perpsWithdraw,
+    ]) ||
     !metamaskPay?.isPostQuote ||
     !metamaskPay?.targetFiat
   ) {
@@ -1050,6 +1055,7 @@ export default async function decodeTransaction(args) {
     switch (actionKey) {
       case strings('transactions.tx_review_musd_conversion'):
       case strings('transactions.tx_review_perps_deposit'):
+      case strings('transactions.tx_review_perps_withdraw'):
       case strings('transactions.tx_review_predict_deposit'):
       case strings('transactions.tx_review_predict_withdraw'):
         [transactionElement, transactionDetails] = await decodeTransferTx({

--- a/app/components/UI/TransactionElement/utils.test.js
+++ b/app/components/UI/TransactionElement/utils.test.js
@@ -378,6 +378,10 @@ describe('Transaction Element Utils', () => {
         strings('transactions.tx_review_perps_deposit'),
       ],
       [
+        TransactionType.perpsWithdraw,
+        strings('transactions.tx_review_perps_withdraw'),
+      ],
+      [
         TransactionType.predictDeposit,
         strings('transactions.tx_review_predict_deposit'),
       ],

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -11,6 +11,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
 
 const TRANSACTION_TYPES = [
+  TransactionType.perpsWithdraw,
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
 ];

--- a/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
@@ -54,6 +54,20 @@ describe('TransactionDetailsBridgeFeeRow', () => {
     expect(getByText('Provider fee')).toBeOnTheScreen();
   });
 
+  it('renders "Provider fee" label for perps withdrawals', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        type: TransactionType.perpsWithdraw,
+        metamaskPay: {
+          bridgeFeeFiat: BRIDGE_FEE_FIAT_MOCK,
+        },
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+    expect(getByText('Provider fee')).toBeOnTheScreen();
+  });
+
   it('renders nothing if no bridge fee fiat', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {

--- a/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
@@ -15,11 +15,12 @@ export function TransactionDetailsBridgeFeeRow() {
   const { metamaskPay } = transactionMeta;
   const { bridgeFeeFiat } = metamaskPay || {};
 
-  const isPredictWithdraw = hasTransactionType(transactionMeta, [
+  const isWithdraw = hasTransactionType(transactionMeta, [
     TransactionType.predictWithdraw,
+    TransactionType.perpsWithdraw,
   ]);
 
-  const label = isPredictWithdraw
+  const label = isWithdraw
     ? strings('transaction_details.label.provider_fee')
     : strings('transaction_details.label.bridge_fee');
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -35,6 +35,7 @@ const SUPPORTED_TYPES = [
   TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
 ];

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -11,6 +11,7 @@ import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testId
 import { usePayFiatFormatter } from '../../../hooks/pay/usePayFiatFormatter';
 
 const FALLBACK_TYPES = [
+  TransactionType.perpsWithdraw,
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
   TransactionType.musdClaim,

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -13,11 +13,13 @@ import { USER_CURRENCY_TYPES } from '../../../constants/confirmations';
 
 const FALLBACK_TYPES = [
   TransactionType.musdClaim,
+  TransactionType.perpsWithdraw,
   TransactionType.predictWithdraw,
 ];
 
 const RECEIVE_TYPES = [
   TransactionType.musdClaim,
+  TransactionType.perpsWithdraw,
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
 ];

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -254,6 +254,23 @@ describe('TransactionDetails', () => {
       );
     });
 
+    it('returns perps_withdraw title for perpsWithdraw type', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
+        } as unknown as TransactionMeta,
+      });
+
+      render();
+
+      expect(mockSetOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: strings('transaction_details.title.perps_withdraw'),
+        }),
+      );
+    });
+
     it('returns default title for other transaction types', () => {
       render();
 

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -89,6 +89,10 @@ function getTitle(transactionMeta: TransactionMeta) {
     return strings('transaction_details.title.predict_withdraw');
   }
 
+  if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
+    return strings('transaction_details.title.perps_withdraw');
+  }
+
   switch (transactionMeta.type) {
     case TransactionType.musdConversion:
       return strings('transaction_details.title.musd_conversion');

--- a/app/core/Analytics/events/transactions/utils.ts
+++ b/app/core/Analytics/events/transactions/utils.ts
@@ -17,6 +17,7 @@ export function getMonetizedPrimitive(
       return MonetizedPrimitive.Swaps;
     case TransactionType.perpsDeposit:
     case TransactionType.perpsDepositAndOrder:
+    case TransactionType.perpsWithdraw:
       return MonetizedPrimitive.Perps;
     case TransactionType.predictDeposit:
     case TransactionType.predictWithdraw:

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.test.ts
@@ -101,6 +101,7 @@ describe('getTransactionTypeValue', () => {
     ['predict_claim', TransactionType.predictClaim],
     ['predict_deposit', TransactionType.predictDeposit],
     ['predict_withdraw', TransactionType.predictWithdraw],
+    ['perps_withdraw', TransactionType.perpsWithdraw],
     ['musd_conversion', TransactionType.musdConversion],
     ['musd_claim', TransactionType.musdClaim],
   ])('returns %s if nested transaction type is %s', (expected, nestedType) => {

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
@@ -66,6 +66,10 @@ export function getTransactionTypeValue(
     return 'predict_withdraw';
   }
 
+  if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
+    return 'perps_withdraw';
+  }
+
   if (hasTransactionType(transactionMeta, [TransactionType.predictClaim])) {
     return 'predict_claim';
   }

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -30,6 +30,7 @@ const COPY_METRICS = [
 
 const PAY_TYPES = [
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
 ];

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -26,6 +26,7 @@ export const SKIP_NOTIFICATION_TRANSACTION_TYPES = [
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -235,6 +235,9 @@ const actionKeys = {
   [TransactionType.predictWithdraw]: strings(
     'transactions.tx_review_predict_withdraw',
   ),
+  [TransactionType.perpsWithdraw]: strings(
+    'transactions.tx_review_perps_withdraw',
+  ),
   [TransactionType.musdConversion]: strings(
     'transactions.tx_review_musd_conversion',
   ),
@@ -610,6 +613,10 @@ export async function getTransactionActionKey(transaction, chainId) {
 
   if (hasTransactionType(transaction, [TransactionType.predictWithdraw])) {
     return TransactionType.predictWithdraw;
+  }
+
+  if (hasTransactionType(transaction, [TransactionType.perpsWithdraw])) {
+    return TransactionType.perpsWithdraw;
   }
 
   if (!to) {

--- a/app/util/transactions/index.test.ts
+++ b/app/util/transactions/index.test.ts
@@ -1667,6 +1667,7 @@ describe('Transactions utils :: getTransactionActionKey', () => {
     TransactionType.lendingDeposit,
     TransactionType.lendingWithdraw,
     TransactionType.perpsDeposit,
+    TransactionType.perpsWithdraw,
     TransactionType.predictDeposit,
   ])('returns transaction type if type is %s', async (type) => {
     const transaction = { type };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3993,6 +3993,7 @@
     "tx_review_predict_deposit": "Funded predictions",
     "tx_review_predict_claim": "Claimed wins",
     "tx_review_predict_withdraw": "Predictions withdraw",
+    "tx_review_perps_withdraw": "Perps withdraw",
     "tx_review_musd_conversion": "mUSD conversion",
     "claim": "Claim",
     "sent_ether": "Sent ETH",
@@ -6497,9 +6498,9 @@
       "switch_account_type": "Account update",
       "approve": "Approve request",
       "perps_deposit": "Add funds",
+      "perps_withdraw": "Withdraw",
       "predict_deposit": "Add Prediction funds",
-      "predict_withdraw": "Withdraw",
-      "perps_withdraw": "Withdraw"
+      "predict_withdraw": "Withdraw"
     },
     "sub_title": {
       "permit": "This site wants permission to spend your tokens.",
@@ -8039,6 +8040,7 @@
       "musd_conversion": "Converted to mUSD",
       "musd_claim": "Claimed mUSD",
       "perps_deposit": "Funded perps account",
+      "perps_withdraw": "Withdrawal",
       "predict_claim": "Claimed winnings",
       "predict_deposit": "Funded Predict account",
       "predict_withdraw": "Withdrawal",
@@ -8066,6 +8068,7 @@
       "musd_convert_send": "Sent {{sourceSymbol}} from {{sourceChain}}",
       "musd_claim": "Claim mUSD",
       "perps_deposit": "Add funds",
+      "perps_withdraw": "Withdrawal",
       "predict_deposit": "Add funds",
       "swap": "Swap tokens",
       "swap_approval": "Approve tokens"


### PR DESCRIPTION
## **Description**

Adds `TransactionType.perpsWithdraw` support across the activity list, transaction details, analytics, metrics, and notifications — mirroring the existing patterns for `predictWithdraw` and `perpsDeposit`.

This is the first of two PRs for Perps Withdraw. It makes the app correctly display, label, and handle `perpsWithdraw` transactions without any changes to the confirmation flow. All additions are to existing arrays/switch statements and are dormant until the transaction type is actually used.

## **Changelog**

CHANGELOG entry: Add Perps Withdraw transaction display and activity support

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1112

## **Manual testing steps**

```gherkin
Feature: Perps Withdraw transaction display

  Scenario: user views a completed perpsWithdraw transaction in Activity
    Given the user has a completed perpsWithdraw transaction

    When user opens the Activity tab
    Then the transaction displays as "Perps withdraw" with the correct fiat value

  Scenario: user views perpsWithdraw transaction details
    Given the user has a completed perpsWithdraw transaction

    When user taps the transaction in the Activity list
    Then the transaction details page shows "Withdrawal" as the title
    And the fee row shows "Provider fee" instead of "Bridge fee"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive wiring for a new `TransactionType.perpsWithdraw`, but it touches shared transaction decoding, metrics/analytics classification, and notification-suppression lists which could affect reporting or user-visible notifications if misclassified.
> 
> **Overview**
> Adds end-to-end display support for `TransactionType.perpsWithdraw` in Activity and the new Transaction Details screen, including correct titles, network badge chain selection, totals/fee labeling (using *Provider fee* for withdrawals), and post-quote `metamaskPay.targetFiat` amount display.
> 
> Extends transaction action-key mapping/decoding, analytics monetization classification, MetaMetrics transaction-type values, MetaMask Pay metrics handling, and the notification skip list to recognize `perpsWithdraw`, with corresponding unit tests and new i18n strings (e.g., `tx_review_perps_withdraw`, `transaction_details.title.perps_withdraw`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7750ce7bbcc1acd2dcff7989ba42ad8398066823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->