### PR TITLE
feat: migrate Button (ramp scope/Deposit, NativeFlow & shared)

### DIFF
--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -610,173 +610,214 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                               showsHorizontalScrollIndicator={false}
                             >
                               <View>
-                                <TouchableOpacity
+                                <View
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "flex-start",
-                                      "backgroundColor": "#b4b4b528",
-                                      "borderColor": "transparent",
-                                      "borderRadius": 12,
-                                      "borderWidth": 1,
-                                      "flexDirection": "row",
-                                      "height": 32,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "alignSelf": "flex-start",
+                                        "backgroundColor": "#b4b4b528",
+                                        "borderColor": "transparent",
+                                        "borderRadius": 12,
+                                        "borderWidth": 1,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 32,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                 >
                                   <View
-                                    alignItems="center"
-                                    flexDirection="row"
-                                    gap={8}
-                                    style={
-                                      [
-                                        {
-                                          "alignItems": "center",
-                                          "flexDirection": "row",
-                                          "gap": 8,
-                                        },
-                                        undefined,
-                                      ]
-                                    }
+                                    style={{}}
                                   >
                                     <View
-                                      flexDirection="row-reverse"
-                                      gap={0}
+                                      alignItems="center"
+                                      flexDirection="row"
+                                      gap={8}
                                       style={
                                         [
                                           {
-                                            "flexDirection": "row-reverse",
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "gap": 8,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
                                       <View
+                                        flexDirection="row-reverse"
+                                        gap={0}
                                         style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
+                                          [
+                                            {
+                                              "flexDirection": "row-reverse",
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
-                                      </View>
-                                      <View
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
-                                        }
-                                      >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
-                                      </View>
-                                      <View
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
-                                        }
-                                      >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
                                       </View>
+                                      <Text
+                                        accessibilityRole="text"
+                                        style={
+                                          {
+                                            "color": "#131416",
+                                            "fontFamily": "Geist-Regular",
+                                            "fontSize": 16,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          }
+                                        }
+                                      >
+                                        All networks
+                                      </Text>
+                                      <SvgMock
+                                        color="#131416"
+                                        fill="currentColor"
+                                        height={12}
+                                        name="ArrowDown"
+                                        style={
+                                          {
+                                            "height": 12,
+                                            "width": 12,
+                                          }
+                                        }
+                                        width={12}
+                                      />
                                     </View>
-                                    <Text
-                                      accessibilityRole="text"
-                                      style={
-                                        {
-                                          "color": "#131416",
-                                          "fontFamily": "Geist-Regular",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
-                                      }
-                                    >
-                                      All networks
-                                    </Text>
-                                    <SvgMock
-                                      color="#131416"
-                                      fill="currentColor"
-                                      height={12}
-                                      name="ArrowDown"
-                                      style={
-                                        {
-                                          "height": 12,
-                                          "width": 12,
-                                        }
-                                      }
-                                      width={12}
-                                    />
                                   </View>
-                                </TouchableOpacity>
+                                </View>
                               </View>
                             </RCTScrollView>
                             <View

--- a/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/AdditionalVerification.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/AdditionalVerification.tsx
@@ -7,11 +7,11 @@ import ScreenLayout from '../../../Aggregator/components/ScreenLayout';
 import { getDepositNavbarOptions } from '../../../../Navbar';
 import { useNavigation } from '@react-navigation/native';
 import PoweredByTransak from '../../components/PoweredByTransak';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import additionalVerificationImage from '../../assets/additional-verification.png';
 import { strings } from '../../../../../../../locales/i18n';
 import { TextVariant } from '../../../../../../component-library/components/Texts/Text/Text.types';
@@ -85,10 +85,11 @@ const AdditionalVerification = () => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleContinuePress}
-            label={strings('deposit.additional_verification.button')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-          />
+            variant={ButtonVariant.Primary}
+            isFullWidth
+          >
+            {strings('deposit.additional_verification.button')}
+          </Button>
           <PoweredByTransak name="powered-by-transak-logo" />
         </ScreenLayout.Content>
       </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
@@ -497,9 +497,57 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/AdditionalVerification/__snapshots__/AdditionalVerification.test.tsx.snap
@@ -317,42 +317,90 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -497,57 +545,9 @@ exports[`AdditionalVerification Component render matches snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/BankDetails/BankDetails.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BankDetails/BankDetails.tsx
@@ -39,10 +39,11 @@ import { useTheme } from '../../../../../../util/theme';
 import { RootState } from '../../../../../../reducers';
 import { hasDepositOrderField } from '../../utils';
 import { useDepositSDK } from '../../sdk';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import PrivacySection from '../../components/PrivacySection';
 import useAnalytics from '../../../hooks/useAnalytics';
 import { isString } from 'lodash';
@@ -499,24 +500,26 @@ const BankDetails = () => {
             <View style={styles.buttonContainer}>
               <Button
                 style={styles.button}
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 onPress={handleCancelOrder}
-                label={strings('deposit.order_processing.cancel_order_button')}
                 size={ButtonSize.Lg}
-                loading={isLoadingCancelOrder}
-                disabled={isLoadingConfirmPayment}
-              />
+                isLoading={isLoadingCancelOrder}
+                isDisabled={isLoadingConfirmPayment}
+              >
+                {strings('deposit.order_processing.cancel_order_button')}
+              </Button>
 
               <Button
                 style={styles.button}
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 onPress={handleBankTransferSent}
                 testID={BANK_DETAILS_TEST_IDS.MAIN_ACTION_BUTTON}
-                label={strings('deposit.bank_details.button')}
                 size={ButtonSize.Lg}
-                disabled={isLoadingCancelOrder}
-                loading={isLoadingConfirmPayment}
-              />
+                isDisabled={isLoadingCancelOrder}
+                isLoading={isLoadingConfirmPayment}
+              >
+                {strings('deposit.bank_details.button')}
+              </Button>
             </View>
           </View>
         </ScreenLayout.Content>

--- a/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
@@ -616,6 +616,57 @@ exports[`BankDetails Component render matches snapshot 1`] = `
                                       "paddingVertical": 8,
                                     }
                                   }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "alignSelf": "flex-start",
+                                        "backgroundColor": "#b4b4b528",
+                                        "borderColor": "transparent",
+                                        "borderRadius": 12,
+                                        "borderWidth": 1,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                      },
+                                      {
+                                        "flex": 1,
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
+                                  }
                                 >
                                   <View
                                     style={
@@ -1789,6 +1840,57 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
                                       "padding": 16,
                                       "paddingVertical": 8,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "alignSelf": "flex-start",
+                                        "backgroundColor": "#b4b4b528",
+                                        "borderColor": "transparent",
+                                        "borderRadius": 12,
+                                        "borderWidth": 1,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                      },
+                                      {
+                                        "flex": 1,
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                 >
                                   <View

--- a/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BankDetails/__snapshots__/BankDetails.test.tsx.snap
@@ -616,57 +616,6 @@ exports[`BankDetails Component render matches snapshot 1`] = `
                                       "paddingVertical": 8,
                                     }
                                   }
-                                  accessibilityValue={
-                                    {
-                                      "max": undefined,
-                                      "min": undefined,
-                                      "now": undefined,
-                                      "text": undefined,
-                                    }
-                                  }
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "alignSelf": "flex-start",
-                                        "backgroundColor": "#b4b4b528",
-                                        "borderColor": "transparent",
-                                        "borderRadius": 12,
-                                        "borderWidth": 1,
-                                        "columnGap": 8,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "minWidth": 80,
-                                        "opacity": 1,
-                                        "overflow": "hidden",
-                                        "paddingLeft": 16,
-                                        "paddingRight": 16,
-                                      },
-                                      {
-                                        "flex": 1,
-                                      },
-                                      {
-                                        "transform": [
-                                          {
-                                            "scale": 1,
-                                          },
-                                        ],
-                                      },
-                                    ]
-                                  }
                                 >
                                   <View
                                     style={
@@ -740,87 +689,183 @@ exports[`BankDetails Component render matches snapshot 1`] = `
                                     }
                                   }
                                 >
-                                  <TouchableOpacity
+                                  <View
+                                    accessibilityLabel="Cancel order"
                                     accessibilityRole="button"
-                                    accessible={true}
-                                    activeOpacity={1}
-                                    disabled={false}
-                                    loading={false}
-                                    onPress={[Function]}
-                                    onPressIn={[Function]}
-                                    onPressOut={[Function]}
-                                    style={
+                                    accessibilityState={
                                       {
-                                        "alignItems": "center",
-                                        "alignSelf": "flex-start",
-                                        "backgroundColor": "#b4b4b528",
-                                        "borderColor": "transparent",
-                                        "borderRadius": 12,
-                                        "borderWidth": 1,
-                                        "flex": 1,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "overflow": "hidden",
-                                        "paddingHorizontal": 16,
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": false,
+                                        "expanded": undefined,
+                                        "selected": undefined,
                                       }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "alignSelf": "flex-start",
+                                          "backgroundColor": "#b4b4b528",
+                                          "borderColor": "transparent",
+                                          "borderRadius": 12,
+                                          "borderWidth": 1,
+                                          "columnGap": 8,
+                                          "flexDirection": "row",
+                                          "height": 48,
+                                          "justifyContent": "center",
+                                          "minWidth": 80,
+                                          "opacity": 1,
+                                          "overflow": "hidden",
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                        },
+                                        {
+                                          "flex": 1,
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                        },
+                                      ]
                                     }
                                   >
                                     <Text
                                       accessibilityRole="text"
+                                      ellipsizeMode="clip"
+                                      numberOfLines={1}
                                       style={
-                                        {
-                                          "color": "#131416",
-                                          "fontFamily": "Geist-Medium",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {
+                                            "color": "#131416",
+                                            "flexGrow": 0,
+                                            "flexShrink": 1,
+                                            "flexWrap": "wrap",
+                                            "fontFamily": "Geist-Medium",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       Cancel order
                                     </Text>
-                                  </TouchableOpacity>
-                                  <TouchableOpacity
+                                  </View>
+                                  <View
+                                    accessibilityLabel="Confirm transfer"
                                     accessibilityRole="button"
-                                    accessible={true}
-                                    activeOpacity={1}
-                                    disabled={false}
-                                    loading={false}
-                                    onPress={[Function]}
-                                    onPressIn={[Function]}
-                                    onPressOut={[Function]}
-                                    style={
+                                    accessibilityState={
                                       {
-                                        "alignItems": "center",
-                                        "alignSelf": "flex-start",
-                                        "backgroundColor": "#131416",
-                                        "borderRadius": 12,
-                                        "flex": 1,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "overflow": "hidden",
-                                        "paddingHorizontal": 16,
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": false,
+                                        "expanded": undefined,
+                                        "selected": undefined,
                                       }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "alignSelf": "flex-start",
+                                          "backgroundColor": "#131416",
+                                          "borderRadius": 12,
+                                          "columnGap": 8,
+                                          "flexDirection": "row",
+                                          "height": 48,
+                                          "justifyContent": "center",
+                                          "minWidth": 80,
+                                          "opacity": 1,
+                                          "overflow": "hidden",
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                        },
+                                        {
+                                          "flex": 1,
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                        },
+                                      ]
                                     }
                                     testID="main-action-button"
                                   >
                                     <Text
                                       accessibilityRole="text"
+                                      ellipsizeMode="clip"
+                                      numberOfLines={1}
                                       style={
-                                        {
-                                          "color": "#ffffff",
-                                          "fontFamily": "Geist-Medium",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {
+                                            "color": "#ffffff",
+                                            "flexGrow": 0,
+                                            "flexShrink": 1,
+                                            "flexWrap": "wrap",
+                                            "fontFamily": "Geist-Medium",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       Confirm transfer
                                     </Text>
-                                  </TouchableOpacity>
+                                  </View>
                                 </View>
                               </View>
                             </View>
@@ -1841,57 +1886,6 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
                                       "paddingVertical": 8,
                                     }
                                   }
-                                  accessibilityValue={
-                                    {
-                                      "max": undefined,
-                                      "min": undefined,
-                                      "now": undefined,
-                                      "text": undefined,
-                                    }
-                                  }
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "alignSelf": "flex-start",
-                                        "backgroundColor": "#b4b4b528",
-                                        "borderColor": "transparent",
-                                        "borderRadius": 12,
-                                        "borderWidth": 1,
-                                        "columnGap": 8,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "minWidth": 80,
-                                        "opacity": 1,
-                                        "overflow": "hidden",
-                                        "paddingLeft": 16,
-                                        "paddingRight": 16,
-                                      },
-                                      {
-                                        "flex": 1,
-                                      },
-                                      {
-                                        "transform": [
-                                          {
-                                            "scale": 1,
-                                          },
-                                        ],
-                                      },
-                                    ]
-                                  }
                                 >
                                   <View
                                     style={
@@ -1965,87 +1959,183 @@ exports[`BankDetails Component render matches snapshot with bank info shown 1`] 
                                     }
                                   }
                                 >
