### PR TITLE
fix(homepage): predictions privacy mode for positions and claim (TMCU-615)

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictionsSection from './PredictionsSection';
 import Routes from '../../../../../constants/navigation/Routes';
+import { PREDICT_CLAIM_BUTTON_TEST_IDS } from '../../../../UI/Predict/components/PredictActionButtons/PredictClaimButton.testIds';
 
 const mockNavigate = jest.fn();
 const mockClaim = jest.fn();
@@ -35,7 +36,7 @@ jest.mock('../../../../UI/Predict/hooks/useUnrealizedPnL', () => ({
 
 jest.mock('../../../../../selectors/preferencesController', () => ({
   ...jest.requireActual('../../../../../selectors/preferencesController'),
-  selectPrivacyMode: () => false,
+  selectPrivacyMode: jest.fn(() => false),
 }));
 
 jest.mock('@tanstack/react-query', () => {
@@ -80,6 +81,9 @@ const mockUsePredictMarketsForHomepage =
   jest.requireMock('./hooks').usePredictMarketsForHomepage;
 const mockUsePredictPositionsForHomepage =
   jest.requireMock('./hooks').usePredictPositionsForHomepage;
+const mockSelectPrivacyMode = jest.requireMock(
+  '../../../../../selectors/preferencesController',
+).selectPrivacyMode as jest.Mock;
 
 const mockActivePositions = [
   {
@@ -143,6 +147,7 @@ describe('PredictionsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockClaim.mockResolvedValue(undefined);
+    mockSelectPrivacyMode.mockReturnValue(false);
 
     // Reset mock return value to default (true) to ensure test isolation
     jest
@@ -472,6 +477,76 @@ describe('PredictionsSection', () => {
       });
 
       fireEvent.press(screen.getByText('Claim $200.00'));
+
+      await waitFor(() => {
+        expect(mockClaim).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('privacy mode', () => {
+    beforeEach(() => {
+      mockSelectPrivacyMode.mockReturnValue(true);
+    });
+
+    it('hides monetary values on position rows', async () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
+          positions: claimable ? [] : mockActivePositions,
+          isLoading: false,
+          error: null,
+          totalClaimableValue: 0,
+          refetch: jest.fn(),
+        }),
+      );
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Position 1')).toBeOnTheScreen();
+      });
+
+      expect(screen.queryByText('$10 on Yes to win $15')).toBeNull();
+      expect(screen.queryByText('$12')).toBeNull();
+      expect(screen.queryByText('20%')).toBeNull();
+      expect(screen.queryByText('-40%')).toBeNull();
+      expect(screen.queryAllByText(/•+/).length).toBeGreaterThan(0);
+    });
+
+    it('masks claim amount and still invokes claim on press', async () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
+          positions: claimable ? mockClaimablePositions : mockActivePositions,
+          isLoading: false,
+          error: null,
+          totalClaimableValue: claimable ? 200 : 0,
+          refetch: jest.fn(),
+        }),
+      );
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(
+            PREDICT_CLAIM_BUTTON_TEST_IDS.PREDICT_CLAIM_BUTTON,
+          ),
+        ).toBeOnTheScreen();
+      });
+
+      expect(screen.queryByText('Claim $200.00')).toBeNull();
+
+      fireEvent.press(
+        screen.getByTestId(PREDICT_CLAIM_BUTTON_TEST_IDS.PREDICT_CLAIM_BUTTON),
+      );
 
       await waitFor(() => {
         expect(mockClaim).toHaveBeenCalledTimes(1);

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -283,6 +283,7 @@ const PredictionsSection = forwardRef<
                   key={`${position.outcomeId}:${position.outcomeIndex}`}
                   position={position}
                   onPress={handlePositionPress}
+                  privacyMode={Boolean(privacyMode)}
                 />
               ))
             )}
