### PR TITLE
fix: enhance multichain address sorting and block explorer integration

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.test.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.test.ts
@@ -156,6 +156,23 @@ describe('MultichainAddressRowsList Utils', () => {
       expect(sorted[0].networkName).toBe('A Network');
       expect(sorted[1].networkName).toBe('Z Network');
     });
+
+    it('sorts decimal eip155 Polygon with same priority tier as hex eip155:0x89', () => {
+      const items: NetworkAddressItem[] = [
+        { chainId: 'eip155:137', networkName: 'Polygon A', address: '0x123' },
+        { chainId: 'eip155:0x89', networkName: 'Polygon B', address: '0x123' },
+        {
+          chainId: `eip155:${CHAIN_IDS.MAINNET}`,
+          networkName: 'Ethereum',
+          address: '0x123',
+        },
+      ];
+
+      const sorted = sortNetworkAddressItems(items);
+      expect(sorted[0].chainId).toBe(`eip155:${CHAIN_IDS.MAINNET}`);
+      expect(sorted[1].networkName).toBe('Polygon A');
+      expect(sorted[2].networkName).toBe('Polygon B');
+    });
   });
 
   describe('getCompatibleNetworksForAccount', () => {

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRowsList/MultichainAddressRowsList.utils.ts
@@ -4,6 +4,7 @@ import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
 import { CaipChainId } from '@metamask/utils';
 import { TEST_NETWORK_IDS } from '../../../../constants/network';
 import { PopularList } from '../../../../util/networks/customNetworks';
+import { getHexEvmChainId } from '../../../../util/networks';
 import { toFormattedAddress } from '../../../../util/address';
 
 export interface NetworkAddressItem {
@@ -13,21 +14,11 @@ export interface NetworkAddressItem {
 }
 
 /**
- * Extracts hex chain ID from CAIP chain ID format for EVM networks
- * @param chainId - Chain ID (can be hex or CAIP format)
- * @returns Hex chain ID for EVM networks, original for non-EVM
+ * Hex EVM chain id for comparisons (CHAIN_IDS, PopularList, testnets), or the
+ * original CAIP id for non-EVM. Uses shared {@link getHexEvmChainId}.
  */
-const extractHexChainId = (chainId: CaipChainId): string => {
-  if (chainId.startsWith('eip155:')) {
-    const chainIdPart = chainId.split(':')[1];
-    // Convert decimal to hex format if needed (CAIP format uses decimal)
-    if (!chainIdPart.startsWith('0x')) {
-      return `0x${parseInt(chainIdPart, 10).toString(16)}`;
-    }
-    return chainIdPart;
-  }
-  return chainId;
-};
+const evmHexOrOriginalChainId = (chainId: CaipChainId): string =>
+  getHexEvmChainId(chainId) ?? chainId;
 
 /**
  * Gets priority score for sorting networks (lower = higher priority)
@@ -36,8 +27,7 @@ const extractHexChainId = (chainId: CaipChainId): string => {
  * @returns Priority score
  */
 const getNetworkPriority = (chainId: CaipChainId): number => {
-  // For EVM networks, extract hex chain ID for comparison
-  const hexChainId = extractHexChainId(chainId);
+  const hexChainId = evmHexOrOriginalChainId(chainId);
 
   // Hardcoded order for top networks
   if (hexChainId === CHAIN_IDS.MAINNET) {

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -8,11 +8,10 @@ import { fontStyles } from '../../../../styles/common';
 import { strings } from '../../../../../locales/i18n';
 import {
   getBlockExplorerName,
+  findBlockExplorerUrlForChain,
   isMainNet,
   isMultiLayerFeeNetwork,
   getBlockExplorerTxUrl,
-  findBlockExplorerForNonEvmChainId,
-  isLineaMainnetChainId,
 } from '../../../../util/networks';
 import Logger from '../../../../util/Logger';
 import EthereumAddress from '../../EthereumAddress';
@@ -50,7 +49,6 @@ import {
   selectTransactions,
 } from '../../../../selectors/transactionController';
 import { getGlobalEthQuery } from '../../../../util/networks/global-network';
-import { isNonEvmChainId } from '../../../../core/Multichain/utils';
 import { hasGasFeeTokenSelected } from '../../../Views/confirmations/utils/transaction';
 import Avatar, {
   AvatarSize,
@@ -58,15 +56,8 @@ import Avatar, {
 } from '../../../../component-library/components/Avatars/Avatar';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { WalletViewSelectorsIDs } from '../../../Views/Wallet/WalletView.testIds';
-import {
-  LINEA_MAINNET_BLOCK_EXPLORER,
-  LINEA_SEPOLIA_BLOCK_EXPLORER,
-  MAINNET_BLOCK_EXPLORER,
-  SEPOLIA_BLOCK_EXPLORER,
-} from '../../../../constants/urls';
-import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import TagBase from '../../../../component-library/base-components/TagBase';
-import { PopularList } from '../../../../util/networks/customNetworks';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -180,41 +171,9 @@ class TransactionDetails extends PureComponent {
    * @param {Object} networkConfigurations - The network configurations object
    * @returns {string} The block explorer URL
    */
-  getBlockExplorerForChain = (txChainId, networkConfigurations) => {
-    // First check for network configuration block explorer
-    let blockExplorer =
-      networkConfigurations?.[txChainId]?.blockExplorerUrls[
-        networkConfigurations[txChainId]?.defaultBlockExplorerUrlIndex
-      ] || NO_RPC_BLOCK_EXPLORER;
-
-    // Check for default block explorers based on chain ID
-    if (isMainNet(txChainId)) {
-      blockExplorer = MAINNET_BLOCK_EXPLORER;
-    } else if (isLineaMainnetChainId(txChainId)) {
-      blockExplorer = LINEA_MAINNET_BLOCK_EXPLORER;
-    } else if (txChainId === CHAIN_IDS.LINEA_SEPOLIA) {
-      blockExplorer = LINEA_SEPOLIA_BLOCK_EXPLORER;
-    } else if (txChainId === CHAIN_IDS.SEPOLIA) {
-      blockExplorer = SEPOLIA_BLOCK_EXPLORER;
-    }
-
-    // Check PopularList for additional networks (e.g. Arbitrum, Polygon, BNB)
-    if (blockExplorer === NO_RPC_BLOCK_EXPLORER) {
-      const popularNetwork = PopularList.find(
-        (network) => network.chainId === txChainId,
-      );
-      if (popularNetwork?.rpcPrefs?.blockExplorerUrl) {
-        blockExplorer = popularNetwork.rpcPrefs.blockExplorerUrl;
-      }
-    }
-
-    // Check for non-EVM chain block explorer
-    if (isNonEvmChainId(txChainId)) {
-      blockExplorer = findBlockExplorerForNonEvmChainId(txChainId);
-    }
-
-    return blockExplorer;
-  };
+  getBlockExplorerForChain = (txChainId, networkConfigurations) =>
+    findBlockExplorerUrlForChain(txChainId, networkConfigurations) ??
+    NO_RPC_BLOCK_EXPLORER;
 
   /**
    * Updates transactionDetails for multilayer fee networks (e.g. for Optimism).

--- a/app/components/UI/Transactions/TransactionsFooter.test.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.test.tsx
@@ -158,6 +158,39 @@ describe('TransactionsFooter', () => {
       expect(getByText('View full history on Gnosisscan')).toBeTruthy();
     });
 
+    it('uses explorer hostname for label when omitGlobalProviderExplorerFallback is set', () => {
+      mockIsMainnetByChainId.mockReturnValue(false);
+      mockGetBlockExplorerName.mockReturnValue('Lineascan');
+
+      const { queryByText, getByText } = render(
+        <TransactionsFooter
+          chainId="0xe708"
+          providerType="mainnet"
+          rpcBlockExplorer="https://lineascan.build"
+          omitGlobalProviderExplorerFallback
+          onViewBlockExplorer={mockOnViewBlockExplorer}
+        />,
+      );
+
+      expect(queryByText('View full history on Etherscan')).toBeNull();
+      expect(getByText('View full history on Lineascan')).toBeTruthy();
+    });
+
+    it('does not show generic Etherscan fallback without explorer URL when omitGlobalProviderExplorerFallback', () => {
+      mockIsMainnetByChainId.mockReturnValue(false);
+
+      const { queryByText } = render(
+        <TransactionsFooter
+          chainId="0xe708"
+          providerType="mainnet"
+          omitGlobalProviderExplorerFallback
+          onViewBlockExplorer={mockOnViewBlockExplorer}
+        />,
+      );
+
+      expect(queryByText(/View full history/)).toBeNull();
+    });
+
     it('hides button for RPC networks without block explorer', () => {
       mockIsMainnetByChainId.mockReturnValue(false);
 

--- a/app/components/UI/Transactions/TransactionsFooter.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.tsx
@@ -63,6 +63,11 @@ interface TransactionsFooterProps {
    */
   isNonEvmChain?: boolean;
   /**
+   * When true, do not use the globally selected network's provider type to show
+   * a generic "Etherscan" fallback (e.g. token details must match the asset chain only).
+   */
+  omitGlobalProviderExplorerFallback?: boolean;
+  /**
    * Handler for view block explorer button press
    */
   onViewBlockExplorer: () => void;
@@ -77,6 +82,7 @@ const TransactionsFooter = ({
   providerType,
   rpcBlockExplorer,
   isNonEvmChain = false,
+  omitGlobalProviderExplorerFallback = false,
   onViewBlockExplorer,
   showDisclaimer = true,
 }: TransactionsFooterProps) => {
@@ -105,7 +111,12 @@ const TransactionsFooter = ({
       }
     }
 
-    if (isMainnetByChainId(chainId) || (providerType && providerType !== RPC)) {
+    const allowProviderFallback =
+      !omitGlobalProviderExplorerFallback &&
+      providerType &&
+      providerType !== RPC;
+
+    if (isMainnetByChainId(chainId) || allowProviderFallback) {
       return strings('transactions.view_full_history_on_etherscan');
     }
 

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -22,6 +22,7 @@ import { getDeviceId } from '../../../core/Ledger/Ledger';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import NotificationManager from '../../../core/NotificationManager';
 import { TransactionError } from '../../../core/Transaction/TransactionError';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 import { collectibleContractsSelector } from '../../../reducers/collectibles';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
@@ -43,8 +44,10 @@ import Logger from '../../../util/Logger';
 import {
   findBlockExplorerForNonEvmChainId,
   findBlockExplorerForRpc,
+  findBlockExplorerUrlForChain,
   getBlockExplorerAddressUrl,
   getBlockExplorerName,
+  getHexEvmChainId,
 } from '../../../util/networks';
 import { mockTheme, ThemeContext } from '../../../util/theme';
 import {
@@ -231,6 +234,27 @@ class Transactions extends PureComponent {
     return isNonEvmChainId(this.props.chainId);
   }
 
+  /**
+   * Chain used for the "View full history" footer and explorer link.
+   * On token / asset details, only the asset chain is used — never the globally
+   * selected network from Redux.
+   */
+  get explorerContextChainId() {
+    const { tokenChainId, chainId, location } = this.props;
+    if (location === TransactionDetailLocation.AssetDetails) {
+      return tokenChainId;
+    }
+    return tokenChainId ?? chainId;
+  }
+
+  get isAssetDetailsExplorer() {
+    return this.props.location === TransactionDetailLocation.AssetDetails;
+  }
+
+  get isExplorerContextNonEvm() {
+    return isNonEvmChainId(this.explorerContextChainId);
+  }
+
   get isTokenNonEvmChain() {
     return isNonEvmChainId(this.props.tokenChainId);
   }
@@ -255,16 +279,27 @@ class Transactions extends PureComponent {
     const {
       providerConfig: { type, rpcUrl },
       networkConfigurations,
-      chainId,
+      tokenChainId,
     } = this.props;
+    const explorerChainId = this.explorerContextChainId;
     let blockExplorer;
-    if (type === RPC) {
+
+    const useAssetOnlyExplorer =
+      this.isAssetDetailsExplorer || Boolean(tokenChainId);
+
+    if (!explorerChainId && useAssetOnlyExplorer) {
+      blockExplorer = undefined;
+    } else if (this.isExplorerContextNonEvm) {
+      blockExplorer = findBlockExplorerForNonEvmChainId(explorerChainId);
+    } else if (useAssetOnlyExplorer) {
+      blockExplorer = findBlockExplorerUrlForChain(
+        explorerChainId,
+        networkConfigurations,
+      );
+    } else if (type === RPC) {
       blockExplorer =
         findBlockExplorerForRpc(rpcUrl, networkConfigurations) ||
         NO_RPC_BLOCK_EXPLORER;
-    } else if (this.isNonEvmChain) {
-      // TODO: [SOLANA] - block explorer needs to be implemented
-      blockExplorer = findBlockExplorerForNonEvmChainId(chainId);
     }
 
     this.setState({ rpcBlockExplorer: blockExplorer });
@@ -386,13 +421,29 @@ class Transactions extends PureComponent {
       providerConfig: { type },
       selectedAddress,
       close,
-      chainId,
+      networkConfigurations,
     } = this.props;
     const { rpcBlockExplorer } = this.state;
+    const useAssetOnlyExplorer =
+      this.isAssetDetailsExplorer || Boolean(this.props.tokenChainId);
+
     try {
       let url, title;
 
-      if (this.isNonEvmChain && rpcBlockExplorer) {
+      if (useAssetOnlyExplorer) {
+        const base =
+          rpcBlockExplorer && rpcBlockExplorer !== NO_RPC_BLOCK_EXPLORER
+            ? rpcBlockExplorer
+            : findBlockExplorerUrlForChain(
+                this.explorerContextChainId,
+                networkConfigurations,
+              );
+        if (!base) {
+          throw new Error('Missing block explorer for asset chain');
+        }
+        url = `${base}/address/${selectedAddress}`;
+        title = getBlockExplorerName(base);
+      } else if (this.isExplorerContextNonEvm && rpcBlockExplorer) {
         url = `${rpcBlockExplorer}/address/${selectedAddress}`;
         title = getBlockExplorerName(rpcBlockExplorer);
       } else {
@@ -690,14 +741,24 @@ class Transactions extends PureComponent {
     const {
       chainId,
       providerConfig: { type },
+      tokenChainId,
     } = this.props;
+
+    const useAssetOnlyExplorer =
+      this.isAssetDetailsExplorer || Boolean(tokenChainId);
+
+    const footerChainId = useAssetOnlyExplorer
+      ? (getHexEvmChainId(this.explorerContextChainId) ??
+        this.explorerContextChainId)
+      : chainId;
 
     return (
       <TransactionsFooter
-        chainId={chainId}
+        chainId={footerChainId}
         providerType={type}
         rpcBlockExplorer={this.state.rpcBlockExplorer}
-        isNonEvmChain={this.isNonEvmChain}
+        isNonEvmChain={this.isExplorerContextNonEvm}
+        omitGlobalProviderExplorerFallback={this.isAssetDetailsExplorer}
         onViewBlockExplorer={this.viewOnBlockExplore}
         showDisclaimer
       />

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -13,7 +13,11 @@ import {
   getBlockExplorerName,
   findBlockExplorerForNonEvmChainId,
   findBlockExplorerForRpc,
+  findBlockExplorerUrlForChain,
+  getHexEvmChainId,
 } from '../../../util/networks';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
+import { NO_RPC_BLOCK_EXPLORER } from '../../../constants/network';
 import { isHardwareAccount } from '../../../util/address';
 import NotificationManager from '../../../core/NotificationManager';
 import { updateIncomingTransactions } from '../../../util/transaction-controller';
@@ -41,6 +45,8 @@ jest.mock('../../../util/networks', () => ({
   getBlockExplorerName: jest.fn(),
   findBlockExplorerForNonEvmChainId: jest.fn(),
   findBlockExplorerForRpc: jest.fn(),
+  findBlockExplorerUrlForChain: jest.fn(),
+  getHexEvmChainId: jest.fn(),
   isMainnetByChainId: jest.fn(),
 }));
 
@@ -195,6 +201,13 @@ const mockFindBlockExplorerForRpc =
   findBlockExplorerForRpc as jest.MockedFunction<
     typeof findBlockExplorerForRpc
   >;
+const mockFindBlockExplorerUrlForChain =
+  findBlockExplorerUrlForChain as jest.MockedFunction<
+    typeof findBlockExplorerUrlForChain
+  >;
+const mockGetHexEvmChainId = getHexEvmChainId as jest.MockedFunction<
+  typeof getHexEvmChainId
+>;
 const mockIsHardwareAccount = isHardwareAccount as jest.MockedFunction<
   typeof isHardwareAccount
 >;
@@ -2316,5 +2329,170 @@ describe('UnconnectedTransactions Component Direct Method Testing', () => {
     instance.retry();
 
     expect(instance.setState).toHaveBeenCalled();
+  });
+
+  describe('asset-chain explorer (tokenChainId / AssetDetails)', () => {
+    beforeEach(() => {
+      mockFindBlockExplorerUrlForChain.mockReset();
+      mockGetHexEvmChainId.mockReset();
+    });
+
+    it('updateBlockExplorer resolves EVM asset chain via findBlockExplorerUrlForChain when tokenChainId is set', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+      mockFindBlockExplorerUrlForChain.mockReturnValue(
+        'https://polygonscan.com',
+      );
+      instance.setState = jest.fn();
+      instance.props = {
+        ...defaultTestProps,
+        tokenChainId: 'eip155:137',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        networkConfigurations: { '0x89': {} },
+        providerConfig: { type: 'mainnet' },
+      };
+
+      instance.updateBlockExplorer();
+
+      expect(mockFindBlockExplorerUrlForChain).toHaveBeenCalledWith(
+        'eip155:137',
+        instance.props.networkConfigurations,
+      );
+      expect(instance.setState).toHaveBeenCalledWith({
+        rpcBlockExplorer: 'https://polygonscan.com',
+      });
+    });
+
+    it('updateBlockExplorer sets no explorer when AssetDetails has no tokenChainId', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+      instance.setState = jest.fn();
+      instance.props = {
+        ...defaultTestProps,
+        location: TransactionDetailLocation.AssetDetails,
+        tokenChainId: undefined,
+        chainId: '0x1',
+        providerConfig: { type: 'mainnet' },
+      };
+
+      instance.updateBlockExplorer();
+
+      expect(mockFindBlockExplorerUrlForChain).not.toHaveBeenCalled();
+      expect(instance.setState).toHaveBeenCalledWith({
+        rpcBlockExplorer: undefined,
+      });
+    });
+
+    it('updateBlockExplorer uses tokenChainId for non-EVM when location is AssetDetails', () => {
+      mockIsNonEvmChainId.mockImplementation(
+        (id: string) => id?.startsWith('solana:') ?? false,
+      );
+      mockFindBlockExplorerForNonEvmChainId.mockReturnValue(
+        'https://solscan.io',
+      );
+      instance.setState = jest.fn();
+      instance.props = {
+        ...defaultTestProps,
+        location: TransactionDetailLocation.AssetDetails,
+        tokenChainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        chainId: '0x1',
+        providerConfig: { type: 'mainnet' },
+      };
+
+      instance.updateBlockExplorer();
+
+      expect(mockFindBlockExplorerForNonEvmChainId).toHaveBeenCalledWith(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      );
+      expect(mockFindBlockExplorerUrlForChain).not.toHaveBeenCalled();
+    });
+
+    it('viewOnBlockExplore uses asset rpcBlockExplorer when tokenChainId is set', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+      mockGetBlockExplorerName.mockReturnValue('Polygonscan');
+      instance.props = {
+        ...defaultTestProps,
+        navigation: mockNavigation,
+        tokenChainId: '0x89',
+        chainId: '0x1',
+        providerConfig: { type: 'mainnet' },
+      };
+      instance.state = { rpcBlockExplorer: 'https://polygonscan.com' };
+
+      instance.viewOnBlockExplore();
+
+      expect(mockGetBlockExplorerAddressUrl).not.toHaveBeenCalled();
+      expect(mockNavigation.push).toHaveBeenCalledWith('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://polygonscan.com/address/0x123',
+          title: 'Polygonscan',
+        },
+      });
+    });
+
+    it('viewOnBlockExplore falls back to findBlockExplorerUrlForChain when state explorer is NO_RPC_BLOCK_EXPLORER', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+      mockGetBlockExplorerName.mockReturnValue('Polygonscan');
+      mockFindBlockExplorerUrlForChain.mockReturnValue(
+        'https://polygonscan.com',
+      );
+      instance.props = {
+        ...defaultTestProps,
+        navigation: mockNavigation,
+        tokenChainId: '0x89',
+        networkConfigurations: {},
+        providerConfig: { type: 'mainnet' },
+      };
+      instance.state = { rpcBlockExplorer: NO_RPC_BLOCK_EXPLORER };
+
+      instance.viewOnBlockExplore();
+
+      expect(mockFindBlockExplorerUrlForChain).toHaveBeenCalledWith('0x89', {});
+      expect(mockNavigation.push).toHaveBeenCalledWith('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://polygonscan.com/address/0x123',
+          title: 'Polygonscan',
+        },
+      });
+    });
+
+    it('viewOnBlockExplore logs when asset chain has no block explorer', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+      mockFindBlockExplorerUrlForChain.mockReturnValue(undefined);
+      instance.props = {
+        ...defaultTestProps,
+        navigation: mockNavigation,
+        tokenChainId: '0x999',
+        networkConfigurations: {},
+        providerConfig: { type: 'mainnet' },
+      };
+      instance.state = { rpcBlockExplorer: undefined };
+
+      instance.viewOnBlockExplore();
+
+      expect(Logger.error).toHaveBeenCalled();
+      expect(mockNavigation.push).not.toHaveBeenCalled();
+    });
+
+    it('footer passes omitGlobalProviderExplorerFallback and hex chainId from getHexEvmChainId for AssetDetails', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+      mockGetHexEvmChainId.mockReturnValue('0x89');
+      instance.props = {
+        ...defaultTestProps,
+        location: TransactionDetailLocation.AssetDetails,
+        tokenChainId: 'eip155:137',
+        chainId: '0x1',
+        providerConfig: { type: 'mainnet' },
+      };
+      instance.state = { rpcBlockExplorer: 'https://polygonscan.com' };
+      instance.viewOnBlockExplore = jest.fn();
+
+      const footer = instance.footer;
+
+      expect(mockGetHexEvmChainId).toHaveBeenCalledWith('eip155:137');
+      expect(footer.props.omitGlobalProviderExplorerFallback).toBe(true);
+      expect(footer.props.chainId).toBe('0x89');
+      expect(footer.props.isNonEvmChain).toBe(false);
+    });
   });
 });

--- a/app/components/hooks/useBlockExplorer.test.ts
+++ b/app/components/hooks/useBlockExplorer.test.ts
@@ -295,6 +295,15 @@ describe('useBlockExplorer', () => {
       const url = getBlockExplorerUrl(address, hexChainId);
       expect(url).toBe('https://polygonscan.com/address/0x1234567890abcdef');
     });
+
+    it('resolves Polygon from decimal eip155 CAIP (same as getHexEvmChainId)', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const address = '0x1234567890abcdef';
+
+      const url = getBlockExplorerUrl(address, 'eip155:137');
+      expect(url).toBe('https://polygonscan.com/address/0x1234567890abcdef');
+    });
   });
 
   describe('Built-in block explorer coverage', () => {

--- a/app/components/hooks/useBlockExplorer.ts
+++ b/app/components/hooks/useBlockExplorer.ts
@@ -3,6 +3,7 @@ import { RPC } from '../../constants/network';
 import {
   findBlockExplorerForRpc,
   getBlockExplorerName as getBlockExplorerNameFromUrl,
+  getHexEvmChainId,
 } from '../../util/networks';
 import {
   getEtherscanAddressUrl,
@@ -30,8 +31,6 @@ import {
 } from '../../core/Multichain/networks';
 import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../core/Multichain/constants';
 import { isNonEvmChainId } from '../../core/Multichain/utils';
-import { parseCaipChainId, isCaipChainId } from '@metamask/utils';
-import { toHex } from '@metamask/controller-utils';
 import { PopularList } from '../../util/networks/customNetworks';
 
 const useBlockExplorer = (chainId?: string) => {
@@ -39,19 +38,10 @@ const useBlockExplorer = (chainId?: string) => {
   const providerConfig = useSelector(selectProviderConfig);
   const networkConfigurations = useSelector(selectNetworkConfigurations);
 
-  // Helper function to convert CAIP chain ID to hex chain ID for EVM networks
-  const convertToHexChainId = useCallback((inputChainId: string): string => {
-    if (isCaipChainId(inputChainId)) {
-      const { namespace, reference } = parseCaipChainId(inputChainId);
-      if (namespace === 'eip155') {
-        return toHex(reference);
-      }
-      // For non-EVM chains, return as-is
-      return inputChainId;
-    }
-    // Already in hex format or other format
-    return inputChainId;
-  }, []);
+  const toHexChainIdForEvmLookup = useCallback(
+    (inputChainId: string) => getHexEvmChainId(inputChainId) ?? inputChainId,
+    [],
+  );
 
   // Helper function to get base block explorer URL for EVM chains
   const getEvmBlockExplorerUrl = useCallback((targetChainId: string) => {
@@ -100,7 +90,7 @@ const useBlockExplorer = (chainId?: string) => {
 
       // For specific EVM chain block explorers
       if (currentChainId) {
-        const hexChainId = convertToHexChainId(currentChainId);
+        const hexChainId = toHexChainIdForEvmLookup(currentChainId);
         const baseUrl = getEvmBlockExplorerUrl(hexChainId);
         if (baseUrl) {
           return `${baseUrl}/address/${address}`;
@@ -125,7 +115,7 @@ const useBlockExplorer = (chainId?: string) => {
       providerConfig,
       networkConfigurations,
       getEvmBlockExplorerUrl,
-      convertToHexChainId,
+      toHexChainIdForEvmLookup,
     ],
   );
 
@@ -172,7 +162,7 @@ const useBlockExplorer = (chainId?: string) => {
 
       // For specific EVM chain block explorers
       if (currentChainId) {
-        const hexChainId = convertToHexChainId(currentChainId);
+        const hexChainId = toHexChainIdForEvmLookup(currentChainId);
         const baseUrl = getEvmBlockExplorerUrl(hexChainId);
         if (baseUrl) {
           return baseUrl;
@@ -197,7 +187,7 @@ const useBlockExplorer = (chainId?: string) => {
       providerConfig,
       networkConfigurations,
       getEvmBlockExplorerUrl,
-      convertToHexChainId,
+      toHexChainIdForEvmLookup,
     ],
   );
 
@@ -236,7 +226,7 @@ const useBlockExplorer = (chainId?: string) => {
 
       // For specific EVM chain block explorers
       if (currentChainId) {
-        const hexChainId = convertToHexChainId(currentChainId);
+        const hexChainId = toHexChainIdForEvmLookup(currentChainId);
         const baseUrl = getEvmBlockExplorerUrl(hexChainId);
         if (baseUrl) {
           return getBlockExplorerNameFromUrl(baseUrl);
@@ -263,7 +253,7 @@ const useBlockExplorer = (chainId?: string) => {
       providerConfig,
       networkConfigurations,
       getEvmBlockExplorerUrl,
-      convertToHexChainId,
+      toHexChainIdForEvmLookup,
     ],
   );
 

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -8,6 +8,7 @@ import {
   LINEA_GOERLI,
   LINEA_MAINNET,
   LINEA_SEPOLIA,
+  NO_RPC_BLOCK_EXPLORER,
   MEGAETH_TESTNET,
   MEGAETH_TESTNET_V2,
   MONAD_TESTNET,
@@ -426,6 +427,87 @@ export function findBlockExplorerForNonEvmChainId(chainId) {
   const blockExplorerUrls =
     MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[chainId];
   return blockExplorerUrls?.url;
+}
+
+/**
+ * Returns the hex EVM chain id for lookups in `networkConfigurations` (when the
+ * input is hex or CAIP-2 `eip155:*`). Returns `undefined` for non-EVM CAIP chains.
+ *
+ * @param {string} chainId
+ * @returns {string|undefined}
+ */
+export function getHexEvmChainId(chainId) {
+  if (!chainId || typeof chainId !== 'string') {
+    return undefined;
+  }
+  if (isNonEvmChainId(chainId)) {
+    return undefined;
+  }
+  if (isCaipChainId(chainId)) {
+    const { namespace, reference } = parseCaipChainId(chainId);
+    if (namespace !== KnownCaipNamespace.Eip155) {
+      return undefined;
+    }
+    return toHex(reference);
+  }
+  if (chainId.startsWith('0x')) {
+    return chainId;
+  }
+  return undefined;
+}
+
+/**
+ * Resolves the block explorer base URL for a chain, independent of the globally
+ * selected network (e.g. token details on Linea while Solana is selected).
+ *
+ * @param {string} chainId - Hex, CAIP-2, or non-EVM CAIP chain id
+ * @param {object} networkConfigurations - from `selectNetworkConfigurations`
+ * @returns {string|undefined}
+ */
+export function findBlockExplorerUrlForChain(chainId, networkConfigurations) {
+  if (!chainId) {
+    return undefined;
+  }
+  if (isNonEvmChainId(chainId)) {
+    return findBlockExplorerForNonEvmChainId(chainId);
+  }
+
+  const hexChainId = getHexEvmChainId(chainId);
+  if (!hexChainId) {
+    return undefined;
+  }
+
+  const networkConfig = networkConfigurations?.[hexChainId];
+  let blockExplorer =
+    networkConfig?.blockExplorerUrls?.[
+      networkConfig?.defaultBlockExplorerUrlIndex ?? 0
+    ];
+
+  if (isMainNet(hexChainId)) {
+    blockExplorer = MAINNET_BLOCK_EXPLORER;
+  } else if (isLineaMainnetChainId(hexChainId)) {
+    blockExplorer = LINEA_MAINNET_BLOCK_EXPLORER;
+  } else if (hexChainId === CHAIN_IDS.LINEA_SEPOLIA) {
+    blockExplorer = LINEA_SEPOLIA_BLOCK_EXPLORER;
+  } else if (hexChainId === CHAIN_IDS.SEPOLIA) {
+    blockExplorer = SEPOLIA_BLOCK_EXPLORER;
+  } else if (hexChainId === CHAIN_IDS.BASE) {
+    blockExplorer = BASE_MAINNET_BLOCK_EXPLORER;
+  }
+
+  if (!blockExplorer || blockExplorer === NO_RPC_BLOCK_EXPLORER) {
+    const popularNetwork = PopularList.find(
+      (network) => network.chainId === hexChainId,
+    );
+    if (popularNetwork?.rpcPrefs?.blockExplorerUrl) {
+      blockExplorer = popularNetwork.rpcPrefs.blockExplorerUrl;
+    }
+  }
+
+  if (!blockExplorer || blockExplorer === NO_RPC_BLOCK_EXPLORER) {
+    return undefined;
+  }
+  return blockExplorer;
 }
 
 /**

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -6,6 +6,8 @@ import NetworkList, {
   getAllNetworks,
   getNetworkTypeById,
   findBlockExplorerForRpc,
+  findBlockExplorerUrlForChain,
+  getHexEvmChainId,
   compareRpcUrls,
   getBlockExplorerAddressUrl,
   getBlockExplorerTxUrl,
@@ -41,13 +43,17 @@ import {
 } from '../../../app/constants/network';
 import { NetworkSwitchErrorType } from '../../../app/constants/error';
 import Engine from './../../core/Engine';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import { CHAIN_IDS, TransactionMeta } from '@metamask/transaction-controller';
 import {
   MOCK_SOLANA_ACCOUNT,
   MOCK_ACCOUNT_BIP122_P2WPKH,
   MOCK_ACCOUNT_BIP122_P2WPKH_TESTNET,
 } from '../test/accountsControllerTestUtils';
 import { BtcScope, SolScope } from '@metamask/keyring-api';
+import {
+  BASE_MAINNET_BLOCK_EXPLORER,
+  LINEA_MAINNET_BLOCK_EXPLORER,
+} from '../../constants/urls';
 import {
   selectMultichainNetworkControllerState,
   selectSelectedNonEvmNetworkChainId,
@@ -287,6 +293,58 @@ describe('network-utils', () => {
       expect(
         findBlockExplorerForRpc(mockRpcUrl, networkConfigurationsMock),
       ).toBe(undefined);
+    });
+  });
+
+  describe('getHexEvmChainId', () => {
+    it('returns hex chain id for CAIP-2 eip155', () => {
+      expect(getHexEvmChainId('eip155:59144')).toBe(CHAIN_IDS.LINEA_MAINNET);
+      expect(getHexEvmChainId('eip155:1')).toBe('0x1');
+    });
+
+    it('returns the same hex id when already hex', () => {
+      expect(getHexEvmChainId(CHAIN_IDS.LINEA_MAINNET)).toBe(
+        CHAIN_IDS.LINEA_MAINNET,
+      );
+    });
+
+    it('returns undefined for non-EVM CAIP chains', () => {
+      expect(getHexEvmChainId(SolScope.Mainnet)).toBeUndefined();
+    });
+
+    it('normalizes eip155 reference when reference is already hex', () => {
+      expect(getHexEvmChainId('eip155:0x1')).toBe('0x1');
+    });
+
+    it('normalizes decimal CAIP reference (Polygon)', () => {
+      expect(getHexEvmChainId('eip155:137')).toBe('0x89');
+    });
+  });
+
+  describe('findBlockExplorerUrlForChain', () => {
+    it('resolves Linea mainnet from CAIP without network config', () => {
+      expect(findBlockExplorerUrlForChain('eip155:59144', {})).toBe(
+        LINEA_MAINNET_BLOCK_EXPLORER,
+      );
+    });
+
+    it('resolves Base mainnet from hex without network config', () => {
+      expect(findBlockExplorerUrlForChain(CHAIN_IDS.BASE, {})).toBe(
+        BASE_MAINNET_BLOCK_EXPLORER,
+      );
+    });
+
+    it('uses network configuration block explorer for non-built-in chains', () => {
+      const configs = {
+        '0x999': {
+          blockExplorerUrls: ['https://custom-scan.test'],
+          chainId: '0x999',
+          defaultBlockExplorerUrlIndex: 0,
+        },
+      };
+      expect(findBlockExplorerUrlForChain('0x999', configs)).toBe(
+        'https://custom-scan.test',
+      );
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Reason:** On the token details screen, the transactions list footer (“View full history on …”) and the in-app block explorer link used **Redux’s globally selected network** (`selectChainId`) instead of the **token’s chain**. If the user had a non-EVM network selected (e.g. Solana) while viewing an EVM token (e.g. ETH on Linea), the UI could show **Solscan** and open the wrong explorer.

**Solution:**  
- **`Transactions`**: Derive explorer context from `tokenChainId` when present, and from **`tokenChainId` only** when `location === AssetDetails` (token details), so the selected wallet network is ignored for that screen. Resolve the base explorer with **`findBlockExplorerUrlForChain`** and open address URLs without going through the global provider’s `getBlockExplorerAddressUrl` in that case.  
- **`TransactionsFooter`**: Add **`omitGlobalProviderExplorerFallback`** for asset details so we do not fall back to the generic “Etherscan” label based on the global provider when the asset is on another chain.  
- **`app/util/networks`**: Add **`getHexEvmChainId`** and **`findBlockExplorerUrlForChain`** (network config, built-in explorers for core chains, then **PopularList**).  
- **Deduping:** **`TransactionDetails`** now uses **`findBlockExplorerUrlForChain`**; **`useBlockExplorer`** uses **`getHexEvmChainId`**; **`MultichainAddressRowsList.utils`** uses **`getHexEvmChainId`** for EVM hex normalization (same as the rest of the app).

**Tests:** Extended/added coverage in `app/util/networks/index.test.ts`, `useBlockExplorer.test.ts`, `TransactionsFooter.test.tsx`, `MultichainAddressRowsList.utils.test.ts`, and relevant `Transactions` explorer/footer tests.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed token details “View full history” block explorer using the wrong network when the globally selected chain did not match the token’s chain.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28160

## **Manual testing steps**

```gherkin
Feature: Token details block explorer matches the token’s chain

  Scenario: EVM token details with a non-EVM network selected
    Given the wallet has an account with ETH (or an ERC-20) on Linea (or another EVM chain) visible in the token list
    And the globally selected network is Solana (or another non-EVM network)
    When the user opens token details for that Linea asset and scrolls to the transaction list footer
    Then the footer shows the correct explorer name for that EVM chain (e.g. Lineascan for Linea), not Solscan
    When the user taps “View full history on …”
    Then the in-app browser opens that chain’s explorer address page for the account, not Solscan

  Scenario: Token details with matching global network (regression)
    Given the globally selected network is the same as the token’s chain
    When the user opens token details and uses “View full history on …”
    Then the explorer link and label still match that chain
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="400" height="831" alt="Screenshot 2026-04-02 at 11 50 25" src="https://github.com/user-attachments/assets/39fb2c43-7db2-4311-b2e9-0bdb5ff95a86" />

<!-- [screenshots/recordings] -->

### **After**
<img width="393" height="832" alt="Screenshot 2026-04-02 at 12 28 57" src="https://github.com/user-attachments/assets/d32cc1f8-da86-4252-9b0c-a1073a0496b6" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes block-explorer resolution and navigation logic across transaction UI, which could misroute users or hide explorer links if chain-id normalization or fallback ordering is wrong.
> 
> **Overview**
> Fixes transaction *block explorer* links/labels to resolve against the **asset’s chain** (via `tokenChainId` and `AssetDetails` location) instead of the globally selected network, preventing wrong explorers (e.g., Solana) from being shown/opened for EVM assets.
> 
> Adds shared network helpers `getHexEvmChainId` (CAIP `eip155:*` → hex) and `findBlockExplorerUrlForChain` (network config → built-ins → `PopularList`) and refactors `TransactionDetails`, `Transactions`, `TransactionsFooter`, `useBlockExplorer`, and multichain address sorting to use these normalized lookups; includes new tests covering CAIP/decimal IDs (e.g., Polygon `eip155:137`) and the new footer fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 864323ac10df6116501e27f18e327fb0d10d466e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->