### PR TITLE
ci(ios): reject previous TestFlight build waiting for review

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -101,6 +101,7 @@ platform :ios do
     testflight_options = {
       api_key: api_key,
       ipa: ipa_path,
+      reject_build_waiting_for_review: true,
       distribute_external: distribute_external,
       groups: groups,
       notify_external_testers: notify_external_testers,


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The nightly iOS TestFlight uploads fail when a previous build in the same version train is already waiting for beta review. Apple only allows one build per version to be in beta review at a time, causing a `Spaceship::UnexpectedResponse` error that fails the CI job even though the IPA uploaded successfully.

This adds `reject_build_waiting_for_review: true` to the `upload_to_testflight` Fastlane action, which automatically rejects the previous build's pending review submission before submitting the new one. This ensures back-to-back builds (e.g. nightly exp then rc) can always distribute to external testers without manual intervention. Previously approved builds remain available in TestFlight — only the pending review submission is cancelled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: TestFlight upload with reject_build_waiting_for_review

  Scenario: nightly build uploads when previous build is waiting for review
    Given a previous iOS build is waiting for beta review in App Store Connect

    When a new nightly build triggers the upload-to-testflight workflow
    Then the previous build's review submission should be rejected
    And the new build should be uploaded and submitted for beta review
    And the workflow should complete successfully
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI configuration tweak that only affects TestFlight upload behavior; main risk is unintended cancellation of a prior build that was still awaiting beta review in the same version train.
> 
> **Overview**
> Updates iOS Fastlane `upload_to_testflight_only` to pass `reject_build_waiting_for_review: true` to `upload_to_testflight`, automatically rejecting any prior build stuck *waiting for beta review* before submitting a new one.
> 
> This prevents CI/TestFlight uploads from failing when Apple allows only one build per version to be in review at a time, enabling back-to-back external distribution without manual intervention.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2af86afe6904e9759f8cf478606cf51115c404bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->