### PR TITLE
fix(oauth): sync marketing opt-in and analytics after OAuth rehydration unlock cp-7.72.0

### DIFF
--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -139,8 +139,14 @@ jest.mock('../../../core/Engine', () => ({
   },
 }));
 
+const mockGetMarketingOptInStatus = jest.fn().mockResolvedValue({
+  is_opt_in: false,
+});
+
 jest.mock('../../../core/OAuthService/OAuthService', () => ({
   resetOauthState: jest.fn(),
+  getMarketingOptInStatus: (...args: unknown[]) =>
+    mockGetMarketingOptInStatus(...args),
 }));
 
 jest.mock('../../../util/metrics/TrackOnboarding/trackOnboarding');
@@ -223,6 +229,7 @@ describe('OAuthRehydration', () => {
       await waitFor(() => {
         expect(mockReplace).toHaveBeenCalledWith(Routes.ONBOARDING.HOME_NAV);
       });
+      expect(mockGetMarketingOptInStatus).toHaveBeenCalled();
       expect(mockUnlockWallet.mock.invocationCallOrder[0]).toBeLessThan(
         mockRequestBiometricsAccessControlForIOS.mock.invocationCallOrder[0],
       );
@@ -923,6 +930,7 @@ describe('OAuthRehydration', () => {
           }),
         );
       });
+      expect(mockGetMarketingOptInStatus).not.toHaveBeenCalled();
       expect(mockUnlockWallet.mock.invocationCallOrder[0]).toBeLessThan(
         mockRequestBiometricsAccessControlForIOS.mock.invocationCallOrder[0],
       );

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -10,6 +10,7 @@ import OAuthRehydration from './index';
 import OAuthService from '../../../core/OAuthService/OAuthService';
 import { strings } from '../../../../locales/i18n';
 import {
+  AuthConnection,
   SeedlessOnboardingControllerErrorMessage,
   RecoveryError as SeedlessOnboardingControllerRecoveryError,
 } from '@metamask/seedless-onboarding-controller';
@@ -24,6 +25,8 @@ import { captureException } from '@sentry/react-native';
 import { UNLOCK_WALLET_ERROR_MESSAGES } from '../../../core/Authentication/constants';
 import { MetaMetricsEvents } from '../../../core/Analytics/MetaMetrics.events';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
+import { AccountType } from '../../../constants/onboarding';
+import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockEngine = jest.mocked(Engine) as any;
@@ -37,6 +40,8 @@ const mockRevealSRP = jest.fn();
 const mockRevealPrivateKey = jest.fn();
 const mockRequestBiometricsAccessControlForIOS = jest.fn();
 const mockUpdateAuthPreference = jest.fn();
