### PR TITLE
chore: Abstract build from upload to testflight

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -4,21 +4,6 @@ name: Build and upload to TestFlight
 # Summary metadata is passed from build.yml outputs (no second checkout for version parsing).
 #
 on:
-  # workflow_call:
-  #   inputs:
-  #     source_branch:
-  #       description: 'Branch, tag, or SHA to build'
-  #       required: true
-  #       type: string
-  #     environment:
-  #       description: 'Build environment / track (exp, beta, rc)'
-  #       required: true
-  #       type: string
-  #     testflight_group:
-  #       description: 'TestFlight external testing group'
-  #       required: false
-  #       type: string
-  #       default: 'MetaMask BETA & Release Candidates'
   workflow_dispatch:
     inputs:
       source_branch:

--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -1,0 +1,101 @@
+name: Build and upload to TestFlight
+
+# Creates a temp branch, bumps version (build.yml), uploads IPA via upload-to-testflight.yml.
+# Summary metadata is passed from build.yml outputs (no second checkout for version parsing).
+#
+on:
+  # workflow_call:
+  #   inputs:
+  #     source_branch:
+  #       description: 'Branch, tag, or SHA to build'
+  #       required: true
+  #       type: string
+  #     environment:
+  #       description: 'Build environment / track (exp, beta, rc)'
+  #       required: true
+  #       type: string
+  #     testflight_group:
+  #       description: 'TestFlight external testing group'
+  #       required: false
+  #       type: string
+  #       default: 'MetaMask BETA & Release Candidates'
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Branch, tag, or SHA to build'
+        required: true
+        type: string
+        default: 'main'
+      environment:
+        description: 'Build environment / track'
+        required: true
+        type: choice
+        options:
+          - exp
+          - beta
+          - rc
+        default: rc
+      testflight_group:
+        description: 'TestFlight external testing group'
+        required: true
+        type: choice
+        default: 'MetaMask BETA & Release Candidates'
+        options:
+          - 'MetaMask BETA & Release Candidates'
+          - 'MM Card Team'
+          - 'Ramp Provider Testing'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  prepare-build-branch:
+    uses: ./.github/workflows/create-build-branch.yml
+    with:
+      source_branch: ${{ inputs.source_branch }}
+    secrets: inherit
+
+  build:
+    name: Build iOS (${{ inputs.environment }})
+    needs: [prepare-build-branch]
+    uses: ./.github/workflows/build.yml
+    with:
+      build_name: main-${{ inputs.environment }}
+      platform: ios
+      skip_version_bump: false
+      source_branch: ${{ needs.prepare-build-branch.outputs.build_branch }}
+    secrets: inherit
+
+  upload-ios-testflight:
+    needs: [prepare-build-branch, build]
+    uses: ./.github/workflows/upload-to-testflight.yml
+    with:
+      source_branch: ${{ needs.prepare-build-branch.outputs.build_branch }}
+      environment: ${{ inputs.environment }}
+      testflight_group: ${{ inputs.testflight_group || 'MetaMask BETA & Release Candidates' }}
+      build_name: main-${{ inputs.environment }}
+      summary_logical_source_branch: ${{ inputs.source_branch }}
+      summary_build_ref: ${{ needs.prepare-build-branch.outputs.build_branch }}
+      summary_build_version: ${{ needs.build.outputs.semantic_version }}
+      summary_android_version_code: ${{ needs.build.outputs.android_version_code }}
+      summary_built_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
+    secrets: inherit
+
+  cleanup-build-branch:
+    name: Cleanup build branch
+    needs: [prepare-build-branch, upload-ios-testflight]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PR_TOKEN || github.token }}
+      - name: Delete temporary build branch
+        env:
+          BRANCH: ${{ needs.prepare-build-branch.outputs.build_branch }}
+        run: |
+          if [ -n "$BRANCH" ]; then
+            git push origin --delete "$BRANCH" || true
+            echo "🧹 Deleted build branch: $BRANCH"
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,28 @@ on:
         required: false
         type: boolean
         default: false
+    outputs:
+      build_name:
+        description: 'build_name input passed to this workflow'
+        value: ${{ inputs.build_name }}
+      platform:
+        description: 'platform input (android, ios, or both)'
+        value: ${{ inputs.platform }}
+      source_branch_input:
+        description: 'source_branch input (empty means default ref was used)'
+        value: ${{ inputs.source_branch }}
+      checkout_ref:
+        description: 'Git ref used for checkout (version-bump commit SHA or source_branch / triggering ref)'
+        value: ${{ jobs.emit-build-metadata.outputs.checkout_ref }}
+      built_commit_sha:
+        description: 'Resolved commit SHA at checkout_ref after build succeeded'
+        value: ${{ jobs.emit-build-metadata.outputs.built_commit_sha }}
+      semantic_version:
+        description: 'package.json version at the built commit'
+        value: ${{ jobs.emit-build-metadata.outputs.semantic_version }}
+      android_version_code:
+        description: 'android/app/build.gradle versionCode at the built commit'
+        value: ${{ jobs.emit-build-metadata.outputs.android_version_code }}
   workflow_dispatch:
     inputs:
       build_name:
