### PR TITLE
refactor: extract route param types for accounts team screens

### DIFF
--- a/app/components/Views/MultichainAccounts/AccountDetails/AccountDetails.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/AccountDetails.tsx
@@ -8,24 +8,25 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../reducers';
 import Routes from '../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import PrivateKeyAccountDetails from './AccountTypes/PrivateKeyAccountDetails';
 import HardwareAccountDetails from './AccountTypes/HardwareAccountDetails';
 import { isHardwareAccount } from '../../../../util/address';
 import SnapAccountDetails from './AccountTypes/SnapAccountDetails';
 
-interface AccountDetailsProps {
-  route: {
-    params: {
-      account: InternalAccount;
-    };
-  };
+export interface AccountDetailsRouteParams {
+  account: InternalAccount;
 }
+
+type AccountDetailsProps = StackScreenProps<
+  RootStackParamList,
+  'MultichainAccountDetails'
+>;
 
 export const AccountDetails = (props: AccountDetailsProps) => {
   const navigation = useNavigation();
-  const {
-    account: { address },
-  } = props.route.params;
+  const { address } = props.route.params?.account ?? {};
   const account: InternalAccount | undefined = useSelector((state: RootState) =>
     getMemoizedInternalAccountByAddress(state, address),
   );

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import {
   BackHandler,
   SafeAreaView,
@@ -60,17 +62,19 @@ import {
 import Routes from '../../../../constants/navigation/Routes';
 import { selectAvatarAccountType } from '../../../../selectors/settings';
 
-interface AccountGroupDetailsProps {
-  route: {
-    params: {
-      accountGroup: AccountGroupObject;
-    };
-  };
+export interface AccountGroupDetailsRouteParams {
+  accountGroup: AccountGroupObject;
 }
+
+type AccountGroupDetailsProps = StackScreenProps<
+  RootStackParamList,
+  'MultichainAccountGroupDetails'
+>;
 
 export const AccountGroupDetails = (props: AccountGroupDetailsProps) => {
   const navigation = useNavigation();
-  const { accountGroup: initialAccountGroup } = props.route.params;
+  const { accountGroup: initialAccountGroup } =
+    props.route.params ?? ({} as AccountGroupDetailsRouteParams);
   const { id } = initialAccountGroup;
 
   // Use selector to get current account group data from Redux store

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
@@ -24,6 +24,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setMultichainAccountsIntroModalSeen } from '../../../../actions/user';
 import { LEARN_MORE_BOTTOM_SHEET_TEST_IDS } from './LearnMoreBottomSheet.testIds';
 
+export interface LearnMoreBottomSheetParams {
+  onClose: () => void;
+}
+
 interface LearnMoreBottomSheetProps {
   onClose: () => void;
 }

--- a/app/components/Views/MultichainAccounts/WalletDetails/WalletDetails.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/WalletDetails.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { BaseWalletDetails } from './BaseWalletDetails';
 import { selectWalletById } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { AccountWalletId } from '@metamask/account-api';
 
-interface WalletDetailsProps {
-  route: {
-    params: {
-      walletId: AccountWalletId;
-    };
-  };
+export interface WalletDetailsRouteParams {
+  walletId: AccountWalletId;
 }
 
+type WalletDetailsProps = StackScreenProps<
+  RootStackParamList,
+  'MultichainWalletDetails'
+>;
+
 export const WalletDetails = (props: WalletDetailsProps) => {
-  const { walletId } = props.route.params;
+  const walletId = props.route.params?.walletId;
   const selectWallet = useSelector(selectWalletById);
-  const wallet = selectWallet?.(walletId);
+  const wallet = walletId ? selectWallet?.(walletId) : undefined;
 
   if (!wallet) {
     return null;

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -156,9 +156,6 @@ import type {
   ShareAddressQRParams,
   DeleteAccountParams,
   SmartAccountParams,
-  MultichainAccountDetailsParams,
-  MultichainAccountGroupDetailsParams,
-  MultichainWalletDetailsParams,
   MultichainAddressListParams,
   PrivateKeyListParams,
 } from '../../components/Views/MultichainAccounts/MultichainAccounts.types';
@@ -198,6 +195,11 @@ import type {
   SimpleWebviewParams,
 } from '../../components/Views/Webview/Webview.types';
 import { SectionId } from '../../components/Views/TrendingView/sections.config';
+
+import type { LearnMoreBottomSheetParams } from '../../components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet';
+import type { AccountDetailsRouteParams } from '../../components/Views/MultichainAccounts/AccountDetails/AccountDetails';
+import type { AccountGroupDetailsRouteParams } from '../../components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails';
+import type { WalletDetailsRouteParams } from '../../components/Views/MultichainAccounts/WalletDetails/WalletDetails';
 
 /**
  * Flattened param list for React Navigation compatibility.
@@ -331,7 +333,9 @@ export interface RootStackParamList extends ParamListBase {
     | MultichainAccountDetailActionsParams
     | undefined;
   MultichainAccountsIntroModal: undefined;
-  MultichainAccountsLearnMoreBottomSheet: undefined;
+  MultichainAccountsLearnMoreBottomSheet:
+    | LearnMoreBottomSheetParams
+    | undefined;
   Pna25BottomSheet: undefined;
   RewardsBottomSheetModal: undefined;
   RewardsClaimBottomSheetModal: undefined;
@@ -568,11 +572,9 @@ export interface RootStackParamList extends ParamListBase {
   ImportSRPView: undefined;
 
   // Multichain accounts routes
-  MultichainAccountDetails: MultichainAccountDetailsParams | undefined;
-  MultichainAccountGroupDetails:
-    | MultichainAccountGroupDetailsParams
-    | undefined;
-  MultichainWalletDetails: MultichainWalletDetailsParams | undefined;
+  MultichainAccountDetails: AccountDetailsRouteParams | undefined;
+  MultichainAccountGroupDetails: AccountGroupDetailsRouteParams | undefined;
+  MultichainWalletDetails: WalletDetailsRouteParams | undefined;
   MultichainAddressList: MultichainAddressListParams | undefined;
   MultichainPrivateKeyList: PrivateKeyListParams | undefined;
 


### PR DESCRIPTION
## Summary
- Moves MultichainAccounts route param types (AccountDetails, AccountGroupDetails, WalletDetails, LearnMoreBottomSheet) to source files
- Converts manual Props interfaces to `StackScreenProps<RootStackParamList>`
- Updates `NavigationService/types.ts` imports

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify MultichainAccountDetails, MultichainAccountGroupDetails, MultichainWalletDetails, and LearnMoreBottomSheet screens render correctly

Made with [Cursor](https://cursor.com)