### PR TITLE
refactor(rewards): lift portfolio and leaderboard position hook calls to parent views

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -166,14 +166,14 @@ jest.mock('../components/Campaigns/OndoPortfolio', () => {
   };
 });
 
-jest.mock('../components/Campaigns/CampaignEntriesClosedBanner', () => {
+jest.mock('../components/RewardsInfoBanner', () => {
   const ReactActual = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
   return {
     __esModule: true,
     default: () =>
       ReactActual.createElement(View, {
-        testID: 'campaign-entries-closed-banner',
+        testID: 'competition-ended-banner',
       }),
   };
 });
@@ -257,8 +257,10 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.campaigns_view.error_description': 'Please try again.',
       'rewards.campaigns_view.retry_button': 'Retry',
       'rewards.campaign_details.join_campaign': 'Join Campaign',
-      'rewards.campaign_details.entries_closed_title': 'Entries closed',
-      'rewards.campaign_details.entries_closed_description': 'Missed window',
+      'rewards.campaign_details.competition_closed_title':
+        'Competition no longer open',
+      'rewards.campaign_details.competition_closed_description':
+        'Entries are now closed',
     };
     return translations[key] || key;
   },
@@ -655,7 +657,7 @@ describe('OndoCampaignDetailsView', () => {
     });
   });
 
-  describe('entries-closed banner', () => {
+  describe('competition ended banner', () => {
     it('shows the banner when campaign is active, past cutoff, and user is not opted in', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
@@ -669,7 +671,26 @@ describe('OndoCampaignDetailsView', () => {
         ],
       });
       const { getByTestId } = render(<OndoCampaignDetailsView />);
-      expect(getByTestId('campaign-entries-closed-banner')).toBeDefined();
+      expect(getByTestId('competition-ended-banner')).toBeDefined();
+    });
+
+    it('shows the banner when campaign is complete and user is not opted in', () => {
+      const lastMonth = new Date();
+      lastMonth.setMonth(lastMonth.getMonth() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            startDate: lastMonth.toISOString(),
+            endDate: yesterday.toISOString(),
+          }),
+        ],
+      });
+      const { getByTestId } = render(<OndoCampaignDetailsView />);
+      expect(getByTestId('competition-ended-banner')).toBeDefined();
     });
 
     it('does not show the banner when entries are still open', () => {
@@ -678,10 +699,10 @@ describe('OndoCampaignDetailsView', () => {
         campaigns: [createTestCampaign()],
       });
       const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('campaign-entries-closed-banner')).toBeNull();
+      expect(queryByTestId('competition-ended-banner')).toBeNull();
     });
 
-    it('does not show the banner when the user is opted in', () => {
+    it('does not show the banner when the user is opted in with portfolio fetching', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -699,11 +720,12 @@ describe('OndoCampaignDetailsView', () => {
         hasError: false,
         refetch: jest.fn(),
       });
+      // Portfolio not yet fetched — banner should be hidden while data loads
       const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('campaign-entries-closed-banner')).toBeNull();
+      expect(queryByTestId('competition-ended-banner')).toBeNull();
     });
 
-    it('does not show the banner while participant status is loading', () => {
+    it('shows the banner even while participant status is loading (entries closed)', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -721,8 +743,8 @@ describe('OndoCampaignDetailsView', () => {
         hasError: false,
         refetch: jest.fn(),
       });
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('campaign-entries-closed-banner')).toBeNull();
+      const { getByTestId } = render(<OndoCampaignDetailsView />);
+      expect(getByTestId('competition-ended-banner')).toBeDefined();
     });
   });
 

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -11,6 +11,8 @@ import {
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
+import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
+import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
 import Routes from '../../../../constants/navigation/Routes';
 
 const mockGoBack = jest.fn();
@@ -236,6 +238,18 @@ const mockUseGetOndoLeaderboard = useGetOndoLeaderboard as jest.MockedFunction<
   typeof useGetOndoLeaderboard
 >;
 
+jest.mock('../hooks/useGetOndoLeaderboardPosition');
+const mockUseGetOndoLeaderboardPosition =
+  useGetOndoLeaderboardPosition as jest.MockedFunction<
+    typeof useGetOndoLeaderboardPosition
+  >;
+
+jest.mock('../hooks/useGetOndoPortfolioPosition');
+const mockUseGetOndoPortfolioPosition =
+  useGetOndoPortfolioPosition as jest.MockedFunction<
+    typeof useGetOndoPortfolioPosition
+  >;
+
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const translations: Record<string, string> = {
@@ -305,6 +319,20 @@ describe('OndoCampaignDetailsView', () => {
       selectedTierData: null,
       computedAt: null,
       setSelectedTier: jest.fn(),
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      position: null,
+      isLoading: false,
+      hasError: false,
+      hasFetched: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      portfolio: null,
+      isLoading: false,
+      hasError: false,
+      hasFetched: false,
       refetch: jest.fn(),
     });
   });
@@ -463,7 +491,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(queryByTestId('campaign-how-it-works')).toBeNull();
     });
 