-                                  <TouchableOpacity
+                                  <View
+                                    accessibilityLabel="Cancel order"
                                     accessibilityRole="button"
-                                    accessible={true}
-                                    activeOpacity={1}
-                                    disabled={false}
-                                    loading={false}
-                                    onPress={[Function]}
-                                    onPressIn={[Function]}
-                                    onPressOut={[Function]}
-                                    style={
+                                    accessibilityState={
                                       {
-                                        "alignItems": "center",
-                                        "alignSelf": "flex-start",
-                                        "backgroundColor": "#b4b4b528",
-                                        "borderColor": "transparent",
-                                        "borderRadius": 12,
-                                        "borderWidth": 1,
-                                        "flex": 1,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "overflow": "hidden",
-                                        "paddingHorizontal": 16,
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": false,
+                                        "expanded": undefined,
+                                        "selected": undefined,
                                       }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "alignSelf": "flex-start",
+                                          "backgroundColor": "#b4b4b528",
+                                          "borderColor": "transparent",
+                                          "borderRadius": 12,
+                                          "borderWidth": 1,
+                                          "columnGap": 8,
+                                          "flexDirection": "row",
+                                          "height": 48,
+                                          "justifyContent": "center",
+                                          "minWidth": 80,
+                                          "opacity": 1,
+                                          "overflow": "hidden",
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                        },
+                                        {
+                                          "flex": 1,
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                        },
+                                      ]
                                     }
                                   >
                                     <Text
                                       accessibilityRole="text"
+                                      ellipsizeMode="clip"
+                                      numberOfLines={1}
                                       style={
-                                        {
-                                          "color": "#131416",
-                                          "fontFamily": "Geist-Medium",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {
+                                            "color": "#131416",
+                                            "flexGrow": 0,
+                                            "flexShrink": 1,
+                                            "flexWrap": "wrap",
+                                            "fontFamily": "Geist-Medium",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       Cancel order
                                     </Text>
-                                  </TouchableOpacity>
-                                  <TouchableOpacity
+                                  </View>
+                                  <View
+                                    accessibilityLabel="Confirm transfer"
                                     accessibilityRole="button"
-                                    accessible={true}
-                                    activeOpacity={1}
-                                    disabled={false}
-                                    loading={false}
-                                    onPress={[Function]}
-                                    onPressIn={[Function]}
-                                    onPressOut={[Function]}
-                                    style={
+                                    accessibilityState={
                                       {
-                                        "alignItems": "center",
-                                        "alignSelf": "flex-start",
-                                        "backgroundColor": "#131416",
-                                        "borderRadius": 12,
-                                        "flex": 1,
-                                        "flexDirection": "row",
-                                        "height": 48,
-                                        "justifyContent": "center",
-                                        "overflow": "hidden",
-                                        "paddingHorizontal": 16,
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": false,
+                                        "expanded": undefined,
+                                        "selected": undefined,
                                       }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "alignSelf": "flex-start",
+                                          "backgroundColor": "#131416",
+                                          "borderRadius": 12,
+                                          "columnGap": 8,
+                                          "flexDirection": "row",
+                                          "height": 48,
+                                          "justifyContent": "center",
+                                          "minWidth": 80,
+                                          "opacity": 1,
+                                          "overflow": "hidden",
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                        },
+                                        {
+                                          "flex": 1,
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": 1,
+                                            },
+                                          ],
+                                        },
+                                      ]
                                     }
                                     testID="main-action-button"
                                   >
                                     <Text
                                       accessibilityRole="text"
