### PR TITLE
fix(predict): persist activeBuyOrder state and fix multiple Predict buy-with-any-token issues

### DIFF
--- a/app/components/UI/Predict/README.md
+++ b/app/components/UI/Predict/README.md
@@ -174,19 +174,25 @@ Flow logic (deposit → order chaining, error handling, state transitions) lives
 
 ## Active Order Lifecycle
 
-The `activeBuyOrder` in `PredictControllerState` tracks the full lifecycle of a single buy order from preview to completion. Only one order can be active at a time. All state transitions are owned by `PredictController` methods — hooks react to state changes via effects rather than driving transitions themselves.
+The `activeBuyOrders` map in `PredictControllerState` tracks the full lifecycle of buy orders **per account address**. Each address can have at most one active order at a time. All state transitions are owned by `PredictController` methods — hooks react to state changes via effects rather than driving transitions themselves.
+
+The active order **persists across navigation**. When a user places a deposit-and-order bet and navigates away, the order state (DEPOSITING, PLACING_ORDER) is preserved. The user cannot place a second order while one is in-flight — the UI blocks interaction via `isPlacingOrder`. When the background order completes, `onPlaceOrderSuccess()` resets the entry to PREVIEW (never null).
 
 When the active order enters `PAY_WITH_ANY_TOKEN` and `placeOrder()` is called, the controller stores the preview and analytics in an in-memory `pendingOrderPreviews` map keyed by `transactionId`. After the deposit transaction confirms, `handleTransactionSideEffects()` looks up the stored preview and automatically calls `placeOrder()` to complete the order.
 
 ### State Shape
 
 ```typescript
-activeBuyOrder: {
-  transactionId?: string;                          // Transaction ID linking deposit to order (for deposit-and-order flow)
-  state: ActiveOrderState;                         // Current lifecycle state
-  error?: string;                                  // Error message from failed operations
-} | null;
+activeBuyOrders: {
+  [address: string]: {
+    transactionId?: string;    // Transaction ID linking deposit to order (deposit-and-order flow only)
+    state: ActiveOrderState;   // Current lifecycle state
+    error?: string;            // Error message from failed operations
+  };
+};
 ```
+
+Entries are lazily created by `initPayWithAnyToken()` on first buy screen mount for a given address. Default state is `{}` (empty map). The selector `selectPredictActiveBuyOrder` resolves the current account address to read the correct entry.
 
 ### ActiveOrderState
 
@@ -196,7 +202,7 @@ enum ActiveOrderState {
   PAY_WITH_ANY_TOKEN = 'pay_with_any_token', // External token selected, deposit-and-order tx prepared in background
   DEPOSITING = 'depositing', // Deposit transaction in progress (set by placeOrder when state is PAY_WITH_ANY_TOKEN)
   PLACING_ORDER = 'placing_order', // Order submission in flight
-  SUCCESS = 'success', // Order completed, about to dismiss
+  SUCCESS = 'success', // Order completed, about to reset
 }
 ```
 
@@ -204,7 +210,7 @@ enum ActiveOrderState {
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PREVIEW: initPayWithAnyToken()
+    [*] --> PREVIEW: initPayWithAnyToken() [creates entry if absent]
 
     PREVIEW --> PAY_WITH_ANY_TOKEN: selectPaymentToken(external token)
     PAY_WITH_ANY_TOKEN --> PREVIEW: selectPaymentToken(balance token)
@@ -213,38 +219,50 @@ stateDiagram-v2
     PAY_WITH_ANY_TOKEN --> DEPOSITING: placeOrder() [external token selected]
 
     DEPOSITING --> PLACING_ORDER: handleTransactionSideEffects(depositAndOrder confirmed) → placeOrder()
-    DEPOSITING --> PREVIEW: handleTransactionSideEffects(depositAndOrder failed) [sets error, retries initPayWithAnyToken]
+    DEPOSITING --> PAY_WITH_ANY_TOKEN: handleTransactionSideEffects(depositAndOrder failed) [sets error, retries initPayWithAnyToken]
 
     PLACING_ORDER --> SUCCESS: placeOrder() succeeds
     PLACING_ORDER --> PREVIEW: placeOrder() fails [sets error, clears payment token, retries initPayWithAnyToken]
 
-    SUCCESS --> [*]: onPlaceOrderEnd() + navigation pop
+    SUCCESS --> PREVIEW: onPlaceOrderSuccess() [resets to initial state]
 ```
 
 Notes:
 
-- Back navigation or approval rejection triggers `onPlaceOrderEnd()`, which clears the active order, payment token, and deposit preview.
-- Deposit failure resets to `PREVIEW`, stores the error on `activeBuyOrder.error`, clears `transactionId`, and automatically retries `initPayWithAnyToken()`.
+- The active order is **never set to null** during normal flows. On SUCCESS, `onPlaceOrderSuccess()` resets the entry to `{ state: PREVIEW }` instead of removing it. On navigation back, `beforeRemove` clears only the `transactionId` (via `clearActiveOrderTransactionId()`) and rejects pending approvals — it does not clear the order entry.
+- Deposit failure resets to `PAY_WITH_ANY_TOKEN`, stores the error on `activeBuyOrders[address].error`, clears `transactionId`, and automatically retries `initPayWithAnyToken()`.
 - Order failure resets to `PREVIEW`, stores the error, clears `selectedPaymentToken`, and if a `transactionId` was present, clears it and retries `initPayWithAnyToken()`.
-- The `transitionEnd` listener in `usePredictBuyActions` triggers `initPayWithAnyToken()` once on initial mount to prepare the deposit-and-order batch when an external token is selected.
+- The `transitionEnd` listener in `usePredictBuyActions` triggers `resetSelectedPaymentToken()` then `initPayWithAnyToken()` once on initial mount to prepare the deposit-and-order batch. This ensures each new buy screen starts with Predict balance selected.
+- `initPayWithAnyToken()` guards against duplicate calls: if the order is already in DEPOSITING or PLACING_ORDER, it returns early. If the order is in stale SUCCESS (from a background completion), it resets via `onPlaceOrderSuccess()` first.
 - Transaction status events (`TransactionController:transactionStatusUpdated`) for `predictDepositAndOrder` are handled by `handleTransactionSideEffects()` in the controller, which chains deposit confirmation into `placeOrder()` automatically using the preview stored in `pendingOrderPreviews`.
 - When `placeOrder()` is called while the active order state is `PAY_WITH_ANY_TOKEN`, it transitions to `DEPOSITING`, stores the preview in `pendingOrderPreviews[transactionId]`, and returns early. The actual order placement happens when the deposit transaction confirms.
-- On successful order placement, foreground flows invalidate order-related queries in Predict hooks, while background flows publish `PredictController:transactionStatusChanged` events that trigger app-level query invalidation and toast notifications.
+
+### Foreground vs Background Notification
+
+Order success always publishes a `PredictController:transactionStatusChanged` event (for toast + query invalidation). Order **failure** events use `transactionId` matching to distinguish foreground from background:
+
+- **Foreground** (user on buy screen): `params.transactionId` matches `activeBuyOrders[address].transactionId` → error shown inline on screen, no toast.
+- **Background** (user navigated away): `transactionId` was cleared on navigation back via `clearActiveOrderTransactionId()`, so no match → toast fires.
+- **Balance flow** (no `transactionId`): error always shown inline, no toast (balance orders complete fast).
+
+The `didInitiateOrderRef` in `usePredictBuyActions` tracks whether the current screen instance initiated the order. On SUCCESS, navigation only pops if the ref is true — preventing a background completion from dismissing a different buy screen.
+
 - State transitions are gated behind the `predictWithAnyToken` feature flag — when disabled, `placeOrder()` behaves as a direct order without active order state management.
 
 ### Controller Methods (State Transitions)
 
