### PR TITLE
fix(ramps): Single-owner React Query fetching for providers, tokens, and payment methods

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,7 +15,7 @@ npmAuditIgnoreAdvisories:
   - 1113402 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
   - 1113441 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
   - 1113442 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
-  - 1115765 # XML injection via unsafe CDATA serialization allows attacker-controlled markup insertion https://github.com/advisories/GHSA-wh4c-j3r5-mjhp
+  - 1115765 # @xmldom/xmldom advisory GHSA-wh4c-j3r5-mjhp. Current lock resolves 0.8.11 and patched 0.8.12 isn't available via current dependency graph; suppress temporarily to unblock CI.
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,7 +15,7 @@ npmAuditIgnoreAdvisories:
   - 1113402 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
   - 1113441 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
   - 1113442 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
-  - 1115765 # @xmldom/xmldom advisory GHSA-wh4c-j3r5-mjhp. Current lock resolves 0.8.11 and patched 0.8.12 isn't available via current dependency graph; suppress temporarily to unblock CI.
+  - 1115765 # XML injection via unsafe CDATA serialization allows attacker-controlled markup insertion https://github.com/advisories/GHSA-wh4c-j3r5-mjhp
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs
 

--- a/app/components/UI/Ramp/RampsBootstrap.test.tsx
+++ b/app/components/UI/Ramp/RampsBootstrap.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { configureStore } from '@reduxjs/toolkit';
 import RampsBootstrap from './RampsBootstrap';
 
 const mockUseRampsSmartRouting = jest.fn();
 const mockUseRampsProviders = jest.fn();
+const mockUseRampsPaymentMethods = jest.fn();
 
 jest.mock('./hooks/useRampsSmartRouting', () => ({
   __esModule: true,
@@ -15,26 +19,72 @@ jest.mock('./hooks/useRampsProviders', () => ({
   default: (...args: unknown[]) => mockUseRampsProviders(...args),
 }));
 
+jest.mock('./hooks/useRampsPaymentMethods', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseRampsPaymentMethods(...args),
+}));
+
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    RampsController: {
+      getTokens: jest.fn().mockResolvedValue({ topTokens: [], allTokens: [] }),
+    },
+  },
+}));
+
+const createMockStore = () =>
+  configureStore({
+    reducer: {
+      engine: () => ({
+        backgroundState: {
+          RampsController: {
+            userRegion: {
+              regionCode: 'us',
+              country: { currency: 'USD' },
+            },
+          },
+        },
+      }),
+    },
+  });
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const renderBootstrap = () => {
+  const store = createMockStore();
+  return render(
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <RampsBootstrap />
+      </QueryClientProvider>
+    </Provider>,
+  );
+};
+
 describe('RampsBootstrap', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('calls useRampsSmartRouting on mount', () => {
-    render(<RampsBootstrap />);
-
+    renderBootstrap();
     expect(mockUseRampsSmartRouting).toHaveBeenCalledTimes(1);
   });
 
   it('calls useRampsProviders on mount', () => {
-    render(<RampsBootstrap />);
-
+    renderBootstrap();
     expect(mockUseRampsProviders).toHaveBeenCalledTimes(1);
   });
 
-  it('renders null', () => {
-    const { toJSON } = render(<RampsBootstrap />);
+  it('calls useRampsPaymentMethods on mount', () => {
+    renderBootstrap();
+    expect(mockUseRampsPaymentMethods).toHaveBeenCalledTimes(1);
+  });
 
+  it('renders null', () => {
+    const { toJSON } = renderBootstrap();
     expect(toJSON()).toBeNull();
   });
 });

--- a/app/components/UI/Ramp/RampsBootstrap.tsx
+++ b/app/components/UI/Ramp/RampsBootstrap.tsx
@@ -22,7 +22,7 @@ import Engine from '../../../core/Engine';
  */
 function RampsBootstrap(): null {
   useRampsSmartRouting();
-  useRampsProviders();
+  useRampsProviders({ enableSideEffects: true });
   useRampsPaymentMethods();
 
   // Fetch tokens when region is available. Tokens don't use React Query

--- a/app/components/UI/Ramp/RampsBootstrap.tsx
+++ b/app/components/UI/Ramp/RampsBootstrap.tsx
@@ -1,5 +1,10 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import useRampsSmartRouting from './hooks/useRampsSmartRouting';
 import useRampsProviders from './hooks/useRampsProviders';
+import useRampsPaymentMethods from './hooks/useRampsPaymentMethods';
+import { selectUserRegion } from '../../../selectors/rampsController';
+import Engine from '../../../core/Engine';
 
 /**
  * Ramps app bootstrap: runs smart routing, controller hydration, and provider
@@ -11,10 +16,25 @@ import useRampsProviders from './hooks/useRampsProviders';
  *
  * V2: RampsController is initialized by Engine (rampsControllerInit). Provider
  * auto-selection runs when providers load. Mount at app root.
+ *
+ * Tokens, providers, and payment methods are all fetched here so they are
+ * ready when the user enters the buy flow.
  */
 function RampsBootstrap(): null {
   useRampsSmartRouting();
   useRampsProviders();
+  useRampsPaymentMethods();
+
+  // Fetch tokens when region is available. Tokens don't use React Query
+  // (they're needed for controller-side validation in setSelectedToken),
+  // so we trigger the fetch directly.
+  const userRegion = useSelector(selectUserRegion);
+  useEffect(() => {
+    if (userRegion?.regionCode) {
+      Engine.context.RampsController.getTokens(userRegion.regionCode, 'buy');
+    }
+  }, [userRegion?.regionCode]);
+
   return null;
 }
 

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
@@ -362,7 +362,7 @@ describe('PaymentSelectionModal', () => {
     });
   });
 
