### PR TITLE
fix(ci): remove unused riskLevel destructuring in smart e2e selection

### DIFF
--- a/.github/scripts/e2e-smart-selection.mjs
+++ b/.github/scripts/e2e-smart-selection.mjs
@@ -63,7 +63,7 @@ function generatePRComment(summaryContent) {
 }
 
 function setGitHubOutputs(analysis) {
-  const { tags, confidence, riskLevel, performanceTests } = analysis;
+  const { tags, confidence, performanceTests } = analysis;
   setGithubOutputs('ai_e2e_test_tags', tags);
   setGithubOutputs('ai_confidence', confidence);
   // Performance test tags (empty array means no performance tests needed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removes an unused `riskLevel` variable from `setGitHubOutputs` in `.github/scripts/e2e-smart-selection.mjs`.

This addresses the Bugbot review comment on PR #28194 about dead destructuring after `ai_risk_level` output was removed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
Refs: https://github.com/MetaMask/metamask-mobile/pull/28194

## **Manual testing steps**

```gherkin
Feature: Smart E2E selection script outputs

  Scenario: script parses after cleanup
    Given the repository is on the fix branch
    When running `node --check .github/scripts/e2e-smart-selection.mjs`
    Then the command succeeds with no syntax errors
```

## **Screenshots/Recordings**

### **Before**

N/A (non-UI change)

### **After**

N/A (non-UI change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b03101c-8b8d-4652-a18e-0b0499ebc2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b03101c-8b8d-4652-a18e-0b0499ebc2e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

