### PR TITLE
refactor: remove redundant wallet_connection_user_approved/rejected V2 events

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -263,7 +263,6 @@ export class ConnectionRegistry {
       await this.store.save(connInfo);
       this.hostapp.syncConnectionList(Array.from(this.connections.values()));
 
-      trackWalletEvent('wallet_connection_user_approved', baseProps);
       logger.debug('Handled connect deeplink.', connInfo?.id);
     } catch (error) {
       logger.error('Failed to handle connect deeplink:', error, redactUrl(url));
@@ -271,9 +270,9 @@ export class ConnectionRegistry {
       if (conn) await this.disconnect(conn.id);
 
       // This catch only handles connection-setup failures (parse, network,
-      // protocol). User rejections of wallet_createSession are asynchronous
-      // and tracked separately as wallet_connection_user_rejected in
-      // Connection's response handler — no double-fire occurs.
+      // protocol). User rejections of wallet_createSession are tracked by
+      // the existing CONNECT_REQUEST_CANCELLED MetaMetrics event (with
+      // source: 'sdk_connect_v2') — no double-fire occurs.
       trackWalletEvent('wallet_connection_request_failed', {
         anon_id: connReq?.sessionRequest?.id ?? 'unknown',
         platform: 'mobile',

--- a/app/core/SDKConnectV2/services/connection.ts
+++ b/app/core/SDKConnectV2/services/connection.ts
@@ -16,7 +16,6 @@ import { IHostApplicationAdapter } from '../types/host-application-adapter';
 import { errorCodes, providerErrors } from '@metamask/rpc-errors';
 import Engine from '../../Engine';
 import NavigationService from '../../NavigationService';
-import { trackWalletEvent } from './v2-analytics';
 
 /**
  * Known user-rejection error codes across ecosystems.
@@ -62,8 +61,6 @@ export class Connection {
   public readonly hostApp: IHostApplicationAdapter;
   public readonly bridge: IRPCBridgeAdapter;
 
-  private pendingSessionRequestId: unknown = undefined;
-
   private constructor(
     connInfo: ConnectionInfo,
     client: WalletClient,
@@ -95,10 +92,6 @@ export class Connection {
         typeof payload.data === 'object' &&
         'method' in payload.data &&
         payload.data.method === 'wallet_createSession';
-
-      if (isWalletCreateSessionRequest) {
-        this.pendingSessionRequestId = data?.id;
-      }
 
       // If the request is a wallet_createSession request and there are pending approval requests, clear those pending approvals before
       // showing the wallet_createSession approval. We do this to prevent the user from seeing a stale wallet_createSession approval in the
@@ -154,19 +147,6 @@ export class Connection {
 
           if (REJECTION_CODES.has(errCode) || isRejectionMessage(errMessage)) {
             this.hostApp.showConfirmationRejectionError(this.info);
-
-            if (
-              this.pendingSessionRequestId !== undefined &&
-              responseData.id === this.pendingSessionRequestId
-            ) {
-              this.pendingSessionRequestId = undefined;
-              trackWalletEvent('wallet_connection_user_rejected', {
-                anon_id: this.id,
-                platform: 'mobile',
-                sdk_version: this.info.metadata?.sdk?.version,
-                sdk_platform: this.info.metadata?.sdk?.platform,
-              });
-            }
           } else if (isInternalError(errCode)) {
             this.hostApp.showInternalError(this.info);
           } else {

--- a/app/core/SDKConnectV2/services/v2-analytics.test.ts
+++ b/app/core/SDKConnectV2/services/v2-analytics.test.ts
@@ -59,7 +59,7 @@ describe('trackWalletEvent', () => {
   it('sends POST request with correct payload when analytics is enabled', () => {
     mockAnalytics.isEnabled.mockReturnValue(true);
     const eventName: WalletConnectionEventName =
-      'wallet_connection_user_approved';
+      'wallet_connection_request_received';
     const properties = createProperties({ sdk_version: '1.0.0' });
 
     trackWalletEvent(eventName, properties);
@@ -96,7 +96,7 @@ describe('trackWalletEvent', () => {
       found_in_store: true,
     });
 
-    trackWalletEvent('wallet_connection_user_rejected', properties);
+    trackWalletEvent('wallet_connection_request_failed', properties);
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(body[0].properties).toStrictEqual(properties);

--- a/app/core/SDKConnectV2/services/v2-analytics.ts
+++ b/app/core/SDKConnectV2/services/v2-analytics.ts
@@ -17,9 +17,7 @@ const V2_ANALYTICS_ENDPOINT =
  */
 export type WalletConnectionEventName =
   | 'wallet_connection_request_received'
-  | 'wallet_connection_request_failed'
-  | 'wallet_connection_user_approved'
-  | 'wallet_connection_user_rejected';
+  | 'wallet_connection_request_failed';
 
 export interface WalletEventProperties {
   anon_id: string;


### PR DESCRIPTION
## Summary

Pointed at #27864

With the `useOriginSource` fix ([WAPI-1380](https://consensyssoftware.atlassian.net/browse/WAPI-1380) / PR [#28290](https://github.com/MetaMask/metamask-mobile/pull/28290)), V2/MWP connections flow through the connection approval UI, which already fires `CONNECT_REQUEST_COMPLETED` / `CONNECT_REQUEST_CANCELLED` with the correct source. Adding `wallet_connection_user_approved` / `wallet_connection_user_rejected` in the relay layer re-implements the same signal.

**Removed** (covered by existing events with correct source):
- `wallet_connection_user_approved` — same signal as `CONNECT_REQUEST_COMPLETED`
- `wallet_connection_user_rejected` — same signal as `CONNECT_REQUEST_CANCELLED`
- `pendingSessionRequestId` tracking in `Connection` (existed solely for the rejected event)

**Kept** (no existing MetaMetrics event covers these):
- `wallet_connection_request_received` — fires at deeplink parse time, before transport/approval. This is the key signal for measuring drop-off between dapp-initiated and wallet-received.
- `wallet_connection_request_failed` — catches pre-permission transport/parsing failures.

## Context

See discussion in PR #27864 and the analysis in WAPI-1380. The `useOriginSource` fix was merged to `main` in #28290, which means `source` now correctly identifies V2 connections in the standard `CONNECT_REQUEST_*` events — eliminating the need for dedicated approve/reject events on the V2 analytics relay.

Also: Cursor's bot flagged in #27864 that `wallet_connection_user_approved` was firing at `conn.connect()` resolution (WebSocket transport ready), not at actual user approval — so removing it also fixes that correctness issue.

## Test plan

- [x] Verify `wallet_connection_request_received` still fires on MWP deeplink
- [x] Verify `wallet_connection_request_failed` still fires on transport/parse error
- [x] Verify `CONNECT_REQUEST_COMPLETED` fires with correct source on approval
- [x] Verify `CONNECT_REQUEST_CANCELLED` fires with correct source on rejection
- [x] Verify no `wallet_connection_user_approved` or `wallet_connection_user_rejected` events are sent