### PR TITLE
chore(deps): bump lodash to 4.18.1

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,7 +12,6 @@ plugins:
 
 npmAuditIgnoreAdvisories:
   - 1109627 # TODO: Upgrade @react-native-community/cli to 17.0.1+ when ready. Suppressing for now to unblock CI.
-  - 1112455 # lodash prototype pollution in _.unset and _.omit. No fix available yet (latest is 4.17.21, affected <=4.17.22). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-xxjr-mmjv-4gpg
   - 1113402 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
   - 1113441 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf
   - 1113442 # bn.js affected by an infinite loop. No fix available yet (latest is 5.2.1, affected <=5.2.3). Suppressing for now to unblock CI. https://github.com/advisories/GHSA-378v-28hj-76wf

--- a/package.json
+++ b/package.json
@@ -192,7 +192,8 @@
     "expo-web-browser@npm:~14.0.2": "patch:expo-web-browser@npm%3A14.0.2#~/.yarn/patches/expo-web-browser-npm-14.0.2-98d00ce880.patch",
     "@metamask/messenger@^0.3.0": "^1.0.0",
     "@metamask/accounts-controller": "^37.1.0",
-    "@metamask/profile-sync-controller": "^28.0.2"
+    "@metamask/profile-sync-controller": "^28.0.2",
+    "lodash": "4.18.1"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",

--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
     "humanize-duration": "^3.27.2",
     "is-url": "^1.2.4",
     "js-sha3": "0.9.3",
-    "lodash": "^4.17.21",
+    "lodash": "4.18.1",
     "lottie-react-native": "6.7.2",
     "luxon": "^3.5.0",
     "mockttp": "^3.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34854,13 +34854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4, lodash@npm:^4.0.0, lodash@npm:^4.16.4, lodash@npm:^4.16.6, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.2.1":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
-  languageName: node
-  linkType: hard
-
 "lodash@npm:4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -34861,6 +34861,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:4.1.0, log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -35669,7 +35676,7 @@ __metadata:
     koa: "npm:^2.14.2"
     lint-staged: "npm:10.5.4"
     listr2: "npm:^8.0.2"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:4.18.1"
     lottie-react-native: "npm:6.7.2"
     luxon: "npm:^3.5.0"
     metro-react-native-babel-preset: "npm:~0.76.9"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Bumps `lodash` from `^4.17.21` to pinned `4.18.1`, which includes a fix for
the prototype pollution vulnerability in `_.unset` and `_.omit`
([GHSA-xxjr-mmjv-4gpg](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg)).

The corresponding npm audit advisory suppression (1112455) is removed from
`.yarnrc.yml` since it is no longer needed with the patched version.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a security vulnerability by bumping lodash to 4.18.1

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — dependency bump with no UI or behavioral changes.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump: updates a widely used utility library and lockfile; potential risk is subtle behavior changes in lodash impacting callers, but scope is limited to version pinning.
> 
> **Overview**
> Updates `lodash` across the repo from `^4.17.21` to pinned `4.18.1` (including `resolutions` and the dependency entry) and refreshes `yarn.lock` accordingly.
> 
> Removes the `.yarnrc.yml` `npmAuditIgnoreAdvisories` suppression for the previously-audited lodash prototype-pollution issue since the upgrade addresses it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00b95dfe88cc4f989be19a03b31ef5fc380ad32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->