@@ -291,7 +292,7 @@ const PredictionsSection = forwardRef<
               totalClaimableValue > 0 && (
                 <Box paddingHorizontal={4} paddingTop={1} paddingBottom={3}>
                   <PredictClaimButton
-                    amount={totalClaimableValue}
+                    amount={privacyMode ? undefined : totalClaimableValue}
                     onPress={handleClaim}
                   />
                 </Box>

--- a/app/components/Views/Homepage/Sections/Predictions/components/PredictPositionRow.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/PredictPositionRow.tsx
@@ -11,15 +11,24 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../../util/theme';
+import SensitiveText, {
+  SensitiveTextLength,
+} from '../../../../../../component-library/components/Texts/SensitiveText';
+import {
+  TextVariant as ComponentTextVariant,
+  TextColor as ComponentTextColor,
+} from '../../../../../../component-library/components/Texts/Text/Text.types';
 import {
   formatPercentage,
   formatPrice,
 } from '../../../../../UI/Predict/utils/format';
 import type { PredictPosition } from '../../../../../UI/Predict/types';
+import { strings } from '../../../../../../../locales/i18n';
 
 interface PredictPositionRowProps {
   position: PredictPosition;
   onPress: (position: PredictPosition) => void;
+  privacyMode: boolean;
 }
 
 /**
@@ -32,6 +41,7 @@ interface PredictPositionRowProps {
 export const PredictPositionRow = ({
   position,
   onPress,
+  privacyMode,
 }: PredictPositionRowProps) => {
   const tw = useTailwind();
 
@@ -39,11 +49,14 @@ export const PredictPositionRow = ({
     onPress(position);
   }, [onPress, position]);
 
+  const { title, outcome, initialValue, size, currentValue, percentPnl } =
+    position;
+
   return (
     <TouchableOpacity
       onPress={handlePress}
       accessibilityRole="button"
-      accessibilityLabel={`${position.title} - ${position.outcome}`}
+      accessibilityLabel={`${title} - ${outcome}`}
     >
       <Box
         flexDirection={BoxFlexDirection.Row}
@@ -62,32 +75,46 @@ export const PredictPositionRow = ({
         )}
         <Box style={tw.style('flex-1')} gap={0}>
           <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
-            {position.title}
+            {title}
           </Text>
-          <Text
-            variant={TextVariant.BodyMd}
-            color={TextColor.TextAlternative}
+          <SensitiveText
+            variant={ComponentTextVariant.BodySMMedium}
+            color={ComponentTextColor.Alternative}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Long}
             numberOfLines={1}
           >
-            {formatPrice(position.initialValue, { maximumDecimals: 2 })} on{' '}
-            {position.outcome} to win{' '}
-            {formatPrice(position.size, { maximumDecimals: 2 })}
-          </Text>
+            {strings('predict.position_info', {
+              initialValue: formatPrice(initialValue, {
+                maximumDecimals: 2,
+              }),
+              outcome,
+              shares: formatPrice(size, {
+                maximumDecimals: 2,
+              }),
+            })}
+          </SensitiveText>
         </Box>
         <Box twClassName="items-end" gap={0}>
-          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
-            {formatPrice(position.currentValue, { maximumDecimals: 2 })}
-          </Text>
-          <Text
-            variant={TextVariant.BodyMd}
-            color={
-              position.percentPnl >= 0
-                ? TextColor.SuccessDefault
-                : TextColor.ErrorDefault
-            }
+          <SensitiveText
+            variant={ComponentTextVariant.BodyMDMedium}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
           >
-            {formatPercentage(position.percentPnl)}
-          </Text>
+            {formatPrice(currentValue, { maximumDecimals: 2 })}
+          </SensitiveText>
+          <SensitiveText
+            variant={ComponentTextVariant.BodySMMedium}
+            color={
+              percentPnl > 0
+                ? ComponentTextColor.Success
+                : ComponentTextColor.Error
+            }
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Short}
+          >
+            {formatPercentage(percentPnl)}
+          </SensitiveText>
         </Box>
       </Box>
     </TouchableOpacity>

--- a/app/components/Views/Homepage/Sections/Predictions/components/PredictPositionRow.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/PredictPositionRow.tsx
@@ -106,7 +106,7 @@ export const PredictPositionRow = ({
           <SensitiveText
             variant={ComponentTextVariant.BodySMMedium}
             color={
-              percentPnl > 0
+              percentPnl >= 0
                 ? ComponentTextColor.Success
                 : ComponentTextColor.Error
             }


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Homepage **Predictions** showed open position amounts and the claim total in plain text when **privacy mode** was on. This aligns the section with the Predict tab: monetary lines use `SensitiveText`, and the claim button uses `PredictClaimButton`’s `isHidden` so the amount is not readable on-screen.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed homepage Predictions section so open positions and claim amounts respect privacy mode

## **Related issues**

Fixes:

Refs: [TMCU-615](https://consensyssoftware.atlassian.net/browse/TMCU-615)

## **Manual testing steps**

```gherkin
Feature: Homepage predictions privacy mode

  Scenario: Position amounts are hidden when privacy mode is on
    Given the user has Predict positions on the homepage
    And privacy mode is enabled in settings
    When the user views the wallet homepage Predictions section
    Then position titles remain visible
    And currency and PnL values are masked

  Scenario: Claim amount is hidden when privacy mode is on
    Given the user has claimable Predict winnings on the homepage
    And privacy mode is enabled
    When the user views the Predictions claim button
    Then the exact claim dollar amount is not shown
    And tapping the button still runs claim
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" src="https://github.com/user-attachments/assets/99286ccf-3fcf-46e7-a085-7d24a7ea1ed4" />


### **After**

<img width="300" src="https://github.com/user-attachments/assets/3c7b9d50-7d67-438a-b528-538556dc68ec" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that only affects how values are displayed under privacy mode, with added tests to prevent regressions.
> 
> **Overview**
> Homepage **Predictions** now respects *privacy mode* by masking monetary/PNL text in position rows via `SensitiveText` and passing `privacyMode` down to `PredictPositionRow`.
> 
> The claim CTA no longer renders the exact dollar amount when privacy mode is enabled (by omitting the `amount` passed to `PredictClaimButton`), while still allowing the claim action to be triggered. Tests were updated/added to cover these privacy-mode behaviors, including verifying masked output and claim invocation via the button `testID`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a1e63efa1049c1e5cdf6656c5e9c322e9a9f941. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->