### PR TITLE
fix: point DIGEST_API_URL to production endpoint cp-7.71.1 cp-7.72.0

### DIFF
--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -216,8 +216,7 @@ export default {
     process.env.DECODING_API_URL ||
     'https://signature-insights.api.cx.metamask.io/v1',
   DIGEST_API_URL:
-    process.env.DIGEST_API_URL ||
-    'https://digest.api.cx.metamask.io/api/v1',
+    process.env.DIGEST_API_URL || 'https://digest.api.cx.metamask.io/api/v1',
   // Rewards/Baanx: GH Actions use builds.yml (env set per build). Fallback mapping for local when env not set.
   REWARDS_API_URL: {
     DEV: 'https://rewards.dev-api.cx.metamask.io',

--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -1,6 +1,6 @@
+import { DEFAULT_SERVER_URL } from '@metamask/sdk-communication-layer';
 import { CoreTypes } from '@walletconnect/types';
 import Device from '../util/device';
-import { DEFAULT_SERVER_URL } from '@metamask/sdk-communication-layer';
 
 const DEVELOPMENT = 'development';
 
@@ -217,7 +217,7 @@ export default {
     'https://signature-insights.api.cx.metamask.io/v1',
   DIGEST_API_URL:
     process.env.DIGEST_API_URL ||
-    'https://digest.dev-api.cx.metamask.io/api/v1',
+    'https://digest.api.cx.metamask.io/api/v1',
   // Rewards/Baanx: GH Actions use builds.yml (env set per build). Fallback mapping for local when env not set.
   REWARDS_API_URL: {
     DEV: 'https://rewards.dev-api.cx.metamask.io',


### PR DESCRIPTION
## **Description**

<!-- 1. What is the reason for the change? The fallback URL for `DIGEST_API_URL` was pointing at the development endpoint. -->
<!-- 2. What is the improvement/solution? Switch the hardcoded fallback to the production endpoint so that builds without an explicit env var hit production. -->

Switches the hardcoded fallback value for `DIGEST_API_URL` in `AppConstants.ts` from the dev endpoint (`digest.dev-api.cx.metamask.io`) to the production endpoint (`digest.api.cx.metamask.io`).

Also moves the `@metamask/sdk-communication-layer` import to the top of the file to follow alphabetical import ordering.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a constant fallback URL and import ordering. Main impact is that builds without `DIGEST_API_URL` will now call the production digest service instead of the dev endpoint.
> 
> **Overview**
> Updates `AppConstants.DIGEST_API_URL` to default to the production `https://digest.api.cx.metamask.io/api/v1` endpoint when the `DIGEST_API_URL` env var is not set.
> 
> Also reorders the `DEFAULT_SERVER_URL` import to match expected import ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d584a41ba4a0679b01af799f51436faa25422da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->