### PR TITLE
fix(ramps): prevent onHttpError from racing with Transak Apple Pay redirect callback

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -358,9 +358,17 @@ const Checkout = () => {
           onHttpError={(syntheticEvent) => {
             const { nativeEvent } = syntheticEvent;
             const errorUrl = nativeEvent.url;
+            // When a callbackKey is active (Transak native / Deposit flows), the
+            // redirect to the fake-callback URL intentionally returns a 404. The
+            // registered callback handler processes the URL instead, so treating
+            // that 404 as a fatal error would tear down the WebView and race with
+            // the order-completion callback -- causing the "confirm order" loop.
+            const isExpectedCallbackError =
+              callbackKeyRef.current && errorUrl.startsWith(callbackBaseUrl);
             if (
-              errorUrl === initialUriRef.current ||
-              errorUrl.startsWith(callbackBaseUrl)
+              !isExpectedCallbackError &&
+              (errorUrl === initialUriRef.current ||
+                errorUrl.startsWith(callbackBaseUrl))
             ) {
               const webviewHttpError = strings(
                 'fiat_on_ramp_aggregator.webview_received_error',

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -9,7 +9,7 @@ import {
   normalizeProviderCode,
   type TransakBuyQuote,
 } from '@metamask/ramps-controller';
-import { REDIRECTION_URL } from '../Deposit/constants';
+import { getRampCallbackBaseUrl } from '../utils/getRampCallbackBaseUrl';
 import { generateThemeParameters } from '../Deposit/utils';
 import { BasicInfoFormData } from '../Deposit/Views/BasicInfo/BasicInfo';
 import { AddressFormData } from '../Deposit/Views/EnterAddress/EnterAddress';
@@ -270,7 +270,7 @@ export const useTransakRouting = (_config?: UseTransakRoutingConfig) => {
 
   const handleNavigationStateChange = useCallback(
     async ({ url }: { url: string }) => {
-      if (!url.startsWith(REDIRECTION_URL)) return;
+      if (!url.startsWith(getRampCallbackBaseUrl())) return;
 
       let orderId: string | null = null;
       try {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Problem

When buying tokens with Apple Pay via Transak Native, after the payment sheet completes, users are returned to the Transak "Confirm Order" screen instead of being redirected to the order details. The payment goes through on Transak's side but the app doesn't acknowledge it.

**Root cause:** The unified `Checkout.tsx` WebView's `onHttpError` handler treats any HTTP error on the fake-callback URL (`on-ramp-content.api.cx.metamask.io/regions/fake-callback`) as a fatal error, calling `setError()` which tears down the WebView. However, when a `callbackKey` is active (Transak native / Deposit flows), that 404 is **expected** -- the registered callback handler in `handleNavigationStateChangeWithDedup` is supposed to intercept the URL and process the order. The `onHttpError` fires and destroys the WebView before the callback can complete, creating a race condition.

This is especially visible with Apple Pay because Transak compliance checks (risk scoring, shared wallet detection) introduce processing delays that widen the race window.

The legacy `Deposit/WebviewModal` does **not** have this bug because its `onHttpError` only matches the original source URL, not the callback URL.

Additionally, `useTransakRouting` used a hardcoded production-only `REDIRECTION_URL` constant, making staging/EXP builds unable to match the staging callback URL -- breaking dev testing entirely.

### Solution

1. **Skip the `callbackBaseUrl` error check when a `callbackKey` is active** in `Checkout.tsx`. The fake-callback 404 is expected and should not be treated as a fatal error, matching the behavior of the legacy `WebviewModal`.

2. **Replace the hardcoded `REDIRECTION_URL`** import in `useTransakRouting` with the environment-aware `getRampCallbackBaseUrl()`, restoring staging/EXP testing parity.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where Apple Pay purchases via Transak would loop back to the confirmation screen instead of completing

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3347

## **Manual testing steps**

```gherkin
Feature: Apple Pay Transak order redirect

  Scenario: user completes Apple Pay purchase via Transak Native
    Given the user is on the Buy screen with Transak selected
    And the user has Apple Pay configured

    When user selects Apple Pay and completes the payment
    Then the app should navigate to the order details screen
    And the order should appear in the activity tab

  Scenario: user completes Apple Pay purchase that triggers compliance delay
    Given the user is on the Buy screen with Transak selected
    And the user has Apple Pay configured
    And the Transak compliance check introduces a processing delay

    When user selects Apple Pay and completes the payment
    Then the app should still navigate to the order details screen
    And not loop back to the "Confirm Order" widget

  Scenario: staging builds correctly match redirect URL
    Given the user is testing on a staging/EXP build
    And the user completes a Transak Native order

    When Transak redirects to the staging fake-callback URL
    Then the redirect handler should match and process the order
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)