### PR TITLE
fix(tron): correct unstaking withdrawal period from 3 to 14 days

### DIFF
--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -6215,7 +6215,7 @@
       "energy": "Energie",
       "estimated_annual_reward": "Geschätzte jährliche Belohnung",
       "trx_locked_for": "TRX gesperrt für",
-      "trx_locked_for_minimum_time": "~3 Tage",
+      "trx_locked_for_minimum_time": "~14 Tage",
       "trx_released_in": "TRX freigegeben in",
       "trx_released_in_minimum_time": "~14 Tage",
       "fee": "Gebühr",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -6215,7 +6215,7 @@
       "energy": "Ενέργεια",
       "estimated_annual_reward": "Εκτ. ετήσια ανταμοιβή",
       "trx_locked_for": "Τα TRX κλειδωμένα για",
-      "trx_locked_for_minimum_time": "~3 ημέρες",
+      "trx_locked_for_minimum_time": "~14 ημέρες",
       "trx_released_in": "Τα TRX θα είναι διαθέσιμα σε",
       "trx_released_in_minimum_time": "~14 ημέρες",
       "fee": "Τέλη",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6228,7 +6228,7 @@
       "energy": "Energy",
       "estimated_annual_reward": "Est. annual reward",
       "trx_locked_for": "TRX locked for",
-      "trx_locked_for_minimum_time": "~3 days",
+      "trx_locked_for_minimum_time": "~14 days",
       "trx_released_in": "TRX released in",
       "trx_released_in_minimum_time": "~14 days",
       "fee": "Fee",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -6215,7 +6215,7 @@
       "energy": "Energía",
       "estimated_annual_reward": "Recompensa anual est.",
       "trx_locked_for": "TRX bloqueado durante",
-      "trx_locked_for_minimum_time": "~3 días",
+      "trx_locked_for_minimum_time": "~14 días",
       "trx_released_in": "TRX liberado en",
       "trx_released_in_minimum_time": "~14 días",
       "fee": "Tarifa",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -6215,7 +6215,7 @@
       "energy": "Énergie",
       "estimated_annual_reward": "Estimation de la récompense annuelle",
       "trx_locked_for": "TRX bloqué pour",
-      "trx_locked_for_minimum_time": "environ 3 jours",
+      "trx_locked_for_minimum_time": "environ 14 jours",
       "trx_released_in": "TRX libéré dans",
       "trx_released_in_minimum_time": "environ 14 jours",
       "fee": "Frais",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -6215,7 +6215,7 @@
       "energy": "ऊर्जा",
       "estimated_annual_reward": "अनुमानित वार्षिक रिवॉर्ड",
       "trx_locked_for": "के लिए TRX लॉक किया गया",
-      "trx_locked_for_minimum_time": "~3 दिन के लिए",
+      "trx_locked_for_minimum_time": "~14 दिन के लिए",
       "trx_released_in": "TRX रिलीज़ किया गया",
       "trx_released_in_minimum_time": "~14 दिनों में",
       "fee": "फीस",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -6215,7 +6215,7 @@
       "energy": "Energi",
       "estimated_annual_reward": "Estimasi reward tahunan",
       "trx_locked_for": "TRX dikunci selama",
-      "trx_locked_for_minimum_time": "~3 hari",
+      "trx_locked_for_minimum_time": "~14 hari",
       "trx_released_in": "TRX dirilis dalam",
       "trx_released_in_minimum_time": "~14 hari",
       "fee": "Biaya",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -6215,7 +6215,7 @@
       "energy": "エネルギー",
       "estimated_annual_reward": "予想年間報酬",
       "trx_locked_for": "TRXのロック期間",
-      "trx_locked_for_minimum_time": "最大3日",
+      "trx_locked_for_minimum_time": "最大14日",
       "trx_released_in": "TRXのロック解除までの待機期間",
       "trx_released_in_minimum_time": "最大14日",
       "fee": "手数料",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -6215,7 +6215,7 @@
       "energy": "에너지",
       "estimated_annual_reward": "예상 연간 보상",
       "trx_locked_for": "TRX 잠김:",
-      "trx_locked_for_minimum_time": "~3일",
+      "trx_locked_for_minimum_time": "~14일",
       "trx_released_in": "TRX 해제 예정일:",
       "trx_released_in_minimum_time": "~14일",
       "fee": "수수료",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -6215,7 +6215,7 @@
       "energy": "Energia",
       "estimated_annual_reward": "Recompensa anual estimada",
       "trx_locked_for": "TRX bloqueado por",
