### PR TITLE
refactor: migrate RootModalFlow wrapper to useRoute()

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -370,272 +370,283 @@ const DetectedTokensFlow = () => (
   </Stack.Navigator>
 );
 
-interface RootModalFlowProps {
-  route: {
-    params: Record<string, unknown>;
-  };
-}
-const RootModalFlow = (props: RootModalFlowProps) => (
-  <Stack.Navigator
-    screenOptions={{ ...clearStackNavigatorOptions, presentation: 'modal' }}
-  >
-    <Stack.Screen
-      name={Routes.MODAL.WALLET_ACTIONS}
-      component={WalletActions}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.TRADE_WALLET_ACTIONS}
-      component={TradeWalletActions}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.FUND_ACTION_MENU}
-      component={FundActionMenu}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.MORE_TOKEN_ACTIONS_MENU}
-      component={MoreTokenActionsMenu}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.SECURITY_BADGE_BOTTOM_SHEET}
-      component={SecurityBadgeBottomSheet}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.DELETE_WALLET}
-      component={DeleteWalletModal}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.MODAL_CONFIRMATION}
-      component={ModalConfirmation as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.MODAL_MANDATORY}
-      component={ModalMandatory as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ONBOARDING_SHEET}
-      component={OnboardingSheet as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SEEDPHRASE_MODAL}
-      component={SeedphraseModal as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SKIP_ACCOUNT_SECURITY_MODAL}
-      component={SkipAccountSecurityModal as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SUCCESS_ERROR_SHEET}
-      component={SuccessErrorSheet as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ELIGIBILITY_FAILED_MODAL}
-      component={EligibilityFailedModal}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.UNSUPPORTED_REGION_MODAL}
-      component={RampUnsupportedModal}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ACCOUNT_SELECTOR}
-      component={AccountSelector}
-      options={{
-        cardStyle: { backgroundColor: importedColors.transparent },
-        cardStyleInterpolator: () => ({
-          overlayStyle: {
-            opacity: 0,
-          },
-        }),
-        detachPreviousScreen: false,
-      }}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ADDRESS_SELECTOR}
-      component={AddressSelector}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ADD_ACCOUNT}
-      component={AddNewAccountBottomSheet as ScreenComponent}
-    />
-    <Stack.Screen name={Routes.SHEET.SDK_LOADING} component={SDKLoadingModal} />
-    <Stack.Screen
-      name={Routes.SHEET.SDK_FEEDBACK}
-      component={SDKFeedbackModal}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SDK_MANAGE_CONNECTIONS}
-      component={SDKSessionModal as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.EXPERIENCE_ENHANCER}
-      component={ExperienceEnhancerModal}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.DATA_COLLECTION}
-      component={DataCollectionModal}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SDK_DISCONNECT}
-      component={SDKDisconnectModal as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ACCOUNT_CONNECT}
-      component={MultichainAccountConnect as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ACCOUNT_PERMISSIONS}
-      component={MultichainAccountPermissions as ScreenComponent}
-      initialParams={{ initialScreen: AccountPermissionsScreens.Connected }}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.REVOKE_ALL_ACCOUNT_PERMISSIONS}
-      component={AccountPermissionsConfirmRevokeAll as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.CONNECTION_DETAILS}
-      component={ConnectionDetails as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.PERMITTED_NETWORKS_INFO_SHEET}
-      component={PermittedNetworksInfoSheet}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.NETWORK_SELECTOR}
-      component={NetworkSelector as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.TOKEN_SORT}
-      component={TokenSortBottomSheet}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.NETWORK_MANAGER}
-      component={NetworkManager}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.BASIC_FUNCTIONALITY}
-      component={BasicFunctionalityModal as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.CONFIRM_TURN_ON_BACKUP_AND_SYNC}
-      component={ConfirmTurnOnBackupAndSyncModal}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.AMBIGUOUS_ADDRESS}
-      component={AmbiguousAddressSheet}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.TURN_OFF_REMEMBER_ME}
-      component={TurnOffRememberMeModal}
-    />
-    <Stack.Screen
-      name={'AssetHideConfirmation'}
-      component={AssetHideConfirmation as ScreenComponent}
-    />
-    <Stack.Screen name={'DetectedTokens'} component={DetectedTokensFlow} />
-    <Stack.Screen
-      name={'AssetOptions'}
-      component={AssetOptions as ScreenComponent}
-    />
-    <Stack.Screen
-      name={'NftOptions'}
-      component={NftOptions as ScreenComponent}
-    />
-    <Stack.Screen name={Routes.MODAL.UPDATE_NEEDED} component={UpdateNeeded} />
-    <Stack.Screen
-      name={Routes.MODAL.OTA_UPDATES_MODAL}
-      component={OTAUpdatesModal}
-    />
-    {
+const RootModalFlow = () => {
+  const rootModalRoute = useRoute();
+  return (
+    <Stack.Navigator
+      screenOptions={{ ...clearStackNavigatorOptions, presentation: 'modal' }}
+    >
       <Stack.Screen
-        name={Routes.SHEET.SELECT_SRP}
-        component={SelectSRPBottomSheet}
+        name={Routes.MODAL.WALLET_ACTIONS}
+        component={WalletActions}
       />
-    }
-    <Stack.Screen
-      name={Routes.MODAL.SRP_REVEAL_QUIZ}
-      component={SRPQuiz as ScreenComponent}
-      initialParams={{ ...props.route.params }}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ACCOUNT_ACTIONS}
-      component={AccountActions}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.FIAT_ON_TESTNETS_FRICTION}
-      component={FiatOnTestnetsFriction}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SHOW_IPFS}
-      component={ShowIpfsGatewaySheet}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.SHOW_NFT_DISPLAY_MEDIA}
-      component={ShowDisplayNftMediaSheet}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.NFT_AUTO_DETECTION_MODAL}
-      component={NFTAutoDetectionModal}
-    />
-    <Stack.Screen name={Routes.MODAL.WHATS_NEW} component={WhatsNewModal} />
-    {isNetworkUiRedesignEnabled() ? (
       <Stack.Screen
-        name={Routes.MODAL.MULTI_RPC_MIGRATION_MODAL}
-        component={MultiRpcModal}
+        name={Routes.MODAL.TRADE_WALLET_ACTIONS}
+        component={TradeWalletActions}
       />
-    ) : null}
-    <Stack.Screen
-      name={Routes.SHEET.SHOW_TOKEN_ID}
-      component={ShowTokenIdSheet}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.ORIGIN_SPAM_MODAL}
-      component={OriginSpamModal as ScreenComponent}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.CHANGE_IN_SIMULATION_MODAL}
-      component={ChangeInSimulationModal as ScreenComponent}
-    />
-    <Stack.Screen name={Routes.SHEET.TOOLTIP_MODAL} component={TooltipModal} />
-    <Stack.Screen
-      name={Routes.MODAL.DEEP_LINK_MODAL}
-      component={DeepLinkModal}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.MULTICHAIN_ACCOUNTS_INTRO}
-      component={MultichainAccountsIntroModal}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.MULTICHAIN_ACCOUNTS_LEARN_MORE}
-      component={LearnMoreBottomSheet as ScreenComponent}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
-      name={Routes.MODAL.PNA25_NOTICE_BOTTOM_SHEET}
-      component={Pna25BottomSheet}
-    />
-    <Stack.Screen
-      name={Routes.SDK.RETURN_TO_DAPP_NOTIFICATION}
-      component={ReturnToAppNotification as ScreenComponent}
-      initialParams={{ ...props.route.params }}
-    />
-    <Stack.Screen
-      name={Routes.CARD.NOTIFICATION}
-      component={CardNotification}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.MULTICHAIN_TRANSACTION_DETAILS}
-      component={MultichainTransactionDetailsSheet}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.TRANSACTION_DETAILS}
-      component={TransactionDetailsSheet}
-    />
-    <Stack.Screen
-      name={Routes.SHEET.IMPORT_WALLET_TIP}
-      component={ImportWalletTipBottomSheet}
-    />
-  </Stack.Navigator>
-);
+      <Stack.Screen
+        name={Routes.MODAL.FUND_ACTION_MENU}
+        component={FundActionMenu}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.MORE_TOKEN_ACTIONS_MENU}
+        component={MoreTokenActionsMenu}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.SECURITY_BADGE_BOTTOM_SHEET}
+        component={SecurityBadgeBottomSheet}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.DELETE_WALLET}
+        component={DeleteWalletModal}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.MODAL_CONFIRMATION}
+        component={ModalConfirmation as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.MODAL_MANDATORY}
+        component={ModalMandatory as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ONBOARDING_SHEET}
+        component={OnboardingSheet as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SEEDPHRASE_MODAL}
+        component={SeedphraseModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SKIP_ACCOUNT_SECURITY_MODAL}
+        component={SkipAccountSecurityModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SUCCESS_ERROR_SHEET}
+        component={SuccessErrorSheet as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ELIGIBILITY_FAILED_MODAL}
+        component={EligibilityFailedModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.UNSUPPORTED_REGION_MODAL}
+        component={RampUnsupportedModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ACCOUNT_SELECTOR}
+        component={AccountSelector}
+        options={{
+          cardStyle: { backgroundColor: importedColors.transparent },
+          cardStyleInterpolator: () => ({
+            overlayStyle: {
+              opacity: 0,
+            },
+          }),
+          detachPreviousScreen: false,
+        }}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ADDRESS_SELECTOR}
+        component={AddressSelector}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ADD_ACCOUNT}
+        component={AddNewAccountBottomSheet as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SDK_LOADING}
+        component={SDKLoadingModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SDK_FEEDBACK}
+        component={SDKFeedbackModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SDK_MANAGE_CONNECTIONS}
+        component={SDKSessionModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.EXPERIENCE_ENHANCER}
+        component={ExperienceEnhancerModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.DATA_COLLECTION}
+        component={DataCollectionModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SDK_DISCONNECT}
+        component={SDKDisconnectModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ACCOUNT_CONNECT}
+        component={MultichainAccountConnect as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ACCOUNT_PERMISSIONS}
+        component={MultichainAccountPermissions as ScreenComponent}
+        initialParams={{ initialScreen: AccountPermissionsScreens.Connected }}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.REVOKE_ALL_ACCOUNT_PERMISSIONS}
+        component={AccountPermissionsConfirmRevokeAll as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.CONNECTION_DETAILS}
+        component={ConnectionDetails as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.PERMITTED_NETWORKS_INFO_SHEET}
+        component={PermittedNetworksInfoSheet}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.NETWORK_SELECTOR}
+        component={NetworkSelector as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.TOKEN_SORT}
+        component={TokenSortBottomSheet}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.NETWORK_MANAGER}
+        component={NetworkManager}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.BASIC_FUNCTIONALITY}
+        component={BasicFunctionalityModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.CONFIRM_TURN_ON_BACKUP_AND_SYNC}
+        component={ConfirmTurnOnBackupAndSyncModal}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.AMBIGUOUS_ADDRESS}
+        component={AmbiguousAddressSheet}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.TURN_OFF_REMEMBER_ME}
+        component={TurnOffRememberMeModal}
+      />
+      <Stack.Screen
+        name={'AssetHideConfirmation'}
+        component={AssetHideConfirmation as ScreenComponent}
+      />
+      <Stack.Screen name={'DetectedTokens'} component={DetectedTokensFlow} />
+      <Stack.Screen
+        name={'AssetOptions'}
+        component={AssetOptions as ScreenComponent}
+      />
+      <Stack.Screen
+        name={'NftOptions'}
+        component={NftOptions as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.UPDATE_NEEDED}
+        component={UpdateNeeded}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.OTA_UPDATES_MODAL}
+        component={OTAUpdatesModal}
+      />
+      {
+        <Stack.Screen
+          name={Routes.SHEET.SELECT_SRP}
+          component={SelectSRPBottomSheet}
+        />
+      }
+      <Stack.Screen
+        name={Routes.MODAL.SRP_REVEAL_QUIZ}
+        component={SRPQuiz as ScreenComponent}
+        initialParams={{
+          ...(rootModalRoute?.params as Record<string, unknown>),
+        }}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ACCOUNT_ACTIONS}
+        component={AccountActions}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.FIAT_ON_TESTNETS_FRICTION}
+        component={FiatOnTestnetsFriction}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SHOW_IPFS}
+        component={ShowIpfsGatewaySheet}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.SHOW_NFT_DISPLAY_MEDIA}
+        component={ShowDisplayNftMediaSheet}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.NFT_AUTO_DETECTION_MODAL}
+        component={NFTAutoDetectionModal}
+      />
+      <Stack.Screen name={Routes.MODAL.WHATS_NEW} component={WhatsNewModal} />
+      {isNetworkUiRedesignEnabled() ? (
+        <Stack.Screen
+          name={Routes.MODAL.MULTI_RPC_MIGRATION_MODAL}
+          component={MultiRpcModal}
+        />
+      ) : null}
+      <Stack.Screen
+        name={Routes.SHEET.SHOW_TOKEN_ID}
+        component={ShowTokenIdSheet}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.ORIGIN_SPAM_MODAL}
+        component={OriginSpamModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.CHANGE_IN_SIMULATION_MODAL}
+        component={ChangeInSimulationModal as ScreenComponent}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.TOOLTIP_MODAL}
+        component={TooltipModal}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.DEEP_LINK_MODAL}
+        component={DeepLinkModal}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.MULTICHAIN_ACCOUNTS_INTRO}
+        component={MultichainAccountsIntroModal}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.MULTICHAIN_ACCOUNTS_LEARN_MORE}
+        component={LearnMoreBottomSheet as ScreenComponent}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.PNA25_NOTICE_BOTTOM_SHEET}
+        component={Pna25BottomSheet}
+      />
+      <Stack.Screen
+        name={Routes.SDK.RETURN_TO_DAPP_NOTIFICATION}
+        component={ReturnToAppNotification as ScreenComponent}
+        initialParams={{
+          ...(rootModalRoute?.params as Record<string, unknown>),
+        }}
+      />
+      <Stack.Screen
+        name={Routes.CARD.NOTIFICATION}
+        component={CardNotification}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.MULTICHAIN_TRANSACTION_DETAILS}
+        component={MultichainTransactionDetailsSheet}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.TRANSACTION_DETAILS}
+        component={TransactionDetailsSheet}
+      />
+      <Stack.Screen
+        name={Routes.SHEET.IMPORT_WALLET_TIP}
+        component={ImportWalletTipBottomSheet}
+      />
+    </Stack.Navigator>
+  );
+};
 
 const ImportPrivateKeyView = () => {
   const { colors } = useTheme();
@@ -947,7 +958,7 @@ const AppFlow = () => {
       />
       <Stack.Screen
         name={Routes.MODAL.ROOT_MODAL_FLOW}
-        component={RootModalFlow as ScreenComponent}
+        component={RootModalFlow}
         options={{
           presentation: 'modal',
           detachPreviousScreen: false,


### PR DESCRIPTION
## **Description**

Switch the `RootModalFlow` nested navigator wrapper from prop-based route access to `useRoute()` hook (PR 12 of 13).

`RootModalFlow` receives route params from the parent navigator and forwards them as `initialParams` to `SRPQuiz` and `ReturnToAppNotification` screens. After this change, it uses `useRoute()` instead of receiving `route` through its `RootModalFlowProps` interface.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — pure refactoring.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to navigation wrapper wiring; primary risk is mis-propagating `initialParams` for `SRPQuiz` and `ReturnToAppNotification` if route params shape differs.
> 
> **Overview**
> **Refactors `RootModalFlow` to stop accepting `route` props and instead read params via `useRoute()`.**
> 
> This removes the `RootModalFlowProps` interface and updates `SRPQuiz` and `ReturnToAppNotification` to receive `initialParams` from `rootModalRoute.params`, and updates the `Routes.MODAL.ROOT_MODAL_FLOW` registration to use the new component signature (no casting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc8b8a55c158611661786d3492e35c2d485a1321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->