### PR TITLE
feat(perps): add Perps Withdraw confirmation flow and post-quote config

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -41,6 +41,7 @@ const TRANSACTION_TYPES_DISABLE_SCROLL = [TransactionType.predictClaim];
 const TRANSACTION_TYPES_DISABLE_ALERT_BANNER = [
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
   TransactionType.moneyAccountDeposit,

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -44,6 +44,7 @@ const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.moneyAccountDeposit,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
   TransactionType.musdConversion,

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -142,6 +142,26 @@ describe('BridgeFeeRow', () => {
     expect(getByText('$1.23')).toBeOnTheScreen();
   });
 
+  it('renders tooltip for perps withdraw', async () => {
+    const { getByTestId } = render({
+      type: TransactionType.perpsWithdraw,
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('info-row-tooltip-open-btn'));
+    });
+
+    expect(getByTestId('info-row-tooltip-open-btn')).toBeDefined();
+  });
+
+  it('renders fee for perps withdraw', () => {
+    const { getByText } = render({
+      type: TransactionType.perpsWithdraw,
+    });
+
+    expect(getByText('$1.23')).toBeDefined();
+  });
+
   it('renders metamask fee in tooltip', async () => {
     useTransactionTotalsMock.mockReturnValue({
       fees: {

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -67,11 +67,16 @@ function TransactionFeeRow({
   const feeTotalUsd = useMemo(() => {
     if (!totals?.fees) return '';
 
+    const metaMask = totals.fees.metaMask.usd ?? 0;
+    const provider = totals.fees.provider.usd;
+    const sourceNetwork = totals.fees.sourceNetwork.estimate.usd;
+    const targetNetwork = totals.fees.targetNetwork.usd;
+
     return formatFiat(
-      new BigNumber(totals.fees.metaMask.usd ?? 0)
-        .plus(totals.fees.provider.usd)
-        .plus(totals.fees.sourceNetwork.estimate.usd)
-        .plus(totals.fees.targetNetwork.usd),
+      new BigNumber(metaMask)
+        .plus(provider)
+        .plus(sourceNetwork)
+        .plus(targetNetwork),
     );
   }, [totals, formatFiat]);
 
@@ -129,13 +134,18 @@ function Tooltip({
     hasTransactionType(transactionMeta, [
       TransactionType.predictDeposit,
       TransactionType.predictWithdraw,
+      TransactionType.perpsWithdraw,
     ])
   ) {
-    message = hasTransactionType(transactionMeta, [
-      TransactionType.predictWithdraw,
-    ])
-      ? strings('confirm.tooltip.predict_withdraw.transaction_fee')
-      : strings('confirm.tooltip.predict_deposit.transaction_fee');
+    if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
+      message = strings('confirm.tooltip.perps_withdraw.transaction_fee');
+    } else if (
+      hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])
+    ) {
+      message = strings('confirm.tooltip.predict_withdraw.transaction_fee');
+    } else {
+      message = strings('confirm.tooltip.predict_deposit.transaction_fee');
+    }
   }
 
   if (hasTransactionType(transactionMeta, [TransactionType.musdConversion])) {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -268,10 +268,21 @@ describe('useInsufficientBalanceAlert', () => {
     expect(result.current[0].key).toBe(AlertKeys.InsufficientBalance);
   });
 
-  it('returns empty array if transaction type ignored', () => {
+  it('returns empty array if transaction type is predictWithdraw', () => {
     mockUseTransactionMetadataRequest.mockReturnValue({
       ...mockTransaction,
       type: TransactionType.predictWithdraw,
+    } as unknown as TransactionMeta);
+
+    const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns empty array if transaction type is perpsWithdraw', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      ...mockTransaction,
+      type: TransactionType.perpsWithdraw,
     } as unknown as TransactionMeta);
 
     const { result } = renderHook(() => useInsufficientBalanceAlert());

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -16,7 +16,10 @@ import { selectUseTransactionSimulations } from '../../../../../selectors/prefer
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
 import { useIsTransactionPayLoading } from '../pay/useTransactionPayData';
 
-const IGNORE_TYPES = [TransactionType.predictWithdraw];
+const IGNORE_TYPES = [
+  TransactionType.perpsWithdraw,
+  TransactionType.predictWithdraw,
+];
 
 export const useInsufficientBalanceAlert = ({
   ignoreGasFeeToken,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import type { Hex } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
 import { useTransactionPayPostQuote } from './useTransactionPayPostQuote';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayWithdraw } from './useTransactionPayWithdraw';
@@ -181,5 +182,58 @@ describe('useTransactionPayPostQuote', () => {
     rerender();
 
     expect(setTransactionConfigMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('sets isHyperliquidSource=true and no refundTo for perpsWithdraw', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      txParams: { from: FROM_MOCK },
+      type: TransactionType.perpsWithdraw,
+    } as never);
+    useTransactionPayWithdrawMock.mockReturnValue({
+      isWithdraw: true,
+      canSelectWithdrawToken: true,
+    });
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    const callback = setTransactionConfigMock.mock.calls[0][1];
+    const config = {} as {
+      isPostQuote?: boolean;
+      refundTo?: Hex;
+      isHyperliquidSource?: boolean;
+    };
+    callback(config);
+
+    expect(config.isPostQuote).toBe(true);
+    expect(config.isHyperliquidSource).toBe(true);
+    expect(config.refundTo).toBeUndefined();
+    expect(computeProxyAddressMock).not.toHaveBeenCalled();
+  });
+
+  it('does not set isHyperliquidSource for non-perps withdrawals', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      txParams: { from: FROM_MOCK },
+      type: TransactionType.predictWithdraw,
+    } as never);
+    useTransactionPayWithdrawMock.mockReturnValue({
+      isWithdraw: true,
+      canSelectWithdrawToken: true,
+    });
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    const callback = setTransactionConfigMock.mock.calls[0][1];
+    const config = {} as {
+      isPostQuote?: boolean;
+      refundTo?: Hex;
+      isHyperliquidSource?: boolean;
+    };
+    callback(config);
+
+    expect(config.isPostQuote).toBe(true);
+    expect(config.refundTo).toBe(PROXY_ADDRESS_MOCK);
+    expect(config.isHyperliquidSource).toBeUndefined();
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
 import { createProjectLogger, type Hex } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
 import { useTransactionPayWithdraw } from './useTransactionPayWithdraw';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { computeProxyAddress } from '../../../../UI/Predict/providers/polymarket/safe/utils';
+import { hasTransactionType } from '../../utils/transaction';
 
 const log = createProjectLogger('transaction-pay-post-quote');
 
@@ -25,6 +27,9 @@ export function useTransactionPayPostQuote(): void {
   const { canSelectWithdrawToken } = useTransactionPayWithdraw();
   const transactionMeta = useTransactionMetadataRequest();
   const transactionId = transactionMeta?.id;
+  const isPerpsWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+  ]);
 
   useEffect(() => {
     if (
@@ -38,21 +43,44 @@ export function useTransactionPayPostQuote(): void {
     try {
       const { TransactionPayController } = Engine.context;
       const from = transactionMeta?.txParams?.from as Hex | undefined;
-      const refundTo = from ? computeProxyAddress(from) : undefined;
+
+      // Predict withdrawals refund to the Safe proxy address.
+      // Perps withdrawals don't use refundTo -- funds go HyperCore -> Relay directly.
+      const refundTo = isPerpsWithdraw
+        ? undefined
+        : from
+          ? computeProxyAddress(from)
+          : undefined;
 
       TransactionPayController.setTransactionConfig(transactionId, (config) => {
         config.isPostQuote = true;
-        config.refundTo = refundTo;
+
+        if (refundTo) {
+          config.refundTo = refundTo;
+        }
+
+        if (isPerpsWithdraw) {
+          config.isHyperliquidSource = true;
+        }
       });
 
       isSet.current = transactionId;
 
-      log('Initialized post-quote transaction', { transactionId, refundTo });
+      log('Initialized post-quote transaction', {
+        transactionId,
+        refundTo,
+        isPerpsWithdraw,
+      });
     } catch (error) {
       log('Error initializing post-quote transaction', {
         error,
         transactionId,
       });
     }
-  }, [canSelectWithdrawToken, transactionId, transactionMeta?.txParams?.from]);
+  }, [
+    canSelectWithdrawToken,
+    isPerpsWithdraw,
+    transactionId,
+    transactionMeta?.txParams?.from,
+  ]);
 }

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -21,6 +21,7 @@ import { useMusdConfirmNavigation } from '../../../../UI/Earn/hooks/useMusdConfi
 const log = createProjectLogger('transaction-confirm');
 
 export const GO_BACK_TYPES = [
+  TransactionType.perpsWithdraw,
   TransactionType.predictClaim,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -445,6 +445,48 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('8642.46');
     });
 
+    it('to percentage of perps available balance', async () => {
+      (Engine.context as Record<string, unknown>).PerpsController = {
+        state: {
+          accountState: {
+            availableBalance: '500.00',
+          },
+        },
+      };
+
+      const { result } = runHook({
+        transactionMeta: {
+          type: TransactionType.perpsWithdraw,
+        },
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(50);
+      });
+
+      expect(result.current.amountFiat).toBe('250');
+    });
+
+    it('returns 0 for perps withdraw when no available balance', async () => {
+      (Engine.context as Record<string, unknown>).PerpsController = {
+        state: {
+          accountState: {},
+        },
+      };
+
+      const { result } = runHook({
+        transactionMeta: {
+          type: TransactionType.perpsWithdraw,
+        },
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(result.current.amountFiat).toBe('0');
+    });
+
     it('sets isMax to false when percentage is not 100 and isMaxAmount is true', async () => {
       useTransactionPayIsMaxAmountMock.mockReturnValue(true);
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -13,13 +13,13 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import { debounce } from 'lodash';
 import { hasTransactionType } from '../../utils/transaction';
 import { usePredictBalance } from '../../../../UI/Predict/hooks/usePredictBalance';
+import Engine from '../../../../../core/Engine';
 import {
   useTransactionPayIsMaxAmount,
   useTransactionPayTotals,
 } from '../pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { useConfirmationMetricEvents } from '../metrics/useConfirmationMetricEvents';
-import Engine from '../../../../../core/Engine';
 
 export const MAX_LENGTH = 28;
 const DEBOUNCE_DELAY = 500;
@@ -197,6 +197,12 @@ function useTokenBalance(tokenUsdRate: number) {
   const predictBalanceUsd = new BigNumber(predictBalanceHuman ?? '0')
     .multipliedBy(tokenUsdRate)
     .toNumber();
+
+  if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
+    const perpsState = Engine.context.PerpsController?.state;
+    const availableBalance = perpsState?.accountState?.availableBalance;
+    return availableBalance ? parseFloat(availableBalance) : 0;
+  }
 
   return hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])
     ? predictBalanceUsd

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6542,6 +6542,9 @@
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predictions. Swap providers may charge a fee, but MetaMask won't."
       },
+      "perps_withdraw": {
+        "transaction_fee": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD."
+      },
       "predict_withdraw": {
         "transaction_fee": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD."
       },


### PR DESCRIPTION
## **Description**

Wires up the confirmation UI and post-quote logic so that `perpsWithdraw` transactions go through the correct gasless HyperLiquid withdrawal flow via Relay.

This is the second of two PRs for Perps Withdraw (follows the first one which added activity/display support).

### Changes

- **Post-quote config** (`useTransactionPayPostQuote`): Sets `isHyperliquidSource = true` for perps withdrawals, skips `refundTo` (funds go HyperCore → Relay directly, no Safe proxy involved)
- **Custom amount** (`useTransactionCustomAmount`): Sources available balance from `PerpsController.state.accountState.availableBalance` for perps withdrawals
- **Insufficient balance alert** (`useInsufficientBalanceAlert`): Suppresses the "not enough ETH for gas" alert for `perpsWithdraw` since the withdrawal is gasless
- **Confirmation UI**: Adds `perpsWithdraw` to `TRANSACTION_TYPES_DISABLE_ALERT_BANNER`, `HIDE_FOOTER_BY_DEFAULT_TYPES`, and `GO_BACK_TYPES`
- **Bridge fee row**: Shows withdraw-specific tooltip text and "Provider fee" label for `perpsWithdraw`
- **Metrics** (`useTransactionPayMetrics`): Includes `perpsWithdraw` in pay metrics tracking

### Core dependency

- [feat(transaction-pay-controller): add HyperLiquid withdrawal submission via Relay](https://github.com/MetaMask/core/pull/8314)

## **Changelog**

CHANGELOG entry: Add Perps Withdraw confirmation flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1115

## **Manual testing steps**

~~~gherkin
Feature: Perps Withdraw confirmation flow

  Scenario: user withdraws from HyperLiquid Perps to any token
    Given the user has a funded HyperLiquid Perps account
    And the user navigates to the Perps Withdraw page via Developer Options

    When user enters a withdrawal amount
    And selects a destination token (e.g. BNB)
    Then the transaction fee is shown with a tooltip
    And no "Insufficient funds" alert is displayed
    And the available Perps balance is shown correctly

    When user confirms the withdrawal
    Then the withdrawal completes successfully
    And the transaction appears in the Activity list as "Perps withdraw"
~~~

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `perpsWithdraw` handling across confirmation UI and Transaction Pay post-quote configuration; mistakes could misroute withdrawals or misconfigure bridge/refund behavior. Changes are scoped to the confirmations/pay flow and include tests and copy updates.
> 
> **Overview**
> Enables the confirmations flow to properly support **Perps withdrawals** (`TransactionType.perpsWithdraw`) across UI behavior, fee display, and Transaction Pay configuration.
> 
> Perps withdrawals are now treated as *gasless/Hyperliquid-sourced* in `useTransactionPayPostQuote` (sets `isPostQuote` and `isHyperliquidSource`, and skips `refundTo`), suppress the insufficient native-balance alert, and use `PerpsController.state.accountState.availableBalance` for custom-amount percentage calculations.
> 
> Confirmation presentation is adjusted for `perpsWithdraw` (hide alert banner/footer by default and include it in go-back handling), and the transaction-fee tooltip/copy is extended with a new `perps_withdraw` localized message; related unit tests were updated/added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fdd9cbfd6dea460e55d9f6dfef7a47dedbe7ce4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->