### PR TITLE
chore: refactoring onboarding screens to design system

### DIFF
--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -351,33 +351,86 @@ exports[`Login renders matching snapshot 1`] = `
           Unlock
         </Text>
       </View>
-      <TouchableOpacity
+      <View
+        accessibilityLabel="Forgot password?"
         accessibilityRole="button"
-        accessible={true}
-        disabled={false}
-        onPress={[Function]}
-        style={
+        accessibilityState={
           {
-            "alignSelf": "center",
-            "marginBottom": 0,
-            "marginTop": 0,
-            "paddingTop": 16,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "marginTop": 16,
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="reset-wallet-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
-                "alignSelf": "center",
-                "color": "#66676a",
+                "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -385,7 +438,7 @@ exports[`Login renders matching snapshot 1`] = `
         >
           Forgot password?
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
   <View
@@ -789,33 +842,86 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
           Unlock
         </Text>
       </View>
-      <TouchableOpacity
+      <View
+        accessibilityLabel="Forgot password?"
         accessibilityRole="button"
-        accessible={true}
-        disabled={false}
-        onPress={[Function]}
-        style={
+        accessibilityState={
           {
-            "alignSelf": "center",
-            "marginBottom": 0,
-            "marginTop": 0,
-            "paddingTop": 16,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "marginTop": 16,
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="reset-wallet-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
-                "alignSelf": "center",
-                "color": "#66676a",
+                "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -823,7 +929,7 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
         >
           Forgot password?
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
   <View

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -21,14 +21,10 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
-  TextVariant,
-  FontWeight,
   TextField,
   Button,
   ButtonSize,
   ButtonVariant,
-  Text,
-  TextColor,
 } from '@metamask/design-system-react-native';
 import { ThemeContext } from '../../../util/theme';
 import { TextVariant as DSTextVariant } from '../../../component-library/components/Texts/Text';
@@ -498,23 +494,17 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
               >
                 {strings('login.unlock_button')}
               </Button>
-              <TouchableOpacity
-                accessibilityRole="button"
-                accessible
-                testID={LoginViewSelectors.RESET_WALLET}
+              <Button
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Lg}
                 onPress={toggleWarningModal}
-                disabled={loading}
-                style={tw.style('my-0 self-center pt-4')}
+                isDisabled={loading}
+                testID={LoginViewSelectors.RESET_WALLET}
+                isFullWidth
+                twClassName="mt-4"
               >
-                <Text
-                  twClassName="self-center"
-                  color={TextColor.TextAlternative}
-                  fontWeight={FontWeight.Medium}
-                  variant={TextVariant.BodyMd}
-                >
-                  {strings('login.forgot_password')}
-                </Text>
-              </TouchableOpacity>
+                {strings('login.forgot_password')}
+              </Button>
             </Box>
           </Box>
         </KeyboardAwareScrollView>

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -32,7 +32,6 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-  TextButton,
   BoxAlignItems,
   BoxJustifyContent,
 } from '@metamask/design-system-react-native';
