### PR TITLE
fix: derive mm_pay_* metrics from controller state for reliable Transaction Finalized tracking

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -234,29 +234,6 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
-  it('includes dust property for non-native quote', async () => {
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: PAY_TOKEN_MOCK,
-      setPayToken: noop,
-    } as ReturnType<typeof useTransactionPayToken>);
-
-    useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK, QUOTE_MOCK]);
-
-    runHook();
-
-    await act(async () => noop());
-
-    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-      id: transactionIdMock,
-      params: {
-        properties: expect.objectContaining({
-          mm_pay_dust_usd: '0.5',
-        }),
-        sensitiveProperties: {},
-      },
-    });
-  });
-
   describe('mm_pay_quote_requested', () => {
     it('is false initially', async () => {
       useTransactionPayTokenMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -23,7 +23,6 @@ import { Json } from '@metamask/utils';
 import {
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
-  useTransactionPayTotals,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { useAccountTokens } from '../send/useAccountTokens';
@@ -82,7 +81,6 @@ describe('useTransactionPayMetrics', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const updateConfirmationMetricMock = jest.mocked(updateConfirmationMetric);
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
-  const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
 
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
@@ -122,7 +120,7 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
-  it('does not update metrics if no pay token selected', async () => {
+  it('dispatches empty properties if no pay token selected', async () => {
     runHook();
 
     await act(async () => noop());
@@ -136,7 +134,7 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
-  it('includes pay token properties if pay token selected', async () => {
+  it('includes UI-only properties when pay token is selected', async () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,
       setPayToken: noop,
@@ -150,28 +148,55 @@ describe('useTransactionPayMetrics', () => {
       id: transactionIdMock,
       params: {
         properties: expect.objectContaining({
-          mm_pay: true,
-          mm_pay_token_selected: PAY_TOKEN_MOCK.symbol,
-          mm_pay_chain_selected: CHAIN_ID_MOCK,
           mm_pay_token_presented: PAY_TOKEN_MOCK.symbol,
           mm_pay_chain_presented: PAY_TOKEN_MOCK.chainId,
+          mm_pay_payment_token_list_size: 5,
+          mm_pay_quote_requested: false,
+          mm_pay_quote_loaded: false,
+          mm_pay_chain_highest_balance_caip: null,
         }),
         sensitiveProperties: {},
       },
     });
   });
 
-  it('includes step properties based on number of quotes', async () => {
+  it('does not include builder-owned properties', async () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,
       setPayToken: noop,
     } as ReturnType<typeof useTransactionPayToken>);
 
-    useTransactionPayQuotesMock.mockReturnValue([
-      QUOTE_MOCK,
-      QUOTE_MOCK,
-      QUOTE_MOCK,
-    ]);
+    useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
+
+    runHook();
+
+    await act(async () => noop());
+
+    const calledProps = (
+      updateConfirmationMetricMock.mock.calls[0]?.[0] as {
+        params: { properties: Record<string, unknown> };
+      }
+    )?.params?.properties;
+
+    expect(calledProps).not.toHaveProperty('mm_pay');
+    expect(calledProps).not.toHaveProperty('mm_pay_token_selected');
+    expect(calledProps).not.toHaveProperty('mm_pay_chain_selected');
+    expect(calledProps).not.toHaveProperty('mm_pay_use_case');
+    expect(calledProps).not.toHaveProperty('mm_pay_sending_value_usd');
+    expect(calledProps).not.toHaveProperty('mm_pay_receiving_value_usd');
+    expect(calledProps).not.toHaveProperty('mm_pay_metamask_fee_usd');
+    expect(calledProps).not.toHaveProperty('mm_pay_strategy');
+    expect(calledProps).not.toHaveProperty('mm_pay_network_fee_usd');
+    expect(calledProps).not.toHaveProperty('mm_pay_provider_fee_usd');
+    expect(calledProps).not.toHaveProperty('mm_pay_transaction_step');
+    expect(calledProps).not.toHaveProperty('mm_pay_transaction_step_total');
+  });
+
+  it('includes simulation_sending_assets_total_value for perps deposit', async () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: noop,
+    } as ReturnType<typeof useTransactionPayToken>);
 
     runHook();
 
@@ -181,35 +206,6 @@ describe('useTransactionPayMetrics', () => {
       id: transactionIdMock,
       params: {
         properties: expect.objectContaining({
-          mm_pay_transaction_step_total: 4,
-          mm_pay_transaction_step: 4,
-        }),
-        sensitiveProperties: {},
-      },
-    });
-  });
-
-  it('includes perps deposit properties', async () => {
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: PAY_TOKEN_MOCK,
-      setPayToken: noop,
-    } as ReturnType<typeof useTransactionPayToken>);
-
-    useTransactionPayQuotesMock.mockReturnValue([
-      QUOTE_MOCK,
-      QUOTE_MOCK,
-      QUOTE_MOCK,
-    ]);
-
-    runHook();
-
-    await act(async () => noop());
-
-    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-      id: transactionIdMock,
-      params: {
-        properties: expect.objectContaining({
-          mm_pay_use_case: 'perps_deposit',
           simulation_sending_assets_total_value: 1.23,
         }),
         sensitiveProperties: {},
@@ -217,17 +213,11 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
-  it('includes predict deposit properties', async () => {
+  it('includes simulation_sending_assets_total_value for predict deposit', async () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,
       setPayToken: noop,
     } as ReturnType<typeof useTransactionPayToken>);
-
-    useTransactionPayQuotesMock.mockReturnValue([
-      QUOTE_MOCK,
-      QUOTE_MOCK,
-      QUOTE_MOCK,
-    ]);
 
     runHook({ type: TransactionType.predictDeposit });
 
@@ -237,31 +227,7 @@ describe('useTransactionPayMetrics', () => {
       id: transactionIdMock,
       params: {
         properties: expect.objectContaining({
-          mm_pay_use_case: 'predict_deposit',
           simulation_sending_assets_total_value: 1.23,
-        }),
-        sensitiveProperties: {},
-      },
-    });
-  });
-
-  it('includes predict withdraw properties', async () => {
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: PAY_TOKEN_MOCK,
-      setPayToken: noop,
-    } as ReturnType<typeof useTransactionPayToken>);
-
-    useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
-
-    runHook({ type: TransactionType.predictWithdraw });
-
-    await act(async () => noop());
-
-    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-      id: transactionIdMock,
-      params: {
-        properties: expect.objectContaining({
-          mm_pay_use_case: 'predict_withdraw',
         }),
         sensitiveProperties: {},
       },
@@ -288,233 +254,6 @@ describe('useTransactionPayMetrics', () => {
         }),
         sensitiveProperties: {},
       },
-    });
-  });
-
-  it('includes token size property', async () => {
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: PAY_TOKEN_MOCK,
-      setPayToken: noop,
-    } as ReturnType<typeof useTransactionPayToken>);
-
-    runHook();
-
-    await act(async () => noop());
-
-    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-      id: transactionIdMock,
-      params: {
-        properties: expect.objectContaining({
-          mm_pay_payment_token_list_size: 5,
-        }),
-        sensitiveProperties: {},
-      },
-    });
-  });
-
-  it('includes quote metrics', async () => {
-    useTransactionPayTotalsMock.mockReturnValue({
-      fees: {
-        sourceNetwork: { estimate: { usd: '1.5', fiat: '1.6' } },
-        targetNetwork: { usd: '2.5', fiat: '2.6' },
-        provider: { usd: '0.5', fiat: '0.6' },
-        metaMask: { usd: '0', fiat: '0' },
-      },
-    } as ReturnType<typeof useTransactionPayTotals>);
-
-    useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
-
-    runHook();
-
-    await act(async () => noop());
-
-    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-      id: transactionIdMock,
-      params: {
-        properties: expect.objectContaining({
-          mm_pay_network_fee_usd: '4',
-          mm_pay_provider_fee_usd: '0.5',
-          mm_pay_strategy: 'mm_swaps_bridge',
-        }),
-        sensitiveProperties: {},
-      },
-    });
-  });
-
-  describe('mm_pay_sending_value_usd', () => {
-    it('tracks USD value from required token amountUsd', async () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: PAY_TOKEN_MOCK,
-        setPayToken: noop,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        {
-          amountHuman: '1.5',
-          amountUsd: '3000.50',
-        } as TransactionPayRequiredToken,
-      ]);
-
-      runHook();
-
-      await act(async () => noop());
-
-      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-        id: transactionIdMock,
-        params: {
-          properties: expect.objectContaining({
-            mm_pay_sending_value_usd: 3000.5,
-          }),
-          sensitiveProperties: {},
-        },
-      });
-    });
-
-    it('defaults to 0 when amountUsd is not available', async () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: PAY_TOKEN_MOCK,
-        setPayToken: noop,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      useTransactionPayRequiredTokensMock.mockReturnValue([
-        {
-          amountHuman: '1.5',
-        } as TransactionPayRequiredToken,
-      ]);
-
-      runHook();
-
-      await act(async () => noop());
-
-      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-        id: transactionIdMock,
-        params: {
-          properties: expect.objectContaining({
-            mm_pay_sending_value_usd: 0,
-          }),
-          sensitiveProperties: {},
-        },
-      });
-    });
-  });
-
-  describe('mm_pay_receiving_value_usd', () => {
-    it('tracks USD value from totals targetAmount', async () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: PAY_TOKEN_MOCK,
-        setPayToken: noop,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      useTransactionPayTotalsMock.mockReturnValue({
-        fees: {
-          sourceNetwork: { estimate: { usd: '1', fiat: '1' } },
-          targetNetwork: { usd: '1', fiat: '1' },
-          provider: { usd: '0', fiat: '0' },
-          metaMask: { usd: '0', fiat: '0' },
-        },
-        targetAmount: { usd: '2950.25', fiat: '2950.25' },
-      } as ReturnType<typeof useTransactionPayTotals>);
-
-      runHook();
-
-      await act(async () => noop());
-
-      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-        id: transactionIdMock,
-        params: {
-          properties: expect.objectContaining({
-            mm_pay_receiving_value_usd: 2950.25,
-          }),
-          sensitiveProperties: {},
-        },
-      });
-    });
-
-    it('is null when totals are not available', async () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: PAY_TOKEN_MOCK,
-        setPayToken: noop,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      useTransactionPayTotalsMock.mockReturnValue(undefined);
-
-      runHook();
-
-      await act(async () => noop());
-
-      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-        id: transactionIdMock,
-        params: {
-          properties: expect.objectContaining({
-            mm_pay_receiving_value_usd: null,
-          }),
-          sensitiveProperties: {},
-        },
-      });
-    });
-  });
-
-  describe('mm_pay_metamask_fee_usd', () => {
-    it('tracks MetaMask fee USD from totals', async () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: PAY_TOKEN_MOCK,
-        setPayToken: noop,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      useTransactionPayTotalsMock.mockReturnValue({
-        fees: {
-          sourceNetwork: { estimate: { usd: '1', fiat: '1' } },
-          targetNetwork: { usd: '0', fiat: '0' },
-          provider: { usd: '0.03', fiat: '0.03' },
-          metaMask: { usd: '0.00435', fiat: '0.00435' },
-        },
-        targetAmount: { usd: '0.46', fiat: '0.46' },
-      } as ReturnType<typeof useTransactionPayTotals>);
-
-      runHook();
-
-      await act(async () => noop());
-
-      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-        id: transactionIdMock,
-        params: {
-          properties: expect.objectContaining({
-            mm_pay_metamask_fee_usd: 0.00435,
-          }),
-          sensitiveProperties: {},
-        },
-      });
-    });
-
-    it('defaults to 0 when metaMask fee is not available', async () => {
-      useTransactionPayTokenMock.mockReturnValue({
-        payToken: PAY_TOKEN_MOCK,
-        setPayToken: noop,
-      } as ReturnType<typeof useTransactionPayToken>);
-
-      useTransactionPayTotalsMock.mockReturnValue({
-        fees: {
-          sourceNetwork: { estimate: { usd: '1', fiat: '1' } },
-          targetNetwork: { usd: '0', fiat: '0' },
-          provider: { usd: '0', fiat: '0' },
-          metaMask: { usd: '0', fiat: '0' },
-        },
-        targetAmount: { usd: '0.46', fiat: '0.46' },
-      } as ReturnType<typeof useTransactionPayTotals>);
-
-      runHook();
-
-      await act(async () => noop());
-
-      expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
-        id: transactionIdMock,
-        params: {
-          properties: expect.objectContaining({
-            mm_pay_metamask_fee_usd: 0,
-          }),
-          sensitiveProperties: {},
-        },
-      });
     });
   });
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -16,24 +16,29 @@ import { hasTransactionType } from '../../utils/transaction';
 import {
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
-  useTransactionPayTotals,
 } from './useTransactionPayData';
