### PR TITLE
fix(MUSD-402): resolve persisting mUSD success toast after rapid transaction confirmation

### DIFF
--- a/app/component-library/components/Toast/Toast.test.tsx
+++ b/app/component-library/components/Toast/Toast.test.tsx
@@ -148,4 +148,38 @@ describe('Toast', () => {
 
     expect(screen.queryByText('Test Label')).toBeNull();
   });
+
+  it('cancels pending toast when showToast is called rapidly in succession', async () => {
+    const inProgressOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [{ label: 'In Progress' }],
+      hasNoTimeout: true,
+    };
+
+    const successOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [{ label: 'Success' }],
+      hasNoTimeout: false,
+    };
+
+    render(<Toast ref={toastRef} />);
+
+    // Call showToast twice in the same tick (simulating approved + confirmed
+    // firing before React processes the first state update).
+    act(() => {
+      toastRef.current?.showToast(inProgressOptions);
+      toastRef.current?.showToast(successOptions);
+    });
+
+    // Without the fix two setTimeout(0) callbacks are queued (one per call);
+    // with the fix the first timeout is cleared, leaving only one pending.
+    expect(jest.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.queryByText('In Progress')).toBeNull();
+    expect(screen.getByText('Success')).toBeOnTheScreen();
+  });
 });

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -5,6 +5,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -64,6 +65,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   );
   const { bottom: bottomNotchSpacing } = useSafeAreaInsets();
   const translateYProgress = useSharedValue(screenHeight);
+  const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const customOffset = toastOptions?.customBottomOffset ?? 0;
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
@@ -78,6 +80,11 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const resetState = () => setToastOptions(undefined);
 
   const showToast = (options: ToastOptions) => {
+    if (pendingTimeoutRef.current !== null) {
+      clearTimeout(pendingTimeoutRef.current);
+      pendingTimeoutRef.current = null;
+    }
+
     let timeoutDuration = 0;
     if (toastOptions) {
       if (!options.hasNoTimeout) {
@@ -87,7 +94,8 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
       // Clear existing toast state to prevent animation conflicts when showing rapid successive toasts
       setToastOptions(undefined);
     }
-    setTimeout(() => {
+    pendingTimeoutRef.current = setTimeout(() => {
+      pendingTimeoutRef.current = null;
       setToastOptions(options);
     }, timeoutDuration);
   };


### PR DESCRIPTION
## Summary
- Fixes a race condition in `Toast.showToast` where rapid successive calls (e.g., transaction approved + confirmed in the same tick on Linea) cause the success toast to persist indefinitely
- Tracks pending `setTimeout` with a ref so only the latest `showToast` call wins, ensuring the success toast renders with its proper auto-dismiss animation
- Adds test coverage for the rapid successive `showToast` scenario

https://github.com/user-attachments/assets/12064e1e-3beb-4d36-82e3-3237b2045eb6

## Test plan
- [x] Toast unit tests pass (`yarn jest app/component-library/components/Toast/Toast.test.tsx`)
- [x] Manual: trigger a Max DAI→mUSD conversion on Linea and verify the success toast auto-dismisses after ~3s
- [x] Verify normal (non-rapid) toast transitions still work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches toast display timing/animation logic; small but could regress toast sequencing or dismissal behavior if timer clearing interacts with existing transitions.
> 
> **Overview**
> Fixes a race in `Toast.showToast` where back-to-back calls could leave multiple queued `setTimeout` updates, causing the wrong toast state/timeout behavior (e.g., a success toast persisting).
> 
> `Toast` now tracks and clears any pending `setTimeout` via a ref so only the latest `showToast` call applies. Adds a unit test asserting rapid successive calls leave a single pending timer and only the latest toast renders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 111df6d217f107f5bedc98e8fdf930374739a3fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->