### PR TITLE
fix(deps): Force-resolve @metamask/messenger to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,8 @@
     "@metamask/bridge-status-controller@npm:^69.0.0": "patch:@metamask/bridge-status-controller@npm%3A69.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-ec19aeeecf.patch",
     "bn.js@npm:4.11.6": "4.12.3",
     "bn.js@npm:5.2.1": "5.2.3",
-    "expo-web-browser@npm:~14.0.2": "patch:expo-web-browser@npm%3A14.0.2#~/.yarn/patches/expo-web-browser-npm-14.0.2-98d00ce880.patch"
+    "expo-web-browser@npm:~14.0.2": "patch:expo-web-browser@npm%3A14.0.2#~/.yarn/patches/expo-web-browser-npm-14.0.2-98d00ce880.patch",
+    "@metamask/messenger@^0.3.0": "^1.0.0"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
@@ -259,7 +260,7 @@
     "@metamask/keyring-utils": "^3.2.0",
     "@metamask/logging-controller": "^8.0.0",
     "@metamask/message-signing-snap": "^1.1.2",
-    "@metamask/messenger": "^0.3.0",
+    "@metamask/messenger": "^1.0.0",
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8886,13 +8886,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@metamask/messenger@npm:0.3.0"
-  checksum: 10/84e9f4193646d749c7260a4958b13974b3c8738cc2e414116279ed31734e1edba687ff56ddbfdb75033bce30aaa9eeb7c391bccb87a66dbc99a902882271f673
-  languageName: node
-  linkType: hard
-
 "@metamask/messenger@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/messenger@npm:1.0.0"
@@ -35613,7 +35606,7 @@ __metadata:
     "@metamask/keyring-utils": "npm:^3.2.0"
     "@metamask/logging-controller": "npm:^8.0.0"
     "@metamask/message-signing-snap": "npm:^1.1.2"
-    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/messenger": "npm:^1.0.0"
     "@metamask/metamask-eth-abis": "npm:3.1.1"
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recently we released `@metamask/messenger` 1.0.0, and we upgraded all core packages to use this version. Unfortunately, this makes it impossible to bump a single core package in this repo. Doing so means that there are two versions of this package in the dependency tree in use at the same time, and this results in a type error, since the `Messenger` type from 1.0.0 is incompatible with the `Messenger` type from previous versions due to the use of private fields (see <https://github.com/microsoft/TypeScript/issues/62486> and other TypeScript issues).

To truly fix this, we would have to upgrade all core packages. This is non-trivial, so to unblock teams we force-resolve `@metamask/messenger` to 1.0.0 across the dependency tree. This should be safe as there are no breaking changes in 1.0.0 (this release was just a formality to communicate that the package is now stable).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

(N/A)

## **Manual testing steps**

Should be already covered by CI, but just in case, try upgrading a core package. `yarn lint:tsc` should still pass.

## **Screenshots/Recordings**

(N/A)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-resolution change; main risk is unforeseen runtime/type incompatibilities if any transitive dependency relied on `@metamask/messenger@0.x` behavior.
> 
> **Overview**
> Forces the dependency tree to use `@metamask/messenger@^1.0.0` by adding a Yarn `resolutions` override, preventing multiple `@metamask/messenger` versions from being installed simultaneously.
> 
> Updates the direct dependency and lockfile to `@metamask/messenger@1.0.0`, removing the locked `0.3.0` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6b17def422be999d8c767a3008c8758e40e6a11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->