### PR TITLE
chore: add GitHub Copilot to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,6 +24,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursorbot,cursoragent'
+          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursorbot,cursoragent,Copilot'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
## **Description**

The CLA Signature Bot treats allowlisted GitHub logins as exempt from the contributor license agreement flow. GitHub Copilot opens or updates pull requests as an app/bot account and cannot sign the CLA like a human contributor.

This change appends the Copilot bot login to the `allowlist` in `.github/workflows/cla.yml` so those PRs are not blocked by the CLA check, consistent with other automation (Dependabot, Cursor, etc.).

Use the exact Copilot username your org sees on commits/PRs (e.g. `copilot` or the `[bot]` form).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: CLA bot allowlist for Copilot

  Scenario: Copilot PR is not blocked by CLA for missing signature
    Given a pull request authored or updated by the GitHub Copilot bot
    When the CLA Signature Bot workflow runs on that pull request
    Then the allowlist matches the Copilot bot login and the CLA bot does not require a manual CLA signature from that identity
```

## **Screenshots/Recordings**

N/A — workflow-only change.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->
