### PR TITLE
Fix test failures onboarding

### DIFF
--- a/tests/framework/fixture/index.ts
+++ b/tests/framework/fixture/index.ts
@@ -103,10 +103,24 @@ export const test = base.extend<TestLevelFixtures>({
       // Create driver and set up test context
       driver = await deviceProvider.getDriver();
 
-      // Set the implicit timeout for the driver
-      await driver.setTimeout({
-        implicit: project.use.expectTimeout ?? DEFAULT_IMPLICIT_WAIT_MS,
-      });
+      // Set the implicit timeout for the driver.
+      // Wrapped in retry because BrowserStack sessions can transiently reject
+      // the setTimeout command before the session is fully initialised.
+      const implicitMs = project.use.expectTimeout ?? DEFAULT_IMPLICIT_WAIT_MS;
+      const maxRetries = 3;
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          await driver.setTimeout({ implicit: implicitMs });
+          break;
+        } catch (err) {
+          if (attempt === maxRetries) throw err;
+          const backoff = attempt * 1000;
+          console.warn(
+            `driver.setTimeout failed (attempt ${attempt}/${maxRetries}), retrying in ${backoff}ms…`,
+          );
+          await new Promise((r) => setTimeout(r, backoff));
+        }
+      }
 
       // Make driver globally accessible for utilities
       globalThis.driver = driver;

--- a/tests/framework/services/providers/browserstack/BrowserStackConfigBuilder.ts
+++ b/tests/framework/services/providers/browserstack/BrowserStackConfigBuilder.ts
@@ -112,6 +112,7 @@ export class BrowserStackConfigBuilder {
           : {
               'appium:bundleId': this.project.use.app?.appId,
             }),
+        'appium:newCommandTimeout': 300,
         'appium:autoGrantPermissions': true,
         'appium:app': appBsUrl,
         'appium:autoAcceptAlerts': true,

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -36,7 +36,7 @@ class CreatePasswordView {
           ),
         ios: () =>
           PlaywrightMatchers.getElementByXPath(
-            '//XCUIElementTypeSecureTextField[@name="create-password-first-input-field"]',
+            '//XCUIElementTypeSecureTextField[@name="create-password-first-input-field"][1]',
           ),
       },
     });
@@ -59,7 +59,7 @@ class CreatePasswordView {
           ),
         ios: () =>
           PlaywrightMatchers.getElementByXPath(
-            '//XCUIElementTypeSecureTextField[@name="create-password-second-input-field"]',
+            '//XCUIElementTypeSecureTextField[@name="create-password-second-input-field"][2]',
           ),
       },
     });

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -35,8 +35,8 @@ class CreatePasswordView {
             `.description("${ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID}")`,
           ),
         ios: () =>
-          PlaywrightMatchers.getElementByXPath(
-            '//XCUIElementTypeSecureTextField[@name="create-password-first-input-field"][1]',
+          PlaywrightMatchers.getElementByCatchAll(
+            ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
           ),
       },
     });
@@ -58,8 +58,8 @@ class CreatePasswordView {
             `.description("${ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID}")`,
           ),
         ios: () =>
-          PlaywrightMatchers.getElementByXPath(
-            '//XCUIElementTypeSecureTextField[@name="create-password-second-input-field"][2]',
+          PlaywrightMatchers.getElementByCatchAll(
+            ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
           ),
       },
     });
@@ -84,8 +84,8 @@ class CreatePasswordView {
             },
           ),
         ios: () =>
-          PlaywrightMatchers.getElementByXPath(
-            '//XCUIElementTypeOther[@name="textfield" and @label="create-password-second-input-field"]',
+          PlaywrightMatchers.getElementByCatchAll(
+            ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
           ),
       },
     });

