### PR TITLE
ci: remove scheduled trigger from Android regression workflow

### DIFF
--- a/.github/workflows/run-e2e-regression-tests-android.yml
+++ b/.github/workflows/run-e2e-regression-tests-android.yml
@@ -1,8 +1,6 @@
 name: Android E2E Regression Tests
 
 on:
-  schedule:
-    - cron: '0 */3 * * *' # Every 3 hours
   workflow_dispatch:
     inputs:
       notify_on_pass:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removed the scheduled cron trigger from `.github/workflows/run-e2e-regression-tests-android.yml` so this workflow no longer runs every 3 hours.

The workflow can still be run manually via `workflow_dispatch`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Android regression workflow trigger behavior

  Scenario: workflow can be manually triggered only
    Given the GitHub Actions workflow file `run-e2e-regression-tests-android.yml`
    When I inspect the `on` section
    Then it contains `workflow_dispatch` inputs
    And it does not contain a `schedule` cron trigger
```

## **Screenshots/Recordings**

Not applicable (CI workflow configuration change only).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6074cff0-b322-43a4-898b-b8b12af5bb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6074cff0-b322-43a4-898b-b8b12af5bb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