-import { TransactionPayStrategy } from '@metamask/transaction-pay-controller';
-import { BigNumber } from 'bignumber.js';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { useAccountTokens } from '../send/useAccountTokens';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 
+/**
+ * Dispatches UI-only mm_pay_* properties to confirmationMetrics.
+ *
+ * Core mm_pay_* properties (token, chain, use_case, fees, strategy, etc.)
+ * are derived from controller state in getMetaMaskPayProperties and do not
+ * depend on the confirmation screen lifecycle.
+ *
+ * This hook only provides properties that require live UI context:
+ * token presented, quote status, available token list size, etc.
+ */
 export function useTransactionPayMetrics() {
   const dispatch = useDispatch();
   const transactionMeta = useTransactionMetadataRequest();
   const { payToken } = useTransactionPayToken();
-  const requiredTokens = useTransactionPayRequiredTokens();
   const highestBalanceChainId = useHighestBalanceCaipChainId();
   const automaticPayToken = useRef<BridgeToken>();
   const hasLoadedQuoteRef = useRef(false);
   const quotes = useTransactionPayQuotes();
-  const totals = useTransactionPayTotals();
   const { availableTokens: tokens } = useTransactionPayAvailableTokens();
 
   const transactionId = transactionMeta?.id ?? '';
@@ -51,8 +56,11 @@ export function useTransactionPayMetrics() {
     () => tokens.filter((t) => !t.disabled),
     [tokens],
   );
-  const { chainId, type } = transactionMeta ?? {};
-  const primaryRequiredToken = requiredTokens.find((t) => !t.skipIfBalance);
+
+  const { chainId } = transactionMeta ?? {};
+  const primaryRequiredToken = useTransactionPayRequiredTokens().find(
+    (t) => !t.skipIfBalance,
+  );
   const sendingValue = Number(primaryRequiredToken?.amountHuman ?? '0');
 
   if (!automaticPayToken.current && payToken) {
@@ -63,14 +71,6 @@ export function useTransactionPayMetrics() {
   const sensitiveProperties: Json = {};
 
   if (payToken) {
-    properties.mm_pay = true;
-    properties.mm_pay_token_selected = payToken.symbol;
-    properties.mm_pay_chain_selected = payToken.chainId;
-    properties.mm_pay_transaction_step_total = (quotes?.length ?? 0) + 1;
-
-    properties.mm_pay_transaction_step =
-      properties.mm_pay_transaction_step_total;
-
     properties.mm_pay_token_presented =
       automaticPayToken.current?.symbol ?? null;
 
@@ -86,33 +86,12 @@ export function useTransactionPayMetrics() {
       highestBalanceChainId ?? null;
   }
 
-  if (payToken && type === TransactionType.perpsDeposit) {
-    properties.mm_pay_use_case = 'perps_deposit';
-    properties.simulation_sending_assets_total_value = sendingValue;
-  }
-
   if (
     payToken &&
-    hasTransactionType(transactionMeta, [TransactionType.predictDeposit])
+    (hasTransactionType(transactionMeta, [TransactionType.perpsDeposit]) ||
+      hasTransactionType(transactionMeta, [TransactionType.predictDeposit]))
   ) {
-    properties.mm_pay_use_case = 'predict_deposit';
     properties.simulation_sending_assets_total_value = sendingValue;
-  }
-
-  if (
-    payToken &&
-    hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])
-  ) {
-    properties.mm_pay_use_case = 'predict_withdraw';
-  }
-
-  if (payToken) {
-    const sendingAmountUsd = Number(primaryRequiredToken?.amountUsd ?? '0');
-    properties.mm_pay_sending_value_usd = sendingAmountUsd;
-
-    properties.mm_pay_receiving_value_usd = totals
-      ? Number(totals.targetAmount.usd)
-      : null;
   }
 
   const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
@@ -123,27 +102,6 @@ export function useTransactionPayMetrics() {
 
   if (nonGasQuote) {
     properties.mm_pay_dust_usd = nonGasQuote.dust.usd;
-  }
-
-  const strategy = quotes?.[0]?.strategy;
-
-  if (strategy === TransactionPayStrategy.Bridge) {
-    properties.mm_pay_strategy = 'mm_swaps_bridge';
-  }
-
-  if (strategy === TransactionPayStrategy.Relay) {
-    properties.mm_pay_strategy = 'relay';
-  }
-
-  if (totals) {
-    properties.mm_pay_network_fee_usd = new BigNumber(
-      totals.fees.sourceNetwork.estimate.usd,
-    )
-      .plus(totals.fees.targetNetwork.usd)
-      .toString(10);
-
-    properties.mm_pay_provider_fee_usd = totals.fees.provider.usd;
-    properties.mm_pay_metamask_fee_usd = Number(totals.fees.metaMask.usd);
   }
 
   const params = useDeepMemo(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -19,7 +19,6 @@ import {
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { useAccountTokens } from '../send/useAccountTokens';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
 
 /**
  * Dispatches UI-only mm_pay_* properties to confirmationMetrics.
@@ -57,7 +56,6 @@ export function useTransactionPayMetrics() {
     [tokens],
   );
 
-  const { chainId } = transactionMeta ?? {};
   const primaryRequiredToken = useTransactionPayRequiredTokens().find(
     (t) => !t.skipIfBalance,
   );
@@ -92,16 +90,6 @@ export function useTransactionPayMetrics() {
       hasTransactionType(transactionMeta, [TransactionType.predictDeposit]))
   ) {
     properties.simulation_sending_assets_total_value = sendingValue;
-  }
-
-  const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
-
-  const nonGasQuote = quotes?.find(
-    (q) => q.request?.targetTokenAddress !== nativeTokenAddress,
-  );
-
-  if (nonGasQuote) {
-    properties.mm_pay_dust_usd = nonGasQuote.dust.usd;
   }
 
   const params = useDeepMemo(

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -116,7 +116,7 @@ describe('Metamask Pay Metrics', () => {
         type: TransactionType.perpsDeposit,
         metamaskPay: { chainId: '0x1', tokenAddress: '0xA0b8' },
         requiredTransactionIds: ['child-1'],
-      } as TransactionMeta,
+      } as unknown as TransactionMeta,
     ];
 
     const result = getMetaMaskPayProperties(request);
@@ -171,7 +171,7 @@ describe('Metamask Pay Metrics', () => {
         type: TransactionType.predictWithdraw,
         metamaskPay: { chainId: '0x38', tokenAddress: '0x000' },
         requiredTransactionIds: ['child-1'],
-      } as TransactionMeta,
+      } as unknown as TransactionMeta,
     ];
 
     const result = getMetaMaskPayProperties(request);

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -17,8 +17,9 @@ const PAY_CONTROLLER_STATE_MOCK = {
         transactionData: {
           'parent-1': {
             quotes: [
-              {},
+              { dust: { usd: '0', fiat: '0' } },
               {
+                dust: { usd: '0', fiat: '0' },
                 original: {
                   metrics: { attempts: 3, buffer: 0.123, latency: 1234 },
                   quote: { bridgeId: 'testBridge' },
@@ -41,10 +42,6 @@ describe('Metamask Pay Metrics', () => {
     Parameters<TransactionMetricsBuilder>[0]['getState']
   > = jest.fn();
 
-  const getUIMetricsMock: jest.MockedFn<
-    Parameters<TransactionMetricsBuilder>[0]['getUIMetrics']
-  > = jest.fn();
-
   let request: Parameters<TransactionMetricsBuilder>[0];
 
   beforeEach(() => {
@@ -57,7 +54,7 @@ describe('Metamask Pay Metrics', () => {
         txParams: { nonce: '0x1' },
       } as TransactionMeta,
       allTransactions: [],
-      getUIMetrics: getUIMetricsMock,
+      getUIMetrics: jest.fn(),
       getState: getStateMock,
       initMessenger: {} as never,
       smartTransactionsController: {} as never,
@@ -86,20 +83,38 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
-  it('copies properties from parent transaction if bridge', () => {
-    getUIMetricsMock.mockReturnValue({
-      properties: {
-        mm_pay: true,
-        mm_pay_use_case: 'test_use_case',
-        mm_pay_transaction_step_total: 3,
+  it('derives parent mm_pay_* properties for child transaction from controller state', () => {
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: { allTokens: {} },
+          TransactionPayController: {
+            transactionData: {
+              'parent-1': {
+                paymentToken: { symbol: 'USDC', chainId: '0x1' },
+                quotes: [{ strategy: TransactionPayStrategy.Relay }],
+                tokens: [{ skipIfBalance: false, amountUsd: '100' }],
+                totals: {
+                  targetAmount: { usd: '99', fiat: '99' },
+                  fees: {
+                    metaMask: { usd: '0.5', fiat: '0.5' },
+                    provider: { usd: '0.3', fiat: '0.3' },
+                    sourceNetwork: { estimate: { usd: '0.1', fiat: '0.1' } },
+                    targetNetwork: { usd: '0.05', fiat: '0.05' },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
-      sensitiveProperties: {},
-    });
+    } as never);
 
     request.allTransactions = [
       {
         id: 'parent-1',
         type: TransactionType.perpsDeposit,
+        metamaskPay: { chainId: '0x1', tokenAddress: '0xA0b8' },
         requiredTransactionIds: ['child-1'],
       } as TransactionMeta,
     ];
@@ -109,30 +124,52 @@ describe('Metamask Pay Metrics', () => {
     expect(result).toStrictEqual({
       properties: expect.objectContaining({
         mm_pay: true,
-        mm_pay_use_case: 'test_use_case',
-        mm_pay_transaction_step_total: 3,
+        mm_pay_use_case: 'perps_deposit',
+        mm_pay_token_selected: 'USDC',
+        mm_pay_chain_selected: '0x1',
+        mm_pay_sending_value_usd: 100,
+        mm_pay_receiving_value_usd: 99,
+        mm_pay_metamask_fee_usd: 0.5,
+        mm_pay_strategy: 'relay',
+        mm_pay_transaction_step: 1,
+        mm_pay_transaction_step_total: 2,
       }),
       sensitiveProperties: {},
     });
   });
 
-  it('copies USD value metrics from predictWithdraw parent to child', () => {
-    getUIMetricsMock.mockReturnValue({
-      properties: {
-        mm_pay: true,
-        mm_pay_use_case: 'predict_withdraw',
-        mm_pay_transaction_step_total: 2,
-        mm_pay_sending_value_usd: 1500.5,
-        mm_pay_receiving_value_usd: 1495.25,
-        mm_pay_metamask_fee_usd: 0.00435,
+  it('derives parent mm_pay_* properties for predictWithdraw child transaction', () => {
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: { allTokens: {} },
+          TransactionPayController: {
+            transactionData: {
+              'parent-1': {
+                paymentToken: { symbol: 'BNB', chainId: '0x38' },
+                quotes: [{ strategy: TransactionPayStrategy.Relay }],
+                tokens: [{ skipIfBalance: false, amountUsd: '1500.50' }],
+                totals: {
+                  targetAmount: { usd: '1495.25', fiat: '1495.25' },
+                  fees: {
+                    metaMask: { usd: '0.00435', fiat: '0.00435' },
+                    provider: { usd: '0', fiat: '0' },
+                    sourceNetwork: { estimate: { usd: '0', fiat: '0' } },
+                    targetNetwork: { usd: '0', fiat: '0' },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
-      sensitiveProperties: {},
-    });
+    } as never);
 
     request.allTransactions = [
       {
         id: 'parent-1',
         type: TransactionType.predictWithdraw,
+        metamaskPay: { chainId: '0x38', tokenAddress: '0x000' },
         requiredTransactionIds: ['child-1'],
       } as TransactionMeta,
     ];
@@ -143,40 +180,9 @@ describe('Metamask Pay Metrics', () => {
       properties: expect.objectContaining({
         mm_pay: true,
         mm_pay_use_case: 'predict_withdraw',
-        mm_pay_transaction_step_total: 2,
         mm_pay_sending_value_usd: 1500.5,
         mm_pay_receiving_value_usd: 1495.25,
         mm_pay_metamask_fee_usd: 0.00435,
-      }),
-      sensitiveProperties: {},
-    });
-  });
-
-  it('copies properties from parent transaction if swap', () => {
-    getUIMetricsMock.mockReturnValue({
-      properties: {
-        mm_pay: true,
-        mm_pay_use_case: 'test_use_case',
-        mm_pay_transaction_step_total: 3,
-      },
-      sensitiveProperties: {},
-    });
-
-    request.allTransactions = [
-      {
-        id: 'parent-1',
-        type: TransactionType.perpsDeposit,
-        requiredTransactionIds: ['child-1'],
-      } as TransactionMeta,
-    ];
-
-    const result = getMetaMaskPayProperties(request);
-
-    expect(result).toStrictEqual({
-      properties: expect.objectContaining({
-        mm_pay: true,
-        mm_pay_use_case: 'test_use_case',
-        mm_pay_transaction_step_total: 3,
       }),
       sensitiveProperties: {},
     });
@@ -282,15 +288,8 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
-  it('adds dust property', () => {
+  it('adds dust property from quote', () => {
     request.transactionMeta.type = TransactionType.bridge;
-
-    getUIMetricsMock.mockReturnValue({
-      properties: {
-        mm_pay_dust_usd: '1.23',
-      },
-      sensitiveProperties: {},
-    });
 
     request.allTransactions = [
       {
@@ -305,7 +304,28 @@ describe('Metamask Pay Metrics', () => {
       request.transactionMeta,
     ];
 
-    getStateMock.mockReturnValue(PAY_CONTROLLER_STATE_MOCK);
+    getStateMock.mockReturnValue(
+      merge({}, PAY_CONTROLLER_STATE_MOCK, {
+        engine: {
+          backgroundState: {
+            TransactionPayController: {
+              transactionData: {
+                'parent-1': {
+                  quotes: [
+                    {},
+                    {
+                      dust: { usd: '1.23', fiat: '1.23' },
+                      request: { targetTokenAddress: '0x123' },
+                      strategy: TransactionPayStrategy.Bridge,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      }) as unknown as RootState,
+    );
 
     const result = getMetaMaskPayProperties(request);
 
@@ -319,13 +339,6 @@ describe('Metamask Pay Metrics', () => {
 
   it('does not add dust property if native bridge', () => {
     request.transactionMeta.type = TransactionType.bridge;
-
-    getUIMetricsMock.mockReturnValue({
-      properties: {
-        mm_pay_dust_usd: '1.23',
-      },
-      sensitiveProperties: {},
-    });
 
     request.allTransactions = [
       {

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -400,7 +400,7 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
-  it('generates fallback properties from transaction metadata', () => {
+  it('derives base properties from metamaskPay metadata', () => {
     request.transactionMeta.metamaskPay = {
       chainId: '0x3',
       tokenAddress: '0x123',
@@ -438,7 +438,77 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
-  it('does not include token symbol in fallback properties if token is not found', () => {
+  it('prefers paymentToken.symbol over token selector lookup', () => {
+    request.transactionMeta.metamaskPay = {
+      chainId: '0x38',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+    };
+
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: { allTokens: {} },
+          TransactionPayController: {
+            transactionData: {
+              'child-1': {
+                paymentToken: { symbol: 'BNB', chainId: '0x38' },
+                tokens: [],
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay: true,
+        mm_pay_chain_selected: '0x38',
+        mm_pay_token_selected: 'BNB',
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
+  it('falls back to token selector when paymentToken is unavailable', () => {
+    request.transactionMeta.metamaskPay = {
+      chainId: '0x3',
+      tokenAddress: '0x123',
+    };
+
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: {
+            allTokens: {
+              '0x3': {
+                '0x123': [
+                  {
+                    address: '0x123',
+                    symbol: 'USDC',
+                    decimals: 18,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay_token_selected: 'USDC',
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
+  it('does not include token symbol if neither source has it', () => {
     request.transactionMeta.metamaskPay = {
       chainId: '0x3',
       tokenAddress: '0x123',
@@ -461,6 +531,90 @@ describe('Metamask Pay Metrics', () => {
         mm_pay: true,
         mm_pay_chain_selected: '0x3',
         mm_pay_token_selected: undefined,
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
+  it('derives mm_pay_use_case from transaction type', () => {
+    request.transactionMeta.type = TransactionType.predictWithdraw;
+    request.transactionMeta.metamaskPay = {
+      chainId: '0x89',
+      tokenAddress: '0x123',
+    };
+
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: { allTokens: {} },
+        },
+      },
+    } as never);
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay_use_case: 'predict_withdraw',
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
+  it('derives fee and value properties from TransactionPayController state', () => {
+    request.transactionMeta.type = TransactionType.predictWithdraw;
+    request.transactionMeta.metamaskPay = {
+      chainId: '0x38',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+    };
+
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: { allTokens: {} },
+          TransactionPayController: {
+            transactionData: {
+              'child-1': {
+                paymentToken: { symbol: 'BNB', chainId: '0x38' },
+                quotes: [{ strategy: TransactionPayStrategy.Relay }],
+                tokens: [
+                  { skipIfBalance: false, amountUsd: '0.30' },
+                  { skipIfBalance: true, amountUsd: '0.10' },
+                ],
+                totals: {
+                  targetAmount: { usd: '0.26', fiat: '0.26' },
+                  fees: {
+                    metaMask: { usd: '0.003', fiat: '0.003' },
+                    provider: { usd: '0.04', fiat: '0.04' },
+                    sourceNetwork: {
+                      estimate: { usd: '0.005', fiat: '0.005' },
+                    },
+                    targetNetwork: { usd: '0.001', fiat: '0.001' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay: true,
+        mm_pay_chain_selected: '0x38',
+        mm_pay_token_selected: 'BNB',
+        mm_pay_use_case: 'predict_withdraw',
+        mm_pay_sending_value_usd: 0.3,
+        mm_pay_receiving_value_usd: 0.26,
+        mm_pay_metamask_fee_usd: 0.003,
+        mm_pay_provider_fee_usd: '0.04',
+        mm_pay_network_fee_usd: '0.006',
+        mm_pay_strategy: 'relay',
+        mm_pay_transaction_step_total: 2,
+        mm_pay_transaction_step: 2,
       }),
       sensitiveProperties: {},
     });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -19,15 +19,6 @@ import { BigNumber } from 'bignumber.js';
 
 const FOUR_BYTE_SAFE_PROXY_CREATE = '0xa1884d2c';
 
-const COPY_METRICS = [
-  'mm_pay',
-  'mm_pay_use_case',
-  'mm_pay_transaction_step_total',
-  'mm_pay_sending_value_usd',
-  'mm_pay_receiving_value_usd',
-  'mm_pay_metamask_fee_usd',
-] as const;
-
 const PAY_TYPES = [
   TransactionType.perpsDeposit,
   TransactionType.perpsWithdraw,
@@ -46,7 +37,6 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
   eventType,
   transactionMeta,
   allTransactions,
-  getUIMetrics,
   getState,
 }) => {
   const properties: JsonMap = {};
@@ -82,13 +72,7 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
     };
   }
 
-  const parentMetrics = getUIMetrics(parentTransaction.id);
-
-  for (const key of COPY_METRICS) {
-    if (parentMetrics?.properties?.[key] !== undefined) {
-      properties[key] = parentMetrics.properties[key];
-    }
-  }
+  addPayTypeProperties(properties, parentTransaction, getState());
 
   const relatedTransactionIds = parentTransaction.requiredTransactionIds ?? [];
 
@@ -130,7 +114,7 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
     }
 
     if (quote && quote.request.targetTokenAddress !== NATIVE_TOKEN_ADDRESS) {
-      properties.mm_pay_dust_usd = parentMetrics?.properties?.mm_pay_dust_usd;
+      properties.mm_pay_dust_usd = quote.dust.usd;
     }
   }
 

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -15,6 +15,7 @@ import { RootState } from '../../../../../reducers';
 import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
 import { Hex } from '@metamask/utils';
 import { TRANSACTION_EVENTS } from '../../../../Analytics/events/confirmations';
+import { BigNumber } from 'bignumber.js';
 
 const FOUR_BYTE_SAFE_PROXY_CREATE = '0xa1884d2c';
 
@@ -32,6 +33,13 @@ const PAY_TYPES = [
   TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
+];
+
+const USE_CASE_MAP: [TransactionType[], string][] = [
+  [[TransactionType.predictWithdraw], 'predict_withdraw'],
+  [[TransactionType.predictDeposit], 'predict_deposit'],
+  [[TransactionType.perpsDeposit], 'perps_deposit'],
+  [[TransactionType.perpsWithdraw], 'perps_withdraw'],
 ];
 
 export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
@@ -57,7 +65,7 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
   }
 
   if (isPayType || !parentTransaction) {
-    addFallbackProperties(properties, transactionMeta, getState());
+    addPayTypeProperties(properties, transactionMeta, getState());
 
     if (isPayType || properties.mm_pay) {
       addTimeToComplete(
@@ -169,12 +177,17 @@ function addTimeToComplete(
     Math.round(Date.now() - submittedTime) / 1000;
 }
 
-function addFallbackProperties(
+/**
+ * Derives mm_pay_* properties from controller state for PAY_TYPE transactions.
+ * Uses transactionMeta.metamaskPay and TransactionPayController.transactionData
+ * as the single source of truth, independent of UI hook lifecycle.
+ */
+function addPayTypeProperties(
   properties: JsonMap,
   transaction: TransactionMeta,
   state: RootState,
 ) {
-  const { metamaskPay } = transaction;
+  const { metamaskPay, id: transactionId } = transaction;
 
   if (
     !metamaskPay?.chainId ||
@@ -189,11 +202,58 @@ function addFallbackProperties(
   properties.mm_pay = true;
   properties.mm_pay_chain_selected = chainId;
 
-  properties.mm_pay_token_selected = getTokenSymbol(
-    state,
-    chainId,
-    tokenAddress,
+  const txPayData =
+    state.engine.backgroundState.TransactionPayController?.transactionData?.[
+      transactionId
+    ];
+
+  properties.mm_pay_token_selected =
+    txPayData?.paymentToken?.symbol ??
+    getTokenSymbol(state, chainId, tokenAddress);
+
+  for (const [types, useCase] of USE_CASE_MAP) {
+    if (hasTransactionType(transaction, types)) {
+      properties.mm_pay_use_case = useCase;
+      break;
+    }
+  }
+
+  if (!txPayData) {
+    return;
+  }
+
+  const { quotes, totals, tokens } = txPayData;
+  const primaryRequiredToken = tokens?.find(
+    (t: { skipIfBalance: boolean }) => !t.skipIfBalance,
   );
+
+  if (primaryRequiredToken) {
+    properties.mm_pay_sending_value_usd = Number(
+      primaryRequiredToken.amountUsd ?? '0',
+    );
+  }
+
+  if (totals) {
+    properties.mm_pay_receiving_value_usd = Number(totals.targetAmount.usd);
+    properties.mm_pay_metamask_fee_usd = Number(totals.fees.metaMask.usd);
+    properties.mm_pay_provider_fee_usd = totals.fees.provider.usd;
+    properties.mm_pay_network_fee_usd = new BigNumber(
+      totals.fees.sourceNetwork.estimate.usd,
+    )
+      .plus(totals.fees.targetNetwork.usd)
+      .toString(10);
+  }
+
+  const strategy = quotes?.[0]?.strategy;
+
+  if (strategy === TransactionPayStrategy.Bridge) {
+    properties.mm_pay_strategy = 'mm_swaps_bridge';
+  } else if (strategy === TransactionPayStrategy.Relay) {
+    properties.mm_pay_strategy = 'relay';
+  }
+
+  properties.mm_pay_transaction_step_total = (quotes?.length ?? 0) + 1;
+  properties.mm_pay_transaction_step = properties.mm_pay_transaction_step_total;
 }
 
 function getTokenSymbol(state: RootState, chainId: Hex, tokenAddress: Hex) {


### PR DESCRIPTION
## **Description**

MM Pay analytics properties (`mm_pay_*`) on the `Transaction Finalized` event were intermittently missing for `predict_deposit`, `perps_deposit` and for `predict_withdraw` transactions.

The properties were set by a React hook (`useTransactionPayMetrics`) that dispatches to Redux via `useEffect`. When the confirmation screen unmounted before the effect fired, the data was lost.

This PR moves core `mm_pay_*` derivation into the `getMetaMaskPayProperties` metrics builder, reading directly from `transactionMeta.metamaskPay` and `TransactionPayController.transactionData` — controller state that persists regardless of UI lifecycle. The hook now only dispatches UI-specific properties (e.g., `mm_pay_token_presented`, `mm_pay_quote_loaded`).

## **Changelog**

CHANGELOG entry: fix: derive mm_pay_* metrics from controller state for reliable Transaction Finalized tracking

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1102

## **Manual testing steps**

```gherkin
Feature: MM Pay predict withdraw analytics

  Scenario: Transaction Finalized event includes all mm_pay_* properties
    Given user has a Polymarket position to withdraw
    And user has tokens on a different chain (e.g., BNB on BSC)

    When user initiates a predict withdraw with MM Pay
    And user approves the transaction quickly
    Then the "Transaction Finalized" event for transaction_type "predict_withdraw" includes all mm_pay_* properties (mm_pay, mm_pay_use_case, mm_pay_token_selected, mm_pay_chain_selected, mm_pay_sending_value_usd, mm_pay_receiving_value_usd, mm_pay_metamask_fee_usd, mm_pay_strategy)
```

## **Screenshots/Recordings**

### **Before**

`mm_pay_*` properties intermittently missing on predict_withdraw Transaction Finalized events.

### **After**

All core `mm_pay_*` properties reliably present, derived from controller state.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics metric composition for MetaMask Pay transactions and changes the source of truth for fee/value/strategy fields; mistakes could silently regress tracking correctness across pay flows.
> 
> **Overview**
> Ensures `Transaction Finalized` analytics consistently include core `mm_pay_*` properties by **deriving them in `getMetaMaskPayProperties` from `transactionMeta.metamaskPay` and `TransactionPayController.transactionData`**, rather than relying on confirmation-screen lifecycle.
> 
> `useTransactionPayMetrics` is reduced to dispatching **UI-only** fields (e.g., `mm_pay_token_presented`, quote loaded/requested, token list size, highest-balance chain) and now explicitly avoids emitting builder-owned properties like token/chain selected, use case, fees, strategy, dust, and step counts.
> 
> Tests are updated accordingly: hook tests assert only UI-scoped metrics are dispatched, and `metamask-pay` builder tests now validate fee/value/strategy/use-case/step/dust derivation from controller state (including preference for `paymentToken.symbol` over token lookup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bbf16be2856e5b49256dbb33b540963b1538623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->