### PR TITLE
fix(perps): show actionable HL error messages for failed orders

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
@@ -38,12 +38,12 @@ const mockPerpsToastOptions = {
         full: {
           closeFullPositionInProgress: jest.fn(),
           closeFullPositionSuccess: jest.fn(),
-          closeFullPositionFailed: {},
+          closeFullPositionFailed: jest.fn().mockReturnValue({}),
         },
         partial: {
           closePartialPositionInProgress: jest.fn(),
           closePartialPositionSuccess: jest.fn(),
-          closePartialPositionFailed: {},
+          closePartialPositionFailed: jest.fn().mockReturnValue({}),
         },
       },
       limitClose: {
@@ -649,11 +649,10 @@ describe('usePerpsClosePosition', () => {
 
           // Should show progress toast first, then failure toast
           expect(mockShowToast).toHaveBeenCalledTimes(2);
-          expect(mockShowToast).toHaveBeenNthCalledWith(
-            2,
+          expect(
             mockPerpsToastOptions.positionManagement.closePosition.marketClose
               .full.closeFullPositionFailed,
-          );
+          ).toHaveBeenCalled();
         });
 
         it('should show failure toast for partial position market close', async () => {
@@ -677,11 +676,10 @@ describe('usePerpsClosePosition', () => {
 
           // Should show progress toast first, then failure toast
           expect(mockShowToast).toHaveBeenCalledTimes(2);
-          expect(mockShowToast).toHaveBeenNthCalledWith(
-            2,
+          expect(
             mockPerpsToastOptions.positionManagement.closePosition.marketClose
               .partial.closePartialPositionFailed,
-          );
+          ).toHaveBeenCalled();
         });
 
         it('should show failure toast when size is empty string (treated as full close)', async () => {
@@ -703,11 +701,10 @@ describe('usePerpsClosePosition', () => {
             ).rejects.toThrow();
           });
 
-          expect(mockShowToast).toHaveBeenNthCalledWith(
-            2,
+          expect(
             mockPerpsToastOptions.positionManagement.closePosition.marketClose
               .full.closeFullPositionFailed,
-          );
+          ).toHaveBeenCalled();
         });
 
         it('should show failure toast with undefined error', async () => {
@@ -730,11 +727,10 @@ describe('usePerpsClosePosition', () => {
           });
 
           // Should still show failure toast even with undefined error
-          expect(mockShowToast).toHaveBeenNthCalledWith(
-            2,
+          expect(
             mockPerpsToastOptions.positionManagement.closePosition.marketClose
               .partial.closePartialPositionFailed,
-          );
+          ).toHaveBeenCalled();
         });
       });
 
@@ -893,11 +889,10 @@ describe('usePerpsClosePosition', () => {
           expect(mockShowToast).toHaveBeenNthCalledWith(1, progressToastResult);
 
           // Second call should be failure toast
-          expect(mockShowToast).toHaveBeenNthCalledWith(
-            2,
+          expect(
             mockPerpsToastOptions.positionManagement.closePosition.marketClose
               .partial.closePartialPositionFailed,
-          );
+          ).toHaveBeenCalled();
         });
       });
     });

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -170,15 +170,17 @@ export const usePerpsClosePosition = (
             // Market full close failed
             if (isFullClose) {
               showToast(
-                PerpsToastOptions.positionManagement.closePosition.marketClose
-                  .full.closeFullPositionFailed,
+                PerpsToastOptions.positionManagement.closePosition.marketClose.full.closeFullPositionFailed(
+                  result.error,
+                ),
               );
             }
             // Market partial close failed
             else {
               showToast(
-                PerpsToastOptions.positionManagement.closePosition.marketClose
-                  .partial.closePartialPositionFailed,
+                PerpsToastOptions.positionManagement.closePosition.marketClose.partial.closePartialPositionFailed(
+                  result.error,
+                ),
               );
             }
           }

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -719,11 +719,10 @@ describe('usePerpsToasts', () => {
         expect(typeof config.closeButtonOptions?.onPress).toBe('function');
       });
 
