### PR TITLE
fix: fix text size when the user increases it cp-7.73.0

### DIFF
--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -268,6 +268,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
               <Text
                 variant={TextVariant.BodySm}
                 color={TextColor.TextAlternative}
+                twClassName="shrink"
               >
                 {strings('market_insights.card_footer_disclaimer')}
                 {' • '}

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.tsx
@@ -27,6 +27,10 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
+    top: 0,
+  },
+  sizer: {
+    opacity: 0,
   },
 });
 
@@ -169,11 +173,21 @@ const SlidingTextCarousel: React.FC<SlidingTextCarouselProps> = ({
 
   return (
     <Box
-      twClassName="h-[44px]"
       style={styles.overflowHidden}
       onLayout={handleContainerLayout}
       testID={testID}
     >
+      {/* Invisible sizer that establishes the container height based on
+          actual font metrics, so the card adapts to Dynamic Type scaling. */}
+      <Text
+        variant={TextVariant.BodySm}
+        numberOfLines={2}
+        style={styles.sizer}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        {'Mg\nMg'}
+      </Text>
       <Animated.View style={[styles.slidingText, slotAStyle]}>
         <Text
           variant={TextVariant.BodySm}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Before the text and layout were not adjusting when the user increased the font size in the phone, now it does:

<img  height="800" alt="Simulator Screenshot - iPhone 16e - 2026-04-02 at 13 00 56" src="https://github.com/user-attachments/assets/82507ffc-5098-4d8b-b1d8-cdc438443816" />
<img  height="800" alt="Simulator Screenshot - iPhone 16e - 2026-04-02 at 13 00 45" src="https://github.com/user-attachments/assets/71a6ac90-1b9f-4a0a-8cca-45fbe3f17572" />
<img  height="800" alt="Screenshot 2026-04-02 at 13 00 32" src="https://github.com/user-attachments/assets/2f32f0f5-2582-4b04-a3e8-2b0c52ab12db" />
<img  height="800" alt="Simulator Screenshot - iPhone 16e - 2026-04-02 at 13 01 24" src="https://github.com/user-attachments/assets/5b366e68-6335-4c5a-b0c6-b28b0a5d62ca" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout changes to improve Dynamic Type behavior; main potential issue is unintended spacing/overlap regressions in the `SlidingTextCarousel` container across devices and font scales.
> 
> **Overview**
> Improves Market Insights entry card layout under larger system font sizes.
> 
> `SlidingTextCarousel` no longer relies on a fixed container height; it now uses an invisible two-line "sizer" `Text` to establish height from actual font metrics (and pins animated text to `top: 0`) so the rotating text doesn’t clip/overlap when Dynamic Type scales.
> 
> The footer disclaimer text in `MarketInsightsEntryCard` is also marked as `shrink` to avoid layout overflow next to the info icon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30fb5ef7f59c4fc785f6c68ab0590141d3609e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->