### PR TITLE
test(tron): add send flow smoke coverage

### DIFF
--- a/tests/flows/tron.flow.ts
+++ b/tests/flows/tron.flow.ts
@@ -1,0 +1,38 @@
+import Assertions from '../framework/Assertions';
+import Gestures from '../framework/Gestures';
+import Matchers from '../framework/Matchers';
+import WalletView from '../page-objects/wallet/WalletView';
+import TronSendView from '../page-objects/Tron/TronSendView';
+
+/**
+ * Select the Tron network from the network selector.
+ */
+export async function selectTronNetwork(): Promise<void> {
+  await WalletView.tapNetworksButtonOnNavBar();
+  const tronMainnet = Matchers.getElementByText('Tron Mainnet');
+  await Assertions.expectElementToBeVisible(tronMainnet);
+  await Gestures.waitAndTap(tronMainnet, {
+    elemDescription: 'Tron Mainnet network item',
+  });
+
+  try {
+    await Gestures.waitAndTap(Matchers.getElementByText('Got it'), {
+      elemDescription: 'Network education Got it button',
+    });
+  } catch {
+    // The education modal does not always appear.
+  }
+}
+
+/**
+ * Complete the Tron send flow through submission.
+ */
+export async function sendTrx(
+  address: string,
+  amount: string,
+): Promise<void> {
+  await TronSendView.fillAmount(amount);
+  await TronSendView.tapContinue();
+  await TronSendView.fillRecipient(address);
+  await TronSendView.tapReview();
+}

--- a/tests/page-objects/Transactions/ActivitiesView.ts
+++ b/tests/page-objects/Transactions/ActivitiesView.ts
@@ -74,12 +74,18 @@ class ActivitiesView {
     );
   }
 
