### PR TITLE
test: tap visibility button on create password

### DIFF
--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -540,6 +540,8 @@ export const onboardingFlowImportSRPPlaywright = async (
   await CreatePasswordView.reEnterPassword(
     getPasswordForScenario('onboarding') ?? '',
   );
+  await CreatePasswordView.tapPasswordVisibilityIcon();
+  await PlaywrightGestures.hideKeyboard();
   await CreatePasswordView.tapIUnderstandCheckBox();
   await CreatePasswordView.tapCreatePasswordButton();
 

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -13,6 +13,7 @@ import { encapsulatedAction } from '../../framework/encapsulatedAction';
 import PlaywrightAssertions from '../../framework/PlaywrightAssertions';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import UnifiedGestures from '../../framework/UnifiedGestures';
+import { ImportFromSeedSelectorsIDs } from '../../../app/components/Views/ImportFromSecretRecoveryPhrase/ImportFromSeed.testIds';
 
 class CreatePasswordView {
   get container(): DetoxElement {
@@ -37,6 +38,25 @@ class CreatePasswordView {
         ios: () =>
           PlaywrightMatchers.getElementByCatchAll(
             ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+          ),
+      },
+    });
+  }
+  get passwordVisibilityIcon(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(
+          ImportFromSeedSelectorsIDs.NEW_PASSWORD_VISIBILITY_ID,
+        ),
+      appium: {
+        android: () =>
+          PlaywrightMatchers.getElementById(
+            ImportFromSeedSelectorsIDs.NEW_PASSWORD_VISIBILITY_ID,
+          ),
+
+        ios: () =>
+          PlaywrightMatchers.getElementByCatchAll(
+            ImportFromSeedSelectorsIDs.NEW_PASSWORD_VISIBILITY_ID,
           ),
       },
     });
@@ -217,6 +237,20 @@ class CreatePasswordView {
       appium: async () => {
         await UnifiedGestures.waitAndTap(this.submitButton, {
           description: 'Create Password Submit Button',
+        });
+      },
+    });
+  }
+  async tapPasswordVisibilityIcon(): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.tap(asDetoxElement(this.passwordVisibilityIcon), {
+          elemDescription: 'Create Password Password Visibility Icon',
+        });
+      },
+      appium: async () => {
+        await UnifiedGestures.tap(this.passwordVisibilityIcon, {
+          description: 'Create Password Password Visibility Icon',
         });
       },
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

> Improves onboarding E2E stability by explicitly toggling the *new password* visibility control during the Playwright SRP import flow, then hiding the keyboard before proceeding.
> 
> Extends `CreatePasswordView` with a `passwordVisibilityIcon` selector and `tapPasswordVisibilityIcon()` action (shared across Detox/Appium) to support the new test step.
> 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Playwright/Detox test flows and page objects, with no production logic or data-handling impact.
> 
> **Overview**
> Improves onboarding E2E stability by explicitly toggling the *new password* visibility control during the Playwright SRP import flow, then hiding the keyboard before proceeding.
> 
> Extends `CreatePasswordView` with a `passwordVisibilityIcon` selector and `tapPasswordVisibilityIcon()` action (shared across Detox/Appium) to support the new test step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99ca067ccf1b8f40f428b4f61be6bd278ab86a33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->