-      it('returns close full position failed configuration', () => {
+      it('returns close full position failed configuration with default message', () => {
         const { result } = renderHook(() => usePerpsToasts());
         const config =
-          result.current.PerpsToastOptions.positionManagement.closePosition
-            .marketClose.full.closeFullPositionFailed;
+          result.current.PerpsToastOptions.positionManagement.closePosition.marketClose.full.closeFullPositionFailed();
 
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
@@ -734,6 +733,20 @@ describe('usePerpsToasts', () => {
           { label: 'Failed to close position', isBold: true },
           { label: '\n', isBold: false },
           { label: 'Your position is still active', isBold: false },
+        ]);
+      });
+
+      it('returns close full position failed configuration with HL error', () => {
+        const { result } = renderHook(() => usePerpsToasts());
+        const config =
+          result.current.PerpsToastOptions.positionManagement.closePosition.marketClose.full.closeFullPositionFailed(
+            'Price too far from oracle',
+          );
+
+        expect(config.labelOptions).toEqual([
+          { label: 'Failed to close position', isBold: true },
+          { label: '\n', isBold: false },
+          { label: 'Price too far from oracle', isBold: false },
         ]);
       });
 
@@ -793,11 +806,10 @@ describe('usePerpsToasts', () => {
         expect(typeof config.closeButtonOptions?.onPress).toBe('function');
       });
 
-      it('returns partial position close failed configuration', () => {
+      it('returns partial position close failed configuration with default message', () => {
         const { result } = renderHook(() => usePerpsToasts());
         const config =
-          result.current.PerpsToastOptions.positionManagement.closePosition
-            .marketClose.partial.closePartialPositionFailed;
+          result.current.PerpsToastOptions.positionManagement.closePosition.marketClose.partial.closePartialPositionFailed();
 
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -122,7 +122,7 @@ export interface PerpsToastOptionsConfig {
             position: Position,
             marketPrice?: string,
           ) => PerpsToastOptions;
-          closeFullPositionFailed: PerpsToastOptions;
+          closeFullPositionFailed: (error?: string) => PerpsToastOptions;
         };
         partial: {
           closePartialPositionInProgress: (
@@ -134,7 +134,7 @@ export interface PerpsToastOptionsConfig {
             position: Position,
             marketPrice?: string,
           ) => PerpsToastOptions;
-          closePartialPositionFailed: PerpsToastOptions;
+          closePartialPositionFailed: (error?: string) => PerpsToastOptions;
         };
       };
       limitClose: {
@@ -753,13 +753,18 @@ const usePerpsToasts = (): {
                   ),
                 };
               },
-              closeFullPositionFailed: {
+              closeFullPositionFailed: (error?: string) => ({
                 ...perpsBaseToastOptions.error,
                 labelOptions: getPerpsToastLabels(
                   strings('perps.close_position.failed_to_close_position'),
-                  strings('perps.close_position.your_position_is_still_active'),
+                  handlePerpsError({
+                    error,
+                    fallbackMessage: strings(
+                      'perps.close_position.your_position_is_still_active',
+                    ),
+                  }),
                 ),
-              },
+              }),
             },
             partial: {
               closePartialPositionInProgress: (
@@ -824,15 +829,20 @@ const usePerpsToasts = (): {
                   ),
                 };
               },
-              closePartialPositionFailed: {
+              closePartialPositionFailed: (error?: string) => ({
                 ...perpsBaseToastOptions.error,
                 labelOptions: getPerpsToastLabels(
                   strings(
                     'perps.close_position.failed_to_partially_close_position',
                   ),
-                  strings('perps.close_position.your_position_is_still_active'),
+                  handlePerpsError({
+                    error,
+                    fallbackMessage: strings(
+                      'perps.close_position.your_position_is_still_active',
+                    ),
+                  }),
                 ),
-              },
+              }),
             },
           },
           limitClose: {
@@ -894,7 +904,10 @@ const usePerpsToasts = (): {
             ...perpsBaseToastOptions.error,
             labelOptions: getPerpsToastLabels(
               strings('perps.position.tpsl.update_failed'),
-              error || strings('perps.errors.tpslUpdateFailed'),
+              handlePerpsError({
+                error,
+                fallbackMessage: strings('perps.errors.tpslUpdateFailed'),
+              }),
             ),
           }),
         },