-  it('shows payment method without quote when only custom-action quote matches', () => {
+  it('filters out payment method when only custom-action quote matches', () => {
     const customActionQuote = {
       provider: '/providers/transak',
       quote: {
@@ -381,7 +381,11 @@ describe('PaymentSelectionModal', () => {
       loading: false,
     }));
 
-    const { getAllByText } = renderWithProvider(PaymentSelectionModal);
-    expect(getAllByText('Debit or Credit').length).toBeGreaterThan(0);
+    const { queryAllByText, getByText } = renderWithProvider(
+      PaymentSelectionModal,
+    );
+    // Payment methods with only custom-action quotes are filtered out
+    expect(queryAllByText('Debit or Credit').length).toBe(0);
+    expect(getByText('fiat_on_ramp.no_payment_methods_available')).toBeTruthy();
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -219,7 +219,18 @@ function PaymentSelectionModal() {
         </ScrollView>
       );
     }
-    if (paymentMethods.length === 0) {
+    // Filter out payment methods that have no available quote once quotes
+    // have loaded. This avoids showing dead-end options to the user.
+    const visiblePaymentMethods =
+      !quotesLoading && quotes
+        ? paymentMethods.filter((pm) =>
+            quotes.success?.some(
+              (q) => q.quote?.paymentMethod === pm.id && !isCustomAction(q),
+            ),
+          )
+        : paymentMethods;
+
+    if (visiblePaymentMethods.length === 0) {
       return (
         <ScrollView
           style={styles.list}
@@ -235,7 +246,7 @@ function PaymentSelectionModal() {
     return (
       <FlatList
         style={styles.list}
-        data={paymentMethods}
+        data={visiblePaymentMethods}
         renderItem={renderPaymentMethod}
         keyExtractor={(item) => item.id}
         keyboardDismissMode="none"

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
@@ -121,8 +121,8 @@ const mockInAppBrowser = InAppBrowser as jest.Mocked<typeof InAppBrowser>;
 let mockSelectedProvider: Provider | null = createMockProvider();
 const mockSetSelectedProvider = jest.fn();
 
-jest.mock('../../../hooks/useRampsController', () => ({
-  useRampsController: () => ({
+jest.mock('../../../hooks/useRampsProviders', () => ({
+  useRampsProviders: () => ({
     selectedProvider: mockSelectedProvider,
     setSelectedProvider: mockSetSelectedProvider,
   }),

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -25,7 +25,7 @@ import {
 import Logger from '../../../../../../util/Logger';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import MenuItem from '../../../components/MenuItem';
-import { useRampsController } from '../../../hooks/useRampsController';
+import { useRampsProviders } from '../../../hooks/useRampsProviders';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import {
@@ -53,7 +53,7 @@ function SettingsModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { toastRef } = useContext(ToastContext);
-  const { selectedProvider, setSelectedProvider } = useRampsController();
+  const { selectedProvider, setSelectedProvider } = useRampsProviders();
 
   const [isAuthenticatedWithProvider, setIsAuthenticatedWithProvider] =
     useState<boolean>(false);

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.test.tsx
@@ -58,9 +58,14 @@ let mockSelectedToken: unknown = {
   symbol: 'USDC',
 };
 
-jest.mock('../../../hooks/useRampsController', () => ({
-  useRampsController: () => ({
+jest.mock('../../../hooks/useRampsProviders', () => ({
+  useRampsProviders: () => ({
     selectedProvider: mockSelectedProvider,
+  }),
+}));
+
+jest.mock('../../../hooks/useRampsTokens', () => ({
+  useRampsTokens: () => ({
     selectedToken: mockSelectedToken,
   }),
 }));

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
@@ -21,7 +21,8 @@ import {
 import Routes from '../../../../../../constants/navigation/Routes';
 import styleSheet from './TokenNotAvailableModal.styles';
 import { useStyles } from '../../../../../hooks/useStyles';
-import { useRampsController } from '../../../hooks/useRampsController';
+import { useRampsProviders } from '../../../hooks/useRampsProviders';
+import { useRampsTokens } from '../../../hooks/useRampsTokens';
 import { createProviderSelectionModalNavigationDetails } from '../ProviderSelectionModal';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
@@ -48,7 +49,8 @@ function TokenNotAvailableModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const { styles } = useStyles(styleSheet, {});
 
-  const { selectedProvider, selectedToken } = useRampsController();
+  const { selectedProvider } = useRampsProviders();
+  const { selectedToken } = useRampsTokens();
 
   const tokenName = selectedToken?.name ?? '';
   const providerName = selectedProvider?.name ?? '';

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
@@ -5,7 +5,6 @@ import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { Country, State, UserRegion } from '@metamask/ramps-controller';
-import useRampsController from '../../../hooks/useRampsController';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -24,8 +23,6 @@ jest.mock('@react-navigation/native', () => {
 });
 
 const mockSetUserRegion = jest.fn().mockResolvedValue(undefined);
-const mockSetSelectedProvider = jest.fn();
-
 const createMockCountry = (
   isoCode: string,
   name: string,
@@ -89,47 +86,27 @@ const mockRegions: Country[] = [
   createMockCountry('XX', 'Unsupported Country', '🏳️', undefined, false),
 ];
 
-const mockUseRampsControllerInitialValues: ReturnType<
-  typeof useRampsController
-> = {
-  userRegion: null,
+const mockUserRegionInitial = {
+  userRegion: null as UserRegion | null,
   setUserRegion: mockSetUserRegion,
-  selectedProvider: null,
-  setSelectedProvider: mockSetSelectedProvider,
-  providers: [],
-  providersLoading: false,
-  providersError: null,
-  tokens: null,
-  selectedToken: null,
-  setSelectedToken: jest.fn(),
-  tokensLoading: false,
-  tokensError: null,
-  countries: mockRegions,
-  countriesLoading: false,
-  countriesError: null,
-  paymentMethods: [],
-  selectedPaymentMethod: null,
-  setSelectedPaymentMethod: jest.fn(),
-  paymentMethodsLoading: false,
-  paymentMethodsError: null,
-  paymentMethodsFetching: false,
-  paymentMethodsStatus: 'idle' as const,
-  getQuotes: jest.fn(),
-  getBuyWidgetData: jest.fn(),
-  orders: [],
-  getOrderById: jest.fn(),
-  addOrder: jest.fn(),
-  addPrecreatedOrder: jest.fn(),
-  removeOrder: jest.fn(),
-  refreshOrder: jest.fn(),
-  getOrderFromCallback: jest.fn(),
 };
 
-let mockUseRampsControllerValues = mockUseRampsControllerInitialValues;
+const mockCountriesInitial = {
+  countries: mockRegions,
+  isLoading: false,
+  error: null as string | null,
+};
 
-jest.mock('../../../hooks/useRampsController', () =>
-  jest.fn(() => mockUseRampsControllerValues),
-);
+let mockUserRegionValues = { ...mockUserRegionInitial };
+let mockCountriesValues = { ...mockCountriesInitial };
+
+jest.mock('../../../hooks/useRampsUserRegion', () => ({
+  useRampsUserRegion: () => mockUserRegionValues,
+}));
+
+jest.mock('../../../hooks/useRampsCountries', () => ({
+  useRampsCountries: () => mockCountriesValues,
+}));
 
 function render(Component: React.ComponentType) {
   return renderScreen(
@@ -150,9 +127,8 @@ function render(Component: React.ComponentType) {
 describe('RegionSelector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
-    };
+    mockUserRegionValues = { ...mockUserRegionInitial };
+    mockCountriesValues = { ...mockCountriesInitial };
   });
 
   it('renders countries list', () => {
@@ -161,29 +137,29 @@ describe('RegionSelector', () => {
   });
 
   it('renders loading state when regions are loading', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: [],
-      countriesLoading: true,
+      isLoading: true,
     };
     render(RegionSelector);
     expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders error state when countries error occurs', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: [],
-      countriesLoading: false,
-      countriesError: 'Failed to fetch countries',
+      isLoading: false,
+      error: 'Failed to fetch countries',
     };
     render(RegionSelector);
     expect(screen.toJSON()).toMatchSnapshot();
   });
 
   it('renders with selected user region', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ca'),
     };
     render(RegionSelector);
@@ -195,8 +171,8 @@ describe('RegionSelector', () => {
       createMockCountry('US', 'United States', '🇺🇸', undefined, true, true),
       createMockCountry('CA', 'Canada', '🇨🇦', undefined, true, false),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: recommendedRegions,
     };
     render(RegionSelector);
@@ -271,8 +247,8 @@ describe('RegionSelector', () => {
         createMockState('US-CA', 'California'),
       ]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: countriesWithPrefixedStateId,
     };
     render(RegionSelector);
@@ -302,8 +278,8 @@ describe('RegionSelector', () => {
   });
 
   it('renders when country has states and user region state is shown', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ca'),
     };
     render(RegionSelector);
@@ -334,8 +310,8 @@ describe('RegionSelector', () => {
   });
 
   it('renders with empty regions array', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: [],
     };
     render(RegionSelector);
@@ -348,8 +324,8 @@ describe('RegionSelector', () => {
         createMockState('CA', 'California'),
       ]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithoutFlag,
     };
     render(RegionSelector);
@@ -364,8 +340,8 @@ describe('RegionSelector', () => {
     const regionsWithStateWithoutId = [
       createMockCountry('US', 'United States', '🇺🇸', [stateWithoutId]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithStateWithoutId,
     };
     render(RegionSelector);
@@ -380,8 +356,8 @@ describe('RegionSelector', () => {
         unsupportedState,
       ]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithUnsupportedState,
     };
     render(RegionSelector);
@@ -394,8 +370,8 @@ describe('RegionSelector', () => {
     const errorMock = jest
       .fn()
       .mockRejectedValue(new Error('Failed to set region'));
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       setUserRegion: errorMock,
     };
     render(RegionSelector);
@@ -453,8 +429,8 @@ describe('RegionSelector', () => {
       },
       regionCode: 'us-ca',
     };
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: userRegionWithState,
     };
     render(RegionSelector);
@@ -480,8 +456,8 @@ describe('RegionSelector', () => {
         standaloneState,
       ]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithStandaloneState,
     };
     render(RegionSelector);
@@ -492,8 +468,8 @@ describe('RegionSelector', () => {
 
   it('displays standalone countries in search results', () => {
     const standaloneCountry = createMockCountry('DE', 'Germany', '🇩🇪');
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: [...mockRegions, standaloneCountry],
     };
     render(RegionSelector);
@@ -515,8 +491,8 @@ describe('RegionSelector', () => {
         unsupportedState,
       ]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithUnsupportedState,
     };
     render(RegionSelector);
@@ -554,8 +530,8 @@ describe('RegionSelector', () => {
       undefined,
       false,
     );
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: [unsupportedCountry],
     };
     render(RegionSelector);
@@ -567,8 +543,8 @@ describe('RegionSelector', () => {
     const regionsWithUnsupportedState = [
       createMockCountry('US', 'United States', '🇺🇸', [unsupportedState]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithUnsupportedState,
     };
     render(RegionSelector);
@@ -585,8 +561,8 @@ describe('RegionSelector', () => {
     const regionsWithStateWithoutId = [
       createMockCountry('US', 'United States', '🇺🇸', [stateWithoutId]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithStateWithoutId,
     };
     render(RegionSelector);
@@ -604,8 +580,8 @@ describe('RegionSelector', () => {
     const manyRegions = Array.from({ length: 30 }, (_, i) =>
       createMockCountry(`C${i}`, `Country ${i}`, '🏳️'),
     );
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: manyRegions,
     };
     render(RegionSelector);
@@ -620,8 +596,8 @@ describe('RegionSelector', () => {
       createMockCountry('FR', 'France', '🇫🇷', undefined, true, true),
       createMockCountry('CA', 'Canada', '🇨🇦', undefined, true, false),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regions,
     };
     render(RegionSelector);
@@ -633,8 +609,8 @@ describe('RegionSelector', () => {
     const initialSnapshot = screen.toJSON();
 
     const newRegions = [createMockCountry('DE', 'Germany', '🇩🇪')];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: newRegions,
     };
 
@@ -643,8 +619,8 @@ describe('RegionSelector', () => {
   });
 
   it('highlights country when regionCode exactly matches country code', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('fr'),
     };
     render(RegionSelector);
@@ -652,8 +628,8 @@ describe('RegionSelector', () => {
   });
 
   it('highlights country when regionCode starts with country code and state is selected', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ca'),
     };
     render(RegionSelector);
@@ -661,8 +637,8 @@ describe('RegionSelector', () => {
   });
 
   it('highlights state when selected in state view', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ca'),
     };
     render(RegionSelector);
@@ -672,8 +648,8 @@ describe('RegionSelector', () => {
   });
 
   it('highlights state in grouped search results when parent country matches', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ca'),
     };
     render(RegionSelector);
@@ -683,8 +659,8 @@ describe('RegionSelector', () => {
   });
 
   it('does not highlight state when country does not match', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('ca-on'),
     };
     render(RegionSelector);
@@ -694,8 +670,8 @@ describe('RegionSelector', () => {
   });
 
   it('does not highlight state when state ID does not match', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ny'),
     };
     render(RegionSelector);
@@ -717,8 +693,8 @@ describe('RegionSelector', () => {
       state: null,
       regionCode: 'us',
     };
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: userRegionWithoutState,
     };
     render(RegionSelector);
@@ -728,8 +704,8 @@ describe('RegionSelector', () => {
   });
 
   it('does not highlight country when regionCode does not match', () => {
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('de'),
     };
     render(RegionSelector);
@@ -745,9 +721,12 @@ describe('RegionSelector', () => {
     const regionsWithStandaloneState = [
       createMockCountry('US', 'United States', '🇺🇸', [standaloneState]),
     ];
-    mockUseRampsControllerValues = {
-      ...mockUseRampsControllerInitialValues,
+    mockCountriesValues = {
+      ...mockCountriesInitial,
       countries: regionsWithStandaloneState,
+    };
+    mockUserRegionValues = {
+      ...mockUserRegionInitial,
       userRegion: createMockUserRegion('us-ca'),
     };
     render(RegionSelector);

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.tsx
@@ -44,7 +44,8 @@ import { getNavigationOptionsTitle } from '../../../../Navbar';
 import { strings } from '../../../../../../../locales/i18n';
 import { useAppTheme } from '../../../../../../util/theme';
 import { Country, State } from '@metamask/ramps-controller';
-import useRampsController from '../../../hooks/useRampsController';
+import { useRampsUserRegion } from '../../../hooks/useRampsUserRegion';
+import { useRampsCountries } from '../../../hooks/useRampsCountries';
 import { REGION_SELECTOR_TEST_IDS } from './RegionSelector.testIds';
 
 const MAX_REGION_RESULTS = 20;
@@ -109,13 +110,12 @@ function RegionSelector() {
   const { colors } = useAppTheme();
   const listRef = useRef<FlatList<ListItem>>(null);
 
+  const { userRegion, setUserRegion } = useRampsUserRegion();
   const {
-    userRegion,
-    setUserRegion,
     countries,
-    countriesLoading,
-    countriesError,
-  } = useRampsController();
+    isLoading: countriesLoading,
+    error: countriesError,
+  } = useRampsCountries();
 
   const [searchString, setSearchString] = useState('');
   const [activeView, setActiveView] = useState(RegionViewType.COUNTRY);

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
@@ -225,7 +225,7 @@ describe('useRampsPaymentMethods', () => {
     expect(result.current.paymentMethods).toEqual([]);
   });
 
-  it('calls Engine.context.RampsController.setSelectedPaymentMethod with payment method id', () => {
+  it('calls Engine.context.RampsController.setSelectedPaymentMethod with full payment method object', () => {
     const store = createMockStore({
       providers: { ...baseRampsState.providers, selected: null },
     });
@@ -241,10 +241,10 @@ describe('useRampsPaymentMethods', () => {
 
     expect(
       Engine.context.RampsController.setSelectedPaymentMethod,
-    ).toHaveBeenCalledWith(mockPaymentMethods[0].id);
+    ).toHaveBeenCalledWith(mockPaymentMethods[0]);
   });
 
-  it('calls Engine.context.RampsController.setSelectedPaymentMethod with undefined when payment method is null', () => {
+  it('calls Engine.context.RampsController.setSelectedPaymentMethod with null when payment method is null', () => {
     const store = createMockStore({
       providers: { ...baseRampsState.providers, selected: null },
     });
@@ -260,6 +260,6 @@ describe('useRampsPaymentMethods', () => {
 
     expect(
       Engine.context.RampsController.setSelectedPaymentMethod,
-    ).toHaveBeenCalledWith(undefined);
+    ).toHaveBeenCalledWith(null);
   });
 });

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts
@@ -115,7 +115,7 @@ describe('useRampsPaymentMethods', () => {
     jest.clearAllMocks();
   });
 
-  it('returns idle before an active request exists', () => {
+  it('returns idle when no provider is selected', () => {
     const store = createMockStore({
       providers: { ...baseRampsState.providers, selected: null },
     });
@@ -138,7 +138,7 @@ describe('useRampsPaymentMethods', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('returns loading while the active query is in flight', () => {
+  it('returns loading while the query is in flight', () => {
     const store = createMockStore();
     const { Wrapper } = createWrapper(store);
 
@@ -242,45 +242,6 @@ describe('useRampsPaymentMethods', () => {
     expect(
       Engine.context.RampsController.setSelectedPaymentMethod,
     ).toHaveBeenCalledWith(mockPaymentMethods[0].id);
-  });
-
-  it('disables the query when the token is missing from supportedCryptoCurrencies', () => {
-    const store = createMockStore({
-      providers: {
-        ...baseRampsState.providers,
-        selected: {
-          id: '/providers/banxa',
-          name: 'Banxa',
-          supportedCryptoCurrencies: {
-            'eip155:1/slip44:60': true,
-            // MUSD assetId is NOT in the map — treated as unsupported
-          },
-        },
-      },
-      tokens: {
-        ...baseRampsState.tokens,
-        selected: {
-          assetId: 'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
-          chainId: 'eip155:1',
-          name: 'MetaMask USD',
-          symbol: 'MUSD',
-          decimals: 6,
-          iconUrl: '',
-          tokenSupported: true,
-        },
-      },
-    });
-    const { Wrapper } = createWrapper(store);
-
-    const { result } = renderHook(() => useRampsPaymentMethods(), {
-      wrapper: Wrapper,
-    });
-
-    expect(result.current.status).toBe('idle');
-    expect(result.current.isLoading).toBe(false);
-    expect(
-      Engine.context.RampsController.getPaymentMethods,
-    ).not.toHaveBeenCalled();
   });
 
   it('calls Engine.context.RampsController.setSelectedPaymentMethod with undefined when payment method is null', () => {

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import {
   selectPaymentMethods,
   selectProviders,
-  selectTokens,
   selectUserRegion,
 } from '../../../../selectors/rampsController';
 import { type PaymentMethod } from '@metamask/ramps-controller';
@@ -53,36 +52,30 @@ export interface UseRampsPaymentMethodsResult {
 }
 
 /**
- * Hook to get payment methods state from RampsController.
- * This hook assumes Engine is already initialized.
+ * Hook to get payment methods via React Query.
+ *
+ * The query fires only when a provider is selected (provider change is the
+ * sole trigger). Token and fiat are passed to the API call but are NOT part
+ * of the query key, so changing them does not cause a refetch.
  *
  * @returns Payment methods state.
  */
 export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
   const { selected: selectedPaymentMethod } = useSelector(selectPaymentMethods);
   const { selected: selectedProvider } = useSelector(selectProviders);
-  const { selected: selectedToken } = useSelector(selectTokens);
   const userRegion = useSelector(selectUserRegion);
-
-  const tokenSupportedByProvider = selectedProvider?.supportedCryptoCurrencies
-    ? selectedProvider.supportedCryptoCurrencies[
-        selectedToken?.assetId ?? ''
-      ] === true
-    : true;
 
   const queryEnabled = Boolean(
     userRegion?.regionCode &&
       userRegion?.country?.currency &&
-      selectedToken?.assetId &&
-      selectedProvider?.id &&
-      tokenSupportedByProvider,
+      selectedProvider?.id,
   );
 
   const paymentMethodsQuery = useQuery({
     ...rampsQueries.paymentMethods.options({
       regionCode: userRegion?.regionCode ?? '',
       fiat: userRegion?.country?.currency ?? '',
-      assetId: selectedToken?.assetId ?? '',
+      assetId: '', // not used in the query key; provider scope is sufficient
       providerId: selectedProvider?.id ?? '',
     }),
     enabled: queryEnabled,

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import {
   selectPaymentMethods,
   selectProviders,
+  selectTokens,
   selectUserRegion,
 } from '../../../../selectors/rampsController';
 import { type PaymentMethod } from '@metamask/ramps-controller';
@@ -63,6 +64,7 @@ export interface UseRampsPaymentMethodsResult {
 export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
   const { selected: selectedPaymentMethod } = useSelector(selectPaymentMethods);
   const { selected: selectedProvider } = useSelector(selectProviders);
+  const { selected: selectedToken } = useSelector(selectTokens);
   const userRegion = useSelector(selectUserRegion);
 
   const queryEnabled = Boolean(
@@ -75,7 +77,7 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     ...rampsQueries.paymentMethods.options({
       regionCode: userRegion?.regionCode ?? '',
       fiat: userRegion?.country?.currency ?? '',
-      assetId: '', // not used in the query key; provider scope is sufficient
+      assetId: selectedToken?.assetId ?? '', // passed to API but not in the query key
       providerId: selectedProvider?.id ?? '',
     }),
     enabled: queryEnabled,

--- a/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
+++ b/app/components/UI/Ramp/hooks/useRampsPaymentMethods.ts
@@ -85,9 +85,13 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
 
   const setSelectedPaymentMethod = useCallback(
     (paymentMethod: PaymentMethod | null) =>
-      Engine.context.RampsController.setSelectedPaymentMethod(
-        paymentMethod?.id,
-      ),
+      (
+        Engine.context.RampsController as {
+          setSelectedPaymentMethod: (
+            pm?: PaymentMethod | string | null,
+          ) => void;
+        }
+      ).setSelectedPaymentMethod(paymentMethod),
     [],
   );
 

--- a/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
@@ -289,7 +289,7 @@ describe('useRampsProviders', () => {
         autoSelected: false,
       });
 
-      renderHook(() => useRampsProviders(), {
+      renderHook(() => useRampsProviders({ enableSideEffects: true }), {
         wrapper: wrapper(store),
       });
 
@@ -307,7 +307,7 @@ describe('useRampsProviders', () => {
         autoSelected: false,
       });
 
-      renderHook(() => useRampsProviders(), {
+      renderHook(() => useRampsProviders({ enableSideEffects: true }), {
         wrapper: wrapper(store),
       });
 
@@ -321,7 +321,7 @@ describe('useRampsProviders', () => {
       mockGetOrders.mockReturnValue(emptyOrders);
       mockDeterminePreferredProvider.mockReturnValue(null);
 
-      renderHook(() => useRampsProviders(), {
+      renderHook(() => useRampsProviders({ enableSideEffects: true }), {
         wrapper: wrapper(store),
       });
 

--- a/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.test.ts
@@ -1,6 +1,10 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
-import { useQuery } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from '@tanstack/react-query';
 import { configureStore } from '@reduxjs/toolkit';
 import React from 'react';
 import { useRampsProviders } from './useRampsProviders';
@@ -106,10 +110,22 @@ const createMockStore = (
     },
   });
 
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
 const wrapper =
   (store: ReturnType<typeof createMockStore>) =>
   ({ children }: { children: React.ReactNode }) =>
-    React.createElement(Provider, { store } as never, children);
+    React.createElement(
+      Provider,
+      { store } as never,
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      ),
+    );
 
 describe('useRampsProviders', () => {
   beforeEach(() => {
@@ -297,7 +313,7 @@ describe('useRampsProviders', () => {
 
       expect(
         Engine.context.RampsController.setSelectedProvider,
-      ).toHaveBeenCalledWith(mockProviders[1].id, { autoSelected: false });
+      ).toHaveBeenCalledWith(mockProviders[1], { autoSelected: false });
     });
 
     it('does not call setSelectedProvider when determinePreferredProvider returns null', () => {

--- a/app/components/UI/Ramp/hooks/useRampsProviders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   selectProviders,
   selectUserRegion,
@@ -49,30 +49,43 @@ export interface UseRampsProvidersResult {
 }
 
 /**
- * Hook to get providers state from RampsController.
- * This hook assumes Engine is already initialized.
+ * Hook to get providers via React Query.
  *
- * Uses react-query with a 15min staleTime and refetchOnMount so that
- * providers (including supportedCryptoCurrencies) are refreshed when
- * stale data is detected on mount.
+ * The query fires when the region changes. Provider data is read from the
+ * React Query cache (not controller state) so that region-switching with
+ * cached data works correctly.
  *
  * @returns Providers state.
  */
 export function useRampsProviders(): UseRampsProvidersResult {
-  const {
-    data: providers,
-    selected: selectedProvider,
-    isLoading,
-    error,
-  } = useSelector(selectProviders);
+  const { selected: selectedProvider } = useSelector(selectProviders);
 
   const userRegion = useSelector(selectUserRegion);
   const regionCode = userRegion?.regionCode ?? '';
+  const queryClient = useQueryClient();
 
-  useQuery({
+  // Invalidate all ramp queries when region changes so that stale cached
+  // data from a previous region is not served. The queryFn will re-run,
+  // hit the controller's internal executeRequest cache (fast), and
+  // repopulate controller state.
+  const prevRegionRef = useRef(regionCode);
+  useEffect(() => {
+    if (regionCode && prevRegionRef.current !== regionCode) {
+      prevRegionRef.current = regionCode;
+      queryClient.invalidateQueries({ queryKey: ['ramps'] });
+    }
+  }, [regionCode, queryClient]);
+
+  const providersQuery = useQuery({
     ...rampsQueries.providers.options({ regionCode }),
     enabled: Boolean(regionCode),
   });
+
+  // Keep a stable array reference for hook dependencies.
+  const providers = useMemo(
+    () => providersQuery.data ?? [],
+    [providersQuery.data],
+  );
 
   const legacyOrders = useSelector(getOrders);
   const controllerOrders = useSelector(
@@ -100,7 +113,14 @@ export function useRampsProviders(): UseRampsProvidersResult {
     if (providers && providers.length > 0 && !selectedProvider) {
       const result = determinePreferredProvider(completedOrders, providers);
       if (result) {
-        Engine.context.RampsController.setSelectedProvider(result.provider.id, {
+        (
+          Engine.context.RampsController as {
+            setSelectedProvider: (
+              providerOrId: Provider | string | null,
+              options?: { autoSelected?: boolean },
+            ) => void;
+          }
+        ).setSelectedProvider(result.provider, {
           autoSelected: result.autoSelected,
         });
       }
@@ -111,8 +131,11 @@ export function useRampsProviders(): UseRampsProvidersResult {
     providers,
     selectedProvider,
     setSelectedProvider,
-    isLoading,
-    error,
+    isLoading: providersQuery.isLoading,
+    error:
+      providersQuery.error instanceof Error
+        ? providersQuery.error.message
+        : null,
   };
 }
 

--- a/app/components/UI/Ramp/hooks/useRampsProviders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsProviders.ts
@@ -57,24 +57,45 @@ export interface UseRampsProvidersResult {
  *
  * @returns Providers state.
  */
-export function useRampsProviders(): UseRampsProvidersResult {
-  const { selected: selectedProvider } = useSelector(selectProviders);
+/**
+ * @param options.enableSideEffects - When true, runs region-change invalidation and provider auto-selection.
+ * Should only be true in RampsBootstrap to avoid duplicate side effects from multiple consumers.
+ */
+export function useRampsProviders(options?: {
+  enableSideEffects?: boolean;
+}): UseRampsProvidersResult {
+  const enableSideEffects = options?.enableSideEffects ?? false;
+  const {
+    data: providersStateData,
+    selected: selectedProvider,
+    isLoading: providersStateIsLoading,
+    error: providersStateError,
+  } = useSelector(selectProviders);
 
   const userRegion = useSelector(selectUserRegion);
   const regionCode = userRegion?.regionCode ?? '';
   const queryClient = useQueryClient();
 
-  // Invalidate all ramp queries when region changes so that stale cached
-  // data from a previous region is not served. The queryFn will re-run,
-  // hit the controller's internal executeRequest cache (fast), and
-  // repopulate controller state.
+  // Mark all ramp queries as stale when region changes so that switching
+  // back to a previously visited region triggers a fresh fetch instead of
+  // serving cached data. refetchType: 'none' avoids a duplicate fetch —
+  // the query-key change already causes React Query to fetch for the new
+  // region; without 'none', invalidateQueries would trigger a second fetch
+  // on the same active query.
   const prevRegionRef = useRef(regionCode);
   useEffect(() => {
-    if (regionCode && prevRegionRef.current !== regionCode) {
+    if (
+      enableSideEffects &&
+      regionCode &&
+      prevRegionRef.current !== regionCode
+    ) {
       prevRegionRef.current = regionCode;
-      queryClient.invalidateQueries({ queryKey: ['ramps'] });
+      queryClient.invalidateQueries({
+        queryKey: ['ramps'],
+        refetchType: 'none',
+      });
     }
-  }, [regionCode, queryClient]);
+  }, [enableSideEffects, regionCode, queryClient]);
 
   const providersQuery = useQuery({
     ...rampsQueries.providers.options({ regionCode }),
@@ -82,9 +103,11 @@ export function useRampsProviders(): UseRampsProvidersResult {
   });
 
   // Keep a stable array reference for hook dependencies.
+  // React Query is authoritative when present; fallback to controller state
+  // keeps initial renders and test mocks resilient.
   const providers = useMemo(
-    () => providersQuery.data ?? [],
-    [providersQuery.data],
+    () => providersQuery?.data ?? providersStateData ?? [],
+    [providersQuery?.data, providersStateData],
   );
 
   const legacyOrders = useSelector(getOrders);
@@ -101,16 +124,21 @@ export function useRampsProviders(): UseRampsProvidersResult {
   );
 
   const setSelectedProvider = useCallback(
-    (provider: Provider | null, options?: { autoSelected?: boolean }) =>
+    (provider: Provider | null, setOptions?: { autoSelected?: boolean }) =>
       Engine.context.RampsController.setSelectedProvider(
         provider?.id ?? null,
-        options,
+        setOptions,
       ),
     [],
   );
 
   useEffect(() => {
-    if (providers && providers.length > 0 && !selectedProvider) {
+    if (
+      enableSideEffects &&
+      providers &&
+      providers.length > 0 &&
+      !selectedProvider
+    ) {
       const result = determinePreferredProvider(completedOrders, providers);
       if (result) {
         (
@@ -125,17 +153,17 @@ export function useRampsProviders(): UseRampsProvidersResult {
         });
       }
     }
-  }, [providers, selectedProvider, completedOrders]);
+  }, [enableSideEffects, providers, selectedProvider, completedOrders]);
 
   return {
     providers,
     selectedProvider,
     setSelectedProvider,
-    isLoading: providersQuery.isLoading,
+    isLoading: providersQuery?.isLoading ?? providersStateIsLoading,
     error:
-      providersQuery.error instanceof Error
+      providersQuery?.error instanceof Error
         ? providersQuery.error.message
-        : null,
+        : providersStateError,
   };
 }
 

--- a/app/components/UI/Ramp/queries/paymentMethods.test.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.test.ts
@@ -4,25 +4,16 @@ import {
 } from './paymentMethods';
 
 describe('rampsPaymentMethodsOptions', () => {
-  it('creates a stable normalized query key', () => {
+  it('creates a stable normalized query key from regionCode and providerId only', () => {
     expect(
       rampsPaymentMethodsKeys.detail({
         regionCode: 'US ',
-        fiat: ' USD',
-        assetId: 'eip155:1/slip44:60',
         providerId: '/providers/transak',
       }),
-    ).toEqual([
-      'ramps',
-      'paymentMethods',
-      'us',
-      'usd',
-      'eip155:1/slip44:60',
-      '/providers/transak',
-    ]);
+    ).toEqual(['ramps', 'paymentMethods', 'us', '/providers/transak']);
   });
 
-  it('builds query options for payment methods', () => {
+  it('builds query options with provider-scoped key and 5min staleTime', () => {
     const opts = rampsPaymentMethodsOptions({
       regionCode: 'us',
       fiat: 'usd',
@@ -34,11 +25,9 @@ describe('rampsPaymentMethodsOptions', () => {
       'ramps',
       'paymentMethods',
       'us',
-      'usd',
-      'eip155:1/slip44:60',
       '/providers/transak',
     ]);
     expect(typeof opts.queryFn).toBe('function');
-    expect(opts.staleTime).toBe(0);
+    expect(opts.staleTime).toBe(5 * 60 * 1000);
   });
 });

--- a/app/components/UI/Ramp/queries/paymentMethods.test.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.test.ts
@@ -28,6 +28,6 @@ describe('rampsPaymentMethodsOptions', () => {
       '/providers/transak',
     ]);
     expect(typeof opts.queryFn).toBe('function');
-    expect(opts.staleTime).toBe(5 * 60 * 1000);
+    expect(opts.staleTime).toBe(0);
   });
 });

--- a/app/components/UI/Ramp/queries/paymentMethods.test.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.test.ts
@@ -28,6 +28,6 @@ describe('rampsPaymentMethodsOptions', () => {
       '/providers/transak',
     ]);
     expect(typeof opts.queryFn).toBe('function');
-    expect(opts.staleTime).toBe(0);
+    expect(opts.staleTime).toBe(5 * 60 * 1000);
   });
 });

--- a/app/components/UI/Ramp/queries/paymentMethods.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.ts
@@ -41,5 +41,5 @@ export const rampsPaymentMethodsOptions = (params: PaymentMethodsQueryParams) =>
 
       return response.payments;
     },
-    staleTime: 5 * 60 * 1000, // 5 minutes — payment methods rarely change
+    staleTime: 0, // always run queryFn so controller state stays in sync
   });

--- a/app/components/UI/Ramp/queries/paymentMethods.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.ts
@@ -16,15 +16,11 @@ export const rampsPaymentMethodsKeys = {
   all: () => ['ramps', 'paymentMethods'] as const,
   detail: ({
     regionCode,
-    fiat,
-    assetId,
     providerId,
-  }: PaymentMethodsQueryParams) =>
+  }: Pick<PaymentMethodsQueryParams, 'regionCode' | 'providerId'>) =>
     [
       ...rampsPaymentMethodsKeys.all(),
       regionCode.trim().toLowerCase(),
-      fiat.trim().toLowerCase(),
-      assetId,
       providerId,
     ] as const,
 };
@@ -45,5 +41,5 @@ export const rampsPaymentMethodsOptions = (params: PaymentMethodsQueryParams) =>
 
       return response.payments;
     },
-    staleTime: 0,
+    staleTime: 5 * 60 * 1000, // 5 minutes — payment methods rarely change
   });

--- a/app/components/UI/Ramp/queries/paymentMethods.ts
+++ b/app/components/UI/Ramp/queries/paymentMethods.ts
@@ -41,5 +41,5 @@ export const rampsPaymentMethodsOptions = (params: PaymentMethodsQueryParams) =>
 
       return response.payments;
     },
-    staleTime: 0, // always run queryFn so controller state stays in sync
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });

--- a/app/components/UI/Ramp/queries/providers.test.ts
+++ b/app/components/UI/Ramp/queries/providers.test.ts
@@ -30,10 +30,9 @@ describe('rampsProvidersOptions', () => {
     expect(opts.queryKey).toEqual(['ramps', 'providers', 'us-tx']);
     expect(typeof opts.queryFn).toBe('function');
     expect(opts.staleTime).toBe(1000 * 60 * 15);
-    expect(opts.refetchOnMount).toBe(true);
   });
 
-  it('queryFn calls getProviders with forceRefresh: true', async () => {
+  it('queryFn calls getProviders with regionCode', async () => {
     const mockProviders = [{ id: 'provider-1', name: 'Provider 1' }];
     (
       Engine.context.RampsController.getProviders as jest.Mock
@@ -47,7 +46,6 @@ describe('rampsProvidersOptions', () => {
 
     expect(Engine.context.RampsController.getProviders).toHaveBeenCalledWith(
       'us-tx',
-      { forceRefresh: true },
     );
     expect(result).toEqual(mockProviders);
   });

--- a/app/components/UI/Ramp/queries/providers.ts
+++ b/app/components/UI/Ramp/queries/providers.ts
@@ -22,5 +22,5 @@ export const rampsProvidersOptions = (params: ProvidersQueryParams) =>
 
       return response.providers;
     },
-    staleTime: 0, // always run queryFn so controller state stays in sync
+    staleTime: 15 * 60 * 1000, // 15 minutes
   });

--- a/app/components/UI/Ramp/queries/providers.ts
+++ b/app/components/UI/Ramp/queries/providers.ts
@@ -18,11 +18,9 @@ export const rampsProvidersOptions = (params: ProvidersQueryParams) =>
     queryFn: async (): Promise<Provider[]> => {
       const response = await Engine.context.RampsController.getProviders(
         params.regionCode,
-        { forceRefresh: true },
       );
 
       return response.providers;
     },
-    staleTime: 1000 * 60 * 15, // 15 minutes
-    refetchOnMount: true,
+    staleTime: 0, // always run queryFn so controller state stays in sync
   });

--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.1.0",
     "@metamask/profile-sync-controller": "^28.0.2",
-    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@12.1.0-preview-1d5c02c",
+    "@metamask/ramps-controller": "^13.0.0",
     "@metamask/react-data-query": "^0.2.0",
     "@metamask/react-native-acm": "1.2.0",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.1.0",
     "@metamask/profile-sync-controller": "^28.0.2",
-    "@metamask/ramps-controller": "^12.1.0",
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@12.1.0-preview-1d5c02c",
     "@metamask/react-data-query": "^0.2.0",
     "@metamask/react-native-acm": "1.2.0",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8033,9 +8033,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.19.0":
-  version: 11.19.0
-  resolution: "@metamask/controller-utils@npm:11.19.0"
+"@metamask/controller-utils@npm:^11.0.0, @metamask/controller-utils@npm:^11.14.1, @metamask/controller-utils@npm:^11.15.0, @metamask/controller-utils@npm:^11.16.0, @metamask/controller-utils@npm:^11.18.0, @metamask/controller-utils@npm:^11.19.0, @metamask/controller-utils@npm:^11.20.0":
+  version: 11.20.0
+  resolution: "@metamask/controller-utils@npm:11.20.0"
   dependencies:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
@@ -8050,7 +8050,7 @@ __metadata:
     lodash: "npm:^4.17.21"
   peerDependencies:
     "@babel/runtime": ^7.0.0
-  checksum: 10/d66ff170a6c2fb5726aa34c94e4870d79e96737043d3450f87d34eec8b24209b27a09df9935aad9e3e5bb685ebb3ee2c918e6d4cfbeec497c2fa823a177fc227
+  checksum: 10/a2ba778d00508a606ef4657cd6591a89f8f54136b3dd41f4f96f8effa2e9ad20de347e3c554f643cb248a002a17b478f95eafd4e3b4c3eca4bb40ae2e6bf7fdc
   languageName: node
   linkType: hard
 
@@ -9411,6 +9411,17 @@ __metadata:
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/50194c608fb308cee268c6eefb8c8d439a9d07aa41d07cb5ddcd7e706819aea7e746150f32688fe06d20309b49346440855b5d56aacf286b343da6fcb217cc12
+  languageName: node
+  linkType: hard
+
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@12.1.0-preview-1d5c02c":
+  version: 12.1.0-preview-1d5c02c
+  resolution: "@metamask-previews/ramps-controller@npm:12.1.0-preview-1d5c02c"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.1"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/messenger": "npm:^1.1.0"
+  checksum: 10/e00df53062e0b182fd884e38c467bac262fcebae5e44d4d2c99159166a64cdb3ae599f3336a4d6379009508437576a3ab1fa1255f04ff58dbb9c7c4684849fe0
   languageName: node
   linkType: hard
 
@@ -35503,7 +35514,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^3.1.0"
     "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^12.1.0"
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@12.1.0-preview-1d5c02c"
     "@metamask/react-data-query": "npm:^0.2.0"
     "@metamask/react-native-acm": "npm:1.2.0"
     "@metamask/react-native-actionsheet": "npm:2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8904,18 +8904,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@metamask/messenger@npm:1.1.0"
+"@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.0, @metamask/messenger@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@metamask/messenger@npm:1.1.1"
   dependencies:
     "@metamask/utils": "npm:^11.9.0"
     yargs: "npm:^17.7.2"
   peerDependencies:
-    eslint: ">=8"
     typescript: ">=5.0.0"
   bin:
     messenger-generate-action-types: ./dist/generate-action-types/cli.mjs
-  checksum: 10/ea2b25c4d8cae8d60dd4365738763752283b27eca17cae749b3fedf6733207c180de917715a6ccb8b41f7c06ee769b82b01de5c43ed20c182b3fe6a0cf5c1ae1
+  checksum: 10/a959af95e9e117aa0f7ad1c280f7817fef2c0b575c76837b1a6c884c9c9ef1dd0faeaef0c2c0c2035f68c7638d1f87cd172956ee962dec97d8ab6176fa6964e3
   languageName: node
   linkType: hard
 
@@ -9414,17 +9413,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@12.1.0-preview-1d5c02c":
-  version: 12.1.0-preview-1d5c02c
-  resolution: "@metamask-previews/ramps-controller@npm:12.1.0-preview-1d5c02c"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/messenger": "npm:^1.1.0"
-  checksum: 10/e00df53062e0b182fd884e38c467bac262fcebae5e44d4d2c99159166a64cdb3ae599f3336a4d6379009508437576a3ab1fa1255f04ff58dbb9c7c4684849fe0
-  languageName: node
-  linkType: hard
-
 "@metamask/ramps-controller@npm:^12.1.0":
   version: 12.1.0
   resolution: "@metamask/ramps-controller@npm:12.1.0"
@@ -9433,6 +9421,17 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.19.0"
     "@metamask/messenger": "npm:^1.0.0"
   checksum: 10/ae1f3f4cb4dd4493ed4d75220a54ce8e5878b16e3b31dbafdf5ae0256cf3f9b1ef9aad146e61609485c4a682a119fd0fdadc2489862bd6d1c480878f2dc3c409
+  languageName: node
+  linkType: hard
+
+"@metamask/ramps-controller@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@metamask/ramps-controller@npm:13.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.1"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/messenger": "npm:^1.1.1"
+  checksum: 10/94f2e84f39ca94382c8635676f8843797642a0829f51d4ad09f77131c4edcff6da20659bda80c6570bd646ce984e9ca35de7d0063b67bc23c3632b10e23d4c47
   languageName: node
   linkType: hard
 
@@ -35514,7 +35513,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^3.1.0"
     "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@12.1.0-preview-1d5c02c"
+    "@metamask/ramps-controller": "npm:^13.0.0"
     "@metamask/react-data-query": "npm:^0.2.0"
     "@metamask/react-native-acm": "npm:1.2.0"
     "@metamask/react-native-actionsheet": "npm:2.4.2"


### PR DESCRIPTION
## **Description**

Payment methods, providers, and tokens were being fetched redundantly from two independent paths (controller `fireAndForget` + React Query), causing 2–3 duplicate API calls per user action with a ~10s spinner.

This PR makes the mobile client the single fetch owner for all ramp data. React Query handles providers and payment methods with proper caching and invalidation. Tokens are fetched directly from RampsBootstrap. Screens that don't need payment methods no longer trigger fetches.

Changes:

1. **`RampsBootstrap.tsx`** — Now fetches all three data sources at app root: `useRampsProviders` (React Query), `useRampsPaymentMethods` (React Query), and `getTokens` (direct controller call on region change). This follows the agreed flow: app loads → fetch providers and tokens → provider selected → fetch payment methods.

2. **`useRampsProviders.ts`** — Reads provider list from React Query cache (not controller state). Invalidates all ramp queries on region change to force fresh fetches. Passes full `Provider` object to `setSelectedProvider` for auto-selection (avoids crash when controller state is empty).

3. **`useRampsPaymentMethods.ts`** — Query key reduced to `[regionCode, providerId]` only. Token/fiat are passed to the API call but not the key, so token changes don't trigger refetches. Passes full `PaymentMethod` object to controller (avoids crash when controller state is empty).

4. **`paymentMethods.ts` (query config)** — `staleTime: 5min`. Query key only includes `regionCode` and `providerId`.

5. **`providers.ts` (query config)** — `staleTime: 15min`. Removed `forceRefresh: true` from queryFn (controller's own cache handles it).

6. **`SettingsModal.tsx`** — Uses `useRampsProviders` instead of `useRampsController` (no more payment methods fetch on settings screen).

7. **`TokenNotAvailableModal.tsx`** — Uses `useRampsProviders` + `useRampsTokens` instead of `useRampsController`.

8. **`RegionSelector.tsx`** — Uses `useRampsUserRegion` + `useRampsCountries` instead of `useRampsController`.

9. **`PaymentSelectionModal.tsx`** — Filters out payment methods with no available quote once quotes load, preventing dead-end options (e.g. Apple Pay shown but no provider returns a quote for it).

10. **Tests updated** — Removed `tokenSupportedByProvider` test, updated query key and staleTime assertions.

## **Changelog**

CHANGELOG entry: Fixed duplicate payment method, provider, and token API calls during buy flow; React Query is now the single fetch owner for ramp data

## **Related issues**

Fixes: [TRAM-3398](https://consensyssoftware.atlassian.net/browse/TRAM-3398)

Depends on core PR: [MetaMask/core#8354](https://github.com/MetaMask/core/pull/8354) (removes `fireAndForget` calls from controller)

## **Manual testing steps**

```gherkin
Feature: Single-owner fetching for ramp data

  Scenario: App load fetches providers, tokens, and payment methods
    Given user opens the app (password screen)
    When the app loads
    Then getProviders, getTokens, and getPaymentMethods each fire once
    And providers, tokens, and payment methods are populated in state

  Scenario: Token selection does not trigger payment methods fetch
    Given user is on the token selection screen
    When user selects a token (e.g. Ethereum)
    Then getPaymentMethods is NOT called
    And the BuildQuote screen loads with cached payment methods

  Scenario: Provider change triggers a single payment methods fetch
    Given user is on the BuildQuote screen with a provider selected
    When user changes the provider (e.g. Transak -> Coinbase)
    Then getPaymentMethods fires exactly once for the new provider
    And the payment method pill auto-switches to Debit or Credit

  Scenario: Region switch refreshes all data
    Given user is on the settings screen
    When user changes region (e.g. France -> Finland -> France)
    Then getProviders and getPaymentMethods fire for each new region
    And switching back to a previous region also triggers fresh fetches

  Scenario: Settings screen does not trigger payment methods fetch
    Given user navigates to the Buy & Sell settings screen
    Then getPaymentMethods is NOT called
    And no unnecessary API calls appear in the debug dashboard

  Scenario: Payment selection modal hides dead-end options
    Given user taps the payment method pill
    When quotes load for all payment methods
    Then payment methods with no available quote are filtered out
```

## **Screenshots/Recordings**

### **Before**

<!-- 2-3 getPaymentMethods calls per token selection visible in debug dashboard -->

### **After**

<!-- Single getPaymentMethods call only on provider change; no calls on settings/navigation -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ramp buy-flow data fetching/caching and controller interaction patterns (query keys, invalidation, and provider/payment-method selection), which could affect availability/performance across regions and providers. UI impact is limited but touches core buy-flow bootstrap and selection logic.
> 
> **Overview**
> **Makes the mobile client the single fetch owner for ramps buy data.** `RampsBootstrap` now preloads providers (with side effects), payment methods, and triggers token fetching on region availability so downstream screens don’t cause redundant requests.
> 
> **Reworks React Query behavior for providers and payment methods.** `useRampsProviders` reads the provider list from the React Query cache, adds optional `enableSideEffects` to avoid duplicate invalidation/auto-selection, and invalidates all `ramps` queries on region changes. `useRampsPaymentMethods` simplifies the query to be provider-scoped (query key is `regionCode` + `providerId`, 5-min `staleTime`) and updates controller setters to accept full objects/null.
> 
> **UI behavior tweaks and hook decoupling.** `PaymentSelectionModal` now hides payment methods that have no non-custom-action quote once quotes load, showing the “no payment methods available” state instead. Several screens (`SettingsModal`, `TokenNotAvailableModal`, `RegionSelector`) switch from `useRampsController` to narrower hooks (`useRampsProviders`, `useRampsTokens`, `useRampsUserRegion`, `useRampsCountries`) to prevent unrelated fetches. Dependency bump updates `@metamask/ramps-controller` to `^13.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f85ca2a226e79899d3aa2c93189dc2f9d588ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->