### PR TITLE
fix: distinguish swaps trending token details source

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.test.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 import BridgeTrendingTokensSection from './BridgeTrendingTokensSection';
 import { useTokenListFilters } from '../../../Trending/hooks/useTokenListFilters/useTokenListFilters';
 import { useTrendingRequest } from '../../../Trending/hooks/useTrendingRequest/useTrendingRequest';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import { BridgeTrendingTokensSectionTestIds } from './BridgeTrendingTokensSection.testIds';
+
+const mockTrendingTokenRowItem = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => ({})),
@@ -35,8 +38,16 @@ jest.mock(
     const { View } = jest.requireActual('react-native');
     return {
       __esModule: true,
-      default: ({ token }: { token: { assetId: string } }) =>
-        ReactLib.createElement(View, { testID: `row-${token.assetId}` }),
+      default: ({
+        token,
+        tokenDetailsSource,
+      }: {
+        token: { assetId: string };
+        tokenDetailsSource?: TokenDetailsSource;
+      }) => {
+        mockTrendingTokenRowItem({ token, tokenDetailsSource });
+        return ReactLib.createElement(View, { testID: `row-${token.assetId}` });
+      },
     };
   },
 );
@@ -119,6 +130,12 @@ describe('BridgeTrendingTokensSection', () => {
 
     const rows = getAllByTestId(/^row-/);
     expect(rows).toHaveLength(12);
+    expect(mockTrendingTokenRowItem).toHaveBeenCalledTimes(12);
+    expect(mockTrendingTokenRowItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenDetailsSource: TokenDetailsSource.TrendingSwaps,
+      }),
+    );
     expect(
       getByTestId(BridgeTrendingTokensSectionTestIds.SHOW_MORE),
     ).toBeTruthy();