+const mockAnalyticsIdentify = jest.fn();
+const mockAnalyticsTrackEvent = jest.fn();
 
 jest.mock('../../../core/Authentication/hooks/useAuthentication', () => ({
   __esModule: true,
@@ -55,6 +60,21 @@ jest.mock('../../../core/Authentication/hooks/useAuthentication', () => ({
 }));
 
 jest.mock('../../../util/Logger');
+
+jest.mock('../../../util/analytics/analytics', () => ({
+  analytics: {
+    identify: (...args: unknown[]) => mockAnalyticsIdentify(...args),
+    trackEvent: (...args: unknown[]) => mockAnalyticsTrackEvent(...args),
+    trackView: jest.fn(),
+    optIn: jest.fn().mockResolvedValue(undefined),
+    optOut: jest.fn().mockResolvedValue(undefined),
+    getAnalyticsId: jest
+      .fn()
+      .mockResolvedValue('01c53eb9-aeb9-4cd1-9414-7194419fe88b'),
+    isEnabled: jest.fn().mockReturnValue(true),
+    isOptedIn: jest.fn().mockResolvedValue(true),
+  },
+}));
 
 jest.mock('../../../images/branding/fox.png', () => 'fox-logo');
 jest.mock('../../../images/branding/metamask-name.png', () => 'metamask-name');
@@ -179,6 +199,9 @@ const enterPasswordAndSubmit = async (
 describe('OAuthRehydration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetMarketingOptInStatus.mockResolvedValue({
+      is_opt_in: false,
+    });
     mockRoute.mockReturnValue({
       params: { locked: false, oauthLoginSuccess: true },
     });
@@ -229,7 +252,9 @@ describe('OAuthRehydration', () => {
       await waitFor(() => {
         expect(mockReplace).toHaveBeenCalledWith(Routes.ONBOARDING.HOME_NAV);
       });
-      expect(mockGetMarketingOptInStatus).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockGetMarketingOptInStatus).toHaveBeenCalled();
+      });
       expect(mockUnlockWallet.mock.invocationCallOrder[0]).toBeLessThan(
         mockRequestBiometricsAccessControlForIOS.mock.invocationCallOrder[0],
       );
@@ -244,6 +269,43 @@ describe('OAuthRehydration', () => {
 
       await waitFor(() => {
         expect(mockTrackOnboarding).toHaveBeenCalled();
+      });
+    });
+
+    it('syncs marketing consent into Redux and analytics after unlock', async () => {
+      mockGetMarketingOptInStatus.mockResolvedValueOnce({
+        is_opt_in: true,
+      });
+
+      const { getByTestId, store } = renderWithProvider(<OAuthRehydration />, {
+        state: {
+          engine: {
+            backgroundState: {
+              SeedlessOnboardingController: {
+                authConnection: AuthConnection.Google,
+              },
+            },
+          },
+        },
+      });
+      await enterPasswordAndSubmit(getByTestId);
+
+      await waitFor(() => {
+        expect(store.getState().security.dataCollectionForMarketing).toBe(true);
+        expect(mockAnalyticsIdentify).toHaveBeenCalledWith({
+          [UserProfileProperty.HAS_MARKETING_CONSENT]: UserProfileProperty.ON,
+        });
+        expect(mockAnalyticsTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
+            properties: expect.objectContaining({
+              [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
+              updated_after_onboarding: true,
+              location: 'oauth_rehydration',
+              account_type: AccountType.ImportedGoogle,
+            }),
+          }),
+        );
       });
     });
 

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -30,7 +30,7 @@ import {
   OnboardingActionTypes,
   saveOnboardingEvent as saveEvent,
 } from '../../../actions/onboarding';
-import { connect } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import { Dispatch } from 'redux';
 import Routes from '../../../constants/navigation/Routes';
 import ErrorBoundary from '../ErrorBoundary';
@@ -97,6 +97,11 @@ import { containsErrorMessage } from '../../../util/errorHandling';
 import { ensureError } from '../../../util/errorUtils';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 import type { AuthData } from '../../../core/Authentication/Authentication';
+import { setDataCollectionForMarketing } from '../../../actions/security';
+import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
+import { analytics } from '../../../util/analytics/analytics';
+import { getSocialAccountType } from '../../../constants/onboarding';
+import { selectSeedlessOnboardingAuthConnection } from '../../../selectors/seedlessOnboardingController';
 
 const EmptyRecordConstant = {};
 
@@ -115,6 +120,10 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
   saveOnboardingEvent,
 }) => {
   const { isEnabled: isMetricsEnabled } = useAnalytics();
+  const dispatch = useDispatch();
+
+  const authConnection =
+    useSelector(selectSeedlessOnboardingAuthConnection) ?? '';
 
   const fieldRef = useRef<TextInput>(null);
 
@@ -184,6 +193,37 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
       );
     }
   }, [password, requestBiometricsAccessControlForIOS, updateAuthPreference]);
+
+  const syncMarketingOptInAfterUnlock = useCallback(async () => {
+    try {
+      const marketingOptInStatus = await OAuthService.getMarketingOptInStatus();
+      dispatch(setDataCollectionForMarketing(marketingOptInStatus.is_opt_in));
+      analytics.identify({
+        [UserProfileProperty.HAS_MARKETING_CONSENT]:
+          marketingOptInStatus.is_opt_in
+            ? UserProfileProperty.ON
+            : UserProfileProperty.OFF,
+      });
+      analytics.trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(
+          MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED,
+        )
+          .addProperties({
+            [UserProfileProperty.HAS_MARKETING_CONSENT]:
+              marketingOptInStatus.is_opt_in,
+            updated_after_onboarding: true,
+            location: 'oauth_rehydration',
+            account_type: getSocialAccountType(authConnection, true),
+          })
+          .build(),
+      );
+    } catch (err) {
+      Logger.error(
+        ensureError(err, 'Marketing opt-in sync failed'),
+        'OAuthRehydration',
+      );
+    }
+  }, [dispatch, authConnection]);
 
   const track = useCallback(
     (
@@ -533,6 +573,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         },
       );
 
