### PR TITLE
ci: skip smart e2e ai selection for cherry-pick PRs targeting release branch

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: 'false'
   base-ref:
-    description: 'Base branch ref (must be main or release/* for analysis to run)'
+    description: 'PR base branch ref (main → AI selection; release/* → skip AI, full E2E; other → skip AI, no force_run)'
     required: false
     default: ''
   is-draft:
@@ -52,7 +52,7 @@ outputs:
     description: 'Performance test tags to run (JSON array format, empty [] means no performance tests)'
     value: ${{ steps.final-outputs.outputs.ai_performance_test_tags }}
   force_run:
-    description: 'Whether to force E2E builds/tests regardless of path filter (true when skip-smart-e2e-selection label is used)'
+    description: 'Whether to force E2E builds/tests regardless of path filter (true for skip-smart-e2e-selection label or PRs targeting release/*)'
     value: ${{ steps.final-outputs.outputs.force_run }}
 
 runs:
@@ -71,21 +71,35 @@ runs:
           echo "⏭️ SKIP=true due to 'skip-smart-e2e-selection' label on PR"
         fi
 
+    - name: Check release target branch (full E2E, no AI selection)
+      id: check-release-target
+      shell: bash
+      run: |
+        echo "skip_ai_run_all=false" >> "$GITHUB_OUTPUT"
+        if [[ "${{ inputs.event-name }}" != "pull_request" ]]; then
+          exit 0
+        fi
+        BASE='${{ inputs.base-ref }}'
+        if [[ -n "$BASE" && "$BASE" == release/* ]]; then
+          echo "skip_ai_run_all=true" >> "$GITHUB_OUTPUT"
+          echo "⏭️ Base branch is release/* — skipping AI E2E selection; full E2E suite will run"
+        fi
+
     - name: Checkout for PR analysis
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.skip_ai_run_all != 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 1 # Shallow clone - only need PR commit
 
     - name: Disable sparse checkout and restore all files
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.skip_ai_run_all != 'true'
       shell: bash
       run: |
         git sparse-checkout disable
         git checkout HEAD -- .
 
     - name: Fetch base branch for comparison
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.skip_ai_run_all != 'true'
       shell: bash
       run: |
         # Unshallow the repository first (if it's shallow)
@@ -94,13 +108,13 @@ runs:
         git fetch origin "${{ inputs.base-ref || 'main' }}" 2>/dev/null || true
 
     - name: Setup Node.js
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.skip_ai_run_all != 'true'
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
 
     - name: Install minimal dependencies for AI analysis
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.skip_ai_run_all != 'true'
       shell: bash
       run: |
         echo "📦 Installing only required packages for AI analysis..."
@@ -112,7 +126,7 @@ runs:
         echo "✅ AI analysis dependencies installed in /tmp/ai-deps"
 
     - name: Copy AI dependencies to workspace
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.skip_ai_run_all != 'true'
       shell: bash
       run: |
         echo "📋 Copying AI dependencies to workspace..."
@@ -150,6 +164,11 @@ runs:
         elif [[ -n "${{ steps.check-skip-label.outputs.SKIP }}" ]] && [[ "${{ steps.check-skip-label.outputs.SKIP }}" == "true" ]]; then
           SHOULD_SKIP=true
           SKIP_REASON="skip-smart-e2e-selection label found"
+          FORCE_RUN=true
+          echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ steps.check-release-target.outputs.skip_ai_run_all }}" == "true" ]]; then
+          SHOULD_SKIP=true
+          SKIP_REASON="PR targets a release branch (release/*)"
           FORCE_RUN=true
           echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
         elif [[ "$IS_DRAFT" == "true" ]]; then
@@ -192,7 +211,7 @@ runs:
         else
           echo 'ai_performance_test_tags=[]' >> "$GITHUB_OUTPUT"
         fi
-        # Force run flag (true when skip-smart-e2e-selection label is used)
+        # Force run flag (skip-smart-e2e-selection label or PR base release/*)
         FORCE_RUN='${{ steps.ai-analysis.outputs.FORCE_RUN }}'
         if [[ "$FORCE_RUN" == "true" ]]; then
           echo "force_run=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR is to make release cherry-pick PRs execute the full smoke e2e instead of a reduced tag set chosen by ai.

On main, iterating quickly with a risk-scored subset is a reasonable tradeoff: we accept some residual risk in exchange for speed and we will catch more in follow-up PRs. A PR into release/* is effectively “this build is a candidate to ship.” 
Smart selection saves CI time on high-volume main development. Release cherry-picks are low volume and high impact, and we cannot afford to merge cherry-pick that breaks the CI on release branch due to release urgency.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3464

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

cherry-pick PRs should run all e2e tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI behavior for release-branch PRs by bypassing AI selection and forcing full E2E runs, which can affect build time and which tests execute. Logic is localized to a single composite action and does not touch product code.
> 
> **Overview**
> Updates the `smart-e2e-selection` composite action to **detect PRs targeting `release/*`** and skip the AI-based E2E test selection in that case.
> 
> For `release/*` PRs it now **forces full E2E execution** by setting `force_run=true` (and `ai_confidence=100`), and it avoids the checkout/dependency install steps used only for AI analysis; copy updates output/input descriptions to reflect the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 122d8e68354df1c69058b54d46a39b24339e4bd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->