### PR TITLE
feat(perps): wire Perps Withdraw button to feature-flagged confirmation flow

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -96,6 +96,12 @@ jest.mock('../../hooks', () => ({
   })),
 }));
 
+jest.mock('../../hooks/usePerpsWithdrawConfirmation', () => ({
+  usePerpsWithdrawConfirmation: jest.fn(() => ({
+    withdrawWithConfirmation: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 jest.mock('../../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
   useConfirmNavigation: jest.fn(),
 }));

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -49,6 +49,13 @@ jest.mock('./usePerpsEventTracking', () => ({
   })),
 }));
 
+const mockWithdrawWithConfirmation = jest.fn().mockResolvedValue(undefined);
+jest.mock('./usePerpsWithdrawConfirmation', () => ({
+  usePerpsWithdrawConfirmation: jest.fn(() => ({
+    withdrawWithConfirmation: mockWithdrawWithConfirmation,
+  })),
+}));
+
 describe('usePerpsHomeActions', () => {
   const mockNavigation = {
     navigate: jest.fn(),
@@ -62,6 +69,7 @@ describe('usePerpsHomeActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockTrack.mockClear();
+    mockWithdrawWithConfirmation.mockResolvedValue(undefined);
     (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
     (useSelector as jest.Mock).mockReturnValue(true);
     (usePerpsTrading as jest.Mock).mockReturnValue({
@@ -309,6 +317,72 @@ describe('usePerpsHomeActions', () => {
           [PERPS_EVENT_PROPERTY.IS_GEO_BLOCKED]: false,
         }),
       );
+    });
+  });
+
+  describe('handleWithdraw - feature flag enabled (withdraw to any token)', () => {
+    beforeEach(() => {
+      // First call: selectPerpsEligibility → true
+      // Second call: selectPayQuoteConfig → { enabled: true }
+      (useSelector as jest.Mock)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce({ enabled: true });
+    });
+
+    it('calls withdrawWithConfirmation instead of legacy navigation', async () => {
+      const { result } = renderHook(() => usePerpsHomeActions());
+
+      await act(async () => {
+        await result.current.handleWithdraw();
+      });
+
+      expect(mockWithdrawWithConfirmation).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('triggers onWithdrawSuccess after withdrawWithConfirmation', async () => {
+      const onWithdrawSuccess = jest.fn();
+      const { result } = renderHook(() =>
+        usePerpsHomeActions({ onWithdrawSuccess }),
+      );
+
+      await act(async () => {
+        await result.current.handleWithdraw();
+      });
+
+      await waitFor(() => {
+        expect(onWithdrawSuccess).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('handles error from withdrawWithConfirmation', async () => {
+      mockWithdrawWithConfirmation.mockRejectedValueOnce(
+        new Error('Withdraw failed'),
+      );
+
+      const onError = jest.fn();
+      const { result } = renderHook(() => usePerpsHomeActions({ onError }));
+
+      await act(async () => {
+        await result.current.handleWithdraw();
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toEqual(new Error('Withdraw failed'));
+        expect(onError).toHaveBeenCalledWith(expect.any(Error), 'withdraw');
+      });
+    });
+
+    it('resets isProcessing after completion', async () => {
+      const { result } = renderHook(() => usePerpsHomeActions());
+
+      await act(async () => {
+        await result.current.handleWithdraw();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isProcessing).toBe(false);
+      });
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -15,6 +15,9 @@ import {
 import { ensureError } from '../../../../util/errorUtils';
 import { usePerpsEventTracking } from './usePerpsEventTracking';
 import { MetaMetricsEvents } from '../../../../core/Analytics/MetaMetrics.events';
+import { selectPayQuoteConfig } from '../../../../selectors/featureFlagController/confirmations';
+import { RootState } from '../../../../reducers';
+import { usePerpsWithdrawConfirmation } from './usePerpsWithdrawConfirmation';
 
 export type PerpsHomeActionType = 'deposit' | 'withdraw';
 
@@ -67,6 +70,10 @@ export const usePerpsHomeActions = (
   const isEligible = useSelector(selectPerpsEligibility);
   const { depositWithConfirmation } = usePerpsTrading();
   const { navigateToConfirmation } = useConfirmNavigation();
+  const perpsWithdrawConfig = useSelector((state: RootState) =>
+    selectPayQuoteConfig(state, 'perpsWithdraw'),
+  );
+  const { withdrawWithConfirmation } = usePerpsWithdrawConfirmation();
 
   const [isEligibilityModalVisible, setIsEligibilityModalVisible] =
     useState(false);
@@ -167,11 +174,19 @@ export const usePerpsHomeActions = (
     });
 
     try {
-      navigation.navigate(Routes.PERPS.ROOT, {
-        screen: Routes.PERPS.WITHDRAW,
-      });
-
-      DevLogger.log('[usePerpsHomeActions] Navigated to withdraw screen');
+      if (perpsWithdrawConfig.enabled) {
+        await withdrawWithConfirmation();
+        DevLogger.log(
+          '[usePerpsHomeActions] Started withdraw-to-any-token flow',
+        );
+      } else {
+        navigation.navigate(Routes.PERPS.ROOT, {
+          screen: Routes.PERPS.WITHDRAW,
+        });
+        DevLogger.log(
+          '[usePerpsHomeActions] Navigated to legacy withdraw screen',
+        );
+      }
 
       if (onWithdrawSuccess) {
         onWithdrawSuccess();
@@ -195,6 +210,8 @@ export const usePerpsHomeActions = (
   }, [
     isEligible,
     navigation,
+    perpsWithdrawConfig.enabled,
+    withdrawWithConfirmation,
     onWithdrawSuccess,
     onError,
     track,

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -120,23 +120,16 @@ describe('usePerpsWithdrawConfirmation', () => {
     });
   });
 
-  it('logs error to console when addTransactionBatch fails', async () => {
+  it('propagates error when addTransactionBatch fails', async () => {
     const error = new Error('batch failed');
     mockAddTransactionBatch.mockRejectedValueOnce(error);
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
     const { result } = renderHook(() => usePerpsWithdrawConfirmation());
 
-    await act(async () => {
-      await result.current.withdrawWithConfirmation();
-    });
-
-    // Allow the rejected promise .catch to fire
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
-    });
-
-    expect(consoleSpy).toHaveBeenCalledWith('Perps transaction error', error);
-    consoleSpy.mockRestore();
+    await expect(
+      act(async () => {
+        await result.current.withdrawWithConfirmation();
+      }),
+    ).rejects.toThrow('batch failed');
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -1,0 +1,142 @@
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { renderHook, act } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectDefaultEndpointByChainId } from '../../../../selectors/networkController';
+import { addTransactionBatch } from '../../../../util/transaction-controller';
+import { generateTransferData } from '../../../../util/transactions';
+import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
+import Routes from '../../../../constants/navigation/Routes';
+import { usePerpsWithdrawConfirmation } from './usePerpsWithdrawConfirmation';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../selectors/accountsController'),
+  selectSelectedInternalAccountAddress: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/networkController', () => ({
+  ...jest.requireActual('../../../../selectors/networkController'),
+  selectDefaultEndpointByChainId: jest.fn(),
+}));
+
+jest.mock('../../../../util/transaction-controller', () => ({
+  addTransactionBatch: jest.fn(),
+}));
+
+jest.mock('../../../../util/transactions', () => ({
+  generateTransferData: jest.fn(),
+}));
+
+jest.mock('../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
+  useConfirmNavigation: jest.fn(),
+}));
+
+const MOCK_ACCOUNT = '0x1234567890123456789012345678901234567890' as Hex;
+const MOCK_TRANSFER_DATA = '0xabcdef' as Hex;
+const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
+const mockNavigateToConfirmation = jest.fn();
+
+describe('usePerpsWithdrawConfirmation', () => {
+  const mockAddTransactionBatch = jest.mocked(addTransactionBatch);
+  const mockGenerateTransferData = jest.mocked(generateTransferData);
+  const mockSelectSelectedInternalAccountAddress = jest.mocked(
+    selectSelectedInternalAccountAddress,
+  );
+  const mockSelectDefaultEndpointByChainId = jest.mocked(
+    selectDefaultEndpointByChainId,
+  );
+  const mockUseConfirmNavigation = jest.mocked(useConfirmNavigation);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSelectSelectedInternalAccountAddress.mockReturnValue(MOCK_ACCOUNT);
+    mockSelectDefaultEndpointByChainId.mockReturnValue({
+      networkClientId: MOCK_NETWORK_CLIENT_ID,
+    } as never);
+    mockGenerateTransferData.mockReturnValue(MOCK_TRANSFER_DATA);
+    mockAddTransactionBatch.mockResolvedValue(undefined as never);
+    mockUseConfirmNavigation.mockReturnValue({
+      navigateToConfirmation: mockNavigateToConfirmation,
+    } as never);
+
+    (useSelector as jest.Mock).mockImplementation(((
+      selector: (state: object) => unknown,
+    ) => selector({})) as typeof useSelector);
+  });
+
+  it('navigates to confirmation with CustomAmount loader on Perps stack', async () => {
+    const { result } = renderHook(() => usePerpsWithdrawConfirmation());
+
+    await act(async () => {
+      await result.current.withdrawWithConfirmation();
+    });
+
+    expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+      loader: ConfirmationLoader.CustomAmount,
+      stack: Routes.PERPS.ROOT,
+    });
+  });
+
+  it('adds a perpsWithdraw transaction batch on Arbitrum', async () => {
+    const { result } = renderHook(() => usePerpsWithdrawConfirmation());
+
+    await act(async () => {
+      await result.current.withdrawWithConfirmation();
+    });
+
+    expect(mockSelectDefaultEndpointByChainId).toHaveBeenCalledWith(
+      {},
+      CHAIN_IDS.ARBITRUM,
+    );
+    expect(mockGenerateTransferData).toHaveBeenCalledWith('transfer', {
+      toAddress: ARBITRUM_USDC.address,
+      amount: '0x0',
+    });
+    expect(mockAddTransactionBatch).toHaveBeenCalledWith({
+      from: MOCK_ACCOUNT,
+      origin: ORIGIN_METAMASK,
+      networkClientId: MOCK_NETWORK_CLIENT_ID,
+      disableHook: true,
+      disableSequential: true,
+      transactions: [
+        {
+          params: {
+            to: ARBITRUM_USDC.address,
+            data: MOCK_TRANSFER_DATA,
+          },
+          type: TransactionType.perpsWithdraw,
+        },
+      ],
+    });
+  });
+
+  it('logs error to console when addTransactionBatch fails', async () => {
+    const error = new Error('batch failed');
+    mockAddTransactionBatch.mockRejectedValueOnce(error);
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const { result } = renderHook(() => usePerpsWithdrawConfirmation());
+
+    await act(async () => {
+      await result.current.withdrawWithConfirmation();
+    });
+
+    // Allow the rejected promise .catch to fire
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith('Perps transaction error', error);
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
@@ -40,7 +40,7 @@ export function usePerpsWithdrawConfirmation() {
       stack: Routes.PERPS.ROOT,
     });
 
-    addTransactionBatch({
+    await addTransactionBatch({
       from: selectedAccount as Hex,
       origin: ORIGIN_METAMASK,
       networkClientId,
@@ -55,8 +55,6 @@ export function usePerpsWithdrawConfirmation() {
           type: TransactionType.perpsWithdraw,
         },
       ],
-    }).catch((e) => {
-      console.error('Perps transaction error', e);
     });
   }, [navigateToConfirmation, networkClientId, selectedAccount, transferData]);
 

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import { Hex } from '@metamask/utils';
+import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import { useSelector } from 'react-redux';
+import { addTransactionBatch } from '../../../../util/transaction-controller';
+import { selectDefaultEndpointByChainId } from '../../../../selectors/networkController';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { generateTransferData } from '../../../../util/transactions';
+import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
+import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
+import { RootState } from '../../../../reducers';
+import Routes from '../../../../constants/navigation/Routes';
+
+/**
+ * Hook that triggers the Perps "withdraw to any token" confirmation flow.
+ *
+ * Creates a dummy ERC-20 transfer on Arbitrum typed as `perpsWithdraw`,
+ * which the confirmation UI + PayController detect to drive the
+ * CustomAmount / MetaMask Pay experience.
+ */
+export function usePerpsWithdrawConfirmation() {
+  const selectedAccount = useSelector(selectSelectedInternalAccountAddress);
+  const { navigateToConfirmation } = useConfirmNavigation();
+
+  const { networkClientId } =
+    useSelector((state: RootState) =>
+      selectDefaultEndpointByChainId(state, CHAIN_IDS.ARBITRUM),
+    ) ?? {};
+
+  const transferData = generateTransferData('transfer', {
+    toAddress: ARBITRUM_USDC.address,
+    amount: '0x0',
+  }) as Hex;
+
+  const withdrawWithConfirmation = useCallback(async () => {
+    navigateToConfirmation({
+      loader: ConfirmationLoader.CustomAmount,
+      stack: Routes.PERPS.ROOT,
+    });
+
+    addTransactionBatch({
+      from: selectedAccount as Hex,
+      origin: ORIGIN_METAMASK,
+      networkClientId,
+      disableHook: true,
+      disableSequential: true,
+      transactions: [
+        {
+          params: {
+            to: ARBITRUM_USDC.address,
+            data: transferData,
+          },
+          type: TransactionType.perpsWithdraw,
+        },
+      ],
+    }).catch((e) => {
+      console.error('Perps transaction error', e);
+    });
+  }, [navigateToConfirmation, networkClientId, selectedAccount, transferData]);
+
+  return { withdrawWithConfirmation };
+}

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -24,11 +24,11 @@ import { useConfirmNavigation } from '../../../hooks/useConfirmNavigation';
 import { selectSelectedInternalAccountAddress } from '../../../../../../selectors/accountsController';
 import { RootState } from '../../../../../../reducers';
 import { ConfirmationsDeveloperOptionsTestIds } from './confirmations-developer-options.testIds';
-import { ARBITRUM_USDC } from '../../../constants/perps';
 import {
   selectMoneyAccountDepositEnabledFlag,
   selectMoneyAccountWithdrawEnabledFlag,
 } from '../../../../../../selectors/featureFlagController/moneyAccount';
+import { usePerpsWithdrawConfirmation } from '../../../../../../components/UI/Perps/hooks/usePerpsWithdrawConfirmation';
 
 const POLYGON_USDCE_ADDRESS =
   '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174' as Hex;
@@ -57,14 +57,11 @@ export function ConfirmationsDeveloperOptions() {
 }
 
 function PerpsWithdraw() {
-  const { addTransactionBatchAndNavigate } = useAddPerpsTransactionBatch();
+  const { withdrawWithConfirmation } = usePerpsWithdrawConfirmation();
 
   const handleWithdraw = useCallback(() => {
-    addTransactionBatchAndNavigate({
-      loader: ConfirmationLoader.CustomAmount,
-      transactionType: TransactionType.perpsWithdraw,
-    });
-  }, [addTransactionBatchAndNavigate]);
+    withdrawWithConfirmation();
+  }, [withdrawWithConfirmation]);
 
   return (
     <DeveloperButton
@@ -235,60 +232,6 @@ function useAddTransactionBatch() {
         ],
       }).catch((e) => {
         console.error('Predict transaction error', e);
-      });
-    },
-    [navigateToConfirmation, networkClientId, selectedAccount, transferData],
-  );
-
-  return {
-    addTransactionBatchAndNavigate,
-  };
-}
-
-function useAddPerpsTransactionBatch() {
-  const selectedAccount = useSelector(selectSelectedInternalAccountAddress);
-  const { navigateToConfirmation } = useConfirmNavigation();
-
-  const { networkClientId } =
-    useSelector((state: RootState) =>
-      selectDefaultEndpointByChainId(state, CHAIN_IDS.ARBITRUM),
-    ) ?? {};
-
-  const transferData = generateTransferData('transfer', {
-    toAddress: ARBITRUM_USDC.address,
-    amount: '0x0',
-  }) as Hex;
-
-  const addTransactionBatchAndNavigate = useCallback(
-    async ({
-      loader,
-      transactionType,
-    }: {
-      loader?: ConfirmationLoader;
-      transactionType: TransactionType;
-    }) => {
-      navigateToConfirmation({
-        loader,
-        stack: Routes.PERPS.ROOT,
-      });
-
-      addTransactionBatch({
-        from: selectedAccount as Hex,
-        origin: ORIGIN_METAMASK,
-        networkClientId,
-        disableHook: true,
-        disableSequential: true,
-        transactions: [
-          {
-            params: {
-              to: ARBITRUM_USDC.address,
-              data: transferData,
-            },
-            type: transactionType,
-          },
-        ],
-      }).catch((e) => {
-        console.error('Perps transaction error', e);
       });
     },
     [navigateToConfirmation, networkClientId, selectedAccount, transferData],


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the full Perps Withdraw "to any token" feature, allowing users to withdraw Perps funds to any supported token via MetaMask Pay and the Relay bridge, instead of only withdrawing native USDC through HyperLiquid's 5-minute bridge.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added feature-flagged "withdraw to any token" flow for Perps, allowing users to withdraw Perps funds to any supported token via MetaMask Pay

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1121

## **Manual testing steps**

```gherkin
Feature: Perps Withdraw to any token

  Scenario: user withdraws via the new confirmation flow (flag enabled)
    Given the user has a Perps balance
    And the confirmations_pay_post_quote remote flag has overrides.perpsWithdraw.enabled = true
    When user taps "Withdraw" on the Perps home page
    Then the full-screen CustomAmount confirmation UI is shown
    And the available Perps balance is displayed
    And the user can select a receive token via the "Receive as" picker
    And confirming the withdrawal triggers the MetaMask Pay flow

  Scenario: user withdraws via the legacy flow (flag disabled)
    Given the user has a Perps balance
    And the confirmations_pay_post_quote remote flag has overrides.perpsWithdraw.enabled = false or is missing
    When user taps "Withdraw" on the Perps home page
    Then the legacy PerpsWithdrawView is shown

  Scenario: developer triggers Perps withdraw from Developer Options
    Given the user has Developer Options enabled in Settings
    When user navigates to Settings > Developer Options > Perps Withdraw and taps "Withdraw"
    Then the full-screen CustomAmount confirmation UI is shown regardless of feature flag state

  Scenario: perpsWithdraw transaction appears in activity
    Given a perpsWithdraw transaction has been submitted
    When the user views the activity tab
    Then the transaction is listed as "Perps withdraw"
    And tapping it shows the transaction details with title "Withdrawal"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes withdraw initiation and transaction-batch creation (including network selection) in a user-funds flow, which can affect confirmations and activity history if the flag/config is wrong.
> 
> **Overview**
> Updates Perps withdraw to be **feature-flagged**: when `selectPayQuoteConfig(..., 'perpsWithdraw').enabled` is true, the Withdraw button now starts a new confirmation-based flow instead of navigating to the legacy withdraw screen.
> 
> Introduces `usePerpsWithdrawConfirmation`, which navigates to the `CustomAmount` confirmation UI on the Perps stack and creates a dummy Arbitrum ERC-20 transfer batch typed as `TransactionType.perpsWithdraw` to drive the MetaMask Pay experience; Developer Options “Perps Withdraw” is rewired to this hook. Tests are updated/added to cover the flag branching, success/error handling, and the new transaction-batch behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a80e4b70bbdf1ddc16b964cfc5fed036d30fd833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->