-| Method                      | Transition                           | Notes                                                                                                                                                      |
-| --------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initPayWithAnyToken()`     | Sets `transactionId` on active order | Prepares deposit-and-order batch via provider; initializes to `PREVIEW` if no active order exists; guards against duplicates                               |
-| `selectPaymentToken()`      | `PREVIEW ↔ PAY_WITH_ANY_TOKEN`      | Toggles between balance and external token; sets/clears `selectedPaymentToken` and clears error                                                            |
-| `placeOrder()`              | `PAY_WITH_ANY_TOKEN -> DEPOSITING`   | When external token selected: stores preview in `pendingOrderPreviews`, transitions to `DEPOSITING`, returns early                                         |
-| `placeOrder()`              | `PREVIEW -> PLACING_ORDER`           | When balance selected: submits order directly to provider                                                                                                  |
-| `placeOrder()`              | `PLACING_ORDER -> SUCCESS`           | On successful order completion; optimistically updates balance; foreground hooks invalidate queries, and background flows publish an order confirmed event |
-| `placeOrder()`              | `PLACING_ORDER -> PREVIEW`           | On order failure; stores error, clears payment token; if `transactionId` present, clears it and retries `initPayWithAnyToken()`                            |
-| `onPlaceOrderEnd()`         | `-> null`                            | Clears active order, payment token, and deposit preview                                                                                                    |
-| `clearOrderError()`         | (no state change)                    | Removes error from active order                                                                                                                            |
-| `setSelectedPaymentToken()` | (no state change)                    | Directly sets or clears the selected payment token in state                                                                                                |
+| Method                            | Transition                            | Notes                                                                                                                                          |
+| --------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initPayWithAnyToken()`           | Creates entry or resets stale SUCCESS | Prepares deposit-and-order batch via provider; creates `{ state: PREVIEW }` entry if absent; guards against DEPOSITING/PLACING_ORDER in-flight |
+| `selectPaymentToken()`            | `PREVIEW ↔ PAY_WITH_ANY_TOKEN`       | Toggles between balance and external token; sets/clears `selectedPaymentToken` and clears error                                                |
+| `placeOrder()`                    | `PAY_WITH_ANY_TOKEN -> DEPOSITING`    | When external token selected: stores preview in `pendingOrderPreviews`, transitions to `DEPOSITING`, returns early                             |
+| `placeOrder()`                    | `PREVIEW -> PLACING_ORDER`            | When balance selected: submits order directly to provider                                                                                      |
+| `placeOrder()`                    | `PLACING_ORDER -> SUCCESS`            | On successful order completion; optimistically updates balance; always publishes order confirmed event                                         |
+| `placeOrder()`                    | `PLACING_ORDER -> PREVIEW`            | On order failure; stores error, clears payment token; publishes failed event only for background orders (transactionId mismatch)               |
+| `onPlaceOrderSuccess()`           | `-> PREVIEW`                          | Resets active order entry to `{ state: PREVIEW }` and clears `selectedPaymentToken`                                                            |
+| `clearActiveOrderTransactionId()` | (clears transactionId only)           | Called on navigation back to signal the screen is no longer handling the order; enables background toast for subsequent failures               |
+| `clearOrderError()`               | (no state change)                     | Removes error from active order                                                                                                                |
+| `setSelectedPaymentToken()`       | (no state change)                     | Directly sets or clears the selected payment token in state                                                                                    |
 
 ## Core Types and Utilities
 

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -1214,7 +1214,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('does not publish order confirmed event when there is an active buy order', async () => {
+    it('publishes order confirmed event when there is an active buy order', async () => {
       const mockResult = {
         success: true as const,
         response: {
@@ -1239,8 +1239,8 @@ describe('PredictController', () => {
 
           await controller.placeOrder({ preview });
 
-          expect(handler).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'order' }),
+          expect(handler).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'order', status: 'confirmed' }),
           );
         },
         {
@@ -1351,7 +1351,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('does not publish order failed event when buy order fails and there is an active buy order', async () => {
+    it('publishes order failed event when buy order fails and there is an active buy order', async () => {
       await withController(
         async ({ controller, messenger }) => {
           mockPolymarketProvider.placeOrder.mockRejectedValue(
@@ -1372,8 +1372,8 @@ describe('PredictController', () => {
             'Order placement failed',
           );
 
-          expect(handler).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'order' }),
+          expect(handler).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'order', status: 'failed' }),
           );
         },
         {
@@ -4150,6 +4150,7 @@ describe('PredictController', () => {
 
     it('still sets selectedPaymentToken when activeOrder is null', () => {
       withController(({ controller }) => {
+        controller.clearActiveOrder();
         expect(controller.state.activeBuyOrder).toBeNull();
 
         controller.selectPaymentToken(
@@ -4197,6 +4198,7 @@ describe('PredictController', () => {
 
     it('does not throw when activeOrder is null', () => {
       withController(({ controller }) => {
+        controller.clearActiveOrder();
         expect(controller.state.activeBuyOrder).toBeNull();
 
         expect(() => controller.clearOrderError()).not.toThrow();
@@ -4268,7 +4270,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('onPlaceOrderEnd sets activeBuyOrder to null and does not clear pendingOrderPreviews', () => {
+    it('clearActiveOrder sets activeBuyOrder to null and does not clear pendingOrderPreviews', () => {
       withController(({ controller }) => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.SUCCESS,
@@ -4278,7 +4280,7 @@ describe('PredictController', () => {
           signerAddress: MOCK_ADDRESS,
         };
 
-        controller.onPlaceOrderEnd();
+        controller.clearActiveOrder();
 
         expect(controller.state.activeBuyOrder).toBeNull();
         expect(getPendingOrderPreviews(controller)['tx-123']).toBeDefined();
@@ -4340,7 +4342,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('isCurrentActiveBuyOrder returns false when activeBuyOrder has no transactionId and a transactionId is provided', async () => {
+    it('updates activeBuyOrder to SUCCESS when buy order completes regardless of transactionId mismatch', async () => {
       await withController(
         async ({ controller }) => {
           setActiveOrderForTest(controller, {
@@ -4364,7 +4366,7 @@ describe('PredictController', () => {
           });
 
           expect(controller.state.activeBuyOrder?.state).toBe(
-            ActiveOrderState.PREVIEW,
+            ActiveOrderState.SUCCESS,
           );
         },
         {
@@ -4379,7 +4381,7 @@ describe('PredictController', () => {
   });
 
   describe('payWithAnyTokenConfirmation', () => {
-    it('initializes an order when there is no active order', async () => {
+    it('initializes deposit batch with default active order in PREVIEW state', async () => {
       await withController(async ({ controller }) => {
         controller.setSelectedPaymentToken({
           address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
@@ -4398,7 +4400,6 @@ describe('PredictController', () => {
         expect(controller.state.activeBuyOrder?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
-        expect(controller.state.selectedPaymentToken).toBeNull();
         expect(mockPolymarketProvider.prepareDeposit).toHaveBeenCalled();
         expect(addTransactionBatch).toHaveBeenCalled();
       });
@@ -4985,7 +4986,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('clears preview activeOrder when deposit-and-order transaction is rejected after switching back to balance', () => {
+    it('resets activeOrder to PREVIEW when deposit-and-order transaction is rejected after switching back to balance', () => {
       withController(({ controller, messenger }) => {
         const transactionMeta = createPredictTransactionMeta({
           nestedType: TransactionType.predictDeposit,
@@ -5008,11 +5009,14 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrder?.state).toBe(
+          ActiveOrderState.PREVIEW,
+        );
+        expect(controller.state.activeBuyOrder?.transactionId).toBeUndefined();
       });
     });
 
-    it('clears activeOrder when deposit-and-order transaction is rejected from preview while an external token is still selected', () => {
+    it('resets activeOrder to PREVIEW and clears selectedPaymentToken when deposit-and-order transaction is rejected from preview while an external token is still selected', () => {
       withController(({ controller, messenger }) => {
         const transactionMeta = createPredictTransactionMeta({
           nestedType: TransactionType.predictDeposit,
@@ -5040,12 +5044,15 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrder?.state).toBe(
+          ActiveOrderState.PREVIEW,
+        );
+        expect(controller.state.activeBuyOrder?.transactionId).toBeUndefined();
         expect(controller.state.selectedPaymentToken).toBeNull();
       });
     });
 
-    it('clears activeOrder when deposit-and-order transaction is rejected outside preview', () => {
+    it('resets activeOrder to PREVIEW when deposit-and-order transaction is rejected outside preview', () => {
       withController(({ controller, messenger }) => {
         const transactionMeta = createPredictTransactionMeta({
           nestedType: TransactionType.predictDeposit,
@@ -5068,7 +5075,10 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrder?.state).toBe(
+          ActiveOrderState.PREVIEW,
+        );
+        expect(controller.state.activeBuyOrder?.transactionId).toBeUndefined();
       });
     });
 
@@ -7445,8 +7455,8 @@ describe('PredictController', () => {
     });
   });
 
-  describe('onPlaceOrderEnd', () => {
-    it('clears activeOrder and selectedPaymentToken', () => {
+  describe('onPlaceOrderSuccess', () => {
+    it('resets activeBuyOrder to PREVIEW and clears selectedPaymentToken', () => {
       withController(({ controller }) => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.SUCCESS,
@@ -7457,14 +7467,16 @@ describe('PredictController', () => {
           symbol: 'USDC',
         });
 
-        controller.onPlaceOrderEnd();
+        controller.onPlaceOrderSuccess();
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrder).toEqual({
+          state: ActiveOrderState.PREVIEW,
+        });
         expect(controller.state.selectedPaymentToken).toBeNull();
       });
     });
 
-    it('does not clear pendingOrderPreviews on navigation away', () => {
+    it('does not clear pendingOrderPreviews on success reset', () => {
       withController(({ controller }) => {
         (
           controller as unknown as {
@@ -7480,7 +7492,7 @@ describe('PredictController', () => {
           signerAddress: MOCK_ADDRESS,
         };
 
-        controller.onPlaceOrderEnd();
+        controller.onPlaceOrderSuccess();
 
         expect(
           (
@@ -7696,7 +7708,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('does not update activeBuyOrder when background order completes for a different active order', async () => {
+    it('updates activeBuyOrder to SUCCESS when background order completes for any buy order', async () => {
       await withController(
         async ({ controller }) => {
           setActiveOrderForTest(controller, {
@@ -7736,7 +7748,7 @@ describe('PredictController', () => {
           });
 
           expect(controller.state.activeBuyOrder?.state).toBe(
-            ActiveOrderState.PREVIEW,
+            ActiveOrderState.SUCCESS,
           );
           expect(mockPolymarketProvider.placeOrder).toHaveBeenCalled();
           expect(
@@ -7762,7 +7774,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('does not clear selectedPaymentToken when background order fails for a different active order', async () => {
+    it('clears selectedPaymentToken when buy order fails with flag enabled', async () => {
       await withController(
         async ({ controller }) => {
           setActiveOrderForTest(controller, {
@@ -7785,11 +7797,7 @@ describe('PredictController', () => {
             controller.placeOrder({ preview, transactionId: 'tx-bg-1' }),
           ).rejects.toThrow('Order failed');
 
-          expect(controller.state.selectedPaymentToken).toEqual({
-            address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-            chainId: '0x89',
-            symbol: 'USDC',
-          });
+          expect(controller.state.selectedPaymentToken).toBeNull();
         },
         {
           mocks: {
@@ -7906,7 +7914,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('does not enter PAY_WITH_ANY_TOKEN branch when transactionId has existing pending preview', async () => {
+    it('skips PAY_WITH_ANY_TOKEN deposit branch and places order directly when transactionId has existing pending preview', async () => {
       await withController(
         async ({ controller }) => {
           setActiveOrderForTest(controller, {
@@ -7946,7 +7954,7 @@ describe('PredictController', () => {
           });
 
           expect(controller.state.activeBuyOrder?.state).toBe(
-            ActiveOrderState.PAY_WITH_ANY_TOKEN,
+            ActiveOrderState.SUCCESS,
           );
           expect(mockPolymarketProvider.placeOrder).toHaveBeenCalled();
         },
@@ -8010,7 +8018,9 @@ describe('PredictController', () => {
 
         await controller.placeOrder({ preview });
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrder?.state).toBe(
+          ActiveOrderState.PREVIEW,
+        );
       });
     });
 
@@ -8207,7 +8217,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('returns activeBuyOrder to preview and retries when depositAndOrder transaction fails', () => {
+    it('returns activeBuyOrder to PAY_WITH_ANY_TOKEN and retries when depositAndOrder transaction fails', () => {
       withController(({ controller, messenger }) => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.DEPOSITING,
@@ -8235,7 +8245,7 @@ describe('PredictController', () => {
         } as { transactionMeta: TransactionMeta });
 
         expect(controller.state.activeBuyOrder?.state).toBe(
-          ActiveOrderState.PREVIEW,
+          ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
         expect(retrySpy).toHaveBeenCalledTimes(1);
       });
@@ -8278,7 +8288,7 @@ describe('PredictController', () => {
 
         expect(retrySpy).toHaveBeenCalledTimes(1);
         expect(controller.state.activeBuyOrder?.state).toBe(
-          ActiveOrderState.PREVIEW,
+          ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
         expect(controller.state.activeBuyOrder?.error).toBe(
           'User rejected the request.',
@@ -8350,7 +8360,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('does not publish order failed event when depositAndOrder fails and there is an active buy order', () => {
+    it('publishes order failed event when depositAndOrder fails and there is an active buy order', () => {
       withController(({ controller, messenger }) => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.DEPOSITING,
@@ -8383,8 +8393,8 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(handler).not.toHaveBeenCalledWith(
-          expect.objectContaining({ type: 'order' }),
+        expect(handler).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'order', status: 'failed' }),
         );
       });
     });
@@ -8450,7 +8460,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('does not retry initPayWithAnyToken when deposit fails for a different active order', () => {
+    it('retries initPayWithAnyToken when deposit fails and activeBuyOrder exists', () => {
       withController(({ controller, messenger }) => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.PREVIEW,
@@ -8476,9 +8486,9 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(retrySpy).not.toHaveBeenCalled();
+        expect(retrySpy).toHaveBeenCalledTimes(1);
         expect(controller.state.activeBuyOrder?.state).toBe(
-          ActiveOrderState.PREVIEW,
+          ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
       });
     });
@@ -8636,7 +8646,7 @@ describe('PredictController', () => {
 
           expect(retrySpy).toHaveBeenCalled();
           expect(controller.state.activeBuyOrder?.state).toBe(
-            ActiveOrderState.PREVIEW,
+            ActiveOrderState.PAY_WITH_ANY_TOKEN,
           );
         });
       });

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -174,10 +174,10 @@ const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
 
 function setActiveOrderForTest(
   controller: PredictController,
-  order: PredictControllerState['activeBuyOrder'],
+  order: PredictControllerState['activeBuyOrders'][string],
 ) {
   controller.updateStateForTesting((state) => {
-    state.activeBuyOrder = order;
+    state.activeBuyOrders[MOCK_ADDRESS] = order;
   });
 }
 
@@ -1330,9 +1330,12 @@ describe('PredictController', () => {
 
           const preview = createMockOrderPreview({ side: Side.BUY });
 
-          await expect(controller.placeOrder({ preview })).rejects.toThrow(
-            'Order placement failed',
-          );
+          await expect(
+            controller.placeOrder({
+              preview,
+              transactionId: 'tx-background',
+            }),
+          ).rejects.toThrow('Order placement failed');
 
           expect(handler).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -1364,13 +1367,17 @@ describe('PredictController', () => {
           );
           setActiveOrderForTest(controller, {
             state: ActiveOrderState.PLACING_ORDER,
+            transactionId: 'tx-active',
           });
 
           const preview = createMockOrderPreview({ side: Side.BUY });
 
-          await expect(controller.placeOrder({ preview })).rejects.toThrow(
-            'Order placement failed',
-          );
+          await expect(
+            controller.placeOrder({
+              preview,
+              transactionId: 'tx-background',
+            }),
+          ).rejects.toThrow('Order placement failed');
 
           expect(handler).toHaveBeenCalledWith(
             expect.objectContaining({ type: 'order', status: 'failed' }),
@@ -3965,7 +3972,7 @@ describe('PredictController', () => {
 
         controller.clearActiveOrder();
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toBeUndefined();
       });
     });
 
@@ -4080,13 +4087,15 @@ describe('PredictController', () => {
           }),
         );
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
-        expect(controller.state.activeBuyOrder?.transactionId).toBe(
-          'batch-123',
-        );
-        expect(controller.state.activeBuyOrder?.error).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
+        ).toBe('batch-123');
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
       });
     });
 
@@ -4103,10 +4112,12 @@ describe('PredictController', () => {
           }),
         );
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
-        expect(controller.state.activeBuyOrder?.error).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
         expect(mockPolymarketProvider.prepareDeposit).not.toHaveBeenCalled();
         expect(addTransactionBatch).not.toHaveBeenCalled();
       });
@@ -4124,7 +4135,7 @@ describe('PredictController', () => {
           }),
         );
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
       });
@@ -4142,7 +4153,7 @@ describe('PredictController', () => {
           }),
         );
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
       });
@@ -4151,7 +4162,7 @@ describe('PredictController', () => {
     it('still sets selectedPaymentToken when activeOrder is null', () => {
       withController(({ controller }) => {
         controller.clearActiveOrder();
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toBeUndefined();
 
         controller.selectPaymentToken(
           createAssetToken({
@@ -4180,7 +4191,9 @@ describe('PredictController', () => {
 
         controller.clearOrderError();
 
-        expect(controller.state.activeBuyOrder?.error).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
       });
     });
 
@@ -4192,14 +4205,16 @@ describe('PredictController', () => {
 
         controller.clearOrderError();
 
-        expect(controller.state.activeBuyOrder?.error).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
       });
     });
 
     it('does not throw when activeOrder is null', () => {
       withController(({ controller }) => {
         controller.clearActiveOrder();
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toBeUndefined();
 
         expect(() => controller.clearOrderError()).not.toThrow();
       });
@@ -4214,7 +4229,7 @@ describe('PredictController', () => {
 
         controller.clearOrderError();
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
       });
@@ -4250,7 +4265,7 @@ describe('PredictController', () => {
 
         controller.clearActiveOrder();
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toBeUndefined();
       });
     });
 
@@ -4263,8 +4278,10 @@ describe('PredictController', () => {
 
         controller.clearOrderError();
 
-        expect(controller.state.activeBuyOrder?.error).toBeUndefined();
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
       });
@@ -4282,7 +4299,7 @@ describe('PredictController', () => {
 
         controller.clearActiveOrder();
 
-        expect(controller.state.activeBuyOrder).toBeNull();
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toBeUndefined();
         expect(getPendingOrderPreviews(controller)['tx-123']).toBeDefined();
       });
     });
@@ -4303,7 +4320,7 @@ describe('PredictController', () => {
             transactionId: 'tx-100',
           });
 
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
             ActiveOrderState.DEPOSITING,
           );
           expect(
@@ -4336,7 +4353,7 @@ describe('PredictController', () => {
           symbol: 'USDC.e',
         } as any);
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
       });
@@ -4365,7 +4382,7 @@ describe('PredictController', () => {
             transactionId: 'tx-1',
           });
 
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
             ActiveOrderState.SUCCESS,
           );
         },
@@ -4383,6 +4400,9 @@ describe('PredictController', () => {
   describe('payWithAnyTokenConfirmation', () => {
     it('initializes deposit batch with default active order in PREVIEW state', async () => {
       await withController(async ({ controller }) => {
+        setActiveOrderForTest(controller, {
+          state: ActiveOrderState.PREVIEW,
+        });
         controller.setSelectedPaymentToken({
           address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
           chainId: '0x89',
@@ -4397,7 +4417,7 @@ describe('PredictController', () => {
             batchId: 'default-batch',
           },
         });
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
         expect(mockPolymarketProvider.prepareDeposit).toHaveBeenCalled();
@@ -4415,7 +4435,7 @@ describe('PredictController', () => {
         const result = await controller.initPayWithAnyToken();
 
         expect(result.success).toBe(true);
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
       });
@@ -4512,7 +4532,7 @@ describe('PredictController', () => {
     it('clears error on activeBuyOrder after successful batch creation', async () => {
       await withController(async ({ controller }) => {
         controller.updateStateForTesting((state) => {
-          state.activeBuyOrder = {
+          state.activeBuyOrders[MOCK_ADDRESS] = {
             state: ActiveOrderState.PREVIEW,
             error: 'previous-error',
           };
@@ -4526,7 +4546,9 @@ describe('PredictController', () => {
             batchId: 'default-batch',
           },
         });
-        expect(controller.state.activeBuyOrder?.error).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
       });
     });
   });
@@ -5009,10 +5031,12 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
-        expect(controller.state.activeBuyOrder?.transactionId).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
+        ).toBeUndefined();
       });
     });
 
@@ -5044,10 +5068,12 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
-        expect(controller.state.activeBuyOrder?.transactionId).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
+        ).toBeUndefined();
         expect(controller.state.selectedPaymentToken).toBeNull();
       });
     });
@@ -5075,10 +5101,12 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
-        expect(controller.state.activeBuyOrder?.transactionId).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
+        ).toBeUndefined();
       });
     });
 
@@ -7469,7 +7497,7 @@ describe('PredictController', () => {
 
         controller.onPlaceOrderSuccess();
 
-        expect(controller.state.activeBuyOrder).toEqual({
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toEqual({
           state: ActiveOrderState.PREVIEW,
         });
         expect(controller.state.selectedPaymentToken).toBeNull();
@@ -7530,7 +7558,7 @@ describe('PredictController', () => {
             success: false,
             response: { status: 'deposit_in_progress' },
           });
-          expect(controller.state.activeBuyOrder).toEqual({
+          expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toEqual({
             state: ActiveOrderState.DEPOSITING,
             transactionId: 'tx-deposit-1',
           });
@@ -7566,7 +7594,7 @@ describe('PredictController', () => {
 
           await controller.placeOrder({ preview });
 
-          expect(controller.state.activeBuyOrder).toEqual({
+          expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toEqual({
             state: ActiveOrderState.SUCCESS,
           });
         },
@@ -7609,12 +7637,12 @@ describe('PredictController', () => {
 
           expect(retrySpy).toHaveBeenCalledTimes(1);
           expect(
-            controller.state.activeBuyOrder?.transactionId,
+            controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
           ).toBeUndefined();
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
             ActiveOrderState.PREVIEW,
           );
-          expect(controller.state.activeBuyOrder?.error).toBe(
+          expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.error).toBe(
             'Order placement failed',
           );
         },
@@ -7633,8 +7661,10 @@ describe('PredictController', () => {
 
       await withController(
         async ({ controller }) => {
-          setActiveOrderForTest(controller, {
-            state: ActiveOrderState.PREVIEW,
+          controller.updateStateForTesting((state) => {
+            state.activeBuyOrders[explicitAddress] = {
+              state: ActiveOrderState.PREVIEW,
+            };
           });
 
           mockPolymarketProvider.placeOrder.mockResolvedValue({
@@ -7650,7 +7680,7 @@ describe('PredictController', () => {
 
           await controller.placeOrder({ preview, address: explicitAddress });
 
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[explicitAddress]?.state).toBe(
             ActiveOrderState.SUCCESS,
           );
           expect(mockPolymarketProvider.placeOrder).toHaveBeenCalledWith(
@@ -7709,10 +7739,13 @@ describe('PredictController', () => {
     });
 
     it('updates activeBuyOrder to SUCCESS when background order completes for any buy order', async () => {
+      const bgAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       await withController(
         async ({ controller }) => {
-          setActiveOrderForTest(controller, {
-            state: ActiveOrderState.PREVIEW,
+          controller.updateStateForTesting((state) => {
+            state.activeBuyOrders[bgAddress] = {
+              state: ActiveOrderState.PREVIEW,
+            };
           });
 
           (
@@ -7727,7 +7760,7 @@ describe('PredictController', () => {
             }
           ).pendingOrderPreviews['tx-bg-1'] = {
             preview: createMockOrderPreview({ side: Side.BUY }),
-            signerAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            signerAddress: bgAddress,
           };
 
           mockPolymarketProvider.placeOrder.mockResolvedValue({
@@ -7743,11 +7776,11 @@ describe('PredictController', () => {
 
           await controller.placeOrder({
             preview,
-            address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            address: bgAddress,
             transactionId: 'tx-bg-1',
           });
 
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[bgAddress]?.state).toBe(
             ActiveOrderState.SUCCESS,
           );
           expect(mockPolymarketProvider.placeOrder).toHaveBeenCalled();
@@ -7915,10 +7948,13 @@ describe('PredictController', () => {
     });
 
     it('skips PAY_WITH_ANY_TOKEN deposit branch and places order directly when transactionId has existing pending preview', async () => {
+      const bgAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       await withController(
         async ({ controller }) => {
-          setActiveOrderForTest(controller, {
-            state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+          controller.updateStateForTesting((state) => {
+            state.activeBuyOrders[bgAddress] = {
+              state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+            };
           });
 
           (
@@ -7933,7 +7969,7 @@ describe('PredictController', () => {
             }
           ).pendingOrderPreviews['tx-bg-1'] = {
             preview: createMockOrderPreview({ side: Side.BUY }),
-            signerAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            signerAddress: bgAddress,
           };
 
           mockPolymarketProvider.placeOrder.mockResolvedValue({
@@ -7949,11 +7985,11 @@ describe('PredictController', () => {
 
           await controller.placeOrder({
             preview,
-            address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            address: bgAddress,
             transactionId: 'tx-bg-1',
           });
 
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[bgAddress]?.state).toBe(
             ActiveOrderState.SUCCESS,
           );
           expect(mockPolymarketProvider.placeOrder).toHaveBeenCalled();
@@ -7995,7 +8031,7 @@ describe('PredictController', () => {
 
         expect(result.success).toBe(true);
         expect(mockPolymarketProvider.placeOrder).toHaveBeenCalled();
-        expect(controller.state.activeBuyOrder?.state).not.toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).not.toBe(
           ActiveOrderState.DEPOSITING,
         );
       });
@@ -8018,9 +8054,7 @@ describe('PredictController', () => {
 
         await controller.placeOrder({ preview });
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
-          ActiveOrderState.PREVIEW,
-        );
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toBeUndefined();
       });
     });
 
@@ -8044,7 +8078,7 @@ describe('PredictController', () => {
 
         await controller.placeOrder({ preview });
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
       });
@@ -8065,7 +8099,7 @@ describe('PredictController', () => {
           'Order failed',
         );
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PLACING_ORDER,
         );
         expect(controller.state.lastError).toBe('Order failed');
@@ -8097,7 +8131,9 @@ describe('PredictController', () => {
         );
 
         expect(retrySpy).not.toHaveBeenCalled();
-        expect(controller.state.activeBuyOrder?.transactionId).toBe('batch-1');
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
+        ).toBe('batch-1');
       });
     });
   });
@@ -8244,7 +8280,7 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
         expect(retrySpy).toHaveBeenCalledTimes(1);
@@ -8287,10 +8323,10 @@ describe('PredictController', () => {
         } as { transactionMeta: TransactionMeta });
 
         expect(retrySpy).toHaveBeenCalledTimes(1);
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
-        expect(controller.state.activeBuyOrder?.error).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.error).toBe(
           'User rejected the request.',
         );
       });
@@ -8322,7 +8358,9 @@ describe('PredictController', () => {
           },
         } as { transactionMeta: TransactionMeta });
 
-        expect(controller.state.activeBuyOrder?.error).toBeDefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeDefined();
         expect(retrySpy).toHaveBeenCalledTimes(1);
       });
     });
@@ -8364,7 +8402,7 @@ describe('PredictController', () => {
       withController(({ controller, messenger }) => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.DEPOSITING,
-          transactionId: 'tx-1',
+          transactionId: 'tx-active',
         });
 
         jest
@@ -8454,7 +8492,7 @@ describe('PredictController', () => {
           address: accountAddress,
           transactionId: 'tx-1',
         });
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PREVIEW,
         );
       });
@@ -8487,7 +8525,7 @@ describe('PredictController', () => {
         } as { transactionMeta: TransactionMeta });
 
         expect(retrySpy).toHaveBeenCalledTimes(1);
-        expect(controller.state.activeBuyOrder?.state).toBe(
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.state).toBe(
           ActiveOrderState.PAY_WITH_ANY_TOKEN,
         );
       });
@@ -8574,7 +8612,7 @@ describe('PredictController', () => {
             } as any);
 
           controller.updateStateForTesting((state) => {
-            state.activeBuyOrder = {
+            state.activeBuyOrders[MOCK_ADDRESS] = {
               state: ActiveOrderState.DEPOSITING,
               transactionId: 'tx-switched',
             };
@@ -8620,7 +8658,7 @@ describe('PredictController', () => {
       it('forwards the transaction address to initPayWithAnyToken when depositAndOrder fails after account switch', () => {
         withController(({ controller, messenger }) => {
           controller.updateStateForTesting((state) => {
-            state.activeBuyOrder = {
+            state.activeBuyOrders[originalAddress] = {
               state: ActiveOrderState.DEPOSITING,
               transactionId: 'tx-switched',
             };
@@ -8645,7 +8683,7 @@ describe('PredictController', () => {
           } as { transactionMeta: TransactionMeta });
 
           expect(retrySpy).toHaveBeenCalled();
-          expect(controller.state.activeBuyOrder?.state).toBe(
+          expect(controller.state.activeBuyOrders[originalAddress]?.state).toBe(
             ActiveOrderState.PAY_WITH_ANY_TOKEN,
           );
         });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -151,11 +151,13 @@ export type PredictControllerState = {
   // TODO: change to be per-account basis
   withdrawTransaction: PredictWithdraw | null;
 
-  activeBuyOrder: {
-    transactionId?: string;
-    state: ActiveOrderState;
-    error?: string;
-  } | null;
+  activeBuyOrders: {
+    [address: string]: {
+      transactionId?: string;
+      state: ActiveOrderState;
+      error?: string;
+    };
+  };
 
   selectedPaymentToken: {
     address: string;
@@ -181,9 +183,7 @@ export const getDefaultPredictControllerState = (): PredictControllerState => ({
   pendingDeposits: {},
   pendingClaims: {},
   withdrawTransaction: null,
-  activeBuyOrder: {
-    state: ActiveOrderState.PREVIEW,
-  },
+  activeBuyOrders: {},
   selectedPaymentToken: null,
   accountMeta: {},
 });
@@ -246,7 +246,7 @@ const metadata: StateMetadata<PredictControllerState> = {
     includeInStateLogs: false,
     usedInUi: true,
   },
-  activeBuyOrder: {
+  activeBuyOrders: {
     persist: false,
     includeInDebugSnapshot: false,
     includeInStateLogs: false,
@@ -1481,7 +1481,7 @@ export class PredictController extends BaseController<
 
     if (
       predictWithAnyTokenEnabled &&
-      this.state.activeBuyOrder?.state ===
+      this.state.activeBuyOrders[activeOrderAddress]?.state ===
         ActiveOrderState.PAY_WITH_ANY_TOKEN &&
       !isExistingPendingOrder
     ) {
@@ -1494,9 +1494,11 @@ export class PredictController extends BaseController<
         };
       }
       this.update((state) => {
-        if (state.activeBuyOrder) {
-          state.activeBuyOrder.state = ActiveOrderState.DEPOSITING;
-          state.activeBuyOrder.transactionId = transactionId;
+        if (state.activeBuyOrders[activeOrderAddress]) {
+          state.activeBuyOrders[activeOrderAddress].state =
+            ActiveOrderState.DEPOSITING;
+          state.activeBuyOrders[activeOrderAddress].transactionId =
+            transactionId;
         }
       });
       return {
@@ -1507,8 +1509,9 @@ export class PredictController extends BaseController<
 
     if (isBuyWithAnyToken) {
       this.update((state) => {
-        if (state.activeBuyOrder) {
-          state.activeBuyOrder.state = ActiveOrderState.PLACING_ORDER;
+        if (state.activeBuyOrders[activeOrderAddress]) {
+          state.activeBuyOrders[activeOrderAddress].state =
+            ActiveOrderState.PLACING_ORDER;
         }
       });
     }
@@ -1575,8 +1578,9 @@ export class PredictController extends BaseController<
 
       if (isBuyWithAnyToken) {
         this.update((state) => {
-          if (state.activeBuyOrder) {
-            state.activeBuyOrder.state = ActiveOrderState.SUCCESS;
+          if (state.activeBuyOrders[activeOrderAddress]) {
+            state.activeBuyOrders[activeOrderAddress].state =
+              ActiveOrderState.SUCCESS;
           }
         });
       }
@@ -1660,9 +1664,10 @@ export class PredictController extends BaseController<
       this.update((state) => {
         state.lastError = errorMessage;
         state.lastUpdateTimestamp = Date.now();
-        if (isBuyWithAnyToken && state.activeBuyOrder) {
-          state.activeBuyOrder.state = ActiveOrderState.PREVIEW;
-          state.activeBuyOrder.error = errorMessage;
+        if (isBuyWithAnyToken && state.activeBuyOrders[activeOrderAddress]) {
+          state.activeBuyOrders[activeOrderAddress].state =
+            ActiveOrderState.PREVIEW;
+          state.activeBuyOrders[activeOrderAddress].error = errorMessage;
         }
         if (isBuyWithAnyToken) {
           state.selectedPaymentToken = null;
@@ -1671,7 +1676,12 @@ export class PredictController extends BaseController<
 
       traceData = { success: false, error: errorMessage };
 
-      if (isBuyWithAnyToken) {
+      const isBackgroundOrder =
+        params.transactionId !== undefined &&
+        params.transactionId !==
+          this.state.activeBuyOrders[activeOrderAddress]?.transactionId;
+
+      if (isBuyWithAnyToken && isBackgroundOrder) {
         this.messenger.publish('PredictController:transactionStatusChanged', {
           type: 'order',
           status: 'failed',
@@ -1693,10 +1703,13 @@ export class PredictController extends BaseController<
         }),
       );
 
-      if (isBuyWithAnyToken && this.state.activeBuyOrder?.transactionId) {
+      if (
+        isBuyWithAnyToken &&
+        this.state.activeBuyOrders[activeOrderAddress]?.transactionId
+      ) {
         this.update((state) => {
-          if (state.activeBuyOrder) {
-            state.activeBuyOrder.transactionId = undefined;
+          if (state.activeBuyOrders[activeOrderAddress]) {
+            state.activeBuyOrders[activeOrderAddress].transactionId = undefined;
           }
         });
         this.initPayWithAnyToken().catch((err) => {
@@ -2052,20 +2065,31 @@ export class PredictController extends BaseController<
   }
 
   public clearOrderError(): void {
+    const address = this.getEvmAccountAddress();
     this.update((state) => {
-      if (state.activeBuyOrder) {
-        delete state.activeBuyOrder.error;
+      if (state.activeBuyOrders[address]) {
+        delete state.activeBuyOrders[address].error;
       }
     });
   }
 
   public onPlaceOrderSuccess(): void {
+    const address = this.getEvmAccountAddress();
     this.update((state) => {
-      state.activeBuyOrder = {
+      state.activeBuyOrders[address] = {
         state: ActiveOrderState.PREVIEW,
       };
     });
     this.setSelectedPaymentToken(null);
+  }
+
+  public clearActiveOrderTransactionId(): void {
+    const address = this.getEvmAccountAddress();
+    this.update((state) => {
+      if (state.activeBuyOrders[address]?.transactionId) {
+        state.activeBuyOrders[address].transactionId = undefined;
+      }
+    });
   }
 
   public selectPaymentToken(token: AssetType | null): void {
@@ -2086,7 +2110,8 @@ export class PredictController extends BaseController<
           },
     );
 
-    const activeOrder = this.state.activeBuyOrder;
+    const address = this.getEvmAccountAddress();
+    const activeOrder = this.state.activeBuyOrders[address];
     if (!activeOrder) {
       return;
     }
@@ -2098,8 +2123,8 @@ export class PredictController extends BaseController<
         return;
       }
       this.update((state) => {
-        if (state.activeBuyOrder) {
-          state.activeBuyOrder.state = ActiveOrderState.PREVIEW;
+        if (state.activeBuyOrders[address]) {
+          state.activeBuyOrders[address].state = ActiveOrderState.PREVIEW;
         }
       });
       return;
@@ -2110,16 +2135,18 @@ export class PredictController extends BaseController<
         return;
       }
       this.update((state) => {
-        if (state.activeBuyOrder) {
-          state.activeBuyOrder.state = ActiveOrderState.PAY_WITH_ANY_TOKEN;
+        if (state.activeBuyOrders[address]) {
+          state.activeBuyOrders[address].state =
+            ActiveOrderState.PAY_WITH_ANY_TOKEN;
         }
       });
     }
   }
 
   public clearActiveOrder(): void {
+    const address = this.getEvmAccountAddress();
     this.update((state) => {
-      state.activeBuyOrder = null;
+      delete state.activeBuyOrders[address];
     });
   }
 
@@ -2264,7 +2291,15 @@ export class PredictController extends BaseController<
    */
   public async initPayWithAnyToken(): Promise<Result<{ batchId: string }>> {
     const provider = this.provider;
-    const currentState = this.state.activeBuyOrder?.state;
+    const address = this.getEvmAccountAddress();
+
+    if (!this.state.activeBuyOrders[address]) {
+      this.update((state) => {
+        state.activeBuyOrders[address] = { state: ActiveOrderState.PREVIEW };
+      });
+    }
+
+    const currentState = this.state.activeBuyOrders[address]?.state;
 
     // Reset stale SUCCESS from a background-completed order
     if (currentState === ActiveOrderState.SUCCESS) {
@@ -2345,8 +2380,8 @@ export class PredictController extends BaseController<
       const { batchId } = batchResult;
 
       this.update((state) => {
-        if (state.activeBuyOrder) {
-          delete state.activeBuyOrder.error;
+        if (state.activeBuyOrders[address]) {
+          delete state.activeBuyOrders[address].error;
         }
       });
 
@@ -2530,19 +2565,24 @@ export class PredictController extends BaseController<
         : null;
       const marketId = pendingOrder?.analyticsProperties?.marketId;
 
+      const isBackgroundOrder =
+        transactionId !== undefined &&
+        transactionId !== this.state.activeBuyOrders[address]?.transactionId;
+
       if (transactionId) {
         delete this.pendingOrderPreviews[transactionId];
       }
 
-      if (this.state.activeBuyOrder) {
+      if (this.state.activeBuyOrders[address]) {
         const errorMessage =
           transactionMeta.error?.message ?? PREDICT_ERROR_CODES.DEPOSIT_FAILED;
 
         this.update((state) => {
-          if (state.activeBuyOrder) {
-            state.activeBuyOrder.state = ActiveOrderState.PAY_WITH_ANY_TOKEN;
-            state.activeBuyOrder.error = errorMessage;
-            state.activeBuyOrder.transactionId = undefined;
+          if (state.activeBuyOrders[address]) {
+            state.activeBuyOrders[address].state =
+              ActiveOrderState.PAY_WITH_ANY_TOKEN;
+            state.activeBuyOrders[address].error = errorMessage;
+            state.activeBuyOrders[address].transactionId = undefined;
           }
         });
         this.initPayWithAnyToken().catch((error) => {
@@ -2555,12 +2595,14 @@ export class PredictController extends BaseController<
         });
       }
 
-      this.messenger.publish('PredictController:transactionStatusChanged', {
-        type: 'order',
-        status: 'failed',
-        senderAddress: address,
-        marketId,
-      });
+      if (isBackgroundOrder) {
+        this.messenger.publish('PredictController:transactionStatusChanged', {
+          type: 'order',
+          status: 'failed',
+          senderAddress: address,
+          marketId,
+        });
+      }
     }
 
     if (type === 'depositAndOrder' && status === 'rejected') {
@@ -2569,11 +2611,11 @@ export class PredictController extends BaseController<
         delete this.pendingOrderPreviews[transactionId];
       }
 
-      if (this.state.activeBuyOrder) {
+      if (this.state.activeBuyOrders[address]) {
         this.update((state) => {
-          if (state.activeBuyOrder) {
-            state.activeBuyOrder.state = ActiveOrderState.PREVIEW;
-            state.activeBuyOrder.transactionId = undefined;
+          if (state.activeBuyOrders[address]) {
+            state.activeBuyOrders[address].state = ActiveOrderState.PREVIEW;
+            state.activeBuyOrders[address].transactionId = undefined;
           }
         });
         this.setSelectedPaymentToken(null);

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1697,7 +1697,11 @@ export class PredictController extends BaseController<
 
       traceData = { success: false, error: errorMessage };
 
-      if (!canUpdateActiveBuyOrder) {
+      if (
+        predictWithAnyTokenEnabled &&
+        preview.side === Side.BUY &&
+        !canUpdateActiveBuyOrder
+      ) {
         this.messenger.publish('PredictController:transactionStatusChanged', {
           type: 'order',
           status: 'failed',

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1559,9 +1559,6 @@ export class PredictController extends BaseController<
 
       const signer = this.getSigner(activeOrderAddress);
 
-      //await new Promise((resolve) => setTimeout(resolve, 1000));
-      //throw new Error('Test error');
-
       // Track Predict Trade Transaction with submitted status (fire and forget)
       this.trackPredictOrderEvent({
         status: PredictTradeStatus.SUBMITTED,

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -181,7 +181,9 @@ export const getDefaultPredictControllerState = (): PredictControllerState => ({
   pendingDeposits: {},
   pendingClaims: {},
   withdrawTransaction: null,
-  activeBuyOrder: null,
+  activeBuyOrder: {
+    state: ActiveOrderState.PREVIEW,
+  },
   selectedPaymentToken: null,
   accountMeta: {},
 });
@@ -524,13 +526,6 @@ export class PredictController extends BaseController<
       fakOrdersEnabled,
       predictWithAnyTokenEnabled,
     };
-  }
-
-  private isCurrentActiveBuyOrder(transactionId?: string): boolean {
-    if (!this.state.activeBuyOrder) return false;
-    if (!transactionId) return true;
-    if (!this.state.activeBuyOrder.transactionId) return false;
-    return this.state.activeBuyOrder.transactionId === transactionId;
   }
 
   private getEvmAccountAddress(): string {
@@ -1477,9 +1472,8 @@ export class PredictController extends BaseController<
   async placeOrder(params: PlaceOrderParams): Promise<Result> {
     const activeOrderAddress = params.address ?? this.getEvmAccountAddress();
     const { predictWithAnyTokenEnabled } = this.resolveFeatureFlags();
-    const canUpdateActiveBuyOrder = this.isCurrentActiveBuyOrder(
-      params.transactionId,
-    );
+    const isBuyWithAnyToken =
+      predictWithAnyTokenEnabled && params.preview.side === Side.BUY;
 
     const isExistingPendingOrder =
       !!params.transactionId &&
@@ -1511,11 +1505,7 @@ export class PredictController extends BaseController<
       } as unknown as Result;
     }
 
-    if (
-      predictWithAnyTokenEnabled &&
-      params.preview.side === Side.BUY &&
-      canUpdateActiveBuyOrder
-    ) {
+    if (isBuyWithAnyToken) {
       this.update((state) => {
         if (state.activeBuyOrder) {
           state.activeBuyOrder.state = ActiveOrderState.PLACING_ORDER;
@@ -1583,11 +1573,7 @@ export class PredictController extends BaseController<
         throw new Error(result.error);
       }
 
-      if (
-        predictWithAnyTokenEnabled &&
-        preview.side === Side.BUY &&
-        canUpdateActiveBuyOrder
-      ) {
+      if (isBuyWithAnyToken) {
         this.update((state) => {
           if (state.activeBuyOrder) {
             state.activeBuyOrder.state = ActiveOrderState.SUCCESS;
@@ -1631,11 +1617,7 @@ export class PredictController extends BaseController<
         // If we can't get real share price, continue without it
       }
 
-      if (
-        predictWithAnyTokenEnabled &&
-        preview.side === Side.BUY &&
-        !canUpdateActiveBuyOrder
-      ) {
+      if (isBuyWithAnyToken) {
         this.messenger.publish('PredictController:transactionStatusChanged', {
           type: 'order',
           status: 'confirmed',
@@ -1678,27 +1660,18 @@ export class PredictController extends BaseController<
       this.update((state) => {
         state.lastError = errorMessage;
         state.lastUpdateTimestamp = Date.now();
-        if (
-          predictWithAnyTokenEnabled &&
-          preview.side === Side.BUY &&
-          canUpdateActiveBuyOrder &&
-          state.activeBuyOrder
-        ) {
+        if (isBuyWithAnyToken && state.activeBuyOrder) {
           state.activeBuyOrder.state = ActiveOrderState.PREVIEW;
           state.activeBuyOrder.error = errorMessage;
         }
-        if (canUpdateActiveBuyOrder) {
+        if (isBuyWithAnyToken) {
           state.selectedPaymentToken = null;
         }
       });
 
       traceData = { success: false, error: errorMessage };
 
-      if (
-        predictWithAnyTokenEnabled &&
-        preview.side === Side.BUY &&
-        !canUpdateActiveBuyOrder
-      ) {
+      if (isBuyWithAnyToken) {
         this.messenger.publish('PredictController:transactionStatusChanged', {
           type: 'order',
           status: 'failed',
@@ -1720,11 +1693,7 @@ export class PredictController extends BaseController<
         }),
       );
 
-      if (
-        predictWithAnyTokenEnabled &&
-        canUpdateActiveBuyOrder &&
-        this.state.activeBuyOrder?.transactionId
-      ) {
+      if (isBuyWithAnyToken && this.state.activeBuyOrder?.transactionId) {
         this.update((state) => {
           if (state.activeBuyOrder) {
             state.activeBuyOrder.transactionId = undefined;
@@ -2090,9 +2059,11 @@ export class PredictController extends BaseController<
     });
   }
 
-  public onPlaceOrderEnd(): void {
+  public onPlaceOrderSuccess(): void {
     this.update((state) => {
-      state.activeBuyOrder = null;
+      state.activeBuyOrder = {
+        state: ActiveOrderState.PREVIEW,
+      };
     });
     this.setSelectedPaymentToken(null);
   }
@@ -2293,21 +2264,11 @@ export class PredictController extends BaseController<
    */
   public async initPayWithAnyToken(): Promise<Result<{ batchId: string }>> {
     const provider = this.provider;
+    const currentState = this.state.activeBuyOrder?.state;
 
-    if (!this.state.activeBuyOrder) {
-      this.update((state) => {
-        state.selectedPaymentToken = null;
-        state.activeBuyOrder = {
-          state: ActiveOrderState.PREVIEW,
-        };
-      });
-    }
-
-    const activeOrder = this.state.activeBuyOrder;
-    if (!activeOrder) {
-      throw new Error(
-        'Active order is required for pay-with-any-token confirmation',
-      );
+    // Reset stale SUCCESS from a background-completed order
+    if (currentState === ActiveOrderState.SUCCESS) {
+      this.onPlaceOrderSuccess();
     }
 
     try {
@@ -2573,15 +2534,13 @@ export class PredictController extends BaseController<
         delete this.pendingOrderPreviews[transactionId];
       }
 
-      const canUpdateActiveBuyOrder =
-        this.isCurrentActiveBuyOrder(transactionId);
-      if (canUpdateActiveBuyOrder) {
+      if (this.state.activeBuyOrder) {
         const errorMessage =
           transactionMeta.error?.message ?? PREDICT_ERROR_CODES.DEPOSIT_FAILED;
 
         this.update((state) => {
           if (state.activeBuyOrder) {
-            state.activeBuyOrder.state = ActiveOrderState.PREVIEW;
+            state.activeBuyOrder.state = ActiveOrderState.PAY_WITH_ANY_TOKEN;
             state.activeBuyOrder.error = errorMessage;
             state.activeBuyOrder.transactionId = undefined;
           }
@@ -2594,14 +2553,14 @@ export class PredictController extends BaseController<
             }),
           );
         });
-      } else {
-        this.messenger.publish('PredictController:transactionStatusChanged', {
-          type: 'order',
-          status: 'failed',
-          senderAddress: address,
-          marketId,
-        });
       }
+
+      this.messenger.publish('PredictController:transactionStatusChanged', {
+        type: 'order',
+        status: 'failed',
+        senderAddress: address,
+        marketId,
+      });
     }
 
     if (type === 'depositAndOrder' && status === 'rejected') {
@@ -2610,8 +2569,14 @@ export class PredictController extends BaseController<
         delete this.pendingOrderPreviews[transactionId];
       }
 
-      if (this.isCurrentActiveBuyOrder(transactionId)) {
-        this.onPlaceOrderEnd();
+      if (this.state.activeBuyOrder) {
+        this.update((state) => {
+          if (state.activeBuyOrder) {
+            state.activeBuyOrder.state = ActiveOrderState.PREVIEW;
+            state.activeBuyOrder.transactionId = undefined;
+          }
+        });
+        this.setSelectedPaymentToken(null);
       }
     }
 

--- a/app/components/UI/Predict/hooks/usePredictActiveOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActiveOrder.test.ts
@@ -20,22 +20,49 @@ jest.mock('react-redux', () => ({
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
+const MOCK_ADDRESS = '0xabc123';
+
+const mockAccountsController = {
+  internalAccounts: {
+    selectedAccount: 'acct-1',
+    accounts: {
+      'acct-1': {
+        address: MOCK_ADDRESS,
+        type: 'eip155:eoa',
+        id: 'acct-1',
+        metadata: {
+          name: 'Account 1',
+          keyring: { type: 'HD Key Tree' },
+          importTime: 0,
+          lastSelected: 0,
+        },
+        options: {},
+        methods: [],
+        scopes: [],
+      },
+    },
+  },
+};
+
+const createMockState = (activeBuyOrder: Record<string, unknown> | null) => ({
+  engine: {
+    backgroundState: {
+      PredictController: {
+        activeBuyOrders: activeBuyOrder
+          ? { [MOCK_ADDRESS]: activeBuyOrder }
+          : {},
+      },
+      AccountsController: mockAccountsController,
+    },
+  },
+});
+
 describe('usePredictActiveOrder', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSelector.mockImplementation((selector) => {
       if (typeof selector === 'function') {
-        return selector({
-          engine: {
-            backgroundState: {
-              PredictController: {
-                activeBuyOrder: {
-                  state: ActiveOrderState.PREVIEW,
-                },
-              },
-            },
-          },
-        });
+        return selector(createMockState({ state: ActiveOrderState.PREVIEW }));
       }
 
       return undefined;
@@ -63,17 +90,8 @@ describe('usePredictActiveOrder', () => {
       };
       mockUseSelector.mockImplementation((selector) => {
         if (typeof selector === 'function') {
-          return selector({
-            engine: {
-              backgroundState: {
-                PredictController: {
-                  activeBuyOrder: mockActiveOrder,
-                },
-              },
-            },
-          });
+          return selector(createMockState(mockActiveOrder));
         }
-
         return undefined;
       });
 
@@ -85,19 +103,10 @@ describe('usePredictActiveOrder', () => {
     it('returns isDepositing when active order is depositing', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (typeof selector === 'function') {
-          return selector({
-            engine: {
-              backgroundState: {
-                PredictController: {
-                  activeBuyOrder: {
-                    state: ActiveOrderState.DEPOSITING,
-                  },
-                },
-              },
-            },
-          });
+          return selector(
+            createMockState({ state: ActiveOrderState.DEPOSITING }),
+          );
         }
-
         return undefined;
       });
 
@@ -110,19 +119,10 @@ describe('usePredictActiveOrder', () => {
     it('returns isPlacingOrder when active order is placing order', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (typeof selector === 'function') {
-          return selector({
-            engine: {
-              backgroundState: {
-                PredictController: {
-                  activeBuyOrder: {
-                    state: ActiveOrderState.PLACING_ORDER,
-                  },
-                },
-              },
-            },
-          });
+          return selector(
+            createMockState({ state: ActiveOrderState.PLACING_ORDER }),
+          );
         }
-
         return undefined;
       });
 
@@ -135,17 +135,8 @@ describe('usePredictActiveOrder', () => {
     it('returns false flags when there is no active buy order', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (typeof selector === 'function') {
-          return selector({
-            engine: {
-              backgroundState: {
-                PredictController: {
-                  activeBuyOrder: null,
-                },
-              },
-            },
-          });
+          return selector(createMockState(null));
         }
-
         return undefined;
       });
 

--- a/app/components/UI/Predict/hooks/usePredictActiveOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictActiveOrder.ts
@@ -20,6 +20,10 @@ export const usePredictActiveOrder = () => {
     PredictController.clearOrderError();
   }, [PredictController]);
 
+  const clearActiveOrderTransactionId = useCallback(() => {
+    PredictController.clearActiveOrderTransactionId();
+  }, [PredictController]);
+
   const currentState = useMemo(() => activeOrder?.state, [activeOrder]);
 
   const isDepositing = useMemo(
@@ -37,5 +41,6 @@ export const usePredictActiveOrder = () => {
     isDepositing,
     isPlacingOrder,
     clearOrderError,
+    clearActiveOrderTransactionId,
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.test.ts
@@ -418,6 +418,139 @@ describe('usePredictOrderPreview', () => {
     });
   });
 
+  describe('sticky error behavior', () => {
+    it('preserves error during background auto-refresh', async () => {
+      const { Wrapper } = createWrapper();
+      mockPreviewOrder.mockRejectedValue(new Error('Not enough shares'));
+
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      const params = { ...defaultParams, autoRefreshTimeout: 1000 };
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Failed to preview order');
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.error).toBe('Failed to preview order');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('clears error when auto-refresh succeeds after previous failure', async () => {
+      const { Wrapper } = createWrapper();
+      mockPreviewOrder.mockRejectedValue(new Error('Not enough shares'));
+
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      const params = { ...defaultParams, autoRefreshTimeout: 1000 };
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Failed to preview order');
+      });
+
+      mockPreviewOrder.mockResolvedValue(mockPreview);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeNull();
+      });
+
+      expect(result.current.preview).toEqual(mockPreview);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('clears error when size changes', async () => {
+      const { Wrapper } = createWrapper();
+      mockPreviewOrder.mockRejectedValue(new Error('Not enough shares'));
+
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      const { result, rerender } = renderHook(
+        (props: PreviewOrderParams) => usePredictOrderPreview(props),
+        { wrapper: Wrapper, initialProps: defaultParams },
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Failed to preview order');
+      });
+
+      mockPreviewOrder.mockResolvedValue(mockPreview);
+      rerender({ ...defaultParams, size: 200 });
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeNull();
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('returns false for isLoading when sticky error exists during refetch', async () => {
+      const { Wrapper } = createWrapper();
+      mockPreviewOrder.mockRejectedValue(new Error('Not enough shares'));
+
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      const params = { ...defaultParams, autoRefreshTimeout: 1000 };
+      const { result } = renderHook(() => usePredictOrderPreview(params), {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.isLoading).toBe(false);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe('parameter changes', () => {
     it('reacts to outcomeTokenId changes', async () => {
       const { Wrapper } = createWrapper();

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
@@ -67,15 +67,29 @@ export function usePredictOrderPreview(
       hasValidSize && autoRefreshTimeout ? autoRefreshTimeout : false,
   });
 
+  const [stickyError, setStickyError] = useState<string | null>(null);
+
   const preview = hasValidSize ? (query.data ?? null) : null;
-  const error = query.error
+  const parsedError = query.error
     ? parseErrorMessage({
         error: query.error,
         defaultCode: PREDICT_ERROR_CODES.PREVIEW_FAILED,
       })
     : null;
-  const isLoading = preview === null && !error;
+  const isLoading = preview === null && !parsedError && !stickyError;
   const isCalculating = query.isFetching;
+
+  useEffect(() => {
+    if (parsedError) {
+      setStickyError(parsedError);
+    } else if (query.isSuccess) {
+      setStickyError(null);
+    }
+  }, [parsedError, query.isSuccess]);
+
+  useEffect(() => {
+    setStickyError(null);
+  }, [debouncedParams.size]);
 
   useEffect(() => {
     if (!query.error) return;
@@ -108,6 +122,6 @@ export function usePredictOrderPreview(
     preview,
     isLoading,
     isCalculating,
-    error,
+    error: stickyError,
   };
 }

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
@@ -796,39 +796,6 @@ describe('usePredictToastRegistrations', () => {
       );
     });
 
-    it('shows prediction placed toast with View button when marketId is present', () => {
-      const handler = getHandler();
-
-      handler(
-        {
-          type: 'order',
-          status: 'confirmed',
-          senderAddress: selectedAddress,
-          marketId: 'market-123',
-        },
-        showToast,
-      );
-
-      expect(showToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: 'Icon',
-          iconName: 'Check',
-          linkButtonOptions: expect.objectContaining({
-            label: 'predict.order.view',
-            onPress: expect.any(Function),
-          }),
-        }),
-      );
-
-      const onView = showToast.mock.calls[0][0].linkButtonOptions.onPress;
-      onView();
-
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
-        screen: Routes.PREDICT.MARKET_DETAILS,
-        params: { marketId: 'market-123' },
-      });
-    });
-
     it('shows prediction placed toast without View button when marketId is absent', () => {
       const handler = getHandler();
 
@@ -867,38 +834,6 @@ describe('usePredictToastRegistrations', () => {
           hasNoTimeout: false,
         }),
       );
-    });
-
-    it('shows error toast with Try Again button when marketId is present', () => {
-      const handler = getHandler();
-
-      handler(
-        {
-          type: 'order',
-          status: 'failed',
-          senderAddress: selectedAddress,
-          marketId: 'market-456',
-        },
-        showToast,
-      );
-
-      expect(showToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          iconName: 'Error',
-          linkButtonOptions: expect.objectContaining({
-            label: 'predict.order.try_again',
-            onPress: expect.any(Function),
-          }),
-        }),
-      );
-
-      const onRetry = showToast.mock.calls[0][0].linkButtonOptions.onPress;
-      onRetry();
-
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
-        screen: Routes.PREDICT.MARKET_DETAILS,
-        params: { marketId: 'market-456' },
-      });
     });
 
     it('shows error toast without Try Again button when marketId is absent', () => {

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -349,19 +349,6 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
               },
             ],
             hasNoTimeout: false,
-            ...(marketId
-              ? {
-                  linkButtonOptions: {
-                    label: strings('predict.order.view'),
-                    onPress: () => {
-                      navigation.navigate(Routes.PREDICT.ROOT, {
-                        screen: Routes.PREDICT.MARKET_DETAILS,
-                        params: { marketId },
-                      });
-                    },
-                  },
-                }
-              : {}),
           });
           return;
         }
@@ -371,17 +358,6 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
             showToast,
             title: strings('predict.order.prediction_failed'),
             description: strings('predict.order.order_failed_generic'),
-            ...(marketId
-              ? {
-                  retryLabel: strings('predict.order.try_again'),
-                  onRetry: () => {
-                    navigation.navigate(Routes.PREDICT.ROOT, {
-                      screen: Routes.PREDICT.MARKET_DETAILS,
-                      params: { marketId },
-                    });
-                  },
-                }
-              : {}),
             backgroundColor: theme.colors.accent04.normal,
             iconColor: theme.colors.error.default,
           });

--- a/app/components/UI/Predict/selectors/predictController/index.test.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.test.ts
@@ -142,7 +142,29 @@ describe('Predict Controller Selectors', () => {
   });
 
   describe('selectPredictActiveBuyOrder', () => {
-    it('returns active buy order when it exists', () => {
+    const mockAccountsController = {
+      internalAccounts: {
+        selectedAccount: 'acct-1',
+        accounts: {
+          'acct-1': {
+            address: '0xabc123',
+            type: 'eip155:eoa',
+            id: 'acct-1',
+            metadata: {
+              name: 'Account 1',
+              keyring: { type: 'HD Key Tree' },
+              importTime: 0,
+              lastSelected: 0,
+            },
+            options: {},
+            methods: [],
+            scopes: [],
+          },
+        },
+      },
+    };
+
+    it('returns active buy order for the selected account address', () => {
       const activeBuyOrder = {
         state: 'preview',
         transactionId: 'tx-1',
@@ -152,8 +174,9 @@ describe('Predict Controller Selectors', () => {
         engine: {
           backgroundState: {
             PredictController: {
-              activeBuyOrder,
+              activeBuyOrders: { '0xabc123': activeBuyOrder },
             },
+            AccountsController: mockAccountsController,
           },
         },
       };
@@ -164,13 +187,14 @@ describe('Predict Controller Selectors', () => {
       expect(result).toEqual(activeBuyOrder);
     });
 
-    it('returns null when active buy order is null', () => {
+    it('returns null when no order exists for the selected address', () => {
       const mockState = {
         engine: {
           backgroundState: {
             PredictController: {
-              activeBuyOrder: null,
+              activeBuyOrders: {},
             },
+            AccountsController: mockAccountsController,
           },
         },
       };
@@ -186,6 +210,7 @@ describe('Predict Controller Selectors', () => {
         engine: {
           backgroundState: {
             PredictController: undefined,
+            AccountsController: mockAccountsController,
           },
         },
       };

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { RootState } from '../../../../../reducers';
 import { PredictPositionStatus } from '../../types';
+import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
 
 const selectPredictControllerState = (state: RootState) =>
   state.engine.backgroundState.PredictController;
@@ -22,7 +23,11 @@ const selectPredictWithdrawTransaction = createSelector(
 
 const selectPredictActiveBuyOrder = createSelector(
   selectPredictControllerState,
-  (predictState) => predictState?.activeBuyOrder ?? null,
+  selectSelectedInternalAccountAddress,
+  (predictState, address) => {
+    if (!predictState || !address) return null;
+    return predictState.activeBuyOrders[address] ?? null;
+  },
 );
 
 const selectPredictClaimablePositions = createSelector(

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -40,7 +40,7 @@ import { usePredictBuyActions } from './hooks/usePredictBuyActions';
 import { usePredictMeasurement } from '../../hooks/usePredictMeasurement';
 import { usePredictOrderPreview } from '../../hooks/usePredictOrderPreview';
 import { usePredictOrderRetry } from '../../hooks/usePredictOrderRetry';
-import { usePredictPlaceOrder } from '../../hooks/usePredictPlaceOrder';
+
 import {
   selectPredictFakOrdersEnabledFlag,
   selectPredictWithAnyTokenEnabledFlag,
@@ -62,8 +62,6 @@ const PredictBuyWithAnyToken = () => {
   const { market, outcome, outcomeToken, entryPoint } = route.params;
 
   const { isPlacingOrder } = usePredictActiveOrder();
-  const { showOrderPlacedToast, invalidateOrderQueries } =
-    usePredictPlaceOrder();
 
   const [isFeeBreakdownVisible, setIsFeeBreakdownVisible] = useState(false);
 
@@ -175,8 +173,6 @@ const PredictBuyWithAnyToken = () => {
     analyticsProperties,
     preview,
     setIsConfirming,
-    showOrderPlacedToast,
-    invalidateOrderQueries,
   });
 
   useEffect(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
@@ -87,9 +87,13 @@ jest.mock('../../../../../Views/confirmations/hooks/useConfirmActions', () => ({
   }),
 }));
 
+const mockClearActiveOrderTransactionId = jest.fn();
+
 jest.mock('../../../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: () => ({
     activeOrder: mockActiveOrder,
+    clearActiveOrderTransactionId: (...args: unknown[]) =>
+      mockClearActiveOrderTransactionId(...args),
   }),
 }));
 
@@ -112,6 +116,8 @@ jest.mock('../../../../../../core/Engine', () => ({
         mockSetSelectedPaymentToken(...args),
       onPlaceOrderSuccess: (...args: unknown[]) =>
         mockOnPlaceOrderSuccess(...args),
+      clearActiveOrderTransactionId: (...args: unknown[]) =>
+        mockClearActiveOrderTransactionId(...args),
     },
   },
 }));

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
@@ -13,11 +13,10 @@ const mockDispatch = jest.fn();
 const mockOnConfirmActionsReject = jest.fn();
 const mockOnApprovalConfirm = jest.fn();
 const mockUnsubscribe = jest.fn();
-const mockShowOrderPlacedToast = jest.fn();
-const mockInvalidateOrderQueries = jest.fn();
+const mockSetSelectedPaymentToken = jest.fn();
+const mockOnPlaceOrderSuccess = jest.fn();
 const mockTrackPredictOrderEvent = jest.fn();
 const mockPlaceOrder = jest.fn<Promise<unknown>, [PlaceOrderParams]>();
-const mockOnPlaceOrderEnd = jest.fn();
 const mockOnOrderCancelled = jest.fn();
 const mockInitPayWithAnyToken = jest.fn();
 const mockSetIsConfirming = jest.fn();
@@ -104,12 +103,15 @@ jest.mock('../../../hooks/usePredictTrading', () => ({
 jest.mock('../../../../../../core/Engine', () => ({
   context: {
     PredictController: {
-      onPlaceOrderEnd: (...args: unknown[]) => mockOnPlaceOrderEnd(...args),
       onOrderCancelled: (...args: unknown[]) => mockOnOrderCancelled(...args),
       trackPredictOrderEvent: (...args: unknown[]) =>
         mockTrackPredictOrderEvent(...args),
       initPayWithAnyToken: (...args: unknown[]) =>
         mockInitPayWithAnyToken(...args),
+      setSelectedPaymentToken: (...args: unknown[]) =>
+        mockSetSelectedPaymentToken(...args),
+      onPlaceOrderSuccess: (...args: unknown[]) =>
+        mockOnPlaceOrderSuccess(...args),
     },
   },
 }));
@@ -132,8 +134,6 @@ const createDefaultParams = (): Parameters<typeof usePredictBuyActions>[0] => ({
   } as OrderPreview,
   analyticsProperties: { marketId: 'market-1' },
   setIsConfirming: mockSetIsConfirming,
-  showOrderPlacedToast: mockShowOrderPlacedToast,
-  invalidateOrderQueries: mockInvalidateOrderQueries,
 });
 
 describe('usePredictBuyActions', () => {
@@ -247,7 +247,6 @@ describe('usePredictBuyActions', () => {
       unmount();
 
       expect(mockOnConfirmActionsReject).not.toHaveBeenCalled();
-      expect(mockOnPlaceOrderEnd).not.toHaveBeenCalled();
     });
   });
 
@@ -460,14 +459,35 @@ describe('usePredictBuyActions', () => {
   });
 
   describe('success effect', () => {
-    it('shows toast, cleans up and closes the screen in SUCCESS state', async () => {
+    it('calls onPlaceOrderSuccess when state is SUCCESS', () => {
       mockActiveOrder = { state: ActiveOrderState.SUCCESS };
 
       renderHook(() => usePredictBuyActions(createDefaultParams()));
 
-      expect(mockInvalidateOrderQueries).toHaveBeenCalledTimes(1);
-      expect(mockShowOrderPlacedToast).toHaveBeenCalledTimes(1);
-      expect(mockOnPlaceOrderEnd).toHaveBeenCalledTimes(1);
+      expect(mockOnPlaceOrderSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not navigate pop when handleConfirm was not called before SUCCESS', () => {
+      mockActiveOrder = { state: ActiveOrderState.SUCCESS };
+
+      renderHook(() => usePredictBuyActions(createDefaultParams()));
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('navigates pop when handleConfirm was called before SUCCESS', async () => {
+      mockActiveOrder = { state: ActiveOrderState.PREVIEW };
+      const { result, rerender } = renderHook(() =>
+        usePredictBuyActions(createDefaultParams()),
+      );
+
+      await act(async () => {
+        await result.current.handleConfirm();
+      });
+
+      mockActiveOrder = { state: ActiveOrderState.SUCCESS };
+      rerender(createDefaultParams());
+
       expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
     });
   });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
@@ -35,7 +35,8 @@ export const usePredictBuyActions = ({
   const { onConfirm: onApprovalConfirm, approvalRequest } =
     useApprovalRequest();
   const { onReject } = useConfirmActions();
-  const { activeOrder } = usePredictActiveOrder();
+  const { activeOrder, clearActiveOrderTransactionId } =
+    usePredictActiveOrder();
   const { placeOrder, initPayWithAnyToken } = usePredictTrading();
   const { resetSelectedPaymentToken } = usePredictPaymentToken();
   const currentState = useMemo(() => activeOrder?.state, [activeOrder?.state]);
@@ -88,8 +89,14 @@ export const usePredictBuyActions = ({
 
     return navigation.addListener('beforeRemove', () => {
       onReject(undefined, true);
+      clearActiveOrderTransactionId();
     });
-  }, [navigation, payWithAnyTokenEnabled, onReject]);
+  }, [
+    navigation,
+    payWithAnyTokenEnabled,
+    onReject,
+    clearActiveOrderTransactionId,
+  ]);
 
   const handlePlaceOrder = useCallback(
     async (orderParams: PlaceOrderParams): Promise<PlaceOrderOutcome> => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
@@ -17,21 +17,18 @@ import { usePredictTrading } from '../../../hooks/usePredictTrading';
 import { PlaceOrderOutcome } from '../../../hooks/usePredictPlaceOrder';
 import { PREDICT_ERROR_CODES } from '../../../constants/errors';
 import { useConfirmActions } from '../../../../../Views/confirmations/hooks/useConfirmActions';
+import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 
 interface UsePredictBuyActionsParams {
   preview?: OrderPreview | null;
   analyticsProperties: PlaceOrderParams['analyticsProperties'];
   setIsConfirming: (value: boolean) => void;
-  showOrderPlacedToast: () => void;
-  invalidateOrderQueries: () => void;
 }
 
 export const usePredictBuyActions = ({
   preview,
   analyticsProperties,
   setIsConfirming,
-  showOrderPlacedToast,
-  invalidateOrderQueries,
 }: UsePredictBuyActionsParams) => {
   const navigation =
     useNavigation<StackNavigationProp<PredictNavigationParamList>>();
@@ -40,6 +37,7 @@ export const usePredictBuyActions = ({
   const { onReject } = useConfirmActions();
   const { activeOrder } = usePredictActiveOrder();
   const { placeOrder, initPayWithAnyToken } = usePredictTrading();
+  const { resetSelectedPaymentToken } = usePredictPaymentToken();
   const currentState = useMemo(() => activeOrder?.state, [activeOrder?.state]);
   const { PredictController } = Engine.context;
   const payWithAnyTokenEnabled = useSelector(
@@ -47,6 +45,7 @@ export const usePredictBuyActions = ({
   );
 
   const hasInitializedPayWithAnyTokenRef = useRef(false);
+  const didInitiateOrderRef = useRef(false);
 
   useEffect(() => {
     const controller = Engine.context.PredictController;
@@ -68,12 +67,19 @@ export const usePredictBuyActions = ({
     const unsubscribe = navigation.addListener('transitionEnd', (e) => {
       if (!e.data.closing && !hasInitializedPayWithAnyTokenRef.current) {
         hasInitializedPayWithAnyTokenRef.current = true;
+        resetSelectedPaymentToken();
         initPayWithAnyToken();
       }
     });
 
     return unsubscribe;
-  }, [navigation, initPayWithAnyToken, payWithAnyTokenEnabled]);
+  }, [
+    navigation,
+    initPayWithAnyToken,
+    payWithAnyTokenEnabled,
+    PredictController,
+    resetSelectedPaymentToken,
+  ]);
 
   useEffect(() => {
     if (!payWithAnyTokenEnabled) {
@@ -82,9 +88,8 @@ export const usePredictBuyActions = ({
 
     return navigation.addListener('beforeRemove', () => {
       onReject(undefined, true);
-      PredictController.onPlaceOrderEnd();
     });
-  }, [navigation, payWithAnyTokenEnabled, PredictController, onReject]);
+  }, [navigation, payWithAnyTokenEnabled, onReject]);
 
   const handlePlaceOrder = useCallback(
     async (orderParams: PlaceOrderParams): Promise<PlaceOrderOutcome> => {
@@ -105,11 +110,9 @@ export const usePredictBuyActions = ({
   );
 
   const handleConfirm = useCallback(async () => {
+    didInitiateOrderRef.current = true;
     setIsConfirming(true);
 
-    // Only capture transactionId for PAY_WITH_ANY_TOKEN flow (deposit-order linking).
-    // Balance flow doesn't need it — passing undefined lets isCurrentActiveBuyOrder
-    // match without a strict transactionId check.
     const transactionId =
       currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN
         ? approvalRequest?.id
@@ -162,19 +165,12 @@ export const usePredictBuyActions = ({
 
   useEffect(() => {
     if (currentState === ActiveOrderState.SUCCESS) {
-      invalidateOrderQueries();
-      showOrderPlacedToast();
-      PredictController.onPlaceOrderEnd();
-      navigation.dispatch(StackActions.pop());
+      PredictController.onPlaceOrderSuccess();
+      if (didInitiateOrderRef.current) {
+        navigation.dispatch(StackActions.pop());
+      }
     }
-  }, [
-    PredictController,
-    currentState,
-    invalidateOrderQueries,
-    navigation,
-    setIsConfirming,
-    showOrderPlacedToast,
-  ]);
+  }, [PredictController, currentState, navigation]);
 
   return {
     handleConfirm,

--- a/app/core/Engine/controllers/predict-controller/index.test.ts
+++ b/app/core/Engine/controllers/predict-controller/index.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../components/UI/Predict/controllers/PredictController';
 import { predictControllerInit } from '.';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { ActiveOrderState } from '../../../../components/UI/Predict';
 
 jest.mock(
   '../../../../components/UI/Predict/controllers/PredictController',
@@ -73,7 +74,7 @@ describe('predict controller init', () => {
       withdrawTransaction: null,
       selectedPaymentToken: null,
       accountMeta: {},
-      activeBuyOrder: null,
+      activeBuyOrders: {},
     };
 
     initRequestMock.persistedState = {

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -733,7 +733,7 @@
     "pendingDeposits": {},
     "pendingClaims": {},
     "withdrawTransaction": null,
-    "activeBuyOrder": null,
+    "activeBuyOrders": {},
     "selectedPaymentToken": null,
     "accountMeta": {}
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes several issues with the Predict buy flow when using the pay-with-any-token feature:

1. Order state persists across navigation — When a user places a deposit-and-order bet and navigates away, the active order state (DEPOSITING, PLACING_ORDER) is preserved instead of being cleared. This prevents users from placing concurrent orders and ensures the UI reflects ongoing background bets when re-entering any buy screen.
2. Per-address active orders — Renamed activeBuyOrder (singular) to activeBuyOrders (address-keyed map), matching the pattern used by pendingDeposits and pendingClaims. Each account has its own independent order lifecycle. The selector resolves the current account address to read the correct entry.
3. Foreground vs background error notifications — Order failure toasts are now gated by transactionId matching: foreground errors are shown inline on the buy screen (no toast), while background errors (user navigated away) trigger toast notifications. The transactionId is cleared on navigation back via clearActiveOrderTransactionId() so subsequent background failures are correctly identified. Success toasts always fire.
4. Deposit failure recovery — Deposit failures now reset to PAY_WITH_ANY_TOKEN (was PREVIEW), keeping the external token selected so the user can retry without re-selecting.
5. Minor fixes — Removed debug code left in placeOrder, removed buttons from background toasts, fixed error message blinking during order preview auto-refresh, and updated the README to reflect all changes.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Predict buy order state management and transaction side-effect handling, which can affect in-flight deposit-and-order flows and user notifications across navigation/account switches.
> 
> **Overview**
> **Refactors Predict buy order lifecycle state** from a single `activeBuyOrder` to an address-keyed `activeBuyOrders` map, updating selectors/hooks/tests so each account tracks its own in-flight order and state persists across navigation.
> 
> **Adjusts pay-with-any-token order completion and notifications**: order success always publishes `PredictController:transactionStatusChanged` confirmed events; failures only publish toast-triggering events when the `transactionId` no longer matches the active order (background), while foreground failures remain inline. Deposit-and-order failures now reset back to `PAY_WITH_ANY_TOKEN` (keeping the external token flow) and rejection resets the active order to `PREVIEW` while clearing `transactionId`/selected token as needed.
> 
> **Updates buy screen behavior**: on screen mount it resets to Predict balance then initializes `initPayWithAnyToken()`, back navigation now clears only the active order `transactionId` (via `clearActiveOrderTransactionId`) instead of clearing the order, and SUCCESS resets via `onPlaceOrderSuccess()` with navigation pop only if the current screen initiated the order.
> 
> **Fixes preview UX and toasts**: `usePredictOrderPreview` now uses a sticky error to prevent error flicker during auto-refresh and clears on success/size change, and Predict order toasts remove market-based View/Try Again buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2f9e5f988808174559a085206dca010a69c2c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->