--- a/tests/page-objects/Onboarding/ProtectYourWalletView.ts
+++ b/tests/page-objects/Onboarding/ProtectYourWalletView.ts
@@ -21,10 +21,7 @@ class ProtectYourWalletView {
           ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON,
         ),
       appium: {
-        android: () =>
-          PlaywrightMatchers.getElementByAndroidUIAutomator(
-            'text("Remind me later")',
-          ),
+        android: () => PlaywrightMatchers.getElementByText('Remind me later'),
         ios: () =>
           PlaywrightMatchers.getElementByXPath(
             '(//XCUIElementTypeStaticText[@name="Remind me later"])[2]',

--- a/tests/page-objects/Onboarding/ProtectYourWalletView.ts
+++ b/tests/page-objects/Onboarding/ProtectYourWalletView.ts
@@ -20,13 +20,19 @@ class ProtectYourWalletView {
         Matchers.getElementByID(
           ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON,
         ),
-      appium: () =>
-        PlaywrightMatchers.getElementByXPath(
-          '(//XCUIElementTypeStaticText[@name="Remind me later"])[2]',
-          {
-            exact: true,
-          },
-        ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementByAndroidUIAutomator(
+            'text("Remind me later")',
+          ),
+        ios: () =>
+          PlaywrightMatchers.getElementByXPath(
+            '(//XCUIElementTypeStaticText[@name="Remind me later"])[2]',
+            {
+              exact: true,
+            },
+          ),
+      },
     });
   }
 

--- a/tests/performance/onboarding/import-wallet.spec.ts
+++ b/tests/performance/onboarding/import-wallet.spec.ts
@@ -18,7 +18,7 @@ import WalletView from '../../page-objects/wallet/WalletView';
 import { dismisspredictionsModalPlaywright } from '../../flows/wallet.flow';
 import { fetchProductionFeatureFlags } from '../feature-flag-helper';
 
-const testEnvironment = process.env.BUILD_VARIANT || '';
+const testEnvironment = process.env.E2E_PERFORMANCE_BUILD_VARIANT || '';
 
 /* Scenario 4: Imported wallet with +50 accounts */
 test.describe(PerformanceOnboarding, () => {

--- a/tests/performance/onboarding/new-wallet-account-creation.spec.ts
+++ b/tests/performance/onboarding/new-wallet-account-creation.spec.ts
@@ -22,7 +22,7 @@ import AccountListBottomSheet from '../../page-objects/wallet/AccountListBottomS
 import { fetchProductionFeatureFlags } from '../feature-flag-helper';
 import PredictModalView from '../../page-objects/Predict/PredictModalView.js';
 
-const testEnvironment = process.env.BUILD_VARIANT || '';
+const testEnvironment = process.env.E2E_PERFORMANCE_BUILD_VARIANT || '';
 
 /* Scenario 2: Account creation after fresh install */
 test.describe(`${PerformanceOnboarding} ${PerformanceAccountList}`, () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improves BrowserStack test robustness by retrying driver.setTimeout with backoff during session startup and setting appium:newCommandTimeout to reduce premature session drops.

Updates onboarding page-object selectors to be less brittle on iOS (replacing XPath-based secure text field lookups with getElementByCatchAll) and adds Android-specific handling for the "Remind me later" button.

Adjusts performance onboarding specs to read the build variant from E2E_PERFORMANCE_BUILD_VARIANT instead of BUILD_VARIANT when fetching production feature flags.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes BrowserStack/Appium session capabilities and WebDriver timeout initialization, which can affect all remote test runs and may mask underlying session issues if misconfigured.
> 
> **Overview**
> Improves BrowserStack test robustness by retrying `driver.setTimeout` with backoff during session startup and setting `appium:newCommandTimeout` to reduce premature session drops.
> 
> Updates onboarding page-object selectors to be less brittle on iOS (replacing XPath-based secure text field lookups with `getElementByCatchAll`) and adds Android-specific handling for the "Remind me later" button.
> 
> Adjusts performance onboarding specs to read the build variant from `E2E_PERFORMANCE_BUILD_VARIANT` instead of `BUILD_VARIANT` when fetching production feature flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0991b34c560a6ce4e46c6911e3f2542f507447ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->