-      "trx_locked_for_minimum_time": "cerca de 3 dias",
+      "trx_locked_for_minimum_time": "cerca de 14 dias",
       "trx_released_in": "TRX lançado em",
       "trx_released_in_minimum_time": "cerca de 14 dias",
       "fee": "Taxa",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -6215,7 +6215,7 @@
       "energy": "Энергия",
       "estimated_annual_reward": "Прим. вознаграждение за год",
       "trx_locked_for": "TRX заблокированы на",
-      "trx_locked_for_minimum_time": "~3 дня",
+      "trx_locked_for_minimum_time": "~14 дней",
       "trx_released_in": "TRX разблокируются через",
       "trx_released_in_minimum_time": "~14 дней",
       "fee": "Комиссия",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -6215,7 +6215,7 @@
       "energy": "Enerhiya",
       "estimated_annual_reward": "Tinatayang taunang reward",
       "trx_locked_for": "Naka-lock ang TRX ng",
-      "trx_locked_for_minimum_time": "~3 araw",
+      "trx_locked_for_minimum_time": "~14 araw",
       "trx_released_in": "Ilalabas ang TRX pagkalipas ng",
       "trx_released_in_minimum_time": "~14 na araw",
       "fee": "Bayarin",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -6215,7 +6215,7 @@
       "energy": "Enerji",
       "estimated_annual_reward": "Tahmini yıllık ödül",
       "trx_locked_for": "TRX kilitli kalma süresi",
-      "trx_locked_for_minimum_time": "~3 gün",
+      "trx_locked_for_minimum_time": "~14 gün",
       "trx_released_in": "TRX serbest bırakılmasına kalan süre",
       "trx_released_in_minimum_time": "~14 gün",
       "fee": "Ücret",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -6215,7 +6215,7 @@
       "energy": "Năng lượng",
       "estimated_annual_reward": "Phần thưởng hằng năm ước tính",
       "trx_locked_for": "TRX bị khóa trong",
-      "trx_locked_for_minimum_time": "~3 ngày",
+      "trx_locked_for_minimum_time": "~14 ngày",
       "trx_released_in": "TRX được mở khóa sau",
       "trx_released_in_minimum_time": "~14 ngày",
       "fee": "Phí",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -6215,7 +6215,7 @@
       "energy": "能量",
       "estimated_annual_reward": "预计年度奖励",
       "trx_locked_for": "TRX 锁定时长",
-      "trx_locked_for_minimum_time": "约 3 天",
+      "trx_locked_for_minimum_time": "约 14 天",
       "trx_released_in": "TRX 释放时间",
       "trx_released_in_minimum_time": "约 14 天",
       "fee": "费用",


### PR DESCRIPTION
## **Description**

The `trx_locked_for_minimum_time` localization key was displaying ~3 days across all supported languages as the estimated Tron unstaking duration. The actual withdrawal period is 14 days. This fix updates the value in all 15 language files (de, el, en, es, fr, hi, id, ja, ko, pt, ru, tl, tr, vi, zh).

Note: the sibling key `trx_released_in_minimum_time` already had the correct value of ~14 days.

## **Changelog**

CHANGELOG entry: Fixed incorrect Tron unstaking withdrawal period display from 3 days to the correct 14 days.

## **Related issues**

Fixes: NEB-720

## **Manual testing steps**

\`\`\`gherkin
Feature: Tron unstaking withdrawal period

  Scenario: user views Tron staking information
    Given the user has TRX staked
    When user navigates to the staking details screen
    Then the TRX locked for minimum time should display ~14 days
\`\`\`

## **Screenshots/Recordings**

### **Before**

~3 days shown for TRX locked for minimum time

### **After**

~14 days shown for TRX locked for minimum time

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk localization-only change; it only updates displayed text for the Tron staking lock period with no logic or data-flow changes.
> 
> **Overview**
> Corrects the Tron staking/unstaking informational string `trx_locked_for_minimum_time` from ~3 days to ~14 days across all translated locale JSON files, aligning the displayed minimum lock period with the existing 14-day release/unstaking messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ea43e731b35812e44f86edccc6756e5ee6674d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->