### PR TITLE
fix(ramp): localize buy-flow card labels and transak footer

### DIFF
--- a/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.styles.ts
+++ b/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.styles.ts
@@ -9,6 +9,9 @@ const styleSheet = (params: { theme: Theme }) => {
       height: 24,
       color: theme.colors.text.alternative,
     },
+    text: {
+      textAlign: 'center',
+    },
   });
 };
 

--- a/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.test.tsx
+++ b/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.test.tsx
@@ -12,7 +12,9 @@ describe('PoweredByTransak', () => {
   it('renders svg logo for english locales', () => {
     I18n.locale = 'en-US';
 
-    const { queryByText } = render(<PoweredByTransak />);
+    const { queryByText } = render(
+      <PoweredByTransak name="powered-by-transak-logo" />,
+    );
 
     expect(queryByText('Powered by Transak')).toBeNull();
   });
@@ -20,7 +22,9 @@ describe('PoweredByTransak', () => {
   it('renders localized text for non-english locales', () => {
     I18n.locale = 'es';
 
-    const { getByText } = render(<PoweredByTransak />);
+    const { getByText } = render(
+      <PoweredByTransak name="powered-by-transak-logo" />,
+    );
 
     expect(getByText('Desarrollado por Transak')).toBeOnTheScreen();
   });

--- a/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.test.tsx
+++ b/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import I18n from '../../../../../../../locales/i18n';
+import PoweredByTransak from './PoweredByTransak';
+
+describe('PoweredByTransak', () => {
+  afterEach(() => {
+    I18n.locale = 'en';
+    jest.restoreAllMocks();
+  });
+
+  it('renders svg logo for english locales', () => {
+    I18n.locale = 'en-US';
+
+    const { queryByText } = render(<PoweredByTransak />);
+
+    expect(queryByText('Powered by Transak')).toBeNull();
+  });
+
+  it('renders localized text for non-english locales', () => {
+    I18n.locale = 'es';
+
+    const { getByText } = render(<PoweredByTransak />);
+
+    expect(getByText('Desarrollado por Transak')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.tsx
+++ b/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import PoweredByTransakSVG from '../../assets/powered-by-transak.svg';
+import I18n, { strings } from '../../../../../../../locales/i18n';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './PoweredByTransak.styles';
 
@@ -8,6 +13,21 @@ function PoweredByTransak({
   ...props
 }: React.ComponentProps<typeof PoweredByTransakSVG>) {
   const { styles } = useStyles(styleSheet, {});
+  const showLocalizedText = I18n.locale.toLowerCase().startsWith('en') === false;
+
+  if (showLocalizedText) {
+    return (
+      <Text
+        variant={TextVariant.BodySM}
+        color={TextColor.Alternative}
+        style={styles.text}
+      >
+        {strings('fiat_on_ramp.powered_by_provider', {
+          provider: 'Transak',
+        })}
+      </Text>
+    );
+  }
 
   return (
     <PoweredByTransakSVG

--- a/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.tsx
+++ b/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.tsx
@@ -13,8 +13,8 @@ function PoweredByTransak({
   ...props
 }: React.ComponentProps<typeof PoweredByTransakSVG>) {
   const { styles } = useStyles(styleSheet, {});
-  const showLocalizedText =
-    I18n.locale.toLowerCase().startsWith('en') === false;
+  const locale = typeof I18n.locale === 'string' ? I18n.locale : 'en';
+  const showLocalizedText = locale.toLowerCase().startsWith('en') === false;
 
   if (showLocalizedText) {
     return (

--- a/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.tsx
+++ b/app/components/UI/Ramp/Deposit/components/PoweredByTransak/PoweredByTransak.tsx
@@ -13,7 +13,8 @@ function PoweredByTransak({
   ...props
 }: React.ComponentProps<typeof PoweredByTransakSVG>) {
   const { styles } = useStyles(styleSheet, {});
-  const showLocalizedText = I18n.locale.toLowerCase().startsWith('en') === false;
+  const showLocalizedText =
+    I18n.locale.toLowerCase().startsWith('en') === false;
 
   if (showLocalizedText) {
     return (

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -74,6 +74,7 @@ import { useTransakController } from '../../hooks/useTransakController';
 import { useTransakRouting } from '../../hooks/useTransakRouting';
 import { createV2VerifyIdentityNavDetails } from '../NativeFlow/VerifyIdentity';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { getLocalizedPaymentMethodName } from '../../utils/localizePaymentMethodName';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useSelector } from 'react-redux';
@@ -876,7 +877,7 @@ function BuildQuote() {
                 </View>
                 <PaymentMethodPill
                   label={
-                    selectedPaymentMethod?.name ||
+                    getLocalizedPaymentMethodName(selectedPaymentMethod) ||
                     strings('fiat_on_ramp.select_payment_method')
                   }
                   isLoading={paymentMethodsLoading}

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render } from '@testing-library/react-native';
 import PaymentMethodListItem from './PaymentMethodListItem';
 import { ThemeContext, mockTheme } from '../../../../../../util/theme';
 import type { PaymentMethod, Quote } from '@metamask/ramps-controller';
+import I18n from '../../../../../../../locales/i18n';
 
 const renderWithTheme = (component: React.ReactElement) =>
   render(
@@ -46,6 +47,10 @@ const mockQuote: Quote = {
 };
 
 describe('PaymentMethodListItem', () => {
+  afterEach(() => {
+    I18n.locale = 'en';
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -131,5 +136,18 @@ describe('PaymentMethodListItem', () => {
       />,
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders localized debit card name on non-English locales', () => {
+    I18n.locale = 'es';
+
+    const { getByText } = renderWithTheme(
+      <PaymentMethodListItem
+        paymentMethod={mockPaymentMethod}
+        {...defaultQuoteProps}
+      />,
+    );
+
+    expect(getByText('Tarjeta de débito')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
@@ -18,6 +18,7 @@ import { useFormatters } from '../../../../../hooks/useFormatters';
 import { useTheme } from '../../../../../../util/theme';
 import type { Colors } from '../../../../../../util/theme/models';
 import type { PaymentMethod, Quote } from '@metamask/ramps-controller';
+import { getLocalizedPaymentMethodName } from '../../../utils/localizePaymentMethodName';
 
 const ICON_CIRCLE_SIZE = 44;
 
@@ -62,6 +63,7 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const { formatToken, formatCurrency } = useFormatters();
+  const localizedPaymentMethodName = getLocalizedPaymentMethodName(paymentMethod);
 
   const delayText =
     Array.isArray(paymentMethod.delay) && paymentMethod.delay.length >= 2
@@ -100,7 +102,7 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
       </ListItemColumn>
       <ListItemColumn widthType={WidthType.Fill}>
         <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-          {paymentMethod.name}
+          {localizedPaymentMethodName}
         </Text>
         {delayText ? (
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
@@ -63,7 +63,8 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const { formatToken, formatCurrency } = useFormatters();
-  const localizedPaymentMethodName = getLocalizedPaymentMethodName(paymentMethod);
+  const localizedPaymentMethodName =
+    getLocalizedPaymentMethodName(paymentMethod);
 
   const delayText =
     Array.isArray(paymentMethod.delay) && paymentMethod.delay.length >= 2

--- a/app/components/UI/Ramp/utils/localizePaymentMethodName.test.ts
+++ b/app/components/UI/Ramp/utils/localizePaymentMethodName.test.ts
@@ -23,7 +23,9 @@ describe('localizePaymentMethodName', () => {
 
   it('returns localized debit card label on non-English locales', () => {
     I18n.locale = 'es';
-    const stringsSpy = jest.spyOn(I18n, 't').mockReturnValue('Tarjeta de débito');
+    const stringsSpy = jest
+      .spyOn(I18n, 't')
+      .mockReturnValue('Tarjeta de débito');
 
     const label = getLocalizedPaymentMethodName(makePaymentMethod());
 

--- a/app/components/UI/Ramp/utils/localizePaymentMethodName.test.ts
+++ b/app/components/UI/Ramp/utils/localizePaymentMethodName.test.ts
@@ -1,0 +1,70 @@
+import I18n from '../../../../../locales/i18n';
+import {
+  __TEST_ONLY__,
+  getLocalizedPaymentMethodName,
+} from './localizePaymentMethodName';
+
+const makePaymentMethod = (overrides?: {
+  id?: string;
+  paymentType?: string;
+  name?: string;
+}) => ({
+  id: '/payments/debit-credit-card',
+  paymentType: 'debit-credit-card',
+  name: 'Debit Card',
+  ...overrides,
+});
+
+describe('localizePaymentMethodName', () => {
+  afterEach(() => {
+    I18n.locale = 'en';
+    jest.restoreAllMocks();
+  });
+
+  it('returns localized debit card label on non-English locales', () => {
+    I18n.locale = 'es';
+    const stringsSpy = jest.spyOn(I18n, 't').mockReturnValue('Tarjeta de débito');
+
+    const label = getLocalizedPaymentMethodName(makePaymentMethod());
+
+    expect(label).toBe('Tarjeta de débito');
+    expect(stringsSpy).toHaveBeenCalledWith(
+      'fiat_on_ramp.debit_card',
+      expect.any(Object),
+    );
+  });
+
+  it('returns original provider label for English locales', () => {
+    I18n.locale = 'en-US';
+
+    const label = getLocalizedPaymentMethodName(
+      makePaymentMethod({ name: 'Debit Card' }),
+    );
+
+    expect(label).toBe('Debit Card');
+  });
+
+  it('returns original label for unknown payment methods', () => {
+    I18n.locale = 'es';
+
+    const label = getLocalizedPaymentMethodName(
+      makePaymentMethod({
+        id: '/payments/apple-pay',
+        paymentType: 'apple-pay',
+        name: 'Apple Pay',
+      }),
+    );
+
+    expect(label).toBe('Apple Pay');
+  });
+
+  it('detects card methods across mixed separators and casing', () => {
+    const paymentMethod = makePaymentMethod({
+      id: '/PAYMENTS/CREDIT_DEBIT_CARD',
+      paymentType: 'Credit-Debit-Card',
+      name: 'Credit or Debit Card',
+    });
+
+    expect(__TEST_ONLY__.isCardPaymentMethod(paymentMethod)).toBe(true);
+  });
+});

--- a/app/components/UI/Ramp/utils/localizePaymentMethodName.ts
+++ b/app/components/UI/Ramp/utils/localizePaymentMethodName.ts
@@ -1,0 +1,65 @@
+import I18n, { strings } from '../../../../../locales/i18n';
+import type { PaymentMethod } from '@metamask/ramps-controller';
+
+type PaymentMethodLike = Pick<PaymentMethod, 'id' | 'paymentType' | 'name'>;
+
+const CARD_PAYMENT_METHOD_IDENTIFIERS = [
+  'debit-credit-card',
+  'credit-debit-card',
+  'credit_debit_card',
+  'debit_card',
+  'debit card',
+  'credit debit card',
+  'debit credit card',
+  'credit or debit card',
+] as const;
+
+const normalizeValue = (value?: string): string =>
+  (value ?? '').trim().toLowerCase();
+
+const toComparableValue = (value?: string): string =>
+  normalizeValue(value).replace(/[^a-z0-9]/g, '');
+
+const isEnglishLocale = (): boolean =>
+  normalizeValue(I18n.locale).startsWith('en');
+
+const isCardPaymentMethod = (paymentMethod: PaymentMethodLike): boolean => {
+  const comparableId = toComparableValue(paymentMethod.id);
+  const comparableType = toComparableValue(paymentMethod.paymentType);
+  const comparableName = toComparableValue(paymentMethod.name);
+
+  return CARD_PAYMENT_METHOD_IDENTIFIERS.some(
+    (identifier) => {
+      const comparableIdentifier = toComparableValue(identifier);
+
+      return (
+        comparableId.includes(comparableIdentifier) ||
+        comparableType.includes(comparableIdentifier) ||
+        comparableName.includes(comparableIdentifier)
+      );
+    },
+  );
+};
+
+/**
+ * Localizes payment method labels for known provider methods that are returned
+ * as raw English text from upstream APIs.
+ */
+export const getLocalizedPaymentMethodName = (
+  paymentMethod?: PaymentMethodLike | null,
+): string => {
+  if (!paymentMethod) {
+    return '';
+  }
+
+  if (!isEnglishLocale() && isCardPaymentMethod(paymentMethod)) {
+    return strings('fiat_on_ramp.debit_card');
+  }
+
+  return paymentMethod.name;
+};
+
+export const __TEST_ONLY__ = {
+  isCardPaymentMethod,
+  toComparableValue,
+};

--- a/app/components/UI/Ramp/utils/localizePaymentMethodName.ts
+++ b/app/components/UI/Ramp/utils/localizePaymentMethodName.ts
@@ -28,17 +28,15 @@ const isCardPaymentMethod = (paymentMethod: PaymentMethodLike): boolean => {
   const comparableType = toComparableValue(paymentMethod.paymentType);
   const comparableName = toComparableValue(paymentMethod.name);
 
-  return CARD_PAYMENT_METHOD_IDENTIFIERS.some(
-    (identifier) => {
-      const comparableIdentifier = toComparableValue(identifier);
+  return CARD_PAYMENT_METHOD_IDENTIFIERS.some((identifier) => {
+    const comparableIdentifier = toComparableValue(identifier);
 
-      return (
-        comparableId.includes(comparableIdentifier) ||
-        comparableType.includes(comparableIdentifier) ||
-        comparableName.includes(comparableIdentifier)
-      );
-    },
-  );
+    return (
+      comparableId.includes(comparableIdentifier) ||
+      comparableType.includes(comparableIdentifier) ||
+      comparableName.includes(comparableIdentifier)
+    );
+  });
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This fixes untranslated English strings in the Buy flow that were bypassing locale resources.

Root cause:
- Unified Buy screens rendered payment method names directly from provider API payloads (e.g., `Debit Card` / `Credit or Debit Card`) instead of localized keys.
- Native Transak identity screens rendered a static SVG containing `Powered by Transak` text, which cannot be translated at runtime.

Solution:
- Added a small payment-method localization utility that maps known card payment-method identifiers to `fiat_on_ramp.debit_card` for non-English locales, while preserving provider labels for English and unknown methods.
- Wired that utility into the unified BuildQuote payment pill and payment-method selection list item.
- Updated `PoweredByTransak` to render localized `fiat_on_ramp.powered_by_provider` text for non-English locales, while keeping the existing SVG behavior for English locales to minimize visual risk.
- Applied Prettier formatting updates required by CI `format:check`.
- Fixed TypeScript test typing by passing required SVG props in `PoweredByTransak.test.tsx`.
- Added a defensive locale guard in `PoweredByTransak` to handle tests/environments where `I18n.locale` is undefined.

## **Changelog**

CHANGELOG entry: Fixed untranslated Buy flow labels for card payment method and “Powered by Transak” in non-English locales.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Buy flow localization for payment method and provider footer

  Scenario: non-English locale shows localized card payment method labels
    Given the app locale is set to Spanish
    And the user opens unified Buy amount input
    When a debit/credit card payment method is selected or listed
    Then the payment method label is shown as the localized debit-card string

  Scenario: non-English locale shows localized powered-by footer in Transak native flow
    Given the app locale is set to Spanish
    And the user enters a Transak native identity screen
    When the footer is rendered
    Then the footer text uses the localized "Powered by {{provider}}" string

  Scenario: English locale behavior remains unchanged
    Given the app locale is set to English
    When the user views the same Buy and Transak footer surfaces
    Then provider/payment labels remain in expected English form
```

## **Screenshots/Recordings**

### **Before**

- Buy flow showed untranslated `Debit Card` / `Credit or Debit Card` in Spanish.
- Transak native footer showed untranslated `Powered by Transak` in Spanish.

### **After**

- Buy flow card method labels are localized in non-English locales.
- Transak footer uses localized `Powered by {{provider}}` text in non-English locales.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C04G8UGLL4R/p1774897190549919?thread_ts=1774897190.549919&cid=C04G8UGLL4R)

<div><a href="https://cursor.com/agents/bc-1ba16e52-2716-5386-855a-57050d57fb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba16e52-2716-5386-855a-57050d57fb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