+      await syncMarketingOptInAfterUnlock();
+
       await upgradeKeychainAuthAfterSuccessfulUnlock();
 
       // Best-effort post-unlock UX: show biometric cancelled alert if needed.
@@ -572,6 +614,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     promptBiometricFailedAlert,
     unlockWallet,
     upgradeKeychainAuthAfterSuccessfulUnlock,
+    syncMarketingOptInAfterUnlock,
   ]);
 
   const newGlobalPasswordLogin = useCallback(async () => {

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -573,7 +573,9 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         },
       );
 
-      await syncMarketingOptInAfterUnlock();
+      syncMarketingOptInAfterUnlock().catch((err) => {
+        Logger.error(err, 'Failed to sync marketing opt-in after unlock');
+      });
 
       await upgradeKeychainAuthAfterSuccessfulUnlock();
 

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -573,9 +573,8 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         },
       );
 
-      syncMarketingOptInAfterUnlock().catch((err) => {
-        Logger.error(err, 'Failed to sync marketing opt-in after unlock');
-      });
+      // run syncMarketingOptInAfterUnlock in the background
+      syncMarketingOptInAfterUnlock();
 
       await upgradeKeychainAuthAfterSuccessfulUnlock();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
After a seedless / social-account wallet unlock on the OAuth rehydration screen, local marketing consent and analytics could drift from the account’s server-side marketing opt-in. That meant user profile properties and preference events were not reliably aligned with `getMarketingOptInStatus` until some other flow ran.

This change calls `OAuthService.getMarketingOptInStatus()` immediately after a successful unlock on `OAuthRehydration`, then:

- Dispatches `setDataCollectionForMarketing` so Redux matches the server flag.
- Updates MetaMetrics identity with `HAS_MARKETING_CONSENT`.
- Fires `ANALYTICS_PREFERENCE_SELECTED` with `updated_after_onboarding: true`, `location: 'oauth_rehydration'`, and `account_type` from the seedless auth connection.

Failures are logged and do not block unlock. Unit tests assert the marketing sync runs on the happy path and is skipped when navigation does not complete that path.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28249

## **Manual testing steps**

```gherkin
Feature: OAuth rehydration marketing opt-in sync

  Scenario: Successful unlock syncs marketing preference and analytics
    Given the user completes social / seedless onboarding and reaches OAuth rehydration
    And the app can reach OAuth marketing opt-in APIs
    When the user enters a valid password and unlock succeeds
    Then local marketing data collection state should match the server opt-in response
    And analytics should record preference / identity updates for marketing consent (verify in debug / staging tooling if available)

  Scenario: Unlock path that does not complete rehydration navigation
    Given a flow where OAuth rehydration does not navigate to home after unlock (e.g. error or alternate path covered by tests)
    When unlock handling does not take the success path that replaces with onboarding home
    Then marketing opt-in sync should not run (no redundant or incorrect preference sync)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the post-unlock path of `OAuthRehydration` by adding a background network call plus Redux/analytics side effects; failures are best-effort but bugs here could desync consent state or misfire analytics.
> 
> **Overview**
> After a successful OAuth rehydration unlock, the app now fetches server-side marketing consent via `OAuthService.getMarketingOptInStatus()` and **syncs it locally**.
> 
> The unlock flow dispatches `setDataCollectionForMarketing`, updates MetaMetrics identity (`HAS_MARKETING_CONSENT`), and emits `ANALYTICS_PREFERENCE_SELECTED` with `updated_after_onboarding`, `location: 'oauth_rehydration'`, and an `account_type` derived from the seedless `authConnection`; errors are logged and do not block unlock.
> 
> Tests were updated to mock `analytics`/`getMarketingOptInStatus`, assert the sync runs on the successful rehydration path, verify Redux + analytics payloads, and confirm the sync is skipped for the *outdated password* (non-oauth2) unlock path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0738153a848d76150fd2aca4eade11a4aabfecaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->