@@ -453,3 +475,31 @@ jobs:
           name: android-sourcemaps-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_sourcemap_dir }}
           if-no-files-found: warn
+
+  # Single fan-in job so workflow_call outputs work with matrix `build` (matrix jobs cannot feed workflow outputs directly).
+  emit-build-metadata:
+    name: Emit build metadata
+    needs: [prepare, build]
+    if: ${{ !failure() && !cancelled() && needs.prepare.result == 'success' && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      checkout_ref: ${{ steps.meta.outputs.checkout_ref }}
+      built_commit_sha: ${{ steps.meta.outputs.built_commit_sha }}
+      semantic_version: ${{ steps.meta.outputs.semantic_version }}
+      android_version_code: ${{ steps.meta.outputs.android_version_code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.checkout_ref_for_setup }}
+
+      - name: Read metadata from tree at built ref
+        id: meta
+        run: |
+          REF="${{ needs.prepare.outputs.checkout_ref_for_setup }}"
+          echo "checkout_ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "built_commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "semantic_version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          # versionCode 4138 (no '=' in this repo)
+          VC=$(awk '/versionCode[[:space:]]/{print $2; exit}' android/app/build.gradle | tr -d '\r')
+          echo "android_version_code=$VC" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,7 +4,7 @@ name: Nightly Build
 # Each build creates its own ephemeral branch via create-build-branch.yml,
 # so the persistent chore/temp-nightly branch is no longer needed.
 #
-# iOS builds are handled end-to-end by upload-to-testflight.yml (build + upload).
+# iOS builds use build-and-upload-to-testflight.yml (temp branch, build.yml, TestFlight upload).
 # Android builds use create-build-branch.yml + build.yml (build artifacts only).
 #
 # rc depends on exp within each platform stream to ensure the external version
@@ -26,7 +26,7 @@ jobs:
   # ── iOS exp: build + TestFlight upload ─────────────────────────────────
   ios-exp:
     name: Nightly iOS exp
-    uses: ./.github/workflows/upload-to-testflight.yml
+    uses: ./.github/workflows/build-and-upload-to-testflight.yml
     with:
       source_branch: main
       environment: exp
@@ -37,7 +37,7 @@ jobs:
   ios-rc:
     name: Nightly iOS rc
     needs: [ios-exp]
-    uses: ./.github/workflows/upload-to-testflight.yml
+    uses: ./.github/workflows/build-and-upload-to-testflight.yml
     with:
       source_branch: main
       environment: rc
@@ -82,7 +82,7 @@ jobs:
     secrets: inherit
 
   # ── Cleanup Android ephemeral branches ─────────────────────────────────
-  # iOS branches are cleaned up by upload-to-testflight.yml internally.
+  # iOS ephemeral branches are cleaned up by build-and-upload-to-testflight.yml.
   cleanup:
     name: Cleanup Android build branches
     needs: [android-exp-branch, android-rc-branch, android-exp, android-rc]

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -1,13 +1,13 @@
 name: Upload to TestFlight
 
-# Dedicated workflow to build iOS (via build.yml) and upload to TestFlight.
-# All TestFlight logic lives here; build.yml only builds and uploads artifacts.
+# Upload a pre-built iOS IPA (artifact from build.yml) to TestFlight.
+# Summary table uses workflow inputs only (no checkout / repo parsing in the summary job).
 #
 on:
   workflow_call:
     inputs:
       source_branch:
-        description: 'Branch, tag, or SHA to build'
+        description: 'Git ref used for the upload script changelog (usually the ref that was built)'
         required: true
         type: string
       environment:
@@ -19,89 +19,60 @@ on:
         required: false
         type: string
         default: 'MetaMask BETA & Release Candidates'
-  workflow_dispatch:
-    inputs:
-      source_branch:
-        description: 'Branch, tag, or SHA to build'
+      build_name:
+        description: 'Must match build.yml build_name (artifact ios-ipa-{build_name})'
         required: true
         type: string
-        default: 'main'
-      environment:
-        description: 'Build environment / track'
+      summary_logical_source_branch:
+        description: 'Original branch the user asked to build (e.g. main); from caller'
         required: true
-        type: choice
-        options:
-          - exp
-          - beta
-          - rc
-        default: rc
-      testflight_group:
-        description: 'TestFlight external testing group'
+        type: string
+      summary_build_ref:
+        description: 'Ref that was built (e.g. temp version-bump branch); from caller'
         required: true
-        type: choice
-        default: 'MetaMask BETA & Release Candidates'
-        options:
-          - 'MetaMask BETA & Release Candidates'
-          - 'MM Card Team'
-          - 'Ramp Provider Testing'
+        type: string
+      summary_build_version:
+        description: 'Semantic version at built commit; from build.yml semantic_version output'
+        required: true
+        type: string
+      summary_android_version_code:
+        description: 'Android versionCode at built commit; from build.yml android_version_code output'
+        required: true
+        type: string
+      summary_built_commit_sha:
+        description: 'Built commit SHA; from build.yml built_commit_sha output'
+        required: true
+        type: string
 
-# contents: write required by build.yml update-build-version job (version bump)
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
-  # Create a temporary branch so the version-bump commit can be pushed without
-  # hitting branch-protection rules on the source branch (e.g. main).
-  prepare-build-branch:
-    uses: ./.github/workflows/create-build-branch.yml
-    with:
-      source_branch: ${{ inputs.source_branch }}
-    secrets: inherit
-
-  build:
-    name: Build iOS (${{ inputs.environment || 'rc' }})
-    needs: [prepare-build-branch]
-    uses: ./.github/workflows/build.yml
-    with:
-      build_name: main-${{ inputs.environment || 'rc' }}
-      platform: ios
-      skip_version_bump: false
-      source_branch: ${{ needs.prepare-build-branch.outputs.build_branch }}
-    secrets: inherit
-
   testflight-upload-summary:
     name: TestFlight upload summary
-    needs: [build, prepare-build-branch]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.prepare-build-branch.outputs.build_branch }}
       - name: Display TestFlight upload summary
         run: |
