### PR TITLE
fix(analytics): correct is_empty for Homepage Viewed segment events across homepage sections

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -1350,7 +1350,7 @@ describe('PerpsSection', () => {
       );
     });
 
-    it('passes isEmpty: false when trending markets are shown', () => {
+    it('passes isEmpty: true when trending markets are shown (no positions/orders = empty state)', () => {
       usePerpsMarkets.mockReturnValue({
         markets: [makeTrendingMarket()],
         isLoading: false,
@@ -1364,7 +1364,7 @@ describe('PerpsSection', () => {
       );
 
       expect(mockUseHomeViewedEvent).toHaveBeenLastCalledWith(
-        expect.objectContaining({ isEmpty: false }),
+        expect.objectContaining({ isEmpty: true }),
       );
     });
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -280,7 +280,7 @@ const PerpsSection = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       sectionName: HomeSectionNames.PERPS,
       sectionIndex,
       totalSectionsLoaded,
-      isEmpty: !hasItems && trendingMarkets.length === 0,
+      isEmpty: !hasItems,
       itemCount: hasItems ? displayPositions.length + displayOrders.length : 0,
     });
 

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -186,7 +186,7 @@ const PredictionsSection = forwardRef<
   const isEmpty =
     !isLoading && !hasPositions && markets.length === 0 && !hasError;
 
-  const itemCount = hasPositions ? positions.length : markets.length;
+  const itemCount = hasPositions ? positions.length : 0;
 
   // Determine whether the section will actually render visible content.
   // Pass null when the section returns null so the event fires immediately.
@@ -201,8 +201,9 @@ const PredictionsSection = forwardRef<
     sectionName: HomeSectionNames.PREDICT,
     sectionIndex,
     totalSectionsLoaded,
+    // Empty when user has no positions (showing discovery/promotional content or nothing).
     // Treat error state as empty — there is no useful content to show.
-    isEmpty: isEmpty || !!hasError,
+    isEmpty: !hasPositions || !!hasError,
     itemCount,
   });
 

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -182,7 +182,7 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
       sectionName: HomeSectionNames.TOKENS,
       sectionIndex,
       totalSectionsLoaded,
-      isEmpty: isZeroBalanceAccount,
+      isEmpty: isZeroBalanceAccount || showTokensError,
       itemCount,
     });
 


### PR DESCRIPTION
## **Description**

Fixes incorrect `is_empty` values in the `Homepage Viewed` Segment event across multiple homepage sections.

Sections that show discovery/promotional content (trending markets carousel) when the user has no primary content were reporting `is_empty=false`. The `is_empty` property should reflect whether the user has real content, not whether there is any fallback UI to display.

Changes:
- **Perps**: `isEmpty` was `!hasItems && trendingMarkets.length === 0` — showing the trending carousel (empty state) incorrectly reported `false`. Fixed to `!hasItems`.
- **Predictions**: Same pattern — `isEmpty` only became `true` when there were no markets either. Fixed to `!hasPositions`. Also fixes `item_count`, which was counting trending markets instead of user positions.
- **Tokens**: Error state was not counted as empty. Fixed to include `showTokensError`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-608

## **Manual testing steps**

```gherkin
Feature: Homepage Section Viewed analytics event

  Scenario: user views Perps section with no open positions
    Given the user has no open perps positions or orders
    When the user opens the homepage
    Then the Homepage Viewed event for "perps" fires with is_empty=true and item_count=0

  Scenario: user views Predictions section with no open positions
    Given the user has no open prediction positions
    When the user opens the homepage
    Then the Homepage Viewed event for "predict" fires with is_empty=true and item_count=0

  Scenario: user views Perps section with open positions
    Given the user has open perps positions
    When the user opens the homepage
    Then the Homepage Viewed event for "perps" fires with is_empty=false and item_count > 0
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect analytics payload fields (`isEmpty`/`itemCount`) for homepage sections, without altering core trading/token functionality.
> 
> **Overview**
> Corrects `Homepage Viewed` analytics for sections that show fallback/discovery UI.
> 
> `PerpsSection` now reports `isEmpty: true` whenever the user has no positions/orders (even if a trending carousel is shown), and updates the related test expectation. `PredictionsSection` stops counting trending markets as `itemCount` and marks the section empty whenever the user has no positions (or on error). `TokensSection` now treats token-load error states as `isEmpty` for analytics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e862fd5e17d2b265109a8eaf282d47ef302f60eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->