### PR TITLE
fix(perps): retry candle data fetch on too-many-requests errors cp-7.72.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -27,7 +27,6 @@ import {
   type Position,
   type PerpsMarketData,
   type TPSLTrackingData,
-  CandleData,
 } from '@metamask/perps-controller';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
@@ -143,8 +142,7 @@ import PerpsSelectAdjustMarginActionView from '../PerpsSelectAdjustMarginActionV
 import PerpsSelectModifyActionView from '../PerpsSelectModifyActionView';
 import { createStyles } from './PerpsMarketDetailsView.styles';
 import type { PerpsMarketDetailsViewProps } from './PerpsMarketDetailsView.types';
-import { sleep } from '@walletconnect/utils';
-import { useQuery } from '@tanstack/react-query';
+import { useRefetchCandleDataOnError } from '../../hooks/useRefetchCandleDataOnError';
 
 interface MarketDetailsRouteParams {
   market: PerpsMarketData;
@@ -152,54 +150,6 @@ interface MarketDetailsRouteParams {
   isNavigationFromOrderSuccess?: boolean;
   source?: string;
 }
-
-const useRefetchCandleDataOnError = ({
-  candleData,
-  candleError,
-  fetchMoreHistory,
-}: {
-  candleData: CandleData | null;
-  candleError: Error | null;
-  fetchMoreHistory: () => Promise<void>;
-}) => {
-  const candlesRefetchRef = useRef<{
-    candles: CandleData['candles'];
-    error: Error | null;
-  }>({ candles: [], error: null });
-  const fetchMoreHistoryRef = useRef<() => Promise<void>>(fetchMoreHistory);
-
-  useEffect(() => {
-    candlesRefetchRef.current.candles = candleData?.candles ?? [];
-    candlesRefetchRef.current.error = candleError;
-    fetchMoreHistoryRef.current = fetchMoreHistory;
-  }, [candleData, candleError, fetchMoreHistory]);
-
-  const candleErorrMessage = candleError?.message;
-  const tooManyRequestsRegex = /too many requests/i;
-  const maxRetries = 12;
-  const retryDelay = 5000;
-  const shouldRetry =
-    !!candleErorrMessage && tooManyRequestsRegex.test(candleErorrMessage);
-
-  useEffect(() => {
-    if (!shouldRetry) return;
-    let isMounted = true;
-
-    const retry = async (retryCount: number = 0) => {
-      if (retryCount >= maxRetries) return;
-      if (!isMounted) return;
-      if (candlesRefetchRef.current.candles.length > 0) return;
-      await sleep(retryDelay);
-      await fetchMoreHistoryRef.current();
-      await retry(retryCount + 1);
-    };
-
-    retry();
-    return () => {
-      isMounted = false;
-    };
-  }, [shouldRetry]);
-};
 
 const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Use centralized navigation hook for all Perps navigation

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -27,6 +27,7 @@ import {
   type Position,
   type PerpsMarketData,
   type TPSLTrackingData,
+  CandleData,
 } from '@metamask/perps-controller';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
@@ -142,6 +143,8 @@ import PerpsSelectAdjustMarginActionView from '../PerpsSelectAdjustMarginActionV
 import PerpsSelectModifyActionView from '../PerpsSelectModifyActionView';
 import { createStyles } from './PerpsMarketDetailsView.styles';
 import type { PerpsMarketDetailsViewProps } from './PerpsMarketDetailsView.types';
+import { sleep } from '@walletconnect/utils';
+import { useQuery } from '@tanstack/react-query';
 
 interface MarketDetailsRouteParams {
   market: PerpsMarketData;
@@ -149,6 +152,54 @@ interface MarketDetailsRouteParams {
   isNavigationFromOrderSuccess?: boolean;
   source?: string;
 }
+
+const useRefetchCandleDataOnError = ({
+  candleData,
+  candleError,
+  fetchMoreHistory,
+}: {
+  candleData: CandleData | null;
+  candleError: Error | null;
+  fetchMoreHistory: () => Promise<void>;
+}) => {
+  const candlesRefetchRef = useRef<{
+    candles: CandleData['candles'];
+    error: Error | null;
+  }>({ candles: [], error: null });
+  const fetchMoreHistoryRef = useRef<() => Promise<void>>(fetchMoreHistory);
+
+  useEffect(() => {
+    candlesRefetchRef.current.candles = candleData?.candles ?? [];
+    candlesRefetchRef.current.error = candleError;
+    fetchMoreHistoryRef.current = fetchMoreHistory;
+  }, [candleData, candleError, fetchMoreHistory]);
+
+  const candleErorrMessage = candleError?.message;
+  const tooManyRequestsRegex = /too many requests/i;
+  const maxRetries = 12;
+  const retryDelay = 5000;
+  const shouldRetry =
+    !!candleErorrMessage && tooManyRequestsRegex.test(candleErorrMessage);
+
+  useEffect(() => {
+    if (!shouldRetry) return;
+    let isMounted = true;
+
+    const retry = async (retryCount: number = 0) => {
+      if (retryCount >= maxRetries) return;
+      if (!isMounted) return;
+      if (candlesRefetchRef.current.candles.length > 0) return;
+      await sleep(retryDelay);
+      await fetchMoreHistoryRef.current();
+      await retry(retryCount + 1);
+    };
+
+    retry();
+    return () => {
+      isMounted = false;
+    };
+  }, [shouldRetry]);
+};
 
 const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Use centralized navigation hook for all Perps navigation
@@ -378,11 +429,18 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     isLoading: isLoadingHistory,
     hasHistoricalData,
     fetchMoreHistory,
+    error: candleError,
   } = usePerpsLiveCandles({
     symbol: market?.symbol || '',
     interval: selectedCandlePeriod,
     duration: TimeDuration.YearToDate,
     throttleMs: 1000,
+  });
+
+  useRefetchCandleDataOnError({
+    candleData,
+    candleError,
+    fetchMoreHistory,
   });
 
   // Get current price from the last candle's close price for chart synchronization

--- a/app/components/UI/Perps/hooks/useRefetchCandleDataOnError.test.ts
+++ b/app/components/UI/Perps/hooks/useRefetchCandleDataOnError.test.ts
@@ -1,0 +1,231 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useRefetchCandleDataOnError } from './useRefetchCandleDataOnError';
+import { CandlePeriod, type CandleData } from '@metamask/perps-controller';
+
+jest.mock('@walletconnect/utils', () => ({
+  sleep: (ms: number) =>
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+}));
+
+describe('useRefetchCandleDataOnError', () => {
+  const makeCandleData = (candles: CandleData['candles'] = []): CandleData => ({
+    symbol: 'BTC',
+    interval: CandlePeriod.OneHour,
+    candles,
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not retry when there is no error', () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: null,
+        candleError: null,
+        fetchMoreHistory,
+      }),
+    );
+
+    jest.advanceTimersByTime(60_000);
+
+    expect(fetchMoreHistory).not.toHaveBeenCalled();
+  });
+
+  it('does not retry for non-rate-limit errors', () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: null,
+        candleError: new Error('Network timeout'),
+        fetchMoreHistory,
+      }),
+    );
+
+    jest.advanceTimersByTime(60_000);
+
+    expect(fetchMoreHistory).not.toHaveBeenCalled();
+  });
+
+  it('retries on "too many requests" error', async () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: null,
+        candleError: new Error('Too many requests'),
+        fetchMoreHistory,
+      }),
+    );
+
+    // First retry fires after 5s
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(1);
+
+    // Second retry after another 5s
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops retrying once candles arrive', async () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      (props) => useRefetchCandleDataOnError(props),
+      {
+        initialProps: {
+          candleData: null as CandleData | null,
+          candleError: new Error('Too many requests') as Error | null,
+          fetchMoreHistory,
+        },
+      },
+    );
+
+    // First retry
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(1);
+
+    // Simulate candles arriving via ref update
+    const withCandles = makeCandleData([
+      {
+        time: 1700000000000,
+        open: '50000',
+        high: '51000',
+        low: '49000',
+        close: '50500',
+        volume: '100',
+      },
+    ]);
+    rerender({
+      candleData: withCandles,
+      candleError: new Error('Too many requests'),
+      fetchMoreHistory,
+    });
+
+    // More time passes but no more retries since candles are present
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying after max retries (12)', async () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: null,
+        candleError: new Error('too many requests'),
+        fetchMoreHistory,
+      }),
+    );
+
+    // Advance through all 12 retries (12 * 5s = 60s)
+    for (let i = 0; i < 12; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+    }
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(12);
+
+    // Advance more - no additional retries
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(12);
+  });
+
+  it('stops retrying on unmount', async () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    const { unmount } = renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: null,
+        candleError: new Error('Too many requests'),
+        fetchMoreHistory,
+      }),
+    );
+
+    // First retry
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    // More time passes but no more retries since unmounted
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches "too many requests" case-insensitively', async () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: null,
+        candleError: new Error('TOO MANY REQUESTS'),
+        fetchMoreHistory,
+      }),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry when candles already exist', () => {
+    const fetchMoreHistory = jest.fn().mockResolvedValue(undefined);
+    const existingData = makeCandleData([
+      {
+        time: 1700000000000,
+        open: '50000',
+        high: '51000',
+        low: '49000',
+        close: '50500',
+        volume: '100',
+      },
+    ]);
+
+    renderHook(() =>
+      useRefetchCandleDataOnError({
+        candleData: existingData,
+        candleError: new Error('Too many requests'),
+        fetchMoreHistory,
+      }),
+    );
+
+    jest.advanceTimersByTime(60_000);
+
+    // fetchMoreHistory gets called but the retry loop checks the ref
+    // and stops immediately because candles.length > 0
+    expect(fetchMoreHistory).toHaveBeenCalledTimes(0);
+  });
+});

