### PR TITLE
feat: migrate Button (ramp scope/Aggregator)

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -522,10 +522,9 @@ describe('BuildQuote View', () => {
         isFetching: true,
       };
       render(BuildQuote);
-      expect(getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON)).toHaveProp(
-        'disabled',
-        true,
-      );
+      expect(
+        getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON),
+      ).toBeDisabled();
       expect(
         screen.queryByTestId(BuildQuoteSelectors.REGION_DROPDOWN),
       ).not.toBeOnTheScreen();
@@ -575,10 +574,9 @@ describe('BuildQuote View', () => {
         isFetchingCryptoCurrencies: true,
       };
       render(BuildQuote);
-      expect(getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON)).toHaveProp(
-        'disabled',
-        true,
-      );
+      expect(
+        getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON),
+      ).toBeDisabled();
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
       ).toBeOnTheScreen();
@@ -647,10 +645,9 @@ describe('BuildQuote View', () => {
         isFetching: true,
       };
       render(BuildQuote);
-      expect(getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON)).toHaveProp(
-        'disabled',
-        true,
-      );
+      expect(
+        getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON),
+      ).toBeDisabled();
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
       ).toBeOnTheScreen();
@@ -714,10 +711,9 @@ describe('BuildQuote View', () => {
         isFetchingFiatCurrency: true,
       };
       render(BuildQuote);
-      expect(getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON)).toHaveProp(
-        'disabled',
-        true,
-      );
+      expect(
+        getByRoleButton(BuildQuoteSelectors.GET_QUOTES_BUTTON),
+      ).toBeDisabled();
       expect(
         screen.getByTestId(BuildQuoteSelectors.REGION_DROPDOWN),
       ).toBeOnTheScreen();

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -1049,7 +1049,7 @@ describe('BuildQuote View', () => {
 
     const submitBtn = getByRoleButton('Get quotes');
     expect(submitBtn).toBeTruthy();
-    expect(submitBtn.props.disabled).toBe(true);
+    expect(submitBtn).toBeDisabled();
 
     const initialAmount = '0';
     const validAmount = VALID_AMOUNT.toString();
@@ -1058,7 +1058,7 @@ describe('BuildQuote View', () => {
     fireEvent.press(getByRoleButton(`${denomSymbol}${initialAmount}`));
     fireEvent.press(getByRoleButton(validAmount));
     fireEvent.press(getByRoleButton('Done'));
-    expect(submitBtn.props.disabled).toBe(false);
+    expect(submitBtn).toBeEnabled();
 
     fireEvent.press(submitBtn);
 
@@ -1096,7 +1096,7 @@ describe('BuildQuote View', () => {
 
     const submitBtn = getByRoleButton('Get quotes');
     expect(submitBtn).toBeTruthy();
-    expect(submitBtn.props.disabled).toBe(true);
+    expect(submitBtn).toBeDisabled();
 
     const initialAmount = '0';
     const validAmount = VALID_AMOUNT.toString();
@@ -1104,7 +1104,7 @@ describe('BuildQuote View', () => {
     fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
     fireEvent.press(getByRoleButton(validAmount));
     fireEvent.press(getByRoleButton('Done'));
-    expect(submitBtn.props.disabled).toBe(false);
+    expect(submitBtn).toBeEnabled();
 
     fireEvent.press(submitBtn);
 

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -17,6 +17,9 @@ import BN4 from 'bnjs4';
 import {
   AvatarToken,
   AvatarTokenSize,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 
 import { useRampSDK } from '../../sdk';
@@ -91,11 +94,6 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
 import { BuildQuoteSelectors } from './BuildQuote.testIds';
 
 import { isNonEvmAddress } from '../../../../../../core/Multichain/utils';
@@ -1109,12 +1107,13 @@ const BuildQuote = () => {
             <Button
               size={ButtonSize.Lg}
               onPress={handleGetQuotePress}
-              label={strings('fiat_on_ramp_aggregator.get_quotes')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
+              variant={ButtonVariant.Primary}
+              isFullWidth
               isDisabled={amountNumber <= 0 || isFetching}
               accessibilityRole="button"
-            />
+            >
+              {strings('fiat_on_ramp_aggregator.get_quotes')}
+            </Button>
           </Row>
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
@@ -1145,11 +1144,12 @@ const BuildQuote = () => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleKeypadDone}
-            label={strings('fiat_on_ramp_aggregator.done')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            isFullWidth
             accessibilityRole="button"
-          />
+          >
+            {strings('fiat_on_ramp_aggregator.done')}
+          </Button>
         </ScreenLayout.Content>
       </Animated.View>
     </ScreenLayout>

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -15,11 +15,11 @@ import useThunkDispatch from '../../../../../hooks/useThunkDispatch';
 import ScreenLayout from '../../components/ScreenLayout';
 import OrderDetail from '../../components/OrderDetails';
 import Row from '../../components/Row';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import {
   FiatOrder,
   getOrderById,
@@ -290,12 +290,13 @@ const OrderDetails = () => {
                 <Button
                   size={ButtonSize.Lg}
                   onPress={navigateToSendTransaction}
-                  label={strings(
+                  variant={ButtonVariant.Primary}
+                  isFullWidth
+                >
+                  {strings(
                     'fiat_on_ramp_aggregator.order_details.continue_order',
                   )}
-                  variant={ButtonVariants.Primary}
-                  width={ButtonWidthTypes.Full}
-                />
+                </Button>
               </Row>
             ) : null}
 
@@ -304,12 +305,13 @@ const OrderDetails = () => {
                 <Button
                   size={ButtonSize.Lg}
                   onPress={handleMakeAnotherPurchase}
-                  label={strings(
+                  variant={ButtonVariant.Primary}
+                  isFullWidth
+                >
+                  {strings(
                     'fiat_on_ramp_aggregator.order_details.start_new_order',
                   )}
-                  variant={ButtonVariants.Primary}
-                  width={ButtonWidthTypes.Full}
-                />
+                </Button>
               )}
           </ScreenLayout.Content>
         </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
@@ -16,7 +16,6 @@ import Row from '../../components/Row';
 import ScreenLayout from '../../components/ScreenLayout';
 import PaymentMethodIcon from '../../components/PaymentMethodIcon';
 import Text, {
-  TextColor,
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import Icon, {

--- a/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
@@ -28,11 +28,11 @@ import Avatar, {
   AvatarSize,
   AvatarVariant,
 } from '../../../../../../component-library/components/Avatars/Avatar';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import RemoteImage from '../../../../../Base/RemoteImage';
 
 import styleSheet from './SendTransaction.styles';
@@ -349,22 +349,16 @@ function SendTransaction() {
 
           <Row>
             <Button
-              variant={ButtonVariants.Primary}
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
-              width={ButtonWidthTypes.Full}
+              isFullWidth
               onPress={handleSend}
               accessibilityRole="button"
               accessible
               isDisabled={isConfirming || !networkClientId}
-              label={
-                <Text
-                  variant={TextVariant.BodyLGMedium}
-                  color={TextColor.Inverse}
-                >
-                  {strings('fiat_on_ramp_aggregator.send_transaction.next')}
-                </Text>
-              }
-            />
+            >
+              {strings('fiat_on_ramp_aggregator.send_transaction.next')}
+            </Button>
           </Row>
           {/* <Row>
             <ButtonConfirm onLongPress={handleSend} disabled={isLoadingGas} />

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/ActivationKeyForm.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/ActivationKeyForm.test.tsx
@@ -86,7 +86,7 @@ describe('AddActivationKey', () => {
   it('has button disabled when input is empty', () => {
     render(ActivationKeyForm);
     const addButton = screen.getByRole('button', { name: 'Add' });
-    expect(addButton.props.disabled).toBe(true);
+    expect(addButton).toBeDisabled();
   });
 
   it('navigates back when pressing cancel', () => {

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/ActivationKeyForm.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/ActivationKeyForm.tsx
@@ -6,12 +6,13 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 // External dependencies
 import Row from '../../components/Row';
 import ScreenLayout from '../../components/ScreenLayout';
-import { Label } from '@metamask/design-system-react-native';
-import TextField from '../../../../../../component-library/components/Form/TextField';
-import Button, {
-  ButtonVariants,
+import {
+  Label,
+  Button,
+  ButtonVariant,
   ButtonSize,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
+import TextField from '../../../../../../component-library/components/Form/TextField';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 
 import Routes from '../../../../../../constants/navigation/Routes';
@@ -118,24 +119,24 @@ function ActivationKeyForm() {
 
             <Row style={style.buttons}>
               <Button
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 size={ButtonSize.Lg}
                 style={style.button}
                 onPress={handleCancel}
-                label={strings('app_settings.fiat_on_ramp.cancel')}
-              />
+              >
+                {strings('app_settings.fiat_on_ramp.cancel')}
+              </Button>
               <Button
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
                 style={style.button}
                 onPress={handleSubmit}
-                label={
-                  key
-                    ? strings('app_settings.fiat_on_ramp.update')
-                    : strings('app_settings.fiat_on_ramp.add')
-                }
                 isDisabled={!regex.activationKey.test(activationKey)}
-              />
+              >
+                {key
+                  ? strings('app_settings.fiat_on_ramp.update')
+                  : strings('app_settings.fiat_on_ramp.add')}
+              </Button>
             </Row>
           </ScreenLayout.Content>
         </ScreenLayout.Body>

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/ActivationKeys.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/ActivationKeys.tsx
@@ -15,11 +15,11 @@ import {
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../../component-library/components/Buttons/ButtonIcon';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 
 import Row from '../../components/Row';
 import { strings } from '../../../../../../../locales/i18n';
@@ -180,13 +180,14 @@ function ActivationKeys() {
       ))}
       <Row>
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariant.Secondary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
+          isFullWidth
           isDisabled={isLoadingKeys}
           onPress={handleAddNewKeyPress}
-          label={strings('app_settings.fiat_on_ramp.add_activation_key')}
-        />
+        >
+          {strings('app_settings.fiat_on_ramp.add_activation_key')}
+        </Button>
       </Row>
     </>
   );

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.test.tsx
@@ -339,7 +339,7 @@ describe('Settings', () => {
       });
       const [switchButton] = screen.getAllByRole('switch');
 
-      expect(addActivationKeyButton.props.disabled).toBe(true);
+      expect(addActivationKeyButton).toBeDisabled();
       expect(removeActivationKeyButton.props.disabled).toBe(true);
       expect(switchButton.props.disabled).toBe(true);
     });

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/Settings.tsx
@@ -11,11 +11,11 @@ import Row from '../../components/Row';
 import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonVariants,
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 
 import { strings } from '../../../../../../../locales/i18n';
@@ -91,12 +91,13 @@ function Settings() {
                     </ListItemColumn>
                   </ListItem>
                   <Button
-                    variant={ButtonVariants.Primary}
+                    variant={ButtonVariant.Primary}
                     size={ButtonSize.Lg}
-                    width={ButtonWidthTypes.Full}
+                    isFullWidth
                     onPress={handleChangeRegion}
-                    label={strings('app_settings.fiat_on_ramp.change_region')}
-                  />
+                  >
+                    {strings('app_settings.fiat_on_ramp.change_region')}
+                  </Button>
                 </Row>
               ) : (
                 <Row first>
@@ -122,12 +123,13 @@ function Settings() {
                   </ListItem>
                   {selectedRegion ? (
                     <Button
-                      variant={ButtonVariants.Secondary}
+                      variant={ButtonVariant.Secondary}
                       size={ButtonSize.Lg}
-                      width={ButtonWidthTypes.Full}
+                      isFullWidth
                       onPress={handleResetRegion}
-                      label={strings('app_settings.fiat_on_ramp.reset_region')}
-                    />
+                    >
+                      {strings('app_settings.fiat_on_ramp.reset_region')}
+                    </Button>
                   ) : null}
                 </Row>
               )}

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.test.tsx
@@ -93,7 +93,7 @@ describe('CustomAction Component', () => {
       { state: defaultState },
     );
 
-    expect(queryByText('Continue with Paypal (Staging)')).not.toBeOnTheScreen();
+    expect(queryByText('Continue with Paypal (Staging)')).not.toBeVisible();
   });
 
   it('displays previously used provider tag', () => {

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
@@ -12,11 +12,11 @@ import Animated, {
 import { PaymentCustomAction } from '@consensys/on-ramp-sdk/dist/API';
 import Box from '../Box';
 import Title from '../../../../../Base/Title';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import RemoteImage from '../../../../../Base/RemoteImage';
 import TagColored from '../../../../../../component-library/components-temp/TagColored';
@@ -146,14 +146,15 @@ const CustomAction: React.FC<Props> = ({
                 <Button
                   size={ButtonSize.Lg}
                   onPress={() => onPressCTA?.()}
-                  label={strings('fiat_on_ramp_aggregator.continue_with', {
+                  variant={ButtonVariant.Primary}
+                  isFullWidth
+                  isDisabled={isLoading}
+                  isLoading={isLoading}
+                >
+                  {strings('fiat_on_ramp_aggregator.continue_with', {
                     provider: provider.name,
                   })}
-                  variant={ButtonVariants.Primary}
-                  width={ButtonWidthTypes.Full}
-                  isDisabled={isLoading}
-                  loading={isLoading}
-                />
+                </Button>
               </View>
             </Animated.View>
           }

--- a/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
@@ -4,11 +4,11 @@ import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityI
 import { useTheme } from '../../../../../util/theme';
 import Title from '../../../../Base/Title';
 import Text from '../../../../Base/Text';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { Colors } from '../../../../../util/theme/models';
 import { ScreenLocation } from '../types';
@@ -165,10 +165,11 @@ function ErrorView({
             <Button
               size={ButtonSize.Lg}
               onPress={ctaOnPressCallback}
-              label={ctaLabel || strings('fiat_on_ramp_aggregator.try_again')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
-            />
+              variant={ButtonVariant.Primary}
+              isFullWidth
+            >
+              {ctaLabel || strings('fiat_on_ramp_aggregator.try_again')}
+            </Button>
           </View>
         )}
       </View>

--- a/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/IncompatibleAccountTokenModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/IncompatibleAccountTokenModal.tsx
@@ -10,11 +10,11 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 
 import { useStyles } from '../../../../../hooks/useStyles';
 import { createNavigationDetails } from '../../../../../../util/navigation/navUtils';
@@ -54,12 +54,13 @@ function IncompatibleAccountTokenModal() {
         <Button
           size={ButtonSize.Lg}
           onPress={() => sheetRef.current?.onCloseBottomSheet()}
-          label={strings(
+          variant={ButtonVariant.Primary}
+          isFullWidth
+        >
+          {strings(
             'fiat_on_ramp_aggregator.incompatible_token_account_modal.cta',
           )}
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
-        />
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+  IconName as DesignSystemIconName,
+} from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../util/theme';
 import { Colors } from '../../../../../util/theme/models';
 import { QuickAmount } from '../types';
@@ -43,14 +44,15 @@ const Amount = ({ amount, onPress, isBuy, disabled }: AmountProps) => {
 
   return (
     <Button
-      variant={ButtonVariants.Secondary}
+      variant={ButtonVariant.Secondary}
       size={ButtonSize.Sm}
-      label={label}
       onPress={handlePress}
       style={styles.amount}
-      startIconName={showSparkleIcon ? IconName.Sparkle : undefined}
+      startIconName={showSparkleIcon ? DesignSystemIconName.Sparkle : undefined}
       isDisabled={disabled}
-    />
+    >
+      {label}
+    </Button>
   );
 };
 

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.test.tsx
@@ -134,7 +134,7 @@ describe('Quote Component', () => {
       { state: defaultState },
     );
 
-    expect(queryByText('Continue with Mock Provider')).not.toBeOnTheScreen();
+    expect(queryByText('Continue with Mock Provider')).not.toBeVisible();
   });
 
   it('displays previously used provider tag', () => {

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
@@ -35,11 +35,11 @@ import ListItemColumn, {
 import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { QUOTE_TEST_IDS } from './Quote.testIds';
 
 interface Props {
@@ -203,14 +203,15 @@ const Quote: React.FC<Props> = ({
                   <Button
                     size={ButtonSize.Lg}
                     onPress={() => onPressCTA?.()}
-                    label={strings('fiat_on_ramp_aggregator.continue_with', {
+                    variant={ButtonVariant.Primary}
+                    isFullWidth
+                    isDisabled={isLoading}
+                    isLoading={isLoading}
+                  >
+                    {strings('fiat_on_ramp_aggregator.continue_with', {
                       provider: provider.name,
                     })}
-                    variant={ButtonVariants.Primary}
-                    width={ButtonWidthTypes.Full}
-                    isDisabled={isLoading}
-                    loading={isLoading}
-                  />
+                  </Button>
                 )}
               </View>
             </Animated.View>

--- a/app/components/UI/Ramp/Aggregator/components/UnsupportedRegionModal/UnsupportedRegionModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/UnsupportedRegionModal/UnsupportedRegionModal.tsx
@@ -10,11 +10,11 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 
 import styleSheet from './UnsupportedRegionModal.styles.ts';
 import { useStyles } from '../../../../../hooks/useStyles';
@@ -102,10 +102,11 @@ function UnsupportedRegionModal() {
         <Button
           size={ButtonSize.Lg}
           onPress={handleSelectDifferentRegion}
-          label={strings('fiat_on_ramp_aggregator.region.select_region')}
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
-        />
+          variant={ButtonVariant.Primary}
+          isFullWidth
+        >
+          {strings('fiat_on_ramp_aggregator.region.select_region')}
+        </Button>
       </View>
     </BottomSheet>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrate Button component usage to design system in Ramp Aggregator views and components including BuildQuote, OrderDetails, SendTransaction, Settings, CustomAction, ErrorView, QuickAmounts, Quote, and modals.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/9f75b1f2-2447-45ae-a6b7-63ca600b1c8a

### **After**

https://github.com/user-attachments/assets/aeab6e04-71e6-4cfc-a258-b90d52fefe1a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI component swap (legacy `component-library` `Button` -> design-system `Button`) across ramp aggregator screens; risk is limited to potential visual/interaction regressions in disabled/loading/full-width behavior.
> 
> **Overview**
> Migrates Ramp Aggregator screens/components (e.g., `BuildQuote`, `OrderDetails`, `SendTransaction`, Settings flows, modals, and quote/action rows) from the legacy `component-library` `Button` to `@metamask/design-system-react-native`.
> 
> Updates call sites to the new API (children instead of `label`, `ButtonVariant`, `isFullWidth`, `isLoading`, `isDisabled`) and adjusts tests to assert disabled/enabled/visibility using Testing Library matchers (`toBeDisabled`, `toBeEnabled`, `not.toBeVisible`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d881f4fccd3c023006dab86b186baa41afb00dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->