### PR TITLE
feat: update user's notification locale on the backend as soon as the app language is changed [GE-134]

### DIFF
--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -41,6 +41,9 @@ import Text, {
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { colors as staticColors } from '../../../../styles/common';
+import { enablePushNotifications } from '../../../../actions/notification/helpers';
+import { selectIsMetaMaskPushNotificationsEnabled } from '../../../../selectors/notifications';
+import Logger from '../../../../util/Logger';
 
 const diameter = 40;
 const spacing = 8;
@@ -207,6 +210,10 @@ class Settings extends PureComponent {
      * App theme
      */
     // appTheme: PropTypes.string,
+    /**
+     * Whether push notifications are currently enabled
+     */
+    isPushNotificationsEnabled: PropTypes.bool,
   };
 
   state = {
@@ -224,6 +231,13 @@ class Settings extends PureComponent {
     if (language === this.state.currentLanguage) return;
     setLocale(language);
     this.setState({ currentLanguage: language });
+
+    if (this.props.isPushNotificationsEnabled) {
+      enablePushNotifications().catch((error) => {
+        Logger.error(error, 'Failed to refresh FCM token after locale change');
+      });
+    }
+
     setTimeout(() => this.props.navigation.navigate('Home'), 100);
   };
 
@@ -547,6 +561,7 @@ const mapStateToProps = (state) => ({
   avatarAccountType: state.settings.avatarAccountType,
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
   hideZeroBalanceTokens: state.settings.hideZeroBalanceTokens,
+  isPushNotificationsEnabled: selectIsMetaMaskPushNotificationsEnabled(state),
   // appTheme: state.user.appTheme,
 });
 

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -43,7 +43,6 @@ import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyt
 import { colors as staticColors } from '../../../../styles/common';
 import { enablePushNotifications } from '../../../../actions/notification/helpers';
 import { selectIsMetaMaskPushNotificationsEnabled } from '../../../../selectors/notifications';
-import Logger from '../../../../util/Logger';
 
 const diameter = 40;
 const spacing = 8;
@@ -233,8 +232,8 @@ class Settings extends PureComponent {
     this.setState({ currentLanguage: language });
 
     if (this.props.isPushNotificationsEnabled) {
-      enablePushNotifications().catch((error) => {
-        Logger.error(error, 'Failed to refresh FCM token after locale change');
+      enablePushNotifications().catch(() => {
+        // Best-effort: token will be refreshed on next app launch
       });
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
When the app language is changed in General Settings, the app now calls `enablePushNotifications()` (only if push notifications are already enabled) to refresh the device token/registration so the backend can pick up the new locale without having to wait for the token to be automatically refreshed after a day.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-134

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Triggers a notifications backend call during a language change flow, which could have side effects if the push state/token update behavior is unexpected. Guarded to only run when push is already enabled and errors are swallowed, reducing blast radius.
> 
> **Overview**
> When the app language is changed in General Settings, the app now *best-effort* re-invokes `enablePushNotifications()` (only if push notifications are already enabled) to refresh the device token/registration so the backend can pick up the new locale sooner.
> 
> This wires `isPushNotificationsEnabled` into `GeneralSettings` via `selectIsMetaMaskPushNotificationsEnabled` and updates `propTypes`/`mapStateToProps` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adab898ea48a1ed2b1b4eecdceac634a9e4ad7db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->