### PR TITLE
fix: prevent infinite quote request loop caused by token warning in unified swaps context cp-7.73.0

### DIFF
--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -63,16 +63,10 @@ export const useUnifiedSwapBridgeContext = () => {
       stx_enabled: smartTransactionsEnabled,
       token_symbol_source: fromToken?.symbol ?? '',
       token_symbol_destination: toToken?.symbol ?? '',
-      security_warnings: tokenWarning ? [tokenWarning.description] : [],
+      security_warnings: [], // TODO
       warnings: [], // TODO
       usd_amount_source: usdAmountSource,
     }),
-    [
-      smartTransactionsEnabled,
-      fromToken,
-      toToken,
-      usdAmountSource,
-      tokenWarning,
-    ],
+    [smartTransactionsEnabled, fromToken, toToken, usdAmountSource],
   );
 };

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -4,7 +4,6 @@ import {
   selectDestToken,
   selectSourceToken,
   selectSourceAmount,
-  selectDestTokenWarning,
 } from '../../../../../core/redux/slices/bridge';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { selectCurrencyRates } from '../../../../../selectors/currencyRateController';
@@ -21,7 +20,6 @@ export const useUnifiedSwapBridgeContext = () => {
   const fromToken = useSelector(selectSourceToken);
   const toToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);
-  const tokenWarning = useSelector(selectDestTokenWarning);
 
   const evmMultiChainMarketData = useSelector(selectTokenMarketData);
   const evmMultiChainCurrencyRates = useSelector(selectCurrencyRates);


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a destination token has a security warning (e.g. a Blockaid malicious/suspicious flag), the unified swaps bridge view was entering an infinite quote request loop.

**Root cause:** `tokenWarning` was included as a dependency of the `useMemo` that builds the analytics `context` object in `useUnifiedSwapBridgeContext`. `tokenWarning` is itself derived from quote results (blockaid data returned by the bridge controller). This created a feedback cycle:

```
Quote fetched → tokenWarning updates → context object recreates
→ updateQuoteParams identity changes → useEffect fires
→ new quote request → repeat ∞
```

**Fix:** Remove `tokenWarning` from the `useMemo` dependency array and clear `security_warnings` to `[]` for now. The `security_warnings` field will be populated properly in the bridge controller instead, removing the React dependency cycle entirely.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that caused repeated quote requests when swapping to a token with a security warning.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28367

## **Manual testing steps**

```gherkin
Feature: Unified Swaps/Bridge quote fetching with token warnings

  Scenario: user swaps to a token with a Blockaid security warning
    Given the user has opened the Swap/Bridge screen
    And the user has selected a source token with sufficient balance

    When the user selects a destination token that has a Blockaid security warning
    And the user enters a valid source amount
    Then the app fetches a quote once
    And does not repeatedly fire additional quote requests
    And the security warning banner is displayed on screen

  Scenario: user swaps to a normal token (no warning)
    Given the user has opened the Swap/Bridge screen
    And the user has selected a source token with sufficient balance

    When the user selects a destination token with no security warning
    And the user enters a valid source amount
    Then the app fetches a quote once
    And quote results are displayed normally
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**


Uploading Screen Recording 2026-04-02 at 4.24.51 PM.mov…



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to analytics context memoization, but it temporarily drops `security_warnings` data which could affect warning-related telemetry until re-populated elsewhere.
> 
> **Overview**
> Prevents an infinite bridge quote re-fetch loop by removing destination token warning state from `useUnifiedSwapBridgeContext`’s memoized context object.
> 
> `security_warnings` is now always an empty array (*TODO*) and the `useMemo` dependency list no longer includes the warning selector, stabilizing the `context` identity passed into `BridgeController.updateBridgeQuoteRequestParams`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21dec817a5afd4453181d95d4832fdf6ae008574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->