### PR TITLE
fix(tokens): fix layout shift in token list skeleton

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton.tsx
@@ -12,7 +12,7 @@ const createStyles = (colors: Colors) =>
     skeletonItem: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: 12,
+      height: 64,
     },
     skeletonTextContainer: {
       flex: 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

When switching accounts in the MetaMask app, the token list UI was resizing unexpectedly, causing a visual layout shift and inconsistent user experience. This was caused by a height mismatch between `TokenListSkeleton` and `TokenListItem` components.

**Root Cause:**
- `TokenListItem` uses an explicit `height: 64` style on its wrapper
- `TokenListSkeleton` was using `paddingVertical: 12` instead of explicit height, allowing content to dictate height

**Solution:**
Changed `TokenListSkeleton` to use explicit `height: 64` to match `TokenListItem`, ensuring consistent row heights between skeleton loading states and actual token list items.

## **Changelog**

CHANGELOG entry: Fixed layout shift that occurred in the token list when switching accounts

## **Related issues**

Fixes: The token list layout shift issue reported when switching accounts on Samsung Fold devices

## **Manual testing steps**

```gherkin
Feature: Token List Stability on Account Switch

  Scenario: user switches accounts and token list maintains consistent layout
    Given the MetaMask app is open on the main wallet screen
    And the user has multiple accounts with tokens

    When user switches from one account to another
    Then the token list should maintain consistent size and layout
    And there should be no visible layout shift or resizing of token items
```

## **Screenshots/Recordings**

### **Before**

Token list skeleton items had inconsistent height compared to actual token items, causing visible layout shift when switching accounts.

### **After**

Token list skeleton items now have the same 64px height as token list items, preventing layout shift.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3895378-588f-48d9-b057-699dc50c4461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3895378-588f-48d9-b057-699dc50c4461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

