### PR TITLE
feat: migrate `BottomSheet` (perps scope)

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.test.tsx
@@ -5,100 +5,19 @@ import PerpsTooltipView from './PerpsTooltipView';
 import { PerpsTooltipContentKey } from '../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
 import { PerpsBottomSheetTooltipSelectorsIDs } from '../../Perps.testIds';
 
+jest.mock(
+  'react-native-safe-area-context',
+  () => jest.requireActual('react-native-safe-area-context/jest/mock').default,
+);
+
 // Mock @react-navigation/native
+const mockGoBack = jest.fn();
 const mockUseRoute = useRoute as jest.Mock;
 jest.mock('@react-navigation/native', () => ({
   useRoute: jest.fn(),
+  useNavigation: jest.fn(() => ({ goBack: mockGoBack })),
   RouteProp: jest.fn(),
 }));
-
-// Mock BottomSheet components
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const { View } = jest.requireActual('react-native');
-    const { forwardRef, useImperativeHandle } = jest.requireActual('react');
-    const MockBottomSheet = forwardRef(
-      (
-        props: {
-          children: React.ReactNode;
-          shouldNavigateBack?: boolean;
-          onClose?: () => void;
-        },
-        ref: React.Ref<{
-          onOpenBottomSheet: () => void;
-          onCloseBottomSheet: () => void;
-        }>,
-      ) => {
-        useImperativeHandle(ref, () => ({
-          onOpenBottomSheet: jest.fn(),
-          onCloseBottomSheet: jest.fn(() => {
-            if (props.onClose) {
-              props.onClose();
-            }
-          }),
-        }));
-
-        return <View testID="bottom-sheet">{props.children}</View>;
-      },
-    );
-
-    return {
-      __esModule: true,
-      default: MockBottomSheet,
-    };
-  },
-);
-
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheetHeader',
-  () => {
-    const { View, Text } = jest.requireActual('react-native');
-    return {
-      __esModule: true,
-      default: ({ children }: { children: React.ReactNode }) => (
-        <View testID="bottom-sheet-header">
-          <Text>{children}</Text>
-        </View>
-      ),
-    };
-  },
-);
-
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheetFooter',
-  () => {
-    const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
-    return {
-      __esModule: true,
-      default: ({
-        buttonPropsArray,
-      }: {
-        buttonPropsArray?: {
-          label: string;
-          onPress: () => void;
-          variant?: string;
-          size?: string;
-        }[];
-      }) => (
-        <View testID="bottom-sheet-footer">
-          {buttonPropsArray?.map((buttonProps) => (
-            <TouchableOpacity
-              key={buttonProps.label}
-              testID="got-it-button"
-              onPress={buttonProps.onPress}
-            >
-              <Text>{buttonProps.label}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-      ),
-      ButtonsAlignment: {
-        Horizontal: 'Horizontal',
-      },
-    };
-  },
-);
 
 // Mock Text component
 jest.mock('../../../../../component-library/components/Texts/Text', () => {
@@ -118,16 +37,6 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => {
     },
   };
 });
-
-// Mock Button enums
-jest.mock('../../../../../component-library/components/Buttons/Button', () => ({
-  ButtonSize: {
-    Lg: 'Lg',
-  },
-  ButtonVariants: {
-    Primary: 'Primary',
-  },
-}));
 
 // Mock strings
 jest.mock('../../../../../../locales/i18n', () => ({
@@ -234,11 +143,17 @@ describe('PerpsTooltipView', () => {
     it('renders correctly with valid contentKey', () => {
       render(<PerpsTooltipView />);
 
-      expect(screen.getByTestId('bottom-sheet')).toBeOnTheScreen();
-      expect(screen.getByTestId('bottom-sheet-header')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('perps-tooltip-bottom-sheet'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('perps-tooltip-bottom-sheet-header'),
+      ).toBeOnTheScreen();
       // Content should be rendered (either with testID for custom renderers or as text for default)
       expect(screen.getByText('Content for leverage')).toBeOnTheScreen();
-      expect(screen.getByTestId('bottom-sheet-footer')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('perps-tooltip-bottom-sheet-footer'),
+      ).toBeOnTheScreen();
       expect(screen.getByText('Got it')).toBeOnTheScreen();
     });
 
@@ -345,7 +260,9 @@ describe('PerpsTooltipView', () => {
 
       render(<PerpsTooltipView />);
 
-      expect(screen.getByTestId('bottom-sheet-header')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('perps-tooltip-bottom-sheet-header'),
+      ).toBeOnTheScreen();
       expect(screen.getByText('leverage')).toBeOnTheScreen();
     });
 
@@ -359,7 +276,9 @@ describe('PerpsTooltipView', () => {
       render(<PerpsTooltipView />);
 
       // Should not render the default header
-      expect(screen.queryByTestId('bottom-sheet-header')).toBeNull();
+      expect(
+        screen.queryByTestId('perps-tooltip-bottom-sheet-header'),
+      ).toBeNull();
       expect(screen.getByText('Market Hours Content')).toBeOnTheScreen();
     });
 
@@ -373,7 +292,9 @@ describe('PerpsTooltipView', () => {
       render(<PerpsTooltipView />);
 
       // Should not render the default header
-      expect(screen.queryByTestId('bottom-sheet-header')).toBeNull();
+      expect(
+        screen.queryByTestId('perps-tooltip-bottom-sheet-header'),
+      ).toBeNull();
       expect(screen.getByText('After Hours Trading Content')).toBeOnTheScreen();
     });
   });
@@ -382,19 +303,22 @@ describe('PerpsTooltipView', () => {
     it('renders footer with Got it button', () => {
       render(<PerpsTooltipView />);
 
-      expect(screen.getByTestId('bottom-sheet-footer')).toBeOnTheScreen();
-      expect(screen.getByTestId('got-it-button')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('perps-tooltip-bottom-sheet-footer'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('perps-tooltip-bottom-sheet-footer-got-it-button'),
+      ).toBeOnTheScreen();
       expect(screen.getByText('Got it')).toBeOnTheScreen();
     });
 
     it('calls onCloseBottomSheet when Got it button is pressed', () => {
       render(<PerpsTooltipView />);
 
-      const gotItButton = screen.getByTestId('got-it-button');
+      const gotItButton = screen.getByText('Got it');
 
       fireEvent.press(gotItButton);
 
-      // The BottomSheet mock handles navigation back internally
       // We verify the component handles the press without errors
       expect(gotItButton).toBeOnTheScreen();
     });

--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.tsx
@@ -68,7 +68,6 @@ const PerpsTooltipView: React.FC = () => {
   return (
     <BottomSheet
       ref={bottomSheetRef}
-      shouldNavigateBack
       goBack={navigation.goBack}
       testID="perps-tooltip-bottom-sheet"
     >

--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.tsx
@@ -1,19 +1,15 @@
 import React, { useRef, useCallback } from 'react';
-import { useRoute, RouteProp } from '@react-navigation/native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import BottomSheetFooter, {
-  ButtonsAlignment,
-} from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  ButtonSize,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../hooks/useStyles';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsTooltipContentKey } from '../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
@@ -28,16 +24,13 @@ interface PerpsTooltipViewRouteParams {
 }
 
 const PerpsTooltipView: React.FC = () => {
+  const navigation = useNavigation();
   const route =
     useRoute<RouteProp<Record<string, PerpsTooltipViewRouteParams>, string>>();
   const { styles } = useStyles(createStyles, {});
   const bottomSheetRef = useRef<BottomSheetRef>(null);
 
   const { contentKey, data } = route.params || {};
-
-  const handleClose = useCallback(() => {
-    // BottomSheet will handle navigation.goBack() when shouldNavigateBack is true
-  }, []);
 
   const handleGotItPress = useCallback(() => {
     bottomSheetRef.current?.onCloseBottomSheet();
@@ -68,21 +61,16 @@ const PerpsTooltipView: React.FC = () => {
     );
   };
 
-  const footerButtons = [
-    {
-      label: strings('perps.tooltips.got_it_button'),
-      onPress: handleGotItPress,
-      variant: ButtonVariants.Primary,
-      size: ButtonSize.Lg,
-    },
-  ];
-
   // Content keys that render their own header (with icon)
   const hasCustomHeader =
     contentKey === 'market_hours' || contentKey === 'after_hours_trading';
 
   return (
-    <BottomSheet ref={bottomSheetRef} shouldNavigateBack onClose={handleClose}>
+    <BottomSheet
+      ref={bottomSheetRef}
+      shouldNavigateBack
+      goBack={navigation.goBack}
+    >
       {!hasCustomHeader && (
         <BottomSheetHeader>
           <Text variant={TextVariant.HeadingMD}>{title}</Text>
@@ -90,8 +78,11 @@ const PerpsTooltipView: React.FC = () => {
       )}
       <View style={styles.contentContainer}>{renderContent()}</View>
       <BottomSheetFooter
-        buttonsAlignment={ButtonsAlignment.Horizontal}
-        buttonPropsArray={footerButtons}
+        primaryButtonProps={{
+          children: strings('perps.tooltips.got_it_button'),
+          onPress: handleGotItPress,
+          size: ButtonSize.Lg,
+        }}
         style={styles.footerContainer}
       />
     </BottomSheet>

--- a/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTooltipView/PerpsTooltipView.tsx
@@ -70,18 +70,21 @@ const PerpsTooltipView: React.FC = () => {
       ref={bottomSheetRef}
       shouldNavigateBack
       goBack={navigation.goBack}
+      testID="perps-tooltip-bottom-sheet"
     >
       {!hasCustomHeader && (
-        <BottomSheetHeader>
+        <BottomSheetHeader testID="perps-tooltip-bottom-sheet-header">
           <Text variant={TextVariant.HeadingMD}>{title}</Text>
         </BottomSheetHeader>
       )}
       <View style={styles.contentContainer}>{renderContent()}</View>
       <BottomSheetFooter
+        testID="perps-tooltip-bottom-sheet-footer"
         primaryButtonProps={{
           children: strings('perps.tooltips.got_it_button'),
           onPress: handleGotItPress,
           size: ButtonSize.Lg,
+          testID: 'perps-tooltip-bottom-sheet-footer-got-it-button',
         }}
         style={styles.footerContainer}
       />

--- a/app/components/UI/Perps/components/PerpsQuoteExpiredModal/PerpsQuoteExpiredModal.tsx
+++ b/app/components/UI/Perps/components/PerpsQuoteExpiredModal/PerpsQuoteExpiredModal.tsx
@@ -1,32 +1,24 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import BottomSheetFooter from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../component-library/hooks';
 import createStyles from './PerpsQuoteExpiredModal.styles';
 import { DEPOSIT_CONFIG } from '@metamask/perps-controller';
 
 const PerpsQuoteExpiredModal = () => {
   const navigation = useNavigation();
-  const sheetRef = useRef<BottomSheetRef>(null);
   const { styles } = useStyles(createStyles, {});
   const refreshRate = DEPOSIT_CONFIG.RefreshRate / 1000; // Convert to seconds
-
-  const handleClose = () => {
-    navigation.goBack();
-  };
 
   const handleGetNewQuote = () => {
     // The quote will be automatically refreshed when we navigate back
@@ -34,18 +26,9 @@ const PerpsQuoteExpiredModal = () => {
     navigation.goBack();
   };
 
-  const footerButtonProps = [
-    {
-      label: strings('perps.deposit.quote_expired_modal.get_new_quote'),
-      variant: ButtonVariants.Primary,
-      size: ButtonSize.Lg,
-      onPress: handleGetNewQuote,
-    },
-  ];
-
   return (
-    <BottomSheet ref={sheetRef}>
-      <BottomSheetHeader onClose={handleClose}>
+    <BottomSheet goBack={navigation.goBack}>
+      <BottomSheetHeader onClose={navigation.goBack}>
         <Text variant={TextVariant.HeadingMD}>
           {strings('perps.deposit.quote_expired_modal.title')}
         </Text>
@@ -58,7 +41,11 @@ const PerpsQuoteExpiredModal = () => {
         </Text>
       </View>
       <BottomSheetFooter
-        buttonPropsArray={footerButtonProps}
+        primaryButtonProps={{
+          children: strings('perps.deposit.quote_expired_modal.get_new_quote'),
+          onPress: handleGetNewQuote,
+          size: ButtonSize.Lg,
+        }}
         style={styles.footer}
       />
     </BottomSheet>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `BottomSheet` from DSRN package.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-639

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/bc9f038e-e3ea-40d2-bef3-79e4b70b0be8

### **After**

https://github.com/user-attachments/assets/d74c2631-221d-417e-88d4-9c4578039ecc

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes modal/bottom-sheet integration and navigation close behavior (via `goBack`) in user-facing Perps flows, which could affect dismissal and button actions.
> 
> **Overview**
> Migrates Perps bottom-sheet UIs to use `BottomSheet`, `BottomSheetHeader`, and `BottomSheetFooter` from `@metamask/design-system-react-native`, including switching footer button config to `primaryButtonProps` and wiring dismissal through the new `goBack` prop.
> 
> Updates `PerpsTooltipView` to add explicit `testID`s for the sheet/header/footer and button, and adjusts its tests by removing custom BottomSheet mocks, mocking safe-area/navigation, and asserting against the new IDs and button rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d915613541aca02ddab26e63238b5317aa79881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->