+                                      ellipsizeMode="clip"
+                                      numberOfLines={1}
                                       style={
-                                        {
-                                          "color": "#ffffff",
-                                          "fontFamily": "Geist-Medium",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
+                                        [
+                                          {
+                                            "color": "#ffffff",
+                                            "flexGrow": 0,
+                                            "flexShrink": 1,
+                                            "flexWrap": "wrap",
+                                            "fontFamily": "Geist-Medium",
+                                            "fontSize": 16,
+                                            "fontWeight": 400,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
                                       }
                                     >
                                       Confirm transfer
                                     </Text>
-                                  </TouchableOpacity>
+                                  </View>
                                 </View>
                               </View>
                             </View>

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/BasicInfo.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/BasicInfo.tsx
@@ -30,11 +30,14 @@ import { BuyQuote } from '@consensys/native-ramps-sdk';
 import { useDepositSDK } from '../../sdk';
 import { VALIDATION_REGEX } from '../../constants/constants';
 import { endTrace, TraceName } from '../../../../../../util/trace';
-import Button, {
-  ButtonSize,
+import OldButton, {
   ButtonVariants,
-  ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -487,13 +490,14 @@ const BasicInfo = (): JSX.Element => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleOnPressContinue}
-            label={strings('deposit.basic_info.continue')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            isFullWidth
             isDisabled={loading || !!error}
-            loading={loading}
+            isLoading={loading}
             testID={BASIC_INFO_TEST_IDS.CONTINUE_BUTTON}
-          />
+          >
+            {strings('deposit.basic_info.continue')}
+          </Button>
           <PoweredByTransak name="powered-by-transak-logo" />
         </ScreenLayout.Content>
       </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -1397,6 +1397,8 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -2847,6 +2849,8 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -4297,6 +4301,8 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -5750,6 +5756,8 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -7263,6 +7271,8 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -8758,6 +8768,8 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -10086,6 +10098,8 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -1211,45 +1211,91 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -1397,8 +1443,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -2663,45 +2707,91 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -2849,8 +2939,6 @@ exports[`BasicInfo Component passes regions to DepositPhoneField component 1`] =
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -4115,45 +4203,91 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -4301,8 +4435,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -5570,45 +5702,91 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -5756,8 +5934,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -7085,45 +7261,91 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -7271,8 +7493,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -8582,45 +8802,91 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -8768,8 +9034,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -9912,45 +10176,91 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                   </View>
                                 </View>
                               </View>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="continue-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -10098,8 +10408,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
@@ -68,6 +68,42 @@ const mockUseDepositSDK = jest.fn();
 const mockUseDepositTokenExchange = jest.fn();
 const mockUseRoute = jest.fn().mockReturnValue({ params: {} });
 
+// The design-system Button uses AnimatedPressable which blocks press
+// events when disabled. Override the Button to use TouchableOpacity so
+// that fireEvent.press works regardless of disabled state, matching
+// the previous component-library Button behavior in tests.
+jest.mock('@metamask/design-system-react-native', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-shadow
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { TouchableOpacity, Text } = require('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    Button: ({
+      children,
+      onPress,
+      isDisabled,
+      isLoading,
+      isFullWidth,
+      variant,
+      size,
+      startIconName,
+      ...rest
+    }: Record<string, unknown>) =>
+      React.createElement(
+        TouchableOpacity,
+        {
+          ...rest,
+          onPress,
+          disabled: isDisabled || isLoading,
+          accessibilityRole: 'button',
+        },
+        React.createElement(Text, null, children),
+      ),
+  };
+});
+
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
@@ -772,8 +808,8 @@ describe('BuildQuote Component', () => {
 
       render(BuildQuote);
 
-      const continueButton = screen.getByText('Continue');
       await act(async () => {
+        const continueButton = screen.getByText('Continue');
         fireEvent.press(continueButton);
       });
 
@@ -788,8 +824,8 @@ describe('BuildQuote Component', () => {
 
       render(BuildQuote);
 
-      const continueButton = screen.getByText('Continue');
       await act(async () => {
+        const continueButton = screen.getByText('Continue');
         fireEvent.press(continueButton);
       });
 
@@ -817,8 +853,8 @@ describe('BuildQuote Component', () => {
 
       render(BuildQuote);
 
-      const continueButton = screen.getByText('Continue');
       await act(async () => {
+        const continueButton = screen.getByText('Continue');
         fireEvent.press(continueButton);
       });
 
@@ -833,8 +869,8 @@ describe('BuildQuote Component', () => {
 
       render(BuildQuote);
 
-      const continueButton = screen.getByText('Continue');
       await act(async () => {
+        const continueButton = screen.getByText('Continue');
         fireEvent.press(continueButton);
       });
 
@@ -869,8 +905,8 @@ describe('BuildQuote Component', () => {
 
       render(BuildQuote);
 
-      const continueButton = screen.getByText('Continue');
       await act(async () => {
+        const continueButton = screen.getByText('Continue');
         fireEvent.press(continueButton);
       });
 
@@ -898,8 +934,8 @@ describe('BuildQuote Component', () => {
 
       render(BuildQuote);
 
-      const continueButton = screen.getByText('Continue');
       await act(async () => {
+        const continueButton = screen.getByText('Continue');
         fireEvent.press(continueButton);
       });
 

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -8,11 +8,11 @@ import styleSheet from './BuildQuote.styles';
 
 import ScreenLayout from '../../../Aggregator/components/ScreenLayout';
 import Keypad from '../../../../../Base/Keypad';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextVariant,
   TextColor,
@@ -727,9 +727,8 @@ const BuildQuote = () => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleOnPressContinue}
-            label={'Continue'}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
+            variant={ButtonVariant.Primary}
+            isFullWidth
             isDisabled={
               amountAsNumber <= 0 ||
               isLoading ||
@@ -741,8 +740,10 @@ const BuildQuote = () => {
               !selectedCryptoCurrency ||
               !selectedPaymentMethod
             }
-            loading={isLoading}
-          />
+            isLoading={isLoading}
+          >
+            {'Continue'}
+          </Button>
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
     </ScreenLayout>

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -1504,40 +1504,10 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -3303,40 +3273,10 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -5102,40 +5042,10 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -6840,40 +6750,10 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -8578,39 +8458,10 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={false}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -10315,40 +10166,10 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -12146,40 +11967,10 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -13839,40 +13630,10 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -15577,40 +15338,10 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -17315,40 +17046,10 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -19053,40 +18754,10 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -20791,40 +20462,10 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -22622,40 +22263,10 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -24358,40 +23969,10 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -26187,40 +25768,10 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -28018,40 +27569,10 @@ exports[`BuildQuote Component User Details Error displays user details error ale
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>
@@ -29756,40 +29277,10 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                             >
                               <TouchableOpacity
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
                                 disabled={true}
-                                loading={false}
                                 onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
-                                  }
-                                }
                               >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                >
+                                <Text>
                                   Continue
                                 </Text>
                               </TouchableOpacity>

--- a/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/__snapshots__/DepositOrderDetails.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/DepositOrderDetails/__snapshots__/DepositOrderDetails.test.tsx.snap
@@ -136,42 +136,93 @@ exports[`DepositOrderDetails Component renders an error screen if a CREATED orde
             >
               Test error message
             </Text>
-            <TouchableOpacity
+            <View
+              accessibilityLabel="Try again"
               accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "alignSelf": "center",
-                  "backgroundColor": "#131416",
-                  "borderRadius": 12,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "#131416",
+                    "borderRadius": 12,
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "minWidth": 80,
+                    "opacity": 1,
+                    "overflow": "hidden",
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                  },
+                  {
+                    "alignSelf": "center",
+                  },
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
             >
               <Text
                 accessibilityRole="text"
+                ellipsizeMode="clip"
+                numberOfLines={1}
                 style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#ffffff",
+                      "flexGrow": 0,
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "textAlign": "center",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 Try again
               </Text>
-            </TouchableOpacity>
+            </View>
           </View>
         </View>
       </RNCSafeAreaView>

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.test.tsx
@@ -183,7 +183,7 @@ describe('EnterAddress Component', () => {
   it('disables the continue button when loading is true', () => {
     render(EnterAddress);
     const button = screen.getByTestId('address-continue-button');
-    expect(button.props.disabled).toBe(false);
+    expect(button).toBeEnabled();
 
     fillFormAndSubmit();
 
@@ -193,7 +193,7 @@ describe('EnterAddress Component', () => {
 
     fireEvent.press(button);
 
-    expect(button.props.disabled).toBe(true);
+    expect(button).toBeDisabled();
   });
 
   it('shows text input for state when region is not US', () => {
@@ -205,10 +205,17 @@ describe('EnterAddress Component', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('validates address line 2 when provided', () => {
+  it('validates address line 2 when provided', async () => {
     render(EnterAddress);
 
     fillFormAndSubmit();
+
+    // Wait for the first submission to complete so the button is no longer loading/disabled
+    await waitFor(() => {
+      expect(screen.getByTestId('address-continue-button')).toBeEnabled();
+    });
+
+    mockRouteAfterAuthentication.mockClear();
 
     fireEvent.changeText(screen.getByTestId('address-line-2-input'), '12345');
 

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/EnterAddress.tsx
@@ -22,11 +22,11 @@ import { useDepositSdkMethod } from '../../hooks/useDepositSdkMethod';
 import { BuyQuote } from '@consensys/native-ramps-sdk';
 import PoweredByTransak from '../../components/PoweredByTransak';
 import { BasicInfoFormData } from '../BasicInfo/BasicInfo';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import PrivacySection from '../../components/PrivacySection';
 import { useDepositSDK } from '../../sdk';
 import StateSelector from '../../components/StateSelector';
@@ -376,13 +376,14 @@ const EnterAddress = (): JSX.Element => {
             <Button
               size={ButtonSize.Lg}
               onPress={handleOnPressContinue}
-              label={strings('deposit.enter_address.continue')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
+              variant={ButtonVariant.Primary}
+              isFullWidth
               isDisabled={loading || !!error}
-              loading={loading}
+              isLoading={loading}
               testID={ENTER_ADDRESS_TEST_IDS.CONTINUE_BUTTON}
-            />
+            >
+              {strings('deposit.enter_address.continue')}
+            </Button>
             <PoweredByTransak name="powered-by-transak-logo" />
           </ScreenLayout.Content>
         </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -1314,45 +1314,91 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                     </View>
                                   </View>
                                 </View>
-                                <TouchableOpacity
+                                <View
+                                  accessibilityLabel="Continue"
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  loading={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "backgroundColor": "#131416",
-                                      "borderRadius": 12,
-                                      "flexDirection": "row",
-                                      "height": 48,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#131416",
+                                        "borderRadius": 12,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                        "width": "100%",
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                   testID="address-continue-button"
                                 >
                                   <Text
                                     accessibilityRole="text"
+                                    ellipsizeMode="clip"
+                                    numberOfLines={1}
                                     style={
-                                      {
-                                        "color": "#ffffff",
-                                        "fontFamily": "Geist-Medium",
-                                        "fontSize": 16,
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
+                                      [
+                                        {
+                                          "color": "#ffffff",
+                                          "flexGrow": 0,
+                                          "flexShrink": 1,
+                                          "flexWrap": "wrap",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
                                     }
                                   >
                                     Continue
                                   </Text>
-                                </TouchableOpacity>
+                                </View>
                                 <SvgMock
                                   fill="currentColor"
                                   name="powered-by-transak-logo"
@@ -2795,45 +2841,91 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                     </View>
                                   </View>
                                 </View>
-                                <TouchableOpacity
+                                <View
+                                  accessibilityLabel="Continue"
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  loading={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "backgroundColor": "#131416",
-                                      "borderRadius": 12,
-                                      "flexDirection": "row",
-                                      "height": 48,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#131416",
+                                        "borderRadius": 12,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                        "width": "100%",
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                   testID="address-continue-button"
                                 >
                                   <Text
                                     accessibilityRole="text"
+                                    ellipsizeMode="clip"
+                                    numberOfLines={1}
                                     style={
-                                      {
-                                        "color": "#ffffff",
-                                        "fontFamily": "Geist-Medium",
-                                        "fontSize": 16,
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
+                                      [
+                                        {
+                                          "color": "#ffffff",
+                                          "flexGrow": 0,
+                                          "flexShrink": 1,
+                                          "flexWrap": "wrap",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
                                     }
                                   >
                                     Continue
                                   </Text>
-                                </TouchableOpacity>
+                                </View>
                                 <SvgMock
                                   fill="currentColor"
                                   name="powered-by-transak-logo"
@@ -4288,45 +4380,91 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                     </View>
                                   </View>
                                 </View>
-                                <TouchableOpacity
+                                <View
+                                  accessibilityLabel="Continue"
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  loading={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "backgroundColor": "#131416",
-                                      "borderRadius": 12,
-                                      "flexDirection": "row",
-                                      "height": 48,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#131416",
+                                        "borderRadius": 12,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                        "width": "100%",
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                   testID="address-continue-button"
                                 >
                                   <Text
                                     accessibilityRole="text"
+                                    ellipsizeMode="clip"
+                                    numberOfLines={1}
                                     style={
-                                      {
-                                        "color": "#ffffff",
-                                        "fontFamily": "Geist-Medium",
-                                        "fontSize": 16,
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
+                                      [
+                                        {
+                                          "color": "#ffffff",
+                                          "flexGrow": 0,
+                                          "flexShrink": 1,
+                                          "flexWrap": "wrap",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
                                     }
                                   >
                                     Continue
                                   </Text>
-                                </TouchableOpacity>
+                                </View>
                                 <SvgMock
                                   fill="currentColor"
                                   name="powered-by-transak-logo"
@@ -5802,45 +5940,91 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                     </View>
                                   </View>
                                 </View>
-                                <TouchableOpacity
+                                <View
+                                  accessibilityLabel="Continue"
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  disabled={false}
-                                  loading={false}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "backgroundColor": "#131416",
-                                      "borderRadius": 12,
-                                      "flexDirection": "row",
-                                      "height": 48,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#131416",
+                                        "borderRadius": 12,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 48,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                        "width": "100%",
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                   testID="address-continue-button"
                                 >
                                   <Text
                                     accessibilityRole="text"
+                                    ellipsizeMode="clip"
+                                    numberOfLines={1}
                                     style={
-                                      {
-                                        "color": "#ffffff",
-                                        "fontFamily": "Geist-Medium",
-                                        "fontSize": 16,
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
+                                      [
+                                        {
+                                          "color": "#ffffff",
+                                          "flexGrow": 0,
+                                          "flexShrink": 1,
+                                          "flexWrap": "wrap",
+                                          "fontFamily": "Geist-Medium",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
                                     }
                                   >
                                     Continue
                                   </Text>
-                                </TouchableOpacity>
+                                </View>
                                 <SvgMock
                                   fill="currentColor"
                                   name="powered-by-transak-logo"

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/EnterEmail.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/EnterEmail.tsx
@@ -19,11 +19,11 @@ import { useDepositSdkMethod } from '../../hooks/useDepositSdkMethod';
 import { createOtpCodeNavDetails } from '../OtpCode/OtpCode';
 import { validateEmail } from '../../utils';
 import DepositProgressBar from '../../components/DepositProgressBar/DepositProgressBar';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import PoweredByTransak from '../../components/PoweredByTransak';
 import Logger from '../../../../../../util/Logger';
 import useAnalytics from '../../../hooks/useAnalytics';
@@ -153,12 +153,13 @@ const EnterEmail = () => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleSubmit}
-            label={strings('deposit.enter_email.submit_button')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-            loading={isLoading}
+            variant={ButtonVariant.Primary}
+            isFullWidth
+            isLoading={isLoading}
             isDisabled={isLoading}
-          />
+          >
+            {strings('deposit.enter_email.submit_button')}
+          </Button>
           <PoweredByTransak name="powered-by-transak-logo" />
         </ScreenLayout.Content>
       </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -476,44 +476,90 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Send email"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Send email
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -658,57 +704,9 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -1250,44 +1248,90 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Send email"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Send email
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -1432,57 +1476,9 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -2011,44 +2007,90 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Send email"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Send email
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -2193,57 +2235,9 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -2785,44 +2779,90 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Send email"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Send email
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -2967,57 +3007,9 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -658,9 +658,57 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -1384,9 +1432,57 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -2097,9 +2193,57 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -2823,9 +2967,57 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/KycProcessing/KycProcessing.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/KycProcessing/KycProcessing.tsx
@@ -23,11 +23,11 @@ import Icon, {
 } from '../../../../../../component-library/components/Icons/Icon';
 import { BuyQuote } from '@consensys/native-ramps-sdk';
 import { useDepositSdkMethod } from '../../hooks/useDepositSdkMethod';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import PoweredByTransak from '../../components/PoweredByTransak';
 import { useDepositRouting } from '../../hooks/useDepositRouting';
 import { KycStatus } from '../../constants';
@@ -148,10 +148,11 @@ const KycProcessing = () => {
             <Button
               size={ButtonSize.Lg}
               onPress={handleContinue}
-              label={strings('deposit.kyc_processing.error_button')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
-            />
+              variant={ButtonVariant.Primary}
+              isFullWidth
+            >
+              {strings('deposit.kyc_processing.error_button')}
+            </Button>
             <PoweredByTransak name="powered-by-transak-logo" />
           </ScreenLayout.Content>
         </ScreenLayout.Footer>
@@ -189,10 +190,11 @@ const KycProcessing = () => {
             <Button
               size={ButtonSize.Lg}
               onPress={handleContinue}
-              label={strings('deposit.kyc_processing.success_button')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
-            />
+              variant={ButtonVariant.Primary}
+              isFullWidth
+            >
+              {strings('deposit.kyc_processing.success_button')}
+            </Button>
             <PoweredByTransak name="powered-by-transak-logo" />
           </ScreenLayout.Content>
         </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
@@ -1201,9 +1201,57 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -1844,9 +1892,57 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -3086,9 +3182,57 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -3729,9 +3873,57 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/KycProcessing/__snapshots__/KycProcessing.test.tsx.snap
@@ -1021,42 +1021,90 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Complete your order"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Complete your order
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -1201,57 +1249,9 @@ exports[`KycProcessing Component renders approved state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -1712,42 +1712,90 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Retry verification"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Retry verification
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -1892,57 +1940,9 @@ exports[`KycProcessing Component renders error state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -3002,42 +3002,90 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Retry verification"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Retry verification
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -3182,57 +3230,9 @@ exports[`KycProcessing Component renders pending forms state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {
@@ -3693,42 +3693,90 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Retry verification"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Retry verification
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -3873,57 +3921,9 @@ exports[`KycProcessing Component renders rejected state snapshot 1`] = `
                                   undefined,
                                 ]
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   [
                                     {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/IncompatibleAccountTokenModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/IncompatibleAccountTokenModal.tsx
@@ -14,11 +14,11 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 
 import { useStyles } from '../../../../../../hooks/useStyles';
 import { selectChainId } from '../../../../../../../selectors/networkController';
@@ -61,10 +61,11 @@ function IncompatibleAccountTokenModal() {
         <Button
           size={ButtonSize.Lg}
           onPress={() => sheetRef.current?.onCloseBottomSheet()}
-          label={strings('deposit.incompatible_token_acount_modal.cta')}
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
-        />
+          variant={ButtonVariant.Primary}
+          isFullWidth
+        >
+          {strings('deposit.incompatible_token_acount_modal.cta')}
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -549,9 +549,57 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                   "paddingHorizontal": 16,
                                 }
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   {
                                     "color": "#131416",

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -549,57 +549,9 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                   "paddingHorizontal": 16,
                                 }
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   {
                                     "color": "#131416",
@@ -612,42 +564,90 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                               >
                                 The Ethereum account you’re on doesn't support the selected token. Switch your account or token to continue.
                               </Text>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="I understand"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   I understand
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -610,173 +610,214 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                               showsHorizontalScrollIndicator={false}
                             >
                               <View>
-                                <TouchableOpacity
+                                <View
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "flex-start",
-                                      "backgroundColor": "#b4b4b528",
-                                      "borderColor": "transparent",
-                                      "borderRadius": 12,
-                                      "borderWidth": 1,
-                                      "flexDirection": "row",
-                                      "height": 32,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "alignSelf": "flex-start",
+                                        "backgroundColor": "#b4b4b528",
+                                        "borderColor": "transparent",
+                                        "borderRadius": 12,
+                                        "borderWidth": 1,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 32,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                 >
                                   <View
-                                    alignItems="center"
-                                    flexDirection="row"
-                                    gap={8}
-                                    style={
-                                      [
-                                        {
-                                          "alignItems": "center",
-                                          "flexDirection": "row",
-                                          "gap": 8,
-                                        },
-                                        undefined,
-                                      ]
-                                    }
+                                    style={{}}
                                   >
                                     <View
-                                      flexDirection="row-reverse"
-                                      gap={0}
+                                      alignItems="center"
+                                      flexDirection="row"
+                                      gap={8}
                                       style={
                                         [
                                           {
-                                            "flexDirection": "row-reverse",
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "gap": 8,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
                                       <View
+                                        flexDirection="row-reverse"
+                                        gap={0}
                                         style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
+                                          [
+                                            {
+                                              "flexDirection": "row-reverse",
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
-                                      </View>
-                                      <View
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
-                                        }
-                                      >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
-                                      </View>
-                                      <View
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
-                                        }
-                                      >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
                                       </View>
+                                      <Text
+                                        accessibilityRole="text"
+                                        style={
+                                          {
+                                            "color": "#131416",
+                                            "fontFamily": "Geist-Regular",
+                                            "fontSize": 16,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          }
+                                        }
+                                      >
+                                        All networks
+                                      </Text>
+                                      <SvgMock
+                                        color="#131416"
+                                        fill="currentColor"
+                                        height={12}
+                                        name="ArrowDown"
+                                        style={
+                                          {
+                                            "height": 12,
+                                            "width": 12,
+                                          }
+                                        }
+                                        width={12}
+                                      />
                                     </View>
-                                    <Text
-                                      accessibilityRole="text"
-                                      style={
-                                        {
-                                          "color": "#131416",
-                                          "fontFamily": "Geist-Regular",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
-                                      }
-                                    >
-                                      All networks
-                                    </Text>
-                                    <SvgMock
-                                      color="#131416"
-                                      fill="currentColor"
-                                      height={12}
-                                      name="ArrowDown"
-                                      style={
-                                        {
-                                          "height": 12,
-                                          "width": 12,
-                                        }
-                                      }
-                                      width={12}
-                                    />
                                   </View>
-                                </TouchableOpacity>
+                                </View>
                               </View>
                             </RCTScrollView>
                             <View
@@ -1624,7 +1665,12 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                             </View>
                             <TouchableOpacity
                               accessibilityRole="button"
-                              accessibilityState={
+                              accessible={true}
+                              activeOpacity={1}
+                              onPress={[Function]}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
+                              style={
                                 {
                                   "alignItems": "center",
                                   "alignSelf": "flex-start",
@@ -1637,57 +1683,9 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                   "paddingHorizontal": 16,
                                 }
                               }
-                              accessibilityValue={
-                                {
-                                  "max": undefined,
-                                  "min": undefined,
-                                  "now": undefined,
-                                  "text": undefined,
-                                }
-                              }
-                              accessible={true}
-                              collapsable={false}
-                              focusable={true}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onResponderGrant={[Function]}
-                              onResponderMove={[Function]}
-                              onResponderRelease={[Function]}
-                              onResponderTerminate={[Function]}
-                              onResponderTerminationRequest={[Function]}
-                              onStartShouldSetResponder={[Function]}
-                              style={
-                                [
-                                  {
-                                    "alignItems": "center",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "columnGap": 8,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "minWidth": 80,
-                                    "opacity": 1,
-                                    "overflow": "hidden",
-                                    "paddingLeft": 16,
-                                    "paddingRight": 16,
-                                    "width": "100%",
-                                  },
-                                  {
-                                    "transform": [
-                                      {
-                                        "scale": 1,
-                                      },
-                                    ],
-                                  },
-                                ]
-                              }
                             >
                               <Text
                                 accessibilityRole="text"
-                                ellipsizeMode="clip"
-                                numberOfLines={1}
                                 style={
                                   {
                                     "color": "#4459ff",
@@ -2248,42 +2246,90 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                 }
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Apply"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Apply
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>
@@ -2911,173 +2957,214 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                               showsHorizontalScrollIndicator={false}
                             >
                               <View>
-                                <TouchableOpacity
+                                <View
                                   accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
-                                  onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
+                                  accessibilityState={
                                     {
-                                      "alignItems": "center",
-                                      "alignSelf": "flex-start",
-                                      "backgroundColor": "#b4b4b528",
-                                      "borderColor": "transparent",
-                                      "borderRadius": 12,
-                                      "borderWidth": 1,
-                                      "flexDirection": "row",
-                                      "height": 32,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
                                     }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "alignSelf": "flex-start",
+                                        "backgroundColor": "#b4b4b528",
+                                        "borderColor": "transparent",
+                                        "borderRadius": 12,
+                                        "borderWidth": 1,
+                                        "columnGap": 8,
+                                        "flexDirection": "row",
+                                        "height": 32,
+                                        "justifyContent": "center",
+                                        "minWidth": 80,
+                                        "opacity": 1,
+                                        "overflow": "hidden",
+                                        "paddingLeft": 16,
+                                        "paddingRight": 16,
+                                      },
+                                      {
+                                        "transform": [
+                                          {
+                                            "scale": 1,
+                                          },
+                                        ],
+                                      },
+                                    ]
                                   }
                                 >
                                   <View
-                                    alignItems="center"
-                                    flexDirection="row"
-                                    gap={8}
-                                    style={
-                                      [
-                                        {
-                                          "alignItems": "center",
-                                          "flexDirection": "row",
-                                          "gap": 8,
-                                        },
-                                        undefined,
-                                      ]
-                                    }
+                                    style={{}}
                                   >
                                     <View
-                                      flexDirection="row-reverse"
-                                      gap={0}
+                                      alignItems="center"
+                                      flexDirection="row"
+                                      gap={8}
                                       style={
                                         [
                                           {
-                                            "flexDirection": "row-reverse",
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "gap": 8,
                                           },
                                           undefined,
                                         ]
                                       }
                                     >
                                       <View
+                                        flexDirection="row-reverse"
+                                        gap={0}
                                         style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
+                                          [
+                                            {
+                                              "flexDirection": "row-reverse",
+                                            },
+                                            undefined,
+                                          ]
                                         }
                                       >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
-                                      </View>
-                                      <View
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
-                                        }
-                                      >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
-                                      </View>
-                                      <View
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "backgroundColor": "#ffffff",
-                                            "borderColor": "#ffffff",
-                                            "borderRadius": 4,
-                                            "borderWidth": 1.5,
-                                            "height": 16,
-                                            "justifyContent": "center",
-                                            "marginLeft": -6,
-                                            "overflow": "hidden",
-                                            "width": 16,
-                                          }
-                                        }
-                                      >
-                                        <Image
-                                          onError={[Function]}
-                                          resizeMode="contain"
-                                          source={1}
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                        <View
                                           style={
                                             {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 4,
+                                              "borderWidth": 1.5,
                                               "height": 16,
+                                              "justifyContent": "center",
+                                              "marginLeft": -6,
+                                              "overflow": "hidden",
                                               "width": 16,
                                             }
                                           }
-                                          testID="network-avatar-image"
-                                        />
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 16,
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
                                       </View>
+                                      <Text
+                                        accessibilityRole="text"
+                                        style={
+                                          {
+                                            "color": "#131416",
+                                            "fontFamily": "Geist-Regular",
+                                            "fontSize": 16,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          }
+                                        }
+                                      >
+                                        All networks
+                                      </Text>
+                                      <SvgMock
+                                        color="#131416"
+                                        fill="currentColor"
+                                        height={12}
+                                        name="ArrowDown"
+                                        style={
+                                          {
+                                            "height": 12,
+                                            "width": 12,
+                                          }
+                                        }
+                                        width={12}
+                                      />
                                     </View>
-                                    <Text
-                                      accessibilityRole="text"
-                                      style={
-                                        {
-                                          "color": "#131416",
-                                          "fontFamily": "Geist-Regular",
-                                          "fontSize": 16,
-                                          "letterSpacing": 0,
-                                          "lineHeight": 24,
-                                        }
-                                      }
-                                    >
-                                      All networks
-                                    </Text>
-                                    <SvgMock
-                                      color="#131416"
-                                      fill="currentColor"
-                                      height={12}
-                                      name="ArrowDown"
-                                      style={
-                                        {
-                                          "height": 12,
-                                          "width": 12,
-                                        }
-                                      }
-                                      width={12}
-                                    />
                                   </View>
-                                </TouchableOpacity>
+                                </View>
                               </View>
                             </RCTScrollView>
                             <View

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -1624,12 +1624,7 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                             </View>
                             <TouchableOpacity
                               accessibilityRole="button"
-                              accessible={true}
-                              activeOpacity={1}
-                              onPress={[Function]}
-                              onPressIn={[Function]}
-                              onPressOut={[Function]}
-                              style={
+                              accessibilityState={
                                 {
                                   "alignItems": "center",
                                   "alignSelf": "flex-start",
@@ -1642,9 +1637,57 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                   "paddingHorizontal": 16,
                                 }
                               }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "width": "100%",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
+                              }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
                                   {
                                     "color": "#4459ff",

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/UnsupportedRegionModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/UnsupportedRegionModal.tsx
@@ -11,11 +11,16 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
-  ButtonSize,
+import OldButton, {
+  ButtonSize as OldButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 
 import styleSheet from './UnsupportedRegionModal.styles';
 import { useStyles } from '../../../../../../hooks/useStyles';
@@ -107,8 +112,8 @@ function UnsupportedRegionModal() {
       </View>
 
       <View style={styles.footer}>
-        <Button
-          size={ButtonSize.Lg}
+        <OldButton
+          size={OldButtonSize.Lg}
           onPress={handleSelectDifferentRegion}
           label={strings('deposit.unsupported_region_modal.change_region')}
           variant={ButtonVariants.Link}
@@ -117,10 +122,11 @@ function UnsupportedRegionModal() {
         <Button
           size={ButtonSize.Lg}
           onPress={handleNavigateToBuy}
-          label={strings('deposit.unsupported_region_modal.buy_crypto')}
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
-        />
+          variant={ButtonVariant.Primary}
+          isFullWidth
+        >
+          {strings('deposit.unsupported_region_modal.buy_crypto')}
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -640,42 +640,90 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                                   Change region
                                 </Text>
                               </TouchableOpacity>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Buy crypto"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Buy crypto
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>
@@ -1337,42 +1385,90 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                                   Change region
                                 </Text>
                               </TouchableOpacity>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Buy crypto"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Buy crypto
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/UnsupportedStateModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/UnsupportedStateModal.tsx
@@ -10,11 +10,16 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Button, {
-  ButtonSize,
+import OldButton, {
+  ButtonSize as OldButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 
 import styleSheet from './UnsupportedStateModal.styles';
 import { useStyles } from '../../../../../../hooks/useStyles';
@@ -114,8 +119,8 @@ function UnsupportedStateModal() {
       </View>
 
       <View style={styles.footer}>
-        <Button
-          size={ButtonSize.Lg}
+        <OldButton
+          size={OldButtonSize.Lg}
           onPress={handleSelectDifferentState}
           label={strings('deposit.unsupported_state_modal.change_state')}
           variant={ButtonVariants.Link}
@@ -124,10 +129,11 @@ function UnsupportedStateModal() {
         <Button
           size={ButtonSize.Lg}
           onPress={handleTryAnotherOption}
-          label={strings('deposit.unsupported_state_modal.try_another_option')}
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
-        />
+          variant={ButtonVariant.Primary}
+          isFullWidth
+        >
+          {strings('deposit.unsupported_state_modal.try_another_option')}
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -644,42 +644,90 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                                   Change region
                                 </Text>
                               </TouchableOpacity>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Try another option"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Try another option
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                             </View>
                           </View>
                         </View>

--- a/app/components/UI/Ramp/Deposit/Views/OrderProcessing/OrderProcessing.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/OrderProcessing/OrderProcessing.tsx
@@ -17,10 +17,11 @@ import { strings } from '../../../../../../../locales/i18n';
 import DepositOrderContent from '../../components/DepositOrderContent/DepositOrderContent';
 import { FIAT_ORDER_STATES } from '../../../../../../constants/on-ramp';
 import { TRANSAK_SUPPORT_URL } from '../../constants';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Loader from '../../../../../../component-library/components-temp/Loader/Loader';
 import { ORDER_PROCESSING_TEST_IDS } from './OrderProcessing.testIds';
 
@@ -98,27 +99,25 @@ const OrderProcessing = () => {
                 order.state === FIAT_ORDER_STATES.FAILED) && (
                 <Button
                   style={styles.button}
-                  variant={ButtonVariants.Secondary}
+                  variant={ButtonVariant.Secondary}
                   size={ButtonSize.Lg}
                   onPress={handleContactSupport}
-                  label={strings(
-                    'deposit.order_processing.contact_support_button',
-                  )}
-                />
+                >
+                  {strings('deposit.order_processing.contact_support_button')}
+                </Button>
               )}
               <Button
                 style={styles.button}
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
                 onPress={handleMainAction}
                 testID={ORDER_PROCESSING_TEST_IDS.MAIN_ACTION_BUTTON}
-                label={
-                  order.state === FIAT_ORDER_STATES.CANCELLED ||
-                  order.state === FIAT_ORDER_STATES.FAILED
-                    ? strings('deposit.order_processing.error_button')
-                    : strings('deposit.order_processing.button')
-                }
-              />
+              >
+                {order.state === FIAT_ORDER_STATES.CANCELLED ||
+                order.state === FIAT_ORDER_STATES.FAILED
+                  ? strings('deposit.order_processing.error_button')
+                  : strings('deposit.order_processing.button')}
+              </Button>
             </View>
           </View>
         </ScreenLayout.Content>

--- a/app/components/UI/Ramp/Deposit/Views/OrderProcessing/__snapshots__/OrderProcessing.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/OrderProcessing/__snapshots__/OrderProcessing.test.tsx.snap
@@ -549,44 +549,94 @@ exports[`OrderProcessing Component renders created state correctly 1`] = `
               }
             }
           >
-            <TouchableOpacity
+            <View
+              accessibilityLabel="Close"
               accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#131416",
-                  "borderRadius": 12,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "#131416",
+                    "borderRadius": 12,
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "minWidth": 80,
+                    "opacity": 1,
+                    "overflow": "hidden",
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                  },
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
               testID="main-action-button"
             >
               <Text
                 accessibilityRole="text"
+                ellipsizeMode="clip"
+                numberOfLines={1}
                 style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#ffffff",
+                      "flexGrow": 0,
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "textAlign": "center",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 Close
               </Text>
-            </TouchableOpacity>
+            </View>
           </View>
         </View>
       </View>
@@ -1140,83 +1190,183 @@ exports[`OrderProcessing Component renders error state correctly 1`] = `
               }
             }
           >
-            <TouchableOpacity
+            <View
+              accessibilityLabel="Contact support"
               accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#b4b4b528",
-                  "borderColor": "transparent",
-                  "borderRadius": 12,
-                  "borderWidth": 1,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "#b4b4b528",
+                    "borderColor": "transparent",
+                    "borderRadius": 12,
+                    "borderWidth": 1,
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "minWidth": 80,
+                    "opacity": 1,
+                    "overflow": "hidden",
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                  },
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
             >
               <Text
                 accessibilityRole="text"
+                ellipsizeMode="clip"
+                numberOfLines={1}
                 style={
-                  {
-                    "color": "#131416",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#131416",
+                      "flexGrow": 0,
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "textAlign": "center",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 Contact support
               </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
+            </View>
+            <View
+              accessibilityLabel="Try again"
               accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#131416",
-                  "borderRadius": 12,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "#131416",
+                    "borderRadius": 12,
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "minWidth": 80,
+                    "opacity": 1,
+                    "overflow": "hidden",
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                  },
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
               testID="main-action-button"
             >
               <Text
                 accessibilityRole="text"
+                ellipsizeMode="clip"
+                numberOfLines={1}
                 style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#ffffff",
+                      "flexGrow": 0,
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "textAlign": "center",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 Try again
               </Text>
-            </TouchableOpacity>
+            </View>
           </View>
         </View>
       </View>
@@ -1824,44 +1974,94 @@ exports[`OrderProcessing Component renders processing state correctly 1`] = `
               }
             }
           >
-            <TouchableOpacity
+            <View
+              accessibilityLabel="Close"
               accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#131416",
-                  "borderRadius": 12,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "#131416",
+                    "borderRadius": 12,
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "minWidth": 80,
+                    "opacity": 1,
+                    "overflow": "hidden",
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                  },
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
               testID="main-action-button"
             >
               <Text
                 accessibilityRole="text"
+                ellipsizeMode="clip"
+                numberOfLines={1}
                 style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#ffffff",
+                      "flexGrow": 0,
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "textAlign": "center",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 Close
               </Text>
-            </TouchableOpacity>
+            </View>
           </View>
         </View>
       </View>
@@ -2415,44 +2615,94 @@ exports[`OrderProcessing Component renders success state correctly 1`] = `
               }
             }
           >
-            <TouchableOpacity
+            <View
+              accessibilityLabel="Close"
               accessibilityRole="button"
-              accessible={true}
-              activeOpacity={1}
-              onPress={[Function]}
-              onPressIn={[Function]}
-              onPressOut={[Function]}
-              style={
+              accessibilityState={
                 {
-                  "alignItems": "center",
-                  "alignSelf": "flex-start",
-                  "backgroundColor": "#131416",
-                  "borderRadius": 12,
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "height": 48,
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                  "paddingHorizontal": 16,
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
                 }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "#131416",
+                    "borderRadius": 12,
+                    "columnGap": 8,
+                    "flexDirection": "row",
+                    "height": 48,
+                    "justifyContent": "center",
+                    "minWidth": 80,
+                    "opacity": 1,
+                    "overflow": "hidden",
+                    "paddingLeft": 16,
+                    "paddingRight": 16,
+                  },
+                  {
+                    "flex": 1,
+                  },
+                  {
+                    "transform": [
+                      {
+                        "scale": 1,
+                      },
+                    ],
+                  },
+                ]
               }
               testID="main-action-button"
             >
               <Text
                 accessibilityRole="text"
+                ellipsizeMode="clip"
+                numberOfLines={1}
                 style={
-                  {
-                    "color": "#ffffff",
-                    "fontFamily": "Geist-Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
+                  [
+                    {
+                      "color": "#ffffff",
+                      "flexGrow": 0,
+                      "flexShrink": 1,
+                      "flexWrap": "wrap",
+                      "fontFamily": "Geist-Medium",
+                      "fontSize": 16,
+                      "fontWeight": 400,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "textAlign": "center",
+                    },
+                    undefined,
+                  ]
                 }
               >
                 Close
               </Text>
-            </TouchableOpacity>
+            </View>
           </View>
         </View>
       </View>

--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/OtpCode.tsx
@@ -28,16 +28,17 @@ import { useDepositSDK } from '../../sdk';
 import Row from '../../../Aggregator/components/Row';
 import { TRANSAK_SUPPORT_URL } from '../../constants';
 import PoweredByTransak from '../../components/PoweredByTransak';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+  Box,
+  BoxAlignItems,
+} from '@metamask/design-system-react-native';
 import Logger from '../../../../../../util/Logger';
 import useAnalytics from '../../../hooks/useAnalytics';
 import { createBuildQuoteNavDetails } from '../../../Deposit/Views/BuildQuote/BuildQuote';
 import { trace, TraceName } from '../../../../../../util/trace';
-import { Box, BoxAlignItems } from '@metamask/design-system-react-native';
 import { OTP_CODE_TEST_IDS } from './OtpCode.testIds';
 
 export interface OtpCodeParams {
@@ -357,13 +358,14 @@ const OtpCode = () => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleSubmit}
-            label={strings('deposit.otp_code.submit_button')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-            loading={isLoading}
+            variant={ButtonVariant.Primary}
+            isFullWidth
+            isLoading={isLoading}
             isDisabled={isLoading || value.length !== CELL_COUNT}
             testID={OTP_CODE_TEST_IDS.SUBMIT_BUTTON}
-          />
+          >
+            {strings('deposit.otp_code.submit_button')}
+          </Button>
           <PoweredByTransak name="powered-by-transak-logo" />
         </ScreenLayout.Content>
       </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/OtpCode/__snapshots__/OtpCode.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/OtpCode/__snapshots__/OtpCode.test.tsx.snap
@@ -826,46 +826,91 @@ exports[`OtpCode Screen calls resendOtp when resend link is clicked and properly
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Submit"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={true}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": true,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 0.5,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="otp-code-submit-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Submit
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -1739,46 +1784,91 @@ exports[`OtpCode Screen render matches snapshot 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Submit"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={true}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": true,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 0.5,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="otp-code-submit-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Submit
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -2632,46 +2722,91 @@ exports[`OtpCode Screen renders cooldown timer snapshot after resending OTP 1`] 
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Submit"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={true}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": true,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 0.5,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="otp-code-submit-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Submit
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -3571,45 +3706,91 @@ exports[`OtpCode Screen renders error snapshot when API call fails 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Submit"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={false}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="otp-code-submit-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Submit
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"
@@ -4483,46 +4664,91 @@ exports[`OtpCode Screen renders resend error snapshot when resend fails 1`] = `
                                 ]
                               }
                             >
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Submit"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                disabled={true}
-                                loading={false}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "opacity": 0.5,
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": true,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 0.5,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                                 testID="otp-code-submit-button"
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Submit
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"

--- a/app/components/UI/Ramp/Deposit/Views/VerifyIdentity/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/VerifyIdentity/VerifyIdentity.tsx
@@ -14,11 +14,11 @@ import { getDepositNavbarOptions } from '../../../../Navbar';
 import { strings } from '../../../../../../../locales/i18n';
 import VerifyIdentityImage from '../../assets/verifyIdentityIllustration.png';
 import PoweredByTransak from '../../components/PoweredByTransak';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import {
   TRANSAK_TERMS_URL_US,
   TRANSAK_TERMS_URL_WORLD,
@@ -161,10 +161,11 @@ const VerifyIdentity = () => {
           <Button
             size={ButtonSize.Lg}
             onPress={handleSubmit}
-            label={strings('deposit.verify_identity.button')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-          />
+            variant={ButtonVariant.Primary}
+            isFullWidth
+          >
+            {strings('deposit.verify_identity.button')}
+          </Button>
           <PoweredByTransak name="powered-by-transak-logo" />
         </ScreenLayout.Content>
       </ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/VerifyIdentity/__snapshots__/VerifyIdentity.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/VerifyIdentity/__snapshots__/VerifyIdentity.test.tsx.snap
@@ -568,42 +568,90 @@ exports[`VerifyIdentity Component renders verify identity screen with all conten
                                 </Text>
                                 .
                               </Text>
-                              <TouchableOpacity
+                              <View
+                                accessibilityLabel="Agree and continue"
                                 accessibilityRole="button"
-                                accessible={true}
-                                activeOpacity={1}
-                                onPress={[Function]}
-                                onPressIn={[Function]}
-                                onPressOut={[Function]}
-                                style={
+                                accessibilityState={
                                   {
-                                    "alignItems": "center",
-                                    "alignSelf": "stretch",
-                                    "backgroundColor": "#131416",
-                                    "borderRadius": 12,
-                                    "flexDirection": "row",
-                                    "height": 48,
-                                    "justifyContent": "center",
-                                    "overflow": "hidden",
-                                    "paddingHorizontal": 16,
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": false,
+                                    "expanded": undefined,
+                                    "selected": undefined,
                                   }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                style={
+                                  [
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#131416",
+                                      "borderRadius": 12,
+                                      "columnGap": 8,
+                                      "flexDirection": "row",
+                                      "height": 48,
+                                      "justifyContent": "center",
+                                      "minWidth": 80,
+                                      "opacity": 1,
+                                      "overflow": "hidden",
+                                      "paddingLeft": 16,
+                                      "paddingRight": 16,
+                                      "width": "100%",
+                                    },
+                                    {
+                                      "transform": [
+                                        {
+                                          "scale": 1,
+                                        },
+                                      ],
+                                    },
+                                  ]
                                 }
                               >
                                 <Text
                                   accessibilityRole="text"
+                                  ellipsizeMode="clip"
+                                  numberOfLines={1}
                                   style={
-                                    {
-                                      "color": "#ffffff",
-                                      "fontFamily": "Geist-Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
+                                    [
+                                      {
+                                        "color": "#ffffff",
+                                        "flexGrow": 0,
+                                        "flexShrink": 1,
+                                        "flexWrap": "wrap",
+                                        "fontFamily": "Geist-Medium",
+                                        "fontSize": 16,
+                                        "fontWeight": 400,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                        "textAlign": "center",
+                                      },
+                                      undefined,
+                                    ]
                                   }
                                 >
                                   Agree and continue
                                 </Text>
-                              </TouchableOpacity>
+                              </View>
                               <SvgMock
                                 fill="currentColor"
                                 name="powered-by-transak-logo"

--- a/app/components/UI/Ramp/Deposit/components/ErrorView/ErrorView.tsx
+++ b/app/components/UI/Ramp/Deposit/components/ErrorView/ErrorView.tsx
@@ -12,10 +12,10 @@ import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
 import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button/Button.types';
-import Button from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './ErrorView.styles';
 import ScreenLayout from '../../../Aggregator/components/ScreenLayout';
@@ -60,11 +60,12 @@ function ErrorView({ description, title, ctaLabel, ctaOnPress }: Props) {
         {ctaOnPress && (
           <Button
             style={styles.button}
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             onPress={ctaOnPress}
-            label={ctaLabel || strings('deposit.error_view.try_again')}
             size={ButtonSize.Lg}
-          />
+          >
+            {ctaLabel || strings('deposit.error_view.try_again')}
+          </Button>
         )}
       </ScreenLayout.Content>
     </ScreenLayout>

--- a/app/components/UI/Ramp/Deposit/components/ErrorView/__snapshots__/ErrorView.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/ErrorView/__snapshots__/ErrorView.test.tsx.snap
@@ -405,8 +405,6 @@ exports[`ErrorView Component renders with all props and matches snapshot 1`] = `
                             </View>
                             <Text
                               accessibilityRole="text"
-                              ellipsizeMode="clip"
-                              numberOfLines={1}
                               style={
                                 {
                                   "color": "#ca3542",
@@ -435,42 +433,93 @@ exports[`ErrorView Component renders with all props and matches snapshot 1`] = `
                             >
                               Custom error description
                             </Text>
-                            <TouchableOpacity
+                            <View
+                              accessibilityLabel="custom cta label"
                               accessibilityRole="button"
-                              accessible={true}
-                              activeOpacity={1}
-                              onPress={[MockFunction]}
-                              onPressIn={[Function]}
-                              onPressOut={[Function]}
-                              style={
+                              accessibilityState={
                                 {
-                                  "alignItems": "center",
-                                  "alignSelf": "center",
-                                  "backgroundColor": "#131416",
-                                  "borderRadius": 12,
-                                  "flexDirection": "row",
-                                  "height": 48,
-                                  "justifyContent": "center",
-                                  "overflow": "hidden",
-                                  "paddingHorizontal": 16,
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": false,
+                                  "expanded": undefined,
+                                  "selected": undefined,
                                 }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              style={
+                                [
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "flex-start",
+                                    "backgroundColor": "#131416",
+                                    "borderRadius": 12,
+                                    "columnGap": 8,
+                                    "flexDirection": "row",
+                                    "height": 48,
+                                    "justifyContent": "center",
+                                    "minWidth": 80,
+                                    "opacity": 1,
+                                    "overflow": "hidden",
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                  },
+                                  {
+                                    "alignSelf": "center",
+                                  },
+                                  {
+                                    "transform": [
+                                      {
+                                        "scale": 1,
+                                      },
+                                    ],
+                                  },
+                                ]
                               }
                             >
                               <Text
                                 accessibilityRole="text"
+                                ellipsizeMode="clip"
+                                numberOfLines={1}
                                 style={
-                                  {
-                                    "color": "#ffffff",
-                                    "fontFamily": "Geist-Medium",
-                                    "fontSize": 16,
-                                    "letterSpacing": 0,
-                                    "lineHeight": 24,
-                                  }
+                                  [
+                                    {
+                                      "color": "#ffffff",
+                                      "flexGrow": 0,
+                                      "flexShrink": 1,
+                                      "flexWrap": "wrap",
+                                      "fontFamily": "Geist-Medium",
+                                      "fontSize": 16,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                      "textAlign": "center",
+                                    },
+                                    undefined,
+                                  ]
                                 }
                               >
                                 custom cta label
                               </Text>
-                            </TouchableOpacity>
+                            </View>
                           </View>
                         </View>
                       </RNCSafeAreaView>

--- a/app/components/UI/Ramp/Deposit/components/ErrorView/__snapshots__/ErrorView.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/ErrorView/__snapshots__/ErrorView.test.tsx.snap
@@ -405,6 +405,8 @@ exports[`ErrorView Component renders with all props and matches snapshot 1`] = `
                             </View>
                             <Text
                               accessibilityRole="text"
+                              ellipsizeMode="clip"
+                              numberOfLines={1}
                               style={
                                 {
                                   "color": "#ca3542",

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/NetworksFilterBar.tsx
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/NetworksFilterBar.tsx
@@ -116,7 +116,10 @@ function NetworksFilterBar({
                   }
                 }}
               >
-                <>
+                <Box
+                  flexDirection={FlexDirection.Row}
+                  alignItems={AlignItems.center}
+                >
                   {isSelected && (
                     <AvatarNetwork
                       key={chainId}
@@ -131,7 +134,7 @@ function NetworksFilterBar({
                   >
                     {displayName}
                   </Text>
-                </>
+                </Box>
               </Button>
             );
           })}

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/NetworksFilterBar.tsx
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/NetworksFilterBar.tsx
@@ -6,10 +6,11 @@ import { AvatarSize } from '../../../../../../component-library/components/Avata
 import AvatarNetwork from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 import { Box } from '../../../../Box/Box';
 import { AlignItems, FlexDirection } from '../../../../Box/box.types';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
   TextVariant,
@@ -76,24 +77,23 @@ function NetworksFilterBar({
       {networkFilter && networkFilter.length !== networks.length ? (
         <>
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Sm}
-            label={
-              <Box
-                flexDirection={FlexDirection.Row}
-                alignItems={AlignItems.center}
-                gap={8}
-              >
-                <Text variant={TextVariant.BodyMD}>See all</Text>
-                <Icon
-                  name={IconName.ArrowDown}
-                  size={IconSize.Xs}
-                  color={colors.icon.default}
-                />
-              </Box>
-            }
             onPress={() => setIsEditingNetworkFilter(true)}
-          />
+          >
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={8}
+            >
+              <Text variant={TextVariant.BodyMD}>See all</Text>
+              <Icon
+                name={IconName.ArrowDown}
+                size={IconSize.Xs}
+                color={colors.icon.default}
+              />
+            </Box>
+          </Button>
           {networks.map((chainId) => {
             const isSelected = networkFilter.includes(chainId);
             const { depositNetworkName, networkName, networkImageSource } =
@@ -103,27 +103,9 @@ function NetworksFilterBar({
               <Button
                 key={chainId}
                 variant={
-                  isSelected ? ButtonVariants.Primary : ButtonVariants.Secondary
+                  isSelected ? ButtonVariant.Primary : ButtonVariant.Secondary
                 }
                 size={ButtonSize.Sm}
-                label={
-                  <>
-                    {isSelected && (
-                      <AvatarNetwork
-                        key={chainId}
-                        imageSource={networkImageSource}
-                        name={displayName}
-                        size={AvatarSize.Xs}
-                        style={styles.selectedNetworkIcon}
-                      />
-                    )}
-                    <Text
-                      color={isSelected ? TextColor.Inverse : TextColor.Default}
-                    >
-                      {displayName}
-                    </Text>
-                  </>
-                }
                 onPress={() => {
                   if (isSelected && networkFilter.length > 1) {
                     setNetworkFilter((prev) =>
@@ -133,36 +115,52 @@ function NetworksFilterBar({
                     setNetworkFilter([chainId]);
                   }
                 }}
-              />
+              >
+                <>
+                  {isSelected && (
+                    <AvatarNetwork
+                      key={chainId}
+                      imageSource={networkImageSource}
+                      name={displayName}
+                      size={AvatarSize.Xs}
+                      style={styles.selectedNetworkIcon}
+                    />
+                  )}
+                  <Text
+                    color={isSelected ? TextColor.Inverse : TextColor.Default}
+                  >
+                    {displayName}
+                  </Text>
+                </>
+              </Button>
             );
           })}
         </>
       ) : (
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariant.Secondary}
           size={ButtonSize.Sm}
-          label={
-            <Box
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
-              gap={8}
-            >
-              {allNetworksIcons}
-              <Text variant={TextVariant.BodyMD}>
-                {strings('deposit.networks_filter_bar.all_networks')}
-              </Text>
-              <Icon
-                name={IconName.ArrowDown}
-                size={IconSize.Xs}
-                color={colors.icon.default}
-              />
-            </Box>
-          }
           onPress={() => {
             setNetworkFilter(networks);
             setIsEditingNetworkFilter(true);
           }}
-        />
+        >
+          <Box
+            flexDirection={FlexDirection.Row}
+            alignItems={AlignItems.center}
+            gap={8}
+          >
+            {allNetworksIcons}
+            <Text variant={TextVariant.BodyMD}>
+              {strings('deposit.networks_filter_bar.all_networks')}
+            </Text>
+            <Icon
+              name={IconName.ArrowDown}
+              size={IconSize.Xs}
+              color={colors.icon.default}
+            />
+          </Box>
+        </Button>
       )}
     </ScrollView>
   );

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/__snapshots__/NetworksFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/__snapshots__/NetworksFilterBar.test.tsx.snap
@@ -18,43 +18,384 @@ exports[`NetworksFilterBar renders correctly when networkFilter is a subset of u
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    <TouchableOpacity
+    <View
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flexDirection": "row",
-          "height": 32,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
     >
       <View
-        alignItems="center"
-        flexDirection="row"
-        gap={8}
-        style={
-          [
+        style={{}}
+      >
+        <View
+          alignItems="center"
+          flexDirection="row"
+          gap={8}
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 8,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            See all
+          </Text>
+          <SvgMock
+            color="#131416"
+            fill="currentColor"
+            height={12}
+            name="ArrowDown"
+            style={
+              {
+                "height": 12,
+                "width": 12,
+              }
+            }
+            width={12}
+          />
+        </View>
+      </View>
+    </View>
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#131416",
+            "borderRadius": 12,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
+      }
+    >
+      <View
+        style={{}}
+      >
+        <View
+          style={
             {
               "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 8,
-            },
-            undefined,
-          ]
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
+          }
+        >
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
+            style={
+              {
+                "height": 16,
+                "width": 16,
+              }
+            }
+            testID="network-avatar-image"
+          />
+        </View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist-Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Ethereum
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#131416",
+            "borderRadius": 12,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
+      }
+    >
+      <View
+        style={{}}
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
+          }
+        >
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
+            style={
+              {
+                "height": 16,
+                "width": 16,
+              }
+            }
+            testID="network-avatar-image"
+          />
+        </View>
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist-Regular",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Linea
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
+      }
+    >
+      <View
+        style={{}}
       >
         <Text
           accessibilityRole="text"
@@ -68,187 +409,10 @@ exports[`NetworksFilterBar renders correctly when networkFilter is a subset of u
             }
           }
         >
-          See all
+          BNB Smart Chain
         </Text>
-        <SvgMock
-          color="#131416"
-          fill="currentColor"
-          height={12}
-          name="ArrowDown"
-          style={
-            {
-              "height": 12,
-              "width": 12,
-            }
-          }
-          width={12}
-        />
       </View>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#131416",
-          "borderRadius": 12,
-          "flexDirection": "row",
-          "height": 32,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
-        }
-      }
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderRadius": 4,
-            "height": 16,
-            "justifyContent": "center",
-            "marginRight": 8,
-            "overflow": "hidden",
-            "width": 16,
-          }
-        }
-      >
-        <Image
-          onError={[Function]}
-          resizeMode="contain"
-          source={1}
-          style={
-            {
-              "height": 16,
-              "width": 16,
-            }
-          }
-          testID="network-avatar-image"
-        />
-      </View>
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#ffffff",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
-        }
-      >
-        Ethereum
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#131416",
-          "borderRadius": 12,
-          "flexDirection": "row",
-          "height": 32,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
-        }
-      }
-    >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderRadius": 4,
-            "height": 16,
-            "justifyContent": "center",
-            "marginRight": 8,
-            "overflow": "hidden",
-            "width": 16,
-          }
-        }
-      >
-        <Image
-          onError={[Function]}
-          resizeMode="contain"
-          source={1}
-          style={
-            {
-              "height": 16,
-              "width": 16,
-            }
-          }
-          testID="network-avatar-image"
-        />
-      </View>
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#ffffff",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
-        }
-      >
-        Linea
-      </Text>
-    </TouchableOpacity>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flexDirection": "row",
-          "height": 32,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
-        }
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#131416",
-            "fontFamily": "Geist-Regular",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
-        }
-      >
-        BNB Smart Chain
-      </Text>
-    </TouchableOpacity>
+    </View>
   </View>
 </RCTScrollView>
 `;
@@ -271,173 +435,214 @@ exports[`NetworksFilterBar renders correctly when networkFilter is null 1`] = `
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    <TouchableOpacity
+    <View
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flexDirection": "row",
-          "height": 32,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
     >
       <View
-        alignItems="center"
-        flexDirection="row"
-        gap={8}
-        style={
-          [
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 8,
-            },
-            undefined,
-          ]
-        }
+        style={{}}
       >
         <View
-          flexDirection="row-reverse"
-          gap={0}
+          alignItems="center"
+          flexDirection="row"
+          gap={8}
           style={
             [
               {
-                "flexDirection": "row-reverse",
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 8,
               },
               undefined,
             ]
           }
         >
           <View
+            flexDirection="row-reverse"
+            gap={0}
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#ffffff",
-                "borderRadius": 4,
-                "borderWidth": 1.5,
-                "height": 16,
-                "justifyContent": "center",
-                "marginLeft": -6,
-                "overflow": "hidden",
-                "width": 16,
-              }
+              [
+                {
+                  "flexDirection": "row-reverse",
+                },
+                undefined,
+              ]
             }
           >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
+            <View
               style={
                 {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#ffffff",
+                  "borderRadius": 4,
+                  "borderWidth": 1.5,
                   "height": 16,
+                  "justifyContent": "center",
+                  "marginLeft": -6,
+                  "overflow": "hidden",
                   "width": 16,
                 }
               }
-              testID="network-avatar-image"
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#ffffff",
-                "borderRadius": 4,
-                "borderWidth": 1.5,
-                "height": 16,
-                "justifyContent": "center",
-                "marginLeft": -6,
-                "overflow": "hidden",
-                "width": 16,
-              }
-            }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
+            >
+              <Image
+                onError={[Function]}
+                resizeMode="contain"
+                source={1}
+                style={
+                  {
+                    "height": 16,
+                    "width": 16,
+                  }
+                }
+                testID="network-avatar-image"
+              />
+            </View>
+            <View
               style={
                 {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#ffffff",
+                  "borderRadius": 4,
+                  "borderWidth": 1.5,
                   "height": 16,
+                  "justifyContent": "center",
+                  "marginLeft": -6,
+                  "overflow": "hidden",
                   "width": 16,
                 }
               }
-              testID="network-avatar-image"
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#ffffff",
-                "borderRadius": 4,
-                "borderWidth": 1.5,
-                "height": 16,
-                "justifyContent": "center",
-                "marginLeft": -6,
-                "overflow": "hidden",
-                "width": 16,
-              }
-            }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
+            >
+              <Image
+                onError={[Function]}
+                resizeMode="contain"
+                source={1}
+                style={
+                  {
+                    "height": 16,
+                    "width": 16,
+                  }
+                }
+                testID="network-avatar-image"
+              />
+            </View>
+            <View
               style={
                 {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#ffffff",
+                  "borderRadius": 4,
+                  "borderWidth": 1.5,
                   "height": 16,
+                  "justifyContent": "center",
+                  "marginLeft": -6,
+                  "overflow": "hidden",
                   "width": 16,
                 }
               }
-              testID="network-avatar-image"
-            />
+            >
+              <Image
+                onError={[Function]}
+                resizeMode="contain"
+                source={1}
+                style={
+                  {
+                    "height": 16,
+                    "width": 16,
+                  }
+                }
+                testID="network-avatar-image"
+              />
+            </View>
           </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            All networks
+          </Text>
+          <SvgMock
+            color="#131416"
+            fill="currentColor"
+            height={12}
+            name="ArrowDown"
+            style={
+              {
+                "height": 12,
+                "width": 12,
+              }
+            }
+            width={12}
+          />
         </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          All networks
-        </Text>
-        <SvgMock
-          color="#131416"
-          fill="currentColor"
-          height={12}
-          name="ArrowDown"
-          style={
-            {
-              "height": 12,
-              "width": 12,
-            }
-          }
-          width={12}
-        />
       </View>
-    </TouchableOpacity>
+    </View>
   </View>
 </RCTScrollView>
 `;
@@ -460,173 +665,214 @@ exports[`NetworksFilterBar renders correctly when networkFilter is the same as u
   showsHorizontalScrollIndicator={false}
 >
   <View>
-    <TouchableOpacity
+    <View
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "flex-start",
-          "backgroundColor": "#b4b4b528",
-          "borderColor": "transparent",
-          "borderRadius": 12,
-          "borderWidth": 1,
-          "flexDirection": "row",
-          "height": 32,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
     >
       <View
-        alignItems="center"
-        flexDirection="row"
-        gap={8}
-        style={
-          [
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 8,
-            },
-            undefined,
-          ]
-        }
+        style={{}}
       >
         <View
-          flexDirection="row-reverse"
-          gap={0}
+          alignItems="center"
+          flexDirection="row"
+          gap={8}
           style={
             [
               {
-                "flexDirection": "row-reverse",
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 8,
               },
               undefined,
             ]
           }
         >
           <View
+            flexDirection="row-reverse"
+            gap={0}
             style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#ffffff",
-                "borderRadius": 4,
-                "borderWidth": 1.5,
-                "height": 16,
-                "justifyContent": "center",
-                "marginLeft": -6,
-                "overflow": "hidden",
-                "width": 16,
-              }
+              [
+                {
+                  "flexDirection": "row-reverse",
+                },
+                undefined,
+              ]
             }
           >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
+            <View
               style={
                 {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#ffffff",
+                  "borderRadius": 4,
+                  "borderWidth": 1.5,
                   "height": 16,
+                  "justifyContent": "center",
+                  "marginLeft": -6,
+                  "overflow": "hidden",
                   "width": 16,
                 }
               }
-              testID="network-avatar-image"
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#ffffff",
-                "borderRadius": 4,
-                "borderWidth": 1.5,
-                "height": 16,
-                "justifyContent": "center",
-                "marginLeft": -6,
-                "overflow": "hidden",
-                "width": 16,
-              }
-            }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
+            >
+              <Image
+                onError={[Function]}
+                resizeMode="contain"
+                source={1}
+                style={
+                  {
+                    "height": 16,
+                    "width": 16,
+                  }
+                }
+                testID="network-avatar-image"
+              />
+            </View>
+            <View
               style={
                 {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#ffffff",
+                  "borderRadius": 4,
+                  "borderWidth": 1.5,
                   "height": 16,
+                  "justifyContent": "center",
+                  "marginLeft": -6,
+                  "overflow": "hidden",
                   "width": 16,
                 }
               }
-              testID="network-avatar-image"
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderColor": "#ffffff",
-                "borderRadius": 4,
-                "borderWidth": 1.5,
-                "height": 16,
-                "justifyContent": "center",
-                "marginLeft": -6,
-                "overflow": "hidden",
-                "width": 16,
-              }
-            }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
+            >
+              <Image
+                onError={[Function]}
+                resizeMode="contain"
+                source={1}
+                style={
+                  {
+                    "height": 16,
+                    "width": 16,
+                  }
+                }
+                testID="network-avatar-image"
+              />
+            </View>
+            <View
               style={
                 {
+                  "alignItems": "center",
+                  "backgroundColor": "#ffffff",
+                  "borderColor": "#ffffff",
+                  "borderRadius": 4,
+                  "borderWidth": 1.5,
                   "height": 16,
+                  "justifyContent": "center",
+                  "marginLeft": -6,
+                  "overflow": "hidden",
                   "width": 16,
                 }
               }
-              testID="network-avatar-image"
-            />
+            >
+              <Image
+                onError={[Function]}
+                resizeMode="contain"
+                source={1}
+                style={
+                  {
+                    "height": 16,
+                    "width": 16,
+                  }
+                }
+                testID="network-avatar-image"
+              />
+            </View>
           </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            All networks
+          </Text>
+          <SvgMock
+            color="#131416"
+            fill="currentColor"
+            height={12}
+            name="ArrowDown"
+            style={
+              {
+                "height": 12,
+                "width": 12,
+              }
+            }
+            width={12}
+          />
         </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          All networks
-        </Text>
-        <SvgMock
-          color="#131416"
-          fill="currentColor"
-          height={12}
-          name="ArrowDown"
-          style={
-            {
-              "height": 12,
-              "width": 12,
-            }
-          }
-          width={12}
-        />
       </View>
-    </TouchableOpacity>
+    </View>
   </View>
 </RCTScrollView>
 `;

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/__snapshots__/NetworksFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterBar/__snapshots__/NetworksFilterBar.test.tsx.snap
@@ -188,46 +188,60 @@ exports[`NetworksFilterBar renders correctly when networkFilter is a subset of u
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "marginRight": 8,
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
-        </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#ffffff",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
             }
-          }
-        >
-          Ethereum
-        </Text>
+          >
+            Ethereum
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -292,46 +306,60 @@ exports[`NetworksFilterBar renders correctly when networkFilter is a subset of u
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "marginRight": 8,
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
-        </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#ffffff",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
             }
-          }
-        >
-          Linea
-        </Text>
+          >
+            Linea
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -397,20 +425,34 @@ exports[`NetworksFilterBar renders correctly when networkFilter is a subset of u
       <View
         style={{}}
       >
-        <Text
-          accessibilityRole="text"
+        <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "color": "#131416",
-              "fontFamily": "Geist-Regular",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          BNB Smart Chain
-        </Text>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            BNB Smart Chain
+          </Text>
+        </View>
       </View>
     </View>
   </View>

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/NetworksFilterSelector.tsx
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/NetworksFilterSelector.tsx
@@ -7,11 +7,15 @@ import styleSheet from './NetworksFilterSelector.styles';
 
 import AvatarNetwork from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
-import Button, {
-  ButtonSize,
+import OldButton, {
+  ButtonSize as OldButtonSize,
   ButtonVariants,
-  ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import Checkbox from '../../../../../../component-library/components/Checkbox';
 import ListItemColumn, {
   WidthType,
@@ -58,9 +62,9 @@ function NetworksFilterSelector({
   );
   return (
     <>
-      <Button
+      <OldButton
         variant={ButtonVariants.Link}
-        size={ButtonSize.Sm}
+        size={OldButtonSize.Sm}
         label={
           networks.length === networkFilter?.length
             ? strings('deposit.networks_filter_selector.deselect_all')
@@ -104,10 +108,9 @@ function NetworksFilterSelector({
       ></FlatList>
       <View style={styles.buttonContainer}>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          label={strings('deposit.networks_filter_selector.apply')}
+          isFullWidth
           onPress={() => {
             if (
               networkFilter?.length === networks.length ||
@@ -117,7 +120,9 @@ function NetworksFilterSelector({
             }
             setIsEditingNetworkFilter(false);
           }}
-        />
+        >
+          {strings('deposit.networks_filter_selector.apply')}
+        </Button>
       </View>
     </>
   );

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/__snapshots__/NetworksFilterSelector.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/__snapshots__/NetworksFilterSelector.test.tsx.snap
@@ -569,42 +569,90 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is a subset
       }
     }
   >
-    <TouchableOpacity
+    <View
+      accessibilityLabel="Apply"
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "stretch",
-          "backgroundColor": "#131416",
-          "borderRadius": 12,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#131416",
+            "borderRadius": 12,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "width": "100%",
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
     >
       <Text
         accessibilityRole="text"
+        ellipsizeMode="clip"
+        numberOfLines={1}
         style={
-          {
-            "color": "#ffffff",
-            "fontFamily": "Geist-Medium",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
+          [
+            {
+              "color": "#ffffff",
+              "flexGrow": 0,
+              "flexShrink": 1,
+              "flexWrap": "wrap",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 16,
+              "fontWeight": 400,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+              "textAlign": "center",
+            },
+            undefined,
+          ]
         }
       >
         Apply
       </Text>
-    </TouchableOpacity>
+    </View>
   </View>,
 ]
 `;
@@ -1146,42 +1194,90 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is null 1`]
       }
     }
   >
-    <TouchableOpacity
+    <View
+      accessibilityLabel="Apply"
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "stretch",
-          "backgroundColor": "#131416",
-          "borderRadius": 12,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#131416",
+            "borderRadius": 12,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "width": "100%",
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
     >
       <Text
         accessibilityRole="text"
+        ellipsizeMode="clip"
+        numberOfLines={1}
         style={
-          {
-            "color": "#ffffff",
-            "fontFamily": "Geist-Medium",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
+          [
+            {
+              "color": "#ffffff",
+              "flexGrow": 0,
+              "flexShrink": 1,
+              "flexWrap": "wrap",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 16,
+              "fontWeight": 400,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+              "textAlign": "center",
+            },
+            undefined,
+          ]
         }
       >
         Apply
       </Text>
-    </TouchableOpacity>
+    </View>
   </View>,
 ]
 `;
@@ -1771,42 +1867,90 @@ exports[`NetworksFilterSelector renders correctly when networkFilter is the same
       }
     }
   >
-    <TouchableOpacity
+    <View
+      accessibilityLabel="Apply"
       accessibilityRole="button"
-      accessible={true}
-      activeOpacity={1}
-      onPress={[Function]}
-      onPressIn={[Function]}
-      onPressOut={[Function]}
-      style={
+      accessibilityState={
         {
-          "alignItems": "center",
-          "alignSelf": "stretch",
-          "backgroundColor": "#131416",
-          "borderRadius": 12,
-          "flexDirection": "row",
-          "height": 48,
-          "justifyContent": "center",
-          "overflow": "hidden",
-          "paddingHorizontal": 16,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "backgroundColor": "#131416",
+            "borderRadius": 12,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "width": "100%",
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
     >
       <Text
         accessibilityRole="text"
+        ellipsizeMode="clip"
+        numberOfLines={1}
         style={
-          {
-            "color": "#ffffff",
-            "fontFamily": "Geist-Medium",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-          }
+          [
+            {
+              "color": "#ffffff",
+              "flexGrow": 0,
+              "flexShrink": 1,
+              "flexWrap": "wrap",
+              "fontFamily": "Geist-Medium",
+              "fontSize": 16,
+              "fontWeight": 400,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+              "textAlign": "center",
+            },
+            undefined,
+          ]
         }
       >
         Apply
       </Text>
-    </TouchableOpacity>
+    </View>
   </View>,
 ]
 `;

--- a/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
+++ b/app/components/UI/Ramp/Views/TokenSelection/__snapshots__/TokenSelection.test.tsx.snap
@@ -551,6 +551,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -664,6 +665,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -777,6 +779,7 @@ exports[`TokenSelection Component displays empty state when no tokens match sear
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -1627,6 +1630,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -1740,6 +1744,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -1853,6 +1858,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (V2 ena
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -4209,6 +4215,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -4322,6 +4329,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }
@@ -4435,6 +4443,7 @@ exports[`TokenSelection Component renders correctly and matches snapshot (legacy
                                             "borderRadius": 4,
                                             "height": 16,
                                             "justifyContent": "center",
+                                            "marginRight": 8,
                                             "overflow": "hidden",
                                             "width": 16,
                                           }

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
@@ -436,59 +436,9 @@ exports[`EligibilityFailedModal renders modal with title and description 1`] = `
                             "paddingHorizontal": 24,
                           }
                         }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "backgroundColor": "#b4b4b528",
-                              "borderColor": "transparent",
-                              "borderRadius": 12,
-                              "borderWidth": 1,
-                              "columnGap": 8,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "minWidth": 80,
-                              "opacity": 1,
-                              "overflow": "hidden",
-                              "paddingLeft": 16,
-                              "paddingRight": 16,
-                              "width": "100%",
-                            },
-                            {
-                              "transform": [
-                                {
-                                  "scale": 1,
-                                },
-                              ],
-                            },
-                          ]
-                        }
                       >
                         <Text
                           accessibilityRole="text"
-                          ellipsizeMode="clip"
-                          numberOfLines={1}
                           style={
                             [
                               {
@@ -513,52 +463,6 @@ exports[`EligibilityFailedModal renders modal with title and description 1`] = `
                             "paddingBottom": 24,
                             "paddingHorizontal": 24,
                           }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "backgroundColor": "#131416",
-                              "borderRadius": 12,
-                              "columnGap": 8,
-                              "flexDirection": "row",
-                              "height": 48,
-                              "justifyContent": "center",
-                              "minWidth": 80,
-                              "opacity": 1,
-                              "overflow": "hidden",
-                              "paddingLeft": 16,
-                              "paddingRight": 16,
-                              "width": "100%",
-                            },
-                            {
-                              "transform": [
-                                {
-                                  "scale": 1,
-                                },
-                              ],
-                            },
-                          ]
                         }
                       >
                         <View

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/__snapshots__/EligibilityFailedModal.test.tsx.snap
@@ -436,9 +436,59 @@ exports[`EligibilityFailedModal renders modal with title and description 1`] = `
                             "paddingHorizontal": 24,
                           }
                         }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#b4b4b528",
+                              "borderColor": "transparent",
+                              "borderRadius": 12,
+                              "borderWidth": 1,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
+                        }
                       >
                         <Text
                           accessibilityRole="text"
+                          ellipsizeMode="clip"
+                          numberOfLines={1}
                           style={
                             [
                               {
@@ -463,6 +513,52 @@ exports[`EligibilityFailedModal renders modal with title and description 1`] = `
                             "paddingBottom": 24,
                             "paddingHorizontal": 24,
                           }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        style={
+                          [
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#131416",
+                              "borderRadius": 12,
+                              "columnGap": 8,
+                              "flexDirection": "row",
+                              "height": 48,
+                              "justifyContent": "center",
+                              "minWidth": 80,
+                              "opacity": 1,
+                              "overflow": "hidden",
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                              "width": "100%",
+                            },
+                            {
+                              "transform": [
+                                {
+                                  "scale": 1,
+                                },
+                              ],
+                            },
+                          ]
                         }
                       >
                         <View

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.styles.ts
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.styles.ts
@@ -7,6 +7,9 @@ const styleSheet = () =>
       flexDirection: 'row',
       gap: 8,
     },
+    selectedNetworkIcon: {
+      marginRight: 8,
+    },
   });
 
 export default styleSheet;

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.tsx
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.tsx
@@ -4,6 +4,8 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import AvatarNetwork from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
+import { Box } from '../../../Box/Box';
+import { AlignItems, FlexDirection } from '../../../Box/box.types';
 import {
   Button,
   ButtonSize,
@@ -90,6 +92,7 @@ function TokenNetworkFilterBar({
                 imageSource={networkImageSource}
                 name={displayName}
                 size={AvatarSize.Xs}
+                style={styles.selectedNetworkIcon}
               />
             }
             onPress={() => handleNetworkPress(chainId)}

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.tsx
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/TokenNetworkFilterBar.tsx
@@ -4,8 +4,6 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import AvatarNetwork from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
-import { Box } from '../../../Box/Box';
-import { AlignItems, FlexDirection } from '../../../Box/box.types';
 import {
   Button,
   ButtonSize,

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
@@ -158,112 +158,36 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
           },
         ]
       }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#b4b4b528",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "columnGap": 8,
-            "flexDirection": "row",
-            "height": 32,
-            "justifyContent": "center",
-            "minWidth": 80,
-            "opacity": 1,
-            "overflow": "hidden",
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          {
-            "transform": [
-              {
-                "scale": 1,
-              },
-            ],
-          },
-        ]
-      }
     >
       <View
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Ethereum
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -353,59 +277,31 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Optimism
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -495,59 +391,31 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Polygon
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -735,112 +603,36 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
           },
         ]
       }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#b4b4b528",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "columnGap": 8,
-            "flexDirection": "row",
-            "height": 32,
-            "justifyContent": "center",
-            "minWidth": 80,
-            "opacity": 1,
-            "overflow": "hidden",
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          {
-            "transform": [
-              {
-                "scale": 1,
-              },
-            ],
-          },
-        ]
-      }
     >
       <View
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Ethereum
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -930,59 +722,31 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Optimism
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -1072,59 +836,31 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Polygon
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -1312,110 +1048,36 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
           },
         ]
       }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "alignSelf": "flex-start",
-            "backgroundColor": "#131416",
-            "borderRadius": 12,
-            "columnGap": 8,
-            "flexDirection": "row",
-            "height": 32,
-            "justifyContent": "center",
-            "minWidth": 80,
-            "opacity": 1,
-            "overflow": "hidden",
-            "paddingLeft": 16,
-            "paddingRight": 16,
-          },
-          {
-            "transform": [
-              {
-                "scale": 1,
-              },
-            ],
-          },
-        ]
-      }
     >
       <View
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#ffffff",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Ethereum
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -1505,59 +1167,31 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Optimism
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View
@@ -1647,59 +1281,31 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={{}}
       >
         <View
-          alignItems="center"
-          flexDirection="row"
           style={
-            [
-              {
-                "alignItems": "center",
-                "flexDirection": "row",
-              },
-              undefined,
-            ]
+            {
+              "alignItems": "center",
+              "backgroundColor": "#ffffff",
+              "borderRadius": 4,
+              "height": 16,
+              "justifyContent": "center",
+              "marginRight": 8,
+              "overflow": "hidden",
+              "width": 16,
+            }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
+            resizeMode="contain"
+            source={1}
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#ffffff",
-                "borderRadius": 4,
                 "height": 16,
-                "justifyContent": "center",
-                "marginRight": 8,
-                "overflow": "hidden",
                 "width": 16,
               }
             }
-          >
-            <Image
-              onError={[Function]}
-              resizeMode="contain"
-              source={1}
-              style={
-                {
-                  "height": 16,
-                  "width": 16,
-                }
-              }
-              testID="network-avatar-image"
-            />
-          </View>
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#131416",
-                "fontFamily": "Geist-Regular",
-                "fontSize": 16,
-                "letterSpacing": 0,
-                "lineHeight": 24,
-              }
-            }
-          >
-            Polygon
-          </Text>
+            testID="network-avatar-image"
+          />
         </View>
       </View>
       <View

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
 >
   <View>
     <View
-      accessibilityLabel="All"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -101,7 +100,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
       </View>
     </View>
     <View
-      accessibilityLabel="Ethereum"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -213,30 +211,59 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Ethereum
+          </Text>
         </View>
       </View>
       <View
@@ -263,7 +290,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
       </View>
     </View>
     <View
-      accessibilityLabel="Optimism"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -327,30 +353,59 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Optimism
+          </Text>
         </View>
       </View>
       <View
@@ -377,7 +432,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
       </View>
     </View>
     <View
-      accessibilityLabel="Polygon"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -441,30 +495,59 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Polygon
+          </Text>
         </View>
       </View>
       <View
@@ -513,7 +596,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
 >
   <View>
     <View
-      accessibilityLabel="All"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -595,7 +677,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
       </View>
     </View>
     <View
-      accessibilityLabel="Ethereum"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -707,30 +788,59 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Ethereum
+          </Text>
         </View>
       </View>
       <View
@@ -757,7 +867,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
       </View>
     </View>
     <View
-      accessibilityLabel="Optimism"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -821,30 +930,59 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Optimism
+          </Text>
         </View>
       </View>
       <View
@@ -871,7 +1009,6 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
       </View>
     </View>
     <View
-      accessibilityLabel="Polygon"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -935,30 +1072,59 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Polygon
+          </Text>
         </View>
       </View>
       <View
@@ -1007,7 +1173,6 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
 >
   <View>
     <View
-      accessibilityLabel="All"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1091,7 +1256,6 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
       </View>
     </View>
     <View
-      accessibilityLabel="Ethereum"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1199,30 +1363,59 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#ffffff",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Ethereum
+          </Text>
         </View>
       </View>
       <View
@@ -1249,7 +1442,6 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
       </View>
     </View>
     <View
-      accessibilityLabel="Optimism"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1313,30 +1505,59 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Optimism
+          </Text>
         </View>
       </View>
       <View
@@ -1363,7 +1584,6 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
       </View>
     </View>
     <View
-      accessibilityLabel="Polygon"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1427,30 +1647,59 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
         style={{}}
       >
         <View
+          alignItems="center"
+          flexDirection="row"
           style={
-            {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderRadius": 4,
-              "height": 16,
-              "justifyContent": "center",
-              "overflow": "hidden",
-              "width": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+              undefined,
+            ]
           }
         >
-          <Image
-            onError={[Function]}
-            resizeMode="contain"
-            source={1}
+          <View
             style={
               {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderRadius": 4,
                 "height": 16,
+                "justifyContent": "center",
+                "marginRight": 8,
+                "overflow": "hidden",
                 "width": 16,
               }
             }
-            testID="network-avatar-image"
-          />
+          >
+            <Image
+              onError={[Function]}
+              resizeMode="contain"
+              source={1}
+              style={
+                {
+                  "height": 16,
+                  "width": 16,
+                }
+              }
+              testID="network-avatar-image"
+            />
+          </View>
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#131416",
+                "fontFamily": "Geist-Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Polygon
+          </Text>
         </View>
       </View>
       <View

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
@@ -158,6 +158,54 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
           },
         ]
       }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
+      }
     >
       <View
         style={{}}
@@ -551,6 +599,54 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
           "expanded": undefined,
           "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#b4b4b528",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
       accessibilityValue={
         {
@@ -995,6 +1091,52 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
           "expanded": undefined,
           "selected": undefined,
         }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "alignSelf": "flex-start",
+            "backgroundColor": "#131416",
+            "borderRadius": 12,
+            "columnGap": 8,
+            "flexDirection": "row",
+            "height": 32,
+            "justifyContent": "center",
+            "minWidth": 80,
+            "opacity": 1,
+            "overflow": "hidden",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          {
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
+          },
+        ]
       }
       accessibilityValue={
         {

--- a/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
+++ b/app/components/UI/Ramp/components/TokenNetworkFilterBar/__snapshots__/TokenNetworkFilterBar.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
 >
   <View>
     <View
+      accessibilityLabel="All"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -100,6 +101,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
       </View>
     </View>
     <View
+      accessibilityLabel="Ethereum"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -261,6 +263,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
       </View>
     </View>
     <View
+      accessibilityLabel="Optimism"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -374,6 +377,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (emp
       </View>
     </View>
     <View
+      accessibilityLabel="Polygon"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -509,6 +513,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
 >
   <View>
     <View
+      accessibilityLabel="All"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -590,6 +595,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
       </View>
     </View>
     <View
+      accessibilityLabel="Ethereum"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -751,6 +757,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
       </View>
     </View>
     <View
+      accessibilityLabel="Optimism"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -864,6 +871,7 @@ exports[`TokenNetworkFilterBar renders correctly with all networks selected (nul
       </View>
     </View>
     <View
+      accessibilityLabel="Polygon"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -999,6 +1007,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
 >
   <View>
     <View
+      accessibilityLabel="All"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1082,6 +1091,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
       </View>
     </View>
     <View
+      accessibilityLabel="Ethereum"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1239,6 +1249,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
       </View>
     </View>
     <View
+      accessibilityLabel="Optimism"
       accessibilityRole="button"
       accessibilityState={
         {
@@ -1352,6 +1363,7 @@ exports[`TokenNetworkFilterBar renders correctly with single network selected 1`
       </View>
     </View>
     <View
+      accessibilityLabel="Polygon"
       accessibilityRole="button"
       accessibilityState={
         {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrate Button component usage to design system in Ramp Deposit views, NativeFlow views, OrderDetails, and shared components including EligibilityFailedModal, RampUnsupportedModal, and TokenNetworkFilterBar.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/4e967478-421c-42e6-b2ee-e39f6877dfbe

### **After**

https://github.com/user-attachments/assets/1a7f74b8-f8d5-4b43-8a7f-6fe03e6b91a6

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the Button implementation across multiple Ramp Deposit screens, which can subtly change press/disabled/loading behavior and accessibility semantics; snapshots/tests were updated accordingly but UI interaction regressions are still possible.
> 
> **Overview**
> Migrates Ramp Deposit views (e.g., `AdditionalVerification`, `BankDetails`, `BasicInfo`, `BuildQuote`, `EnterAddress`, `EnterEmail`) from the legacy component-library `Button` API to `@metamask/design-system-react-native` (`variant`, `isFullWidth`, `isDisabled`, `isLoading`, and children-as-label).
> 
> Updates Jest tests/snapshots to match the new rendered output and interaction semantics, including adding a design-system `Button` mock in `BuildQuote.test.tsx` and adjusting `EnterAddress` assertions to use enabled/disabled matchers and await loading state transitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d96826e3911616099f1cdf62d32c5ddf3efb6c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->