### PR TITLE
fix(onboarding): remove header title from SRP import screen

### DIFF
--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -471,7 +471,7 @@ export function getOnboardingNavbarOptions(
             />
           </View>
         )
-      : null,
+      : '',
     headerRight: headerRightHide,
     headerLeft: headerLeftHide,
     headerTintColor: themeColors.primary.default,

--- a/app/components/UI/Navbar/index.test.js
+++ b/app/components/UI/Navbar/index.test.js
@@ -269,7 +269,7 @@ describe('Navbar', () => {
         false,
       );
 
-      expect(options.headerTitle).toBeNull();
+      expect(options.headerTitle).toBe('');
     });
   });
 

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
@@ -170,9 +170,7 @@ exports[`ImportFromSecretRecoveryPhrase Import a wallet UI render matches snapsh
                       "fontWeight": "600",
                     }
                   }
-                >
-                  ImportFromSecretRecoveryPhrase
-                </Text>
+                />
               </View>
               <View
                 collapsable={false}

--- a/app/components/Views/ManualBackupStep1/index.test.tsx
+++ b/app/components/Views/ManualBackupStep1/index.test.tsx
@@ -305,7 +305,7 @@ describe('ManualBackupStep1', () => {
       const opts = setOptions.mock.calls[0][0];
       expect(opts.headerShown).toBeUndefined();
       expect(opts.headerLeft).toBeDefined();
-      expect(opts.headerTitle).toBeNull();
+      expect(opts.headerTitle).toBe('');
     });
 
     it('shows header with back button for settings backup flow', () => {
@@ -318,7 +318,7 @@ describe('ManualBackupStep1', () => {
       const opts = setOptions.mock.calls[0][0];
       expect(opts.headerShown).toBeUndefined();
       expect(opts.headerLeft).toBeDefined();
-      expect(opts.headerTitle).toBeNull();
+      expect(opts.headerTitle).toBe('');
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Set headerTitle to empty string instead of null to prevent the route name from displaying in the navigation bar on the import wallet screen. Also update navigation parent accessor calls.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-31 at 15 56 37" src="https://github.com/user-attachments/assets/a8825128-1707-41c4-b4dc-9bc674620185" />


### **After**

<!-- [screenshots/recordings] -->
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-31 at 15 56 08" src="https://github.com/user-attachments/assets/d1bdd70b-cca3-42d5-beb4-237732e441a8" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation configuration change that only affects how the onboarding header title is rendered when the logo is hidden.
> 
> **Overview**
> Prevents onboarding-related screens from accidentally displaying the route name in the navigation bar by changing `getOnboardingNavbarOptions` to use an empty string (`''`) instead of `null` when `showLogo` is false.
> 
> Updates associated unit tests and the `ImportFromSecretRecoveryPhrase` snapshot to reflect the now-empty header title, and aligns `ManualBackupStep1` header assertions with the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit accacecd64c1750e5e2c1034e025b5d94e2753fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->