### PR TITLE
feat: use new reveal srp flow for seedless account

### DIFF
--- a/app/components/Views/AccountActions/AccountActions.test.tsx
+++ b/app/components/Views/AccountActions/AccountActions.test.tsx
@@ -615,8 +615,8 @@ describe('AccountActions', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
         {
-          shouldUpdateNav: true,
           keyringId: 'hd-keyring-entropy-id',
+          popToTopOnDone: true,
         },
       );
     });

--- a/app/components/Views/AccountActions/AccountActions.test.tsx
+++ b/app/components/Views/AccountActions/AccountActions.test.tsx
@@ -588,6 +588,77 @@ describe('AccountActions', () => {
   });
 
   describe('export srp', () => {
+    const MOCK_HD_ACCOUNT_WITH_ENTROPY = {
+      ...MOCK_ACCOUNT,
+      options: { entropySource: 'hd-keyring-entropy-id' },
+    };
+
+    it('navigates to full-screen reveal SRP when seedless login flow', () => {
+      mockedUseRoute.mockImplementation(() => ({
+        key: 'mock-key',
+        name: 'mock-route',
+        params: {
+          selectedAccount: MOCK_HD_ACCOUNT_WITH_ENTROPY,
+        },
+      }));
+
+      const state = {
+        ...initialState,
+        engine: {
+          backgroundState: {
+            ...initialState.engine.backgroundState,
+            SeedlessOnboardingController: {
+              ...backgroundState.SeedlessOnboardingController,
+              vault: '0xseedlessvault',
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      const { getByTestId } = renderWithProvider(<AccountActions />, {
+        state,
+      });
+
+      fireEvent.press(
+        getByTestId(
+          AccountActionsBottomSheetSelectorsIDs.SHOW_SECRET_RECOVERY_PHRASE,
+        ),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
+        {
+          shouldUpdateNav: true,
+          keyringId: 'hd-keyring-entropy-id',
+        },
+      );
+    });
+
+    it('navigates to modal SRP reveal quiz when not seedless login flow', () => {
+      mockedUseRoute.mockImplementation(() => ({
+        key: 'mock-key',
+        name: 'mock-route',
+        params: {
+          selectedAccount: MOCK_HD_ACCOUNT_WITH_ENTROPY,
+        },
+      }));
+
+      const { getByTestId } = renderWithProvider(<AccountActions />, {
+        state: initialState,
+      });
+
+      fireEvent.press(
+        getByTestId(
+          AccountActionsBottomSheetSelectorsIDs.SHOW_SECRET_RECOVERY_PHRASE,
+        ),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
+        screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+        keyringId: 'hd-keyring-entropy-id',
+      });
+    });
+
     it.each([
       { account: MOCK_ACCOUNT },
       { account: MOCK_BTC_ACCOUNT },

--- a/app/components/Views/AccountActions/AccountActions.test.tsx
+++ b/app/components/Views/AccountActions/AccountActions.test.tsx
@@ -593,48 +593,7 @@ describe('AccountActions', () => {
       options: { entropySource: 'hd-keyring-entropy-id' },
     };
 
-    it('navigates to full-screen reveal SRP when seedless login flow', () => {
-      mockedUseRoute.mockImplementation(() => ({
-        key: 'mock-key',
-        name: 'mock-route',
-        params: {
-          selectedAccount: MOCK_HD_ACCOUNT_WITH_ENTROPY,
-        },
-      }));
-
-      const state = {
-        ...initialState,
-        engine: {
-          backgroundState: {
-            ...initialState.engine.backgroundState,
-            SeedlessOnboardingController: {
-              ...backgroundState.SeedlessOnboardingController,
-              vault: '0xseedlessvault',
-            },
-          },
-        },
-      } as unknown as RootState;
-
-      const { getByTestId } = renderWithProvider(<AccountActions />, {
-        state,
-      });
-
-      fireEvent.press(
-        getByTestId(
-          AccountActionsBottomSheetSelectorsIDs.SHOW_SECRET_RECOVERY_PHRASE,
-        ),
-      );
-
-      expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
-        {
-          shouldUpdateNav: true,
-          keyringId: 'hd-keyring-entropy-id',
-        },
-      );
-    });
-
-    it('navigates to modal SRP reveal quiz when not seedless login flow', () => {
+    it('navigates to full-screen reveal SRP', () => {
       mockedUseRoute.mockImplementation(() => ({
         key: 'mock-key',
         name: 'mock-route',
@@ -653,10 +612,13 @@ describe('AccountActions', () => {
         ),
       );
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.MODAL.SRP_REVEAL_QUIZ,
-        keyringId: 'hd-keyring-entropy-id',
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
+        {
+          shouldUpdateNav: true,
+          keyringId: 'hd-keyring-entropy-id',
+        },
+      );
     });
 
     it.each([

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -169,8 +169,8 @@ const AccountActions = () => {
   const goToExportSRP = () => {
     sheetRef.current?.onCloseBottomSheet(() => {
       navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-        shouldUpdateNav: true,
         keyringId,
+        popToTopOnDone: true,
       });
     });
   };

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -51,6 +51,7 @@ import {
   forgetQrDevice,
   withQrKeyring,
 } from '../../../core/QrKeyring/QrKeyring';
+import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 
 interface AccountActionsParams {
   selectedAccount: InternalAccount;
@@ -82,6 +83,7 @@ const AccountActions = () => {
   );
 
   const providerConfig = useSelector(selectProviderConfig);
+  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const selectedAddress = selectedAccount?.address;
   const keyring = selectedAccount?.metadata.keyring;
@@ -168,6 +170,13 @@ const AccountActions = () => {
 
   const goToExportSRP = () => {
     sheetRef.current?.onCloseBottomSheet(() => {
+      if (isSeedlessLoginFlow) {
+        navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+          shouldUpdateNav: true,
+          keyringId,
+        });
+        return;
+      }
       navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
         screen: Routes.MODAL.SRP_REVEAL_QUIZ,
         keyringId,

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -51,7 +51,6 @@ import {
   forgetQrDevice,
   withQrKeyring,
 } from '../../../core/QrKeyring/QrKeyring';
-import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 
 interface AccountActionsParams {
   selectedAccount: InternalAccount;
@@ -83,7 +82,6 @@ const AccountActions = () => {
   );
 
   const providerConfig = useSelector(selectProviderConfig);
-  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const selectedAddress = selectedAccount?.address;
   const keyring = selectedAccount?.metadata.keyring;
@@ -170,15 +168,8 @@ const AccountActions = () => {
 
   const goToExportSRP = () => {
     sheetRef.current?.onCloseBottomSheet(() => {
-      if (isSeedlessLoginFlow) {
-        navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-          shouldUpdateNav: true,
-          keyringId,
-        });
-        return;
-      }
-      navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+      navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+        shouldUpdateNav: true,
         keyringId,
       });
     });

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
@@ -220,6 +220,31 @@ describe('ExportCredentials', () => {
     );
   });
 
+  it('does not navigate when export mnemonic is pressed but entropySource is missing', () => {
+    const accountWithoutEntropy = {
+      ...createMockInternalAccount('0x123', 'Test Account'),
+      options: {},
+    };
+    mockHdKeyringsWithSnapAccounts.mockReturnValue([
+      {
+        accounts: [accountWithoutEntropy.address],
+        metadata: { id: mockKeyringId },
+      },
+    ]);
+    mockIsHDOrFirstPartySnapAccount.mockReturnValue(true);
+    mockIsPrivateKeyAccount.mockReturnValue(false);
+
+    const { getByText } = render(
+      <ExportCredentials account={accountWithoutEntropy} />,
+    );
+
+    fireEvent.press(
+      getByText(`${strings('accounts.secret_recovery_phrase')} 1`),
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('navigates to reveal private credential when export private key is pressed', () => {
     mockHdKeyringsWithSnapAccounts.mockReturnValue([
       {

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
@@ -23,6 +23,22 @@ jest.mock('react-redux', () => ({
 
 const mockUseSelector = jest.requireMock('react-redux').useSelector;
 
+const buildReduxState = (options?: {
+  seedphraseBackedUp?: boolean;
+  seedlessVault?: string | null;
+}) => ({
+  user: { seedphraseBackedUp: options?.seedphraseBackedUp ?? true },
+  engine: {
+    backgroundState: {
+      SeedlessOnboardingController: {
+        vault: options?.seedlessVault ?? null,
+      },
+    },
+  },
+});
+
+type MockReduxState = ReturnType<typeof buildReduxState>;
+
 const mockHdKeyringsWithSnapAccounts = jest.fn();
 jest.mock('../../../../../hooks/useHdKeyringsWithSnapAccounts', () => ({
   useHdKeyringsWithSnapAccounts: () => mockHdKeyringsWithSnapAccounts(),
@@ -61,9 +77,8 @@ describe('ExportCredentials', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockUseSelector.mockImplementation(
-      (
-        callback: (state: { user: { seedphraseBackedUp: boolean } }) => boolean,
-      ) => callback({ user: { seedphraseBackedUp: true } }),
+      (selector: (state: MockReduxState) => unknown) =>
+        selector(buildReduxState()),
     );
   });
 
@@ -130,9 +145,8 @@ describe('ExportCredentials', () => {
 
   it('shows backup warning when seedphrase is not backed up', () => {
     mockUseSelector.mockImplementation(
-      (
-        callback: (state: { user: { seedphraseBackedUp: boolean } }) => boolean,
-      ) => callback({ user: { seedphraseBackedUp: false } }),
+      (selector: (state: MockReduxState) => unknown) =>
+        selector(buildReduxState({ seedphraseBackedUp: false })),
     );
     mockHdKeyringsWithSnapAccounts.mockReturnValue([
       {
@@ -173,6 +187,37 @@ describe('ExportCredentials', () => {
       screen: Routes.MODAL.SRP_REVEAL_QUIZ,
       keyringId: mockKeyringId,
     });
+  });
+
+  it('navigates to full-screen reveal SRP when export mnemonic is pressed for seedless login', () => {
+    mockUseSelector.mockImplementation(
+      (selector: (state: MockReduxState) => unknown) =>
+        selector(buildReduxState({ seedlessVault: '0xseedlessvault' })),
+    );
+    mockHdKeyringsWithSnapAccounts.mockReturnValue([
+      {
+        accounts: ['0x123'],
+        metadata: { id: mockKeyringId },
+      },
+    ]);
+
+    mockIsHDOrFirstPartySnapAccount.mockReturnValue(true);
+    mockIsPrivateKeyAccount.mockReturnValue(false);
+
+    const { getByText } = render(<ExportCredentials account={mockAccount} />);
+
+    const mnemonicButton = getByText(
+      `${strings('accounts.secret_recovery_phrase')} 1`,
+    );
+    fireEvent.press(mnemonicButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
+      {
+        shouldUpdateNav: true,
+        keyringId: mockKeyringId,
+      },
+    );
   });
 
   it('navigates to reveal private credential when export private key is pressed', () => {

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.test.tsx
@@ -23,18 +23,8 @@ jest.mock('react-redux', () => ({
 
 const mockUseSelector = jest.requireMock('react-redux').useSelector;
 
-const buildReduxState = (options?: {
-  seedphraseBackedUp?: boolean;
-  seedlessVault?: string | null;
-}) => ({
+const buildReduxState = (options?: { seedphraseBackedUp?: boolean }) => ({
   user: { seedphraseBackedUp: options?.seedphraseBackedUp ?? true },
-  engine: {
-    backgroundState: {
-      SeedlessOnboardingController: {
-        vault: options?.seedlessVault ?? null,
-      },
-    },
-  },
 });
 
 type MockReduxState = ReturnType<typeof buildReduxState>;
@@ -165,35 +155,7 @@ describe('ExportCredentials', () => {
     ).toBeTruthy();
   });
 
-  it('navigates to SRP reveal quiz when export mnemonic is pressed', () => {
-    mockHdKeyringsWithSnapAccounts.mockReturnValue([
-      {
-        accounts: ['0x123'],
-        metadata: { id: mockKeyringId },
-      },
-    ]);
-
-    mockIsHDOrFirstPartySnapAccount.mockReturnValue(true);
-    mockIsPrivateKeyAccount.mockReturnValue(false);
-
-    const { getByText } = render(<ExportCredentials account={mockAccount} />);
-
-    const mnemonicButton = getByText(
-      `${strings('accounts.secret_recovery_phrase')} 1`,
-    );
-    fireEvent.press(mnemonicButton);
-
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.MODAL.SRP_REVEAL_QUIZ,
-      keyringId: mockKeyringId,
-    });
-  });
-
-  it('navigates to full-screen reveal SRP when export mnemonic is pressed for seedless login', () => {
-    mockUseSelector.mockImplementation(
-      (selector: (state: MockReduxState) => unknown) =>
-        selector(buildReduxState({ seedlessVault: '0xseedlessvault' })),
-    );
+  it('navigates to full-screen reveal SRP when export mnemonic is pressed', () => {
     mockHdKeyringsWithSnapAccounts.mockReturnValue([
       {
         accounts: ['0x123'],

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
@@ -80,13 +80,12 @@ export const ExportCredentials = ({ account }: ExportCredentialsProps) => {
 
   const onExportMnemonic = useCallback(() => {
     const keyringId = account.options.entropySource;
-    if (!keyringId) {
-      return;
+    if (keyringId) {
+      navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+        shouldUpdateNav: true,
+        keyringId,
+      });
     }
-    navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-      shouldUpdateNav: true,
-      keyringId,
-    });
   }, [navigate, account.options.entropySource]);
 
   const onExportPrivateKey = useCallback(() => {

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
@@ -30,6 +30,7 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import { ExportCredentialsIds } from '../../ExportCredentials.testIds';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { RootState } from '../../../../../../reducers';
+import { selectSeedlessOnboardingLoginFlow } from '../../../../../../selectors/seedlessOnboardingController';
 
 interface ExportCredentialsProps {
   account: InternalAccount;
@@ -37,6 +38,7 @@ interface ExportCredentialsProps {
 
 export const ExportCredentials = ({ account }: ExportCredentialsProps) => {
   const { navigate } = useNavigation();
+  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
   const canExportPrivateKey =
     account.metadata.keyring.type === KeyringTypes.hd ||
     isPrivateKeyAccount(account);
@@ -79,13 +81,22 @@ export const ExportCredentials = ({ account }: ExportCredentialsProps) => {
   }, [seedphraseBackedUp, hdKeyringsWithSnapAccounts, account]);
 
   const onExportMnemonic = useCallback(() => {
-    if (account.options.entropySource) {
-      navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.MODAL.SRP_REVEAL_QUIZ,
-        keyringId: account.options.entropySource,
-      });
+    const keyringId = account.options.entropySource;
+    if (!keyringId) {
+      return;
     }
-  }, [navigate, account.options.entropySource]);
+    if (isSeedlessLoginFlow) {
+      navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+        shouldUpdateNav: true,
+        keyringId,
+      });
+      return;
+    }
+    navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+      keyringId,
+    });
+  }, [navigate, account.options.entropySource, isSeedlessLoginFlow]);
 
   const onExportPrivateKey = useCallback(() => {
     navigate(Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS, {

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/ExportCredentials/ExportCredentials.tsx
@@ -30,7 +30,6 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import { ExportCredentialsIds } from '../../ExportCredentials.testIds';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { RootState } from '../../../../../../reducers';
-import { selectSeedlessOnboardingLoginFlow } from '../../../../../../selectors/seedlessOnboardingController';
 
 interface ExportCredentialsProps {
   account: InternalAccount;
@@ -38,7 +37,6 @@ interface ExportCredentialsProps {
 
 export const ExportCredentials = ({ account }: ExportCredentialsProps) => {
   const { navigate } = useNavigation();
-  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
   const canExportPrivateKey =
     account.metadata.keyring.type === KeyringTypes.hd ||
     isPrivateKeyAccount(account);
@@ -85,18 +83,11 @@ export const ExportCredentials = ({ account }: ExportCredentialsProps) => {
     if (!keyringId) {
       return;
     }
-    if (isSeedlessLoginFlow) {
-      navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-        shouldUpdateNav: true,
-        keyringId,
-      });
-      return;
-    }
-    navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+    navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+      shouldUpdateNav: true,
       keyringId,
     });
-  }, [navigate, account.options.entropySource, isSeedlessLoginFlow]);
+  }, [navigate, account.options.entropySource]);
 
   const onExportPrivateKey = useCallback(() => {
     navigate(Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS, {

--- a/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.test.tsx
@@ -98,6 +98,30 @@ describe('RevealSRP', () => {
     );
   });
 
+  it('navigates to full-screen reveal SRP when get started is pressed for seedless login', () => {
+    const { getByText } = renderWithProvider(<RevealSRP />, {
+      state: {
+        engine: {
+          backgroundState: {
+            SeedlessOnboardingController: { vault: '0xseedless' },
+          },
+        },
+      },
+    });
+
+    const getStartedButton = getByText(
+      strings('multichain_accounts.reveal_srp.get_started'),
+    );
+    fireEvent.press(getStartedButton);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
+      {
+        shouldUpdateNav: true,
+        keyringId: 'test-keyring-id',
+      },
+    );
+  });
+
   it('navigates to webview when learn more button is pressed', () => {
     const { getByText } = render();
 

--- a/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.test.tsx
@@ -83,31 +83,8 @@ describe('RevealSRP', () => {
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates to SRP reveal quiz when get started button is pressed', () => {
+  it('navigates to full-screen reveal SRP when get started button is pressed', () => {
     const { getByText } = render();
-
-    const getStartedButton = getByText(
-      strings('multichain_accounts.reveal_srp.get_started'),
-    );
-    fireEvent.press(getStartedButton);
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SRP_REVEAL_QUIZ,
-      {
-        keyringId: 'test-keyring-id',
-      },
-    );
-  });
-
-  it('navigates to full-screen reveal SRP when get started is pressed for seedless login', () => {
-    const { getByText } = renderWithProvider(<RevealSRP />, {
-      state: {
-        engine: {
-          backgroundState: {
-            SeedlessOnboardingController: { vault: '0xseedless' },
-          },
-        },
-      },
-    });
 
     const getStartedButton = getByText(
       strings('multichain_accounts.reveal_srp.get_started'),

--- a/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.tsx
@@ -35,8 +35,6 @@ import SecurityQuizLockImage from '../../../../../images/security-quiz-intro-loc
 import { ButtonSize } from '../../../../../component-library/components/Buttons/Button';
 import { SRP_GUIDE_URL } from '../../../../../constants/urls';
 import { ExportCredentialsIds } from '../../AccountDetails/ExportCredentials.testIds';
-import { useSelector } from 'react-redux';
-import { selectSeedlessOnboardingLoginFlow } from '../../../../../selectors/seedlessOnboardingController';
 
 interface RootNavigationParamList extends ParamListBase {
   RevealSRP: {
@@ -54,7 +52,6 @@ export const RevealSRP = () => {
   const { navigate, goBack } = useNavigation();
 
   const keyringId = useKeyringId(account);
-  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const handleLearnMoreClick = useCallback(() => {
     navigate(Routes.WEBVIEW.MAIN, {
@@ -70,17 +67,11 @@ export const RevealSRP = () => {
   }, [goBack]);
 
   const handleGetStartedClick = useCallback(() => {
-    if (isSeedlessLoginFlow) {
-      navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-        shouldUpdateNav: true,
-        keyringId,
-      });
-      return;
-    }
-    navigate(Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SRP_REVEAL_QUIZ, {
+    navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+      shouldUpdateNav: true,
       keyringId,
     });
-  }, [isSeedlessLoginFlow, keyringId, navigate]);
+  }, [keyringId, navigate]);
 
   return (
     <SafeAreaView edges={{ bottom: 'additive' }} style={styles.container}>

--- a/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/RevealSRP/RevealSRP.tsx
@@ -35,6 +35,8 @@ import SecurityQuizLockImage from '../../../../../images/security-quiz-intro-loc
 import { ButtonSize } from '../../../../../component-library/components/Buttons/Button';
 import { SRP_GUIDE_URL } from '../../../../../constants/urls';
 import { ExportCredentialsIds } from '../../AccountDetails/ExportCredentials.testIds';
+import { useSelector } from 'react-redux';
+import { selectSeedlessOnboardingLoginFlow } from '../../../../../selectors/seedlessOnboardingController';
 
 interface RootNavigationParamList extends ParamListBase {
   RevealSRP: {
@@ -52,6 +54,7 @@ export const RevealSRP = () => {
   const { navigate, goBack } = useNavigation();
 
   const keyringId = useKeyringId(account);
+  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const handleLearnMoreClick = useCallback(() => {
     navigate(Routes.WEBVIEW.MAIN, {
@@ -67,10 +70,17 @@ export const RevealSRP = () => {
   }, [goBack]);
 
   const handleGetStartedClick = useCallback(() => {
+    if (isSeedlessLoginFlow) {
+      navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+        shouldUpdateNav: true,
+        keyringId,
+      });
+      return;
+    }
     navigate(Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SRP_REVEAL_QUIZ, {
       keyringId,
     });
-  }, [keyringId, navigate]);
+  }, [isSeedlessLoginFlow, keyringId, navigate]);
 
   return (
     <SafeAreaView edges={{ bottom: 'additive' }} style={styles.container}>

--- a/app/components/Views/SelectSRP/SelectSRP.test.tsx
+++ b/app/components/Views/SelectSRP/SelectSRP.test.tsx
@@ -87,4 +87,31 @@ describe('SelectSRP', () => {
       keyringId: mockKeyring1.metadata.id,
     });
   });
+
+  it('navigates to full-screen reveal SRP for seedless login', () => {
+    const seedlessState = {
+      engine: {
+        backgroundState: {
+          ...initialState.engine.backgroundState,
+          SeedlessOnboardingController: {
+            ...backgroundState.SeedlessOnboardingController,
+            vault: '0xseedlessvault',
+          },
+        },
+      },
+    };
+    const { getByText } = renderWithProvider(<SelectSRP />, {
+      state: seedlessState,
+    });
+    fireEvent.press(
+      getByText(`${strings('accounts.secret_recovery_phrase')} 1`),
+    );
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL,
+      {
+        shouldUpdateNav: true,
+        keyringId: mockKeyring1.metadata.id,
+      },
+    );
+  });
 });

--- a/app/components/Views/SelectSRP/SelectSRP.test.tsx
+++ b/app/components/Views/SelectSRP/SelectSRP.test.tsx
@@ -77,32 +77,8 @@ const render = () =>
   });
 
 describe('SelectSRP', () => {
-  it('navigates to the SRP reveal quiz', () => {
+  it('navigates to full-screen reveal SRP', () => {
     const { getByText } = render();
-    fireEvent.press(
-      getByText(`${strings('accounts.secret_recovery_phrase')} 1`),
-    );
-    expect(mockedNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.MODAL.SRP_REVEAL_QUIZ,
-      keyringId: mockKeyring1.metadata.id,
-    });
-  });
-
-  it('navigates to full-screen reveal SRP for seedless login', () => {
-    const seedlessState = {
-      engine: {
-        backgroundState: {
-          ...initialState.engine.backgroundState,
-          SeedlessOnboardingController: {
-            ...backgroundState.SeedlessOnboardingController,
-            vault: '0xseedlessvault',
-          },
-        },
-      },
-    };
-    const { getByText } = renderWithProvider(<SelectSRP />, {
-      state: seedlessState,
-    });
     fireEvent.press(
       getByText(`${strings('accounts.secret_recovery_phrase')} 1`),
     );

--- a/app/components/Views/SelectSRP/SelectSRP.tsx
+++ b/app/components/Views/SelectSRP/SelectSRP.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import SRPList from '../../UI/SRPList';
 import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import Routes from '../../../constants/navigation/Routes';
 import type { ViewStyle } from 'react-native';
-import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 
 const SelectSRP = ({
   containerStyle,
@@ -14,18 +12,10 @@ const SelectSRP = ({
   showArrowName?: string;
 }) => {
   const navigation = useNavigation();
-  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const onKeyringSelect = (keyringId: string) => {
-    if (isSeedlessLoginFlow) {
-      navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
-        shouldUpdateNav: true,
-        keyringId,
-      });
-      return;
-    }
-    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.MODAL.SRP_REVEAL_QUIZ,
+    navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+      shouldUpdateNav: true,
       keyringId,
     });
   };

--- a/app/components/Views/SelectSRP/SelectSRP.tsx
+++ b/app/components/Views/SelectSRP/SelectSRP.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import SRPList from '../../UI/SRPList';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import Routes from '../../../constants/navigation/Routes';
 import type { ViewStyle } from 'react-native';
+import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 
 const SelectSRP = ({
   containerStyle,
@@ -12,8 +14,16 @@ const SelectSRP = ({
   showArrowName?: string;
 }) => {
   const navigation = useNavigation();
+  const isSeedlessLoginFlow = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const onKeyringSelect = (keyringId: string) => {
+    if (isSeedlessLoginFlow) {
+      navigation.navigate(Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL, {
+        shouldUpdateNav: true,
+        keyringId,
+      });
+      return;
+    }
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.MODAL.SRP_REVEAL_QUIZ,
       keyringId,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Seedless wallets were still sent through the legacy SRP reveal quiz bottom sheet (SRPRevealQuiz / SRPQuiz) when revealing the Secret Recovery Phrase from account export paths

This change routes seedless users (selectSeedlessOnboardingLoginFlow) to Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL with the correct keyringId, so the SRP reveal experience matches the standard full-screen flow.

* Jira: https://consensyssoftware.atlassian.net/browse/TO-644
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed inconsistent Secret Recovery Phrase reveal flow for seedless accounts

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Seedless SRP reveal uses full-screen flow

  Scenario: Reveal SRP from account details export (seedless wallet)
    Given the user is logged in with a seedless wallet and the app is unlocked
    When the user opens account details, opens export credentials, and taps the Secret Recovery Phrase row
    Then the app shows the full-screen reveal SRP flow 

  Scenario: Reveal SRP from account actions (seedless wallet)
    Given the user is on a seedless HD account and opens account actions
    When the user chooses the option to export / reveal the Secret Recovery Phrase
    Then the app navigates to the full-screen reveal SRP flow

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/bd6dbf25-5119-4f97-8675-ffde570e45fe


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation for Secret Recovery Phrase reveal/export flows, which are security-sensitive UX paths; mistakes could misroute users or break access to credential reveal screens.
> 
> **Overview**
> Seedless-login users are now routed to the full-screen `Routes.SETTINGS.REVEAL_PRIVATE_CREDENTIAL` flow (with `shouldUpdateNav` and `keyringId`) when attempting to reveal/export the SRP from several entry points, instead of the legacy `SRP_REVEAL_QUIZ` bottom-sheet path.
> 
> This conditional routing is added to `AccountActions`, `ExportCredentials`, `RevealSRP`, and `SelectSRP`, and new/updated tests cover the seedless vs non-seedless navigation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8bb8d73d1c29d0e3c67349887fdafcf85e34320. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->