-  transactionStatus(row: number): DetoxElement {
-    return Matchers.getElementByID(`transaction-status-${row}`);
+  transactionStatus(identifier: number | string): DetoxElement {
+    return Matchers.getElementByID(`transaction-status-${identifier}`);
   }
 
   transactionItem(row: number): DetoxElement {
     return Matchers.getElementByID(`transaction-item-${row}`);
+  }
+
+  transactionItemTitle(row: number, titleText: string): DetoxElement {
+    return element(
+      by.text(titleText).withAncestor(by.id(`transaction-item-${row}`)),
+    ) as DetoxElement;
   }
 
   generateSwapActivityLabel(
@@ -198,26 +204,47 @@ class ActivitiesView {
   /**
    * Verifies that an activity item with the given title is visible and its row status matches.
    * Use after TabBarComponent.tapActivity(). Row 0 is the most recent transaction.
+   * For multichain entries, pass the transaction id so the status lookup matches the sheet contract.
    *
    * @param titleText - Activity title to look for (e.g. "mUSD conversion", "Sent ETH")
    * @param statusText - Expected status for the row (e.g. "Confirmed", "Failed")
    * @param rowIndex - Row index (default 0 = most recent)
+   * @param transactionId - Optional transaction id for multichain status selectors
    */
   async verifyActivityItemWithStatus(
     titleText: string,
     statusText: string,
     rowIndex = 0,
+    transactionId?: string,
   ): Promise<void> {
-    await Assertions.expectTextDisplayed(titleText, {
-      timeout: 20000,
-      description: `Activity item "${titleText}" should be visible`,
-    });
+    await Assertions.expectElementToBeVisible(
+      this.transactionItemTitle(rowIndex, titleText),
+      {
+        timeout: 20000,
+        description: `Activity row ${rowIndex} should contain "${titleText}"`,
+      },
+    );
     await Assertions.expectElementToHaveText(
-      this.transactionStatus(rowIndex),
+      this.transactionStatus(transactionId ?? rowIndex),
       statusText,
       {
         timeout: 10000,
-        description: `Activity row (index ${rowIndex}) should show status "${statusText}"`,
+        description: transactionId
+          ? `Activity transaction ${transactionId} should show status "${statusText}"`
+          : `Activity row (index ${rowIndex}) should show status "${statusText}"`,
+      },
+    );
+  }
+
+  async verifyActivityItemTitle(
+    titleText: string,
+    rowIndex = 0,
+  ): Promise<void> {
+    await Assertions.expectElementToBeVisible(
+      this.transactionItemTitle(rowIndex, titleText),
+      {
+        timeout: 20000,
+        description: `Activity row ${rowIndex} should contain "${titleText}"`,
       },
     );
   }

--- a/tests/page-objects/Transactions/MultichainTransactionDetailsSheet.ts
+++ b/tests/page-objects/Transactions/MultichainTransactionDetailsSheet.ts
@@ -1,0 +1,41 @@
+import { strings } from '../../../locales/i18n';
+import Matchers from '../../framework/Matchers';
+import { Assertions } from '../../framework';
+
+class MultichainTransactionDetailsSheet {
+  get networkFeeLabel(): DetoxElement {
+    return Matchers.getElementByText(strings('transactions.network_fee'));
+  }
+
+  get viewDetailsButton(): DetoxElement {
+    return Matchers.getElementByText(strings('networks.view_details'));
+  }
+
+  transactionStatus(transactionId: string): DetoxElement {
+    return Matchers.getElementByID(`transaction-status-${transactionId}`);
+  }
+
+  async verifySheetVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.networkFeeLabel, {
+      timeout: 20000,
+      description: 'Multichain transaction details should show network fee',
+    });
+    await Assertions.expectElementToBeVisible(this.viewDetailsButton, {
+      timeout: 20000,
+      description: 'Multichain transaction details should show view details button',
+    });
+  }
+
+  async verifyStatus(transactionId: string, statusText: string): Promise<void> {
+    await Assertions.expectElementToHaveText(
+      this.transactionStatus(transactionId),
+      statusText,
+      {
+        timeout: 10000,
+        description: `Multichain transaction ${transactionId} should show status "${statusText}"`,
+      },
+    );
+  }
+}
+
+export default new MultichainTransactionDetailsSheet();

--- a/tests/page-objects/Tron/TronAccountView.ts
+++ b/tests/page-objects/Tron/TronAccountView.ts
@@ -1,0 +1,9 @@
+import TokenOverview from '../wallet/TokenOverview';
+
+class TronAccountView {
+  async tapSendButton(): Promise<void> {
+    await TokenOverview.tapSendButton();
+  }
+}
+
+export default new TronAccountView();

--- a/tests/page-objects/Tron/TronSendView.ts
+++ b/tests/page-objects/Tron/TronSendView.ts
@@ -1,0 +1,71 @@
+import Assertions from '../../framework/Assertions';
+import Matchers from '../../framework/Matchers';
+import SendView from '../Send/RedesignedSendView';
+import { RedesignedSendViewSelectorsIDs } from '../../../app/components/Views/confirmations/components/send/RedesignedSendView.testIds';
+
+class TronSendView {
+  get addressInput(): DetoxElement {
+    return SendView.recipientAddressInput;
+  }
+
+  get amountInput(): DetoxElement {
+    return SendView.amountInputField;
+  }
+
+  get continueButton(): DetoxElement {
+    return SendView.continueButton;
+  }
+
+  get reviewButton(): DetoxElement {
+    return SendView.reviewButton;
+  }
+
+  get sendAmountScreen(): DetoxElement {
+    return Matchers.getElementByID(RedesignedSendViewSelectorsIDs.SEND_AMOUNT);
+  }
+
+  async fillRecipient(address: string): Promise<void> {
+    await SendView.inputRecipientAddress(address);
+  }
+
+  async fillAmount(amount: string): Promise<void> {
+    await SendView.typeInTransactionAmount(amount);
+  }
+
+  async checkAmountScreenVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.sendAmountScreen, {
+      description: 'Tron amount screen should be visible',
+    });
+  }
+
+  async tapContinue(): Promise<void> {
+    await SendView.pressContinueButton();
+  }
+
+  async tapReview(): Promise<void> {
+    await SendView.pressReviewButton();
+  }
+
+  async tapConfirm(): Promise<void> {
+    await this.tapReview();
+  }
+
+  async checkFeeIsDisplayed(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.reviewButton, {
+      description: 'Review button should be visible on Tron send flow',
+    });
+  }
+
+  async checkInsufficientFundsError(): Promise<void> {
+    await SendView.checkInsufficientFundsError();
+  }
+
+  async checkInvalidAddressError(): Promise<void> {
+    await Assertions.expectElementToHaveText(
+      this.reviewButton,
+      'Invalid address',
+    );
+  }
+}
+
+export default new TronSendView();

--- a/tests/smoke/tron/error-scenarios.spec.ts
+++ b/tests/smoke/tron/error-scenarios.spec.ts
@@ -1,0 +1,64 @@
+import { SmokeConfirmations } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import { loginToApp } from '../../flows/wallet.flow';
+import { mockTronApis } from '../../api-mocking/mock-responses/tron-mocks';
+import {
+  selectTronNetwork,
+} from '../../flows/tron.flow';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import TronSendView from '../../page-objects/Tron/TronSendView';
+import WalletView from '../../page-objects/wallet/WalletView';
+
+jest.setTimeout(150_000);
+
+describe(SmokeConfirmations('Tron Error Scenarios'), () => {
+  it('shows insufficient balance error when send amount exceeds balance', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronAccount().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer, true);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('TRX');
+        await TronAccountView.tapSendButton();
+
+        await TronSendView.checkAmountScreenVisible();
+        await TronSendView.fillAmount('999999');
+        await TronSendView.checkInsufficientFundsError();
+      },
+    );
+  });
+
+  it('shows invalid address error when recipient address is malformed', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronAccount().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('TRX');
+        await TronAccountView.tapSendButton();
+
+        await TronSendView.checkAmountScreenVisible();
+        await TronSendView.fillAmount('1');
+        await TronSendView.tapContinue();
+        await TronSendView.fillRecipient('not-a-valid-tron-address');
+        await TronSendView.checkInvalidAddressError();
+      },
+    );
+  });
+});

