### PR TITLE
refactor: extract SDKSessionModal route param type to source file

### DIFF
--- a/app/components/Views/SDK/SDKSessionModal/SDKSessionModal.tsx
+++ b/app/components/Views/SDK/SDKSessionModal/SDKSessionModal.tsx
@@ -4,6 +4,8 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 // External dependencies
 import type { ThemeColors, ThemeTypography } from '@metamask/design-tokens';
 import { useNavigation } from '@react-navigation/native';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { StyleSheet, View } from 'react-native';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
@@ -69,20 +71,18 @@ const createStyles = (
       justifyContent: 'center',
     },
   });
-interface SDKSEssionMoodalProps {
-  route: {
-    params: {
-      channelId?: string;
-      icon?: string;
-      urlOrTitle: string;
-      version?: string;
-      platform?: string;
-      isV2?: boolean;
-    };
-  };
+export interface SDKSessionModalParams {
+  channelId?: string;
+  icon?: string;
+  urlOrTitle: string;
+  version?: string;
+  platform?: string;
+  isV2?: boolean;
 }
 
-const SDKSessionModal = ({ route }: SDKSEssionMoodalProps) => {
+type Props = StackScreenProps<RootStackParamList, 'SDKManageConnections'>;
+
+const SDKSessionModal = ({ route }: Props) => {
   const { params } = route;
   const { channelId, icon, urlOrTitle, version, platform, isV2 } = params;
 

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -199,6 +199,8 @@ import type {
 } from '../../components/Views/Webview/Webview.types';
 import { SectionId } from '../../components/Views/TrendingView/sections.config';
 
+import type { SDKSessionModalParams } from '../../components/Views/SDK/SDKSessionModal/SDKSessionModal';
+
 /**
  * Flattened param list for React Navigation compatibility.
  * Maps actual route name strings to their parameter types.
@@ -393,7 +395,7 @@ export interface RootStackParamList extends ParamListBase {
   SDKFeedback: SDKFeedbackParams | undefined;
   DataCollection: undefined;
   ExperienceEnhancer: undefined;
-  SDKManageConnections: undefined;
+  SDKManageConnections: SDKSessionModalParams | undefined;
   SDKDisconnect: SDKDisconnectParams | undefined;
   AccountConnect: AccountConnectParams | undefined;
   AccountPermissions: AccountPermissionsParams | undefined;


### PR DESCRIPTION
## Summary
- Exports `SDKSessionModalParams` from SDKSessionModal component
- Converts manual Props to `StackScreenProps<RootStackParamList, 'SDKManageConnections'>`
- Updates `NavigationService/types.ts` to import from source

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify SDKSessionModal screen renders correctly

Made with [Cursor](https://cursor.com)