### PR TITLE
fix(deposit): hydrate provider token on Deposit root entry cp-7.72.0

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.test.tsx
@@ -87,8 +87,12 @@ describe('Root Component', () => {
     expect(screen.toJSON()).toMatchSnapshot();
   });
 
-  it('redirects to BUILD_QUOTE immediately when no created orders exist', async () => {
+  it('redirects to BUILD_QUOTE when no created orders exist after hydrating stored token', async () => {
+    mockCheckExistingToken.mockResolvedValue(false);
     render(Root);
+    await waitFor(() => {
+      expect(mockCheckExistingToken).toHaveBeenCalled();
+    });
     await waitFor(() => {
       expect(mockReset).toHaveBeenCalledWith({
         index: 0,
@@ -100,7 +104,6 @@ describe('Root Component', () => {
         ],
       });
     });
-    expect(mockCheckExistingToken).not.toHaveBeenCalled();
   });
 
   it('calls checkExistingToken when a created order exists', async () => {

--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
@@ -64,19 +64,15 @@ const Root = () => {
     };
 
     const initializeFlow = async () => {
-      if (hasCheckedToken.current) return;
-      hasCheckedToken.current = true;
-
-      const createdOrder = orders.find(
-        (order) => order.state === FIAT_ORDER_STATES.CREATED,
-      );
-
-      if (!createdOrder) {
-        navigateToDefaultRoute();
+      // 1. If token has already been checked, do not run again.
+      if (hasCheckedToken.current) {
         return;
       }
 
+      // 2. Default until vault / SDK hydration succeeds.
       let isAuthenticatedFromToken = false;
+
+      // 3. Attempt to restore auth from stored token; mark checked after the attempt finishes.
       try {
         isAuthenticatedFromToken = await withTimeout(
           checkExistingToken(),
@@ -87,11 +83,35 @@ const Root = () => {
           error as Error,
           'Deposit Root: checkExistingToken failed or timed out',
         );
+      } finally {
+        hasCheckedToken.current = true;
       }
 
-      if (!isAuthenticatedFromToken) {
-        const [routeName, navParams] = createEnterEmailNavDetails({
-          redirectToRootAfterAuth: true,
+      // 4. Resume in-progress deposit order if any.
+      const createdOrder = orders.find(
+        (order) => order.state === FIAT_ORDER_STATES.CREATED,
+      );
+
+      // 5. Created order: require auth or continue to bank details.
+      if (createdOrder) {
+        if (!isAuthenticatedFromToken) {
+          const [routeName, navParams] = createEnterEmailNavDetails({
+            redirectToRootAfterAuth: true,
+          });
+          navigation.reset({
+            index: 0,
+            routes: [
+              {
+                name: routeName,
+                params: { ...navParams, animationEnabled: false },
+              },
+            ],
+          });
+          return;
+        }
+
+        const [routeName, navParams] = createBankDetailsNavDetails({
+          orderId: createdOrder.id,
         });
         navigation.reset({
           index: 0,
@@ -105,18 +125,8 @@ const Root = () => {
         return;
       }
 
-      const [routeName, navParams] = createBankDetailsNavDetails({
-        orderId: createdOrder.id,
-      });
-      navigation.reset({
-        index: 0,
-        routes: [
-          {
-            name: routeName,
-            params: { ...navParams, animationEnabled: false },
-          },
-        ],
-      });
+      // 6. No created order: default entry (Build Quote); honor deeplink / intent flags when present.
+      navigateToDefaultRoute();
     };
 
     initializeFlow().catch((error) => {

--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
@@ -35,6 +35,7 @@ const Root = () => {
   const [initialRoute] = useState<string>(Routes.DEPOSIT.BUILD_QUOTE);
   const { checkExistingToken, setIntent } = useDepositSDK();
   const hasCheckedToken = useRef(false);
+  const initializationInFlight = useRef(false);
   const orders = useSelector(getAllDepositOrders);
   const theme = useTheme();
 
@@ -69,34 +70,56 @@ const Root = () => {
         return;
       }
 
-      // 2. Default until vault / SDK hydration succeeds.
-      let isAuthenticatedFromToken = false;
-
-      // 3. Attempt to restore auth from stored token; mark checked after the attempt finishes.
-      try {
-        isAuthenticatedFromToken = await withTimeout(
-          checkExistingToken(),
-          TOKEN_CHECK_TIMEOUT_MS,
-        );
-      } catch (error) {
-        Logger.error(
-          error as Error,
-          'Deposit Root: checkExistingToken failed or timed out',
-        );
-      } finally {
-        hasCheckedToken.current = true;
+      // 2. Single runner: effect can re-run while checkExistingToken is in flight; avoid duplicate work.
+      if (initializationInFlight.current) {
+        return;
       }
+      initializationInFlight.current = true;
 
-      // 4. Resume in-progress deposit order if any.
-      const createdOrder = orders.find(
-        (order) => order.state === FIAT_ORDER_STATES.CREATED,
-      );
+      try {
+        // 3. Default until vault / SDK hydration succeeds.
+        let isAuthenticatedFromToken = false;
 
-      // 5. Created order: require auth or continue to bank details.
-      if (createdOrder) {
-        if (!isAuthenticatedFromToken) {
-          const [routeName, navParams] = createEnterEmailNavDetails({
-            redirectToRootAfterAuth: true,
+        // 4. Attempt to restore auth from stored token; mark checked after the attempt finishes.
+        try {
+          isAuthenticatedFromToken = await withTimeout(
+            checkExistingToken(),
+            TOKEN_CHECK_TIMEOUT_MS,
+          );
+        } catch (error) {
+          Logger.error(
+            error as Error,
+            'Deposit Root: checkExistingToken failed or timed out',
+          );
+        } finally {
+          hasCheckedToken.current = true;
+        }
+
+        // 5. Resume in-progress deposit order if any.
+        const createdOrder = orders.find(
+          (order) => order.state === FIAT_ORDER_STATES.CREATED,
+        );
+
+        // 6. Created order: require auth or continue to bank details.
+        if (createdOrder) {
+          if (!isAuthenticatedFromToken) {
+            const [routeName, navParams] = createEnterEmailNavDetails({
+              redirectToRootAfterAuth: true,
+            });
+            navigation.reset({
+              index: 0,
+              routes: [
+                {
+                  name: routeName,
+                  params: { ...navParams, animationEnabled: false },
+                },
+              ],
+            });
+            return;
+          }
+
+          const [routeName, navParams] = createBankDetailsNavDetails({
+            orderId: createdOrder.id,
           });
           navigation.reset({
             index: 0,
@@ -110,23 +133,11 @@ const Root = () => {
           return;
         }
 
-        const [routeName, navParams] = createBankDetailsNavDetails({
-          orderId: createdOrder.id,
-        });
-        navigation.reset({
-          index: 0,
-          routes: [
-            {
-              name: routeName,
-              params: { ...navParams, animationEnabled: false },
-            },
-          ],
-        });
-        return;
+        // 7. No created order: default entry (Build Quote); honor deeplink / intent flags when present.
+        navigateToDefaultRoute();
+      } finally {
+        initializationInFlight.current = false;
       }
-
-      // 6. No created order: default entry (Build Quote); honor deeplink / intent flags when present.
-      navigateToDefaultRoute();
     };
 
     initializeFlow().catch((error) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Deposit `Root` previously called `checkExistingToken()` only when a fiat order in `CREATED` state existed in Redux. If the user had completed Verify / Email / OTP and stored a provider token, then closed Deposit and reopened it **without** an in-progress `CREATED` order, the vault was never read and `isAuthenticated` stayed false—so Build Quote sent them through the login flow again.

This change always runs `checkExistingToken()` (with the existing timeout) before branching to Build Quote, Enter Email, or Bank Details, so the stored token hydrates the SDK on every Deposit entry. `initializeFlow` is reorganized to match that order (guard → default auth → attempt vault read → `finally` mark token check complete → branch on `createdOrder`).

## **Changelog**

CHANGELOG entry: Fixed Deposit prompting for login again after closing and reopening the flow when a stored session was still valid.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Deposit session persists after closing and reopening

  Scenario: Continue deposit without repeating Verify / Email / OTP
    Given the user completed Deposit authentication (Verify, Email, OTP) and has a valid stored provider token
    And there is no in-progress deposit order in CREATED state
    When the user closes the Deposit flow and opens Deposit again
    And the user enters an amount and taps Continue on Build Quote
    Then the user is not sent to Verify / Email / OTP again
    And the post-quote flow proceeds as an authenticated user
```

## **Screenshots/Recordings**

<!-- Logic-only change; no visual redesign. Before/after screen is unchanged when the fix works (user stays on the happy path). -->

### **Before**

<!-- N/A — bug was erroneous navigation to auth screens. -->

### **After**

<!-- N/A — same Build Quote / next steps UI; difference is correct routing without redundant auth. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Deposit root initialization to always attempt stored-token hydration and to gate navigation decisions on that result, which can affect authentication and routing behavior. Adds re-entrancy guards to avoid duplicate async initialization, reducing race-condition risk but making flow control more complex.
> 
> **Overview**
> Ensures Deposit `Root` always runs `checkExistingToken()` (with timeout/error handling) on entry **before** deciding whether to route to Build Quote, Enter Email, or Bank Details, fixing cases where users were re-prompted to authenticate despite a valid stored provider token.
> 
> Reworks initialization flow to be idempotent and single-flight via `hasCheckedToken` plus a new `initializationInFlight` guard, and updates the Root test to assert token hydration occurs even when there is no `CREATED` order before redirecting to `BUILD_QUOTE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 513271a9c1b0fd332039d1998b5f00290655562b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->