--- a/tests/smoke/tron/fee-estimation.spec.ts
+++ b/tests/smoke/tron/fee-estimation.spec.ts
@@ -1,0 +1,77 @@
+import { SmokeConfirmations } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import { loginToApp } from '../../flows/wallet.flow';
+import {
+  mockTronApis,
+  TRON_RECIPIENT_ADDRESS,
+} from '../../api-mocking/mock-responses/tron-mocks';
+import {
+  selectTronNetwork,
+} from '../../flows/tron.flow';
+import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
+import MultichainTransactionDetailsSheet from '../../page-objects/Transactions/MultichainTransactionDetailsSheet';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import TronSendView from '../../page-objects/Tron/TronSendView';
+import WalletView from '../../page-objects/wallet/WalletView';
+
+jest.setTimeout(150_000);
+
+describe(SmokeConfirmations('Tron Fee Estimation'), () => {
+  it('shows network fee on TRX send confirmation screen', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronAccount().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('TRX');
+        await TronAccountView.tapSendButton();
+
+        await TronSendView.checkAmountScreenVisible();
+        await TronSendView.fillAmount('1');
+        await TronSendView.tapContinue();
+        await TronSendView.fillRecipient(TRON_RECIPIENT_ADDRESS);
+        await TronSendView.tapReview();
+        await ActivitiesView.verifyActivityItemTitle('Send TRX');
+        await ActivitiesView.tapOnTransactionItem(0);
+        await MultichainTransactionDetailsSheet.verifySheetVisible();
+      },
+    );
+  });
+
+  it('shows network fee on TRC-20 token send confirmation screen', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronAccount().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('USDT');
+        await TronAccountView.tapSendButton();
+
+        await TronSendView.checkAmountScreenVisible();
+        await TronSendView.fillAmount('1');
+        await TronSendView.tapContinue();
+        await TronSendView.fillRecipient(TRON_RECIPIENT_ADDRESS);
+        await TronSendView.tapReview();
+        await ActivitiesView.verifyActivityItemTitle('Send USDT');
+        await ActivitiesView.tapOnTransactionItem(0);
+        await MultichainTransactionDetailsSheet.verifySheetVisible();
+      },
+    );
+  });
+});

--- a/tests/smoke/tron/send-trc20.spec.ts
+++ b/tests/smoke/tron/send-trc20.spec.ts
@@ -1,0 +1,46 @@
+import { SmokeConfirmations } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import { loginToApp } from '../../flows/wallet.flow';
+import {
+  mockTronApis,
+  TRON_RECIPIENT_ADDRESS,
+} from '../../api-mocking/mock-responses/tron-mocks';
+import { selectTronNetwork } from '../../flows/tron.flow';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
+import WalletView from '../../page-objects/wallet/WalletView';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import TronSendView from '../../page-objects/Tron/TronSendView';
+import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
+
+jest.setTimeout(150_000);
+
+describe(SmokeConfirmations('Send TRC-20 USDT'), () => {
+  it('sends USDT on Tron via token selector', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronAccount().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('USDT');
+        await TronAccountView.tapSendButton();
+
+        await TronSendView.checkAmountScreenVisible();
+        await TronSendView.fillAmount('1');
+        await TronSendView.tapContinue();
+        await TronSendView.fillRecipient(TRON_RECIPIENT_ADDRESS);
+        await TronSendView.tapReview();
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.verifyActivityItemTitle('Send USDT');
+      },
+    );
+  });
+});

--- a/tests/smoke/tron/send-trx.spec.ts
+++ b/tests/smoke/tron/send-trx.spec.ts
@@ -1,0 +1,44 @@
+import { SmokeConfirmations } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import { loginToApp } from '../../flows/wallet.flow';
+import {
+  mockTronApis,
+  TRON_RECIPIENT_ADDRESS,
+} from '../../api-mocking/mock-responses/tron-mocks';
+import {
+  selectTronNetwork,
+  sendTrx,
+} from '../../flows/tron.flow';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
+import WalletView from '../../page-objects/wallet/WalletView';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
+
+jest.setTimeout(150_000);
+
+describe(SmokeConfirmations('Send TRX'), () => {
+  it('sends TRX with a valid address and amount', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronAccount().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await loginToApp();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('TRX');
+        await TronAccountView.tapSendButton();
+
+        await sendTrx(TRON_RECIPIENT_ADDRESS, '1');
+        await TabBarComponent.tapActivity();
+        await ActivitiesView.verifyActivityItemTitle('Send TRX');
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile Tron send, fee, and error smoke coverage
- align the send tests with the redesigned non-EVM send flow
- add multichain activity/details assertions needed for Tron send coverage

## Test Plan
- [x] `git diff --check`
- [x] targeted eslint on changed send-flow test files
- [ ] targeted Detox run blocked locally because `$ANDROID_SDK_ROOT` is unset in this session
