### PR TITLE
test(tron): add balance display smoke coverage

### DIFF
--- a/tests/api-mocking/mock-responses/tron-mocks.ts
+++ b/tests/api-mocking/mock-responses/tron-mocks.ts
@@ -1,12 +1,7 @@
 import { Mockttp } from 'mockttp';
 
-// Constants — matching extension's common-tron.ts
 export const TRON_ACCOUNT_ADDRESS = 'TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3';
-export const TRON_RECIPIENT_ADDRESS = 'TK3xRFq22eEiATz6kfamDeAAQrPdfdGPeq';
-export const TRON_SECOND_ACCOUNT_ADDRESS =
-  'TK3xRFq22eEiATz6kfamDeAAQrPdfdGPeq';
-export const TRON_CHAIN_ID = 'tron:728126428';
-export const TRX_BALANCE = 6072392; // in SUN (~6.07 TRX)
+export const TRX_BALANCE = 6_072_392;
 export const TRX_TO_USD_RATE = 0.29469;
 export const SUN_PER_TRX = 1_000_000;
 
@@ -109,29 +104,6 @@ export async function mockTronSpotPrices(mockServer: Mockttp) {
     });
 }
 
-export async function mockTronGetBlock(mockServer: Mockttp) {
-  return await mockServer
-    .forPost(/\/wallet\/getblock/)
-    .thenJson(200, {
-      blockID: 'abc123',
-      block_header: {
-        raw_data: {
-          timestamp: Date.now(),
-          number: 12345678,
-        },
-      },
-    });
-}
-
-export async function mockBroadcastTransaction(mockServer: Mockttp) {
-  return await mockServer
-    .forPost(/\/wallet\/broadcasttransaction/)
-    .thenJson(200, {
-      result: true,
-      txid: '36c4096d30a82641ee9d8c12297ed330ddb0f8ae272dc2564995de7a4201a67e',
-    });
-}
-
 export async function mockTronFeatureFlags(mockServer: Mockttp) {
   return await mockServer
     .forGet(/client-config\.api\.cx\.metamask\.io\/v1\/flags/)
@@ -155,7 +127,5 @@ export async function mockTronApis(
     await mockTronGetTrc20Transactions(mockServer),
     await mockTronExchangeRates(mockServer),
     await mockTronSpotPrices(mockServer),
-    await mockTronGetBlock(mockServer),
-    await mockBroadcastTransaction(mockServer),
   ];
 }

--- a/tests/flows/tron.flow.ts
+++ b/tests/flows/tron.flow.ts
@@ -1,0 +1,40 @@
+import { loginToApp } from './wallet.flow';
+import Assertions from '../framework/utils/Assertions';
+import Gestures from '../framework/utils/Gestures';
+import Matchers from '../framework/utils/Matchers';
+import WalletView from '../page-objects/wallet/WalletView';
+import AccountListBottomSheet from '../page-objects/AccountListBottomSheet';
+
+/**
+ * Login and create a Tron account via the account selector.
+ */
+export async function createTronAccount(): Promise<void> {
+  await loginToApp();
+
+  await WalletView.tapIdenticon();
+  const accountList = Matchers.getElementByID(
+    AccountListBottomSheet.accountList,
+  );
+  await Assertions.expectElementToBeVisible(accountList);
+
+  await AccountListBottomSheet.tapAddAccountButton();
+  const addTronButton = Matchers.getElementByID('add-account-add-tron-account');
+  await Gestures.tap(addTronButton);
+}
+
+/**
+ * Select the Tron network from the network selector.
+ */
+export async function selectTronNetwork(): Promise<void> {
+  await WalletView.tapNetworksButtonOnNavBar();
+
+  const tronNetwork = Matchers.getElementByText('Tron Mainnet');
+  await Gestures.tap(tronNetwork);
+
+  try {
+    const gotItButton = Matchers.getElementByText('Got it');
+    await Gestures.tap(gotItButton);
+  } catch {
+    // The education modal is not always shown.
+  }
+}

--- a/tests/page-objects/Tron/TronAccountView.ts
+++ b/tests/page-objects/Tron/TronAccountView.ts
@@ -1,0 +1,22 @@
+import Matchers from '../../framework/utils/Matchers';
+import Assertions from '../../framework/utils/Assertions';
+
+class TronAccountView {
+  async checkBalanceIsDisplayed(expectedBalance: string) {
+    const balanceElement = Matchers.getElementByText(expectedBalance);
+    await Assertions.expectElementToBeVisible(
+      balanceElement,
+      `Tron balance should display: ${expectedBalance}`,
+    );
+  }
+
+  async checkUsdBalanceIsDisplayed(expectedUsd: string) {
+    const usdElement = Matchers.getElementByText(expectedUsd);
+    await Assertions.expectElementToBeVisible(
+      usdElement,
+      `Tron USD balance should display: ${expectedUsd}`,
+    );
+  }
+}
+
+export default new TronAccountView();

--- a/tests/smoke/tron/balance-display.spec.ts
+++ b/tests/smoke/tron/balance-display.spec.ts
@@ -1,0 +1,53 @@
+import { SmokeNetworkExpansion } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import {
+  mockTronApis,
+  TRX_BALANCE,
+  SUN_PER_TRX,
+} from '../../api-mocking/mock-responses/tron-mocks';
+import { createTronAccount, selectTronNetwork } from '../../flows/tron.flow';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+
+jest.setTimeout(150_000);
+
+describe(SmokeNetworkExpansion('Tron Balance Display'), () => {
+  it('shows zero TRX balance for a new account with no funds', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer, true);
+        },
+      },
+      async () => {
+        await createTronAccount();
+        await selectTronNetwork();
+        await TronAccountView.checkBalanceIsDisplayed('0 TRX');
+      },
+    );
+  });
+
+  it('shows TRX balance with USD conversion for a funded account', async () => {
+    const expectedTrx = (TRX_BALANCE / SUN_PER_TRX).toFixed(6);
+    const expectedUsd = '$1.79';
+
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await createTronAccount();
+        await selectTronNetwork();
+        await TronAccountView.checkBalanceIsDisplayed(expectedTrx);
+        await TronAccountView.checkUsdBalanceIsDisplayed(expectedUsd);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile Tron balance display smoke coverage
- keep account overview helpers scoped to this workflow

## Test Plan
- [ ] Not re-run in this session
