### PR TITLE
test(tron): add multi-account and swap smoke coverage

### DIFF
--- a/tests/flows/tron.flow.ts
+++ b/tests/flows/tron.flow.ts
@@ -1,0 +1,42 @@
+import { loginToApp } from './wallet.flow';
+import Assertions from '../framework/Assertions';
+import Gestures from '../framework/Gestures';
+import Matchers from '../framework/Matchers';
+import WalletView from '../page-objects/wallet/WalletView';
+import AccountListBottomSheet from '../page-objects/wallet/AccountListBottomSheet';
+
+/**
+ * Login and create a Tron account via the account selector.
+ */
+export async function createTronAccount(): Promise<void> {
+  await loginToApp();
+
+  await WalletView.tapIdenticon();
+  const accountList = Matchers.getElementByID(
+    AccountListBottomSheet.accountList,
+  );
+  await Assertions.expectElementToBeVisible(accountList);
+
+  await AccountListBottomSheet.tapAddAccountButton();
+  const addTronButton = Matchers.getElementByID(
+    'add-account-add-tron-account',
+  );
+  await Gestures.tap(addTronButton);
+}
+
+/**
+ * Select the Tron network from the network selector.
+ */
+export async function selectTronNetwork(): Promise<void> {
+  await WalletView.tapNetworksButtonOnNavBar();
+
+  const tronNetwork = Matchers.getElementByText('Tron Mainnet');
+  await Gestures.tap(tronNetwork);
+
+  try {
+    const gotItButton = Matchers.getElementByText('Got it');
+    await Gestures.tap(gotItButton);
+  } catch {
+    // The education modal does not always appear.
+  }
+}

--- a/tests/page-objects/Tron/TronAccountView.ts
+++ b/tests/page-objects/Tron/TronAccountView.ts
@@ -1,0 +1,25 @@
+import Matchers from '../../framework/Matchers';
+import Assertions from '../../framework/Assertions';
+import Gestures from '../../framework/Gestures';
+
+const TOKEN_SWAP_BUTTON = 'token-swap-button';
+
+class TronAccountView {
+  get swapButton() {
+    return Matchers.getElementByID(TOKEN_SWAP_BUTTON);
+  }
+
+  async checkBalanceIsDisplayed(expectedBalance: string) {
+    const balanceElement = Matchers.getElementByText(expectedBalance);
+    await Assertions.expectElementToBeVisible(
+      balanceElement,
+      `Tron balance should display: ${expectedBalance}`,
+    );
+  }
+
+  async tapSwapButton() {
+    await Gestures.tap(this.swapButton);
+  }
+}
+
+export default new TronAccountView();

--- a/tests/smoke/tron/multi-account.spec.ts
+++ b/tests/smoke/tron/multi-account.spec.ts
@@ -1,0 +1,91 @@
+import { SmokeNetworkExpansion } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import {
+  mockTronApis,
+  mockTronGetAccount,
+  TRON_ACCOUNT_ADDRESS,
+  TRON_SECOND_ACCOUNT_ADDRESS,
+  TRX_BALANCE,
+} from '../../api-mocking/mock-responses/tron-mocks';
+import { createTronAccount, selectTronNetwork } from '../../flows/tron.flow';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import Assertions from '../../framework/Assertions';
+import Matchers from '../../framework/Matchers';
+import WalletView from '../../page-objects/wallet/WalletView';
+import AccountListBottomSheet from '../../page-objects/wallet/AccountListBottomSheet';
+import Gestures from '../../framework/Gestures';
+
+jest.setTimeout(150_000);
+
+describe(SmokeNetworkExpansion('Tron Multi-Account'), () => {
+  it('creates two Tron accounts and both appear in the account list', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer, true);
+        },
+      },
+      async () => {
+        await createTronAccount();
+
+        await WalletView.tapIdenticon();
+        await AccountListBottomSheet.tapAddAccountButton();
+        const addTronButton = Matchers.getElementByID(
+          'add-account-add-tron-account',
+        );
+        await Gestures.tap(addTronButton);
+
+        await WalletView.tapIdenticon();
+        const firstAccount = Matchers.getElementByText(TRON_ACCOUNT_ADDRESS);
+        await Assertions.expectElementToBeVisible(firstAccount);
+        const secondAccount = Matchers.getElementByText(
+          TRON_SECOND_ACCOUNT_ADDRESS,
+        );
+        await Assertions.expectElementToBeVisible(secondAccount);
+      },
+    );
+  });
+
+  it('switches between Tron accounts and shows independent balances', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+          await mockTronGetAccount(
+            mockServer,
+            true,
+            TRON_SECOND_ACCOUNT_ADDRESS,
+          );
+        },
+      },
+      async () => {
+        await createTronAccount();
+        await selectTronNetwork();
+
+        const firstBalance = `${(TRX_BALANCE / 1_000_000).toFixed(6)} TRX`;
+        await TronAccountView.checkBalanceIsDisplayed(firstBalance);
+
+        await WalletView.tapIdenticon();
+        await AccountListBottomSheet.tapAddAccountButton();
+        const addTronButton = Matchers.getElementByID(
+          'add-account-add-tron-account',
+        );
+        await Gestures.tap(addTronButton);
+
+        await WalletView.tapIdenticon();
+        const secondAccount = Matchers.getElementByText(
+          TRON_SECOND_ACCOUNT_ADDRESS,
+        );
+        await Gestures.tap(secondAccount);
+
+        await TronAccountView.checkBalanceIsDisplayed('0 TRX');
+      },
+    );
+  });
+});

--- a/tests/smoke/tron/swap.spec.ts
+++ b/tests/smoke/tron/swap.spec.ts
@@ -1,0 +1,61 @@
+import { SmokeConfirmations } from '../../tags';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { Mockttp } from 'mockttp';
+import { mockTronApis } from '../../api-mocking/mock-responses/tron-mocks';
+import { createTronAccount, selectTronNetwork } from '../../flows/tron.flow';
+import WalletView from '../../page-objects/wallet/WalletView';
+import TronAccountView from '../../page-objects/Tron/TronAccountView';
+import Matchers from '../../framework/Matchers';
+import Assertions from '../../framework/Assertions';
+
+jest.setTimeout(150_000);
+
+describe(SmokeConfirmations('Tron Swap'), () => {
+  it('gets a TRX to USDT swap quote', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+        },
+      },
+      async () => {
+        await createTronAccount();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('TRX');
+        await TronAccountView.tapSwapButton();
+
+        const quoteText = Matchers.getElementByText('Quote');
+        await Assertions.expectElementToBeVisible(quoteText);
+      },
+    );
+  });
+
+  it('displays no quotes available message', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withTronFeatureFlags().build(),
+        restartDevice: true,
+        testSpecificMock: async (mockServer: Mockttp) => {
+          await mockTronApis(mockServer);
+          await mockServer
+            .forGet(/\/swap\/quotes/)
+            .thenJson(200, { quotes: [] });
+        },
+      },
+      async () => {
+        await createTronAccount();
+        await selectTronNetwork();
+
+        await WalletView.tapOnToken('TRX');
+        await TronAccountView.tapSwapButton();
+
+        const noQuotes = Matchers.getElementByText('No quotes available');
+        await Assertions.expectElementToBeVisible(noQuotes);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile Tron multi-account smoke coverage
- add mobile Tron swap smoke coverage

## Test Plan
- [ ] Not re-run in this session