@@ -449,13 +448,15 @@ const ManualBackupStep1 = () => {
           {strings('manual_backup_step_1.continue')}
         </Button>
         {!hasFunds && !backupFlow && !settingsBackup && (
-          <TextButton
+          <Button
+            variant={ButtonVariant.Tertiary}
             onPress={showRemindLater}
-            variant={TextVariant.BodyMd}
+            size={ButtonSize.Lg}
+            isFullWidth
             testID={ManualBackUpStepsSelectorsIDs.REMIND_ME_LATER_BUTTON}
           >
             {strings('account_backup_step_1.remind_me_later')}
-          </TextButton>
+          </Button>
         )}
       </Box>
     </Box>

--- a/app/components/Views/OnboardingSuccess/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/OnboardingSuccess/__snapshots__/index.test.tsx.snap
@@ -220,28 +220,85 @@ exports[`OnboardingSuccess route params handling uses default successFlow when r
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -249,7 +306,7 @@ exports[`OnboardingSuccess route params handling uses default successFlow when r
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -475,28 +532,85 @@ exports[`OnboardingSuccess route params handling uses default successFlow when s
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -504,7 +618,7 @@ exports[`OnboardingSuccess route params handling uses default successFlow when s
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -730,28 +844,85 @@ exports[`OnboardingSuccess route params successFlow is BACKED_UP_SRP renders mat
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -759,7 +930,7 @@ exports[`OnboardingSuccess route params successFlow is BACKED_UP_SRP renders mat
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -985,28 +1156,85 @@ exports[`OnboardingSuccess route params successFlow is IMPORT_FROM_SEED_PHRASE f
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -1014,7 +1242,7 @@ exports[`OnboardingSuccess route params successFlow is IMPORT_FROM_SEED_PHRASE f
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -1240,28 +1468,85 @@ exports[`OnboardingSuccess route params successFlow is IMPORT_FROM_SEED_PHRASE r
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -1269,7 +1554,7 @@ exports[`OnboardingSuccess route params successFlow is IMPORT_FROM_SEED_PHRASE r
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -1495,28 +1780,85 @@ exports[`OnboardingSuccess route params successFlow is NO_BACKED_UP_SRP renders 
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -1524,7 +1866,7 @@ exports[`OnboardingSuccess route params successFlow is NO_BACKED_UP_SRP renders 
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -1750,28 +2092,85 @@ exports[`OnboardingSuccessComponent renders matching snapshot when successFlow i
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -1779,7 +2178,7 @@ exports[`OnboardingSuccessComponent renders matching snapshot when successFlow i
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -2005,28 +2404,85 @@ exports[`OnboardingSuccessComponent renders matching snapshot when successFlow i
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -2034,7 +2490,7 @@ exports[`OnboardingSuccessComponent renders matching snapshot when successFlow i
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>
@@ -2260,28 +2716,85 @@ exports[`OnboardingSuccessComponent renders matching snapshot when successFlow i
           Done
         </Text>
       </View>
-      <TouchableOpacity
-        onPress={[Function]}
-        style={
+      <View
+        accessibilityLabel="Manage default settings"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "paddingBottom": 8,
-            "paddingTop": 8,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
           }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "borderRadius": 12,
+              "borderWidth": 0,
+              "columnGap": 8,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minWidth": 80,
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "width": "100%",
+            },
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
         }
         testID="onboarding-success-manage-default-settings-button"
       >
         <Text
           accessibilityRole="text"
+          ellipsizeMode="clip"
+          numberOfLines={1}
           style={
             [
               {
                 "color": "#4459ff",
+                "flexGrow": 0,
+                "flexShrink": 1,
+                "flexWrap": "wrap",
                 "fontFamily": "Geist-Medium",
                 "fontSize": 16,
                 "fontWeight": 400,
                 "letterSpacing": 0,
                 "lineHeight": 24,
+                "textAlign": "center",
               },
               undefined,
             ]
@@ -2289,7 +2802,7 @@ exports[`OnboardingSuccessComponent renders matching snapshot when successFlow i
         >
           Manage default settings
         </Text>
-      </TouchableOpacity>
+      </View>
     </View>
   </View>
 </RNCSafeAreaView>

--- a/app/components/Views/OnboardingSuccess/index.test.tsx
+++ b/app/components/Views/OnboardingSuccess/index.test.tsx
@@ -14,12 +14,6 @@ import { ONBOARDING_SUCCESS_FLOW } from '../../../constants/onboarding';
 import Engine from '../../../core/Engine/Engine';
 import { strings } from '../../../../locales/i18n';
 import { useSelector } from 'react-redux';
-import {
-  TextColor,
-  TextVariant,
-  FontWeight,
-} from '@metamask/design-system-react-native';
-import { ReactTestInstance } from 'react-test-renderer';
 
 jest.mock('../../../core/Engine/Engine', () => ({
   context: {
@@ -199,24 +193,6 @@ describe('OnboardingSuccessComponent', () => {
     );
 
     expect(getByTestId('onboarding-success-end-animation')).toBeOnTheScreen();
-  });
-
-  it('renders footer link with Info text color', () => {
-    const { getByTestId } = renderWithProvider(
-      <OnboardingSuccessComponent
-        onDone={jest.fn()}
-        successFlow={ONBOARDING_SUCCESS_FLOW.NO_BACKED_UP_SRP}
-      />,
-    );
-
-    const footerButton = getByTestId(
-      OnboardingSuccessSelectorIDs.MANAGE_DEFAULT_SETTINGS_BUTTON,
-    );
-    const footerText = footerButton.children[0] as ReactTestInstance;
-
-    expect(footerText.props.color).toBe(TextColor.InfoDefault);
-    expect(footerText.props.variant).toBe(TextVariant.BodyMd);
-    expect(footerText.props.fontWeight).toBe(FontWeight.Medium);
   });
 
   it('hides manage default settings button for SETTINGS_BACKUP flow', () => {

--- a/app/components/Views/OnboardingSuccess/index.tsx
+++ b/app/components/Views/OnboardingSuccess/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useLayoutEffect } from 'react';
-import { TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   CommonActions,
@@ -25,7 +24,6 @@ import {
   FontFamily,
   FontWeight,
   Text,
-  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -115,19 +113,15 @@ export const OnboardingSuccessComponent: React.FC<OnboardingSuccessProps> = ({
     }
 
     return (
-      <TouchableOpacity
+      <Button
         onPress={goToDefaultSettings}
         testID={OnboardingSuccessSelectorIDs.MANAGE_DEFAULT_SETTINGS_BUTTON}
-        style={tw.style('py-2 items-center')}
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.Lg}
+        isFullWidth
       >
-        <Text
-          color={TextColor.InfoDefault}
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-        >
-          {strings('onboarding_success.manage_default_settings')}
-        </Text>
-      </TouchableOpacity>
+        {strings('onboarding_success.manage_default_settings')}
+      </Button>
     );
   };
 


### PR DESCRIPTION
## **Description**

Reworked the onboarding-related screens to lean on the design-system `Button` (tertiary variant) instead of scattered text-only controls. This keeps the login modal, the onboarding welcome prompt, and the seed-phrase copy CTA consistent with the rest of the UI kit.

Changes pulled out of: https://github.com/MetaMask/metamask-mobile/pull/28115

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A related to MMDS v27 upgrade https://github.com/MetaMask/metamask-mobile/pull/28115

## **Manual testing steps**

```gherkin
Feature: Onboarding design alignment
  Scenario: login and onboarding actions use tertiary buttons
    Given the login screen or onboarding prompt is rendered
    When the user scans for the “Forgot password?” or “Unlock” call-to-actions
    Then they are presented with tertiary design-system buttons that match the rest of the UI kit
```

## **Screenshots/Recordings**

### **Before**

N/A see screen recordings in code comments

### **After**

N/A see screen recordings in code comments

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps touchable/text-only controls for design-system `Button` components; primary risk is minor layout/interaction regressions on login/onboarding screens.
> 
> **Overview**
> Standardizes secondary onboarding CTAs onto the design-system `Button` (tertiary, large, full-width) instead of ad-hoc `TouchableOpacity`/`TextButton` implementations.
> 
> This updates the Login "Forgot password?" action, Manual Backup Step 1 "Remind me later" action, and Onboarding Success "Manage default settings" footer link, and refreshes related Jest snapshots and a removed style-props assertion in `OnboardingSuccess` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6af0fe44209c81487196e0d1744ea8c8b0712985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->