### PR TITLE
feat(predict): add UCL soccer support with 3-way draw markets

### DIFF
--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.test.tsx
@@ -95,6 +95,53 @@ const createMockGameMarket = (): PredictMarket =>
     },
   });
 
+const createMockDrawCapableGameMarket = (): PredictMarket => {
+  const homeOutcome = createMockOutcome({
+    id: 'outcome-home',
+    groupItemThreshold: 0,
+    tokens: [{ id: 'token-home', title: 'Home', price: 0.42 }],
+  });
+  const drawOutcome = createMockOutcome({
+    id: 'outcome-draw',
+    groupItemThreshold: 1,
+    tokens: [{ id: 'token-draw', title: 'Draw', price: 0.3 }],
+  });
+  const awayOutcome = createMockOutcome({
+    id: 'outcome-away',
+    groupItemThreshold: 2,
+    tokens: [{ id: 'token-away', title: 'Away', price: 0.28 }],
+  });
+
+  return createMockMarket({
+    outcomes: [awayOutcome, drawOutcome, homeOutcome],
+    game: {
+      id: 'game-ucl-1',
+      startTime: '2024-12-15T13:00:00Z',
+      status: 'ongoing',
+      league: 'ucl',
+      elapsed: '65:00',
+      period: '2H',
+      score: { away: 1, home: 2, raw: '1-2' },
+      awayTeam: {
+        id: 'psg',
+        name: 'Paris Saint-Germain',
+        logo: 'https://example.com/psg.png',
+        abbreviation: 'PSG',
+        color: TEST_HEX_COLORS.TEAM_SEA,
+        alias: 'PSG',
+      },
+      homeTeam: {
+        id: 'ars',
+        name: 'Arsenal',
+        logo: 'https://example.com/ars.png',
+        abbreviation: 'ARS',
+        color: TEST_HEX_COLORS.TEAM_DEN,
+        alias: 'Arsenal',
+      },
+    },
+  });
+};
+
 const createDefaultProps = (overrides = {}) => ({
   market: createMockMarket(),
   outcome: createMockOutcome(),
@@ -130,7 +177,7 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.queryByText('YES · 65¢')).not.toBeOnTheScreen();
+      expect(screen.queryByText('YES')).not.toBeOnTheScreen();
     });
   });
 
@@ -202,8 +249,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getAllByText('65¢')).toHaveLength(1);
+      expect(screen.getAllByText('35¢')).toHaveLength(1);
     });
 
     it('calls onBetPress with yes token when yes button is pressed', () => {
@@ -235,8 +284,8 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.queryByText('YES · 65¢')).not.toBeOnTheScreen();
-      expect(screen.queryByText('NO · 35¢')).not.toBeOnTheScreen();
+      expect(screen.queryByText('YES')).not.toBeOnTheScreen();
+      expect(screen.queryByText('NO')).not.toBeOnTheScreen();
     });
 
     it('passes carousel mode to bet buttons', () => {
@@ -261,8 +310,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('SEA · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('DEN · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('SEA')).toBeOnTheScreen();
+      expect(screen.getByText('DEN')).toBeOnTheScreen();
+      expect(screen.getAllByText('65¢')).toHaveLength(1);
+      expect(screen.getAllByText('35¢')).toHaveLength(1);
     });
 
     it('calls onBetPress with correct token for away team', () => {
@@ -294,6 +345,40 @@ describe('PredictActionButtons', () => {
 
       expect(mockOnBetPress).toHaveBeenCalledWith(outcome.tokens[1]);
     });
+
+    it('renders home, draw, and away buttons for draw-capable leagues', () => {
+      const market = createMockDrawCapableGameMarket();
+      const props = createDefaultProps({
+        market,
+        outcome: market.outcomes[0],
+      });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(screen.getByText('ARS')).toBeOnTheScreen();
+      expect(screen.getByText('DRAW')).toBeOnTheScreen();
+      expect(screen.getByText('PSG')).toBeOnTheScreen();
+      expect(screen.getAllByText('42¢')).toHaveLength(1);
+      expect(screen.getAllByText('30¢')).toHaveLength(1);
+      expect(screen.getAllByText('28¢')).toHaveLength(1);
+    });
+
+    it('calls onBetPress with draw token for draw-capable leagues', () => {
+      const market = createMockDrawCapableGameMarket();
+      const mockOnBetPress = jest.fn();
+      const props = createDefaultProps({
+        market,
+        outcome: market.outcomes[0],
+        onBetPress: mockOnBetPress,
+      });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+      fireEvent.press(screen.getByTestId('action-buttons-bet-draw'));
+
+      expect(mockOnBetPress).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'token-draw' }),
+      );
+    });
   });
 
   describe('priority order', () => {
@@ -321,7 +406,7 @@ describe('PredictActionButtons', () => {
       renderWithProvider(<PredictActionButtons {...props} />);
 
       expect(screen.getByText('Claim $50.25')).toBeOnTheScreen();
-      expect(screen.queryByText('YES · 65¢')).not.toBeOnTheScreen();
+      expect(screen.queryByText('YES')).not.toBeOnTheScreen();
     });
   });
 
@@ -361,8 +446,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getAllByText('65¢')).toHaveLength(1);
+      expect(screen.getAllByText('35¢')).toHaveLength(1);
     });
   });
 
