### PR TITLE
fix(perps): sync pending payment token and reset on asset change cp-7.72.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -486,4 +486,129 @@ describe('PerpsPayRow', () => {
       expect(setSelectedPaymentTokenMock).not.toHaveBeenCalled();
     });
   });
+
+  describe('cleanup on asset change', () => {
+    it('resets selectedPaymentToken to null when initialAsset changes', () => {
+      const setSelectedPaymentTokenMock = Engine.context.PerpsController
+        ?.setSelectedPaymentToken as jest.Mock;
+
+      const { rerender } = renderWithProvider(
+        <PerpsPayRow initialAsset="BTC" />,
+      );
+
+      setSelectedPaymentTokenMock.mockClear();
+
+      act(() => {
+        rerender(<PerpsPayRow initialAsset="ETH" />);
+      });
+
+      expect(setSelectedPaymentTokenMock).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('pending config sync when selectedPaymentToken is null', () => {
+    it('applies pending config even when selectedPaymentToken is null', () => {
+      const setPayTokenMock = jest.fn();
+      const pendingToken = {
+        address: '0xPending',
+        chainId: '0x1',
+        description: 'Pending Token',
+      };
+
+      mockUsePerpsSelector.mockReturnValue({
+        selectedPaymentToken: pendingToken,
+      });
+      mockUsePerpsPayWithToken.mockReturnValue(null);
+      mockUseTransactionPayToken.mockReturnValue({
+        payToken: { address: '0xOther', chainId: '0xa4b1', symbol: 'OTHER' },
+        setPayToken: setPayTokenMock,
+      } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+      renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: '0xPending',
+        chainId: '0x1',
+      });
+      expect(
+        Engine.context.PerpsController?.setSelectedPaymentToken,
+      ).toHaveBeenCalledWith({
+        description: 'Pending Token',
+        address: '0xPending',
+        chainId: '0x1',
+      });
+    });
+  });
+
+  describe('sync when payToken matches but selectedPaymentToken differs', () => {
+    it('syncs when payToken matches pending but selectedPaymentToken does not', () => {
+      const setPayTokenMock = jest.fn();
+      const pendingToken = {
+        address: '0xPending',
+        chainId: '0x1',
+        description: 'Pending Token',
+      };
+
+      mockUsePerpsSelector.mockReturnValue({
+        selectedPaymentToken: pendingToken,
+      });
+      mockUsePerpsPayWithToken.mockReturnValue({
+        address: '0xDifferent',
+        chainId: '0x1',
+        description: 'Different Token',
+      });
+      mockUseTransactionPayToken.mockReturnValue({
+        payToken: {
+          address: pendingToken.address,
+          chainId: pendingToken.chainId,
+          symbol: 'PENDING',
+        },
+        setPayToken: setPayTokenMock,
+      } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+      renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: '0xPending',
+        chainId: '0x1',
+      });
+      expect(
+        Engine.context.PerpsController?.setSelectedPaymentToken,
+      ).toHaveBeenCalledWith({
+        description: 'Pending Token',
+        address: '0xPending',
+        chainId: '0x1',
+      });
+    });
+
+    it('does not sync when both payToken and selectedPaymentToken match pending', () => {
+      const setPayTokenMock = jest.fn();
+      const pendingToken = {
+        address: '0xPending',
+        chainId: '0x1',
+        description: 'Pending Token',
+      };
+
+      mockUsePerpsSelector.mockReturnValue({
+        selectedPaymentToken: pendingToken,
+      });
+      mockUsePerpsPayWithToken.mockReturnValue({
+        address: pendingToken.address,
+        chainId: pendingToken.chainId,
+        description: pendingToken.description,
+      });
+      mockUseTransactionPayToken.mockReturnValue({
+        payToken: {
+          address: pendingToken.address,
+          chainId: pendingToken.chainId,
+          symbol: 'PENDING',
+        },
+        setPayToken: setPayTokenMock,
+      } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+      renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -191,17 +191,17 @@ export const PerpsPayRow = ({
           appliedPendingTokenRef.current.chainId === pendingChainId);
     if (alreadyApplied) return;
 
+    appliedPendingTokenRef.current = {
+      address: pendingAddr,
+      chainId: pendingChainId,
+    };
+
     if (
       payToken?.address !== pendingAddr ||
       payToken?.chainId !== pendingChainId ||
       selectedPaymentToken?.address !== pendingAddr ||
       selectedPaymentToken?.chainId !== pendingChainId
     ) {
-      appliedPendingTokenRef.current = {
-        address: pendingAddr,
-        chainId: pendingChainId,
-      };
-
       setPayToken({
         address: pendingAddr as Hex,
         chainId: pendingChainId as Hex,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -145,6 +145,10 @@ export const PerpsPayRow = ({
 
     const defaultToken = defaultPayTokenWhenNoPerpsBalance;
     if (defaultToken != null) {
+      appliedPendingTokenRef.current = {
+        address: defaultToken.address,
+        chainId: defaultToken.chainId,
+      };
       setPayToken({
         address: defaultToken.address as Hex,
         chainId: defaultToken.chainId as Hex,
@@ -154,10 +158,7 @@ export const PerpsPayRow = ({
         address: defaultToken.address as Hex,
         chainId: defaultToken.chainId as Hex,
       });
-      appliedPendingTokenRef.current = {
-        address: defaultToken.address,
-        chainId: defaultToken.chainId,
-      };
+
       return;
     }
 
@@ -170,8 +171,15 @@ export const PerpsPayRow = ({
     setPayToken,
   ]);
 
+  useEffect(
+    () => () => {
+      Engine.context.PerpsController?.setSelectedPaymentToken?.(null);
+    },
+    [initialAsset],
+  );
+
   useEffect(() => {
-    if (!pendingConfigSelectedPaymentToken || !selectedPaymentToken) return;
+    if (!pendingConfigSelectedPaymentToken) return;
 
     const pendingAddr = pendingConfigSelectedPaymentToken.address;
     const pendingChainId = pendingConfigSelectedPaymentToken.chainId;
@@ -185,8 +193,15 @@ export const PerpsPayRow = ({
 
     if (
       payToken?.address !== pendingAddr ||
-      payToken?.chainId !== pendingChainId
+      payToken?.chainId !== pendingChainId ||
+      selectedPaymentToken?.address !== pendingAddr ||
+      selectedPaymentToken?.chainId !== pendingChainId
     ) {
+      appliedPendingTokenRef.current = {
+        address: pendingAddr,
+        chainId: pendingChainId,
+      };
+
       setPayToken({
         address: pendingAddr as Hex,
         chainId: pendingChainId as Hex,
@@ -198,11 +213,8 @@ export const PerpsPayRow = ({
         chainId: pendingChainId as Hex,
       });
     }
-    appliedPendingTokenRef.current = {
-      address: pendingAddr,
-      chainId: pendingChainId,
-    };
   }, [
+    initialAsset,
     payToken,
     pendingConfigSelectedPaymentToken,
     setPayToken,


### PR DESCRIPTION
## **Description**

When switching between perps assets (e.g. from BTC to ETH), the "Pay with" token selection could get out of sync — the pending config from the previous asset would either not be restored or would conflict with the newly selected asset's payment token.


## **Changelog**

CHANGELOG entry: Fixed payment token not restoring correctly when switching between perps assets

## **Related issues**

Fixes jira issue: https://consensyssoftware.atlassian.net/browse/TAT-2785

## **Manual testing steps**

```gherkin
Feature: Perps pay-with token persistence across asset switches

  Scenario: User switches perps asset and pending pay token is restored
    Given the user has a pending pay-with token config saved for ETH perps
    And the user is currently viewing BTC perps order view

    When the user switches to ETH perps
    Then the pay-with token row displays the previously saved payment token for ETH

  Scenario: User switches asset and controller state is reset
    Given the user is viewing BTC perps with a selected payment token

    When the user switches to ETH perps
    Then the controller's selectedPaymentToken is reset to null
    And the new asset's pending config (if any) is applied

  Scenario: User opens perps with no prior selectedPaymentToken in controller
    Given the user has a pending pay-with config but no selectedPaymentToken in the controller

    When the user opens the perps order view
    Then the pending config is applied and the correct pay token is displayed
```

## **Screenshots/Recordings**

N/A — no UI changes, logic-only fix in payment token sync.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps payment-token synchronization logic and controller state resets, which can affect what token a user trades with across asset switches. Changes are localized and covered by new unit tests, but regressions could impact user transaction configuration.
> 
> **Overview**
> Fixes perps “Pay with” token desynchronization when switching `initialAsset` by **clearing `PerpsController.setSelectedPaymentToken` on asset change** and ensuring pending token config is re-applied for the new asset.
> 
> Adjusts pending-config sync so it can apply even when `selectedPaymentToken` is `null`, and only re-syncs when either the `payToken` *or* controller-selected token differs from the pending token (avoiding unnecessary overwrites). Adds targeted tests covering asset-change cleanup and the new sync edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed6e439e9f6c2a205dcace7056a896a1dbd30872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->