### PR TITLE
fix: endless loop after hw tentative sign

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
@@ -523,7 +523,7 @@ describe('HardwareWalletProvider', () => {
     });
 
     describe('retryEnsureDeviceReady (internal, via bottom sheet props)', () => {
-      it('transitions to connecting state when retrying', async () => {
+      it('transitions to connecting state when retrying a connection error', async () => {
         const { result } = renderWithActions();
 
         act(() => {
@@ -551,6 +551,45 @@ describe('HardwareWalletProvider', () => {
         });
 
         expect(mockAdapterInstance.ensureDeviceReady).toHaveBeenCalled();
+      });
+
+      it('closes flow instead of retrying after a signing error', async () => {
+        const { result } = renderWithActions();
+
+        await act(async () => {
+          result.current.actions.showAwaitingConfirmation('transaction');
+        });
+
+        expect(result.current.state.connectionState.status).toBe(
+          ConnectionStatus.AwaitingConfirmation,
+        );
+
+        await act(async () => {
+          result.current.actions.hideAwaitingConfirmation();
+        });
+
+        await act(async () => {
+          result.current.actions.showHardwareWalletError(
+            new Error('Signing failed'),
+          );
+        });
+
+        expect(result.current.state.connectionState.status).toBe(
+          ConnectionStatus.ErrorState,
+        );
+
+        mockAdapterInstance.ensureDeviceReady.mockClear();
+
+        const internalRetry =
+          capturedBottomSheetProps.retryEnsureDeviceReady as () => Promise<void>;
+        await act(async () => {
+          await internalRetry();
+        });
+
+        expect(mockAdapterInstance.ensureDeviceReady).not.toHaveBeenCalled();
+        expect(result.current.state.connectionState.status).toBe(
+          ConnectionStatus.Disconnected,
+        );
       });
     });
   });

--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -99,6 +99,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
   });
 
   const handleFlowStart = useCallback(() => {
+    operationTypeRef.current = null;
     resetAnalyticsState();
     setAnalyticsFlow(derivedAnalyticsFlowRef.current);
   }, [resetAnalyticsState]);
@@ -151,14 +152,25 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
   const hideAwaitingConfirmation = useCallback(() => {
     DevLogger.log('[HardwareWallet] hideAwaitingConfirmation');
     awaitingConfirmationRejectRef.current = null;
-    operationTypeRef.current = null;
     updateConnectionState({ status: ConnectionStatus.Disconnected });
   }, [updateConnectionState]);
 
   const handleCloseFlow = useCallback(() => {
+    operationTypeRef.current = null;
     setAnalyticsFlow(HardwareWalletAnalyticsFlow.Connection);
     closeFlow();
   }, [closeFlow]);
+
+  const handleRetryOrClose = useCallback(async () => {
+    if (operationTypeRef.current !== null) {
+      DevLogger.log(
+        '[HardwareWallet] Post-signing error — closing flow instead of retrying',
+      );
+      handleCloseFlow();
+      return;
+    }
+    await retryEnsureDeviceReady();
+  }, [handleCloseFlow, retryEnsureDeviceReady]);
 
   const handleAwaitingConfirmationCancel = useCallback(() => {
     DevLogger.log('[HardwareWallet] handleAwaitingConfirmationCancel');
@@ -200,7 +212,7 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
         connectionState={connectionState}
         deviceSelection={deviceSelection}
         walletType={effectiveWalletType}
-        retryEnsureDeviceReady={retryEnsureDeviceReady}
+        retryEnsureDeviceReady={handleRetryOrClose}
         selectDevice={selectDevice}
         rescan={rescan}
         connect={connect}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Hardware wallet no longer enters infinite loop when Ledger device disconnects or Ethereum app is closed during transaction signing

## **Related issues**

Fixes:
- https://consensyssoftware.atlassian.net/browse/MUL-1640

## **Manual testing steps**

```gherkin
Feature: fix HW endless loop

  Scenario: user triggers a sign request (e.g swap)
    Given Ledger is fully ready 

    When user is shown the awaiting confirmation sheet, and disconnects the device / closes the eth app
    Then the transaction fails, and no infinite retry mechanism triggers
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware-wallet connection retry behavior based on internal operation state; risk is moderate because it alters error/retry UX and could affect recovery paths for some error scenarios.
> 
> **Overview**
> Fixes an endless retry loop by changing the bottom-sheet `retryEnsureDeviceReady` action to **close the hardware-wallet flow after a post-signing error** (tracked via `operationTypeRef`) instead of attempting to reconnect/ensure readiness again.
> 
> Resets `operationTypeRef` at flow start and on close, and adds/updates provider tests to cover both retrying a connection error and closing on a signing error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d1ccb252824aec90bbc97d0b2f81e681457fad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->