### PR TITLE
refactor: rename analytics source from sdk_connect_v2 to mm_connect

### DIFF
--- a/app/components/hooks/useAnalytics/useAnalytics.types.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.types.ts
@@ -22,7 +22,7 @@ type AnalyticsEventBuilderType = ReturnType<
  */
 export const SourceType = {
   SDK: 'sdk',
-  SDK_CONNECT_V2: 'sdk_connect_v2',
+  MM_CONNECT: 'mm_connect',
   WALLET_CONNECT: 'walletconnect',
   IN_APP_BROWSER: 'in-app browser',
   PERMISSION_SYSTEM: 'permission system',

--- a/app/components/hooks/useMetrics/useMetrics.types.ts
+++ b/app/components/hooks/useMetrics/useMetrics.types.ts
@@ -15,7 +15,7 @@ import { MetricsEventBuilder } from '../../../core/Analytics/MetricsEventBuilder
  */
 export const SourceType = {
   SDK: 'sdk',
-  SDK_CONNECT_V2: 'sdk_connect_v2',
+  MM_CONNECT: 'mm_connect',
   WALLET_CONNECT: 'walletconnect',
   IN_APP_BROWSER: 'in-app browser',
   PERMISSION_SYSTEM: 'permission system',

--- a/app/components/hooks/useOriginSource.test.ts
+++ b/app/components/hooks/useOriginSource.test.ts
@@ -69,7 +69,7 @@ describe('useOriginSource', () => {
     expect(result.current).toBe(SourceType.SDK);
   });
 
-  it('should return SDK_CONNECT_V2 source for UUID origin present in v2Connections', () => {
+  it('should return MM_CONNECT source for UUID origin present in v2Connections', () => {
     const v2Uuid = 'aabbccdd-1122-3344-5566-778899aabbcc';
     const v2State = {
       ...mockState,
@@ -86,10 +86,10 @@ describe('useOriginSource', () => {
     );
 
     const { result } = renderHook(() => useOriginSource({ origin: v2Uuid }));
-    expect(result.current).toBe(SourceType.SDK_CONNECT_V2);
+    expect(result.current).toBe(SourceType.MM_CONNECT);
   });
 
-  it('should prefer SDK_CONNECT_V2 over SDK when UUID exists in both stores', () => {
+  it('should prefer MM_CONNECT over SDK when UUID exists in both stores', () => {
     // UUID '123e4567-...' is recognized by the V1 SDKConnect mock above.
     // When it also appears in v2Connections, V2 should win.
     const sharedUuid = '123e4567-e89b-12d3-a456-426614174000';
@@ -110,10 +110,10 @@ describe('useOriginSource', () => {
     const { result } = renderHook(() =>
       useOriginSource({ origin: sharedUuid }),
     );
-    expect(result.current).toBe(SourceType.SDK_CONNECT_V2);
+    expect(result.current).toBe(SourceType.MM_CONNECT);
   });
 
-  it('should not return SDK_CONNECT_V2 for UUID origin not in v2Connections', () => {
+  it('should not return MM_CONNECT for UUID origin not in v2Connections', () => {
     const unknownUuid = 'aabbccdd-1122-3344-5566-000000000000';
     const { result } = renderHook(() =>
       useOriginSource({ origin: unknownUuid }),

--- a/app/components/hooks/useOriginSource.ts
+++ b/app/components/hooks/useOriginSource.ts
@@ -38,7 +38,7 @@ export const useOriginSource = ({
   // Look it up in the v2Connections store (populated by
   // HostApplicationAdapter.syncConnectionList, keyed by connection ID).
   if (isUUID(origin) && v2Connections?.[origin]) {
-    return SourceType.SDK_CONNECT_V2;
+    return SourceType.MM_CONNECT;
   }
 
   // --- SDK v1 ---


### PR DESCRIPTION
## Summary

The product/brand name is **MetaMask Connect** (MWP), not "SDK Connect V2". This renames the analytics `source` property value from `sdk_connect_v2` to `mm_connect` so events correctly reflect the product name.

**Changes:**
- `SourceType.SDK_CONNECT_V2 = 'sdk_connect_v2'` → `SourceType.MM_CONNECT = 'mm_connect'` in both `useAnalytics.types.ts` (primary) and `useMetrics.types.ts` (deprecated compat copy)
- Updated the return value in `useOriginSource.ts`
- Updated test assertions and descriptions in `useOriginSource.test.ts`

**WAPI-1388** - https://consensyssoftware.atlassian.net/browse/WAPI-1388

Depends on the `useOriginSource` fix from [WAPI-1380](https://consensyssoftware.atlassian.net/browse/WAPI-1380) (already merged to main).

CHANGELOG entry: n/a

## Test plan

- [x] `useOriginSource.test.ts` — all 8 tests pass with renamed values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename of an analytics `SourceType` value and constant key; primary risk is mislabeling or missing any downstream consumers expecting the old value.
> 
> **Overview**
> Renames the analytics source identifier for SDK v2/MetaMask Connect from `sdk_connect_v2` (`SDK_CONNECT_V2`) to `mm_connect` (`MM_CONNECT`) in the canonical `useAnalytics` types and the deprecated `useMetrics` compatibility export.
> 
> Updates `useOriginSource` to emit `SourceType.MM_CONNECT` when an origin matches a v2 connection, and adjusts `useOriginSource` unit tests to assert the new source and wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96ede62d4c8bb8ab8d84172a480a5fd65d22f146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->