--- a/app/components/UI/Perps/hooks/useRefetchCandleDataOnError.test.ts
+++ b/app/components/UI/Perps/hooks/useRefetchCandleDataOnError.test.ts
@@ -2,13 +2,6 @@ import { renderHook, act } from '@testing-library/react-native';
 import { useRefetchCandleDataOnError } from './useRefetchCandleDataOnError';
 import { CandlePeriod, type CandleData } from '@metamask/perps-controller';
 
-jest.mock('@walletconnect/utils', () => ({
-  sleep: (ms: number) =>
-    new Promise<void>((resolve) => {
-      setTimeout(resolve, ms);
-    }),
-}));
-
 describe('useRefetchCandleDataOnError', () => {
   const makeCandleData = (candles: CandleData['candles'] = []): CandleData => ({
     symbol: 'BTC',

--- a/app/components/UI/Perps/hooks/useRefetchCandleDataOnError.ts
+++ b/app/components/UI/Perps/hooks/useRefetchCandleDataOnError.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import { sleep } from '@walletconnect/utils';
+import type { CandleData } from '@metamask/perps-controller';
+
+const TOO_MANY_REQUESTS_REGEX = /too many requests/i;
+const MAX_RETRIES = 12;
+const RETRY_DELAY_MS = 5000;
+
+/**
+ * Retries `fetchMoreHistory` with exponential back-off when the candle
+ * subscription fails with a "too many requests" rate-limit error.
+ *
+ * Stops retrying once candles arrive or the retry budget is exhausted.
+ */
+export const useRefetchCandleDataOnError = ({
+  candleData,
+  candleError,
+  fetchMoreHistory,
+}: {
+  candleData: CandleData | null;
+  candleError: Error | null;
+  fetchMoreHistory: () => Promise<void>;
+}) => {
+  const candlesRefetchRef = useRef<{
+    candles: CandleData['candles'];
+    error: Error | null;
+  }>({ candles: [], error: null });
+  const fetchMoreHistoryRef = useRef<() => Promise<void>>(fetchMoreHistory);
+
+  useEffect(() => {
+    candlesRefetchRef.current.candles = candleData?.candles ?? [];
+    candlesRefetchRef.current.error = candleError;
+    fetchMoreHistoryRef.current = fetchMoreHistory;
+  }, [candleData, candleError, fetchMoreHistory]);
+
+  const candleErrorMessage = candleError?.message;
+  const shouldRetry =
+    !!candleErrorMessage && TOO_MANY_REQUESTS_REGEX.test(candleErrorMessage);
+
+  useEffect(() => {
+    if (!shouldRetry) return;
+    let isMounted = true;
+
+    const retry = async (retryCount: number = 0) => {
+      if (retryCount >= MAX_RETRIES) return;
+      if (!isMounted) return;
+      if (candlesRefetchRef.current.candles.length > 0) return;
+      await sleep(RETRY_DELAY_MS);
+      if (!isMounted) return;
+      if (candlesRefetchRef.current.candles.length > 0) return;
+      await fetchMoreHistoryRef.current();
+      await retry(retryCount + 1);
+    };
+
+    retry();
+    return () => {
+      isMounted = false;
+    };
+  }, [shouldRetry]);
+};

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -798,17 +798,44 @@ describe('CandleStreamChannel', () => {
   });
 
   describe('Fetch Historical Candles', () => {
-    it('returns early when no cached data exists', async () => {
+    it('fetches with Date.now fallback when no cached data exists', async () => {
+      const now = 1700100000000;
+      jest.setSystemTime(now);
+
+      const olderCandles: CandleData = {
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        candles: [
+          {
+            time: 1699996400000,
+            open: '49000',
+            high: '50000',
+            low: '48500',
+            close: '49500',
+            volume: '80',
+          },
+        ],
+      };
+      mockFetchHistoricalCandles.mockResolvedValue(olderCandles);
+
       await channel.fetchHistoricalCandles(
         'BTC',
         CandlePeriod.OneHour,
         TimeDuration.OneDay,
       );
 
-      expect(mockFetchHistoricalCandles).not.toHaveBeenCalled();
+      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        limit: expect.any(Number),
+        endTime: now - 1,
+      });
     });
 
-    it('returns early when cached data has no candles', async () => {
+    it('fetches with Date.now fallback when cached data has no candles', async () => {
+      const now = 1700100000000;
+      jest.setSystemTime(now);
+
       let capturedCallback: ((data: CandleData) => void) | undefined;
       mockSubscribeToCandles.mockImplementation(({ callback }) => {
         capturedCallback = callback;
@@ -829,13 +856,20 @@ describe('CandleStreamChannel', () => {
       };
       capturedCallback?.(emptyData);
 
+      mockFetchHistoricalCandles.mockResolvedValue(null);
+
       await channel.fetchHistoricalCandles(
         'BTC',
         CandlePeriod.OneHour,
         TimeDuration.OneDay,
       );
 
-      expect(mockFetchHistoricalCandles).not.toHaveBeenCalled();
+      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        limit: expect.any(Number),
+        endTime: now - 1,
+      });
     });
 
     it('fetches and merges historical candles successfully', async () => {
@@ -1227,6 +1261,124 @@ describe('CandleStreamChannel', () => {
           interval: CandlePeriod.FourHours,
         }),
       );
+    });
+  });
+
+  describe('onError propagation', () => {
+    it('calls subscriber onError callback when subscription initialization fails', () => {
+      const onError = jest.fn();
+      const subscriptionError = new Error('Too many requests');
+
+      let capturedOnError: ((error: Error) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation(({ onError: onErr }) => {
+        capturedOnError = onErr;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+        onError,
+      });
+
+      // Simulate subscription error from the controller
+      capturedOnError?.(subscriptionError);
+
+      expect(onError).toHaveBeenCalledWith(subscriptionError);
+    });
+
+    it('propagates onError through connect to the controller subscription', () => {
+      const onError = jest.fn();
+
+      mockSubscribeToCandles.mockReturnValue(jest.fn());
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+        onError,
+      });
+
+      // Verify subscribeToCandles was called with an onError handler
+      expect(mockSubscribeToCandles).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onError: expect.any(Function),
+        }),
+      );
+    });
+
+    it('notifies all subscribers for the same cacheKey on error', () => {
+      const onError1 = jest.fn();
+      const onError2 = jest.fn();
+      const subscriptionError = new Error('Too many requests');
+
+      let capturedOnError: ((error: Error) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation(({ onError: onErr }) => {
+        capturedOnError = onErr;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+        onError: onError1,
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+        onError: onError2,
+      });
+
+      capturedOnError?.(subscriptionError);
+
+      expect(onError1).toHaveBeenCalledWith(subscriptionError);
+      expect(onError2).toHaveBeenCalledWith(subscriptionError);
+    });
+
+    it('does not notify subscribers for a different cacheKey on error', () => {
+      const btcOnError = jest.fn();
+      const ethOnError = jest.fn();
+      const subscriptionError = new Error('Too many requests');
+
+      let btcCapturedOnError: ((error: Error) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation(
+        ({ symbol, onError: onErr }) => {
+          if (symbol === 'BTC') {
+            btcCapturedOnError = onErr;
+          }
+          return jest.fn();
+        },
+      );
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+        onError: btcOnError,
+      });
+
+      channel.subscribe({
+        symbol: 'ETH',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+        onError: ethOnError,
+      });
+
+      // Trigger error only on BTC
+      btcCapturedOnError?.(subscriptionError);
+
+      expect(btcOnError).toHaveBeenCalledWith(subscriptionError);
+      expect(ethOnError).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -205,7 +205,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     }
 
     // Ensure WebSocket connected for this symbol+interval
-    this.connect(symbol, interval, cacheKey);
+    this.connect(symbol, interval, cacheKey, onError);
 
     // Return unsubscribe function
     return () => {
@@ -241,6 +241,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     symbol: string,
     interval: CandlePeriod,
     cacheKey: string,
+    onError?: (error: Error) => void,
   ): void {
     // Skip if already connected for this symbol+interval
     if (this.wsSubscriptions.has(cacheKey)) {
@@ -280,7 +281,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
         this.notifySubscribers(cacheKey, candleData);
       },
       onError: (error: Error) => {
-        // Log initialization failure
+        onError?.(error);
         DevLogger.log(
           'CandleStreamChannel: Subscription initialization failed',
           {
@@ -377,24 +378,15 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     duration: TimeDuration,
   ): Promise<void> {
     const cacheKey = this.getCacheKey(symbol, interval);
-    const cachedData = this.cache.get(cacheKey);
-
-    // If no cached data or no candles, nothing to extend
-    if (!cachedData || cachedData.candles.length === 0) {
-      DevLogger.log(
-        'CandleStreamChannel: No cached data to extend, skipping historical fetch',
-        { symbol, interval },
-      );
-      return;
-    }
+    const cachedData = this.cache.get(cacheKey) ?? {
+      symbol,
+      interval,
+      candles: [],
+    };
 
     // Get the oldest candle timestamp
-    const oldestCandle = cachedData.candles[0];
-    if (!oldestCandle) {
-      return;
-    }
-
-    const oldestTime = oldestCandle.time;
+    const oldestCandle = cachedData?.candles?.[0];
+    const oldestTime = oldestCandle?.time ?? Date.now();
     const endTime = oldestTime - 1; // Fetch candles ending just before the oldest
 
     // Calculate dynamic limit based on duration and interval


### PR DESCRIPTION
## **Description**

When the HyperLiquid API returns "too many requests" rate-limiting errors during candle data initialization, the chart would remain permanently empty with no recovery path. This PR adds retry logic so the chart self-heals after being rate-limited.

**Changes:**

- **`CandleStreamChannel.ts`**: Propagates `onError` callback through the `connect` → WebSocket subscription flow so consumers can react to initialization failures. Removes the early return in `fetchMoreHistory` when no cached data exists, allowing history fetches even after a failed initial load (falls back to `Date.now()` as the anchor timestamp).
- **`PerpsMarketDetailsView.tsx`**: Adds a `useRefetchCandleDataOnError` hook that detects "too many requests" errors and retries `fetchMoreHistory` up to 12 times with 5-second intervals, stopping as soon as candles are loaded.

## **Changelog**

CHANGELOG entry: Fixed an issue where the Perps chart would remain empty after being rate-limited by the data provider

## **Related issues**

Partially resolves: https://github.com/MetaMask/metamask-mobile/issues/28141

## **Manual testing steps**

```gherkin
Feature: Perps chart recovery after rate limiting

  Scenario: chart recovers from too-many-requests errors
    Given the user is on the Perps Market Details view
    And the HyperLiquid API is returning "too many requests" errors for candle data

    When the rate limit is lifted within 60 seconds
    Then the chart should automatically populate with candle data
    And no user intervention should be required

  Scenario: chart loads normally without rate limiting
    Given the user is on the Perps Market Details view
    And the HyperLiquid API is responding normally

    When the chart loads
    Then candle data should display immediately
    And no retry behavior should be triggered
```

## **Screenshots/Recordings**

N/A — no UI changes, behavior-only fix.

### **Before**

Chart stays permanently empty after a "too many requests" error.

### **After**

https://github.com/user-attachments/assets/5a1a856f-c0a3-47e4-9714-310a5101b511



Chart automatically retries and recovers once the rate limit lifts.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the candle streaming/retry path used to render Perps charts; incorrect error propagation or retry timing could cause extra network load or continued empty charts, but scope is limited to this data flow.
> 
> **Overview**
> Prevents the Perps chart from getting stuck empty after candle subscription initialization hits a **"too many requests"** rate-limit error.
> 
> `CandleStreamChannel` now **propagates subscription `onError`** back to subscribers and allows `fetchHistoricalCandles` to run even when cache is empty (anchoring with `Date.now()`), enabling recovery after a failed initial load. `PerpsMarketDetailsView` wires in a new `useRefetchCandleDataOnError` hook that retries `fetchMoreHistory` (up to 12 attempts with 5s delay) until candles arrive, and adds unit tests covering retry/stop conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20ff2648a948b548c4c0d464489282ede87f4a06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->