### PR TITLE
test: sets the carousel mocks to false on the netwrok-manager spec

### DIFF
--- a/tests/api-mocking/mock-e2e-allowlist.ts
+++ b/tests/api-mocking/mock-e2e-allowlist.ts
@@ -14,7 +14,6 @@ export const ALLOWLISTED_HOSTS = [
   'nft.dev-api.cx.metamask.io',
   'nft.uat-api.cx.metamask.io',
   'nft.api.cx.metamask.io',
-  'digest.dev-api.cx.metamask.io', // Market digest API for tokens
   'gamma-api.polymarket.com',
   'clob.polymarket.com',
   '*.polymarket.com',
@@ -41,7 +40,6 @@ export const ALLOWLISTED_URLS = [
   'https://token.api.cx.metamask.io/assets/nativeCurrencyLogos/ethereum.svg',
   'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/stETH.svg',
   'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/rETH.svg',
-  'https://cdn.contentful.com:443/spaces/jdkgyfmyd9sw/environments/dev/entries?content_type=promotionalBanner&fields.showInMobile=true',
   'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=POL',
   'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=FTM',
   'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=AVAX',

--- a/tests/smoke/networks/network-manager2.spec.ts
+++ b/tests/smoke/networks/network-manager2.spec.ts
@@ -13,11 +13,19 @@ import TestDApp from '../../page-objects/Browser/TestDApp';
 import ConnectedAccountsModal from '../../page-objects/Browser/ConnectedAccountsModal';
 import ConnectBottomSheet from '../../page-objects/Browser/ConnectBottomSheet';
 import { CustomNetworks } from '../../resources/networks.e2e';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 
 const POLYGON = CustomNetworks.Tenderly.Polygon.providerConfig.nickname;
 
 const isMultichainAccountsState2Enabled =
   process.env.MM_ENABLE_MULTICHAIN_ACCOUNTS_STATE_2 === 'true';
+
+const testSpecificMock = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    carouselBanners: false,
+  });
+};
 
 describe(SmokeNetworkAbstractions('Network Manager'), () => {
   beforeAll(async () => {
@@ -63,6 +71,7 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
             )
             .build(),
           restartDevice: true,
+          testSpecificMock,
         },
         async () => {
           await loginToApp();
@@ -129,6 +138,7 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
           ])
           .build(),
         restartDevice: true,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();
@@ -186,6 +196,7 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
           ])
           .build(),
         restartDevice: true,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();
@@ -238,6 +249,7 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
           .withPopularNetworks()
           .build(),
         restartDevice: true,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();

--- a/tests/smoke/swap/gasless-swap.spec.ts
+++ b/tests/smoke/swap/gasless-swap.spec.ts
@@ -19,6 +19,7 @@ import { testSpecificMock as swapTestSpecificMock } from '../../helpers/swap/swa
 import { setupSmartTransactionsMocks } from '../../helpers/swap/smart-transactions-mocks';
 import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
 import { checkSwapActivity } from '../../helpers/swap/swap-unified-ui';
+import { Gestures } from '../../framework';
 
 describe(SmokeTrade('Gasless Swap - '), (): void => {
   const chainId = '0x1';
@@ -242,6 +243,12 @@ describe(SmokeTrade('Gasless Swap - '), (): void => {
         await QuoteView.enterAmount('1');
         await QuoteView.tapDestinationToken();
         await QuoteView.tapToken(chainId, 'MUSD');
+
+        // Sometimes the keyboard is not dismissed after selecting the
+        // destination token so we tap the network fee label to dismiss it
+        await Gestures.waitAndTap(QuoteView.networkFeeLabel, {
+          elemDescription: 'Network fee label',
+        });
 
         await Assertions.expectElementToBeVisible(QuoteView.networkFeeLabel, {
           timeout: 60000,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR sets the Carousel mocks to false on the network manager spec in order to improve token visibility.
Some urls were also removed from the allow list since they have been mocked previously

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensys.slack.com/archives/C02U025CVU4/p1775117808791299

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E/smoke test setup and allowlist cleanup, with no production runtime logic touched.
> 
> **Overview**
> Stabilizes smoke tests by forcing remote feature flags to disable `carouselBanners` in `network-manager2.spec.ts`, ensuring banner UI doesn’t obscure token visibility during network filtering checks.
> 
> Cleans up E2E request allowlisting by removing now-mocked endpoints from `mock-e2e-allowlist.ts`, and adds a small workaround in the gasless swap 7702 smoke test to dismiss a sticky keyboard via a tap on `QuoteView.networkFeeLabel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d0068c973d6042b4a8f9a764157e698bf797c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->