### PR TITLE
chore: update CODEOWNERS to @MetaMask/money-movement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,16 +59,16 @@ scripts/set-secrets-from-config.js                          @MetaMask/mobile-adm
 # Platform & Snaps Code Fencing File
 metro.transform.js @MetaMask/mobile-platform @MetaMask/core-platform
 
-# Ramps Team
-app/components/UI/Ramp/                                @MetaMask/ramp
-app/reducers/fiatOrders/                               @MetaMask/ramp
-app/core/Engine/controllers/ramps-controller           @MetaMask/ramp
-app/core/Engine/messengers/ramps-controller-messenger  @MetaMask/ramp
-app/core/Engine/messengers/ramps-service-messenger     @MetaMask/ramp
-app/selectors/rampsController                          @MetaMask/ramp
-**/Ramp/**                                              @MetaMask/ramp
-**/ramp/**                                              @MetaMask/ramp
-**/ramps/**                                             @MetaMask/ramp
+# Money Movement Team (formerly Ramps)
+app/components/UI/Ramp/                                @MetaMask/money-movement
+app/reducers/fiatOrders/                               @MetaMask/money-movement
+app/core/Engine/controllers/ramps-controller           @MetaMask/money-movement
+app/core/Engine/messengers/ramps-controller-messenger  @MetaMask/money-movement
+app/core/Engine/messengers/ramps-service-messenger     @MetaMask/money-movement
+app/selectors/rampsController                          @MetaMask/money-movement
+**/Ramp/**                                              @MetaMask/money-movement
+**/ramp/**                                              @MetaMask/money-movement
+**/ramps/**                                             @MetaMask/money-movement
 
 # Card Team
 app/components/UI/Card/                                    @MetaMask/card
@@ -287,9 +287,9 @@ tests/flows/                                   @MetaMask/qa
 # Note: Test builds (main-test, flask-test) in build/builds.yml are owned by QA team
 # but the file itself is protected by mobile-platform for consistency
 
-# Co-owned by Swaps and Ramps teams
-app/util/parseAmount.ts                      @MetaMask/swaps-engineers @MetaMask/ramp
-app/util/parseAmount.test.ts                 @MetaMask/swaps-engineers @MetaMask/ramp
+# Co-owned by Swaps and Money Movement teams
+app/util/parseAmount.ts                      @MetaMask/swaps-engineers @MetaMask/money-movement
+app/util/parseAmount.test.ts                 @MetaMask/swaps-engineers @MetaMask/money-movement
 
 # Snapshots – no code owners assigned
 # This allows anyone with write access to approve changes to any *.snap files.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@ app/selectors/rampsController                          @MetaMask/money-movement
 **/Ramp/**                                              @MetaMask/money-movement
 **/ramp/**                                              @MetaMask/money-movement
 **/ramps/**                                             @MetaMask/money-movement
+**/money-movement/**                                    @MetaMask/money-movement
 
 # Card Team
 app/components/UI/Card/                                    @MetaMask/card


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Ramps lane has been renamed to **Money Movement** on GitHub ([`@MetaMask/money-movement`](https://github.com/orgs/MetaMask/teams/money-movement)). This updates `.github/CODEOWNERS` so review requests and branch-protection ownership resolve to the current org team instead of `@MetaMask/ramp`.

**What changed**

- Section comment renamed to **Money Movement Team (formerly Ramps)**.
- All `@MetaMask/ramp` entries replaced with `@MetaMask/money-movement` (Ramp UI, fiat orders, ramps controller/messengers, selectors, path globs, and Swaps co-owned `parseAmount` / `parseAmount.test.ts`).
- Co-ownership comment updated to reference Money Movement alongside Swaps.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: CODEOWNERS ownership update

  Scenario: No in-app verification required
    Given this pull request only changes .github/CODEOWNERS
    When reviewers validate the team slug and paths
    Then no wallet UI or device manual test is applicable
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only updates `.github/CODEOWNERS` mappings; the main impact is on review routing/branch protection if any paths or the new team slug are incorrect.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to reflect the GitHub team rename from `@MetaMask/ramp` to `@MetaMask/money-movement` for Ramp-related paths (UI, fiat orders, ramps controllers/messengers, selectors, and related glob patterns).
> 
> Adds an additional `**/money-movement/**` ownership rule and updates the Swaps co-owned `parseAmount` entries to use the new Money Movement team.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8efd4d2a77beac6b1ae06f739b285b02bd6959a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->