### PR TITLE
chore/modify runway ota build core workflow

### DIFF
--- a/.github/workflows/runway-ios-production-workflow.yml
+++ b/.github/workflows/runway-ios-production-workflow.yml
@@ -38,5 +38,5 @@ jobs:
       build_name: main-prod
       upload_testflight: true
       create_production_ota_tag: true
-      ios_testflight_summary_title: 'Runway iOS Production'
+      environment: prod
     secrets: inherit

--- a/.github/workflows/runway-ota-build-core.yml
+++ b/.github/workflows/runway-ota-build-core.yml
@@ -42,11 +42,11 @@ on:
         required: false
         type: boolean
         default: false
-      ios_testflight_summary_title:
-        description: 'Step summary heading when upload_testflight is true'
+      environment:
+        description: 'Build environment / track passed to upload-to-testflight (e.g. rc, prod)'
         required: false
         type: string
-        default: 'Runway iOS RC'
+        default: 'rc'
       skip_version_bump:
         description: >-
           If true, build.yml skips update-latest-build-version. Android Runway entry workflows set
@@ -202,88 +202,18 @@ jobs:
       checkout_ref: ${{ inputs.source_branch || github.ref_name }}
     secrets: inherit
 
-  testflight-upload-summary:
-    name: TestFlight upload summary
-    needs: [trigger-build]
-    if: ${{ inputs.platform == 'ios' && inputs.upload_testflight }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.source_branch || github.ref }}
-      - name: Display TestFlight upload summary
-        run: |
-          BUILD_VERSION=$(node -p "require('./package.json').version")
-          {
-            echo "### 📲 TestFlight Upload (${{ inputs.ios_testflight_summary_title }})"
-            echo ""
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| **Ref** | ${{ inputs.source_branch || github.ref_name }} |"
-            echo "| **Build name** | ${{ inputs.build_name }} |"
-            echo "| **Build version** | ${BUILD_VERSION} |"
-            echo "| **TestFlight group** | MetaMask BETA & Release Candidates |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
   upload-ios-testflight:
     name: Upload iOS to TestFlight
-    needs: [trigger-build, testflight-upload-summary]
+    needs: [decide, trigger-build]
     if: ${{ inputs.platform == 'ios' && inputs.upload_testflight }}
-    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia-xl
-    environment: apple
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.source_branch || github.ref }}
-
-      - name: Setup Ruby (iOS)
-        uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb #v1
-        with:
-          ruby-version: '3.2.9'
-          working-directory: ios
-          bundler-cache: true
-
-      - name: Download iOS build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ios-ipa-${{ inputs.build_name }}
-
-      - name: Find IPA path
-        id: ipa
-        run: |
-          IPA=$(find . -name '*.ipa' -type f | head -1)
-          if [ -z "$IPA" ]; then
-            echo "::error::No .ipa file found in artifact"
-            exit 1
-          fi
-          case "$IPA" in /*) ABS="$IPA" ;; *) ABS="$PWD/$IPA" ;; esac
-          echo "path=$ABS" >> "$GITHUB_OUTPUT"
-
-      - name: Setup App Store Connect API Key
-        run: |
-          bash scripts/setup-app-store-connect-api-key.sh \
-            "$APP_STORE_CONNECT_API_KEY_ISSUER_ID" \
-            "$APP_STORE_CONNECT_API_KEY_KEY_ID" \
-            "$APP_STORE_CONNECT_API_KEY_KEY_CONTENT"
-        env:
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CONTENT }}
-
-      - name: Upload to TestFlight
-        run: |
-          bash scripts/upload-to-testflight.sh \
-            "github_actions_${{ inputs.build_name }}" \
-            "${{ inputs.source_branch || github.ref_name }}" \
-            "${{ steps.ipa.outputs.path }}" \
-            "" \
-            "false"
-
-      - name: Cleanup API Key
-        if: always()
-        run: |
-          rm -f ios/AuthKey.p8
-          echo "🧹 Cleaned up API key file"
+    uses: ./.github/workflows/upload-to-testflight.yml
+    with:
+      source_branch: ${{ inputs.source_branch || github.ref_name }}
+      environment: ${{ inputs.environment }}
+      build_name: ${{ inputs.build_name }}
+      summary_logical_source_branch: ${{ inputs.source_branch || github.ref_name }}
+      summary_build_ref: ${{ needs.trigger-build.outputs.checkout_ref }}
+      summary_build_version: ${{ needs.trigger-build.outputs.semantic_version }}
+      summary_android_version_code: ${{ needs.trigger-build.outputs.android_version_code }}
+      summary_built_commit_sha: ${{ needs.trigger-build.outputs.built_commit_sha }}
+    secrets: inherit

--- a/.github/workflows/runway-ota-build-core.yml
+++ b/.github/workflows/runway-ota-build-core.yml
@@ -71,6 +71,14 @@ jobs:
       ota_version: ${{ steps.decide.outputs.ota_version }}
       pr_number: ${{ steps.resolve-pr.outputs.pr_number }}
     steps:
+      - name: Debug ref context
+        run: |
+          echo "github.ref_name = ${{ github.ref_name }}"
+          echo "github.ref      = ${{ github.ref }}"
+          echo "inputs.source_branch = ${{ inputs.source_branch }}"
+          echo "resolved ref (source_branch || github.ref_name) = ${{ inputs.source_branch || github.ref_name }}"
+          echo "resolved ref (source_branch || github.ref)      = ${{ inputs.source_branch || github.ref }}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Refactor runway-ota-build-core.yml so that it uses upload-to-testflight.yml and we can upload builds for external groups.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI release pipeline by replacing the inline TestFlight upload logic with a reusable workflow and new `environment` parameter; misconfiguration could break production uploads or route builds to the wrong track/group.
> 
> **Overview**
> Refactors `runway-ota-build-core.yml` to delegate iOS TestFlight uploads to the reusable `upload-to-testflight.yml` workflow, removing the previous inline upload + step-summary implementation.
> 
> Adds a new `environment` input (default `rc`) that is passed through to the upload workflow, and updates the iOS production entry workflow to set `environment: prod`. Also adds a small debug step to log resolved git ref context and adjusts job dependencies so the upload job depends on `decide` + `trigger-build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3669b3561bc1b9356cd059751cf7be4c1bbe36a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->