--- a/app/components/UI/Bridge/components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.tsx
+++ b/app/components/UI/Bridge/components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.tsx
@@ -32,6 +32,7 @@ import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/brid
 import type { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import type { CaipChainId } from '@metamask/utils';
 import { FilterButton } from '../../../Trending/components/FilterBar/FilterBar';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import { BridgeTrendingTokensSectionTestIds } from './BridgeTrendingTokensSection.testIds';
 
 const TOKEN_CHUNK_SIZE = 12;
@@ -188,6 +189,7 @@ const BridgeTrendingTokensSection = ({
                   position={index}
                   selectedTimeOption={selectedTimeOption}
                   filterContext={filterContext}
+                  tokenDetailsSource={TokenDetailsSource.TrendingSwaps}
                 />
               ))}
         {!isLoading && hasMore ? (

--- a/app/components/UI/TokenDetails/constants/constants.ts
+++ b/app/components/UI/TokenDetails/constants/constants.ts
@@ -11,8 +11,10 @@ export enum TokenDetailsSource {
   MobileTokenListPage = 'mobile-token-list-page',
   /** Homepage section entry point */
   HomeSection = 'home_section',
-  /** Trending tokens section */
+  /** Trending tokens section (e.g. Explore tab) */
   Trending = 'trending',
+  /** Trending tokens section on the Swaps / Bridge view */
+  TrendingSwaps = 'trending-swaps',
   /** Swap/Bridge token selector */
   Swap = 'swap',
   /** Fallback when source cannot be determined */

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -6,6 +6,7 @@ import TrendingTokenRowItem from './TrendingTokenRowItem';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { TimeOption, PriceChangeOption } from '../TrendingTokensBottomSheet';
 import type { TrendingFilterContext } from '../TrendingTokensList/TrendingTokensList';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 
 // Mock the trendingNetworksList module to avoid getNetworkImageSource errors
 jest.mock('../../utils/trendingNetworksList', () => ({
@@ -812,6 +813,71 @@ describe('TrendingTokenRowItem', () => {
           isFromTrending: true,
           rwaData: undefined,
           source: 'trending',
+        }),
+      );
+    });
+
+    it('navigates with tokenDetailsSource TrendingSwaps for Swaps trending analytics', () => {
+      const token = createMockToken({
+        assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+      });
+
+      const networkAddedState = {
+        ...mockState,
+        engine: {
+          ...mockState.engine,
+          backgroundState: {
+            ...mockState.engine.backgroundState,
+            NetworkController: {
+              networkConfigurations: {},
+              networkConfigurationsByChainId: {
+                '0x1': {
+                  chainId: '0x1',
+                  caipChainId: 'eip155:1',
+                  name: 'Ethereum Mainnet',
+                },
+              },
+            },
+            MultichainNetworkController: {
+              ...mockState.engine.backgroundState.MultichainNetworkController,
+              multichainNetworkConfigurationsByChainId: {},
+            },
+          },
+        },
+      };
+
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem
+          token={token}
+          tokenDetailsSource={TokenDetailsSource.TrendingSwaps}
+        />,
+        { state: networkAddedState },
+        false,
+      );
+
+      const tokenRow = getByTestId(
+        'trending-token-row-item-eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      );
+      fireEvent.press(tokenRow);
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        StackActions.push('Asset', {
+          chainId: '0x1',
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+          image:
+            'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+          pricePercentChange1d: 3.44,
+          isNative: false,
+          isETH: false,
+          isFromTrending: true,
+          rwaData: undefined,
+          source: 'trending-swaps',
         }),
       );
     });

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -131,12 +131,20 @@ interface TrendingTokenRowItemProps {
   position?: number;
   /** Filter context for analytics tracking */
   filterContext?: TrendingFilterContext;
+  /**
+   * Token Details `source` for MetaMetrics (e.g. Explore trending vs Swaps trending).
+   * @default TokenDetailsSource.Trending
+   */
+  tokenDetailsSource?: TokenDetailsSource;
 }
 
 /**
  * Converts a TrendingAsset to Asset navigation params
  */
-const getAssetNavigationParams = (token: TrendingAsset) => {
+const getAssetNavigationParams = (
+  token: TrendingAsset,
+  source: TokenDetailsSource = TokenDetailsSource.Trending,
+) => {
   const [caipChainId, assetIdentifier] = token.assetId.split('/');
   if (!isCaipChainId(caipChainId)) return null;
 
@@ -161,7 +169,7 @@ const getAssetNavigationParams = (token: TrendingAsset) => {
     isNative: isNativeToken,
     isETH: isNativeToken && hexChainId === '0x1',
     isFromTrending: true,
-    source: TokenDetailsSource.Trending,
+    source,
     rwaData: token.rwaData,
     securityData: token.securityData,
   };
@@ -172,6 +180,7 @@ const TrendingTokenRowItem = ({
   selectedTimeOption = TimeOption.TwentyFourHours,
   position,
   filterContext,
+  tokenDetailsSource = TokenDetailsSource.Trending,
 }: TrendingTokenRowItemProps) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation();
@@ -187,7 +196,10 @@ const TrendingTokenRowItem = ({
     [token.assetId],
   );
 
-  const assetParams = useMemo(() => getAssetNavigationParams(token), [token]);
+  const assetParams = useMemo(
+    () => getAssetNavigationParams(token, tokenDetailsSource),
+    [token, tokenDetailsSource],
+  );
 
   const networkBadgeImageSource = useMemo(
     () => getNetworkBadgeSource(caipChainId),

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -143,7 +143,7 @@ interface TrendingTokenRowItemProps {
  */
 const getAssetNavigationParams = (
   token: TrendingAsset,
-  source: TokenDetailsSource = TokenDetailsSource.Trending,
+  source: TokenDetailsSource,
 ) => {
   const [caipChainId, assetIdentifier] = token.assetId.split('/');
   if (!isCaipChainId(caipChainId)) return null;


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change separates swaps-trending token detail navigation from the generic explore trending flow so MetaMetrics can attribute those entry points correctly.

It adds a dedicated `trending-swaps` token details source, passes that source from the Bridge/Swaps trending section into `TrendingTokenRowItem`, and keeps the default `trending` source for existing explore-tab behavior. The added test coverage verifies the swaps-trending navigation params include the new source.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [SWAPS-4306](https://consensyssoftware.atlassian.net/browse/SWAPS-4306)

## **Manual testing steps**

```gherkin
Feature: Swaps trending token source tracking

  Scenario: user opens token details from swaps trending
    Given the app is running and the Bridge/Swaps trending tokens section is visible
    When the user taps a token from the Bridge/Swaps trending tokens list
    Then the Asset route is opened for that token
    And the token details navigation params use the source "trending-swaps"

  Scenario: user opens token details from explore trending
    Given the app is running and the Explore trending tokens list is visible
    When the user taps a token from the Explore trending list
    Then the Asset route is opened for that token
    And the token details navigation params continue to use the source "trending"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to navigation params/analytics attribution with a default preserving existing behavior; minimal functional risk aside from potential analytics mislabeling if miswired.
> 
> **Overview**
> Routes opened from the Swaps/Bridge trending tokens section now pass a dedicated token-details `source` value (`TokenDetailsSource.TrendingSwaps`) instead of the generic trending source, allowing analytics to distinguish entry points.
> 
> This introduces the new `trending-swaps` enum value, adds an optional `tokenDetailsSource` prop to `TrendingTokenRowItem` (defaulting to `Trending`), and updates tests to assert the Bridge section forwards the source and that navigation params include `source: 'trending-swaps'` when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6909921f5369b3d1957b216d6ffd119f9c66c327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->