### PR TITLE
refactor: extract route param types for assets team screens

### DIFF
--- a/app/components/Views/AssetHideConfirmation/index.tsx
+++ b/app/components/Views/AssetHideConfirmation/index.tsx
@@ -1,5 +1,7 @@
 import React, { useRef } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../core/NavigationService/types';
 import ReusableModal, { ReusableModalRef } from '../../UI/ReusableModal';
 import { fontStyles } from '../../../styles/common';
 import StyledButton from '../../UI/StyledButton';
@@ -53,13 +55,11 @@ const createStyles = (colors: any) =>
     },
   });
 
-interface Props {
-  route: {
-    params: {
-      onConfirm: () => void;
-    };
-  };
+export interface AssetHideConfirmationParams {
+  onConfirm: () => void;
 }
+
+type Props = StackScreenProps<RootStackParamList, 'AssetHideConfirmation'>;
 
 const AssetHideConfirmation = ({ route }: Props) => {
   const { onConfirm } = route.params;

--- a/app/components/Views/AssetOptions/AssetOptions.tsx
+++ b/app/components/Views/AssetOptions/AssetOptions.tsx
@@ -1,4 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../core/NavigationService/types';
 import React, { useMemo, useRef } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import {
@@ -78,16 +80,14 @@ interface Option {
   icon: IconName;
 }
 
-interface Props {
-  route: {
-    params: {
-      address: string;
-      isNativeCurrency: boolean;
-      chainId: string;
-      asset: TokenI;
-    };
-  };
+export interface AssetOptionsParams {
+  address: string;
+  isNativeCurrency: boolean;
+  chainId: string;
+  asset: TokenI;
 }
+
+type Props = StackScreenProps<RootStackParamList, 'AssetOptions'>;
 
 const AssetOptions = (props: Props) => {
   const {

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -199,6 +199,9 @@ import type {
 } from '../../components/Views/Webview/Webview.types';
 import { SectionId } from '../../components/Views/TrendingView/sections.config';
 
+import type { AssetHideConfirmationParams } from '../../components/Views/AssetHideConfirmation';
+import type { AssetOptionsParams } from '../../components/Views/AssetOptions/AssetOptions';
+
 /**
  * Flattened param list for React Navigation compatibility.
  * Maps actual route name strings to their parameter types.
@@ -416,6 +419,8 @@ export interface RootStackParamList extends ParamListBase {
   SeedphraseModal: SeedphraseModalParams | undefined;
   SkipAccountSecurityModal: undefined;
   SuccessErrorSheet: SuccessErrorSheetParams | undefined;
+  AssetHideConfirmation: AssetHideConfirmationParams;
+  AssetOptions: AssetOptionsParams;
   EligibilityFailedModal: undefined;
   UnsupportedRegionModal: undefined;
   MultichainTransactionDetails: MultichainTransactionDetailsParams | undefined;


### PR DESCRIPTION
## Summary
- Moves AssetHideConfirmation and AssetOptions route param types to source files
- Converts manual Props interfaces to `StackScreenProps<RootStackParamList>`
- Updates `NavigationService/types.ts` imports

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify AssetHideConfirmation and AssetOptions screens render correctly

Made with [Cursor](https://cursor.com)