### PR TITLE
ci: prevent full workflow restart on ready_for_review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Keep full CI scoped to standard PR updates only.
+    # Adding ready_for_review here would restart the entire workflow.
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    # Keep full CI scoped to standard PR updates only.
-    # Adding ready_for_review here would restart the entire workflow.
     types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Addressed the Cursor bot concern about introducing a new PR event trigger that can restart full CI runs.

This change explicitly scopes `ci.yml` `pull_request` triggers to:
- `opened`
- `synchronize`
- `reopened`

This prevents accidental inclusion of `ready_for_review` in the full CI workflow trigger set, which would otherwise cancel in-progress runs (due to workflow concurrency) and restart the entire CI pipeline.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: CI trigger scoping for pull_request events

  Scenario: Full CI does not restart solely from ready-for-review transitions
    Given the main CI workflow is configured with explicit pull_request event types
    When a PR transitions from draft to ready for review
    Then the workflow is not triggered by ready_for_review via this configuration

  Scenario: Full CI still runs on normal PR updates
    Given an open PR targeting main
    When the PR is opened, synchronized, or reopened
    Then the main CI workflow is triggered as expected
```

## **Screenshots/Recordings**

### **Before**

N/A (workflow configuration change)

### **After**

N/A (workflow configuration change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1af9e49-59a1-4f22-9545-c0cb61bd1f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1af9e49-59a1-4f22-9545-c0cb61bd1f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

