### PR TITLE
fix(ci): use native build number instead of run number in artifact names

### DIFF
--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -25,8 +25,35 @@ const packageJson = JSON.parse(
 );
 const appVersion = packageJson.version;
 
-// Get build number from environment (GitHub Actions run number or 1 for local)
-const buildNumber = process.env.GITHUB_RUN_NUMBER || '1';
+/**
+ * Read the native build number from the platform config files
+ * (versionCode in build.gradle for Android, CURRENT_PROJECT_VERSION in
+ * project.pbxproj for iOS) rather than using the GitHub Actions run number.
+ */
+function readNativeBuildNumber() {
+  if (platform === 'android') {
+    const gradle = fs.readFileSync(
+      path.join(__dirname, '../android/app/build.gradle'),
+      'utf8',
+    );
+    const match = gradle.match(/versionCode\s+(\d+)/);
+    if (match) return match[1];
+  } else {
+    const pbxproj = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../ios/MetaMask.xcodeproj/project.pbxproj',
+      ),
+      'utf8',
+    );
+    const match = pbxproj.match(/CURRENT_PROJECT_VERSION\s*=\s*(\d+)/);
+    if (match) return match[1];
+  }
+  console.warn('⚠️  Could not read native build number, falling back to 0');
+  return '0';
+}
+
+const buildNumber = readNativeBuildNumber();
 
 // Required env vars
 const buildType = process.env.METAMASK_BUILD_TYPE;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `scripts/rename-artifacts.js` script was using `GITHUB_RUN_NUMBER` (the workflow run counter) as the build number in artifact file names. This produced names like `metamask-production-main-7.73.0-42.apk` where `42` is the GitHub Actions run number, not the actual app build number.

This PR changes the script to read the real build number from the native config files instead:
- **Android**: `versionCode` from `android/app/build.gradle`
- **iOS**: `CURRENT_PROJECT_VERSION` from `ios/MetaMask.xcodeproj/project.pbxproj`

Artifact names now correctly reflect the app build number (e.g. `metamask-production-main-7.73.0-4138.apk`).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects artifact naming by reading `versionCode`/`CURRENT_PROJECT_VERSION`; main risk is mis-parsing or missing values causing fallback build numbers.
> 
> **Overview**
> Artifact filenames produced by `scripts/rename-artifacts.js` now use the *native* build number instead of `GITHUB_RUN_NUMBER`.
> 
> The script reads Android `versionCode` from `android/app/build.gradle` or iOS `CURRENT_PROJECT_VERSION` from `ios/MetaMask.xcodeproj/project.pbxproj`, with a warning + fallback to `0` if parsing fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66e69f83e20d6f719c909fd9712352f5ab400a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->