### PR TITLE
fix: enhance useMerklBonusClaim with session lock and reward refetching cp-7.72.0

### DIFF
--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useMerklBonusClaim } from './useMerklBonusClaim';
 import { TokenI } from '../../../../Tokens/types';
@@ -9,6 +9,7 @@ const mockClaimRewards = jest.fn().mockResolvedValue(undefined);
 const mockUseMerklRewards = jest.fn((_opts?: unknown) => ({
   claimableReward: null as string | null,
   hasClaimedBefore: false,
+  rewardsFetchVersion: 0,
 }));
 
 jest.mock('./useMerklRewards', () => ({
@@ -140,6 +141,7 @@ describe('useMerklBonusClaim', () => {
     mockUseMerklRewards.mockReturnValue({
       claimableReward: null,
       hasClaimedBefore: false,
+      rewardsFetchVersion: 0,
     });
     mockUsePendingMerklClaim.mockReturnValue({ hasPendingClaim: false });
     mockUseMerklClaimTransaction.mockReturnValue({
@@ -211,10 +213,76 @@ describe('useMerklBonusClaim', () => {
     expect(mockUseMerklClaimTransaction).toHaveBeenCalledWith(eligibleAsset);
   });
 
+  it('hides CTA after successful claim submission until remount', async () => {
+    const mockSuccessfulClaimRewards = jest.fn().mockResolvedValue({
+      txHash: '0x123',
+      transactionMeta: {},
+    });
+    mockUseMerklRewards.mockReturnValue({
+      claimableReward: '1.50',
+      hasClaimedBefore: false,
+      rewardsFetchVersion: 0,
+    });
+    mockUseMerklClaimTransaction.mockReturnValue({
+      claimRewards: mockSuccessfulClaimRewards,
+      isClaiming: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useMerklBonusClaim(eligibleAsset, 'test_location'),
+    );
+
+    expect(result.current.claimableReward).toBe('1.50');
+
+    await act(async () => {
+      await result.current.claimRewards();
+    });
+
+    expect(result.current.claimableReward).toBeNull();
+  });
+
+  it('unlocks CTA after rewards refetch version changes', async () => {
+    const mockSuccessfulClaimRewards = jest.fn().mockResolvedValue({
+      txHash: '0x123',
+      transactionMeta: {},
+    });
+    mockUseMerklRewards.mockReturnValue({
+      claimableReward: '1.50',
+      hasClaimedBefore: false,
+      rewardsFetchVersion: 0,
+    });
+    mockUseMerklClaimTransaction.mockReturnValue({
+      claimRewards: mockSuccessfulClaimRewards,
+      isClaiming: false,
+      error: null,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useMerklBonusClaim(eligibleAsset, 'test_location'),
+    );
+
+    await act(async () => {
+      await result.current.claimRewards();
+    });
+
+    expect(result.current.claimableReward).toBeNull();
+
+    mockUseMerklRewards.mockReturnValue({
+      claimableReward: '1.50',
+      hasClaimedBefore: false,
+      rewardsFetchVersion: 1,
+    });
+    rerender();
+
+    expect(result.current.claimableReward).toBe('1.50');
+  });
+
   it('returns composed data from underlying hooks for eligible asset', () => {
     mockUseMerklRewards.mockReturnValue({
       claimableReward: '1.50',
       hasClaimedBefore: false,
+      rewardsFetchVersion: 0,
     });
     mockUsePendingMerklClaim.mockReturnValue({ hasPendingClaim: true });
     mockUseMerklClaimTransaction.mockReturnValue({
@@ -230,7 +298,7 @@ describe('useMerklBonusClaim', () => {
     expect(result.current.claimableReward).toBe('1.50');
     expect(result.current.hasPendingClaim).toBe(true);
     expect(result.current.isClaiming).toBe(true);
-    expect(result.current.claimRewards).toBe(mockClaimRewards);
+    expect(typeof result.current.claimRewards).toBe('function');
     expect(result.current.error).toBeNull();
   });
 
@@ -238,6 +306,7 @@ describe('useMerklBonusClaim', () => {
     mockUseMerklRewards.mockReturnValue({
       claimableReward: '< 0.01',
       hasClaimedBefore: false,
+      rewardsFetchVersion: 0,
     });
 
     const { result } = renderHook(() =>
@@ -252,6 +321,7 @@ describe('useMerklBonusClaim', () => {
     mockUseMerklRewards.mockReturnValue({
       claimableReward: '0.005',
       hasClaimedBefore: false,
+      rewardsFetchVersion: 0,
     });
 
     const { result } = renderHook(() =>
@@ -267,6 +337,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '5.00',
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
 
       renderHook(() =>
@@ -280,6 +351,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '5.00',
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
 
       renderHook(() =>
@@ -293,6 +365,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '5.00',
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
       mockUsePendingMerklClaim.mockReturnValue({ hasPendingClaim: true });
 
@@ -307,6 +380,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: null,
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
 
       renderHook(() =>
@@ -320,6 +394,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '< 0.01',
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
 
       renderHook(() =>
@@ -333,6 +408,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '0.005',
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
 
       renderHook(() =>
@@ -346,6 +422,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '5.00',
         hasClaimedBefore: false,
+        rewardsFetchVersion: 0,
       });
 
       const { rerender } = renderHook(() =>
@@ -361,6 +438,7 @@ describe('useMerklBonusClaim', () => {
       mockUseMerklRewards.mockReturnValue({
         claimableReward: '5.00',
         hasClaimedBefore: true,
+        rewardsFetchVersion: 0,
       });
 
       renderHook(() =>
@@ -401,6 +479,7 @@ describe('useMerklBonusClaim', () => {
         mockUseMerklRewards.mockReturnValue({
           claimableReward: bonusValue,
           hasClaimedBefore: false,
+          rewardsFetchVersion: 0,
         });
 
         renderHook(() =>

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.test.ts
@@ -278,6 +278,51 @@ describe('useMerklBonusClaim', () => {
     expect(result.current.claimableReward).toBe('1.50');
   });
 
+  it('locks CTA even when rewardsFetchVersion changes while claim is in flight', async () => {
+    let resolveClaim:
+      | ((value: {
+          txHash: string;
+          transactionMeta: Record<string, unknown>;
+        }) => void)
+      | undefined;
+    const delayedClaim = new Promise<{
+      txHash: string;
+      transactionMeta: Record<string, unknown>;
+    }>((resolve) => {
+      resolveClaim = resolve;
+    });
+    const mockDelayedClaimRewards = jest.fn().mockReturnValue(delayedClaim);
+
+    let mockedRewardsFetchVersion = 0;
+    mockUseMerklRewards.mockImplementation(() => ({
+      claimableReward: '1.50',
+      hasClaimedBefore: false,
+      rewardsFetchVersion: mockedRewardsFetchVersion,
+    }));
+    mockUseMerklClaimTransaction.mockReturnValue({
+      claimRewards: mockDelayedClaimRewards,
+      isClaiming: false,
+      error: null,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useMerklBonusClaim(eligibleAsset, 'test_location'),
+    );
+
+    const claimPromise = result.current.claimRewards();
+
+    mockedRewardsFetchVersion = 1;
+    rerender();
+    expect(result.current.claimableReward).toBe('1.50');
+
+    await act(async () => {
+      resolveClaim?.({ txHash: '0x123', transactionMeta: {} });
+      await claimPromise;
+    });
+
+    expect(result.current.claimableReward).toBeNull();
+  });
+
   it('returns composed data from underlying hooks for eligible asset', () => {
     mockUseMerklRewards.mockReturnValue({
       claimableReward: '1.50',

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.ts
@@ -112,6 +112,10 @@ export const useMerklBonusClaim = (
   const [claimLockFetchVersion, setClaimLockFetchVersion] = useState<
     number | null
   >(null);
+  const latestRewardsFetchVersionRef = useRef(rewardsFetchVersion);
+  useEffect(() => {
+    latestRewardsFetchVersionRef.current = rewardsFetchVersion;
+  }, [rewardsFetchVersion]);
   const isClaimLocked =
     claimLockFetchVersion !== null &&
     claimLockFetchVersion === rewardsFetchVersion;
@@ -120,10 +124,10 @@ export const useMerklBonusClaim = (
     const claimResult = await claimRewards();
     // Keep CTA hidden until the next rewards refetch resolves.
     if (claimResult) {
-      setClaimLockFetchVersion(rewardsFetchVersion);
+      setClaimLockFetchVersion(latestRewardsFetchVersionRef.current);
     }
     return claimResult;
-  }, [claimRewards, rewardsFetchVersion]);
+  }, [claimRewards]);
 
   const hasClaimableBonus =
     isEligible &&

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { TokenI } from '../../../../Tokens/types';
@@ -99,20 +99,37 @@ export const useMerklBonusClaim = (
 
   const eligibleAsset = isEligible ? asset : undefined;
 
-  const { claimableReward, hasClaimedBefore } = useMerklRewards({
-    asset: eligibleAsset,
-  });
+  const { claimableReward, hasClaimedBefore, rewardsFetchVersion } =
+    useMerklRewards({
+      asset: eligibleAsset,
+    });
   const { hasPendingClaim } = usePendingMerklClaim();
   const {
     claimRewards,
     isClaiming,
     error: claimError,
   } = useMerklClaimTransaction(eligibleAsset);
+  const [claimLockFetchVersion, setClaimLockFetchVersion] = useState<
+    number | null
+  >(null);
+  const isClaimLocked =
+    claimLockFetchVersion !== null &&
+    claimLockFetchVersion === rewardsFetchVersion;
+
+  const claimRewardsWithSessionLock = useCallback(async () => {
+    const claimResult = await claimRewards();
+    // Keep CTA hidden until the next rewards refetch resolves.
+    if (claimResult) {
+      setClaimLockFetchVersion(rewardsFetchVersion);
+    }
+    return claimResult;
+  }, [claimRewards, rewardsFetchVersion]);
 
   const hasClaimableBonus =
     isEligible &&
     isClaimableBonusAboveThreshold(claimableReward) &&
-    !hasPendingClaim;
+    !hasPendingClaim &&
+    !isClaimLocked;
 
   const hasFiredCtaAvailableEvent = useRef(false);
 
@@ -159,11 +176,12 @@ export const useMerklBonusClaim = (
     }
 
     return {
-      claimableReward: isClaimableBonusAboveThreshold(claimableReward)
-        ? claimableReward
-        : null,
+      claimableReward:
+        !isClaimLocked && isClaimableBonusAboveThreshold(claimableReward)
+          ? claimableReward
+          : null,
       hasPendingClaim,
-      claimRewards,
+      claimRewards: claimRewardsWithSessionLock,
       isClaiming,
       error: claimError,
     };
@@ -171,8 +189,9 @@ export const useMerklBonusClaim = (
     isEligible,
     claimableReward,
     hasPendingClaim,
-    claimRewards,
+    claimRewardsWithSessionLock,
     isClaiming,
     claimError,
+    isClaimLocked,
   ]);
 };

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -174,7 +174,7 @@ describe('useMerklRewards', () => {
   });
 
   it('initializes with null claimableReward', () => {
-    const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
+    const { result } = renderHook(() => useMerklRewards({ asset: undefined }));
 
     expect(result.current.claimableReward).toBe(null);
   });
@@ -1054,5 +1054,45 @@ describe('useMerklRewards', () => {
 
     setIntervalSpy.mockRestore();
     clearIntervalSpy.mockRestore();
+  });
+
+  it('increments rewardsFetchVersion after successful fetch and refetch', async () => {
+    const mockRewardData = {
+      token: {
+        address: AGLAMERKL_ADDRESS_MAINNET,
+        chainId: 1,
+        symbol: 'aglaMerkl',
+        decimals: 18,
+        price: null,
+      },
+      accumulated: '0',
+      unclaimed: '1500000000000000000',
+      pending: '0',
+      proofs: [],
+      amount: '1500000000000000000',
+      claimed: '0',
+      recipient: mockSelectedAddress,
+    };
+
+    mockFetchMerklRewardsForAsset.mockResolvedValue(mockRewardData);
+    mockGetClaimedAmountFromContract.mockResolvedValue('0');
+
+    const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
+
+    await waitFor(() => {
+      expect(result.current.rewardsFetchVersion).toBeGreaterThan(0);
+    });
+
+    const versionAfterInitialFetch = result.current.rewardsFetchVersion;
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewardsFetchVersion).toBeGreaterThan(
+        versionAfterInitialFetch,
+      );
+    });
   });
 });

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.test.ts
@@ -996,4 +996,63 @@ describe('useMerklRewards', () => {
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     expect(mockGetClaimedAmountFromContract).toHaveBeenCalled();
   });
+
+  it('clears stale claimableReward when refetch returns no matching reward', async () => {
+    const mockRewardData = {
+      token: {
+        address: AGLAMERKL_ADDRESS_MAINNET,
+        chainId: 1,
+        symbol: 'aglaMerkl',
+        decimals: 18,
+        price: null,
+      },
+      accumulated: '0',
+      unclaimed: '1500000000000000000',
+      pending: '0',
+      proofs: [],
+      amount: '1500000000000000000',
+      claimed: '0',
+      recipient: mockSelectedAddress,
+    };
+
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(mockRewardData);
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce('0');
+
+    const { result } = renderHook(() => useMerklRewards({ asset: mockAsset }));
+
+    await waitFor(() => {
+      expect(result.current.claimableReward).toBe('1.50');
+    });
+
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.claimableReward).toBe(null);
+    });
+  });
+
+  it('starts auto-refresh interval and clears it on unmount', () => {
+    const intervalId = 123 as unknown as ReturnType<typeof setInterval>;
+    const setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockReturnValue(intervalId);
+    const clearIntervalSpy = jest
+      .spyOn(global, 'clearInterval')
+      .mockImplementation(() => undefined);
+
+    const { unmount } = renderHook(() => useMerklRewards({ asset: mockAsset }));
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60000);
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
 });

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
@@ -17,6 +17,7 @@ import Logger from '../../../../../../util/Logger';
 
 const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET];
 const MUSD_ADDRESS_MAINNET = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
+const MERKL_REWARDS_AUTO_REFRESH_INTERVAL_MS = 60_000;
 
 // Map of chains and eligible tokens
 // mUSD on mainnet is eligible because users earn rewards for holding it,
@@ -59,6 +60,7 @@ interface UseMerklRewardsReturn {
   claimableReward: string | null;
   hasClaimedBefore: boolean;
   refetch: () => void;
+  rewardsFetchVersion: number;
 }
 
 /**
@@ -69,6 +71,7 @@ export const useMerklRewards = ({
 }: UseMerklRewardsOptions): UseMerklRewardsReturn => {
   const [claimableReward, setClaimableReward] = useState<string | null>(null);
   const [hasClaimedBefore, setHasClaimedBefore] = useState(false);
+  const [rewardsFetchVersion, setRewardsFetchVersion] = useState(0);
 
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
@@ -111,6 +114,7 @@ export const useMerklRewards = ({
         }
 
         if (!matchingReward) {
+          setClaimableReward(null);
           setHasClaimedBefore(false);
           return;
         }
@@ -169,6 +173,10 @@ export const useMerklRewards = ({
           error as Error,
           'useMerklRewards: Error fetching claimable rewards',
         );
+      } finally {
+        if (!controller.signal.aborted && process.env.NODE_ENV !== 'test') {
+          setRewardsFetchVersion((version) => version + 1);
+        }
       }
     },
     [asset, selectedAddress],
@@ -191,9 +199,24 @@ export const useMerklRewards = ({
     };
   }, [fetchClaimableRewards]);
 
+  useEffect(() => {
+    if (!asset || !selectedAddress) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      refetch();
+    }, MERKL_REWARDS_AUTO_REFRESH_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [asset, selectedAddress, refetch]);
+
   return {
     claimableReward,
     hasClaimedBefore,
     refetch,
+    rewardsFetchVersion,
   };
 };

--- a/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
+++ b/app/components/UI/Earn/components/MerklRewards/hooks/useMerklRewards.ts
@@ -174,7 +174,7 @@ export const useMerklRewards = ({
           'useMerklRewards: Error fetching claimable rewards',
         );
       } finally {
-        if (!controller.signal.aborted && process.env.NODE_ENV !== 'test') {
+        if (!controller.signal.aborted) {
           setRewardsFetchVersion((version) => version + 1);
         }
       }

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -36,6 +36,7 @@ import { useNetworkEnablement } from '../../hooks/useNetworkEnablement/useNetwor
  * their refresh functionality via refs.
  */
 const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
+  const cashSectionRef = useRef<SectionRefreshHandle>(null);
   const tokensSectionRef = useRef<SectionRefreshHandle>(null);
   const whatsHappeningSectionRef = useRef<SectionRefreshHandle>(null);
   const perpsSectionRef = useRef<SectionRefreshHandle>(null);
@@ -111,6 +112,7 @@ const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   const refresh = useCallback(async () => {
     await Promise.allSettled([
+      cashSectionRef.current?.refresh(),
       tokensSectionRef.current?.refresh(),
       whatsHappeningSectionRef.current?.refresh(),
       perpsSectionRef.current?.refresh(),
@@ -131,6 +133,7 @@ const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
       testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
     >
       <CashSection
+        ref={cashSectionRef}
         sectionIndex={getSectionIndex(HomeSectionNames.CASH)}
         totalSectionsLoaded={totalSectionsLoaded}
       />

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { screen, fireEvent } from '@testing-library/react-native';
+import React, { createRef } from 'react';
+import { screen, fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import CashSection from './CashSection';
 import Routes from '../../../../../constants/navigation/Routes';
+import { SectionRefreshHandle } from '../../types';
 
 const mockNavigate = jest.fn();
 
@@ -48,12 +49,16 @@ jest.mock('../../hooks/useHomeViewedEvent', () => ({
   },
 }));
 
+let musdAggregatedRowRenderCount = 0;
 jest.mock('./MusdAggregatedRow', () => {
   const { Text } = jest.requireActual('react-native');
   const ReactActual = jest.requireActual('react');
   return {
     __esModule: true,
-    default: () => ReactActual.createElement(Text, null, 'MusdAggregatedRow'),
+    default: () => {
+      musdAggregatedRowRenderCount += 1;
+      return ReactActual.createElement(Text, null, 'MusdAggregatedRow');
+    },
   };
 });
 
@@ -86,6 +91,7 @@ describe('CashSection', () => {
       tokenBalanceAggregated: '0',
       fiatBalanceAggregatedFormatted: '$0.00',
     });
+    musdAggregatedRowRenderCount = 0;
   });
 
   it('returns null when mUSD conversion is disabled', () => {
@@ -169,5 +175,26 @@ describe('CashSection', () => {
     );
 
     expect(screen.getByText('MusdAggregatedRow')).toBeOnTheScreen();
+  });
+
+  it('remounts row when refresh is called via section ref', async () => {
+    mockUseMusdBalance.mockReturnValue({
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '1800',
+      fiatBalanceAggregatedFormatted: '$1,800.00',
+    });
+    const ref = createRef<SectionRefreshHandle>();
+
+    renderWithProvider(
+      <CashSection ref={ref} sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(musdAggregatedRowRenderCount).toBe(1);
+
+    await act(async () => {
+      await ref.current?.refresh();
+    });
+
+    expect(musdAggregatedRowRenderCount).toBe(2);
   });
 });

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useRef } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -18,6 +24,7 @@ import MusdAggregatedRow from './MusdAggregatedRow';
 
 import CashGetMusdEmptyState from './CashGetMusdEmptyState';
 import Logger from '../../../../../util/Logger';
+import { SectionRefreshHandle } from '../../types';
 
 interface CashSectionProps {
   sectionIndex: number;
@@ -29,65 +36,72 @@ interface CashSectionProps {
  * Shows aggregated mUSD balance across supported networks and optional "Claim bonus".
  * Section header navigates to the Cash token list page (mUSD-only, per network).
  */
-const CashSection = ({
-  sectionIndex,
-  totalSectionsLoaded,
-}: CashSectionProps) => {
-  const sectionViewRef = useRef<View>(null);
-  const navigation = useNavigation();
-  const isMusdConversionEnabled = useSelector(
-    selectIsMusdConversionFlowEnabledFlag,
-  );
-  const { isEligible: isGeoEligible } = useMusdConversionEligibility();
-  const { hasMusdBalanceOnAnyChain } = useMusdBalance();
-  const isMoneyHomeEnabled = useSelector(selectMoneyHomeScreenEnabledFlag);
-
-  const isCashSectionEnabled = isMusdConversionEnabled && isGeoEligible;
-
-  const handleViewCashTokens = useCallback(() => {
-    if (isMoneyHomeEnabled) {
-      navigation.navigate(Routes.MONEY.ROOT as never);
-    } else {
-      navigation.navigate(Routes.WALLET.CASH_TOKENS_FULL_VIEW as never);
-    }
-  }, [navigation, isMoneyHomeEnabled]);
-
-  const { onLayout } = useHomeViewedEvent({
-    sectionRef: sectionViewRef,
-    isLoading: false,
-    sectionName: HomeSectionNames.CASH,
-    sectionIndex,
-    totalSectionsLoaded,
-    isEmpty: !hasMusdBalanceOnAnyChain,
-    itemCount: hasMusdBalanceOnAnyChain ? 1 : 0,
-  });
-
-  if (!isCashSectionEnabled) {
-    Logger.log(
-      `[CashSection] not rendered flag=${isMusdConversionEnabled} geo=${isGeoEligible} reason=${!isMusdConversionEnabled ? 'flag_off' : 'geo_ineligible'}`,
+const CashSection = forwardRef<SectionRefreshHandle, CashSectionProps>(
+  ({ sectionIndex, totalSectionsLoaded }, ref) => {
+    const sectionViewRef = useRef<View>(null);
+    const [refreshVersion, setRefreshVersion] = useState(0);
+    const navigation = useNavigation();
+    const isMusdConversionEnabled = useSelector(
+      selectIsMusdConversionFlowEnabledFlag,
     );
-    return null;
-  }
+    const { isEligible: isGeoEligible } = useMusdConversionEligibility();
+    const { hasMusdBalanceOnAnyChain } = useMusdBalance();
+    const isMoneyHomeEnabled = useSelector(selectMoneyHomeScreenEnabledFlag);
 
-  const title = strings('homepage.sections.cash');
+    const isCashSectionEnabled = isMusdConversionEnabled && isGeoEligible;
 
-  return (
-    <View ref={sectionViewRef} onLayout={onLayout}>
-      <Box gap={3}>
-        <SectionHeader title={title} onPress={handleViewCashTokens} />
-        {!hasMusdBalanceOnAnyChain ? (
-          <SectionRow>
-            <CashGetMusdEmptyState />
-          </SectionRow>
-        ) : (
-          <SectionRow>
-            <MusdAggregatedRow />
-          </SectionRow>
-        )}
-      </Box>
-    </View>
-  );
-};
+    const handleViewCashTokens = useCallback(() => {
+      if (isMoneyHomeEnabled) {
+        navigation.navigate(Routes.MONEY.ROOT as never);
+      } else {
+        navigation.navigate(Routes.WALLET.CASH_TOKENS_FULL_VIEW as never);
+      }
+    }, [navigation, isMoneyHomeEnabled]);
+
+    const { onLayout } = useHomeViewedEvent({
+      sectionRef: sectionViewRef,
+      isLoading: false,
+      sectionName: HomeSectionNames.CASH,
+      sectionIndex,
+      totalSectionsLoaded,
+      isEmpty: !hasMusdBalanceOnAnyChain,
+      itemCount: hasMusdBalanceOnAnyChain ? 1 : 0,
+    });
+
+    const refresh = useCallback(async () => {
+      // Force a remount so claim session lock and reward hooks are re-initialized.
+      setRefreshVersion((version) => version + 1);
+    }, []);
+
+    useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+    if (!isCashSectionEnabled) {
+      Logger.log(
+        `[CashSection] not rendered flag=${isMusdConversionEnabled} geo=${isGeoEligible} reason=${!isMusdConversionEnabled ? 'flag_off' : 'geo_ineligible'}`,
+      );
+      return null;
+    }
+
+    const title = strings('homepage.sections.cash');
+
+    return (
+      <View ref={sectionViewRef} onLayout={onLayout}>
+        <Box gap={3}>
+          <SectionHeader title={title} onPress={handleViewCashTokens} />
+          {!hasMusdBalanceOnAnyChain ? (
+            <SectionRow>
+              <CashGetMusdEmptyState key={`cash-empty-${refreshVersion}`} />
+            </SectionRow>
+          ) : (
+            <SectionRow>
+              <MusdAggregatedRow key={`cash-row-${refreshVersion}`} />
+            </SectionRow>
+          )}
+        </Box>
+      </View>
+    );
+  },
+);
 
 CashSection.displayName = 'CashSection';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a regression where the Claim bonus CTA for mUSD could remain visible after a successful claim and allow reopening claim flow with effectively no claimable value.

The solution introduces a post-claim lock in useMerklBonusClaim, then unlocks that CTA after reward data is refreshed (manual pull-to-refresh, section refresh/remount, or periodic auto-refresh). It also fixes stale reward state handling so old claimable values are cleared when reward fetch returns no matching reward.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where the mUSD Claim bonus button could remain visible after claiming and trigger another claim flow.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28135

## **Manual testing steps**

```gherkin
Feature: mUSD claim bonus CTA state lifecycle

  Scenario: CTA hides after successful claim and reappears after refresh when claimable again
    Given user has claimable mUSD bonus
    And user is on Homepage with Cash section visible
    When user taps "Claim bonus" and confirms the transaction
    Then loader is shown briefly
    And "Claim bonus" is hidden after successful submission

    When user pulls to refresh Homepage
    Then Cash section refreshes
    And claim bonus eligibility is re-evaluated

    When sufficient time passes for auto-refresh interval
    Then claim bonus eligibility is re-evaluated automatically

  Scenario: stale claimable state is cleared
    Given previous claimable reward was shown
    When rewards fetch returns no matching reward
    Then "Claim bonus" is not shown
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches claim CTA gating and introduces a periodic fetch interval; incorrect locking/versioning could hide the CTA or increase background network activity unexpectedly.
> 
> **Overview**
> Fixes the mUSD Merkl “Claim bonus” CTA lifecycle by adding a **post-claim session lock** in `useMerklBonusClaim` that hides the CTA after a successful claim submission and only re-enables it after rewards data has refreshed (via a new `rewardsFetchVersion`).
> 
> Enhances `useMerklRewards` with **auto-refresh (60s)**, a `rewardsFetchVersion` counter, and clearing of stale `claimableReward` when a refetch returns no matching reward; the Homepage now wires `CashSection` into the global refresh flow and exposes a section `refresh()` that forces a remount of the cash row to reset claim state. Tests were updated/added to cover the lock/unlock behavior, stale clearing, interval cleanup, version increments, and cash row remount on refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67ccc05869730a62ddde71a7c3cdf24b9f05c4c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->