### PR TITLE
fix: apply theme background color to Ramp buy/sell navigation cards

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1095,10 +1095,20 @@ const MainNavigator = () => {
         name={Routes.RAMP.TOKEN_SELECTION}
         component={TokenListRoutes}
       />
-      <Stack.Screen name={Routes.RAMP.BUY}>
+      <Stack.Screen
+        name={Routes.RAMP.BUY}
+        options={{
+          cardStyle: { backgroundColor: colors.background.default },
+        }}
+      >
         {() => <RampRoutes rampType={RampType.BUY} />}
       </Stack.Screen>
-      <Stack.Screen name={Routes.RAMP.SELL}>
+      <Stack.Screen
+        name={Routes.RAMP.SELL}
+        options={{
+          cardStyle: { backgroundColor: colors.background.default },
+        }}
+      >
         {() => <RampRoutes rampType={RampType.SELL} />}
       </Stack.Screen>
       <Stack.Screen name={Routes.DEPOSIT.ID} component={DepositRoutes} />

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -197,9 +197,23 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
   />
   <Screen
     name="RampBuy"
+    options={
+      {
+        "cardStyle": {
+          "backgroundColor": "#ffffff",
+        },
+      }
+    }
   />
   <Screen
     name="RampSell"
+    options={
+      {
+        "cardStyle": {
+          "backgroundColor": "#ffffff",
+        },
+      }
+    }
   />
   <Screen
     component={[Function]}
@@ -590,9 +604,23 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
   />
   <Screen
     name="RampBuy"
+    options={
+      {
+        "cardStyle": {
+          "backgroundColor": "#ffffff",
+        },
+      }
+    }
   />
   <Screen
     name="RampSell"
+    options={
+      {
+        "cardStyle": {
+          "backgroundColor": "#ffffff",
+        },
+      }
+    }
   />
   <Screen
     component={[Function]}
@@ -983,9 +1011,23 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
   />
   <Screen
     name="RampBuy"
+    options={
+      {
+        "cardStyle": {
+          "backgroundColor": "#ffffff",
+        },
+      }
+    }
   />
   <Screen
     name="RampSell"
+    options={
+      {
+        "cardStyle": {
+          "backgroundColor": "#ffffff",
+        },
+      }
+    }
   />
   <Screen
     component={[Function]}


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Ramp BUY and SELL screens in `MainNavigator.js` were missing `cardStyle` with `backgroundColor`, causing the navigation card to use React Navigation's default white background. This made the header (top safe area) and footer (bottom safe area) appear white in dark mode.

Other screens in the same navigator (Send, Bridge, Browser, etc.) already set `cardStyle: { backgroundColor: colors.background.default }`. This PR applies the same pattern to the Ramp screens for consistency.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed white header and footer on Ramp buy/sell screens in dark mode

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramp buy screen dark mode theming

  Scenario: user opens Buy crypto from Perps with dark mode enabled
    Given the app is set to dark mode
    And the user is on the Perps home screen with zero balance

    When user taps "Add funds"
    And user taps "Buy crypto"
    Then the Ramp buy screen header and footer use the dark theme background color
    And there are no white areas at the top or bottom of the screen
```

## **Screenshots/Recordings**

### **Before**

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-04-01 at 09 26 16" src="https://github.com/user-attachments/assets/83c59cdb-c2b7-48e7-b982-15ac10db8cdf" />


### **After**

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2026-04-01 at 09 23 38" src="https://github.com/user-attachments/assets/6467aa48-8c1e-4157-aabd-9950ec3a015e" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only navigation styling change that should not affect Ramp flow logic; primary risk is unintended background color differences on the Ramp screens across themes.
> 
> **Overview**
> Fixes Ramp `BUY`/`SELL` screens in `MainNavigator` to use the app theme background by adding `options.cardStyle.backgroundColor = colors.background.default` on those stack screens, preventing white safe-area/header/footer regions in dark mode.
> 
> Updates the `MainNavigator` Jest snapshots to reflect the new per-screen `options` for `RampBuy` and `RampSell`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11ad411def4439a8b1192240ba55c22684a6ca9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->