### PR TITLE
fix(onboarding): add theme background color and center title in SocialLoginIosUser

### DIFF
--- a/app/components/Views/SocialLoginIosUser/index.styles.ts
+++ b/app/components/Views/SocialLoginIosUser/index.styles.ts
@@ -43,6 +43,9 @@ const styles = StyleSheet.create({
     flex: 1,
     rowGap: Device.isMediumDevice() ? 24 : 32,
   },
+  title: {
+    textAlign: 'center' as const,
+  },
 });
 
 export default styles;

--- a/app/components/Views/SocialLoginIosUser/index.tsx
+++ b/app/components/Views/SocialLoginIosUser/index.tsx
@@ -7,6 +7,7 @@ import {
   StackActions,
 } from '@react-navigation/native';
 import LottieView, { AnimationObject } from 'lottie-react-native';
+import { useTheme } from '../../../util/theme';
 import Text, {
   TextVariant,
   TextColor,
@@ -31,6 +32,7 @@ interface SocialLoginIosUserProps {
 const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
   const navigation = useNavigation();
   const route = useRoute();
+  const { colors } = useTheme();
 
   const { accountName, oauthLoginSuccess, onboardingTraceCtx, provider } =
     (route.params as {
@@ -65,8 +67,13 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
   const isUserTypeNew = type === 'new';
 
   return (
-    <SafeAreaView edges={['bottom', 'left', 'right']} style={styles.wrapper}>
-      <View style={styles.root}>
+    <SafeAreaView
+      edges={['bottom', 'left', 'right']}
+      style={[styles.wrapper, { backgroundColor: colors.background.default }]}
+    >
+      <View
+        style={[styles.root, { backgroundColor: colors.background.default }]}
+      >
         <View style={styles.animationContainer}>
           <View style={styles.largeFoxWrapper}>
             <LottieView
@@ -81,6 +88,7 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
           <Text
             variant={TextVariant.DisplayMD}
             color={TextColor.Default}
+            style={styles.title}
             testID={
               isUserTypeNew
                 ? OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_TITLE


### PR DESCRIPTION
## **Description**

Fixes the `SocialLoginIosUser` screen to properly use the theme background color and center-align the title text. Current dark mode it appears white and hardly legible

### Key changes

- Added `backgroundColor: colors.background.default` to `SafeAreaView` wrapper and root `View` so the screen respects the current theme
- Added `textAlign: 'center'` to the title `Text` via a stylesheet constant (avoids inline style lint violation)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: SocialLoginIosUser screen theming

  Scenario: New social login user sees themed background
    Given user completes social login on iOS as a new user

    When the success screen is shown
    Then the background matches the current theme color
    And the title text is centered

  Scenario: Existing social login user sees themed background
    Given user completes social login on iOS as an existing user

    When the success screen is shown
    Then the background matches the current theme color
    And the title text is centered
```

## **Screenshots/Recordings**

### **Before**

<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/4d359463-be0c-45d7-aae7-c925c386d44e" />


### **After**

<img width="300" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-02 at 18 09 45" src="https://github.com/user-attachments/assets/b8428bbc-985e-494f-a1b7-1c960eeabb5c" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes limited to styling and theming on a single onboarding screen, plus snapshot updates.
> 
> **Overview**
> Ensures the `SocialLoginIosUser` success screen respects the active theme by applying `colors.background.default` to the `SafeAreaView` wrapper and root container.
> 
> Centers the title text via a new `styles.title` rule, and updates Jest snapshots to reflect the new background style arrays and `textAlign: 'center'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 479288b24dd40f8dbcbc89795196bb1aa6c7bac1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->