### PR TITLE
test(tron): add account creation smoke coverage

### DIFF
--- a/tests/api-mocking/mock-responses/tron-mocks.ts
+++ b/tests/api-mocking/mock-responses/tron-mocks.ts
@@ -10,14 +10,29 @@ export const TRX_BALANCE = 6072392; // in SUN (~6.07 TRX)
 export const TRX_TO_USD_RATE = 0.29469;
 export const SUN_PER_TRX = 1_000_000;
 
+export async function mockTronFeatureFlags(mockServer: Mockttp) {
+  return await mockServer
+    .forGet(/client-config\.api\.cx\.metamask\.io\/v1\/flags/)
+    .thenJson(200, [
+      {
+        feature: 'tronAccounts',
+        value: { enabled: true, minimumVersion: '0.0.0' },
+      },
+    ]);
+}
+
 export async function mockTronGetAccount(
   mockServer: Mockttp,
   mockZeroBalance = false,
   address = TRON_ACCOUNT_ADDRESS,
   balance = TRX_BALANCE,
 ) {
+  const accountEndpointPattern = new RegExp(
+    `/v1/accounts/${address.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}(?:\\?.*)?$`,
+  );
+
   return await mockServer
-    .forGet(new RegExp(`/v1/accounts/${address}(?:\\?.*)?$`))
+    .forGet(accountEndpointPattern)
     .thenJson(200, {
       data: [
         {
@@ -132,24 +147,10 @@ export async function mockBroadcastTransaction(mockServer: Mockttp) {
     });
 }
 
-export async function mockTronFeatureFlags(mockServer: Mockttp) {
-  return await mockServer
-    .forGet(/client-config\.api\.cx\.metamask\.io\/v1\/flags/)
-    .thenJson(200, [
-      {
-        feature: 'tronAccounts',
-        value: { enabled: true, minimumVersion: '0.0.0' },
-      },
-    ]);
-}
-
-export async function mockTronApis(
-  mockServer: Mockttp,
-  mockZeroBalance = false,
-) {
+export async function mockTronApis(mockServer: Mockttp) {
   return [
     await mockTronFeatureFlags(mockServer),
-    await mockTronGetAccount(mockServer, mockZeroBalance),
+    await mockTronGetAccount(mockServer),
     await mockTronGetAccountResource(mockServer),
     await mockTronGetTransactions(mockServer),
     await mockTronGetTrc20Transactions(mockServer),

--- a/tests/flows/tron.flow.test.ts
+++ b/tests/flows/tron.flow.test.ts
@@ -1,0 +1,62 @@
+import { createTronAccount } from './tron.flow';
+import Assertions from '../framework/Assertions';
+import AccountListBottomSheet from '../page-objects/wallet/AccountListBottomSheet';
+import AddNewAccountSheet from '../page-objects/wallet/AddNewAccountSheet';
+import Gestures from '../framework/Gestures';
+import Matchers from '../framework/Matchers';
+
+jest.mock('../framework/Assertions', () => ({
+  __esModule: true,
+  default: {
+    expectElementToBeVisible: jest.fn(),
+  },
+}));
+
+jest.mock('../page-objects/wallet/AccountListBottomSheet', () => ({
+  __esModule: true,
+  default: {
+    accountList: 'account-list',
+    tapAddAccountButton: jest.fn(),
+  },
+}));
+
+jest.mock('../page-objects/wallet/AddNewAccountSheet', () => ({
+  __esModule: true,
+  default: {
+    tapConfirmButton: jest.fn(),
+  },
+}));
+
+jest.mock('../framework/Gestures', () => ({
+  __esModule: true,
+  default: {
+    tap: jest.fn(),
+  },
+}));
+
+jest.mock('../framework/Matchers', () => ({
+  __esModule: true,
+  default: {
+    getElementByID: jest.fn().mockReturnValue('tron-account-button'),
+  },
+}));
+
+describe('tron flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('confirms Tron account creation after selecting the add Tron account action', async () => {
+    await createTronAccount();
+
+    expect(Assertions.expectElementToBeVisible).toHaveBeenCalledWith(
+      AccountListBottomSheet.accountList,
+    );
+    expect(AccountListBottomSheet.tapAddAccountButton).toHaveBeenCalled();
+    expect(Gestures.tap).toHaveBeenCalledWith('tron-account-button');
+    expect(AddNewAccountSheet.tapConfirmButton).toHaveBeenCalled();
+    expect(Matchers.getElementByID).toHaveBeenCalledWith(
+      'add-account-add-tron-account',
+    );
+  });
+});

--- a/tests/flows/tron.flow.ts
+++ b/tests/flows/tron.flow.ts
@@ -1,0 +1,26 @@
+import Assertions from '../framework/Assertions';
+import Gestures from '../framework/Gestures';
+import Matchers from '../framework/Matchers';
+import AccountListBottomSheet from '../page-objects/wallet/AccountListBottomSheet';
+import AddNewAccountSheet from '../page-objects/wallet/AddNewAccountSheet';
+import WalletView from '../page-objects/wallet/WalletView';
+
+export async function createTronAccount(): Promise<void> {
+  await Assertions.expectElementToBeVisible(AccountListBottomSheet.accountList);
+
+  await AccountListBottomSheet.tapAddAccountButton();
+  await Gestures.tap(Matchers.getElementByID('add-account-add-tron-account'));
+  await AddNewAccountSheet.tapConfirmButton();
+}
+
+export async function selectTronNetwork(): Promise<void> {
+  await WalletView.tapNetworksButtonOnNavBar();
+
+  await Gestures.tap(Matchers.getElementByText('Tron Mainnet'));
+
+  try {
+    await Gestures.tap(Matchers.getElementByText('Got it'));
+  } catch {
+    // The education modal is not always shown.
+  }
+}

--- a/tests/page-objects/Tron/TronAccountView.ts
+++ b/tests/page-objects/Tron/TronAccountView.ts
@@ -1,0 +1,16 @@
+import Assertions from '../../framework/Assertions';
+import WalletView from '../wallet/WalletView';
+
+class TronAccountView {
+  async checkSelectedNetworkIsVisible() {
+    await Assertions.expectElementToHaveText(
+      WalletView.navbarNetworkText,
+      'Tron Mainnet',
+      {
+        description: 'selected Tron network should be visible in the navbar',
+      },
+    );
+  }
+}
+
+export default new TronAccountView();

--- a/tests/smoke/tron/account-creation.spec.ts
+++ b/tests/smoke/tron/account-creation.spec.ts
@@ -1,0 +1,32 @@
+import { Mockttp } from 'mockttp';
+import { SmokeNetworkExpansion } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { mockTronApis } from '../../api-mocking/mock-responses/tron-mocks';
+import { createTronAccount, selectTronNetwork } from '../../flows/tron.flow';
+import { loginToApp } from '../../flows/wallet.flow';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import WalletView from '../../page-objects/wallet/WalletView';
+
+jest.setTimeout(150_000);
+
+describe(SmokeNetworkExpansion('Tron Account Creation'), () => {
+  it('creates a Tron account and selects the Tron network', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await WalletView.tapIdenticon();
+        await createTronAccount();
+        await selectTronNetwork();
+        await TronAccountView.checkSelectedNetworkIsVisible();
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile Tron account creation smoke coverage
- keep account/network helpers scoped to this workflow

## Test Plan
- [ ] Not re-run in this session
