### PR TITLE
fix(perps): [DESIGN DEBT] Update arrow symbols on perps order pages

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -170,6 +170,7 @@ export const getPerpsMarketRowItemSelector = {
 
 export const PerpsOrderHeaderSelectorsIDs = {
   HEADER: 'perps-order-header',
+  BACK_BUTTON: 'perps-order-header-back-button',
   ASSET_TITLE: 'perps-order-header-asset-title',
   ORDER_TYPE_BUTTON: 'perps-order-header-order-type-button',
 };

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
 import Logger from '../../../../../util/Logger';
 import PerpsAdjustMarginView from './PerpsAdjustMarginView';
 import { type Position } from '@metamask/perps-controller';
@@ -127,7 +127,36 @@ jest.mock('../../components/PerpsOrderHeader', () => {
   };
 });
 jest.mock('../../components/PerpsAmountDisplay', () => 'PerpsAmountDisplay');
-jest.mock('../../components/PerpsSlider', () => 'PerpsSlider');
+jest.mock('../../components/PerpsSlider', () => {
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return function MockPerpsSlider({
+    onValueChange,
+  }: {
+    onValueChange?: (value: number) => void;
+  }) {
+    return ReactModule.createElement(View, {
+      testID: 'mock-perps-slider',
+      onValueChange,
+    });
+  };
+});
+
+jest.mock('../../../../../component-library/components/Icons/Icon', () => {
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ name }: { name: string }) =>
+      ReactModule.createElement(View, { accessibilityLabel: name }),
+    IconName: {
+      ArrowRight: 'ArrowRight',
+      Info: 'Info',
+    },
+    IconSize: { Sm: 'Sm' },
+    IconColor: { Alternative: 'Alternative' },
+  };
+});
 
 describe('PerpsAdjustMarginView', () => {
   const mockPosition: Position = {
@@ -454,6 +483,25 @@ describe('PerpsAdjustMarginView', () => {
         screen.getByText('perps.adjust_margin.margin_available_to_remove'),
       ).toBeOnTheScreen();
       expect(screen.getByText('$200.00')).toBeOnTheScreen();
+    });
+  });
+
+  describe('arrow icon correctness', () => {
+    beforeEach(() => {
+      mockRouteParams = {
+        position: mockPosition,
+        mode: 'add',
+      };
+    });
+
+    it('uses ArrowRight (not Arrow2Right) for liquidation price and distance transition arrows', () => {
+      const { getByTestId } = render(<PerpsAdjustMarginView />);
+
+      // Trigger showTransition by setting a non-zero margin amount via the slider
+      fireEvent(getByTestId('mock-perps-slider'), 'valueChange', 100);
+
+      const arrowIcons = screen.getAllByLabelText('ArrowRight');
+      expect(arrowIcons).toHaveLength(2);
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
@@ -348,7 +348,7 @@ const PerpsAdjustMarginView: React.FC = () => {
                   })}
                 </Text>
                 <Icon
-                  name={IconName.Arrow2Right}
+                  name={IconName.ArrowRight}
                   size={IconSize.Sm}
                   color={colors.icon.alternative}
                 />
@@ -396,7 +396,7 @@ const PerpsAdjustMarginView: React.FC = () => {
                   )}
                 </Text>
                 <Icon
-                  name={IconName.Arrow2Right}
+                  name={IconName.ArrowRight}
                   size={IconSize.Sm}
                   color={colors.icon.alternative}
                 />

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
@@ -232,13 +232,18 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => {
   };
 });
 
-jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: () => null,
-  IconName: { Arrow2Right: 'Arrow2Right', ArrowRight: 'ArrowRight' },
-  IconSize: { Md: 'Md' },
-  IconColor: { Default: 'Default' },
-}));
+jest.mock('../../../../../component-library/components/Icons/Icon', () => {
+  const ReactModule = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ name }: { name: string }) =>
+      ReactModule.createElement(View, { accessibilityLabel: name }),
+    IconName: { ArrowRight: 'ArrowRight' },
+    IconSize: { Md: 'Md' },
+    IconColor: { Default: 'Default' },
+  };
+});
 
 jest.mock('../../../../../component-library/components/Buttons/Button', () => ({
   ButtonSize: { Lg: 'Lg' },
@@ -365,5 +370,11 @@ describe('PerpsFlipPositionConfirmSheet', () => {
 
     // Math.abs(-2.5) = 2.5
     expect(screen.getByText('2.5 ETH')).toBeOnTheScreen();
+  });
+
+  it('uses ArrowRight (not Arrow2Right) for direction transition indicator', () => {
+    render(<PerpsFlipPositionConfirmSheet position={mockLongPosition} />);
+
+    expect(screen.getByLabelText('ArrowRight')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
@@ -235,7 +235,7 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => {
 jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
   __esModule: true,
   default: () => null,
-  IconName: { Arrow2Right: 'Arrow2Right' },
+  IconName: { Arrow2Right: 'Arrow2Right', ArrowRight: 'ArrowRight' },
   IconSize: { Md: 'Md' },
   IconColor: { Default: 'Default' },
 }));

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.tsx
@@ -202,7 +202,7 @@ const PerpsFlipPositionConfirmSheet: React.FC<
                         : strings('perps.order.short_label')}
                     </Text>
                     <Icon
-                      name={IconName.Arrow2Right}
+                      name={IconName.ArrowRight}
                       size={IconSize.Md}
                       color={IconColor.Default}
                     />

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
@@ -80,7 +80,7 @@ describe('PerpsOrderHeader', () => {
     expect(component).toBeDefined();
   });
 
-  it('should use ArrowLeft icon for back button, not Arrow2Left', () => {
+  it('uses ArrowLeft icon for back button, not Arrow2Left', () => {
     const { getByTestId } = render(<PerpsOrderHeader {...defaultProps} />);
     const backButton = getByTestId(PerpsOrderHeaderSelectorsIDs.BACK_BUTTON);
     expect(backButton.props.accessibilityLabel).toBe('ArrowLeft');

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import PerpsOrderHeader from './PerpsOrderHeader';
-import { PerpsHomeViewSelectorsIDs } from '../../Perps.testIds';
+import { PerpsOrderHeaderSelectorsIDs } from '../../Perps.testIds';
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -36,10 +36,22 @@ jest.mock(
     const { TouchableOpacity } = jest.requireActual('react-native');
     return {
       __esModule: true,
-      default: ({ onPress }: { onPress: () => void }) => (
-        <TouchableOpacity testID="back-button" onPress={onPress} />
+      default: ({
+        onPress,
+        iconName,
+        testID,
+      }: {
+        onPress: () => void;
+        iconName: string;
+        testID?: string;
+      }) => (
+        <TouchableOpacity
+          testID={testID ?? 'back-button'}
+          accessibilityLabel={iconName}
+          onPress={onPress}
+        />
       ),
-      ButtonIconSizes: { Sm: 'sm' },
+      ButtonIconSizes: { Sm: 'sm', Md: 'md' },
     };
   },
 );
@@ -68,9 +80,15 @@ describe('PerpsOrderHeader', () => {
     expect(component).toBeDefined();
   });
 
+  it('should use ArrowLeft icon for back button, not Arrow2Left', () => {
+    const { getByTestId } = render(<PerpsOrderHeader {...defaultProps} />);
+    const backButton = getByTestId('perps-order-header-back-button');
+    expect(backButton.props.accessibilityLabel).toBe('ArrowLeft');
+  });
+
   it('should handle navigation back', () => {
     const { getByTestId } = render(<PerpsOrderHeader {...defaultProps} />);
-    const backButton = getByTestId(PerpsHomeViewSelectorsIDs.BACK_BUTTON);
+    const backButton = getByTestId(PerpsOrderHeaderSelectorsIDs.BACK_BUTTON);
     fireEvent.press(backButton);
     expect(mockGoBack).toHaveBeenCalled();
   });
@@ -80,7 +98,7 @@ describe('PerpsOrderHeader', () => {
     const { getByTestId } = render(
       <PerpsOrderHeader {...defaultProps} onBack={mockOnBack} />,
     );
-    const backButton = getByTestId(PerpsHomeViewSelectorsIDs.BACK_BUTTON);
+    const backButton = getByTestId(PerpsOrderHeaderSelectorsIDs.BACK_BUTTON);
     fireEvent.press(backButton);
     expect(mockOnBack).toHaveBeenCalled();
     expect(mockGoBack).not.toHaveBeenCalled();

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
@@ -82,7 +82,7 @@ describe('PerpsOrderHeader', () => {
 
   it('should use ArrowLeft icon for back button, not Arrow2Left', () => {
     const { getByTestId } = render(<PerpsOrderHeader {...defaultProps} />);
-    const backButton = getByTestId('perps-order-header-back-button');
+    const backButton = getByTestId(PerpsOrderHeaderSelectorsIDs.BACK_BUTTON);
     expect(backButton.props.accessibilityLabel).toBe('ArrowLeft');
   });
 

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -71,11 +71,6 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [onOrderTypePress]);
 
   // Format price display with edge case handling
-  // eslint-disable-next-line no-console
-  console.log(
-    '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
-  );
-
   const formattedPrice = useMemo(() => {
     // Handle invalid or edge case values
     if (!price || price <= 0 || !Number.isFinite(price)) {

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsOrderHeaderSelectorsIDs } from '../../Perps.testIds';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -71,12 +72,9 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [onOrderTypePress]);
 
   // Format price display with edge case handling
-  // eslint-disable-next-line no-console
-  if (__DEV__) {
-    console.warn(
-      '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
-    );
-  }
+  DevLogger.log(
+    '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
+  );
 
   const formattedPrice = useMemo(() => {
     // Handle invalid or edge case values

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -104,6 +104,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   return (
     <View style={styles.header} testID={PerpsOrderHeaderSelectorsIDs.HEADER}>
       <ButtonIcon
+        testID={PerpsOrderHeaderSelectorsIDs.BACK_BUTTON}
         iconName={IconName.Arrow2Left}
         onPress={handleBack}
         iconColor={IconColor.Default}

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsOrderHeaderSelectorsIDs } from '../../Perps.testIds';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -72,7 +71,8 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [onOrderTypePress]);
 
   // Format price display with edge case handling
-  DevLogger.log(
+  // eslint-disable-next-line no-console
+  console.log(
     '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
   );
 

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -100,7 +100,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
     <View style={styles.header} testID={PerpsOrderHeaderSelectorsIDs.HEADER}>
       <ButtonIcon
         testID={PerpsOrderHeaderSelectorsIDs.BACK_BUTTON}
-        iconName={IconName.Arrow2Left}
+        iconName={IconName.ArrowLeft}
         onPress={handleBack}
         iconColor={IconColor.Default}
         size={ButtonIconSizes.Md}

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsOrderHeaderSelectorsIDs } from '../../Perps.testIds';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -72,9 +71,12 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [onOrderTypePress]);
 
   // Format price display with edge case handling
-  DevLogger.log(
-    '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
-  );
+  // eslint-disable-next-line no-console
+  if (__DEV__) {
+    console.warn(
+      '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
+    );
+  }
 
   const formattedPrice = useMemo(() => {
     // Handle invalid or edge case values

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsOrderHeaderSelectorsIDs } from '../../Perps.testIds';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -71,6 +72,10 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [onOrderTypePress]);
 
   // Format price display with edge case handling
+  DevLogger.log(
+    '[PR-28072] BUG_MARKER: Arrow2Left used instead of ArrowLeft in PerpsOrderHeader',
+  );
+
   const formattedPrice = useMemo(() => {
     // Handle invalid or edge case values
     if (!price || price <= 0 || !Number.isFinite(price)) {


### PR DESCRIPTION
## **Description**

Replaces `Arrow2Left`/`Arrow2Right` (bidirectional arrow icons) with `ArrowLeft`/`ArrowRight` (standard directional arrows) on three perps screens. The `Arrow2*` variants imply a two-way swap which is incorrect for a back button and before→after value transition indicators.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2368](https://consensyssoftware.atlassian.net/browse/TAT-2368)

## **Manual testing steps**

```gherkin
Feature: Correct arrow icons on perps order screens

  Scenario: Back button uses standard back arrow
    Given I am on the Perps tab with an open BTC position
    When I tap the close position button
    Then the header back button shows a single left-pointing arrow

  Scenario: Flip position direction indicator uses standard right arrow
    Given I have an open position
    When the flip position confirmation sheet is displayed
    Then the arrow between the current and target direction shows a single right-pointing arrow

  Scenario: Adjust margin transition arrows use standard right arrow
    Given I am on the adjust margin screen
    When I change the margin amount
    Then both the liquidation price and distance rows show single right-pointing transition arrows
```

## **Screenshots/Recordings**

_Evidence available in task artifacts — will be added by reviewer if needed._

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/ed23ac56-b5d3-413c-aaa0-baafdc1eefb8


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/0a7905df-94ed-4096-ab92-f267c3810ac0


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "pr": "28072",
  "title": "Arrow symbols on perps order pages use correct icon variants",
  "jira": "TAT-2368",
  "acceptance_criteria": [
    "Back button on perps order pages uses ArrowLeft (not Arrow2Left)",
    "No new TypeScript errors"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "runtime": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "steps": [
        {
          "id": "assert-position-exists",
          "description": "BTC position must exist to access close position view",
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getPositions().then(function(ps){var p=ps.find(function(x){return x.symbol==='BTC'});return JSON.stringify({found:!!p})})",
          "assert": { "operator": "eq", "field": "found", "value": true }
        },
        {
          "id": "nav-market-detail",
          "description": "Navigate to BTC market details",
          "action": "navigate",
          "target": "PerpsMarketDetails",
          "params": {
            "market": {
              "symbol": "BTC",
              "name": "BTC",
              "price": "0",
              "change24h": "0",
              "change24hPercent": "0",
              "volume": "0",
              "maxLeverage": "100"
            }
          }
        },
        {
          "id": "wait-close-button",
          "action": "wait_for",
          "test_id": "perps-market-details-close-button"
        },
        {
          "id": "press-close",
          "action": "press",
          "test_id": "perps-market-details-close-button"
        },
        {
          "id": "wait-order-header",
          "action": "wait_for",
          "test_id": "perps-order-header-back-button"
        },
        {
          "id": "assert-back-arrow-icon",
          "description": "Assert back button uses ArrowLeft, not Arrow2Left",
          "action": "eval_sync",
          "expression": "JSON.stringify((function(){var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!hook)return{iconName:null,error:'no hook'};var found=null;function walk(f){if(!f)return;if(f.memoizedProps&&f.memoizedProps.testID==='perps-order-header-back-button'){found=f;return;}walk(f.child);if(!found)walk(f.sibling);}for(var [id] of hook.renderers){var roots=hook.getFiberRoots?hook.getFiberRoots(id):null;if(roots)roots.forEach(function(r){if(!found)walk(r.current);});}if(!found)return{iconName:null,error:'back btn not found'};return{iconName:found.memoizedProps.iconName||null};})())",
          "assert": { "operator": "eq", "field": "iconName", "value": "ArrowLeft" }
        },
        {
          "id": "evidence-order-header",
          "action": "screenshot",
          "filename": "evidence-order-header-arrow.png"
        },
        {
          "id": "go-back",
          "action": "press",
          "test_id": "perps-order-header-back-button"
        },
        {
          "id": "wait-market-details",
          "action": "wait_for",
          "route": "PerpsMarketDetails"
        },
        {
          "id": "verify-no-errors",
          "action": "log_watch",
          "window_seconds": 5,
          "must_not_appear": ["TypeError", "ReferenceError"]
        }
      ]
    }
  }
}
```

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/test change: swaps icon variants and adds a testID for the perps order header back button, with updated unit tests to assert correct icon usage.
> 
> **Overview**
> **Corrects perps order-page arrow iconography** by replacing `Arrow2Left`/`Arrow2Right` with standard `ArrowLeft`/`ArrowRight` on the order header back button, the flip-position direction transition indicator, and the adjust-margin liquidation price/distance transition arrows.
> 
> Adds `PerpsOrderHeaderSelectorsIDs.BACK_BUTTON` and wires it into `PerpsOrderHeader`’s `ButtonIcon` for stable targeting, and updates/extends unit tests (including mocks) to assert the new icon names and transition behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0306cd64d52189437d7255a0c2e227a06530c16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



