### PR TITLE
ci: decouple nightly exp and rc builds so failures don't cascade

### DIFF
--- a/.github/workflows/nightly-build-temp.yml
+++ b/.github/workflows/nightly-build-temp.yml
@@ -7,10 +7,8 @@ name: Nightly Build (temp)
 # iOS builds are handled end-to-end by upload-to-testflight-temp.yml (build + upload).
 # Android builds use create-build-branch.yml + build.yml (build artifacts only).
 #
-# rc depends on exp within each platform stream to ensure the external version
-# service produces sequential numbers (N for exp, N+1 for rc).
-# iOS and Android streams run in parallel; their version numbers will differ
-# but remain unique, which is all TestFlight / Play Store require.
+# All four streams (ios-exp, ios-rc, android-exp, android-rc) run independently
+# so that a failure in one does not block the others.
 
 on:
   schedule:
@@ -33,10 +31,9 @@ jobs:
       testflight_group: 'MetaMask BETA & Release Candidates'
     secrets: inherit
 
-  # ── iOS rc: build + TestFlight upload (after exp for sequential versions) ─
+  # ── iOS rc: build + TestFlight upload ─────────────────────────────────
   ios-rc:
     name: Nightly iOS rc
-    needs: [ios-exp]
     uses: ./.github/workflows/upload-to-testflight-temp.yml
     with:
       source_branch: main
@@ -62,9 +59,8 @@ jobs:
       source_branch: ${{ needs.android-exp-branch.outputs.build_branch }}
     secrets: inherit
 
-  # ── Android rc: ephemeral branch + build (after exp for sequential versions) ─
+  # ── Android rc: ephemeral branch + build ──────────────────────────────
   android-rc-branch:
-    needs: [android-exp]
     uses: ./.github/workflows/create-build-branch.yml
     with:
       source_branch: main


### PR DESCRIPTION
## **Description**

Removes the `needs` dependency between exp and rc jobs in the nightly build workflow so that a failure in one stream does not block the other.

Previously, `ios-rc` depended on `ios-exp` and `android-rc-branch` depended on `android-exp`, meaning any exp failure would skip the rc build entirely. This was intended to produce sequential version numbers, but sequential numbering is not a hard requirement — TestFlight and Play Store only need unique build numbers.

Now all four streams (ios-exp, ios-rc, android-exp, android-rc) run fully in parallel and independently.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — CI workflow change only. Trigger `nightly-build-temp` via `workflow_dispatch` and verify all four jobs start immediately without waiting on each other.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change, but it alters nightly build orchestration and version-bump sequencing, which could surface as unexpected build-number collisions or skipped artifacts if assumptions elsewhere rely on the old ordering.
> 
> **Overview**
> **Decouples nightly exp and rc streams** in `nightly-build-temp.yml` so a failure in `*-exp` no longer prevents the corresponding `*-rc` job from running.
> 
> Removes the `needs` dependencies (`ios-rc` no longer waits for `ios-exp`, and `android-rc-branch` no longer waits for `android-exp`) and updates the workflow comments to reflect fully independent parallel execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a45b024b6704631ef9dc9f3394a461db3dab77d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->