--- a/app/components/UI/Perps/utils/translatePerpsError.test.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.test.ts
@@ -49,6 +49,7 @@ import {
   translatePerpsError,
   isPerpsErrorCode,
   handlePerpsError,
+  cleanHyperLiquidError,
 } from './translatePerpsError';
 
 // Mock the i18n strings function
@@ -432,14 +433,12 @@ describe('handlePerpsError', () => {
   });
 
   describe('with non-error-code strings', () => {
-    it('returns unknown error for unrecognized strings (for better UX)', () => {
+    it('returns cleaned error for unrecognized strings', () => {
       const result = handlePerpsError({
         error: 'Custom error message',
       });
 
-      // Unrecognized error strings now return the generic unknown error for better UX
-      // instead of showing raw technical error messages to users
-      expect(result).toBe('perps.errors.unknownError');
+      expect(result).toBe('Custom error message');
     });
 
     it('uses fallback message for empty string', () => {
@@ -451,13 +450,13 @@ describe('handlePerpsError', () => {
       expect(result).toBe('Fallback message');
     });
 
-    it('uses fallback message when provided for non-error-code strings', () => {
+    it('returns cleaned error over fallback for non-error-code strings', () => {
       const result = handlePerpsError({
         error: 'Some error',
         fallbackMessage: 'Fallback message',
       });
 
-      expect(result).toBe('Fallback message');
+      expect(result).toBe('Some error');
     });
   });
 
@@ -518,15 +517,14 @@ describe('handlePerpsError', () => {
       });
     });
 
-    it('uses fallbackMessage for Error object without valid error code', () => {
-      // Use an unrecognizable error string that won't match any pattern
+    it('returns cleaned error for Error object without valid error code', () => {
       const error = new Error('Something unexpected happened xyz123');
       const result = handlePerpsError({
         error,
         fallbackMessage: 'Connection error, please try again',
       });
 
-      expect(result).toBe('Connection error, please try again');
+      expect(result).toBe('Something unexpected happened xyz123');
     });
   });
 
@@ -756,8 +754,8 @@ describe('handlePerpsError', () => {
         fallbackMessage: 'Order operation failed',
       });
 
-      // Should NOT match batch cancel pattern - should use fallback
-      expect(result).toBe('Order operation failed');
+      // Should NOT match batch cancel pattern - shows cleaned error
+      expect(result).toBe('Order cancellation failed');
     });
 
     it('translates batch close failed error pattern', () => {
@@ -782,8 +780,8 @@ describe('handlePerpsError', () => {
         fallbackMessage: 'Position operation failed',
       });
 
-      // Should NOT match batch close pattern - should use fallback
-      expect(result).toBe('Position operation failed');
+      // Should NOT match batch close pattern - shows cleaned error
+      expect(result).toBe('Position close failed');
     });
 
     it('translates service unavailable error pattern', () => {
@@ -826,13 +824,95 @@ describe('handlePerpsError', () => {
       expect(result).toBe('perps.errors.orderLeverageReductionFailed');
     });
 
-    it('uses fallback for unrecognized patterns', () => {
+    it('shows cleaned error for unrecognized patterns', () => {
       const result = handlePerpsError({
         error: 'Completely random error xyz123',
         fallbackMessage: 'Something went wrong',
       });
 
-      expect(result).toBe('Something went wrong');
+      expect(result).toBe('Completely random error xyz123');
     });
+
+    it('cleans HL JSON-wrapped error and strips Order N prefix', () => {
+      const result = handlePerpsError({
+        error:
+          'Order failed: {"status":"err","response":"Order 0: Price too far from oracle, asset = 12345"}',
+        fallbackMessage: 'Your funds have been returned to you',
+      });
+
+      expect(result).toBe('Price too far from oracle');
+    });
+
+    it('cleans TP/SL update failed JSON-wrapped error', () => {
+      const result = handlePerpsError({
+        error:
+          'TP/SL update failed: {"status":"err","response":"Order 0: Price too far from oracle, asset = 999"}',
+        fallbackMessage: 'Failed to update TP/SL',
+      });
+
+      expect(result).toBe('Price too far from oracle');
+    });
+  });
+});
+
+describe('cleanHyperLiquidError', () => {
+  it('strips "Order failed:" JSON wrapper and extracts response', () => {
+    const result = cleanHyperLiquidError(
+      'Order failed: {"status":"err","response":"Price too far from oracle"}',
+    );
+    expect(result).toBe('Price too far from oracle');
+  });
+
+  it('strips "TP/SL update failed:" JSON wrapper', () => {
+    const result = cleanHyperLiquidError(
+      'TP/SL update failed: {"status":"err","response":"Invalid trigger price"}',
+    );
+    expect(result).toBe('Invalid trigger price');
+  });
+
+  it('strips "Order N:" prefix', () => {
+    const result = cleanHyperLiquidError('Order 0: Price too far from oracle');
+    expect(result).toBe('Price too far from oracle');
+  });
+
+  it('strips "Order N:" with higher numbers', () => {
+    const result = cleanHyperLiquidError('Order 3: Insufficient margin');
+    expect(result).toBe('Insufficient margin');
+  });
+
+  it('strips trailing ", asset = <id>"', () => {
+    const result = cleanHyperLiquidError(
+      'Price too far from oracle, asset = 12345',
+    );
+    expect(result).toBe('Price too far from oracle');
+  });
+
+  it('strips both "Order N:" prefix and ", asset = <id>" suffix', () => {
+    const result = cleanHyperLiquidError(
+      'Order 0: Price too far from oracle, asset = 12345',
+    );
+    expect(result).toBe('Price too far from oracle');
+  });
+
+  it('handles full JSON-wrapped error with Order N and asset', () => {
+    const result = cleanHyperLiquidError(
+      'Order failed: {"status":"err","response":"Order 0: Price too far from oracle, asset = 12345"}',
+    );
+    expect(result).toBe('Price too far from oracle');
+  });
+
+  it('returns plain error strings unchanged', () => {
+    const result = cleanHyperLiquidError('Something went wrong');
+    expect(result).toBe('Something went wrong');
+  });
+
+  it('handles malformed JSON gracefully', () => {
+    const result = cleanHyperLiquidError('Order failed: {not valid json}');
+    expect(result).toBe('{not valid json}');
+  });
+
+  it('handles empty string', () => {
+    const result = cleanHyperLiquidError('');
+    expect(result).toBe('');
   });
 });

--- a/app/components/UI/Perps/utils/translatePerpsError.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.ts
@@ -298,6 +298,39 @@ export function isPerpsErrorCode(
 }
 
 /**
+ * Strips HL-specific noise from raw error strings so the user sees
+ * the meaningful part only (e.g. "Price too far from oracle" instead of
+ * "Order failed: {"status":"err","response":"Order 0: Price too far from oracle, asset = 12345"}").
+ */
+export function cleanHyperLiquidError(raw: string): string {
+  let cleaned = raw;
+
+  // Unwrap JSON wrappers: "Order failed: {…}" / "TP/SL update failed: {…}"
+  const jsonPrefixRegex = /^(?:Order failed|TP\/SL update failed):\s*(.+)$/is;
+  const jsonPrefixMatch = jsonPrefixRegex.exec(cleaned);
+  if (jsonPrefixMatch) {
+    try {
+      const parsed = JSON.parse(jsonPrefixMatch[1]);
+      const inner =
+        typeof parsed === 'string'
+          ? parsed
+          : (parsed?.response ?? JSON.stringify(parsed));
+      cleaned = typeof inner === 'string' ? inner : JSON.stringify(inner);
+    } catch {
+      cleaned = jsonPrefixMatch[1];
+    }
+  }
+
+  // Strip "Order N: " prefix (e.g. "Order 0: Price too far from oracle")
+  cleaned = cleaned.replace(/^Order \d+:\s*/i, '');
+
+  // Strip trailing ", asset = <id>" / ", asset=<id>"
+  cleaned = cleaned.replace(/,\s*asset\s*=\s*\S+$/i, '');
+
+  return cleaned.trim();
+}
+
+/**
  * Parameters for handling Perps errors
  */
 export interface HandlePerpsErrorParams {
@@ -395,8 +428,21 @@ export function handlePerpsError(params: HandlePerpsErrorParams): string {
     }
   }
 
-  // For any other error/error string that was not matched, use fallback
-  // Important: Always prefer fallback over raw error strings for better UX
+  // For unmatched errors, clean the raw HL message so the user sees
+  // actionable text (e.g. "Price too far from oracle") instead of a
+  // generic "Your funds have been returned to you".
+  if (errorString) {
+    const cleaned = cleanHyperLiquidError(errorString);
+    if (cleaned) {
+      debugLogger?.log('PerpsErrorHandler: Using cleaned HL error message', {
+        originalError: errorString,
+        cleaned,
+      });
+      return cleaned;
+    }
+  }
+
+  // Fallback when no meaningful message could be extracted
   if (fallbackMessage) {
     debugLogger?.log('PerpsErrorHandler: Using fallback message', {
       originalError: errorString,
@@ -406,7 +452,6 @@ export function handlePerpsError(params: HandlePerpsErrorParams): string {
   }
 
   // Last resort: return the generic unknown error message
-  // Avoid showing raw technical error strings to users
   debugLogger?.log('PerpsErrorHandler: No match found, using generic error', {
     originalError: errorString,
   });


### PR DESCRIPTION
## **Description**

Currently, when a Perps order fails, the toast shows a generic message like "Your funds have been returned to you" (for trades/flips) or "Your position is still active" (for close position), which gives users no insight into *why* the order failed.

This PR improves failed order error messaging across all order types (trade, position close, TP/SL) by:

1. **Adding `cleanHyperLiquidError()`** — a utility that strips HL-specific noise from raw error strings:
   - Unwraps JSON wrappers (`Order failed: {"status":"err","response":"..."}`)
   - Removes `Order N:` prefixes (e.g. `Order 0:`)
   - Removes trailing `, asset = <id>` suffixes
2. **Updating `handlePerpsError()`** — now prefers showing the cleaned HL error message instead of falling back to a generic message. Fallback is only used when no error string is available at all.
3. **Updating close position toasts** — `closeFullPositionFailed` and `closePartialPositionFailed` now accept an `error` parameter and pass it through `handlePerpsError`.
4. **Updating TP/SL error toast** — now routes the error through `handlePerpsError` for consistent cleaning.

**Example — Before vs After:**
- Before: `Order failed` / `Your funds have been returned to you`
- After: `Order failed` / `Price too far from oracle`

## **Changelog**

CHANGELOG entry: Improved error messaging for failed Perps orders to show actionable details instead of generic messages

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps failed order error messaging

  Scenario: user sees actionable error when market order fails
    Given user has a Perps account with balance
    And the user is on the order form

    When user submits a market order that fails (e.g. price too far from oracle)
    Then the toast shows "Order failed" as the title
    And the toast subtitle shows the specific HL error (e.g. "Price too far from oracle")
    And the subtitle does NOT show "Your funds have been returned to you"
    And the subtitle does NOT contain "Order 0:" or "asset = 12345"

  Scenario: user sees actionable error when closing a position fails
    Given user has an open Perps position

    When user attempts to close the position and it fails
    Then the toast shows "Failed to close position" as the title
    And the toast subtitle shows the specific HL error instead of "Your position is still active"

  Scenario: user sees actionable error when TP/SL update fails
    Given user has an open Perps position with TP/SL

    When user updates TP/SL and it fails
    Then the toast shows "Failed to update TP/SL" as the title
    And the toast subtitle shows the specific HL error

  Scenario: fallback message shown when no error details available
    Given user has a Perps account

    When an order fails with no error message (null/undefined)
    Then the toast shows the appropriate fallback message (e.g. "Your position is still active")
```

## **Screenshots/Recordings**

N/A — toast text changes only, no visual/layout changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
