### PR TITLE
refactor(onboarding): remove stale unlock CTA and tests

### DIFF
--- a/app/components/Views/Login/LoginView.testIds.ts
+++ b/app/components/Views/Login/LoginView.testIds.ts
@@ -1,3 +1,5 @@
+import enContent from '../../../../locales/languages/en.json';
+
 export const LoginViewSelectors = {
   CONTAINER: 'login',
   PASSWORD_ERROR: 'invalid-password-error',
@@ -9,4 +11,8 @@ export const LoginViewSelectors = {
   PASSWORD_INPUT: 'login-password-input',
   DEVICE_AUTHENTICATION_ICON: 'device-authentication-icon',
   OTHER_METHODS_BUTTON: 'other-methods-button',
+};
+
+export const LoginViewSelectorText = {
+  UNLOCK_BUTTON: enContent.login.unlock_button,
 };

--- a/app/components/Views/Onboarding/Onboarding.testIds.ts
+++ b/app/components/Views/Onboarding/Onboarding.testIds.ts
@@ -21,5 +21,4 @@ export const OnboardingSelectorIDs = {
 
 export const OnboardingSelectorText = {
   SUCCESSFUL_WALLET_RESET: enContent.onboarding.your_wallet,
-  UNLOCK_BUTTON: enContent.onboarding.unlock,
 };

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -844,60 +844,6 @@ describe('Onboarding', () => {
     });
   });
 
