### PR TITLE
feat: integrate analytics tracking for NFT actions in NFTsSection

### DIFF
--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.test.tsx
@@ -5,8 +5,20 @@ import { backgroundState } from '../../../../../util/test/initial-root-state';
 import NFTsSection from './NFTsSection';
 import Routes from '../../../../../constants/navigation/Routes';
 import { SectionRefreshHandle } from '../../types';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
+import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
 
 const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics');
+jest.mocked(useAnalytics).mockReturnValue(
+  createMockUseAnalyticsHook({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+  }),
+);
 const mockOnRefresh = jest.fn().mockResolvedValue(undefined);
 const mockDetectNfts = jest.fn().mockResolvedValue(undefined);
 const mockAbortDetection = jest.fn();
@@ -91,6 +103,12 @@ const stateWithNftPreferences = {
 describe('NFTsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        trackEvent: mockTrackEvent,
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
     // Reset mock return values to defaults to ensure test isolation
     jest.requireMock('./hooks').useOwnedNfts.mockReturnValue([]);
     jest
@@ -132,6 +150,15 @@ describe('NFTsSection', () => {
     expect(mockNavigate).toHaveBeenCalledWith('AddAsset', {
       assetType: 'collectible',
     });
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Wallet View',
+        properties: expect.objectContaining({
+          action: 'Wallet View',
+          name: 'Add Collectibles',
+        }),
+      }),
+    );
   });
 
   it('renders section title when user has NFTs', () => {

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -29,6 +29,8 @@ import useHomeViewedEvent, {
   HomeSectionNames,
 } from '../../hooks/useHomeViewedEvent';
 import { Nft } from '@metamask/assets-controllers';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 
 const MAX_NFTS_DISPLAYED = 6;
 const NFTS_PER_ROW = 3;
@@ -66,6 +68,7 @@ const NFTsSection = forwardRef<SectionRefreshHandle, NFTsSectionProps>(
   ({ sectionIndex, totalSectionsLoaded }, ref) => {
     const sectionViewRef = useRef<View>(null);
     const navigation = useNavigation();
+    const { trackEvent, createEventBuilder } = useAnalytics();
     const ownedNfts = useOwnedNfts();
     const hasNfts = ownedNfts.length > 0;
     const isNftFetchingProgress = useSelector(isNftFetchingProgressSelector);
@@ -129,8 +132,13 @@ const NFTsSection = forwardRef<SectionRefreshHandle, NFTsSectionProps>(
     const handleImportNfts = useCallback(() => {
       setIsAddNFTEnabled(false);
       navigation.navigate('AddAsset', { assetType: 'collectible' });
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.WALLET_ADD_COLLECTIBLES)
+          .addProperties({ action: 'Wallet View', name: 'Add Collectibles' })
+          .build(),
+      );
       setTimeout(() => setIsAddNFTEnabled(true), 1000);
-    }, [navigation]);
+    }, [navigation, trackEvent, createEventBuilder]);
 
     // Pass null while loading so the hook uses the immediate-fire path and
     // does not fire from viewport visibility with stale itemCount/isEmpty.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On the redesigned homepage, tapping **Import NFTs** in the NFTs section empty state navigated to `AddAsset` but did not emit the same MetaMetrics event as the wallet NFT tab (`NftGrid` → `WALLET_ADD_COLLECTIBLES` / Wallet View with `Add Collectibles` properties). That broke parity with the tab flow and made Segment funnels miss homepage-origin imports.

**Solution:** Call `trackEvent` + `createEventBuilder(MetaMetricsEvents.WALLET_ADD_COLLECTIBLES)` with the same payload as `NftGrid.goToAddCollectible`. Unit test updated to assert the event.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->


CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-606

## **Manual testing steps**

```gherkin
Feature: Homepage NFT empty state import analytics

  Scenario: Import NFTs records add collectibles event
    Given the user is on Home with the homepage redesign enabled
    And the NFTs section is visible with no NFTs (empty state, not loading)
    When the user taps "Import NFTs" on the empty state
    Then the app navigates to the add collectible / Add Asset flow
    And a Wallet View analytics event fires with Add Collectibles properties (verify via MetaMetrics debugger or Segment in dev)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a MetaMetrics tracking call on an existing navigation action and updates unit tests to assert the event payload.
> 
> **Overview**
> Adds MetaMetrics tracking to the homepage `NFTsSection` empty-state action so tapping **Import NFTs** now emits `MetaMetricsEvents.WALLET_ADD_COLLECTIBLES` (matching the wallet `NftGrid` flow) in addition to navigating to `AddAsset`.
> 
> Updates `NFTsSection` unit tests to mock `useAnalytics` and assert that `trackEvent` is called with the expected `Wallet View` / `Add Collectibles` properties when the import card is pressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73cbf7ca88ab3a91d02d761814168ab733d802f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->