-          BUILD_VERSION=$(node -p "require('./package.json').version")
-          BUILD_NUMBER=$(awk '/versionCode/{print $2}' android/app/build.gradle)
           {
             echo "### 📲 TestFlight Upload"
             echo ""
             echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| **Source branch** | \`${{ inputs.source_branch }}\` |"
-            echo "| **Build branch** | \`${{ needs.prepare-build-branch.outputs.build_branch }}\` |"
-            echo "| **Build name** | \`main-${{ inputs.environment || 'rc' }}\` |"
-            echo "| **Build version** | \`${BUILD_VERSION}\` |"
-            echo "| **Build number** | \`${BUILD_NUMBER}\` |"
+            echo "| **Source branch** | \`${{ inputs.summary_logical_source_branch }}\` |"
+            echo "| **Build ref** | \`${{ inputs.summary_build_ref }}\` |"
+            echo "| **Build name** | \`${{ inputs.build_name }}\` |"
+            echo "| **Build version** | \`${{ inputs.summary_build_version }}\` |"
+            echo "| **Build number** | \`${{ inputs.summary_android_version_code }}\` |"
+            echo "| **Built commit** | \`${{ inputs.summary_built_commit_sha }}\` |"
             echo "| **TestFlight group** | ${{ inputs.testflight_group || 'MetaMask BETA & Release Candidates' }} |"
-            echo "| **Workflow ref** | \`${{ github.ref_name }}\` (required for AWS) |"
+            echo "| **Workflow ref** | \`${{ github.ref_name }}\` (Will fail if workflow is not run from \`main\`! Enforced by AWS secrets policy.) |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Pulls App Store Connect API keys from AWS Secrets Manager (OIDC).
-  # Workflow must run from main; build uses the temporary build branch.
   upload-ios-testflight:
     name: Upload iOS to TestFlight
-    needs: [build, testflight-upload-summary]
+    needs: [testflight-upload-summary]
     runs-on: ghcr.io/cirruslabs/macos-runner:sequoia-xl
     steps:
       - name: Checkout repository
@@ -119,7 +90,7 @@ jobs:
       - name: Download iOS IPA artifact
         uses: actions/download-artifact@v4
         with:
-          name: ios-ipa-main-${{ inputs.environment || 'rc' }}
+          name: ios-ipa-${{ inputs.build_name }}
 
       - name: Find IPA path
         id: ipa
@@ -197,21 +168,3 @@ jobs:
         run: |
           rm -f ios/AuthKey.p8
           echo "🧹 Cleaned up API key file"
-
-  cleanup-build-branch:
-    name: Cleanup build branch
-    needs: [prepare-build-branch, upload-ios-testflight]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PR_TOKEN || github.token }}
-      - name: Delete temporary build branch
-        env:
-          BRANCH: ${{ needs.prepare-build-branch.outputs.build_branch }}
-        run: |
-          if [ -n "$BRANCH" ]; then
-            git push origin --delete "$BRANCH" || true
-            echo "🧹 Deleted build branch: $BRANCH"
-          fi


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR increases workflow modularity by abstracting the build step outside of the `upload-to-testflight.yml` workflow.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions release pipeline for iOS by splitting build vs. upload and altering how metadata/artifacts are passed, which could break nightly/TestFlight automation if any inputs/artifact names mismatch. No application/runtime code is touched.
> 
> **Overview**
> Introduces a new `build-and-upload-to-testflight.yml` workflow that creates an ephemeral version-bump branch, runs `build.yml`, then calls `upload-to-testflight.yml`, and finally deletes the temp branch.
> 
> Refactors `upload-to-testflight.yml` to **only** upload a pre-built `ios-ipa-{build_name}` artifact and to render its summary purely from caller-provided inputs (removing the internal build/branch-creation/cleanup and reducing `contents` permissions to read).
> 
> Updates `build.yml` to emit reusable **build metadata outputs** (e.g., `semantic_version`, `android_version_code`, `built_commit_sha`) via a new fan-in job for matrix builds, and switches `nightly-build.yml` iOS jobs to use the new combined workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bf561e6fdf7a0b04a5d32a093cb346ae04a4960. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->