### PR TITLE
test: improve TabBarComponent retry logic to reduce trade smoke flakiness

### DIFF
--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -13,6 +13,7 @@ import SettingsView from '../Settings/SettingsView';
 import AccountMenu from '../AccountMenu/AccountMenu';
 import WalletView from './WalletView';
 import TrendingView from '../Trending/TrendingView';
+import WalletActionsBottomSheet from './WalletActionsBottomSheet';
 
 class TabBarComponent {
   get tabBarExploreButton(): EncapsulatedElementType {
@@ -174,28 +175,60 @@ class TabBarComponent {
   }
 
   async tapActions(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.tabBarActionButton, {
-      description: 'Tab Bar - Trade Button',
-    });
+    await Utilities.executeWithRetry(
+      async () => {
+        await UnifiedGestures.waitAndTap(this.tabBarActionButton, {
+          timeout: 2000,
+          description: 'Tab Bar - Trade Button',
+        });
+        await Assertions.expectElementToBeVisible(
+          WalletActionsBottomSheet.swapButton,
+          { timeout: 500 },
+        );
+      },
+      {
+        maxRetries: 15,
+        timeout: 45000,
+        description: 'Tap Actions Button with Validation',
+      },
+    );
   }
 
   async tapTrade(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.tabBarTradeButton, {
-      description: 'Tab Bar - Trade Button',
-    });
+    await Utilities.executeWithRetry(
+      async () => {
+        await UnifiedGestures.waitAndTap(this.tabBarTradeButton, {
+          timeout: 2000,
+          description: 'Tab Bar - Trade Button',
+        });
+        await Assertions.expectElementToBeVisible(
+          WalletActionsBottomSheet.swapButton,
+          { timeout: 500 },
+        );
+      },
+      {
+        maxRetries: 15,
+        timeout: 45000,
+        description: 'Tap Trade Button with Validation',
+      },
+    );
   }
 
   async tapAccountsMenu(): Promise<void> {
+    await this.tapWallet();
     await Utilities.executeWithRetry(
       async () => {
-        await UnifiedGestures.waitAndTap(this.tabBarWalletButton);
-        await Assertions.expectElementToBeVisible(WalletView.container);
-        await Gestures.waitAndTap(WalletView.hamburgerMenuButton);
-        await Assertions.expectElementToBeVisible(AccountMenu.container);
+        await Gestures.waitAndTap(WalletView.hamburgerMenuButton, {
+          timeout: 2000,
+        });
+        await Assertions.expectElementToBeVisible(AccountMenu.container, {
+          timeout: 500,
+        });
       },
       {
+        maxRetries: 15,
         timeout: 45000,
-        description: 'Tap Accounts Menu Button',
+        description: 'Tap Hamburger Menu to open Accounts Menu',
       },
     );
   }


### PR DESCRIPTION
## **Description**

The `trade-ios-smoke-1` CI job has been flaky since ~Feb 26. Investigation traced one contributing cause to `tapAccountsMenu()` (formerly `tapSettings()` via PR #26568), which wrapped a multi-step navigation sequence (wallet tap → assert wallet → hamburger tap → assert menu) in a single `executeWithRetry` block. When any intermediate step failed, the retry restarted the **entire** sequence from scratch, potentially tapping wallet mid-navigation and leaving the app in a broken state.

This PR makes three improvements to `TabBarComponent`:

1. **Split `tapAccountsMenu()` into two separately retried steps**: First calls `this.tapWallet()` (which already has its own retry + validation pattern), then retries only the hamburger→accounts menu step independently. A failure opening the accounts menu no longer restarts wallet navigation.

2. **Add retry logic to `tapActions()`**: Was a bare `UnifiedGestures.waitAndTap()` without any retry or validation. Now wrapped in `executeWithRetry` with a visibility assertion on the actions bottom sheet swap button.

3. **Add retry logic to `tapTrade()`**: Same treatment as `tapActions()` — wrapped in `executeWithRetry` with validation.

Both `tapActions()` and `tapTrade()` now follow the same resilient pattern used by `tapWallet()`, `tapExploreButton()`, `tapActivity()`, and `tapRewards()`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #26568

## **Manual testing steps**

```gherkin
Feature: Trade smoke E2E reliability

  Scenario: swap/bridge/stake tests navigate to settings without flaking
    Given a CI environment running trade-ios-smoke-1

    When swap-action-smoke, bridge-action-smoke, or stake-action-smoke tests
         call tapSettings() or tapActions()
    Then navigation succeeds reliably without retry-induced broken state
```

## **Screenshots/Recordings**

N/A — no UI changes, E2E test infrastructure only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)