@@ -388,8 +475,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 73¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 29¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getAllByText('73¢')).toHaveLength(1);
+      expect(screen.getAllByText('29¢')).toHaveLength(1);
     });
 
     it('falls back to static prices when live prices unavailable', () => {
@@ -403,8 +492,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getAllByText('65¢')).toHaveLength(1);
+      expect(screen.getAllByText('35¢')).toHaveLength(1);
     });
 
     it('uses partial live prices with fallback for missing tokens', () => {
@@ -424,8 +515,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('YES · 81¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getAllByText('81¢')).toHaveLength(1);
+      expect(screen.getAllByText('35¢')).toHaveLength(1);
     });
 
     it('subscribes with correct token IDs', () => {
@@ -463,6 +556,21 @@ describe('PredictActionButtons', () => {
       );
     });
 
+    it('subscribes with sorted token IDs for draw-capable leagues', () => {
+      const market = createMockDrawCapableGameMarket();
+      const props = createDefaultProps({
+        market,
+        outcome: market.outcomes[0],
+      });
+
+      renderWithProvider(<PredictActionButtons {...props} />);
+
+      expect(mockUseLiveMarketPrices).toHaveBeenCalledWith(
+        ['token-home', 'token-draw', 'token-away'],
+        { enabled: true },
+      );
+    });
+
     it('displays live prices for game markets', () => {
       const priceMap = new Map<string, PriceUpdate>([
         [
@@ -486,8 +594,10 @@ describe('PredictActionButtons', () => {
 
       renderWithProvider(<PredictActionButtons {...props} />);
 
-      expect(screen.getByText('SEA · 56¢')).toBeOnTheScreen();
-      expect(screen.getByText('DEN · 46¢')).toBeOnTheScreen();
+      expect(screen.getByText('SEA')).toBeOnTheScreen();
+      expect(screen.getByText('DEN')).toBeOnTheScreen();
+      expect(screen.getAllByText('56¢')).toHaveLength(1);
+      expect(screen.getAllByText('46¢')).toHaveLength(1);
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
@@ -4,12 +4,27 @@ import PredictBetButtons from './PredictBetButtons';
 import PredictClaimButton from './PredictClaimButton';
 import PredictDetailsButtonsSkeleton from '../PredictDetailsButtonsSkeleton';
 import { PredictActionButtonsProps } from './PredictActionButtons.types';
-import { PredictMarketStatus } from '../../types';
+import { PredictMarketStatus, PredictOutcomeToken } from '../../types';
 import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
+import { isDrawCapableLeague } from '../../constants/sports';
 import {
   BASE_PREDICT_ACTION_BUTTONS_TEST_IDS,
   PREDICT_ACTION_BUTTONS_TEST_IDS,
 } from './PredictActionButtons.testIds';
+
+interface ButtonConfig {
+  yesLabel: string;
+  yesPrice: number;
+  yesTeamColor?: string;
+  yesToken: PredictOutcomeToken;
+  noLabel: string;
+  noPrice: number;
+  noTeamColor?: string;
+  noToken: PredictOutcomeToken;
+  drawLabel?: string;
+  drawPrice?: number;
+  drawToken?: PredictOutcomeToken;
+}
 
 const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
   market,
@@ -25,16 +40,73 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
   const isGameMarket = Boolean(market.game);
   const isMarketOpen = market.status === PredictMarketStatus.OPEN;
 
-  const tokenIds = useMemo(
-    () => outcome.tokens.map((token) => token.id),
-    [outcome.tokens],
-  );
+  const tokenIds = useMemo(() => {
+    if (
+      isGameMarket &&
+      market.game &&
+      isDrawCapableLeague(market.game.league) &&
+      market.outcomes.length >= 3
+    ) {
+      const sortedOutcomes = [...market.outcomes].sort(
+        (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
+      );
+
+      return sortedOutcomes
+        .map((marketOutcome) => marketOutcome.tokens[0]?.id)
+        .filter((tokenId): tokenId is string => Boolean(tokenId));
+    }
+
+    return outcome.tokens.map((token) => token.id);
+  }, [isGameMarket, market.game, market.outcomes, outcome.tokens]);
 
   const { getPrice } = useLiveMarketPrices(tokenIds, {
     enabled: isMarketOpen && !isLoading,
   });
 
-  const buttonConfig = useMemo(() => {
+  const buttonConfig = useMemo<ButtonConfig | null>(() => {
+    if (
+      isGameMarket &&
+      market.game &&
+      isDrawCapableLeague(market.game.league) &&
+      market.outcomes.length >= 3
+    ) {
+      const sortedOutcomes = [...market.outcomes].sort(
+        (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
+      );
+
+      const homeOutcome = sortedOutcomes[0];
+      const drawOutcome = sortedOutcomes[1];
+      const awayOutcome = sortedOutcomes[2];
+
+      const homeToken = homeOutcome?.tokens[0];
+      const drawToken = drawOutcome?.tokens[0];
+      const awayToken = awayOutcome?.tokens[0];
+
+      if (!homeToken || !drawToken || !awayToken) {
+        return null;
+      }
+
+      const { homeTeam, awayTeam } = market.game;
+
+      const homePrice = getPrice(homeToken.id);
+      const drawPrice = getPrice(drawToken.id);
+      const awayPrice = getPrice(awayToken.id);
+
+      return {
+        yesLabel: homeTeam.abbreviation,
+        yesPrice: Math.round((homePrice?.bestAsk ?? homeToken.price) * 100),
+        yesTeamColor: homeTeam.color,
+        yesToken: homeToken,
+        drawLabel: 'DRAW',
+        drawPrice: Math.round((drawPrice?.bestAsk ?? drawToken.price) * 100),
+        drawToken,
+        noLabel: awayTeam.abbreviation,
+        noPrice: Math.round((awayPrice?.bestAsk ?? awayToken.price) * 100),
+        noTeamColor: awayTeam.color,
+        noToken: awayToken,
+      };
+    }
+
     const tokens = outcome.tokens;
     if (tokens.length < 2) {
       return null;
@@ -55,9 +127,11 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
         yesLabel: awayTeam.abbreviation,
         yesPrice: Math.round(yesPrice * 100),
         yesTeamColor: awayTeam.color,
+        yesToken,
         noLabel: homeTeam.abbreviation,
         noPrice: Math.round(noPrice * 100),
         noTeamColor: homeTeam.color,
+        noToken,
       };
     }
 
@@ -65,11 +139,13 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
       yesLabel: yesToken.title,
       yesPrice: Math.round(yesPrice * 100),
       yesTeamColor: undefined,
+      yesToken,
       noLabel: noToken.title,
       noPrice: Math.round(noPrice * 100),
       noTeamColor: undefined,
+      noToken,
     };
-  }, [outcome.tokens, isGameMarket, market.game, getPrice]);
+  }, [outcome.tokens, isGameMarket, market.game, market.outcomes, getPrice]);
 
   if (isLoading) {
     return (
@@ -93,15 +169,20 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
   }
 
   if (market.status === PredictMarketStatus.OPEN && buttonConfig) {
+    const drawToken = buttonConfig.drawToken;
+
     return (
       <Box twClassName="w-full mt-4">
         <PredictBetButtons
           yesLabel={buttonConfig.yesLabel}
           yesPrice={buttonConfig.yesPrice}
-          onYesPress={() => onBetPress(outcome.tokens[0])}
+          onYesPress={() => onBetPress(buttonConfig.yesToken)}
+          drawLabel={buttonConfig.drawLabel}
+          drawPrice={buttonConfig.drawPrice}
+          onDrawPress={drawToken ? () => onBetPress(drawToken) : undefined}
           noLabel={buttonConfig.noLabel}
           noPrice={buttonConfig.noPrice}
-          onNoPress={() => onBetPress(outcome.tokens[1])}
+          onNoPress={() => onBetPress(buttonConfig.noToken)}
           yesTeamColor={buttonConfig.yesTeamColor}
           noTeamColor={buttonConfig.noTeamColor}
           testID={`${testID}${PREDICT_ACTION_BUTTONS_TEST_IDS.PREDICT_BET_BUTTON}`}

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.tsx
@@ -40,40 +40,37 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
   const isGameMarket = Boolean(market.game);
   const isMarketOpen = market.status === PredictMarketStatus.OPEN;
 
-  const tokenIds = useMemo(() => {
-    if (
-      isGameMarket &&
-      market.game &&
-      isDrawCapableLeague(market.game.league) &&
-      market.outcomes.length >= 3
-    ) {
-      const sortedOutcomes = [...market.outcomes].sort(
-        (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
-      );
+  const isDrawCapable =
+    isGameMarket &&
+    market.game &&
+    isDrawCapableLeague(market.game.league) &&
+    market.outcomes.length >= 3;
 
+  const sortedOutcomes = useMemo(() => {
+    if (!isDrawCapable) {
+      return null;
+    }
+    return [...market.outcomes].sort(
+      (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
+    );
+  }, [isDrawCapable, market.outcomes]);
+
+  const tokenIds = useMemo(() => {
+    if (sortedOutcomes) {
       return sortedOutcomes
         .map((marketOutcome) => marketOutcome.tokens[0]?.id)
         .filter((tokenId): tokenId is string => Boolean(tokenId));
     }
 
     return outcome.tokens.map((token) => token.id);
-  }, [isGameMarket, market.game, market.outcomes, outcome.tokens]);
+  }, [sortedOutcomes, outcome.tokens]);
 
   const { getPrice } = useLiveMarketPrices(tokenIds, {
     enabled: isMarketOpen && !isLoading,
   });
 
   const buttonConfig = useMemo<ButtonConfig | null>(() => {
-    if (
-      isGameMarket &&
-      market.game &&
-      isDrawCapableLeague(market.game.league) &&
-      market.outcomes.length >= 3
-    ) {
-      const sortedOutcomes = [...market.outcomes].sort(
-        (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
-      );
-
+    if (sortedOutcomes && market.game) {
       const homeOutcome = sortedOutcomes[0];
       const drawOutcome = sortedOutcomes[1];
       const awayOutcome = sortedOutcomes[2];
@@ -145,7 +142,7 @@ const PredictActionButtons: React.FC<PredictActionButtonsProps> = ({
       noTeamColor: undefined,
       noToken,
     };
-  }, [outcome.tokens, isGameMarket, market.game, market.outcomes, getPrice]);
+  }, [outcome.tokens, isGameMarket, market.game, sortedOutcomes, getPrice]);
 
   if (isLoading) {
     return (

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
@@ -5,7 +5,7 @@ import {
 } from '../../types';
 import { ButtonBaseSize } from '@metamask/design-system-react-native';
 
-export type PredictBetButtonVariant = 'yes' | 'no';
+export type PredictBetButtonVariant = 'yes' | 'no' | 'draw';
 
 export interface PredictBetButtonProps {
   label: string;
@@ -22,6 +22,9 @@ export interface PredictBetButtonsProps {
   yesLabel: string;
   yesPrice: number;
   onYesPress: () => void;
+  drawLabel?: string;
+  drawPrice?: number;
+  onDrawPress?: () => void;
   noLabel: string;
   noPrice: number;
   onNoPress: () => void;

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.test.tsx
@@ -24,7 +24,8 @@ describe('PredictBetButton', () => {
 
       renderWithProvider(<PredictBetButton {...props} />);
 
-      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('65¢')).toBeOnTheScreen();
     });
 
     it('renders with no variant label and price', () => {
@@ -36,7 +37,21 @@ describe('PredictBetButton', () => {
 
       renderWithProvider(<PredictBetButton {...props} />);
 
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getByText('35¢')).toBeOnTheScreen();
+    });
+
+    it('renders with draw variant label and price', () => {
+      const props = createDefaultProps({
+        label: 'Draw',
+        price: 20,
+        variant: 'draw',
+      });
+
+      renderWithProvider(<PredictBetButton {...props} />);
+
+      expect(screen.getByText('DRAW')).toBeOnTheScreen();
+      expect(screen.getByText('20¢')).toBeOnTheScreen();
     });
 
     it('renders team abbreviation as label for game markets', () => {
@@ -48,7 +63,8 @@ describe('PredictBetButton', () => {
 
       renderWithProvider(<PredictBetButton {...props} />);
 
-      expect(screen.getByText('SEA · 49¢')).toBeOnTheScreen();
+      expect(screen.getByText('SEA')).toBeOnTheScreen();
+      expect(screen.getByText('49¢')).toBeOnTheScreen();
     });
 
     it('renders with testID', () => {
@@ -138,7 +154,8 @@ describe('PredictBetButton', () => {
 
       renderWithProvider(<PredictBetButton {...props} />);
 
-      expect(screen.getByText('YES · 0¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('0¢')).toBeOnTheScreen();
     });
 
     it('renders with 100 price', () => {
@@ -146,7 +163,8 @@ describe('PredictBetButton', () => {
 
       renderWithProvider(<PredictBetButton {...props} />);
 
-      expect(screen.getByText('YES · 100¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('100¢')).toBeOnTheScreen();
     });
 
     it('renders with empty label', () => {
@@ -154,7 +172,7 @@ describe('PredictBetButton', () => {
 
       renderWithProvider(<PredictBetButton {...props} />);
 
-      expect(screen.getByText(' · 65¢')).toBeOnTheScreen();
+      expect(screen.getByText('65¢')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.tsx
@@ -23,12 +23,18 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
     if (hasTeamColor) {
       return teamColor;
     }
+    if (variant === 'draw') {
+      return colors.background.muted;
+    }
     return variant === 'yes' ? colors.success.muted : colors.error.muted;
   };
 
   const getTextColor = (): string => {
     if (hasTeamColor) {
       return 'text-white';
+    }
+    if (variant === 'draw') {
+      return 'text-default';
     }
     return variant === 'yes' ? 'text-success-default' : 'text-error-default';
   };
@@ -42,8 +48,14 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
       isFullWidth
       size={size}
     >
-      <Text style={tw.style('font-medium', getTextColor())}>
-        {label.toUpperCase()} · {price}¢
+      <Text
+        style={tw.style('font-medium text-center', getTextColor())}
+        numberOfLines={1}
+      >
+        {label.toUpperCase()}
+      </Text>
+      <Text style={tw.style('font-medium text-center', getTextColor())}>
+        {price}¢
       </Text>
     </Button>
   );

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.test.tsx
@@ -26,8 +26,10 @@ describe('PredictBetButtons', () => {
 
       renderWithProvider(<PredictBetButtons {...props} />);
 
-      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('65¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getByText('35¢')).toBeOnTheScreen();
     });
 
     it('renders with custom labels', () => {
@@ -38,8 +40,8 @@ describe('PredictBetButtons', () => {
 
       renderWithProvider(<PredictBetButtons {...props} />);
 
-      expect(screen.getByText('SEA · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('DEN · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('SEA')).toBeOnTheScreen();
+      expect(screen.getByText('DEN')).toBeOnTheScreen();
     });
 
     it('renders with custom prices', () => {
@@ -50,8 +52,8 @@ describe('PredictBetButtons', () => {
 
       renderWithProvider(<PredictBetButtons {...props} />);
 
-      expect(screen.getByText('YES · 49¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 51¢')).toBeOnTheScreen();
+      expect(screen.getByText('49¢')).toBeOnTheScreen();
+      expect(screen.getByText('51¢')).toBeOnTheScreen();
     });
 
     it('renders with testID prefix for each button', () => {
@@ -61,6 +63,29 @@ describe('PredictBetButtons', () => {
 
       expect(screen.getByTestId('custom-buttons-yes')).toBeOnTheScreen();
       expect(screen.getByTestId('custom-buttons-no')).toBeOnTheScreen();
+    });
+
+    it('renders draw button between yes and no when draw props are provided', () => {
+      const props = createDefaultProps({
+        drawLabel: 'DRAW',
+        drawPrice: 20,
+        onDrawPress: jest.fn(),
+      });
+
+      renderWithProvider(<PredictBetButtons {...props} />);
+
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('DRAW')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getByTestId('bet-buttons-draw')).toBeOnTheScreen();
+    });
+
+    it('does not render draw button when draw props are missing', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictBetButtons {...props} />);
+
+      expect(screen.queryByTestId('bet-buttons-draw')).not.toBeOnTheScreen();
     });
   });
 
@@ -101,6 +126,20 @@ describe('PredictBetButtons', () => {
       expect(mockOnYesPress).not.toHaveBeenCalled();
       expect(mockOnNoPress).not.toHaveBeenCalled();
     });
+
+    it('calls onDrawPress when draw button is pressed', () => {
+      const mockOnDrawPress = jest.fn();
+      const props = createDefaultProps({
+        drawLabel: 'DRAW',
+        drawPrice: 20,
+        onDrawPress: mockOnDrawPress,
+      });
+
+      renderWithProvider(<PredictBetButtons {...props} />);
+      fireEvent.press(screen.getByTestId('bet-buttons-draw'));
+
+      expect(mockOnDrawPress).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('team colors', () => {
@@ -137,8 +176,9 @@ describe('PredictBetButtons', () => {
 
       renderWithProvider(<PredictBetButtons {...props} />);
 
-      expect(screen.getByText('YES · 50¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 50¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getAllByText('50¢')).toHaveLength(2);
     });
 
     it('renders with extreme prices', () => {
@@ -149,8 +189,10 @@ describe('PredictBetButtons', () => {
 
       renderWithProvider(<PredictBetButtons {...props} />);
 
-      expect(screen.getByText('YES · 99¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 1¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('99¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getByText('1¢')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.testIds.ts
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.testIds.ts
@@ -4,5 +4,6 @@ export const BASE_PREDICT_BET_BUTTONS_TEST_IDS = {
 
 export const PREDICT_BET_BUTTONS_TEST_IDS = {
   PREDICT_BET_BUTTON_YES: '-yes',
+  PREDICT_BET_BUTTON_DRAW: '-draw',
   PREDICT_BET_BUTTON_NO: '-no',
 } as const;

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButtons.tsx
@@ -15,6 +15,9 @@ const PredictBetButtons: React.FC<PredictBetButtonsProps> = ({
   yesLabel,
   yesPrice,
   onYesPress,
+  drawLabel,
+  drawPrice,
+  onDrawPress,
   noLabel,
   noPrice,
   onNoPress,
@@ -37,6 +40,19 @@ const PredictBetButtons: React.FC<PredictBetButtonsProps> = ({
         size={isCarousel ? ButtonBaseSize.Md : undefined}
       />
     </Box>
+    {drawLabel !== undefined && drawPrice !== undefined && onDrawPress && (
+      <Box twClassName="flex-1">
+        <PredictBetButton
+          label={drawLabel}
+          price={drawPrice}
+          onPress={onDrawPress}
+          variant="draw"
+          disabled={disabled}
+          testID={`${testID}${PREDICT_BET_BUTTONS_TEST_IDS.PREDICT_BET_BUTTON_DRAW}`}
+          size={isCarousel ? ButtonBaseSize.Md : undefined}
+        />
+      </Box>
+    )}
     <Box twClassName="flex-1">
       <PredictBetButton
         label={noLabel}

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.test.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.test.ts
@@ -62,8 +62,8 @@ describe('getSeparatedLabelYPositions', () => {
     });
   });
 
-  describe('three positions with no overlap', () => {
-    it('returns originals', () => {
+  describe('three positions with no overlap but bottom overflow', () => {
+    it('preserves spacing and shifts group upward', () => {
       const input = [{ dotY: 20 }, { dotY: 100 }, { dotY: 180 }];
 
       const result = getSeparatedLabelYPositions(input);

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.test.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.test.ts
@@ -1,0 +1,224 @@
+import {
+  getSeparatedLabelYPositions,
+  CHART_HEIGHT,
+  LABEL_HEIGHT,
+  MIN_LABEL_GAP,
+} from './PredictGameChart.constants';
+
+describe('getSeparatedLabelYPositions', () => {
+  const minSpacing = LABEL_HEIGHT + MIN_LABEL_GAP; // 48
+
+  describe('empty array', () => {
+    it('returns empty array', () => {
+      const result = getSeparatedLabelYPositions([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('single position', () => {
+    it('returns its dotY', () => {
+      const input = [{ dotY: 100 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      expect(result).toEqual([100]);
+    });
+  });
+
+  describe('two positions with sufficient gap', () => {
+    it('returns original positions unchanged', () => {
+      const input = [{ dotY: 50 }, { dotY: 120 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      expect(result).toEqual([50, 120]);
+    });
+  });
+
+  describe('two positions with insufficient gap, first above second', () => {
+    it('applies symmetric centering', () => {
+      const input = [{ dotY: 50 }, { dotY: 80 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      const midPoint = (50 + 80) / 2; // 65
+      const offset = minSpacing / 2; // 24
+      expect(result).toEqual([midPoint - offset, midPoint + offset]);
+      expect(result).toEqual([41, 89]);
+    });
+  });
+
+  describe('two positions with insufficient gap, first below second', () => {
+    it('applies symmetric centering reversed', () => {
+      const input = [{ dotY: 100 }, { dotY: 120 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      const midPoint = (100 + 120) / 2; // 110
+      const offset = minSpacing / 2; // 24
+      expect(result).toEqual([midPoint - offset, midPoint + offset]);
+      expect(result).toEqual([86, 134]);
+    });
+  });
+
+  describe('three positions with no overlap', () => {
+    it('returns originals', () => {
+      const input = [{ dotY: 20 }, { dotY: 100 }, { dotY: 180 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [20, 100, 180]
+      // After spacing: [20, 100, 180] (no gaps < minSpacing)
+      // maxY = 160, overflow = 180 - 160 = 20
+      // Shift all up by 20: [0, 80, 160]
+      expect(result).toEqual([0, 80, 160]);
+    });
+  });
+
+  describe('three positions that overlap', () => {
+    it('pushes down correctly', () => {
+      const input = [{ dotY: 50 }, { dotY: 60 }, { dotY: 70 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // First stays at 50
+      // Second pushed to 50 + 48 = 98
+      // Third pushed to 98 + 48 = 146
+      expect(result).toEqual([50, 98, 146]);
+    });
+  });
+
+  describe('three positions near bottom of chart', () => {
+    it('shifted upward so nothing exceeds CHART_HEIGHT - LABEL_HEIGHT', () => {
+      const input = [{ dotY: 140 }, { dotY: 150 }, { dotY: 160 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [140, 150, 160]
+      // After spacing: [140, 188, 236]
+      // maxY = 200 - 40 = 160
+      // overflow = 236 - 160 = 76
+      // Shift all up by 76: [64, 112, 160]
+      expect(result).toEqual([64, 112, 160]);
+    });
+  });
+
+  describe('three positions where overflow shift would push top below 0', () => {
+    it('clamped to 0', () => {
+      const input = [{ dotY: 10 }, { dotY: 20 }, { dotY: 30 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [10, 20, 30]
+      // After spacing: [10, 58, 106]
+      // maxY = 160
+      // overflow = 106 - 160 = -54 (no overflow)
+      // No shift needed
+      expect(result).toEqual([10, 58, 106]);
+    });
+  });
+
+  describe('three positions with extreme overflow requiring clamping', () => {
+    it('clamps top position to 0 when shift would go negative', () => {
+      const input = [{ dotY: 150 }, { dotY: 160 }, { dotY: 170 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [150, 160, 170]
+      // After spacing: [150, 198, 246]
+      // maxY = 160
+      // overflow = 246 - 160 = 86
+      // Shift all up by 86: [64, 112, 160]
+      // No clamping needed since 64 > 0
+      expect(result).toEqual([64, 112, 160]);
+    });
+  });
+
+  describe('preserves original order in result array', () => {
+    it('maps positions back to original indices', () => {
+      const input = [{ dotY: 100 }, { dotY: 50 }, { dotY: 150 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // Input order: [100, 50, 150]
+      // Sorted internally: [50, 100, 150] with indices [1, 0, 2]
+      // After spacing: [50, 98, 146]
+      // maxY = 160, overflow = 146 - 160 = -14 (no overflow)
+      // Result maps back to original order: result[0]=100, result[1]=50, result[2]=150
+      expect(result[0]).toBe(100); // original first (100) stays 100
+      expect(result[1]).toBe(50); // original second (50) stays 50
+      expect(result[2]).toBe(150); // original third (150) stays 150
+    });
+  });
+
+  describe('edge case: all positions at same Y', () => {
+    it('spreads them with minSpacing', () => {
+      const input = [{ dotY: 100 }, { dotY: 100 }, { dotY: 100 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [100, 100, 100]
+      // After spacing: [100, 148, 196]
+      // maxY = 160, overflow = 196 - 160 = 36
+      // Shift all up by 36: [64, 112, 160]
+      expect(result).toEqual([64, 112, 160]);
+    });
+  });
+
+  describe('edge case: two positions at exact minSpacing boundary', () => {
+    it('returns original positions when gap equals minSpacing', () => {
+      const input = [{ dotY: 50 }, { dotY: 98 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      expect(result).toEqual([50, 98]);
+    });
+  });
+
+  describe('three positions with no overflow', () => {
+    it('does not shift when all fit within bounds', () => {
+      const input = [{ dotY: 10 }, { dotY: 80 }, { dotY: 150 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [10, 80, 150]
+      // After spacing: [10, 80, 150] (gaps are 70 and 70, both >= 48)
+      // maxY = 160, overflow = 150 - 160 = -10 (no overflow)
+      // No shift applied
+      expect(result).toEqual([10, 80, 150]);
+    });
+  });
+
+  describe('three positions with extreme overflow clamping to 0', () => {
+    it('clamps top position to 0 when shift exceeds bounds', () => {
+      const input = [{ dotY: 10 }, { dotY: 100 }, { dotY: 190 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [10, 100, 190]
+      // After spacing: [10, 100, 190] (gaps are 90 and 90, both >= 48)
+      // maxY = 160, overflow = 190 - 160 = 30
+      // Shift all up by 30: [0, 70, 160]
+      // First position clamped to 0 since 10 - 30 = -20 < 0
+      expect(result).toEqual([0, 70, 160]);
+    });
+  });
+
+  describe('four positions with mixed gaps', () => {
+    it('handles both sufficient and insufficient gaps', () => {
+      const input = [{ dotY: 20 }, { dotY: 30 }, { dotY: 100 }, { dotY: 150 }];
+
+      const result = getSeparatedLabelYPositions(input);
+
+      // After sorting: [20, 30, 100, 150]
+      // Gap 1: 30 - 20 = 10 < 48, push to 20 + 48 = 68
+      // Gap 2: 100 - 68 = 32 < 48, push to 68 + 48 = 116
+      // Gap 3: 150 - 116 = 34 < 48, push to 116 + 48 = 164
+      // After spacing: [20, 68, 116, 164]
+      // maxY = 160, overflow = 164 - 160 = 4
+      // Shift all up by 4: [16, 64, 112, 160]
+      expect(result).toEqual([16, 64, 112, 160]);
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.test.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.test.ts
@@ -190,8 +190,8 @@ describe('getSeparatedLabelYPositions', () => {
     });
   });
 
-  describe('three positions with extreme overflow clamping to 0', () => {
-    it('clamps top position to 0 when shift exceeds bounds', () => {
+  describe('three positions with overflow exceeding top position', () => {
+    it('limits shift to top position value preserving spacing', () => {
       const input = [{ dotY: 10 }, { dotY: 100 }, { dotY: 190 }];
 
       const result = getSeparatedLabelYPositions(input);
@@ -199,9 +199,11 @@ describe('getSeparatedLabelYPositions', () => {
       // After sorting: [10, 100, 190]
       // After spacing: [10, 100, 190] (gaps are 90 and 90, both >= 48)
       // maxY = 160, overflow = 190 - 160 = 30
-      // Shift all up by 30: [0, 70, 160]
-      // First position clamped to 0 since 10 - 30 = -20 < 0
-      expect(result).toEqual([0, 70, 160]);
+      // shift = Math.min(30, 10) = 10 (limited by top position)
+      // After shift: [0, 90, 180] — spacing preserved even though bottom overflows
+      expect(result).toEqual([0, 90, 180]);
+      expect(result[1] - result[0]).toBeGreaterThanOrEqual(minSpacing);
+      expect(result[2] - result[1]).toBeGreaterThanOrEqual(minSpacing);
     });
   });
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -30,18 +30,24 @@ export const getSeparatedLabelYPositions = (
     return dotPositions.map((pos) => pos.dotY);
   }
 
-  const [first, second] = dotPositions;
-  const gap = Math.abs(first.dotY - second.dotY);
+  const minSpacing = LABEL_HEIGHT + MIN_LABEL_GAP;
+  const positions = dotPositions.map((pos, index) => ({
+    index,
+    y: pos.dotY,
+  }));
 
-  if (gap >= LABEL_HEIGHT + MIN_LABEL_GAP) {
-    return [first.dotY, second.dotY];
+  positions.sort((a, b) => a.y - b.y);
+
+  for (let i = 1; i < positions.length; i++) {
+    const gap = positions[i].y - positions[i - 1].y;
+    if (gap < minSpacing) {
+      positions[i].y = positions[i - 1].y + minSpacing;
+    }
   }
 
-  const midPoint = (first.dotY + second.dotY) / 2;
-  const offset = (LABEL_HEIGHT + MIN_LABEL_GAP) / 2;
-
-  if (first.dotY < second.dotY) {
-    return [midPoint - offset, midPoint + offset];
+  const result = new Array<number>(dotPositions.length);
+  for (const pos of positions) {
+    result[pos.index] = pos.y;
   }
-  return [midPoint + offset, midPoint - offset];
+  return result;
 };

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -69,8 +69,9 @@ export const getSeparatedLabelYPositions = (
   const maxY = CHART_HEIGHT - LABEL_HEIGHT;
   const overflow = positions[positions.length - 1].y - maxY;
   if (overflow > 0) {
+    const shift = Math.min(overflow, positions[0].y);
     for (const pos of positions) {
-      pos.y = Math.max(0, pos.y - overflow);
+      pos.y -= shift;
     }
   }
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -31,6 +31,26 @@ export const getSeparatedLabelYPositions = (
   }
 
   const minSpacing = LABEL_HEIGHT + MIN_LABEL_GAP;
+
+  // For 2 labels, use symmetric centering around the midpoint
+  if (dotPositions.length === 2) {
+    const [first, second] = dotPositions;
+    const gap = Math.abs(first.dotY - second.dotY);
+
+    if (gap >= minSpacing) {
+      return [first.dotY, second.dotY];
+    }
+
+    const midPoint = (first.dotY + second.dotY) / 2;
+    const offset = minSpacing / 2;
+
+    if (first.dotY < second.dotY) {
+      return [midPoint - offset, midPoint + offset];
+    }
+    return [midPoint + offset, midPoint - offset];
+  }
+
+  // For 3+ labels, sort and push overlapping labels downward
   const positions = dotPositions.map((pos, index) => ({
     index,
     y: pos.dotY,

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.constants.ts
@@ -65,6 +65,15 @@ export const getSeparatedLabelYPositions = (
     }
   }
 
+  // Shift group upward if bottom label overflows chart bounds
+  const maxY = CHART_HEIGHT - LABEL_HEIGHT;
+  const overflow = positions[positions.length - 1].y - maxY;
+  if (overflow > 0) {
+    for (const pos of positions) {
+      pos.y = Math.max(0, pos.y - overflow);
+    }
+  }
+
   const result = new Array<number>(dotPositions.length);
   for (const pos of positions) {
     result[pos.index] = pos.y;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -8,6 +8,8 @@ import React, {
 import { PredictGameStatus, PredictPriceHistoryInterval } from '../../types';
 import { usePredictPriceHistory } from '../../hooks/usePredictPriceHistory';
 import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
+import { isDrawCapableLeague } from '../../constants/sports';
+import { useTheme } from '../../../../../util/theme';
 import PredictGameChartContent from './PredictGameChartContent';
 import {
   PredictGameChartProps,
@@ -66,23 +68,42 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
   testID,
 }) => {
   const game = market.game;
+  const { colors } = useTheme();
   const gameStatus = game?.status;
   const isGameEnded = gameStatus === 'ended';
   const isGameOngoing = gameStatus === 'ongoing';
 
   const tokenIds = useMemo(() => {
+    if (
+      game?.league &&
+      isDrawCapableLeague(game.league) &&
+      market.outcomes.length >= 3
+    ) {
+      return [...market.outcomes]
+        .sort(
+          (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
+        )
+        .map((o) => o.tokens[0]?.id)
+        .filter((id): id is string => Boolean(id));
+    }
     const tokens = market.outcomes[0]?.tokens ?? [];
     return tokens.map((t) => t.id);
-  }, [market.outcomes]);
+  }, [market.outcomes, game?.league]);
 
-  const seriesConfig: [GameChartSeriesConfig, GameChartSeriesConfig] | null =
-    useMemo(() => {
-      if (!game) return null;
+  const seriesConfig: GameChartSeriesConfig[] | null = useMemo(() => {
+    if (!game) return null;
+    if (isDrawCapableLeague(game.league) && market.outcomes.length >= 3) {
       return [
-        { label: game.awayTeam.abbreviation, color: game.awayTeam.color },
         { label: game.homeTeam.abbreviation, color: game.homeTeam.color },
+        { label: 'DRAW', color: colors.icon.muted },
+        { label: game.awayTeam.abbreviation, color: game.awayTeam.color },
       ];
-    }, [game]);
+    }
+    return [
+      { label: game.awayTeam.abbreviation, color: game.awayTeam.color },
+      { label: game.homeTeam.abbreviation, color: game.homeTeam.color },
+    ];
+  }, [game, market.outcomes.length, colors.icon.muted]);
 
   const [timeframe, setTimeframe] = useState<ChartTimeframe>(() =>
     getDefaultTimeframe(gameStatus),
@@ -119,19 +140,20 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
       startTs,
       endTs,
       fidelity,
-      enabled: tokenIds.length === 2,
+      enabled: tokenIds.length >= 2,
     });
 
   const { prices } = useLiveMarketPrices(tokenIds, {
-    enabled: isLive && tokenIds.length === 2,
+    enabled: isLive && tokenIds.length >= 2,
   });
 
   const historicalChartData: GameChartSeries[] = useMemo(() => {
-    if (priceHistories.length < 2 || !seriesConfig) return [];
+    if (priceHistories.length < tokenIds.length || !seriesConfig) return [];
 
     return tokenIds.map((_tokenId, index) => {
       const history = priceHistories[index] ?? [];
       const config = seriesConfig[index];
+      if (!config) return { label: '', color: '', data: [] };
 
       return {
         label: config.label,
@@ -170,9 +192,8 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
     }
 
     if (
-      historicalChartData.length === 2 &&
-      historicalChartData[0].data.length > 0 &&
-      historicalChartData[1].data.length > 0
+      historicalChartData.length >= 2 &&
+      historicalChartData.every((s) => s.data.length > 0)
     ) {
       setLiveChartData(historicalChartData);
       initialDataLoadedRef.current = true;
@@ -186,7 +207,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
     const currentMinute = getMinuteTimestamp(now);
 
     setLiveChartData((prevData) => {
-      if (prevData.length !== 2) return prevData;
+      if (prevData.length < 2) return prevData;
 
       const lastPointSeries0 = prevData[0].data[prevData[0].data.length - 1];
       if (!lastPointSeries0) return prevData;
@@ -240,9 +261,7 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
 
   const chartData = isLive ? liveChartData : historicalChartData;
   const hasChartData =
-    chartData.length >= 2 &&
-    chartData[0]?.data?.length > 0 &&
-    chartData[1]?.data?.length > 0;
+    chartData.length >= 2 && chartData.every((s) => s?.data?.length > 0);
   const isLoading =
     isFetching || !hasChartData || (isLive && !initialDataLoadedRef.current);
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
@@ -42,7 +42,7 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
   const chartWidthRef = useRef<number>(0);
   const primaryDataLengthRef = useRef<number>(0);
 
-  const seriesToRender = useMemo(() => data.slice(0, 2), [data]);
+  const seriesToRender = data;
   const nonEmptySeries = useMemo(
     () => seriesToRender.filter((series) => series.data.length > 0),
     [seriesToRender],

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.test.tsx
@@ -187,8 +187,10 @@ describe('PredictGameDetailsFooter', () => {
 
       renderWithProvider(<PredictGameDetailsFooter {...props} />);
 
-      expect(screen.getByText('YES · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('NO · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('65¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO')).toBeOnTheScreen();
+      expect(screen.getByText('35¢')).toBeOnTheScreen();
     });
 
     it('renders team buttons for game market', () => {
@@ -198,8 +200,8 @@ describe('PredictGameDetailsFooter', () => {
 
       renderWithProvider(<PredictGameDetailsFooter {...props} />);
 
-      expect(screen.getByText('SEA · 65¢')).toBeOnTheScreen();
-      expect(screen.getByText('DEN · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('SEA')).toBeOnTheScreen();
+      expect(screen.getByText('DEN')).toBeOnTheScreen();
     });
 
     it('calls onBetPress when bet button is pressed', () => {

--- a/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsFooter/PredictGameDetailsFooter.tsx
@@ -14,6 +14,7 @@ import {
   IconName,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
+import { isDrawCapableLeague } from '../../constants/sports';
 import { formatVolume } from '../../utils/format';
 import { PredictActionButtons } from '../PredictActionButtons';
 import { PredictGameDetailsFooterProps } from './PredictGameDetailsFooter.types';
@@ -43,6 +44,10 @@ const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
     market.status !== 'open' || market.game?.status === 'ended';
   const hasClaimableWinnings = claimableAmount > 0;
   const showClaimButton = hasClaimableWinnings && onClaimPress;
+  const labelKey =
+    market.game?.league && isDrawCapableLeague(market.game.league)
+      ? 'predict.game_details_footer.make_your_prediction'
+      : 'predict.game_details_footer.pick_a_winner';
 
   if (isMarketClosed && !hasClaimableWinnings) {
     return null;
@@ -70,7 +75,7 @@ const PredictGameDetailsFooter: React.FC<PredictGameDetailsFooterProps> = ({
               color={TextColor.TextAlternative}
               testID={`${testID}${PREDICT_GAME_DETAILS_FOOTER_TEST_IDS.LABEL}`}
             >
-              {strings('predict.game_details_footer.pick_a_winner')}
+              {strings(labelKey)}
             </Text>
             <ButtonIcon
               size={ButtonIconSize.Sm}

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicksForCard.test.tsx
@@ -132,7 +132,7 @@ describe('PredictPicksForCard', () => {
 
       render(<PredictPicksForCard marketId="market-1" />);
 
-      expect(screen.getByText(/Yes to win/)).toBeOnTheScreen();
+      expect(screen.getByText(/on Yes/)).toBeOnTheScreen();
     });
 
     it('displays formatted initialValue', () => {
@@ -289,8 +289,8 @@ describe('PredictPicksForCard', () => {
 
       render(<PredictPicksForCard marketId="market-1" />);
 
-      expect(screen.getByText(/Yes to win/)).toBeOnTheScreen();
-      expect(screen.getByText(/No to win/)).toBeOnTheScreen();
+      expect(screen.getByText(/on Yes/)).toBeOnTheScreen();
+      expect(screen.getByText(/on No/)).toBeOnTheScreen();
     });
 
     it('calls formatPrice for each position cashPnl', () => {
@@ -389,8 +389,8 @@ describe('PredictPicksForCard', () => {
         />,
       );
 
-      expect(screen.getByText(/Provided Yes to win/)).toBeOnTheScreen();
-      expect(screen.queryByText(/Fetched to win/)).toBeNull();
+      expect(screen.getByText(/on Provided Yes/)).toBeOnTheScreen();
+      expect(screen.queryByText(/on Fetched/)).toBeNull();
     });
 
     it('renders provided positions correctly', () => {
@@ -406,8 +406,8 @@ describe('PredictPicksForCard', () => {
         />,
       );
 
-      expect(screen.getByText(/Team A to win/)).toBeOnTheScreen();
-      expect(screen.getByText(/Team B to win/)).toBeOnTheScreen();
+      expect(screen.getByText(/on Team A/)).toBeOnTheScreen();
+      expect(screen.getByText(/on Team B/)).toBeOnTheScreen();
     });
 
     it('returns null when provided positions is empty', () => {
@@ -445,7 +445,7 @@ describe('PredictPicksForCard', () => {
 
       render(<PredictPicksForCard marketId="market-1" />);
 
-      expect(screen.getByText(/Maybe to win/)).toBeOnTheScreen();
+      expect(screen.getByText(/on Maybe/)).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicksForCardItem.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicksForCardItem.tsx
@@ -27,8 +27,8 @@ const PredictPicksForCardItem: React.FC<PredictPicksForCardItemProps> = ({
       testID={testID}
       twClassName="flex-row justify-between items-center gap-2"
     >
-      <Text>
-        {strings('predict.position_pick_info_to_win', {
+      <Text numberOfLines={1} twClassName="flex-shrink">
+        {strings('predict.position_pick_info', {
           initialValue: formatPrice(position.initialValue, {
             maximumDecimals: 2,
           }),

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -76,6 +76,13 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
 
   const handleBetPress = useCallback(
     (token: PredictOutcomeToken) => {
+      const matchingOutcome =
+        market.outcomes.find((marketOutcome) =>
+          marketOutcome.tokens.some(
+            (marketToken) => marketToken.id === token.id,
+          ),
+        ) ?? market.outcomes?.[0];
+
       executeGuardedAction(
         () => {
           // When accessed from Carousel, we're outside the Predict navigator,
@@ -87,7 +94,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
           navigateToBuyPreview(
             {
               market,
-              outcome,
+              outcome: matchingOutcome,
               outcomeToken: token,
               entryPoint: resolvedEntryPoint,
             },
@@ -105,7 +112,6 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
       resolvedEntryPoint,
       navigateToBuyPreview,
       market,
-      outcome,
     ],
   );
 

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -162,6 +162,30 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
     ? awayHasPossession
     : homeHasPossession;
 
+  const leftTestIds = isHomeFirst
+    ? {
+        icon: PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_TEAM_ICON,
+        possession: PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_POSSESSION,
+        winner: PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_WINNER,
+      }
+    : {
+        icon: PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_TEAM_ICON,
+        possession: PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_POSSESSION,
+        winner: PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_WINNER,
+      };
+
+  const rightTestIds = isHomeFirst
+    ? {
+        icon: PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_TEAM_ICON,
+        possession: PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_POSSESSION,
+        winner: PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_WINNER,
+      }
+    : {
+        icon: PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_TEAM_ICON,
+        possession: PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_POSSESSION,
+        winner: PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_WINNER,
+      };
+
   const renderCenterContent = () => {
     if (isPreGame) {
       return (
@@ -252,13 +276,13 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
           <config.TeamIcon
             color={leftTeam.color}
             size={TEAM_ICON_SIZE}
-            testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_TEAM_ICON}`}
+            testID={`${testID}${leftTestIds.icon}`}
           />
         ) : (
           <PredictSportTeamLogo
             uri={leftTeam.logo}
             size={TEAM_ICON_SIZE}
-            testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_TEAM_ICON}`}
+            testID={`${testID}${leftTestIds.icon}`}
           />
         )}
 
@@ -269,13 +293,13 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             color={rightTeam.color}
             size={TEAM_ICON_SIZE}
             flipped
-            testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_TEAM_ICON}`}
+            testID={`${testID}${rightTestIds.icon}`}
           />
         ) : (
           <PredictSportTeamLogo
             uri={rightTeam.logo}
             size={TEAM_ICON_SIZE}
-            testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_TEAM_ICON}`}
+            testID={`${testID}${rightTestIds.icon}`}
           />
         )}
       </Box>
@@ -302,7 +326,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             <Box twClassName="ml-1">
               <config.PossessionIcon
                 size={POSSESSION_ICON_SIZE}
-                testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_POSSESSION}`}
+                testID={`${testID}${leftTestIds.possession}`}
               />
             </Box>
           )}
@@ -310,7 +334,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             <Box twClassName="ml-1">
               <PredictSportWinner
                 size={POSSESSION_ICON_SIZE}
-                testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_WINNER}`}
+                testID={`${testID}${leftTestIds.winner}`}
               />
             </Box>
           )}
@@ -324,7 +348,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             <Box twClassName="mr-1">
               <config.PossessionIcon
                 size={POSSESSION_ICON_SIZE}
-                testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_POSSESSION}`}
+                testID={`${testID}${rightTestIds.possession}`}
               />
             </Box>
           )}
@@ -332,7 +356,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             <Box twClassName="mr-1">
               <PredictSportWinner
                 size={POSSESSION_ICON_SIZE}
-                testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_WINNER}`}
+                testID={`${testID}${rightTestIds.winner}`}
               />
             </Box>
           )}

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -15,6 +15,7 @@ import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
 import PredictSportWinner from '../PredictSportWinner/PredictSportWinner';
 import { PredictMarketGame } from '../../types';
 import { useLiveGameUpdates } from '../../hooks/useLiveGameUpdates';
+import { isDrawCapableLeague } from '../../constants/sports';
 import { PREDICT_SPORT_SCOREBOARD_TEST_IDS } from './PredictSportScoreboard.testIds';
 
 export interface PredictSportScoreboardProps {
@@ -109,6 +110,8 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
     [game.startTime],
   );
 
+  const isHomeFirst = isDrawCapableLeague(game.league);
+
   const period = mergedData.period;
 
   const isPreGame = mergedData.status === 'scheduled' || period === 'NS';
@@ -147,6 +150,17 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
     mergedData.awayScore !== undefined &&
     mergedData.homeScore !== undefined &&
     mergedData.homeScore > mergedData.awayScore;
+
+  const leftTeam = isHomeFirst ? game.homeTeam : game.awayTeam;
+  const rightTeam = isHomeFirst ? game.awayTeam : game.homeTeam;
+  const leftScore = isHomeFirst ? mergedData.homeScore : mergedData.awayScore;
+  const rightScore = isHomeFirst ? mergedData.awayScore : mergedData.homeScore;
+  const leftWon = isHomeFirst ? homeWon : awayWon;
+  const rightWon = isHomeFirst ? awayWon : homeWon;
+  const leftHasPossession = isHomeFirst ? homeHasPossession : awayHasPossession;
+  const rightHasPossession = isHomeFirst
+    ? awayHasPossession
+    : homeHasPossession;
 
   const renderCenterContent = () => {
     if (isPreGame) {
@@ -197,7 +211,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             variant={TextVariant.DisplayMd}
             twClassName="text-default leading-none"
           >
-            {mergedData.awayScore ?? 0}
+            {leftScore ?? 0}
           </Text>
 
           <Box twClassName="items-center">
@@ -214,7 +228,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             variant={TextVariant.DisplayMd}
             twClassName="text-default leading-none"
           >
-            {mergedData.homeScore ?? 0}
+            {rightScore ?? 0}
           </Text>
         </Box>
       );
@@ -236,14 +250,13 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
       >
         {config.TeamIcon ? (
           <config.TeamIcon
-            color={game.awayTeam.color}
+            color={leftTeam.color}
             size={TEAM_ICON_SIZE}
             testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_TEAM_ICON}`}
           />
         ) : (
           <PredictSportTeamLogo
-            uri={game.awayTeam.logo}
-            color={game.awayTeam.color}
+            uri={leftTeam.logo}
             size={TEAM_ICON_SIZE}
             testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.AWAY_TEAM_ICON}`}
           />
@@ -253,15 +266,14 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
 
         {config.TeamIcon ? (
           <config.TeamIcon
-            color={game.homeTeam.color}
+            color={rightTeam.color}
             size={TEAM_ICON_SIZE}
             flipped
             testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_TEAM_ICON}`}
           />
         ) : (
           <PredictSportTeamLogo
-            uri={game.homeTeam.logo}
-            color={game.homeTeam.color}
+            uri={rightTeam.logo}
             size={TEAM_ICON_SIZE}
             testID={`${testID}${PREDICT_SPORT_SCOREBOARD_TEST_IDS.HOME_TEAM_ICON}`}
           />
@@ -283,10 +295,10 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
               fontWeight={FontWeight.Medium}
               twClassName="text-alternative text-center"
             >
-              {game.awayTeam.abbreviation.toUpperCase()}
+              {leftTeam.abbreviation.toUpperCase()}
             </Text>
           </Box>
-          {config.PossessionIcon && awayHasPossession && (
+          {config.PossessionIcon && leftHasPossession && (
             <Box twClassName="ml-1">
               <config.PossessionIcon
                 size={POSSESSION_ICON_SIZE}
@@ -294,7 +306,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
               />
             </Box>
           )}
-          {awayWon && (
+          {leftWon && (
             <Box twClassName="ml-1">
               <PredictSportWinner
                 size={POSSESSION_ICON_SIZE}
@@ -308,7 +320,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
         >
-          {config.PossessionIcon && homeHasPossession && (
+          {config.PossessionIcon && rightHasPossession && (
             <Box twClassName="mr-1">
               <config.PossessionIcon
                 size={POSSESSION_ICON_SIZE}
@@ -316,7 +328,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
               />
             </Box>
           )}
-          {homeWon && (
+          {rightWon && (
             <Box twClassName="mr-1">
               <PredictSportWinner
                 size={POSSESSION_ICON_SIZE}
@@ -330,7 +342,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
               fontWeight={FontWeight.Medium}
               twClassName="text-alternative text-center"
             >
-              {game.homeTeam.abbreviation.toUpperCase()}
+              {rightTeam.abbreviation.toUpperCase()}
             </Text>
           </Box>
         </Box>

--- a/app/components/UI/Predict/components/PredictSportTeamLogo/PredictSportTeamLogo.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportTeamLogo/PredictSportTeamLogo.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import PredictSportTeamLogo from './PredictSportTeamLogo';
-import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
 
 describe('PredictSportTeamLogo', () => {
   const defaultProps = {
     uri: 'https://example.com/logo.png',
-    color: TEST_HEX_COLORS.TEAM_SEA,
     testID: 'team-logo',
   };
 
@@ -118,57 +116,6 @@ describe('PredictSportTeamLogo', () => {
   });
 
   describe('edge cases', () => {
-    it('renders logo with hex color including alpha channel', () => {
-      const colorWithAlpha = TEST_HEX_COLORS.TEAM_SEA_ALPHA;
-
-      const { getByTestId } = render(
-        <PredictSportTeamLogo {...defaultProps} color={colorWithAlpha} />,
-      );
-
-      const container = getByTestId('team-logo');
-      expect(container.props.style).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            backgroundColor: colorWithAlpha,
-          }),
-        ]),
-      );
-    });
-
-    it('renders logo with short hex color format', () => {
-      const shortHexColor = TEST_HEX_COLORS.WHITE_SHORT;
-
-      const { getByTestId } = render(
-        <PredictSportTeamLogo {...defaultProps} color={shortHexColor} />,
-      );
-
-      const container = getByTestId('team-logo');
-      expect(container.props.style).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            backgroundColor: shortHexColor,
-          }),
-        ]),
-      );
-    });
-
-    it('renders logo with RGB color format', () => {
-      const rgbColor = 'rgb(0, 34, 68)';
-
-      const { getByTestId } = render(
-        <PredictSportTeamLogo {...defaultProps} color={rgbColor} />,
-      );
-
-      const container = getByTestId('team-logo');
-      expect(container.props.style).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            backgroundColor: rgbColor,
-          }),
-        ]),
-      );
-    });
-
     it('hides image when onError is triggered', () => {
       const { getByTestId, queryByTestId } = render(
         <PredictSportTeamLogo {...defaultProps} />,

--- a/app/components/UI/Predict/components/PredictSportTeamLogo/PredictSportTeamLogo.tsx
+++ b/app/components/UI/Predict/components/PredictSportTeamLogo/PredictSportTeamLogo.tsx
@@ -9,7 +9,6 @@ import {
 
 interface PredictSportTeamLogoProps {
   uri: string; // Remote image URL (team.logo field)
-  color: string; // Team primary color (hex) — used as placeholder background
   size?: number; // Size in pixels (default: 48, same as helmet default)
   flipped?: boolean; // Accepted for API compatibility but IGNORED (logos don't need mirroring)
   testID?: string;
@@ -21,7 +20,6 @@ interface PredictSportTeamLogoProps {
  */
 const PredictSportTeamLogo: React.FC<PredictSportTeamLogoProps> = ({
   uri,
-  color,
   size = 48,
   testID,
 }) => {
@@ -36,7 +34,6 @@ const PredictSportTeamLogo: React.FC<PredictSportTeamLogoProps> = ({
       style={tw.style('overflow-hidden rounded-lg', {
         width: size,
         height: size,
-        backgroundColor: color,
       })}
     >
       {!hasError && (

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -5,11 +5,15 @@ import { PredictSportsLeague } from '../types';
  *
  * To add a new league:
  * 1. Add the league to `PredictSportsLeague` type in `../types/index.ts`
- * 2. Add a slug pattern regex to `LEAGUE_SLUG_PATTERNS` in `../utils/gameParser.ts`
+ * 2. Add a slug config to `LEAGUE_SLUG_CONFIGS` in `../utils/gameParser.ts`
  * 3. Add the league to this array
  * 4. Add tests for the new league's slug parsing
  */
-export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = ['nfl', 'nba'];
+export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = [
+  'nfl',
+  'nba',
+  'ucl',
+];
 
 export const filterSupportedLeagues = (
   leagues: string[],
@@ -17,3 +21,8 @@ export const filterSupportedLeagues = (
   leagues.filter((league): league is PredictSportsLeague =>
     SUPPORTED_SPORTS_LEAGUES.includes(league as PredictSportsLeague),
   );
+
+const DRAW_CAPABLE_LEAGUES: ReadonlySet<PredictSportsLeague> = new Set(['ucl']);
+
+export const isDrawCapableLeague = (league: PredictSportsLeague): boolean =>
+  DRAW_CAPABLE_LEAGUES.has(league);

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -937,8 +937,13 @@ export class PolymarketProvider implements PredictProvider {
     }
     const positionsData = (await response.json()) as PolymarketPosition[];
 
+    const teamLookup = this.#createTeamLookup(
+      this.#getSupportedLeagues().length > 0,
+    );
+
     const parsedPositions = await parsePolymarketPositions({
       positions: positionsData,
+      teamLookup,
     });
 
     // Apply optimistic updates (unified for BUY/SELL/CLAIM)

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -7,6 +7,7 @@ export interface PolymarketPosition {
   icon: string;
   title: string;
   slug: string;
+  eventSlug?: string;
   size: number;
   outcome: string;
   outcomeIndex: number;

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -2314,6 +2314,135 @@ describe('polymarket utils', () => {
       expect(result).toEqual([]);
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    describe('negRisk outcome label resolution', () => {
+      it('non-negRisk position outcome stays as original', async () => {
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: false,
+            outcome: 'Yes',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({ positions });
+
+        expect(result[0].outcome).toBe('Yes');
+      });
+
+      it('negRisk position without eventSlug outcome stays as original', async () => {
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: true,
+            eventSlug: undefined,
+            outcome: 'Yes',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({ positions });
+
+        expect(result[0].outcome).toBe('Yes');
+      });
+
+      it('negRisk position with non-draw-capable league eventSlug outcome stays as original', async () => {
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: true,
+            eventSlug: 'politics-election-2024',
+            slug: 'politics-election-2024-candidate-a',
+            outcome: 'Yes',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({ positions });
+
+        expect(result[0].outcome).toBe('Yes');
+      });
+
+      it('negRisk position with UCL eventSlug and draw suffix resolves to Draw', async () => {
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: true,
+            eventSlug: 'ucl-final-2024',
+            slug: 'ucl-final-2024-draw',
+            outcome: 'Draw',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({ positions });
+
+        expect(result[0].outcome).toBe('Draw');
+      });
+
+      it('negRisk position with UCL eventSlug and team abbreviation with teamLookup resolves to team name', async () => {
+        const mockTeamLookup = jest.fn(
+          (league: string, abbreviation: string) => {
+            if (league === 'ucl' && abbreviation === 'mci') {
+              return {
+                id: 'team-1',
+                name: 'Manchester City',
+                logo: 'https://example.com/mci.png',
+                abbreviation: 'mci',
+                color: 'team-blue',
+                alias: 'City',
+              };
+            }
+            return undefined;
+          },
+        );
+
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: true,
+            eventSlug: 'ucl-final-2024',
+            slug: 'ucl-final-2024-mci',
+            outcome: 'Manchester City',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({
+          positions,
+          teamLookup: mockTeamLookup,
+        });
+
+        expect(result[0].outcome).toBe('Manchester City');
+        expect(mockTeamLookup).toHaveBeenCalledWith('ucl', 'mci');
+      });
+
+      it('negRisk position with UCL eventSlug and team abbreviation without teamLookup resolves to uppercase abbreviation', async () => {
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: true,
+            eventSlug: 'ucl-final-2024',
+            slug: 'ucl-final-2024-mci',
+            outcome: 'MCI',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({ positions });
+
+        expect(result[0].outcome).toBe('MCI');
+      });
+
+      it('negRisk position with UCL eventSlug and team abbreviation with teamLookup returning undefined resolves to uppercase abbreviation', async () => {
+        const mockTeamLookup = jest.fn(() => undefined);
+
+        const positions = [
+          createPosition('1', 0, {
+            negativeRisk: true,
+            eventSlug: 'ucl-final-2024',
+            slug: 'ucl-final-2024-xyz',
+            outcome: 'XYZ',
+          }),
+        ];
+
+        const result = await parsePolymarketPositions({
+          positions,
+          teamLookup: mockTeamLookup,
+        });
+
+        expect(result[0].outcome).toBe('XYZ');
+      });
+    });
   });
 
   describe('getPredictPositionStatus', () => {

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -27,6 +27,10 @@ import {
   mapApiTeamToPredictTeam,
   type TeamLookup,
 } from '../../utils/gameParser';
+import {
+  isDrawCapableLeague,
+  SUPPORTED_SPORTS_LEAGUES,
+} from '../../constants/sports';
 import type {
   GetMarketsParams,
   OrderPreview,
@@ -547,6 +551,17 @@ const sortOutcomeTokens = (
   return outcomeTokens;
 };
 
+const getNegRiskYesTokenTitle = (
+  market: PolymarketApiMarket,
+): string | undefined => {
+  if (!market.negRisk || !isMoneylineMarket(market) || !market.groupItemTitle) {
+    return undefined;
+  }
+  return market.groupItemTitle.toLowerCase().startsWith('draw')
+    ? 'Draw'
+    : market.groupItemTitle;
+};
+
 const parsePolymarketMarketOutcomes = (
   market: PolymarketApiMarket,
   event: PolymarketApiEvent,
@@ -558,10 +573,16 @@ const parsePolymarketMarketOutcomes = (
   const outcomePrices = market.outcomePrices
     ? JSON.parse(market.outcomePrices)
     : [];
+
+  const negRiskYesTitle = getNegRiskYesTokenTitle(market);
+
   const outcomeTokens = outcomeTokensIds.map(
     (tokenId: string, index: number) => ({
       id: tokenId,
-      title: outcomes[index],
+      title:
+        negRiskYesTitle && outcomes[index] === 'Yes'
+          ? negRiskYesTitle
+          : outcomes[index],
       price: parseFloat(outcomePrices[index]),
     }),
   );
@@ -674,6 +695,10 @@ export const parsePolymarketMarket = (
   description: market.description,
   image: market.icon ?? market.image,
   groupItemTitle: formatMarketGroupItemTitle(market),
+  groupItemThreshold:
+    market.groupItemThreshold != null
+      ? Number(market.groupItemThreshold)
+      : undefined,
   status: market.closed ? PredictMarketStatus.CLOSED : PredictMarketStatus.OPEN,
   volume: market.volumeNum ?? 0,
   tokens: parsePolymarketMarketOutcomes(market, event),
@@ -733,11 +758,9 @@ export const parsePolymarketEvents = (
       // guaranteed to be accurate. They also do this on their webbsite.
       //
       // However, we noticed that the above statement is not correct, at least for game events.
-      const moneylineMarket = event.markets?.find((m) => isMoneylineMarket(m));
-      const description =
-        moneylineMarket?.description ??
-        event.markets?.[0]?.description ??
-        event.description;
+      const description = game
+        ? event.description
+        : (event.markets?.[0]?.description ?? event.description);
 
       return {
         id: event.id,
@@ -995,10 +1018,45 @@ export const getPredictPositionStatus = ({
   return PredictPositionStatus.LOST;
 };
 
+const resolveNegRiskOutcomeLabel = (
+  position: PolymarketPosition,
+  teamLookup?: TeamLookup,
+): string | undefined => {
+  if (!position.negativeRisk || !position.eventSlug) {
+    return undefined;
+  }
+
+  const prefix = position.eventSlug + '-';
+  if (!position.slug.startsWith(prefix)) {
+    return undefined;
+  }
+
+  const outcomeToken = position.slug.slice(prefix.length);
+  if (!outcomeToken) {
+    return undefined;
+  }
+
+  if (outcomeToken === 'draw') {
+    return 'Draw';
+  }
+
+  const league = SUPPORTED_SPORTS_LEAGUES.find(
+    (l) => isDrawCapableLeague(l) && position.eventSlug?.startsWith(`${l}-`),
+  );
+
+  if (!league || !teamLookup) {
+    return outcomeToken.toUpperCase();
+  }
+
+  return teamLookup(league, outcomeToken)?.name ?? outcomeToken.toUpperCase();
+};
+
 export const parsePolymarketPositions = async ({
   positions,
+  teamLookup,
 }: {
   positions: PolymarketPosition[];
+  teamLookup?: TeamLookup;
 }) => {
   const parsedPositions: PredictPosition[] = positions.map(
     (position: PolymarketPosition) => ({
@@ -1006,7 +1064,8 @@ export const parsePolymarketPositions = async ({
       providerId: POLYMARKET_PROVIDER_ID,
       marketId: position.eventId,
       outcomeId: position.conditionId,
-      outcome: position.outcome,
+      outcome:
+        resolveNegRiskOutcomeLabel(position, teamLookup) ?? position.outcome,
       outcomeTokenId: position.asset,
       outcomeIndex: position.outcomeIndex,
       negRisk: position.negativeRisk,

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1026,6 +1026,14 @@ const resolveNegRiskOutcomeLabel = (
     return undefined;
   }
 
+  const league = SUPPORTED_SPORTS_LEAGUES.find(
+    (l) => isDrawCapableLeague(l) && position.eventSlug?.startsWith(`${l}-`),
+  );
+
+  if (!league) {
+    return undefined;
+  }
+
   const prefix = position.eventSlug + '-';
   if (!position.slug.startsWith(prefix)) {
     return undefined;
@@ -1040,11 +1048,7 @@ const resolveNegRiskOutcomeLabel = (
     return 'Draw';
   }
 
-  const league = SUPPORTED_SPORTS_LEAGUES.find(
-    (l) => isDrawCapableLeague(l) && position.eventSlug?.startsWith(`${l}-`),
-  );
-
-  if (!league || !teamLookup) {
+  if (!teamLookup) {
     return outcomeToken.toUpperCase();
   }
 

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -129,7 +129,7 @@ export type PredictCategory =
   | 'hot';
 
 // Sports league types
-export type PredictSportsLeague = 'nfl' | 'nba';
+export type PredictSportsLeague = 'nfl' | 'nba' | 'ucl';
 
 // Game status
 export type PredictGameStatus = 'scheduled' | 'ongoing' | 'ended';
@@ -164,6 +164,10 @@ export type PredictGamePeriod =
   | 'OT' // Overtime
   | 'FT' // Final
   | 'VFT' // Verified fulltime (when closed=true)
+  | '1H' // First Half (soccer)
+  | '2H' // Second Half (soccer)
+  | 'ET' // Extra Time (soccer)
+  | 'PK' // Penalties (soccer)
   | (string & {}); // Escape hatch for future sports with different period formats
 
 // Game data attached to market
@@ -209,6 +213,7 @@ export type PredictOutcome = {
   tokens: PredictOutcomeToken[];
   volume: number;
   groupItemTitle: string;
+  groupItemThreshold?: number;
   negRisk?: boolean;
   tickSize?: string;
   resolvedBy?: string;

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -10,12 +10,26 @@ import {
   PolymarketApiTeam,
 } from '../providers/polymarket/types';
 
-const NFL_SLUG_PATTERN = /^nfl-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/;
-const NBA_SLUG_PATTERN = /^nba-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/;
+type SlugTeamOrder = 'away-home' | 'home-away';
 
-const LEAGUE_SLUG_PATTERNS: Record<PredictSportsLeague, RegExp> = {
-  nfl: NFL_SLUG_PATTERN,
-  nba: NBA_SLUG_PATTERN,
+interface LeagueSlugConfig {
+  pattern: RegExp;
+  teamOrder: SlugTeamOrder;
+}
+
+const LEAGUE_SLUG_CONFIGS: Record<PredictSportsLeague, LeagueSlugConfig> = {
+  nfl: {
+    pattern: /^nfl-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/,
+    teamOrder: 'away-home',
+  },
+  nba: {
+    pattern: /^nba-([a-z]+)-([a-z]+)-(\d{4}-\d{2}-\d{2})$/,
+    teamOrder: 'away-home',
+  },
+  ucl: {
+    pattern: /^ucl-([a-z0-9]+)-([a-z0-9]+)-(\d{4}-\d{2}-\d{2})$/,
+    teamOrder: 'home-away',
+  },
 };
 
 export type TeamLookup = (
@@ -38,10 +52,10 @@ export function getEventLeague(
     return null;
   }
 
-  const leagues = Object.keys(LEAGUE_SLUG_PATTERNS) as PredictSportsLeague[];
+  const leagues = Object.keys(LEAGUE_SLUG_CONFIGS) as PredictSportsLeague[];
   for (const league of leagues) {
     const hasLeagueTag = tags.some((tag) => tag.slug === league);
-    const pattern = LEAGUE_SLUG_PATTERNS[league];
+    const { pattern } = LEAGUE_SLUG_CONFIGS[league];
     const hasValidSlug = pattern.test(event.slug);
     if (hasLeagueTag && hasValidSlug) {
       return league;
@@ -63,17 +77,18 @@ export function parseGameSlugTeams(
   slug: string,
   league: PredictSportsLeague,
 ): ParsedGameSlug | null {
-  const pattern = LEAGUE_SLUG_PATTERNS[league];
-  if (!pattern) {
+  const config = LEAGUE_SLUG_CONFIGS[league];
+  if (!config) {
     return null;
   }
-  const match = slug.match(pattern);
+  const match = slug.match(config.pattern);
   if (!match) {
     return null;
   }
+  const isHomeFirst = config.teamOrder === 'home-away';
   return {
-    awayAbbreviation: match[1],
-    homeAbbreviation: match[2],
+    awayAbbreviation: isHomeFirst ? match[2] : match[1],
+    homeAbbreviation: isHomeFirst ? match[1] : match[2],
     dateString: match[3],
   };
 }
@@ -92,6 +107,14 @@ export function formatPeriodDisplay(period: string): string {
     case 'FT':
     case 'VFT':
       return 'Final';
+    case '1H':
+      return '1st Half';
+    case '2H':
+      return '2nd Half';
+    case 'ET':
+      return 'Extra Time';
+    case 'PK':
+      return 'Penalties';
     default:
       return period;
   }

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -192,11 +192,15 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     }
     executeGuardedAction(
       () => {
-        // Use open outcomes with updated prices if available
-        const firstOpenOutcome = openOutcomes[0];
+        const matchingOutcome =
+          market.outcomes.find((outcome) =>
+            outcome.tokens.some((marketToken) => marketToken.id === token.id),
+          ) ??
+          openOutcomes[0] ??
+          market.outcomes?.[0];
         navigateToBuyPreview({
           market,
-          outcome: firstOpenOutcome ?? market.outcomes?.[0],
+          outcome: matchingOutcome,
           outcomeToken: token,
           entryPoint:
             entryPoint || PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2391,6 +2391,7 @@
     },
     "game_details_footer": {
       "pick_a_winner": "Pick a winner",
+      "make_your_prediction": "Make your prediction",
       "volume_display": "${{volume}} Vol",
       "read_terms": "Read the full contract terms and conditions"
     },


### PR DESCRIPTION
## **Description**

Adds UEFA Champions League (UCL) soccer support to the Predict product. Unlike NFL/NBA where one team always wins, soccer matches can end in a draw. This introduces 3-way market support throughout the prediction flow — from data parsing to UI rendering.

**Key changes:**
- New `ucl` league type with home-first team ordering (opposite of NFL/NBA)
- Draw button (gray/muted theme) rendered between team buttons for soccer matches
- Polymarket negRisk 3-outcome events parsed into 3 `PredictOutcome`s sorted by `groupItemThreshold`
- Game chart generalized from hardcoded 2-series to N-series (3rd line for draw)
- Scoreboard respects home-first ordering for soccer leagues
- Position labels resolved from slug-based team lookup via TeamsCache (zero network overhead)
- Token titles enriched at parse time for negRisk moneyline markets

## **Changelog**

CHANGELOG entry: Added UCL soccer league support with 3-way draw predictions

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-755

## **Manual testing steps**

```gherkin
Feature: UCL soccer predictions with draw button

  Scenario: user views a UCL match card in the feed
    Given the UCL league is enabled in the feature flag
    And a UCL match event exists on Polymarket

    When user views the Predict feed
    Then a sport card renders with the UCL match
    And the scoreboard shows home team on the left, away team on the right
    And three action buttons appear: Home | DRAW (gray) | Away

  Scenario: user places a draw prediction
    Given user is viewing a UCL match card

    When user taps the DRAW button
    Then the buy preview opens with the draw outcome
    And after purchase, the position shows "$x on Draw"

  Scenario: user views the game chart for a UCL match
    Given user opens a UCL match detail page

    When user views the price chart
    Then three lines are rendered: Home (team color), Draw (gray), Away (team color)
    And all three endpoint labels are visible

  Scenario: user views existing UCL positions on a card
    Given user has positions on a UCL match

    When user views the sport card
    Then positions show "$x on Team Name" (not "$x on Yes to win")
    And long team names are truncated with ellipsis
```

## **Screenshots/Recordings**

### **Before ** 

N/A — UCL soccer was not previously supported

### **After**

Before vs After screenshots:


<img width="871" height="876" alt="Screenshot 2026-03-30 at 2 05 17 PM" src="https://github.com/user-attachments/assets/19b07205-b24c-48b4-95ee-e84a29963cef" />

<img width="891" height="880" alt="Screenshot 2026-03-30 at 2 03 48 PM" src="https://github.com/user-attachments/assets/aacc883c-b477-42f0-a54b-58bfa37c0ade" />
<img width="881" height="879" alt="Screenshot 2026-03-30 at 2 04 25 PM" src="https://github.com/user-attachments/assets/fd26d148-dc39-4929-b9fb-e33580387bbb" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands core Predict flows (market parsing, outcome/token selection, live price subscriptions, and chart rendering) from 2-way to 3-way outcomes, which could cause mismatched outcome/token mapping or incomplete data rendering if backend data is inconsistent.
> 
> **Overview**
> Adds **3-way (home/draw/away) support** for draw-capable leagues (now including `ucl`), with a new `isDrawCapableLeague` helper and `groupItemThreshold` ordering used to consistently sort outcomes/tokens.
> 
> Updates the prediction UI to render an optional **DRAW** bet button (new `draw` variant + testIDs), split bet button label/price into separate lines, and ensures bet/preview navigation selects the **matching outcome** for the tapped token (in `PredictMarketDetails` and `PredictSportCardFooter`).
> 
> Generalizes game visuals for soccer: `PredictGameChart` now supports **N-series** (incl. draw line with muted color) and improves endpoint label collision handling for 3+ labels; the scoreboard and footer copy adapt to **home-first** leagues.
> 
> Enhances Polymarket integration by adding `ucl` slug parsing (home-away order), surfacing `groupItemThreshold` on outcomes, improving negRisk token titles (e.g., “Draw”), and resolving negRisk position outcome labels from `eventSlug`/slug with optional team lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 024cc192b72ed2df0e023f7063ec25ca39fcac7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->