### PR TITLE
refactor: remove ScreenComponent any cast from Bridge routes

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
@@ -11,6 +11,21 @@ import { initialState } from '../../_mocks_/initialState';
 import BlockExplorersModal from './BlockExplorersModal';
 import { fireEvent } from '@testing-library/react-native';
 
+const mockTx = {
+  id: 'test-tx-id',
+  chainId: '0x1',
+  hash: '0x123',
+  networkClientId: 'mainnet',
+  time: Date.now(),
+  txParams: {
+    from: '0x123',
+    to: '0x456',
+    value: '0x0',
+    data: '0x',
+  },
+  status: TransactionStatus.submitted,
+} as TransactionMeta;
+
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -20,6 +35,13 @@ jest.mock('@react-navigation/native', () => {
       navigate: mockNavigate,
       setOptions: jest.fn(),
     }),
+    useRoute: () => ({
+      key: '1',
+      name: 'params',
+      params: {
+        evmTxMeta: mockTx,
+      },
+    }),
   };
 });
 
@@ -27,29 +49,6 @@ describe('BlockExplorersModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-
-  const mockTx = {
-    id: 'test-tx-id',
-    chainId: '0x1',
-    hash: '0x123',
-    networkClientId: 'mainnet',
-    time: Date.now(),
-    txParams: {
-      from: '0x123',
-      to: '0x456',
-      value: '0x0',
-      data: '0x',
-    },
-    status: TransactionStatus.submitted,
-  } as TransactionMeta;
-
-  const mockProps = {
-    route: {
-      params: {
-        evmTxMeta: mockTx,
-      },
-    },
-  };
 
   const mockState = {
     ...initialState,
@@ -71,7 +70,7 @@ describe('BlockExplorersModal', () => {
 
   it('should render without crashing', () => {
     const { getByText } = renderScreen(
-      () => <BlockExplorersModal {...mockProps} />,
+      () => <BlockExplorersModal />,
       {
         name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
       },
@@ -82,7 +81,7 @@ describe('BlockExplorersModal', () => {
 
   it('should display both source and destination chain block explorer buttons', () => {
     const { getAllByText } = renderScreen(
-      () => <BlockExplorersModal {...mockProps} />,
+      () => <BlockExplorersModal />,
       {
         name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
       },
@@ -123,7 +122,7 @@ describe('BlockExplorersModal', () => {
     };
 
     const { getAllByText } = renderScreen(
-      () => <BlockExplorersModal {...mockProps} />,
+      () => <BlockExplorersModal />,
       {
         name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
       },
@@ -135,7 +134,7 @@ describe('BlockExplorersModal', () => {
 
   it('should navigate to webview when source chain explorer button is pressed', () => {
     const { getAllByText } = renderScreen(
-      () => <BlockExplorersModal {...mockProps} />,
+      () => <BlockExplorersModal />,
       {
         name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
       },
@@ -155,7 +154,7 @@ describe('BlockExplorersModal', () => {
 
   it('should navigate to webview when destination chain explorer button is pressed', () => {
     const { getByText } = renderScreen(
-      () => <BlockExplorersModal {...mockProps} />,
+      () => <BlockExplorersModal />,
       {
         name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER,
       },

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -18,7 +18,7 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
 import { Theme } from '../../../../../util/theme/models';
-import { useNavigation } from '@react-navigation/native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
@@ -36,21 +36,19 @@ const styleSheet = (params: { theme: Theme }) =>
     },
   });
 
-interface BlockExplorersModalProps {
-  route: {
-    params: {
-      evmTxMeta?: TransactionMeta;
-      multiChainTx?: Transaction;
-    };
-  };
+interface BlockExplorersModalRouteParams {
+  evmTxMeta?: TransactionMeta;
+  multiChainTx?: Transaction;
 }
 
-const BlockExplorersModal = (props: BlockExplorersModalProps) => {
+const BlockExplorersModal = () => {
   const navigation = useNavigation();
+  const route =
+    useRoute<RouteProp<{ params: BlockExplorersModalRouteParams }, 'params'>>();
   const { styles } = useStyles(styleSheet, {});
 
-  const evmTxMeta = props.route.params.evmTxMeta;
-  const multiChainTx = props.route.params.multiChainTx;
+  const evmTxMeta = route.params.evmTxMeta;
+  const multiChainTx = route.params.multiChainTx;
 
   const { bridgeTxHistoryItem } = useBridgeTxHistoryData({
     evmTxMeta,

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -21,9 +21,6 @@ const clearStackNavigatorOptions = {
   animationEnabled: false,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ScreenComponent = React.ComponentType<any>;
-
 const Stack = createStackNavigator();
 export const BridgeScreenStack = () => (
   <Stack.Navigator
@@ -64,7 +61,7 @@ export const BridgeModalStack = () => (
     />
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER}
-      component={BlockExplorersModal as ScreenComponent}
+      component={BlockExplorersModal}
     />
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.BLOCKAID_MODAL}


### PR DESCRIPTION
## **Description**

Migrate BlockExplorersModal from prop-based route access to useRoute() hook.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria

Made with [Cursor](https://cursor.com)