-  describe('Navigation behavior', () => {
-    it('navigates to HOME_NAV when unlock is pressed and password is not set', async () => {
-      const { getByText } = renderScreen(
-        Onboarding,
-        { name: 'Onboarding' },
-        {
-          state: mockInitialStateWithExistingUser,
-        },
-      );
-
-      await waitFor(() => {
-        expect(getByText('Unlock')).toBeTruthy();
-      });
-
-      jest.advanceTimersByTime(600);
-
-      const unlockButton = getByText('Unlock');
-
-      await act(async () => {
-        fireEvent.press(unlockButton);
-      });
-
-      expect(Authentication.resetVault).toHaveBeenCalled();
-      expect(mockReplace).toHaveBeenCalledWith(
-        Routes.ONBOARDING.HOME_NAV,
-        undefined,
-      );
-    });
-
-    it('navigates to LOGIN when unlock is pressed and password is set', async () => {
-      const { getByText } = renderScreen(
-        Onboarding,
-        { name: 'Onboarding' },
-        {
-          state: mockInitialStateWithExistingUserAndPassword,
-        },
-      );
-
-      await waitFor(() => {
-        expect(getByText('Unlock')).toBeTruthy();
-      });
-
-      jest.advanceTimersByTime(600);
-
-      const unlockButton = getByText('Unlock');
-
-      await act(async () => {
-        fireEvent.press(unlockButton);
-      });
-
-      expect(Authentication.lockApp).toHaveBeenCalled();
-    });
-  });
-
   describe('componentDidMount behavior', () => {
     it('checks for existing user on mount', async () => {
       renderScreen(

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -101,7 +101,6 @@ import {
   ButtonSize,
   ButtonVariant,
   Text,
-  TextButton,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import {
@@ -1118,14 +1117,6 @@ const Onboarding = () => {
               </Box>
             )}
           </Box>
-
-          {existingUser && !loading && (
-            <Box twClassName="mb-10 -mt-10">
-              <TextButton onPress={onLogin}>
-                {strings('onboarding.unlock')}
-              </TextButton>
-            </Box>
-          )}
         </ScrollView>
 
         <FadeOutOverlay />

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -318,15 +318,6 @@ const Onboarding = () => {
       }
     }, [navigation, route]);
 
-  const onLogin = useCallback(async (): Promise<void> => {
-    if (!passwordSet) {
-      await Authentication.resetVault();
-      navigation.dispatch(StackActions.replace(Routes.ONBOARDING.HOME_NAV));
-    } else {
-      await Authentication.lockApp({ navigateToLogin: true });
-    }
-  }, [navigation, passwordSet]);
-
   const handleExistingUser = useCallback(
     async (action: () => void | Promise<void>): Promise<void> => {
       if (state.existingUser) {

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Wallet synchronisieren oder importieren",
     "new_to_crypto": "Crypto-Neuling?",
     "start_exploring_now": "Neues Wallet erstellen",
-    "unlock": "Entsperren",
     "new_to_metamask": "Neu bei MetaMask?",
     "already_have_wallet": "Sie haben bereits ein Wallet?",
     "optin_back_title": "Achtung!",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Συγχρονισμός ή εισαγωγή πορτοφολιού",
     "new_to_crypto": "Νέος στα κρυπτονομίσματα;",
     "start_exploring_now": "Δημιουργήστε ένα καινούργιο πορτοφόλι",
-    "unlock": "Ξεκλείδωμα",
     "new_to_metamask": "Νέος στο MetaMask;",
     "already_have_wallet": "Έχετε ήδη πορτοφόλι;",
     "optin_back_title": "Προσοχή!",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Sync or import wallet",
     "new_to_crypto": "New to crypto?",
     "start_exploring_now": "Create a new wallet",
-    "unlock": "Unlock",
     "new_to_metamask": "New to MetaMask?",
     "already_have_wallet": "Already have a wallet?",
     "optin_back_title": "Heads up!",
@@ -8293,7 +8292,6 @@
   "homepage": {
     "sections": {
       "cash": "Cash",
-
       "cash_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Cash section on the homepage.",
       "cash_empty_description_network_filter": "No mUSD on this network. Switch network to see your mUSD.",
       "tokens": "Tokens",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Sincronizar o importar monedero",
     "new_to_crypto": "¿Primera vez que usa criptomonedas?",
     "start_exploring_now": "Crear una billetera nueva",
-    "unlock": "Desbloquear",
     "new_to_metamask": "¿Es nuevo en MetaMask?",
     "already_have_wallet": "¿Ya tiene un monedero?",
     "optin_back_title": "¡Atención!",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Synchroniser ou importer un portefeuille",
     "new_to_crypto": "Vous êtes novice en matière de cryptomonnaies ?",
     "start_exploring_now": "Créer un nouveau portefeuille",
-    "unlock": "Déverrouiller",
     "new_to_metamask": "Nouveau/Nouvelle sur MetaMask ?",
     "already_have_wallet": "Vous avez déjà un portefeuille ?",
     "optin_back_title": "Attention !",

--- a/locales/languages/hi-in.json
+++ b/locales/languages/hi-in.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "वॉलेट सिंक करें या आयात करें",
     "new_to_crypto": "क्रिप्टो पर नए हैं?",
     "start_exploring_now": "एक नया वॉलेट बनाएँ",
-    "unlock": "लॉग इन करें",
     "new_to_metamask": "MetaMask पर नए हैं?",
     "already_have_wallet": "पहले से एक वॉलेट है?",
     "optin_back_title": "सचेत रहें!",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "वॉलेट इम्पोर्ट करें या सिंक करें",
     "new_to_crypto": "क्रिप्टो आपके लिए नया है?",
     "start_exploring_now": "एक नया वॉलेट बनाएं",
-    "unlock": "अनलॉक करें",
     "new_to_metamask": "MetaMask पर नए हैं?",
     "already_have_wallet": "पहले से ही एक वॉलेट है?",
     "optin_back_title": "सतर्क रहें!",

--- a/locales/languages/id-id.json
+++ b/locales/languages/id-id.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "Sinkronkan atau impor dompet",
     "new_to_crypto": "Baru menggunakan kripto?",
     "start_exploring_now": "Buat dompet baru",
-    "unlock": "Masuk",
     "new_to_metamask": "Baru menggunakan MetaMask?",
     "already_have_wallet": "Sudah punya dompet?",
     "optin_back_title": "Perhatian!",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Sinkronkan atau impor dompet",
     "new_to_crypto": "Baru mengenal kripto?",
     "start_exploring_now": "Buat dompet baru",
-    "unlock": "Buka",
     "new_to_metamask": "Baru mengenal MetaMask?",
     "already_have_wallet": "Sudah memiliki dompet?",
     "optin_back_title": "Perhatian!",

--- a/locales/languages/ja-jp.json
+++ b/locales/languages/ja-jp.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "ウォレットの同期またはインポート",
     "new_to_crypto": "暗号化が初めての場合",
     "start_exploring_now": "新しいウォレットの作成",
-    "unlock": "ログイン",
     "new_to_metamask": "MetaMask が初めての場合",
     "already_have_wallet": "すでにウォレットがある場合",
     "optin_back_title": "注意!",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "ウォレットを同期またはインポート",
     "new_to_crypto": "暗号資産は初めてですか？",
     "start_exploring_now": "新規ウォレットを作成",
-    "unlock": "ロックを解除",
     "new_to_metamask": "MetaMaskを初めてご利用ですか？",
     "already_have_wallet": "すでにウォレットをお持ちですか？",
     "optin_back_title": "ご注意！",

--- a/locales/languages/ko-kr.json
+++ b/locales/languages/ko-kr.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "지갑 동기화 또는 가져오기",
     "new_to_crypto": "암호화폐가 처음이세요?",
     "start_exploring_now": "새 지갑 생성",
-    "unlock": "로그인",
     "new_to_metamask": "MetaMask가 처음이세요?",
     "already_have_wallet": "이미 지갑이 있나요?",
     "optin_back_title": "주의하세요!",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "지갑 동기화 또는 불러오기",
     "new_to_crypto": "암호화 화폐의 세계에 처음 오셨나요?",
     "start_exploring_now": "새 지갑 생성하기",
-    "unlock": "잠금 해제",
     "new_to_metamask": "MetaMask에 처음 오셨나요?",
     "already_have_wallet": "이미 지갑이 있으신가요?",
     "optin_back_title": "조심하세요!",

--- a/locales/languages/pt-br.json
+++ b/locales/languages/pt-br.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "Sincronizar ou importar carteira",
     "new_to_crypto": "A criptomoeda é uma novidade para você?",
     "start_exploring_now": "Criar nova carteira",
-    "unlock": "Desbloquear",
     "new_to_metamask": "O MetaMask é uma novidade para você?",
     "already_have_wallet": "Já tem uma carteira?",
     "optin_back_title": "Fique de olho!",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Sincronizar ou importar carteira",
     "new_to_crypto": "Novo nas criptomoedas?",
     "start_exploring_now": "Criar uma nova carteira",
-    "unlock": "Desbloquear",
     "new_to_metamask": "Novo na MetaMask?",
     "already_have_wallet": "Já tem uma carteira?",
     "optin_back_title": "Atenção!",

--- a/locales/languages/ru-ru.json
+++ b/locales/languages/ru-ru.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "Синхронизировать или импортировать кошелек",
     "new_to_crypto": "Новичок в криптовалюте?",
     "start_exploring_now": "Создать новый кошелек",
-    "unlock": "Войти в систему",
     "new_to_metamask": "Впервые в MetaMask?",
     "already_have_wallet": "Кошелек уже есть?",
     "optin_back_title": "Предупреждение.",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Синхронизировать или импортировать кошелек",
     "new_to_crypto": "Новичок в криптоактивах?",
     "start_exploring_now": "Создайте новый кошелек",
-    "unlock": "Разблокировать",
     "new_to_metamask": "Новичок в MetaMask?",
     "already_have_wallet": "Уже есть кошелек?",
     "optin_back_title": "Внимание!",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Mag-sync o mag-import ng wallet",
     "new_to_crypto": "Bago ka lang ba sa crypto?",
     "start_exploring_now": "Gumawa ng bagong wallet",
-    "unlock": "I-unlock",
     "new_to_metamask": "Bago ka ba sa MetaMask?",
     "already_have_wallet": "May wallet ka na ba?",
     "optin_back_title": "Paalala!",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Cüzdanı senkronize et veya içe aktar",
     "new_to_crypto": "Kriptoda yeni misiniz?",
     "start_exploring_now": "Yeni bir cüzdan oluştur",
-    "unlock": "Kilidini Aç",
     "new_to_metamask": "MetaMask'te yeni misiniz?",
     "already_have_wallet": "Zaten bir cüzdanınız var mı?",
     "optin_back_title": "Dikkat!",

--- a/locales/languages/vi-vn.json
+++ b/locales/languages/vi-vn.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "Đồng bộ hóa hoặc nhập ví",
     "new_to_crypto": "Bạn mới sử dụng tiền mã hóa?",
     "start_exploring_now": "Tạo một ví mới",
-    "unlock": "Đăng nhập",
     "new_to_metamask": "Bạn mới sử dụng MetaMask?",
     "already_have_wallet": "Bạn đã có ví?",
     "optin_back_title": "Chú ý!",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "Đồng bộ hoặc nhập ví",
     "new_to_crypto": "Bạn mới tìm hiểu về tiền mã hóa?",
     "start_exploring_now": "Tạo một ví mới",
-    "unlock": "Mở khóa",
     "new_to_metamask": "Bạn mới sử dụng MetaMask?",
     "already_have_wallet": "Bạn đã có ví?",
     "optin_back_title": "Chú ý!",

--- a/locales/languages/zh-cn.json
+++ b/locales/languages/zh-cn.json
@@ -34,7 +34,6 @@
     "import_wallet_button": "同步或导入钱包",
     "new_to_crypto": "新接触加密币？",
     "start_exploring_now": "创建新钱包",
-    "unlock": "登录",
     "new_to_metamask": "MetaMask 的新用户？",
     "already_have_wallet": "已有钱包？",
     "optin_back_title": "注意！",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -240,7 +240,6 @@
     "import_wallet_button": "同步或导入钱包",
     "new_to_crypto": "新接触加密币？",
     "start_exploring_now": "创建新钱包",
-    "unlock": "登录",
     "new_to_metamask": "MetaMask 的新用户？",
     "already_have_wallet": "已有钱包？",
     "optin_back_title": "注意！",

--- a/tests/page-objects/wallet/LoginView.ts
+++ b/tests/page-objects/wallet/LoginView.ts
@@ -1,4 +1,7 @@
-import { LoginViewSelectors } from '../../../app/components/Views/Login/LoginView.testIds';
+import {
+  LoginViewSelectors,
+  LoginViewSelectorText,
+} from '../../../app/components/Views/Login/LoginView.testIds';
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
 import { PlaywrightAssertions } from '../../framework';
@@ -10,7 +13,6 @@ import {
 import { encapsulatedAction } from '../../framework/encapsulatedAction';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import UnifiedGestures from '../../framework/UnifiedGestures';
-import { OnboardingSelectorText } from '../../../app/components/Views/Onboarding/Onboarding.testIds';
 
 class LoginView {
   get container(): EncapsulatedElementType {
@@ -56,7 +58,7 @@ class LoginView {
       detox: () => Matchers.getElementByID(LoginViewSelectors.LOGIN_BUTTON_ID),
       appium: () =>
         PlaywrightMatchers.getElementByText(
-          OnboardingSelectorText.UNLOCK_BUTTON,
+          LoginViewSelectorText.UNLOCK_BUTTON,
         ),
     });
   }


### PR DESCRIPTION
## **Description**

Removing what looks like a incorrect Unlock button component on the initial onboarding screen along with tests and locales. Updated e2e tests to use the correct "Unlock" content key.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A ([Related to MMDS v26 upgrade](https://github.com/MetaMask/metamask-mobile/pull/28115)

## **Manual testing steps**

```gherkin
Feature: onboarding unlock cleanup

  Scenario: user opens onboarding
    Given the app is on the onboarding screen

    When user views available onboarding actions
    Then only create/import onboarding actions are shown

  Scenario: unit tests for onboarding
    Given the code changes are applied
    When running `yarn jest app/components/Views/Onboarding/index.test.tsx`
    Then the onboarding suite passes without unlock-button assertions
```

## **Screenshots/Recordings**

### **Before**

(Not visible without removing conditional logic but this is what it looks like when it's displayed)

https://github.com/user-attachments/assets/15419f2a-f48e-469e-96d5-7ef102077e60

<img width="192" height="168" alt="Screenshot 2026-03-31 at 4 05 54 PM" src="https://github.com/user-attachments/assets/81c6ef11-6c20-42d1-a32c-541838cd19c4" /><img width="214" height="195" alt="Screenshot 2026-03-31 at 4 06 00 PM" src="https://github.com/user-attachments/assets/554c90d6-eb8b-430e-a988-28e32bb6ab0d" />

### **After**

N/A (test-only/stale UI cleanup)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes an unused onboarding "Unlock" CTA path and its locale strings, and updates E2E selectors to reference the login screen’s unlock label instead.
> 
> **Overview**
> Removes the stale **existing-user "Unlock" CTA** from the `Onboarding` screen (and the associated `onLogin` navigation logic), so onboarding only presents create/import actions.
> 
> Cleans up related test coverage by deleting the onboarding navigation tests around this CTA, removes the `onboarding.unlock` locale string across languages, and updates the E2E `LoginView` page object to locate the login button using a new `LoginViewSelectorText.UNLOCK_BUTTON` instead of onboarding text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a4c6e6324d4d406a83311ce4d112fd492b83849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->