### PR TITLE
refactor: extract switch-account-type-modal route param type to source file

### DIFF
--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal.tsx
@@ -2,7 +2,9 @@ import React, { useCallback } from 'react';
 import { Hex } from '@metamask/utils';
 import { TouchableOpacity, View } from 'react-native';
 import { useSelector } from 'react-redux';
-import { useNavigation, RouteProp } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
+import { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../../../../core/NavigationService/types';
 
 import Avatar, {
   AvatarSize,
@@ -25,21 +27,14 @@ import Icon, {
 } from '../../../../../../component-library/components/Icons/Icon';
 import Engine from '../../../../../../core/Engine';
 
-interface SwitchAccountTypeModalRouteParams {
+export interface SwitchAccountTypeModalRouteParams {
   address?: Hex;
 }
 
-interface SwitchAccountTypeModalParamList {
-  ConfirmationSwitchAccountType: SwitchAccountTypeModalRouteParams;
-  [key: string]: object | undefined;
-}
-
-interface SwitchAccountTypeModalProps {
-  route: RouteProp<
-    SwitchAccountTypeModalParamList,
-    'ConfirmationSwitchAccountType'
-  >;
-}
+type SwitchAccountTypeModalProps = StackScreenProps<
+  RootStackParamList,
+  'ConfirmationSwitchAccountType'
+>;
 
 const SwitchAccountTypeModal = ({ route }: SwitchAccountTypeModalProps) => {
   const { styles } = useStyles(styleSheet, {});

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -199,6 +199,8 @@ import type {
 } from '../../components/Views/Webview/Webview.types';
 import { SectionId } from '../../components/Views/TrendingView/sections.config';
 
+import type { SwitchAccountTypeModalRouteParams } from '../../components/Views/confirmations/components/modals/switch-account-type-modal/switch-account-type-modal';
+
 /**
  * Flattened param list for React Navigation compatibility.
  * Maps actual route name strings to their parameter types.
@@ -522,7 +524,7 @@ export interface RootStackParamList extends ParamListBase {
   // Misc routes
   LockScreen: undefined;
   ConfirmationRequestModal: undefined;
-  ConfirmationSwitchAccountType: undefined;
+  ConfirmationSwitchAccountType: SwitchAccountTypeModalRouteParams | undefined;
   ConfirmationPayWithModal: undefined;
   ConfirmationPayWithNetworkModal: undefined;
   SmartAccountOptIn: undefined;


### PR DESCRIPTION
## Summary
- Exports `SwitchAccountTypeModalRouteParams` from switch-account-type-modal source file
- Converts from local `RouteProp` typing to `StackScreenProps<RootStackParamList, 'ConfirmationSwitchAccountType'>`
- Updates `NavigationService/types.ts` to import from source

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify ConfirmationSwitchAccountType modal renders correctly

Made with [Cursor](https://cursor.com)