-    it('renders OndoLeaderboardPosition when participant is opted in', () => {
+    it('renders OndoLeaderboardPosition when participant is opted in with positions', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
@@ -472,6 +500,13 @@ describe('OndoCampaignDetailsView', () => {
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,
         hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
         refetch: jest.fn(),
       });
       const { getByTestId } = render(<OndoCampaignDetailsView />);
@@ -692,7 +727,7 @@ describe('OndoCampaignDetailsView', () => {
   });
 
   describe('leaderboard position', () => {
-    it('shows OndoLeaderboardPosition when participant is opted in', () => {
+    it('shows OndoLeaderboardPosition when participant is opted in with positions', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
@@ -701,6 +736,13 @@ describe('OndoCampaignDetailsView', () => {
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,
         hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
         refetch: jest.fn(),
       });
       const { getByTestId } = render(<OndoCampaignDetailsView />);
@@ -808,7 +850,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(queryByText('rewards.ondo_campaign_leaderboard.title')).toBeNull();
     });
 
-    it('shows leaderboard section header when opted in', () => {
+    it('shows leaderboard section header when opted in with positions', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
@@ -817,6 +859,13 @@ describe('OndoCampaignDetailsView', () => {
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,
         hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
         refetch: jest.fn(),
       });
       const { getByText } = render(<OndoCampaignDetailsView />);

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -725,7 +725,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(queryByTestId('competition-ended-banner')).toBeNull();
     });
 
-    it('shows the banner even while participant status is loading (entries closed)', () => {
+    it('does not show the banner while participant status is loading (entries closed)', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -743,8 +743,8 @@ describe('OndoCampaignDetailsView', () => {
         hasError: false,
         refetch: jest.fn(),
       });
-      const { getByTestId } = render(<OndoCampaignDetailsView />);
-      expect(getByTestId('competition-ended-banner')).toBeDefined();
+      const { queryByTestId } = render(<OndoCampaignDetailsView />);
+      expect(queryByTestId('competition-ended-banner')).toBeNull();
     });
   });
 

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -101,7 +101,7 @@ const OndoCampaignDetailsView: React.FC = () => {
 
   const hasPositions = Boolean(portfolioData?.positions.length);
 
-  const optinAllowed = campaign !== null && !isOptinAllowed(campaign);
+  const isOptinClosed = campaign !== null && !isOptinAllowed(campaign);
 
   const {
     tierNames,
@@ -145,7 +145,7 @@ const OndoCampaignDetailsView: React.FC = () => {
     const showCompetitionEndedBanner =
       getCampaignStatus(campaign) === 'complete' ||
       (Boolean(participantStatus) &&
-        optinAllowed &&
+        isOptinClosed &&
         (!isOptedIn ||
           (portfolioHasFetched && !hasPositions && !hasPortfolioError)));
 
@@ -183,7 +183,7 @@ const OndoCampaignDetailsView: React.FC = () => {
     hasPositions,
     areEntriesClosed,
     participantStatus,
-    optinAllowed,
+    isOptinClosed,
     portfolioHasFetched,
     hasPortfolioError,
     isPortfolioLoading,

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -70,7 +70,10 @@ const OndoCampaignDetailsView: React.FC = () => {
     [campaigns, campaignId],
   );
 
-  const participantStatus = useGetCampaignParticipantStatus(campaignId);
+  const {
+    status: participantStatusData,
+    isLoading: isParticipantStatusLoading,
+  } = useGetCampaignParticipantStatus(campaignId);
 
   useEffect(() => {
     if (campaign && getCampaignStatus(campaign) === 'upcoming') {
@@ -78,7 +81,7 @@ const OndoCampaignDetailsView: React.FC = () => {
     }
   }, [campaign, navigation]);
 
-  const isOptedIn = participantStatus?.status?.optedIn === true;
+  const isOptedIn = participantStatusData?.optedIn === true;
 
   // Campaign is active but the deposit cutoff date has passed — user can no longer opt in
   const areEntriesClosed = useMemo(
@@ -144,7 +147,7 @@ const OndoCampaignDetailsView: React.FC = () => {
 
     const showCompetitionEndedBanner =
       getCampaignStatus(campaign) === 'complete' ||
-      (Boolean(participantStatus) &&
+      (!isParticipantStatusLoading &&
         isOptinClosed &&
         (!isOptedIn ||
           (portfolioHasFetched && !hasPositions && !hasPortfolioError)));
@@ -160,7 +163,7 @@ const OndoCampaignDetailsView: React.FC = () => {
     return {
       showHowItWorksSection:
         Boolean(campaign.details?.howItWorks) &&
-        Boolean(participantStatus) &&
+        !isParticipantStatusLoading &&
         !isOptedIn &&
         !areEntriesClosed &&
         getCampaignStatus(campaign) === 'active',
@@ -182,7 +185,7 @@ const OndoCampaignDetailsView: React.FC = () => {
     isOptedIn,
     hasPositions,
     areEntriesClosed,
-    participantStatus,
+    isParticipantStatusLoading,
     isOptinClosed,
     portfolioHasFetched,
     hasPortfolioError,
@@ -408,7 +411,10 @@ const OndoCampaignDetailsView: React.FC = () => {
         {campaign && (
           <CampaignJoinCTA
             campaign={campaign}
-            participantStatus={participantStatus}
+            participantStatus={{
+              status: participantStatusData,
+              isLoading: isParticipantStatusLoading,
+            }}
           />
         )}
       </SafeAreaView>

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -31,6 +31,8 @@ import {
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
+import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
+import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
@@ -79,6 +81,25 @@ const OndoCampaignDetailsView: React.FC = () => {
     [campaign],
   );
 
+  // Single fetch point for portfolio — data is passed to both the portfolio section and
+  // used to gate the leaderboard rank section visibility
+  const {
+    portfolio: portfolioData,
+    isLoading: isPortfolioLoading,
+    hasError: hasPortfolioError,
+    hasFetched: portfolioHasFetched,
+    refetch: refetchPortfolio,
+  } = useGetOndoPortfolioPosition(isOptedIn ? campaignId : undefined);
+
+  const hasPositions =
+    portfolioHasFetched && Boolean(portfolioData?.positions.length);
+
+  // Rank section: only visible when opted in with confirmed portfolio activity
+  const showLeaderboardRankSection = isOptedIn && hasPositions;
+
+  // Portfolio section: hidden only when opted in, cutoff passed, AND confirmed empty
+  const showPortfolioSection = isOptedIn && (hasPositions || !areEntriesClosed);
+
   // Only fetch leaderboard data when we'll actually render the OndoLeaderboard
   // (non-opted-in view of a completed campaign, or active campaign past cutoff date)
   const leaderboardCampaignId = useMemo(
@@ -102,6 +123,14 @@ const OndoCampaignDetailsView: React.FC = () => {
     isLeaderboardNotYetComputed,
     refetch: refetchLeaderboard,
   } = useGetOndoLeaderboard(leaderboardCampaignId);
+
+  const {
+    position,
+    isLoading: isPositionLoading,
+    hasError: hasPositionError,
+    hasFetched: positionHasFetched,
+    refetch: refetchPosition,
+  } = useGetOndoLeaderboardPosition(isOptedIn ? campaignId : undefined);
 
   return (
     <ErrorBoundary navigation={navigation} view="OndoCampaignDetailsView">
@@ -176,11 +205,12 @@ const OndoCampaignDetailsView: React.FC = () => {
                 )}
 
               {!participantStatus.isLoading &&
-                (isOptedIn || Boolean(leaderboardCampaignId)) && (
+                (showLeaderboardRankSection ||
+                  Boolean(leaderboardCampaignId)) && (
                   <>
                     <Box twClassName="border-b border-border-muted" />
                     <Box twClassName="p-4">
-                      {isOptedIn ? (
+                      {showLeaderboardRankSection ? (
                         <>
                           <Pressable
                             onPress={() =>
@@ -213,7 +243,13 @@ const OndoCampaignDetailsView: React.FC = () => {
                               </Box>
                             </Box>
                           </Pressable>
-                          <OndoLeaderboardPosition campaignId={campaignId} />
+                          <OndoLeaderboardPosition
+                            position={position}
+                            isLoading={isPositionLoading}
+                            hasError={hasPositionError}
+                            hasFetched={positionHasFetched}
+                            refetch={refetchPosition}
+                          />
                         </>
                       ) : (
                         <>
@@ -239,11 +275,17 @@ const OndoCampaignDetailsView: React.FC = () => {
                   </>
                 )}
 
-              {!participantStatus.isLoading && isOptedIn && (
+              {!participantStatus.isLoading && showPortfolioSection && (
                 <>
                   <Box twClassName="border-b border-border-muted" />
                   <Box twClassName="p-4">
-                    <OndoPortfolio campaignId={campaignId} />
+                    <OndoPortfolio
+                      portfolio={portfolioData}
+                      isLoading={isPortfolioLoading}
+                      hasError={hasPortfolioError}
+                      hasFetched={portfolioHasFetched}
+                      refetch={refetchPortfolio}
+                    />
                   </Box>
                 </>
               )}

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -11,6 +11,7 @@ import {
   IconSize,
   Skeleton,
   Text,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -23,12 +24,13 @@ import OndoLeaderboard from '../components/Campaigns/OndoLeaderboard';
 import OndoLeaderboardPosition from '../components/Campaigns/OndoLeaderboardPosition';
 import OndoPortfolio from '../components/Campaigns/OndoPortfolio';
 import CampaignJoinCTA from '../components/Campaigns/CampaignJoinCTA';
-import CampaignEntriesClosedBanner from '../components/Campaigns/CampaignEntriesClosedBanner';
 import {
   getCampaignStatus,
   isOptinAllowed,
 } from '../components/Campaigns/CampaignTile.utils';
+import { formatComputedAt } from '../components/Campaigns/OndoLeaderboard.utils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
+import RewardsInfoBanner from '../components/RewardsInfoBanner';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
@@ -36,6 +38,8 @@ import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPositio
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
+import Logger from '../../../../util/Logger';
+import { OndoCampaignHowItWorks } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -54,8 +58,12 @@ const OndoCampaignDetailsView: React.FC = () => {
     useRoute<RouteProp<OndoCampaignDetailsRouteParams, 'CampaignDetails'>>();
   const { campaignId } = route.params;
 
-  const { campaigns, isLoading, hasError, fetchCampaigns } =
-    useRewardCampaigns();
+  const {
+    campaigns,
+    isLoading: isCampaignsLoading,
+    hasError: hasCampaignsError,
+    fetchCampaigns,
+  } = useRewardCampaigns();
 
   const campaign = useMemo(
     () => campaigns.find((c) => c.id === campaignId) ?? null,
@@ -91,26 +99,9 @@ const OndoCampaignDetailsView: React.FC = () => {
     refetch: refetchPortfolio,
   } = useGetOndoPortfolioPosition(isOptedIn ? campaignId : undefined);
 
-  const hasPositions =
-    portfolioHasFetched && Boolean(portfolioData?.positions.length);
+  const hasPositions = Boolean(portfolioData?.positions.length);
 
-  // Rank section: only visible when opted in with confirmed portfolio activity
-  const showLeaderboardRankSection = isOptedIn && hasPositions;
-
-  // Portfolio section: hidden only when opted in, cutoff passed, AND confirmed empty
-  const showPortfolioSection = isOptedIn && (hasPositions || !areEntriesClosed);
-
-  // Only fetch leaderboard data when we'll actually render the OndoLeaderboard
-  // (non-opted-in view of a completed campaign, or active campaign past cutoff date)
-  const leaderboardCampaignId = useMemo(
-    () =>
-      campaign &&
-      !isOptedIn &&
-      (getCampaignStatus(campaign) === 'complete' || areEntriesClosed)
-        ? campaignId
-        : undefined,
-    [campaign, isOptedIn, areEntriesClosed, campaignId],
-  );
+  const optinAllowed = campaign !== null && !isOptinAllowed(campaign);
 
   const {
     tierNames,
@@ -122,15 +113,81 @@ const OndoCampaignDetailsView: React.FC = () => {
     hasError: hasLeaderboardError,
     isLeaderboardNotYetComputed,
     refetch: refetchLeaderboard,
-  } = useGetOndoLeaderboard(leaderboardCampaignId);
+  } = useGetOndoLeaderboard(campaignId);
 
   const {
-    position,
-    isLoading: isPositionLoading,
-    hasError: hasPositionError,
-    hasFetched: positionHasFetched,
-    refetch: refetchPosition,
-  } = useGetOndoLeaderboardPosition(isOptedIn ? campaignId : undefined);
+    position: leaderboardPosition,
+    isLoading: isLeaderboardPositionLoading,
+    hasError: hasLeaderboardPositionError,
+    hasFetched: leaderboardPositionHasFetched,
+    refetch: refetchLeaderboardPosition,
+  } = useGetOndoLeaderboardPosition(
+    isOptedIn && hasPositions ? campaignId : undefined,
+  );
+
+  const {
+    showHowItWorksSection,
+    showCompetitionEndedBanner,
+    showLeaderboardSection,
+    showLeaderboardPositionSection,
+    showPortfolioSection,
+  } = useMemo(() => {
+    if (!campaign) {
+      return {
+        showHowItWorksSection: false,
+        showCompetitionEndedBanner: false,
+        showLeaderboardSection: false,
+        showLeaderboardPositionSection: false,
+        showPortfolioSection: false,
+      };
+    }
+
+    const showCompetitionEndedBanner =
+      getCampaignStatus(campaign) === 'complete' ||
+      (Boolean(participantStatus) &&
+        optinAllowed &&
+        (!isOptedIn ||
+          (portfolioHasFetched && !hasPositions && !hasPortfolioError)));
+
+    const showLeaderboardPositionSection = isOptedIn && hasPositions;
+    const showPortfolioSection =
+      isOptedIn &&
+      (!showCompetitionEndedBanner ||
+        (hasPositions && getCampaignStatus(campaign) === 'complete') ||
+        isPortfolioLoading ||
+        (hasPortfolioError && !hasPositions));
+
+    return {
+      showHowItWorksSection:
+        Boolean(campaign.details?.howItWorks) &&
+        Boolean(participantStatus) &&
+        !isOptedIn &&
+        !areEntriesClosed &&
+        getCampaignStatus(campaign) === 'active',
+
+      showCompetitionEndedBanner,
+      showLeaderboardPositionSection,
+      showLeaderboardSection:
+        (showCompetitionEndedBanner &&
+          !showLeaderboardPositionSection &&
+          !showPortfolioSection) ||
+        (isOptedIn &&
+          !showCompetitionEndedBanner &&
+          !hasPositions &&
+          !isPortfolioLoading),
+      showPortfolioSection,
+    };
+  }, [
+    campaign,
+    isOptedIn,
+    hasPositions,
+    areEntriesClosed,
+    participantStatus,
+    optinAllowed,
+    portfolioHasFetched,
+    hasPortfolioError,
+    isPortfolioLoading,
+  ]);
 
   return (
     <ErrorBoundary navigation={navigation} view="OndoCampaignDetailsView">
@@ -164,14 +221,14 @@ const OndoCampaignDetailsView: React.FC = () => {
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tw.style('pb-4')}
         >
-          {isLoading && !campaign && (
+          {isCampaignsLoading && !campaign && (
             <Box twClassName="px-4 pt-4 gap-4">
               <Skeleton style={tw.style('h-48 rounded-xl')} />
               <Skeleton style={tw.style('h-32 rounded-xl')} />
             </Box>
           )}
 
-          {!isLoading && hasError && !campaign && (
+          {!isCampaignsLoading && hasCampaignsError && !campaign && (
             <Box twClassName="px-4 pt-4">
               <RewardsErrorBanner
                 title={strings('rewards.campaigns_view.error_title')}
@@ -190,92 +247,103 @@ const OndoCampaignDetailsView: React.FC = () => {
             <>
               <CampaignStatus campaign={campaign} optedIn={isOptedIn} />
 
-              {campaign.details?.howItWorks &&
-                !isOptedIn &&
-                !areEntriesClosed &&
-                getCampaignStatus(campaign) === 'active' && (
-                  <>
-                    <Box twClassName="border-b border-border-muted" />
-                    <Box twClassName="px-4 py-4">
-                      <CampaignHowItWorks
-                        howItWorks={campaign.details.howItWorks}
-                      />
-                    </Box>
-                  </>
-                )}
+              {/* Phase 1: Not opted in, show how it works section */}
+              {showHowItWorksSection && (
+                <>
+                  <Box twClassName="border-b border-border-muted" />
+                  <Box twClassName="px-4 py-4">
+                    <CampaignHowItWorks
+                      howItWorks={
+                        campaign.details?.howItWorks as OndoCampaignHowItWorks
+                      }
+                    />
+                  </Box>
+                </>
+              )}
 
-              {!participantStatus.isLoading &&
-                (showLeaderboardRankSection ||
-                  Boolean(leaderboardCampaignId)) && (
-                  <>
-                    <Box twClassName="border-b border-border-muted" />
-                    <Box twClassName="p-4">
-                      {showLeaderboardRankSection ? (
-                        <>
-                          <Pressable
-                            onPress={() =>
-                              navigation.navigate(
-                                Routes.REWARDS_ONDO_CAMPAIGN_LEADERBOARD as never,
-                                { campaignId },
-                              )
-                            }
-                          >
-                            <Box
-                              flexDirection={BoxFlexDirection.Row}
-                              alignItems={BoxAlignItems.Center}
-                              justifyContent={BoxJustifyContent.Between}
-                              twClassName="mb-4"
-                            >
-                              <Box
-                                flexDirection={BoxFlexDirection.Row}
-                                alignItems={BoxAlignItems.Center}
-                                twClassName="gap-2"
-                              >
-                                <Text variant={TextVariant.HeadingMd}>
-                                  {strings(
-                                    'rewards.ondo_campaign_leaderboard.title',
-                                  )}
-                                </Text>
-                                <Icon
-                                  name={IconName.ArrowRight}
-                                  size={IconSize.Md}
-                                />
-                              </Box>
-                            </Box>
-                          </Pressable>
-                          <OndoLeaderboardPosition
-                            position={position}
-                            isLoading={isPositionLoading}
-                            hasError={hasPositionError}
-                            hasFetched={positionHasFetched}
-                            refetch={refetchPosition}
-                          />
-                        </>
-                      ) : (
-                        <>
-                          <OndoLeaderboard
-                            tierNames={tierNames}
-                            selectedTier={selectedTier}
-                            onTierChange={setSelectedTier}
-                            entries={selectedTierData?.entries ?? []}
-                            totalParticipants={
-                              selectedTierData?.totalParticipants ?? 0
-                            }
-                            computedAt={computedAt}
-                            isLoading={isLeaderboardLoading}
-                            hasError={hasLeaderboardError}
-                            isLeaderboardNotYetComputed={
-                              isLeaderboardNotYetComputed
-                            }
-                            onRetry={refetchLeaderboard}
-                          />
-                        </>
+              {/* Competition closed banner
+                  - for when cutoff date has passed and user is not opted in
+                  - or when the campaign is complete */}
+              {showCompetitionEndedBanner && (
+                <>
+                  <Box twClassName="border-b border-border-muted" />
+                  <Box twClassName="px-4 py-4 gap-4">
+                    <RewardsInfoBanner
+                      title={strings(
+                        'rewards.campaign_details.competition_closed_title',
                       )}
-                    </Box>
-                  </>
-                )}
+                      description={strings(
+                        'rewards.campaign_details.competition_closed_description',
+                      )}
+                    />
+                  </Box>
+                </>
+              )}
 
-              {!participantStatus.isLoading && showPortfolioSection && (
+              {showLeaderboardPositionSection && (
+                <>
+                  <Box twClassName="border-b border-border-muted" />
+                  <Box twClassName="p-4">
+                    <>
+                      <Pressable
+                        onPress={() =>
+                          navigation.navigate(
+                            Routes.REWARDS_ONDO_CAMPAIGN_LEADERBOARD as never,
+                            { campaignId },
+                          )
+                        }
+                      >
+                        <Box
+                          flexDirection={BoxFlexDirection.Row}
+                          alignItems={BoxAlignItems.Center}
+                          justifyContent={BoxJustifyContent.Between}
+                          twClassName="mb-4"
+                        >
+                          <Box
+                            flexDirection={BoxFlexDirection.Row}
+                            alignItems={BoxAlignItems.Center}
+                            twClassName="gap-2"
+                          >
+                            <Text variant={TextVariant.HeadingMd}>
+                              {strings(
+                                'rewards.ondo_campaign_leaderboard.title',
+                              )}
+                            </Text>
+                            <Icon
+                              name={IconName.ArrowRight}
+                              size={IconSize.Md}
+                            />
+                          </Box>
+                          {leaderboardPosition?.computedAt && (
+                            <Text
+                              variant={TextVariant.BodyXs}
+                              color={TextColor.TextAlternative}
+                            >
+                              {strings(
+                                'rewards.ondo_campaign_leaderboard_position.updated_at',
+                                {
+                                  time: formatComputedAt(
+                                    leaderboardPosition.computedAt,
+                                  ),
+                                },
+                              )}
+                            </Text>
+                          )}
+                        </Box>
+                      </Pressable>
+                      <OndoLeaderboardPosition
+                        position={leaderboardPosition}
+                        isLoading={isLeaderboardPositionLoading}
+                        hasError={hasLeaderboardPositionError}
+                        hasFetched={leaderboardPositionHasFetched}
+                        refetch={refetchLeaderboardPosition}
+                      />
+                    </>
+                  </Box>
+                </>
+              )}
+
+              {showPortfolioSection && (
                 <>
                   <Box twClassName="border-b border-border-muted" />
                   <Box twClassName="p-4">
@@ -285,6 +353,50 @@ const OndoCampaignDetailsView: React.FC = () => {
                       hasError={hasPortfolioError}
                       hasFetched={portfolioHasFetched}
                       refetch={refetchPortfolio}
+                    />
+                  </Box>
+                </>
+              )}
+
+              {showLeaderboardSection && (
+                <>
+                  <Box twClassName="border-b border-border-muted" />
+                  <Box twClassName="p-4">
+                    {isLeaderboardNotYetComputed && (
+                      <Pressable
+                        onPress={() =>
+                          navigation.navigate(
+                            Routes.REWARDS_ONDO_CAMPAIGN_LEADERBOARD as never,
+                            { campaignId },
+                          )
+                        }
+                      >
+                        <Box
+                          flexDirection={BoxFlexDirection.Row}
+                          alignItems={BoxAlignItems.Center}
+                          twClassName="gap-2 mb-4"
+                        >
+                          <Text variant={TextVariant.HeadingMd}>
+                            {strings('rewards.ondo_campaign_leaderboard.title')}
+                          </Text>
+                          <Icon name={IconName.ArrowRight} size={IconSize.Md} />
+                        </Box>
+                      </Pressable>
+                    )}
+                    <OndoLeaderboard
+                      showTitle={false}
+                      tierNames={tierNames}
+                      selectedTier={selectedTier}
+                      onTierChange={setSelectedTier}
+                      entries={selectedTierData?.entries ?? []}
+                      totalParticipants={
+                        selectedTierData?.totalParticipants ?? 0
+                      }
+                      computedAt={computedAt}
+                      isLoading={isLeaderboardLoading}
+                      hasError={hasLeaderboardError}
+                      isLeaderboardNotYetComputed={isLeaderboardNotYetComputed}
+                      onRetry={refetchLeaderboard}
                     />
                   </Box>
                 </>
@@ -299,18 +411,6 @@ const OndoCampaignDetailsView: React.FC = () => {
             participantStatus={participantStatus}
           />
         )}
-
-        {campaign &&
-          areEntriesClosed &&
-          !isOptedIn &&
-          !participantStatus.isLoading && (
-            <CampaignEntriesClosedBanner
-              title={strings('rewards.campaign_details.entries_closed_title')}
-              description={strings(
-                'rewards.campaign_details.entries_closed_description',
-              )}
-            />
-          )}
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
@@ -4,6 +4,7 @@ import OndoLeaderboardView, {
   ONDO_LEADERBOARD_VIEW_TEST_IDS,
 } from './OndoLeaderboardView';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
+import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
 
 const mockGoBack = jest.fn();
 
@@ -88,9 +89,9 @@ jest.mock('../components/Campaigns/OndoLeaderboardPosition', () => {
   const { View } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ campaignId }: { campaignId: string }) =>
+    default: () =>
       ReactActual.createElement(View, {
-        testID: `ondo-leaderboard-position-${campaignId}`,
+        testID: 'ondo-leaderboard-position',
       }),
   };
 });
@@ -106,10 +107,15 @@ jest.mock('../components/Campaigns/OndoLeaderboard', () => {
 });
 
 jest.mock('../hooks/useGetOndoLeaderboard');
+jest.mock('../hooks/useGetOndoLeaderboardPosition');
 
 const mockUseGetOndoLeaderboard = useGetOndoLeaderboard as jest.MockedFunction<
   typeof useGetOndoLeaderboard
 >;
+const mockUseGetOndoLeaderboardPosition =
+  useGetOndoLeaderboardPosition as jest.MockedFunction<
+    typeof useGetOndoLeaderboardPosition
+  >;
 
 const hookDefaults = {
   leaderboard: null,
@@ -129,9 +135,18 @@ jest.mock('../../../../../locales/i18n', () => ({
 }));
 
 describe('OndoLeaderboardView', () => {
+  const positionDefaults = {
+    position: null,
+    isLoading: false,
+    hasError: false,
+    hasFetched: false,
+    refetch: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseGetOndoLeaderboard.mockReturnValue(hookDefaults);
+    mockUseGetOndoLeaderboardPosition.mockReturnValue(positionDefaults);
   });
 
   it('renders with the correct container testID', () => {
@@ -144,16 +159,21 @@ describe('OndoLeaderboardView', () => {
     expect(getByTestId('campaign-leaderboard')).toBeDefined();
   });
 
-  it('renders the OndoLeaderboardPosition component with the campaign ID', () => {
+  it('renders the OndoLeaderboardPosition component', () => {
     const { getByTestId } = render(<OndoLeaderboardView />);
-    expect(
-      getByTestId('ondo-leaderboard-position-campaign-ondo-123'),
-    ).toBeDefined();
+    expect(getByTestId('ondo-leaderboard-position')).toBeDefined();
   });
 
   it('calls useGetOndoLeaderboard with the campaign ID from route params', () => {
     render(<OndoLeaderboardView />);
     expect(mockUseGetOndoLeaderboard).toHaveBeenCalledWith('campaign-ondo-123');
+  });
+
+  it('calls useGetOndoLeaderboardPosition with the campaign ID from route params', () => {
+    render(<OndoLeaderboardView />);
+    expect(mockUseGetOndoLeaderboardPosition).toHaveBeenCalledWith(
+      'campaign-ondo-123',
+    );
   });
 
   it('navigates back when the back button is pressed', () => {

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from '../../../Views/ErrorBoundary';
 import OndoLeaderboardPosition from '../components/Campaigns/OndoLeaderboardPosition';
 import OndoLeaderboard from '../components/Campaigns/OndoLeaderboard';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
+import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
 import { strings } from '../../../../../locales/i18n';
 
 // ParamListBase requires an index signature, which interfaces don't support
@@ -40,6 +41,14 @@ const OndoLeaderboardView: React.FC = () => {
     refetch: refetchLeaderboard,
   } = useGetOndoLeaderboard(campaignId);
 
+  const {
+    position,
+    isLoading: isPositionLoading,
+    hasError: hasPositionError,
+    hasFetched: positionHasFetched,
+    refetch: refetchPosition,
+  } = useGetOndoLeaderboardPosition(campaignId);
+
   return (
     <ErrorBoundary navigation={navigation} view="OndoLeaderboardView">
       <SafeAreaView
@@ -60,7 +69,13 @@ const OndoLeaderboardView: React.FC = () => {
         >
           {/* User position card */}
           <Box twClassName="px-4 pt-4">
-            <OndoLeaderboardPosition campaignId={campaignId} />
+            <OndoLeaderboardPosition
+              position={position}
+              isLoading={isPositionLoading}
+              hasError={hasPositionError}
+              hasFetched={positionHasFetched}
+              refetch={refetchPosition}
+            />
           </Box>
 
           {/* Full leaderboard */}

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
@@ -75,6 +75,8 @@ const OndoLeaderboardView: React.FC = () => {
               hasError={hasPositionError}
               hasFetched={positionHasFetched}
               refetch={refetchPosition}
+              showTitle
+              computedAt={position?.computedAt}
             />
           </Box>
 
@@ -92,6 +94,7 @@ const OndoLeaderboardView: React.FC = () => {
               hasError={hasLeaderboardError}
               isLeaderboardNotYetComputed={isLeaderboardNotYetComputed}
               onRetry={refetchLeaderboard}
+              showTitle={false}
             />
           </Box>
         </ScrollView>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignJoinCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignJoinCTA.tsx
@@ -36,6 +36,7 @@ const CampaignJoinCTA: React.FC<CampaignJoinCTAProps> = ({
 
   if (
     participantStatus.isLoading ||
+    !participantStatus ||
     participantStatus.status?.optedIn === true ||
     getCampaignStatus(campaign) !== 'active' ||
     !isOptinAllowed(campaign)

--- a/app/components/UI/Rewards/components/Campaigns/CampaignJoinCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignJoinCTA.tsx
@@ -35,8 +35,8 @@ const CampaignJoinCTA: React.FC<CampaignJoinCTAProps> = ({
   const [isOptInSheetOpen, setIsOptInSheetOpen] = useState(false);
 
   if (
-    participantStatus.isLoading ||
     !participantStatus ||
+    participantStatus.isLoading ||
     participantStatus.status?.optedIn === true ||
     getCampaignStatus(campaign) !== 'active' ||
     !isOptinAllowed(campaign)

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -9,6 +9,7 @@ import {
 import {
   getCampaignStatusInfo,
   isCampaignTypeSupported,
+  isOptinAllowed,
 } from './CampaignTile.utils';
 import { selectCampaignParticipantCount } from '../../../../../reducers/rewards/selectors';
 import useGetCampaignParticipantStatus from '../../hooks/useGetCampaignParticipantStatus';
@@ -57,6 +58,7 @@ jest.mock('./CampaignTile.utils', () => ({
     dateLabelIcon: 'Clock',
   }),
   isCampaignTypeSupported: jest.fn().mockReturnValue(true),
+  isOptinAllowed: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../../../../../reducers/rewards/selectors', () => ({
@@ -121,6 +123,7 @@ describe('CampaignTile', () => {
       dateLabelIcon: 'Clock',
     });
     (isCampaignTypeSupported as jest.Mock).mockReturnValue(true);
+    (isOptinAllowed as jest.Mock).mockReturnValue(true);
     setupParticipantCount(null);
     mockUseGetCampaignParticipantStatus.mockReturnValue({
       status: null,
@@ -190,6 +193,16 @@ describe('CampaignTile', () => {
         '•Enter now',
       );
       expect(queryByTestId('campaign-tile-participant-count')).toBeNull();
+    });
+
+    it('does not render enter-now when isOptinAllowed returns false (entries closed)', () => {
+      (isOptinAllowed as jest.Mock).mockReturnValue(false);
+      setupParticipantCount(null);
+      const campaign = createTestCampaign();
+
+      const { queryByTestId } = render(<CampaignTile campaign={campaign} />);
+
+      expect(queryByTestId('campaign-tile-enter-now')).toBeNull();
     });
 
     it('does not render enter-now when status is upcoming', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
@@ -25,6 +25,7 @@ import {
 import {
   getCampaignStatusInfo,
   isCampaignTypeSupported,
+  isOptinAllowed,
 } from './CampaignTile.utils';
 import { selectCampaignParticipantCount } from '../../../../../reducers/rewards/selectors';
 import { strings } from '../../../../../../locales/i18n';
@@ -180,7 +181,8 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign, onPress }) => {
                     </Text>
                   </Box>
                 ) : campaignStatus === 'active' &&
-                  participantStatus?.optedIn !== true ? (
+                  participantStatus?.optedIn !== true &&
+                  isOptinAllowed(campaign) ? (
                   <Box
                     flexDirection={BoxFlexDirection.Row}
                     alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
@@ -248,6 +248,14 @@ describe('OndoLeaderboard', () => {
       expect(getByText('Leaderboard')).toBeDefined();
     });
 
+    it('does not render title when showTitle is false', () => {
+      const { queryByText } = render(
+        <OndoLeaderboard {...defaultProps} showTitle={false} />,
+      );
+
+      expect(queryByText('Leaderboard')).toBeNull();
+    });
+
     it('renders computed at timestamp', () => {
       const { getByTestId } = render(<OndoLeaderboard {...defaultProps} />);
 

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
@@ -292,6 +292,16 @@ describe('OndoLeaderboard', () => {
       ).toBeNull();
     });
 
+    it('renders computed at timestamp for single-tier leaderboard', () => {
+      const { getByTestId } = render(
+        <OndoLeaderboard {...defaultProps} tierNames={['STARTER']} />,
+      );
+
+      expect(
+        getByTestId(CAMPAIGN_LEADERBOARD_TEST_IDS.COMPUTED_AT),
+      ).toBeDefined();
+    });
+
     it('calls onTierChange when tab is pressed', () => {
       const onTierChange = jest.fn();
       const { getByTestId } = render(

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
@@ -255,8 +255,8 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
         </Text>
       )}
 
-      {/* Tier selector + last updated on same row */}
-      {tabs.length > 1 && (
+      {/* Tier selector + last updated */}
+      {tabs.length > 1 ? (
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
@@ -283,7 +283,18 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
             </Text>
           ) : null}
         </Box>
-      )}
+      ) : computedAt ? (
+        <Text
+          variant={TextVariant.BodyXs}
+          color={TextColor.TextAlternative}
+          twClassName="mb-4"
+          testID={CAMPAIGN_LEADERBOARD_TEST_IDS.COMPUTED_AT}
+        >
+          {strings('rewards.ondo_campaign_leaderboard.updated_at', {
+            time: formatComputedAt(computedAt),
+          })}
+        </Text>
+      ) : null}
 
       {/* Error banner when has error but no data to display */}
       {hasError && !isLoading && entries.length === 0 && (

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
@@ -45,6 +45,7 @@ interface CampaignLeaderboardProps {
   isLeaderboardNotYetComputed?: boolean;
   onRetry?: () => void;
   currentUserReferralCode?: string | null;
+  showTitle?: boolean;
 }
 
 /**
@@ -171,6 +172,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
   isLeaderboardNotYetComputed = false,
   onRetry,
   currentUserReferralCode,
+  showTitle = true,
 }) => {
   const tabs = useMemo(
     () =>
@@ -242,38 +244,44 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
 
   return (
     <Box testID={CAMPAIGN_LEADERBOARD_TEST_IDS.CONTAINER}>
-      {/* Header with title and computed at */}
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        justifyContent={BoxJustifyContent.Between}
-        alignItems={BoxAlignItems.Center}
-        twClassName="mb-4"
-      >
-        <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+      {/* Title */}
+      {showTitle && (
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Bold}
+          twClassName="mb-4"
+        >
           {strings('rewards.ondo_campaign_leaderboard.title')}
         </Text>
-        {computedAt ? (
-          <Text
-            variant={TextVariant.BodyXs}
-            color={TextColor.TextAlternative}
-            testID={CAMPAIGN_LEADERBOARD_TEST_IDS.COMPUTED_AT}
-          >
-            {strings('rewards.ondo_campaign_leaderboard.updated_at', {
-              time: formatComputedAt(computedAt),
-            })}
-          </Text>
-        ) : null}
-      </Box>
+      )}
 
-      {/* Tier selector */}
+      {/* Tier selector + last updated on same row */}
       {tabs.length > 1 && (
-        <Box twClassName="mb-4 -mx-4">
-          <TabsBar
-            tabs={tabs}
-            activeIndex={selectedIndex}
-            onTabPress={(index) => onTierChange(tierNames[index])}
-            testID={CAMPAIGN_LEADERBOARD_TEST_IDS.TIER_TOGGLE}
-          />
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="mb-4 -mx-4"
+        >
+          <Box twClassName="flex-1">
+            <TabsBar
+              tabs={tabs}
+              activeIndex={selectedIndex}
+              onTabPress={(index) => onTierChange(tierNames[index])}
+              testID={CAMPAIGN_LEADERBOARD_TEST_IDS.TIER_TOGGLE}
+            />
+          </Box>
+          {computedAt ? (
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+              twClassName="pr-4"
+              testID={CAMPAIGN_LEADERBOARD_TEST_IDS.COMPUTED_AT}
+            >
+              {strings('rewards.ondo_campaign_leaderboard.updated_at', {
+                time: formatComputedAt(computedAt),
+              })}
+            </Text>
+          ) : null}
         </Box>
       )}
 

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.test.tsx
@@ -1,49 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { useSelector } from 'react-redux';
 import OndoLeaderboardPosition, {
   ONDO_LEADERBOARD_POSITION_TEST_IDS,
 } from './OndoLeaderboardPosition';
-import { useGetOndoLeaderboardPosition } from '../../hooks/useGetOndoLeaderboardPosition';
 import type { CampaignLeaderboardPositionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
-import {
-  selectRewardsSubscriptionId,
-  selectCampaignParticipantOptedIn,
-} from '../../../../../selectors/rewards';
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
-
-jest.mock('../../../../../selectors/rewards', () => ({
-  selectRewardsSubscriptionId: jest.fn(),
-  selectCampaignParticipantOptedIn: jest.fn(),
-}));
-
-jest.mock('../../hooks/useGetOndoLeaderboardPosition');
-
-const mockUseGetOndoLeaderboardPosition =
-  useGetOndoLeaderboardPosition as jest.MockedFunction<
-    typeof useGetOndoLeaderboardPosition
-  >;
-const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockSelectCampaignParticipantOptedIn =
-  selectCampaignParticipantOptedIn as jest.MockedFunction<
-    typeof selectCampaignParticipantOptedIn
-  >;
-
-const SUBSCRIPTION_ID = 'sub-456';
-
-function setupSelectors({ isOptedIn = true }: { isOptedIn?: boolean } = {}) {
-  const mockOptedInSelector = jest.fn().mockReturnValue(isOptedIn);
-  mockSelectCampaignParticipantOptedIn.mockReturnValue(mockOptedInSelector);
-
-  mockUseSelector.mockImplementation((selector) => {
-    if (selector === selectRewardsSubscriptionId) return SUBSCRIPTION_ID;
-    if (selector === mockOptedInSelector) return isOptedIn;
-    return undefined;
-  });
-}
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -115,7 +75,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
   },
 }));
 
-const CAMPAIGN_ID = 'campaign-123';
 const mockRefetch = jest.fn();
 
 const MOCK_POSITION: CampaignLeaderboardPositionDto = {
@@ -129,73 +88,23 @@ const MOCK_POSITION: CampaignLeaderboardPositionDto = {
   netDeposit: 8500.0,
 };
 
+const baseProps = {
+  position: null as CampaignLeaderboardPositionDto | null,
+  isLoading: false,
+  hasError: false,
+  hasFetched: false,
+  refetch: mockRefetch,
+};
+
 describe('OndoLeaderboardPosition', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    setupSelectors();
-  });
-
-  describe('opt-in guard', () => {
-    it('renders nothing when user is not opted in', () => {
-      setupSelectors({ isOptedIn: false });
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
-      const { queryByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
-      );
-
-      expect(
-        queryByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.LOADING),
-      ).toBeNull();
-      expect(
-        queryByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.ERROR),
-      ).toBeNull();
-      expect(
-        queryByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.NOT_FOUND),
-      ).toBeNull();
-      expect(
-        queryByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.CONTAINER),
-      ).toBeNull();
-    });
-
-    it('renders nothing when not opted in even if position data exists', () => {
-      setupSelectors({ isOptedIn: false });
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: MOCK_POSITION,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
-      const { queryByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
-      );
-
-      expect(
-        queryByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.CONTAINER),
-      ).toBeNull();
-    });
   });
 
   describe('loading state', () => {
     it('renders skeleton when loading with no data', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: true,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...baseProps} isLoading />,
       );
 
       expect(
@@ -204,16 +113,13 @@ describe('OndoLeaderboardPosition', () => {
     });
 
     it('does not render skeleton when loading but has data', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: MOCK_POSITION,
-        isLoading: true,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { queryByTestId, getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition
+          {...baseProps}
+          position={MOCK_POSITION}
+          isLoading
+          hasFetched
+        />,
       );
 
       expect(
@@ -227,16 +133,12 @@ describe('OndoLeaderboardPosition', () => {
 
   describe('error state', () => {
     it('renders error banner when has error and no data', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: false,
-        hasError: true,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition
+          {...baseProps}
+          hasError
+          hasFetched
+        />,
       );
 
       expect(
@@ -245,16 +147,13 @@ describe('OndoLeaderboardPosition', () => {
     });
 
     it('shows data and hides error banner when has error but position is present', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: MOCK_POSITION,
-        isLoading: false,
-        hasError: true,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId, queryByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition
+          {...baseProps}
+          position={MOCK_POSITION}
+          hasError
+          hasFetched
+        />,
       );
 
       expect(
@@ -268,16 +167,8 @@ describe('OndoLeaderboardPosition', () => {
 
   describe('initial/unfetched state', () => {
     it('renders nothing before any fetch has completed', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
       const { queryByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...baseProps} />,
       );
 
       expect(
@@ -297,16 +188,8 @@ describe('OndoLeaderboardPosition', () => {
 
   describe('not found state', () => {
     it('renders not found message when fetch completed with no data', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...baseProps} hasFetched />,
       );
 
       expect(
@@ -316,19 +199,15 @@ describe('OndoLeaderboardPosition', () => {
   });
 
   describe('position data display', () => {
-    beforeEach(() => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: MOCK_POSITION,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-    });
+    const loadedProps = {
+      ...baseProps,
+      position: MOCK_POSITION,
+      hasFetched: true,
+    };
 
     it('renders position container', () => {
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(
@@ -338,7 +217,7 @@ describe('OndoLeaderboardPosition', () => {
 
     it('renders title', () => {
       const { getByText } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(getByText('Your Position')).toBeDefined();
@@ -346,16 +225,17 @@ describe('OndoLeaderboardPosition', () => {
 
     it('renders rank', () => {
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
-      const rankEl = getByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.RANK);
-      expect(rankEl).toBeDefined();
+      expect(
+        getByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.RANK),
+      ).toBeDefined();
     });
 
     it('renders rank value as #5', () => {
       const { getByText } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(getByText('#5')).toBeDefined();
@@ -363,7 +243,7 @@ describe('OndoLeaderboardPosition', () => {
 
     it('renders projected tier', () => {
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(
@@ -373,7 +253,7 @@ describe('OndoLeaderboardPosition', () => {
 
     it('renders tier value', () => {
       const { getByText } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(getByText('MID')).toBeDefined();
@@ -381,23 +261,19 @@ describe('OndoLeaderboardPosition', () => {
 
     it('renders rate of return with positive sign', () => {
       const { getByText } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(getByText('+15.00%')).toBeDefined();
     });
 
     it('renders negative rate of return without plus sign', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: { ...MOCK_POSITION, rateOfReturn: -0.05 },
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByText } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition
+          {...baseProps}
+          position={{ ...MOCK_POSITION, rateOfReturn: -0.05 }}
+          hasFetched
+        />,
       );
 
       expect(getByText('-5.00%')).toBeDefined();
@@ -405,7 +281,7 @@ describe('OndoLeaderboardPosition', () => {
 
     it('renders total deposited and current value stat cells', () => {
       const { getByTestId } = render(
-        <OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />,
+        <OndoLeaderboardPosition {...loadedProps} />,
       );
 
       expect(
@@ -414,38 +290,6 @@ describe('OndoLeaderboardPosition', () => {
       expect(
         getByTestId(ONDO_LEADERBOARD_POSITION_TEST_IDS.CURRENT_VALUE),
       ).toBeDefined();
-    });
-  });
-
-  describe('hook integration', () => {
-    it('passes campaignId to hook', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
-      render(<OndoLeaderboardPosition campaignId={CAMPAIGN_ID} />);
-
-      expect(mockUseGetOndoLeaderboardPosition).toHaveBeenCalledWith(
-        CAMPAIGN_ID,
-      );
-    });
-
-    it('passes undefined campaignId when not provided', () => {
-      mockUseGetOndoLeaderboardPosition.mockReturnValue({
-        position: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
-      render(<OndoLeaderboardPosition campaignId={undefined} />);
-
-      expect(mockUseGetOndoLeaderboardPosition).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.test.tsx
@@ -70,6 +70,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.ondo_campaign_leaderboard_position.error_loading':
         'Failed to load your position',
       'rewards.ondo_campaign_leaderboard_position.retry': 'Retry',
+      'rewards.ondo_campaign_leaderboard_position.updated_at': `Updated ${params?.time ?? ''}`,
     };
     return translations[key] || key;
   },
@@ -134,11 +135,7 @@ describe('OndoLeaderboardPosition', () => {
   describe('error state', () => {
     it('renders error banner when has error and no data', () => {
       const { getByTestId } = render(
-        <OndoLeaderboardPosition
-          {...baseProps}
-          hasError
-          hasFetched
-        />,
+        <OndoLeaderboardPosition {...baseProps} hasError hasFetched />,
       );
 
       expect(
@@ -215,12 +212,43 @@ describe('OndoLeaderboardPosition', () => {
       ).toBeDefined();
     });
 
-    it('renders title', () => {
-      const { getByText } = render(
+    it('does not render title by default (showTitle defaults to false)', () => {
+      const { queryByText } = render(
         <OndoLeaderboardPosition {...loadedProps} />,
       );
 
+      expect(queryByText('Your Position')).toBeNull();
+    });
+
+    it('renders title when showTitle is true', () => {
+      const { getByText } = render(
+        <OndoLeaderboardPosition {...loadedProps} showTitle />,
+      );
+
       expect(getByText('Your Position')).toBeDefined();
+    });
+
+    it('renders computedAt timestamp when showTitle is true and computedAt is provided', () => {
+      const { getByText } = render(
+        <OndoLeaderboardPosition
+          {...loadedProps}
+          showTitle
+          computedAt={MOCK_POSITION.computedAt}
+        />,
+      );
+
+      expect(getByText(/Updated/)).toBeDefined();
+    });
+
+    it('does not render computedAt when showTitle is false', () => {
+      const { queryByText } = render(
+        <OndoLeaderboardPosition
+          {...loadedProps}
+          computedAt={MOCK_POSITION.computedAt}
+        />,
+      );
+
+      expect(queryByText(/Updated/)).toBeNull();
     });
 
     it('renders rank', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.tsx
@@ -9,17 +9,12 @@ import {
   Skeleton,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
-import { useGetOndoLeaderboardPosition } from '../../hooks/useGetOndoLeaderboardPosition';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import { formatRateOfReturn } from './OndoLeaderboard.utils';
 import formatFiat from '../../../../../util/formatFiat';
 import { BigNumber } from 'bignumber.js';
-import {
-  selectRewardsSubscriptionId,
-  selectCampaignParticipantOptedIn,
-} from '../../../../../selectors/rewards';
+import type { CampaignLeaderboardPositionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 
 export const ONDO_LEADERBOARD_POSITION_TEST_IDS = {
   CONTAINER: 'ondo-leaderboard-position-container',
@@ -34,7 +29,11 @@ export const ONDO_LEADERBOARD_POSITION_TEST_IDS = {
 } as const;
 
 interface OndoLeaderboardPositionProps {
-  campaignId: string | undefined;
+  position: CampaignLeaderboardPositionDto | null;
+  isLoading: boolean;
+  hasError: boolean;
+  hasFetched: boolean;
+  refetch: () => Promise<void>;
 }
 
 const formatUsd = (value: number): string =>
@@ -105,19 +104,12 @@ const StatCell: React.FC<StatCellProps> = ({
  * and current USD value.
  */
 const OndoLeaderboardPosition: React.FC<OndoLeaderboardPositionProps> = ({
-  campaignId,
+  position,
+  isLoading,
+  hasError,
+  hasFetched,
+  refetch,
 }) => {
-  const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const isOptedIn = useSelector(
-    selectCampaignParticipantOptedIn(subscriptionId, campaignId),
-  );
-  const { position, isLoading, hasError, hasFetched, refetch } =
-    useGetOndoLeaderboardPosition(campaignId);
-
-  if (!isOptedIn) {
-    return null;
-  }
-
   if (isLoading && !position) {
     return <PositionSkeleton />;
   }

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboardPosition.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {
   Box,
+  BoxAlignItems,
   BoxFlexDirection,
+  BoxJustifyContent,
   Text,
   TextColor,
   TextVariant,
@@ -11,7 +13,7 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import { formatRateOfReturn } from './OndoLeaderboard.utils';
+import { formatRateOfReturn, formatComputedAt } from './OndoLeaderboard.utils';
 import formatFiat from '../../../../../util/formatFiat';
 import { BigNumber } from 'bignumber.js';
 import type { CampaignLeaderboardPositionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
@@ -34,18 +36,28 @@ interface OndoLeaderboardPositionProps {
   hasError: boolean;
   hasFetched: boolean;
   refetch: () => Promise<void>;
+  showTitle?: boolean;
+  /** When provided and showTitle is true, displays a "Last updated" timestamp */
+  computedAt?: string | null;
 }
 
 const formatUsd = (value: number): string =>
   formatFiat(new BigNumber(value), 'USD');
 
-const PositionSkeleton: React.FC = () => {
+const PositionSkeleton: React.FC<{ showTitle?: boolean }> = ({
+  showTitle = false,
+}) => {
   const tw = useTailwind();
   return (
     <Box
       twClassName="gap-3"
       testID={ONDO_LEADERBOARD_POSITION_TEST_IDS.LOADING}
     >
+      {showTitle && (
+        <Text variant={TextVariant.HeadingMd}>
+          {strings('rewards.ondo_campaign_leaderboard_position.title')}
+        </Text>
+      )}
       {/* Row 1: Rank | Tier */}
       <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-4">
         <Skeleton style={tw.style('h-12 flex-1 rounded-lg')} />
@@ -109,9 +121,11 @@ const OndoLeaderboardPosition: React.FC<OndoLeaderboardPositionProps> = ({
   hasError,
   hasFetched,
   refetch,
+  showTitle = false,
+  computedAt,
 }) => {
   if (isLoading && !position) {
-    return <PositionSkeleton />;
+    return <PositionSkeleton showTitle={showTitle} />;
   }
 
   if (hasError && !position) {
@@ -155,9 +169,28 @@ const OndoLeaderboardPosition: React.FC<OndoLeaderboardPositionProps> = ({
       twClassName="gap-3"
       testID={ONDO_LEADERBOARD_POSITION_TEST_IDS.CONTAINER}
     >
-      <Text variant={TextVariant.HeadingMd}>
-        {strings('rewards.ondo_campaign_leaderboard_position.title')}
-      </Text>
+      {showTitle && (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('rewards.ondo_campaign_leaderboard_position.title')}
+          </Text>
+          {computedAt && (
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {strings(
+                'rewards.ondo_campaign_leaderboard_position.updated_at',
+                { time: formatComputedAt(computedAt) },
+              )}
+            </Text>
+          )}
+        </Box>
+      )}
 
       {/* Grid row 1: Rank | Tier | (empty) */}
       <Box flexDirection={BoxFlexDirection.Row}>

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import OndoPortfolio, { ONDO_PORTFOLIO_TEST_IDS } from './OndoPortfolio';
-import { useGetOndoPortfolioPosition } from '../../hooks/useGetOndoPortfolioPosition';
 import type {
   OndoGmPortfolioDto,
   OndoGmPortfolioPositionDto,
   OndoGmPortfolioSummaryDto,
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
-
-jest.mock('../../hooks/useGetOndoPortfolioPosition');
-
-const mockUseGetOndoPortfolioPosition =
-  useGetOndoPortfolioPosition as jest.MockedFunction<
-    typeof useGetOndoPortfolioPosition
-  >;
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -144,7 +136,6 @@ jest.mock('./OndoLeaderboard.utils', () => ({
   formatComputedAt: jest.fn(() => '1 hour ago'),
 }));
 
-const CAMPAIGN_ID = 'campaign-123';
 const mockRefetch = jest.fn();
 
 const MOCK_POSITION: OndoGmPortfolioPositionDto = {
@@ -175,6 +166,14 @@ const MOCK_PORTFOLIO: OndoGmPortfolioDto = {
   computedAt: '2026-03-20T12:00:00.000Z',
 };
 
+const baseProps = {
+  portfolio: null as OndoGmPortfolioDto | null,
+  isLoading: false,
+  hasError: false,
+  hasFetched: false,
+  refetch: mockRefetch,
+};
+
 describe('OndoPortfolio', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -182,48 +181,29 @@ describe('OndoPortfolio', () => {
 
   describe('loading state', () => {
     it('renders skeleton when loading before first fetch with no data', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: true,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio {...baseProps} isLoading />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeDefined();
     });
 
     it('does not render skeleton when loading but portfolio data already present', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: MOCK_PORTFOLIO,
-        isLoading: true,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { queryByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          isLoading
+          hasFetched
+        />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeNull();
     });
 
     it('renders skeleton during retry (isLoading=true, hasFetched=true, no portfolio)', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: true,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId, queryByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio {...baseProps} isLoading hasFetched />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeDefined();
@@ -233,48 +213,29 @@ describe('OndoPortfolio', () => {
 
   describe('error state', () => {
     it('renders error banner when has error and no data', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: false,
-        hasError: true,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio {...baseProps} hasError hasFetched />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.ERROR)).toBeDefined();
     });
 
     it('does not show empty banner on error even after fetch', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: false,
-        hasError: true,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { queryByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio {...baseProps} hasError hasFetched />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeNull();
     });
 
     it('shows cached portfolio data instead of error banner when portfolio exists', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: MOCK_PORTFOLIO,
-        isLoading: false,
-        hasError: true,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { queryByTestId, getByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          hasError
+          hasFetched
+        />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.ERROR)).toBeNull();
@@ -284,32 +245,20 @@ describe('OndoPortfolio', () => {
 
   describe('empty state', () => {
     it('renders empty banner when fetch completed with no portfolio', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio {...baseProps} hasFetched />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeDefined();
     });
 
     it('does not render empty banner when portfolio data is present', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: MOCK_PORTFOLIO,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { queryByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          hasFetched
+        />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeNull();
@@ -318,17 +267,7 @@ describe('OndoPortfolio', () => {
 
   describe('initial/unfetched state', () => {
     it('renders nothing before any fetch has completed', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
-      const { queryByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
-      );
+      const { queryByTestId } = render(<OndoPortfolio {...baseProps} />);
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeNull();
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.ERROR)).toBeNull();
@@ -338,89 +277,60 @@ describe('OndoPortfolio', () => {
   });
 
   describe('portfolio data display', () => {
-    beforeEach(() => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: MOCK_PORTFOLIO,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-    });
+    const loadedProps = {
+      ...baseProps,
+      portfolio: MOCK_PORTFOLIO,
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+    };
 
     it('renders portfolio container', () => {
-      const { getByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
-      );
+      const { getByTestId } = render(<OndoPortfolio {...loadedProps} />);
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.CONTAINER)).toBeDefined();
     });
 
     it('renders the positions heading', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
 
       expect(getByText('Your Positions')).toBeDefined();
     });
 
     it('renders the token name', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
 
       expect(getByText('Apple Inc.')).toBeDefined();
     });
   });
 
-  describe('hook integration', () => {
-    it('passes campaignId to hook', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: null,
-        isLoading: false,
-        hasError: false,
-        hasFetched: false,
-        refetch: mockRefetch,
-      });
-
-      render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
-
-      expect(mockUseGetOndoPortfolioPosition).toHaveBeenCalledWith(CAMPAIGN_ID);
-    });
-  });
-
   describe('navigation', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: MOCK_PORTFOLIO,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-    });
+    const loadedProps = {
+      ...baseProps,
+      portfolio: MOCK_PORTFOLIO,
+      hasFetched: true,
+    };
 
     it('shows arrow icon in section header when there are positions', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
       fireEvent.press(getByText('Your Positions'));
       // Component handles the press without throwing
       expect(getByText('Your Positions')).toBeDefined();
     });
 
     it('pressing a position row does not throw', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
       fireEvent.press(getByText('Apple Inc.'));
       expect(getByText('Apple Inc.')).toBeDefined();
     });
 
     it('renders empty banner when portfolio has no positions', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: { ...MOCK_PORTFOLIO, positions: [] },
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { getByTestId, queryByTestId } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={{ ...MOCK_PORTFOLIO, positions: [] }}
+          hasFetched
+        />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeDefined();
@@ -429,61 +339,51 @@ describe('OndoPortfolio', () => {
   });
 
   describe('position rendering details', () => {
-    beforeEach(() => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: MOCK_PORTFOLIO,
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-    });
+    const loadedProps = {
+      ...baseProps,
+      portfolio: MOCK_PORTFOLIO,
+      hasFetched: true,
+    };
 
     it('renders the units text', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
       expect(getByText('45.2 units')).toBeDefined();
     });
 
     it('renders the updated at text', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
       expect(getByText('Updated: 1 hour ago')).toBeDefined();
     });
 
     it('renders positive PnL percent in green', () => {
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(<OndoPortfolio {...loadedProps} />);
       expect(getByText('+7.75%')).toBeDefined();
     });
 
     it('renders negative PnL percent for loss position', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: {
-          ...MOCK_PORTFOLIO,
-          positions: [{ ...MOCK_POSITION, unrealizedPnlPercent: '-0.05' }],
-        },
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
-      const { getByText } = render(<OndoPortfolio campaignId={CAMPAIGN_ID} />);
+      const { getByText } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={{
+            ...MOCK_PORTFOLIO,
+            positions: [{ ...MOCK_POSITION, unrealizedPnlPercent: '-0.05' }],
+          }}
+          hasFetched
+        />,
+      );
       expect(getByText('-5.00%')).toBeDefined();
     });
 
     it('does not render PnL percent when value is non-numeric', () => {
-      mockUseGetOndoPortfolioPosition.mockReturnValue({
-        portfolio: {
-          ...MOCK_PORTFOLIO,
-          positions: [{ ...MOCK_POSITION, unrealizedPnlPercent: '—' }],
-        },
-        isLoading: false,
-        hasError: false,
-        hasFetched: true,
-        refetch: mockRefetch,
-      });
-
       const { queryByText } = render(
-        <OndoPortfolio campaignId={CAMPAIGN_ID} />,
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={{
+            ...MOCK_PORTFOLIO,
+            positions: [{ ...MOCK_POSITION, unrealizedPnlPercent: '—' }],
+          }}
+          hasFetched
+        />,
       );
       expect(queryByText('—')).toBeNull();
     });

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -95,7 +95,7 @@ jest.mock('../../../../../util/formatFiat', () => ({
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string, params?: Record<string, string | number>) => {
     const translations: Record<string, string> = {
-      'rewards.ondo_campaign_portfolio.positions_heading': 'Your Positions',
+      'rewards.ondo_campaign_portfolio.title': 'Your Positions',
       'rewards.ondo_campaign_portfolio.empty': 'No positions yet',
       'rewards.ondo_campaign_portfolio.empty_description':
         'Start investing to see your positions',
@@ -201,6 +201,19 @@ describe('OndoPortfolio', () => {
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeNull();
     });
 
+    it('renders skeleton when loading and portfolio has zero positions', () => {
+      const { getByTestId } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={{ ...MOCK_PORTFOLIO, positions: [] }}
+          isLoading
+          hasFetched
+        />,
+      );
+
+      expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeDefined();
+    });
+
     it('renders skeleton during retry (isLoading=true, hasFetched=true, no portfolio)', () => {
       const { getByTestId, queryByTestId } = render(
         <OndoPortfolio {...baseProps} isLoading hasFetched />,
@@ -254,11 +267,7 @@ describe('OndoPortfolio', () => {
 
     it('does not render empty banner when portfolio data is present', () => {
       const { queryByTestId } = render(
-        <OndoPortfolio
-          {...baseProps}
-          portfolio={MOCK_PORTFOLIO}
-          hasFetched
-        />,
+        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} hasFetched />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeNull();

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -32,7 +32,7 @@ import { parseCAIP19AssetId } from '../../../Ramp/Aggregator/utils/parseCaip19As
 import TrendingTokenLogo from '../../../Trending/components/TrendingTokenLogo';
 import { getTrendingTokenImageUrl } from '../../../Trending/utils/getTrendingTokenImageUrl';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
-import { useGetOndoPortfolioPosition } from '../../hooks/useGetOndoPortfolioPosition';
+import type { OndoGmPortfolioDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import RewardsInfoBanner from '../RewardsInfoBanner';
@@ -84,14 +84,22 @@ const formatUsd = (value: string): string => {
 };
 
 interface OndoPortfolioProps {
-  campaignId: string;
+  portfolio: OndoGmPortfolioDto | null;
+  isLoading: boolean;
+  hasError: boolean;
+  hasFetched: boolean;
+  refetch: () => Promise<void>;
 }
 
-const OndoPortfolio: React.FC<OndoPortfolioProps> = ({ campaignId }) => {
+const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
+  portfolio,
+  isLoading,
+  hasError,
+  hasFetched,
+  refetch,
+}) => {
   const tw = useTailwind();
   const navigation = useNavigation();
-  const { portfolio, isLoading, hasError, hasFetched, refetch } =
-    useGetOndoPortfolioPosition(campaignId);
 
   const grouped = useMemo(
     () =>

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -107,13 +107,14 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
     [portfolio],
   );
 
-  const showSkeleton = isLoading && !portfolio;
+  const showSkeleton =
+    isLoading && (!portfolio || portfolio.positions.length === 0);
 
   if (hasError && !portfolio) {
     return (
       <Box twClassName="gap-3" testID={ONDO_PORTFOLIO_TEST_IDS.ERROR}>
         <Text variant={TextVariant.HeadingMd}>
-          {strings('rewards.ondo_campaign_portfolio.positions_heading')}
+          {strings('rewards.ondo_campaign_portfolio.title')}
         </Text>
         <RewardsErrorBanner
           title={strings('rewards.ondo_campaign_portfolio.error_loading')}
@@ -130,6 +131,15 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   if (showSkeleton) {
     return (
       <Box twClassName="gap-3" testID={ONDO_PORTFOLIO_TEST_IDS.LOADING}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="mb-4 gap-2"
+        >
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('rewards.ondo_campaign_portfolio.title')}
+          </Text>
+        </Box>
         <Skeleton style={tw.style('h-32 rounded-xl')} />
         <Skeleton style={tw.style('h-24 rounded-xl')} />
         <Skeleton style={tw.style('h-24 rounded-xl')} />
@@ -141,7 +151,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
     return (
       <Box testID={ONDO_PORTFOLIO_TEST_IDS.EMPTY} twClassName="gap-3">
         <Text variant={TextVariant.HeadingMd}>
-          {strings('rewards.ondo_campaign_portfolio.positions_heading')}
+          {strings('rewards.ondo_campaign_portfolio.title')}
         </Text>
         <RewardsInfoBanner
           title={strings('rewards.ondo_campaign_portfolio.empty')}
@@ -181,7 +191,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
           twClassName="mb-4 gap-2"
         >
           <Text variant={TextVariant.HeadingMd}>
-            {strings('rewards.ondo_campaign_portfolio.positions_heading')}
+            {strings('rewards.ondo_campaign_portfolio.title')}
           </Text>
           {grouped.length > 0 && (
             <Icon
@@ -190,16 +200,18 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
               color={IconColor.IconDefault}
             />
           )}
-          <Box twClassName="flex-1" alignItems={BoxAlignItems.End}>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextAlternative}
-            >
-              {strings('rewards.ondo_campaign_portfolio.updated_at', {
-                time: formatComputedAt(portfolio.computedAt),
-              })}
-            </Text>
-          </Box>
+          {portfolio.computedAt && portfolio.positions.length > 0 && (
+            <Box twClassName="flex-1" alignItems={BoxAlignItems.End}>
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {strings('rewards.ondo_campaign_portfolio.updated_at', {
+                  time: formatComputedAt(portfolio.computedAt),
+                })}
+              </Text>
+            </Box>
+          )}
         </Box>
       </TouchableOpacity>
 

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
@@ -72,23 +72,11 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
         dispatch(setCampaignsLoading(true));
       }
       dispatch(setCampaignsError(false));
-
       const campaignsData = await Engine.controllerMessenger.call(
         'RewardsController:getCampaigns',
         subscriptionId,
       );
-
-      // TODO: REMOVE — force campaign to be over for UI development
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-      const mockedCampaigns = campaignsData.map((c) => ({
-        ...c,
-        details: c.details
-          ? { ...c.details, depositCutoffDate: yesterday.toISOString() }
-          : c.details,
-      }));
-
-      dispatch(setCampaigns(mockedCampaigns));
+      dispatch(setCampaigns(campaignsData));
     } catch {
       dispatch(setCampaignsError(true));
     } finally {

--- a/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
+++ b/app/components/UI/Rewards/hooks/useRewardCampaigns.ts
@@ -78,7 +78,17 @@ export const useRewardCampaigns = (): UseRewardCampaignsReturn => {
         subscriptionId,
       );
 
-      dispatch(setCampaigns(campaignsData));
+      // TODO: REMOVE — force campaign to be over for UI development
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const mockedCampaigns = campaignsData.map((c) => ({
+        ...c,
+        details: c.details
+          ? { ...c.details, depositCutoffDate: yesterday.toISOString() }
+          : c.details,
+      }));
+
+      dispatch(setCampaigns(mockedCampaigns));
     } catch {
       dispatch(setCampaignsError(true));
     } finally {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7961,6 +7961,8 @@
       "join_campaign": "Join the campaign",
       "entries_closed_title": "Entries closed",
       "entries_closed_description": "You missed the opt-in window",
+      "competition_closed_title": "Competition no longer open",
+      "competition_closed_description": "Sorry, this competition is no longer open to join. You can follow the leaderboard below and check back for future campaigns.",
       "checking_opt_in_status": "Checking opt in status",
       "swap": "Swap",
       "how_it_works": "How it works"
@@ -7979,13 +7981,12 @@
       "retry": "Retry"
     },
     "ondo_campaign_portfolio": {
-      "title": "Positions",
+      "title": "My Positions",
       "total_value": "Total value",
       "portfolio_pnl": "P&L",
       "portfolio_pnl_percent": "P&L (%)",
       "summary_cost_basis": "Cost basis",
       "summary_net_deposit": "Net deposit",
-      "positions_heading": "Positions",
       "position_current_value": "Value",
       "position_unrealized_pnl": "P&L",
       "updated_at": "Last updated: {{time}}",


### PR DESCRIPTION
## **Description**

This PR refactors how `OndoCampaignDetailsView` decides which sections to render, replacing ad-hoc inline conditions with a single `useMemo` that computes five boolean flags. It also replaces `CampaignEntriesClosedBanner` with `RewardsInfoBanner` for a unified visual treatment.

### Other changes

- `OndoLeaderboard`: new `showTitle` prop (default `true`) — parent can suppress the section title when rendering inline. `computedAt` timestamp moves to sit alongside the tier-tabs row instead of a standalone header row.
- `OndoLeaderboardPosition`: new `showTitle` (default `false`) and `computedAt` props — full leaderboard view opts in to a header with a "last updated" timestamp.
- `OndoPortfolio`: skeleton now shows when loading with an empty positions array (not just when portfolio is `null`).
- `CampaignTile`: Enter Now badge is gated behind `isOptinAllowed(campaign)` so it disappears once the deposit cutoff has passed.
- `useGetOndoLeaderboard` is now called unconditionally with `campaignId` instead of a computed conditional ID, since all render paths need leaderboard data.

## **Changelog**

CHANGELOG entry: null


## **Screenshots/Recordings**

Phase 1 - Opt in guidance

<img width="1444" height="132" alt="image" src="https://github.com/user-attachments/assets/78fff8c4-ea9b-4292-9876-1f80c66b29ad" />

<img width="722" height="1229" alt="image" src="https://github.com/user-attachments/assets/e36e6278-baa4-47f4-8477-ec92c58f5288" />

---

Phase 1 - Opted in & Position Guidance & Leaderboard

<img width="1585" height="210" alt="image" src="https://github.com/user-attachments/assets/d5c58171-9933-4485-89f3-f9832b2d16f4" />

<img width="947" height="1774" alt="Screenshot from 2026-03-30 14-46-51" src="https://github.com/user-attachments/assets/84792f98-96b5-476f-8c2c-2c409cd86260" />

---

Phase 1 - Opted in & at least one position

<img width="1585" height="246" alt="image" src="https://github.com/user-attachments/assets/9026da48-ee64-4ea0-8d2c-78d42802da3d" />

<img width="934" height="1778" alt="Screenshot from 2026-03-30 14-35-38" src="https://github.com/user-attachments/assets/c4c7a81e-ad75-435f-8f60-8db979f282d4" />

---

Phase 2 - Not Opted in & cut off date reached

<img width="1203" height="244" alt="image" src="https://github.com/user-attachments/assets/3e52588d-2f4a-4e89-a824-f494612442f5" />

<img width="934" height="1778" alt="Screenshot from 2026-03-30 14-41-17" src="https://github.com/user-attachments/assets/6103fd3a-9372-4fa7-becb-f9392517a780" />

---

Phase 2 - Opted in & cut off date reached  & No positions

<img width="1523" height="398" alt="image" src="https://github.com/user-attachments/assets/22bddf1b-7db4-4e26-86a1-03c046ca8912" />

<img width="934" height="1778" alt="Screenshot from 2026-03-30 14-41-17" src="https://github.com/user-attachments/assets/6103fd3a-9372-4fa7-becb-f9392517a780" />

---

Phase 2 - Opted in & cut off date reached  & positions

<img width="934" height="1778" alt="Screenshot from 2026-03-30 14-35-38" src="https://github.com/user-attachments/assets/c4c7a81e-ad75-435f-8f60-8db979f282d4" />

---

Completed - Not opted in or opted in and no positions

<img width="1523" height="240" alt="image" src="https://github.com/user-attachments/assets/db179fdb-2e0e-4902-a5bf-80be2a7305c8" />

<img width="941" height="1811" alt="Screenshot from 2026-03-30 13-39-10" src="https://github.com/user-attachments/assets/bcfad4e3-1dca-47ce-8ad6-e9a83ec69fbd" />

---

Completed - opted in and at least one position

<img width="1444" height="298" alt="image" src="https://github.com/user-attachments/assets/41cb2e04-ca8a-4157-b3c5-5b3e0c9b7e9f" />

<img width="941" height="1811" alt="Screenshot from 2026-03-30 13-50-02" src="https://github.com/user-attachments/assets/71652bc4-f6cb-477f-bfe7-60d2fc236449" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the Ondo rewards screens’ section-gating and data-fetch paths (leaderboard/portfolio/position), which can affect what users see and when network calls happen, but does not touch auth or core transaction flows.
> 
> **Overview**
> Improves Ondo rewards screens by **lifting `useGetOndoPortfolioPosition` and `useGetOndoLeaderboardPosition` calls into the parent views** and passing data/loading/error state down into `OndoPortfolio` and `OndoLeaderboardPosition`, removing their internal hook/selector coupling.
> 
> `OndoCampaignDetailsView` now computes a single set of boolean flags to control *How it works*, portfolio, leaderboard, and position sections, replaces the old entries-closed banner with a unified `RewardsInfoBanner`, and fetches leaderboard data unconditionally for the campaign. `OndoLeaderboardView` similarly wires in the position hook and renders leaderboard/position components without duplicated titles.
> 
> UI behavior tweaks: `CampaignTile` hides the “Enter now” label when opt-in is closed, `OndoLeaderboard` adds `showTitle` and adjusts where the “updated at” timestamp renders (including single-tier), and `OndoPortfolio` shows a skeleton when loading with an empty positions array. Copy updates add new competition-closed strings and rename the portfolio title in `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9477e99a47de267bbf7969c6673c20c7c647d6eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->